### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to 6 dynamo files

### DIFF
--- a/test/dynamo/test_nb_bool.py
+++ b/test/dynamo/test_nb_bool.py
@@ -14,11 +14,16 @@ class _Color(enum.Enum):
 
 import torch.nn
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 @torch._dynamo.config.patch("enable_trace_unittest", True)
 class NbBoolTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- Scalar constants (ConstantVariable path) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_bool.py
+++ b/test/dynamo/test_nb_bool.py
@@ -14,11 +14,15 @@ class _Color(enum.Enum):
 
 import torch.nn
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 @torch._dynamo.config.patch("enable_trace_unittest", True)
 class NbBoolTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- Scalar constants (ConstantVariable path) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_float.py
+++ b/test/dynamo/test_nb_float.py
@@ -3,10 +3,16 @@
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test, skipIfCrossRef
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+    skipIfCrossRef,
+)
 
 
 class NbFloatTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- float / int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_float.py
+++ b/test/dynamo/test_nb_float.py
@@ -3,10 +3,15 @@
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test, skipIfCrossRef
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+    skipIfCrossRef,
+)
 
 
 class NbFloatTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- float / int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_index.py
+++ b/test/dynamo/test_nb_index.py
@@ -5,10 +5,15 @@ import operator
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class NbIndexTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_index.py
+++ b/test/dynamo/test_nb_index.py
@@ -5,10 +5,14 @@ import operator
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class NbIndexTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_int.py
+++ b/test/dynamo/test_nb_int.py
@@ -5,10 +5,15 @@ from _testcapi import instancemethod
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class NbIntTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_int.py
+++ b/test/dynamo/test_nb_int.py
@@ -5,10 +5,14 @@ from _testcapi import instancemethod
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class NbIntTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # --- int / bool (ConstantVariable) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_operators.py
+++ b/test/dynamo/test_nb_operators.py
@@ -8,6 +8,7 @@ import functools
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -169,6 +170,8 @@ _INPLACE_COMBOS = {
 
 
 class TestNbOr(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -869,6 +872,8 @@ class _RSubReturnsMarker:
 
 
 class TestNbSub(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -1348,6 +1353,8 @@ class _InheritedSubAdd(_BaseWithAdd):
 
 
 class TestNbAdd(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest

--- a/test/dynamo/test_nb_shift.py
+++ b/test/dynamo/test_nb_shift.py
@@ -2,12 +2,17 @@
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbLshift(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- Integer lshift ---
     @make_dynamo_test
     def test_lshift_integers(self):
@@ -240,6 +245,8 @@ class TestNbLshift(torch._dynamo.test_case.TestCase):
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 @torch._dynamo.config.patch(enable_trace_load_build_class=True)
 class TestNbRshift(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- Integer rshift ---
     @make_dynamo_test
     def test_rshift_integers(self):


### PR DESCRIPTION
## Summary

This PR adds `hw_classification = HardwareClassification.GENERIC` to 10 test classes across 6 `test/dynamo/test_nb_*.py` files to classify these Dynamo number-protocol tests as device-agnostic.

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` to `NbBoolTests` in `test_nb_bool.py`.
- Added `hw_classification = HardwareClassification.GENERIC` to `NbFloatTests` in `test_nb_float.py`.
- Added `hw_classification = HardwareClassification.GENERIC` to `NbIndexTests` in `test_nb_index.py`.
- Added `hw_classification = HardwareClassification.GENERIC` to `NbIntTests` in `test_nb_int.py`.
- Added `hw_classification = HardwareClassification.GENERIC` to `TestNbOr`, `TestNbSub`, and `TestNbAdd` in `test_nb_operators.py`.
- Added `hw_classification = HardwareClassification.GENERIC` to `TestNbLshift` and `TestNbRshift` in `test_nb_shift.py`.
- Imported `HardwareClassification` from `torch.testing._internal.common_utils` in each file.

## Test plan

`python test/dynamo/test_nb_bool.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_float.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_index.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_int.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_operators.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_shift.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98