### PR TITLE
[Testcase Refactoring] Refactor test_pp_composability with instantiate_device_type_tests and hw-classification

### DIFF
--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -28,14 +28,14 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     at_least_x_gpu,
     MultiProcContinuousTest,
-    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -84,15 +84,26 @@ class MLPModuleEven(torch.nn.Module):
         return x
 
 
-class ComposabilityTest(MultiProcContinuousTest):
+class ComposabilityTestBase(MultiProcContinuousTest):
     @classmethod
-    def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return backend
+    def _resolved_device_type(cls) -> str:
+        # MultiProcContinuousTest subprocesses run tests without calling
+        # PrivateUse1TestBase.setUpClass, so cls.device_type stays the generic
+        # "privateuse1" token; resolve it to the registered backend name.
+        dt = cls.device_type
+        if dt == "privateuse1":
+            dt = torch._C._get_privateuse1_backend_name()
+        return dt
 
     @classmethod
-    def device_type(cls) -> str:
-        return device_type
+    def backend_str(cls) -> str:
+        return torch.distributed.get_default_backend_for_device(
+            cls._resolved_device_type()
+        )
+
+
+class ComposabilityTest(ComposabilityTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     world_size = 8
 
@@ -100,7 +111,6 @@ class ComposabilityTest(MultiProcContinuousTest):
     def device(self):
         return self.rank
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     def test_pp_and_dcp(self):
@@ -183,7 +193,6 @@ class ComposabilityTest(MultiProcContinuousTest):
 
         _dcp_test(self)
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -326,7 +335,6 @@ class ComposabilityTest(MultiProcContinuousTest):
             for optimizer in optimizers:
                 optimizer.step()
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -510,7 +518,6 @@ class ComposabilityTest(MultiProcContinuousTest):
             for ref_optimizer in ref_optimizers:
                 ref_optimizer.step()
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -758,7 +765,12 @@ class ComposabilityTest(MultiProcContinuousTest):
             )
 
 
-instantiate_parametrized_tests(ComposabilityTest)
+instantiate_device_type_tests(
+    ComposabilityTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -93,23 +93,26 @@ class ComposabilityTestBase(MultiProcContinuousTest):
             cls._resolved_device_type()
         )
 
+    def _rank_device(self, device: str) -> torch.device:
+        # `device` is the framework-injected primary device ("{type}:0",
+        # rank-0); resolve to this worker's per-rank device for self.rank.
+        device_type = torch.device(device).type
+        return torch.device(device_type, self.rank)
+
 
 class ComposabilityTest(ComposabilityTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     world_size = 8
 
-    @property
-    def device(self):
-        return self.rank
-
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
-    def test_pp_and_dcp(self):
+    def test_pp_and_dcp(self, device):
         """
         Test that pipeline parallelism and distributed checkpointing can be used together and
         with saved correct FQNs
         """
+        rank_device = self._rank_device(device)
 
         class AppState(Stateful):
             def __init__(self, model, optimizer):
@@ -145,7 +148,7 @@ class ComposabilityTest(ComposabilityTestBase):
                     x = layer(x)
                 return x
 
-        torch.accelerator.set_device_index(self.device)
+        torch.accelerator.set_device_index(rank_device)
         # create "entire model"
         total_layers = 8
         dim = 10
@@ -157,7 +160,7 @@ class ComposabilityTest(ComposabilityTestBase):
         end_index = start_index + 1
         pp_model = PPModelChunk(full_model, start_index, end_index)
 
-        pp_model.to(self.device)
+        pp_model.to(rank_device)
         opt = torch.optim.Adam(pp_model.parameters(), lr=0.1)
 
         # perform work in a temp dir that is cleaned up after the test
@@ -204,8 +207,9 @@ class ComposabilityTest(ComposabilityTestBase):
             torch.float32,
         ],
     )
-    def test_3d_with_tp_dp_pp(self, ScheduleClass, MixedPrecisionParam):
-        torch.accelerator.set_device_index(self.device)
+    def test_3d_with_tp_dp_pp(self, device, ScheduleClass, MixedPrecisionParam):
+        rank_device = self._rank_device(device)
+        torch.accelerator.set_device_index(rank_device)
         dim = 8
         tp_size = 2
         pp_size = 2
@@ -273,7 +277,7 @@ class ComposabilityTest(ComposabilityTestBase):
             end_layer = start_layer + layers_per_stage
             # divide the model layers by the number of stages
             partial_model = nn.Sequential(*full_model[start_layer:end_layer])
-            partial_model.to(self.device)
+            partial_model.to(rank_device)
             tp_model = apply_tp(partial_model, tp_mesh)
             dp_model = apply_fsdp(tp_model)
 
@@ -281,7 +285,7 @@ class ComposabilityTest(ComposabilityTestBase):
                 dp_model,
                 stage_idx,
                 num_stages,
-                self.device,
+                rank_device,
                 group=pp_group,
             )
 
@@ -313,8 +317,8 @@ class ComposabilityTest(ComposabilityTestBase):
         for _train_step in range(5):
             for optimizer in optimizers:
                 optimizer.zero_grad()
-            inputs = torch.rand((num_microbatches, dim), device=self.device)
-            labels = torch.rand((num_microbatches, dim), device=self.device)
+            inputs = torch.rand((num_microbatches, dim), device=rank_device)
+            labels = torch.rand((num_microbatches, dim), device=rank_device)
             is_last_stage = pp_mesh.get_local_rank() == pp_mesh.size() - 1
             if pp_mesh.get_local_rank() == 0:
                 pipeline_schedule.step(inputs)
@@ -346,8 +350,9 @@ class ComposabilityTest(ComposabilityTestBase):
             torch.float32,
         ],
     )
-    def test_replicate_pp(self, ScheduleClass, MixedPrecisionParam):
-        torch.accelerator.set_device_index(self.device)
+    def test_replicate_pp(self, device, ScheduleClass, MixedPrecisionParam):
+        rank_device = self._rank_device(device)
+        torch.accelerator.set_device_index(rank_device)
         dim = 8
         pp_size = 2
         num_microbatches = 8
@@ -409,10 +414,10 @@ class ComposabilityTest(ComposabilityTestBase):
             end_layer = start_layer + layers_per_stage
             # divide the model layers by the number of stages
             partial_model = nn.Sequential(*full_model[start_layer:end_layer])
-            partial_model.to(self.device)
+            partial_model.to(rank_device)
 
             ref_partial_model = nn.Sequential(*ref_full_model[start_layer:end_layer])
-            ref_partial_model.to(self.device)
+            ref_partial_model.to(rank_device)
 
             dp_model = apply_replicate(partial_model)
             ref_dp_model = apply_same_precision(ref_partial_model)
@@ -421,7 +426,7 @@ class ComposabilityTest(ComposabilityTestBase):
                 dp_model,
                 stage_idx,
                 num_stages,
-                self.device,
+                rank_device,
                 group=pp_group,
             )
 
@@ -429,7 +434,7 @@ class ComposabilityTest(ComposabilityTestBase):
                 ref_dp_model,
                 stage_idx,
                 num_stages,
-                self.device,
+                rank_device,
                 group=pp_group,
             )
 
@@ -484,10 +489,10 @@ class ComposabilityTest(ComposabilityTestBase):
                 ref_optimizer.zero_grad()
 
             inputs = torch.rand(
-                (num_microbatches, dim), device=self.device, dtype=MixedPrecisionParam
+                (num_microbatches, dim), device=rank_device, dtype=MixedPrecisionParam
             )
             labels = torch.rand(
-                (num_microbatches, dim), device=self.device, dtype=MixedPrecisionParam
+                (num_microbatches, dim), device=rank_device, dtype=MixedPrecisionParam
             )
             is_last_stage = pp_mesh.get_local_rank() == pp_mesh.size() - 1
             if pp_mesh.get_local_rank() == 0:
@@ -522,8 +527,9 @@ class ComposabilityTest(ComposabilityTestBase):
             ScheduleInterleavedZeroBubble,
         ],
     )
-    def test_replicate_pp_grads(self, ScheduleClass):
-        torch.accelerator.set_device_index(self.device)
+    def test_replicate_pp_grads(self, device, ScheduleClass):
+        rank_device = self._rank_device(device)
+        torch.accelerator.set_device_index(rank_device)
         dim = 8
         pp_size = 2
         num_microbatches = 8
@@ -542,7 +548,7 @@ class ComposabilityTest(ComposabilityTestBase):
         # create "entire model"
         total_layers = 8
         full_model = nn.ModuleList([MLPModule(dim) for _ in range(total_layers)])
-        ref_model = nn.Sequential(*copy.deepcopy(full_model)).to(self.device)
+        ref_model = nn.Sequential(*copy.deepcopy(full_model)).to(rank_device)
 
         # dummy loss needed just to force backwards to run in schedule step
         def loss_fn(y, target):
@@ -652,7 +658,7 @@ class ComposabilityTest(ComposabilityTestBase):
             end_layer = start_layer + layers_per_stage
             # divide the model layers by the number of stages
             partial_model = nn.Sequential(*full_model[start_layer:end_layer])
-            partial_model.to(self.device)
+            partial_model.to(rank_device)
 
             dp_model = apply_replicate(partial_model)
             pipelined_models_parameters(start_layer, dp_model)
@@ -660,7 +666,7 @@ class ComposabilityTest(ComposabilityTestBase):
                 dp_model,
                 stage_idx,
                 num_stages,
-                self.device,
+                rank_device,
                 group=pp_group,
             )
 
@@ -711,8 +717,8 @@ class ComposabilityTest(ComposabilityTestBase):
                 optimizer.zero_grad()
             ref_optimizer.zero_grad()
 
-            inputs = torch.rand((num_microbatches, dim), device=self.device)
-            labels = torch.rand((num_microbatches, dim), device=self.device)
+            inputs = torch.rand((num_microbatches, dim), device=rank_device)
+            labels = torch.rand((num_microbatches, dim), device=rank_device)
 
             # Ensure all ranks use the same inputs/labels for comparison
             torch.distributed.broadcast(inputs, 0)

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -28,14 +28,14 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     at_least_x_gpu,
     MultiProcContinuousTest,
-    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -45,14 +45,6 @@ from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 if TYPE_CHECKING:
     from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
-
-
-device_type = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
-)
-backend = torch.distributed.get_default_backend_for_device(device_type)
 
 
 # MLP Layer
@@ -84,15 +76,26 @@ class MLPModuleEven(torch.nn.Module):
         return x
 
 
-class ComposabilityTest(MultiProcContinuousTest):
+class ComposabilityTestBase(MultiProcContinuousTest):
     @classmethod
-    def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return backend
+    def _resolved_device_type(cls) -> str:
+        # MultiProcContinuousTest subprocesses run tests without calling
+        # PrivateUse1TestBase.setUpClass, so cls.device_type stays the generic
+        # "privateuse1" token; resolve it to the registered backend name.
+        dt = cls.device_type
+        if dt == "privateuse1":
+            dt = torch._C._get_privateuse1_backend_name()
+        return dt
 
     @classmethod
-    def device_type(cls) -> str:
-        return device_type
+    def backend_str(cls) -> str:
+        return torch.distributed.get_default_backend_for_device(
+            cls._resolved_device_type()
+        )
+
+
+class ComposabilityTest(ComposabilityTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     world_size = 8
 
@@ -100,7 +103,6 @@ class ComposabilityTest(MultiProcContinuousTest):
     def device(self):
         return self.rank
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     def test_pp_and_dcp(self):
@@ -183,7 +185,6 @@ class ComposabilityTest(MultiProcContinuousTest):
 
         _dcp_test(self)
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -211,7 +212,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         num_microbatches = 8
         dp_size = self.world_size // (tp_size * pp_size)
         device_mesh = init_device_mesh(
-            device_type,
+            self._resolved_device_type(),
             mesh_shape=(dp_size, pp_size, tp_size),
             mesh_dim_names=("dp", "pp", "tp"),
         )
@@ -326,7 +327,6 @@ class ComposabilityTest(MultiProcContinuousTest):
             for optimizer in optimizers:
                 optimizer.step()
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -353,7 +353,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         num_microbatches = 8
         replicate_size = self.world_size // (pp_size)
         device_mesh = init_device_mesh(
-            device_type,
+            self._resolved_device_type(),
             mesh_shape=(replicate_size, pp_size),
             mesh_dim_names=("replicate", "pp"),
         )
@@ -510,7 +510,6 @@ class ComposabilityTest(MultiProcContinuousTest):
             for ref_optimizer in ref_optimizers:
                 ref_optimizer.step()
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), "Test requires 8+ GPUs")
     @skip_if_lt_x_gpu(8)
     @parametrize(
@@ -530,7 +529,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         num_microbatches = 8
         replicate_size = self.world_size // (pp_size)
         device_mesh = init_device_mesh(
-            device_type,
+            self._resolved_device_type(),
             mesh_shape=(replicate_size, pp_size),
             mesh_dim_names=("replicate", "pp"),
         )
@@ -758,7 +757,12 @@ class ComposabilityTest(MultiProcContinuousTest):
             )
 
 
-instantiate_parametrized_tests(ComposabilityTest)
+instantiate_device_type_tests(
+    ComposabilityTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -78,20 +78,8 @@ class MLPModuleEven(torch.nn.Module):
 
 class ComposabilityTestBase(MultiProcContinuousTest):
     @classmethod
-    def _resolved_device_type(cls) -> str:
-        # MultiProcContinuousTest subprocesses run tests without calling
-        # PrivateUse1TestBase.setUpClass, so cls.device_type stays the generic
-        # "privateuse1" token; resolve it to the registered backend name.
-        dt = cls.device_type
-        if dt == "privateuse1":
-            dt = torch._C._get_privateuse1_backend_name()
-        return dt
-
-    @classmethod
     def backend_str(cls) -> str:
-        return torch.distributed.get_default_backend_for_device(
-            cls._resolved_device_type()
-        )
+        return torch.distributed.get_default_backend_for_device(cls.device_type)
 
     def _rank_device(self, device: str) -> torch.device:
         # `device` is the framework-injected primary device ("{type}:0",
@@ -216,7 +204,7 @@ class ComposabilityTest(ComposabilityTestBase):
         num_microbatches = 8
         dp_size = self.world_size // (tp_size * pp_size)
         device_mesh = init_device_mesh(
-            self._resolved_device_type(),
+            self.device_type,
             mesh_shape=(dp_size, pp_size, tp_size),
             mesh_dim_names=("dp", "pp", "tp"),
         )
@@ -358,7 +346,7 @@ class ComposabilityTest(ComposabilityTestBase):
         num_microbatches = 8
         replicate_size = self.world_size // (pp_size)
         device_mesh = init_device_mesh(
-            self._resolved_device_type(),
+            self.device_type,
             mesh_shape=(replicate_size, pp_size),
             mesh_dim_names=("replicate", "pp"),
         )
@@ -535,7 +523,7 @@ class ComposabilityTest(ComposabilityTestBase):
         num_microbatches = 8
         replicate_size = self.world_size // (pp_size)
         device_mesh = init_device_mesh(
-            self._resolved_device_type(),
+            self.device_type,
             mesh_shape=(replicate_size, pp_size),
             mesh_dim_names=("replicate", "pp"),
         )

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -290,13 +290,7 @@ def import_transformers_or_skip():
 
 
 def at_least_x_gpu(x):
-    if TEST_CUDA and torch.cuda.device_count() >= x:
-        return True
-    if TEST_HPU and torch.hpu.device_count() >= x:
-        return True
-    if TEST_XPU and torch.xpu.device_count() >= x:
-        return True
-    return False
+    return torch.accelerator.is_available() and torch.accelerator.device_count() >= x
 
 
 def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:


### PR DESCRIPTION
## Summary
Refactor `test_pp_composability.py`'s `ComposabilityTest` with `instantiate_device_type_tests` and a hardware-classification label, make the `at_least_x_gpu` test helper device-agnostic so the suite's `@skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), ...)` gate works on any accelerator, and thread the framework-injected `device` param through the test methods and helper chain.

## Changes
- `torch/testing/_internal/common_distributed.py`:
  - Replaced the CUDA/HPU/XPU-specific body of `at_least_x_gpu` with `return torch.accelerator.is_available() and torch.accelerator.device_count() >= x`, so out-of-tree PrivateUse1 accelerators are counted too. Ported from #185184 (which refactors several distributed test helpers; this PR takes only the `at_least_x_gpu` change).
- `test/distributed/_composable/test_composability/test_pp_composability.py`:
  - Switched `ComposabilityTest` to `instantiate_device_type_tests(except_for=["cpu"], allow_xpu=True)`. Variants are generated for every device type except CPU (open by default; the out-of-tree backend decides how to handle its own variant), and the existing `@parametrize` cases expand per variant. Previously the class used `instantiate_parametrized_tests` with module-level device/backend globals and no per-device variant.
  - Added a `ComposabilityTestBase(MultiProcContinuousTest)` intermediate base holding `backend_str`, defined on the base so `instantiate_device_type_tests` inherits it rather than ports it (a ported classmethod is bound to the generic class and cannot see the generated variant's `device_type`). Removed the old `backend_str()`/`device_type()` classmethods. Threaded the framework-injected `device` param through all 4 `test_*` methods and the helper chain: each test derives `rank_device = self._rank_device(device)` (resolves the type from the injected device, rebinds to `self.rank`) and uses `rank_device` for `init_pg` and tensor placement, replacing the old `device` property. Because every `test_*` takes `device`, `instantiate_test_helper` calls `_init_and_get_primary_device` at class-construction time, whose try/except fallback runs `setUpClass`; `PrivateUse1TestBase.setUpClass` resolves `cls.device_type` to the concrete backend name before any test body runs (and spawn workers re-resolve it via module re-import), so `backend_str` and the `init_device_mesh` call sites read `cls.device_type`/`self.device_type` directly with no `privateuse1`-token fallback.
  - Switched `init_pg` to `init_pg(self, device)` calling `torch.accelerator.set_device_index(device)` when an accelerator is available (device-agnostic; each test passes its `rank_device`).
  - Removed `@requires_accelerator_dist_backend()` from every test method. Variants are now open by default and the out-of-tree backend decides whether to run; #192186 will later centralize a spawn-time availability check via `c10d.is_backend_available` as a complementary smart-gate, not a merge prerequisite for this removal.
  - Kept `@skip_if_lt_x_gpu(8)` and `@skip_but_pass_in_sandcastle_if(not at_least_x_gpu(8), ...)` — the canonical framework gates, made device-agnostic by #187650 (`skip_if_lt_x_gpu`) and the `at_least_x_gpu` change above.
  - Classified `ComposabilityTest` as `HardwareClassification.ACCELERATOR`.

## Motivation
Part of the test-case refactoring initiative (#185590) to decouple tests from hardcoded CUDA/NCCL assumptions so out-of-tree PrivateUse1 accelerators can run the suite. This file switches to `instantiate_device_type_tests` (per-device variants), classifies the class, threads the `device` param, and ports the `at_least_x_gpu` helper change so the existing device-count gates work on PrivateUse1.

## Notes
- Removing `@requires_accelerator_dist_backend` lets PrivateUse1/vendor variants run by default (the out-of-tree backend decides whether its variant should run). #192186 will later add a spawn-time availability check (`c10d.is_backend_available`) as a complementary smart-gate; it is not a merge prerequisite for this PR. `#187650` provides the device-agnostic `skip_if_lt_x_gpu`; the `at_least_x_gpu` change is carried in this PR (ported from #185184, a broader helper refactor this PR does not depend on).
