### PR TITLE
Fix nan g gradient and null pointer in weight_norm CPU kernel for empty input

### DIFF
--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -407,6 +407,10 @@ void weight_norm_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
+  if (v.numel() == 0) {
+    norm.zero_();
+    return;
+  }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, v.scalar_type(),
       "weight_norm_kernel", [&]() {
     using accscalar_t = at::opmath_type<scalar_t>;
@@ -432,6 +436,10 @@ void weight_norm_backward_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == saved_v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
+  if (saved_v.numel() == 0) {
+    grad_g.zero_();
+    return;
+  }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, saved_v.scalar_type(),
       "weight_norm_backward_kernel", [&]() {
     using accscalar_t = at::opmath_type<scalar_t>;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1817,6 +1817,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+    @parametrize_test("dtype", [torch.float, torch.bfloat16, torch.float16])
+    def test_weight_norm_empty_input(self, dtype):
+        # Regression test for #181510. The fused CPU kernel reduced over an
+        # empty v, which handed a null data pointer to the vectorized load and
+        # left the saved norm at zero, so the g gradient came back nan.
+        m = torch.nn.utils.weight_norm(nn.Linear(0, 1).to(dtype=dtype))
+        out = m(torch.empty((1, 0), dtype=dtype))
+        self.assertEqual(out.shape, torch.Size([1, 1]))
+
+        out.sum().backward()
+        self.assertEqual(m.weight_g.grad, torch.zeros_like(m.weight_g))
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))


### PR DESCRIPTION
## Issue

Fixes https://github.com/pytorch/pytorch/issues/181510

Supersedes https://github.com/pytorch/pytorch/pull/181665

## Summary

`weight_norm` on a zero-sized dim, e.g. `nn.Linear(0, 1)`, reduces over an empty `v`. The fused CPU kernel hands `v.data_ptr()`, null for a zero-numel tensor, to `Vectorized<T>::loadu(data, 0)`, which `memcpy`s from it, so a sanitizer build reports the nonnull violation in the issue. The same reduction leaves the saved norm at 0 and the backward divides the `g` gradient by it, so `weight_g.grad` comes back `nan` on an ordinary build; the regression test asserts on that half, so it does not need a sanitizer. Both dispatch wrappers now return early with a zeroed output, which covers `dim == 0` and `dim == v.dim() - 1` in one place: the L2 norm of an empty vector is 0, `w` and `grad_v` are zero-numel, and `g` has no gradient signal. `zero_()` is used instead of the `fill_(0)` from the last review round because the file is compiled with `TORCH_ASSERT_NO_OPERATORS` and only includes `TensorBase.h`, where `c10::Scalar` is incomplete, so `fill_(0)` does not compile there.

Scope is one kernel. https://github.com/pytorch/pytorch/pull/181681 raised `group_norm` and `layer_norm` backward as reaching the same `loadu(nullptr, 0)`; on current `main` I could not reproduce either, with those two kernels instrumented as well. `group_norm` rejects an empty `HxW` or `C` with a `TORCH_CHECK` before the kernel, and the `layer_norm` empty-`N` backward is clean. So weight_norm looks like the last reachable one.

<details>
<summary>Red/green, built from source with UBSan scoped to <code>WeightNormKernel.cpp</code></summary>

The host is arm64 macOS, whose libc does not carry glibc's `nonnull` attribute on `memcpy`, so glibc's declaration was force-included into that one translation unit to get the diagnostic the issue reports. The kernel source is unmodified.

**Regression test against the unpatched kernel** (`WeightNormKernel.cpp` reverted to `main`, new test kept):

```
$ python test/test_nn.py -k test_weight_norm_empty_input
  File "test/test_nn.py", line 1830, in test_weight_norm_empty_input
    self.assertEqual(m.weight_g.grad, torch.zeros_like(m.weight_g))
AssertionError: Tensor-likes are not close!
Mismatched elements: 1 / 1 (100.0%)
Greatest absolute difference: nan at index (0, 0) (up to 1e-05 allowed)
Ran 3 tests in 0.011s
FAILED (failures=3)
```

**Issue repro on the unpatched kernel**, one hit per dtype path:

```
vec128_float_neon.h:216:11: runtime error: null pointer passed as argument 2, which is declared to never be null
vec128_bfloat16_neon.h:328:9: runtime error: null pointer passed as argument 2, which is declared to never be null
vec128_half_neon.h:206:9: runtime error: null pointer passed as argument 2, which is declared to never be null

v.numel()=0 v.data_ptr()=0 (0 == nullptr)
grad_g=tensor([[nan]]) grad_v.shape=(1, 0)
```

**With the fix**, same instrumented build, no sanitizer output, and the gradient is finite:

```
v.numel()=0 v.data_ptr()=0 (0 == nullptr)
grad_g=tensor([[0.]]) grad_v.shape=(1, 0)
```

**Sibling kernels from https://github.com/pytorch/pytorch/pull/181681**, same build with `layer_norm_kernel.cpp` and `group_norm_kernel.cpp` instrumented too, no sanitizer output on any of them:

```
layer_norm M>0,N=0     OK  out=(2, 0)
layer_norm 3d N=0      OK  out=(2, 3, 0)
layer_norm inner0      OK  out=(2, 0, 4)
group_norm HxW=0       RuntimeError: Expected HxW to be greater than 0, got 0
group_norm N=0         OK  out=(0, 4, 3)
group_norm C=0         RuntimeError: Expected number of channels to be greater than 0, got 0
```

**Existing coverage:**

```
$ python test/test_nn.py -k weight_norm
Ran 7 tests in 0.037s
OK (skipped=1)

$ python test/nn/test_parametrization.py -k weight_norm
Ran 8 tests in 0.012s
OK
```

</details>

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01