### PR TITLE
[xpu][skip] update skip all platform to skip specific platform for test_max_reads_limits_fusion

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -12,7 +12,7 @@ from torch._inductor import metrics, utils
 from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
-from torch.testing._internal.common_device_type import largeTensorTest, skipXPUIf
+from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
 from unittest import mock
 from unittest.mock import patch
 
@@ -18,6 +19,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     recover_orig_fp32_precision,
     skipIfXpu,
+    TEST_XPU,
 )
 from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -1180,9 +1182,8 @@ class OverFusionTest(TestBase):
     regression. See #179423.
     """
 
-
-    @skipXPUIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+    @unittest.skipIf(
+        TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
         "XPU: SYCL TLA backward does not guarantee precision on non-Xe2 devices. "
         "Re-enable once oneDNN adds SDPA backward support. "
         "See https://github.com/intel/torch-xpu-ops/issues/4094",

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1180,7 +1180,6 @@ class OverFusionTest(TestBase):
     regression. See #179423.
     """
 
-    device_type = GPU_TYPE  # required for skipXPUIf/skipCUDAIf decorators
 
     @skipXPUIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -12,13 +12,14 @@ from torch._inductor import metrics, utils
 from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
-from torch.testing._internal.common_device_type import largeTensorTest
+from torch.testing._internal.common_device_type import largeTensorTest, skipXPUIf
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     recover_orig_fp32_precision,
     skipIfXpu,
 )
+from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -1179,10 +1180,13 @@ class OverFusionTest(TestBase):
     regression. See #179423.
     """
 
-    @skipIfXpu(
-        msg="XPU selects Flash Attention for SDPA backward; the current SYCL TLA"
-        "implementation does not guarantee precision on PVC. Re-enable once oneDNN"
-        "adds SDPA backward support. See https://github.com/intel/torch-xpu-ops/issues/4094"
+    device_type = GPU_TYPE  # required for skipXPUIf/skipCUDAIf decorators
+
+    @skipXPUIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+        "XPU: SYCL TLA backward does not guarantee precision on non-Xe2 devices. "
+        "Re-enable once oneDNN adds SDPA backward support. "
+        "See https://github.com/intel/torch-xpu-ops/issues/4094",
     )
     @inductor_config.patch(
         {


### PR DESCRIPTION
## Summary

Replace the unconditional `@skipIfXpu` on `OverFusionTest.test_max_reads_limits_fusion` with `@skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, ...)` so the test is skipped only on non-Xe2 devices (PVC) and runs on Xe2+ devices (BMG).

## Problem

The failure is not a hardware limitation of PVC. It is a compatibility issue between the PVC LTS driver and SYCL TLA: SYCL TLA does not guarantee precision on the PVC LTS driver, and this driver/library combination is no longer being updated. BMG (Xe2) is not affected and the test passes there.

## Fix

- Add `device_type = GPU_TYPE` to `OverFusionTest` to enable `skipXPUIf`/`skipCUDAIf`-style decorators
- Replace `@skipIfXpu` with `@skipXPUIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU, ...)`
  - `PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU` is `False` on non-Xe2 (PVC) → skip
  - `PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU` is `True` on Xe2+ (BMG) → run
- This mirrors the existing skip pattern used for the same class of SYCL TLA precision issue in `test/test_transformers.py` (see https://github.com/pytorch/pytorch/blob/1c23e463efdf735913fabb00c48f0d0e5f6e2282/test/test_transformers.py#L5278), per the maintainer's suggestion in the tracker issue, so future fixes/unification can be handled consistently in one place.

## Validation

- ✅ BMG (Intel Arc B570, Xe2): test **PASS** with `pytorch-linux-noble-xpu-n-py3-client` docker + torch-xpu-ops CI manylinux wheel
- ⏳ PVC: skip path is logically correct (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU=False` on Xe); needs PVC CI verification

## Related

- Tracker: https://github.com/intel/torch-xpu-ops/issues/4094
- Original skip PR: https://github.com/pytorch/pytorch/pull/187822

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo