### PR TITLE
[distributed] Change FileSystemWriter overwrite default from True to False

### DIFF
--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -380,7 +380,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         sd["foo"] = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
         sd.set_sd_item_called = False
 
-        DCP.save(sd, checkpoint_id=self.temp_dir)
+        DCP.save(
+            sd,
+            storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=True),
+        )
         DCP.load(sd, checkpoint_id=self.temp_dir)
 
         # Validate that the non-stateful state dict was replaced with the loaded state dict

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -488,7 +488,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     "replicated": torch.rand(tensor_size, device=self.rank),
                 }
 
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(path=path, overwrite=True)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -378,7 +378,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count, overwrite=True
+                )
                 save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
                 dist.barrier()
@@ -529,7 +531,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 }
                 dist.broadcast(save_dict["replicated"], src=0)
 
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count, overwrite=True
+                )
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -114,7 +114,7 @@ class FsspecWriter(FileSystemWriter):
         sync_files: bool = True,
         thread_count: int = 1,
         per_thread_copy_ahead: int = 10_000_000,
-        overwrite: bool = True,
+        overwrite: bool = False,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
         **kwargs,
@@ -128,7 +128,7 @@ class FsspecWriter(FileSystemWriter):
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
             per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
-            overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
+            overwrite: Whether to allow overwriting existing checkpoints. Defaults to False.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -596,7 +596,7 @@ class _FileSystemWriter(StorageWriter):
         sync_files: bool = True,
         thread_count: int = 1,
         per_thread_copy_ahead: int = 10_000_000,
-        overwrite: bool = True,
+        overwrite: bool = False,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
         *args: Any,
@@ -611,7 +611,7 @@ class _FileSystemWriter(StorageWriter):
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
             per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
-            overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
+            overwrite: Whether to allow overwriting existing checkpoints. Defaults to False.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
@@ -655,14 +655,7 @@ class _FileSystemWriter(StorageWriter):
     def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
         self.fs.mkdir(self.path)
         if self._metadata_exists():
-            if self.overwrite:
-                warnings.warn(
-                    f"Detected an existing checkpoint in {self.path}, overwriting since {self.overwrite=}."
-                    " Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to"
-                    " maintain this functionality or False to raise when an existing checkpoint is found.",
-                    stacklevel=2,
-                )
-            else:
+            if not self.overwrite:
                 raise RuntimeError(f"Checkpoint already exists and {self.overwrite=}.")
 
         if self.rank is not None and not self.use_collectives:
@@ -993,7 +986,7 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
         thread_count: int = 1,
         per_thread_copy_ahead: int = 10_000_000,
         cache_staged_state_dict: bool = False,
-        overwrite: bool = True,
+        overwrite: bool = False,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
     ) -> None:
@@ -1009,7 +1002,7 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
             cache_staged_state_dict: Whether to cache the staged state_dict. This option decreases staging latency
                 at the cost of increased memory usage. Additionally, if this parameter is set to True, it's the expectation
                 that the stager is maintained and reused for multiple dcp.async_save calls. Default to False.
-            overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
+            overwrite: Whether to allow overwriting existing checkpoints. Defaults to False.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.


### PR DESCRIPTION
## Summary
- Changes `overwrite` default from `True` to `False` in `_FileSystemWriter`, `FileSystemWriter`, and `FsspecWriter`
- Removes the stale deprecation warning in `prepare_local_plan` that advertised this change for "past version 2.5"
- Updates tests that save to the same path multiple times to pass `overwrite=True` explicitly

Split from #191478 per reviewer request to allow independent revert if needed.

Fixes https://github.com/pytorch/pytorch/issues/191398 (overwrite portion)

## Test plan
- [x] `python test/distributed/checkpoint/test_file_system_checkpoint_cpu.py -v` — OK
- [x] `lintrunner -a` — no lint issues

cc @fegin @d4l3k