### PR TITLE
[Testcase Refactoring]Add hw_classification to test_compatibility.py

### DIFF
--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -12,11 +12,16 @@ from torch.distributed.checkpoint.metadata import (
     TensorProperties,
     TensorStorageMetadata,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 
 class TestDCPCompatbility(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def test_metadata(self) -> None:
         # Ensure that all the new fields of all the metadata have the default
         # values so that we can always deserialize from a legacy metadata.

--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -22,6 +22,7 @@ from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 class TestDCPCompatbility(TestCase):
     hw_classification = HardwareClassification.GENERIC
+
     def test_metadata(self) -> None:
         # Ensure that all the new fields of all the metadata have the default
         # values so that we can always deserialize from a legacy metadata.


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to
`TestDCPCompatbility` in `test/distributed/checkpoint/test_compatibility.py`.
This class tests checkpoint metadata serialization, backward
compatibility, and storage format behavior — all device-agnostic
operations that do not require an accelerator.

## Changes

- **Import `HardwareClassification`** from `common_utils`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `TestDCPCompatbility`.  The `GENERIC` label reflects that every test
  in this class exercises device-independent checkpoint metadata logic
  (serialization format, legacy deserialization, storage metadata)
  with no device dependency.

## Not changed

- No test logic, assertions, or checkpoint operations are modified.

## Test plan

- `python test/distributed/checkpoint/test_compatibility.py` — TODO:
  confirm all four tests pass on CPU.