### PR TITLE
[Inductor] Fallback complex tensor constants on Triton

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7845,6 +7845,7 @@ for dtype in (torch.int32, torch.int64):
         # tests element_size > itemsize (complex64 -> float32).
         # This test exercises element_size < itemsize (float32 -> complex64).
         import torch.fx as fx
+
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -7939,6 +7940,7 @@ for dtype in (torch.int32, torch.int64):
         # Non-0-d counterpart of test_view_dtype_0d_smaller_to_larger_element_size.
         # element_size (8) > itemsize (4): complex64 -> float32.
         import torch.fx as fx
+
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -7976,6 +7978,7 @@ for dtype in (torch.int32, torch.int64):
         # Non-0-d counterpart of test_view_dtype_0d_smaller_to_larger_element_size.
         # element_size (4) < itemsize (8): float32 -> complex64.
         import torch.fx as fx
+
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -8015,6 +8018,7 @@ for dtype in (torch.int32, torch.int64):
         # peephole must not fold x * 0 -> 0 (it would drop NaN/Inf when x is not
         # known to be finite). Integer/bool x * 0 is still folded.
         import torch.fx as fx
+
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         for dtype, should_fold in (
@@ -15125,6 +15129,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @skip_if_halide  # bf16
     def test_data_type_propogation(self):
         from torch._dynamo.utils import detect_fake_mode
+
         from torch._inductor.codegen.common import boolean_ops
         from torch._inductor.compile_fx import shape_env_from_inputs
         from torch._inductor.debug import DebugContext

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -62,6 +62,7 @@ from torch._inductor.aoti_eager import (
     load_aoti_eager_cache,
 )
 from torch._inductor.codegen.common import DataTypePropagation, OptimizationContext
+from torch._inductor.ir import is_triton
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import (
     add_scheduler_init_hook,
@@ -7894,6 +7895,31 @@ for dtype in (torch.int32, torch.int64):
         compiled = torch.compile(fn, backend="inductor")
         actual = compiled()
         self.assertEqual(actual, expected)
+
+    @config.patch(fx_graph_cache=False)
+    def test_complex_tensor_constant(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/191330.
+        if not self.is_dtype_supported(torch.complex64):
+            self.skipTest("complex64 not supported on this device")
+
+        def fn(x):
+            weight = torch.tensor(
+                [1 + 2j, 3 + 4j, 5 + 6j],
+                dtype=torch.complex64,
+                device=x.device,
+            )
+            return x + weight
+
+        x = torch.randn(2, 3, device=self.device)
+        expected = fn(x)
+        torch._inductor.metrics.generated_kernel_count = 0
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            torch._inductor.metrics.generated_kernel_count,
+            0 if is_triton(x.device) else 1,
+        )
 
     def test_complex_uniform_constant_folding(self):
         # Fix https://github.com/pytorch/pytorch/issues/174891

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7845,7 +7845,6 @@ for dtype in (torch.int32, torch.int64):
         # tests element_size > itemsize (complex64 -> float32).
         # This test exercises element_size < itemsize (float32 -> complex64).
         import torch.fx as fx
-
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -7897,6 +7896,7 @@ for dtype in (torch.int32, torch.int64):
         actual = compiled()
         self.assertEqual(actual, expected)
 
+    @skip_if_halide  # complex dtypes are not supported
     @config.patch(fx_graph_cache=False)
     def test_complex_tensor_constant(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/191330.
@@ -7940,7 +7940,6 @@ for dtype in (torch.int32, torch.int64):
         # Non-0-d counterpart of test_view_dtype_0d_smaller_to_larger_element_size.
         # element_size (8) > itemsize (4): complex64 -> float32.
         import torch.fx as fx
-
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -7978,7 +7977,6 @@ for dtype in (torch.int32, torch.int64):
         # Non-0-d counterpart of test_view_dtype_0d_smaller_to_larger_element_size.
         # element_size (4) < itemsize (8): float32 -> complex64.
         import torch.fx as fx
-
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         graph = fx.Graph()
@@ -8018,7 +8016,6 @@ for dtype in (torch.int32, torch.int64):
         # peephole must not fold x * 0 -> 0 (it would drop NaN/Inf when x is not
         # known to be finite). Integer/bool x * 0 is still folded.
         import torch.fx as fx
-
         from torch._inductor.fx_passes.joint_graph import UniformValueConstantFolder
 
         for dtype, should_fold in (
@@ -15129,7 +15126,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @skip_if_halide  # bf16
     def test_data_type_propogation(self):
         from torch._dynamo.utils import detect_fake_mode
-
         from torch._inductor.codegen.common import boolean_ops
         from torch._inductor.compile_fx import shape_env_from_inputs
         from torch._inductor.debug import DebugContext

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2840,8 +2840,19 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
     if node.op == "placeholder":
         return False
 
-    # We should be able to remove this special case once `disable_cpp_codegen` is killed.
     if node.target is aten.lift_fresh_copy.default:
+        output = node.meta.get("val")
+        # Lowering this to clone would send a complex TensorArg to Triton,
+        # which cannot represent complex dtypes.
+        if (
+            torch._subclasses.fake_tensor.is_fake_tensor(output)
+            and output.is_complex()
+            and is_triton(output.device)
+        ):
+            return True
+
+        # We should be able to remove this special case once
+        # `disable_cpp_codegen` is killed.
         return False
 
     def check_skip_condition(inp_out_node, is_output):


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #191330

## Summary

Complex tensor constants are represented by `aten.lift_fresh_copy`, whose existing lowering sends a complex `TensorArg` to Triton and fails during code generation. Fall back for this operation only on Triton devices when its output is complex, while preserving the existing compiled CPU path.

The regression test checks numerical correctness and verifies that Triton uses fallback while CPU continues to generate a compiled kernel.

## Testing

- `CpuTests.test_complex_tensor_constant_cpu`
- `GPUTests.test_complex_tensor_constant_cuda`
- CPU and CUDA adjacent complex constant/fallback tests
- Unsupported-`complex64` skip path with a mocked capability check
- Halide backend skip path
- `lintrunner@0.12.7` with the non-clang CI configuration
- `git diff --check`
- `py_compile` for the modified Python files

## Checklist

- [x] Passes lint (`lintrunner@0.12.7`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance-path change)

## BC-breaking?

No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo