### PR TITLE
[Testcase Refactoring] Use is_backend_available for MultiProcContinuousTest backend check

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2077,18 +2077,11 @@ class MultiProcContinuousTest(TestCase):
         # Get world_size (handles both class variable and property)
         cls.world_size = cls._get_world_size(device_type)
 
-        # Check if the specified backend is available before spawning processes
+        # Check if the specified backend is available before spawning processes.
+        # is_backend_available covers OOT/third-party backends too.
         backend = cls.backend_str() if callable(cls.backend_str) else cls.backend_str
-        if backend is not None:
-            backend_checks = {
-                "nccl": c10d.is_nccl_available,
-                "gloo": c10d.is_gloo_available,
-                "mpi": c10d.is_mpi_available,
-                "xccl": c10d.is_xccl_available,
-            }
-            check_fn = backend_checks.get(backend)
-            if check_fn is not None and not check_fn():
-                raise unittest.SkipTest(f"Backend '{backend}' is not available")
+        if backend is not None and not c10d.is_backend_available(backend):
+            raise unittest.SkipTest(f"Backend '{backend}' is not available")
 
         logger.info(
             f"Testing class {cls.__name__} on {cls.world_size} {device_type}"  # noqa: G004


### PR DESCRIPTION
## Summary
Replace `MultiProcContinuousTest`'s hardcoded backend-availability dict in `_ensure_processes_spawned` with `c10d.is_backend_available(backend)`. The generic API covers any backend registered via `Backend.register_backend`, including out-of-tree PrivateUse1 accelerators' backends, so the spawn-time check no longer silently passes through unlisted backends.

## Changes
- `torch/testing/_internal/common_distributed.py`: Replaced the hardcoded `{nccl, gloo, mpi, xccl}` backend-availability dict in `MultiProcContinuousTest._ensure_processes_spawned` with `c10d.is_backend_available(backend)`. This is the prerequisite for test-file PRs (e.g. test_stage, #192044) to drop their `@requires_accelerator_dist_backend` gate: with the backend availability check centralized here, the decorator becomes redundant.

## Motivation
Part of the test-case refactoring initiative (#185590) to decouple tests from hardcoded CUDA/NCCL assumptions so out-of-tree PrivateUse1 accelerators can run the suite. Split out from #192044 per review so the base-class/tooling change lands first and the test-file changes rebase on top.

## Notes
This is part of the test case refactoring initiative tracked in #185590.