### PR TITLE
[Testcase Refactoring] Add GENERIC hw_classification to dynamic_spec and tree_utils export tests

### DIFF
--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -992,10 +992,12 @@ class <lambda>(torch.nn.Module):
 
 
 class TestExportDynamicSpecStrict(_TestExportDynamicSpecBase):
+    hw_classification = HardwareClassification.GENERIC
     strict = True
 
 
 class TestExportDynamicSpecNonStrict(_TestExportDynamicSpecBase):
+    hw_classification = HardwareClassification.GENERIC
     strict = False
 
 
@@ -1561,10 +1563,12 @@ class _TestContainerSpecBase(TestCase):
 
 
 class TestContainerSpecStrict(_TestContainerSpecBase):
+    hw_classification = HardwareClassification.GENERIC
     strict = True
 
 
 class TestContainerSpecNonStrict(_TestContainerSpecBase):
+    hw_classification = HardwareClassification.GENERIC
     strict = False
 
 

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -107,9 +107,9 @@ class _ModBranch(torch.nn.Module):
 
 
 class _TestExportDynamicSpecBase(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     """torch.export.export support for the new ShapesSpec/ParamsSpec API."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()

--- a/test/export/test_dynamic_spec_export.py
+++ b/test/export/test_dynamic_spec_export.py
@@ -28,7 +28,11 @@ from torch.fx.experimental.dynamic_spec import (
     TensorSpec as T,
 )
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def _reset_uid_counter():
@@ -103,6 +107,8 @@ class _ModBranch(torch.nn.Module):
 
 
 class _TestExportDynamicSpecBase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """torch.export.export support for the new ShapesSpec/ParamsSpec API."""
 
     def setUp(self):
@@ -997,6 +1003,8 @@ del _TestExportDynamicSpecBase
 
 
 class _TestContainerSpecBase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         _reset_uid_counter()

--- a/test/export/test_tree_utils.py
+++ b/test/export/test_tree_utils.py
@@ -4,11 +4,13 @@ from collections import OrderedDict
 import torch
 from torch._dynamo.test_case import TestCase
 from torch.export._tree_utils import is_equivalent, reorder_kwargs
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.utils._pytree import tree_structure
 
 
 class TestTreeUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_reorder_kwargs(self):
         original_kwargs = {"a": torch.tensor(0), "b": torch.tensor(1)}
         user_kwargs = {"b": torch.tensor(2), "a": torch.tensor(3)}


### PR DESCRIPTION
## Summary
Add `hw_classification = HardwareClassification.GENERIC` to device-agnostic Export test classes so CI can filter tests via `--hw-classification` without changing test behavior.

## Changes
- `test_dynamic_spec_export.py`: set `GENERIC` on `_TestExportDynamicSpecBase` / `_TestContainerSpecBase` so `TestExportDynamicSpec{Strict,NonStrict}` and `TestContainerSpec{Strict,NonStrict}` inherit the tag
- `test_tree_utils.py`: set `GENERIC` on `TestTreeUtils`

## Test Plan
```bash
python test/export/test_tree_utils.py -v
python test/export/test_dynamic_spec_export.py --hw-classification GENERIC -k test_seq_spec_on_list_of_tensors
```
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
