### PR TITLE
[TEST] Refactor test_masked.py with hw_classification

### DIFF
--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -8,11 +8,17 @@ import torch
 from typing import Any
 from functools import wraps
 import unittest
-from torch.testing._internal.common_utils import skipIfTorchDynamo
 
-
-from torch.testing._internal.common_utils import \
-    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    skipIfTorchDynamo,
+    suppress_warnings,
+    _TestParametrizer,
+    run_tests,
+)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
@@ -264,6 +270,7 @@ class mask_layouts(_TestParametrizer):
 
 
 class TestMasked(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def assertEqualMasked(self, actual, expected, mask):
         strided = to_strided(actual)
@@ -316,6 +323,10 @@ class TestMasked(TestCase):
                 outmask = torch.masked._output_mask(op.op, r_inp, *r_args, **r_kwargs)
             expected = op.op(r_inp, *r_args, **r_kwargs)
             self.assertEqualMasked(actual, expected, outmask)
+
+
+class TestMaskedGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfTorchDynamo("https://github.com/pytorch/torchdynamo/issues/1992")
     @parametrize("sparse_kind,fill_value", [('coo', 0), ('hybrid_coo', 0),
@@ -432,6 +443,7 @@ class TestMasked(TestCase):
 
 
 instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_parametrized_tests(TestMaskedGeneric)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

- Split mixed `TestMasked` into ACCELERATOR op-numerics tests (`TestMasked` with `hw_classification = HwClassification.ACCELERATOR`)
- Move `test_where` into `TestMaskedGeneric` with `hw_classification = HwClassification.GENERIC` (CPU-only sparse where)
- Declare `hw_classification` on both classes

## Test plan

```
lintrunner -a test/test_masked.py
# ok No lint issues.

python -c "import ast; ast.parse(open('test/test_masked.py').read()); print('OK')"

python test/test_masked.py --hw-classification GENERIC -v
# Ran 6 tests in 0.659s — OK

python test/test_masked.py TestMaskedCPU.test_reference_masked_masked_norm_cpu_float32 TestMaskedCUDA.test_reference_masked_masked_norm_cuda_float32 TestMaskedCPU.test_mask_layout_strided_masked_mean_cpu_float32 TestMaskedCUDA.test_mask_layout_strided_masked_mean_cuda_float32 -v
# Ran 4 tests in 3.799s — OK

python test/test_masked.py TestMaskedCPU.test_reference_masked_masked_norm_cpu_float32 TestMaskedGeneric.test_where_coo_fill_value_0 --hw-classification ACCELERATOR -v
# Ran 1 test in 0.943s — OK (GENERIC filtered out)
```

Authored with an AI assistant.
