### PR TITLE
[Testcase Refactoring]Add hw_classification and device-agnostic skip to test_fsspec.py

### DIFF
--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -23,7 +23,9 @@ from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_
 from torch.distributed.checkpoint.utils import CheckpointException
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
     requires_accelerator_dist_backend,
 )
 from torch.testing._internal.common_utils import (
@@ -32,16 +34,8 @@ from torch.testing._internal.common_utils import (
     skip_but_pass_in_sandcastle_if,
     TestCase,
 )
-from torch.testing._internal.distributed._shard.sharded_tensor import (
-    ShardedTensorTestBase,
-    with_comms,
-)
 
 
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-BACKEND = torch.distributed.get_default_backend_for_device(device_type)
 
 
 def with_temp_dir(
@@ -89,26 +83,30 @@ class MyTestModule(torch.nn.Module):
         return self.net4(self.net3(self.net2(self.net1(x))))
 
 
-class TestFSSpec(ShardedTensorTestBase):
+class TestFSSpec(MultiProcContinuousTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def world_size(self) -> int:
-        return 2
+    @classmethod
+    def backend_str(cls) -> str:
+        return dist.get_default_backend_for_device(cls.device_type)
 
-    @with_comms(backend=BACKEND, init_rpc=False)
+    @property
+    def device(self) -> torch.device:
+        return self._dev
+
     @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 2,
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_fsspec(self):
+    def test_fsspec(self, device):
+        self._dev = torch.device(device)
         CHECKPOINT_DIR = self.temp_dir
 
-        model = FSDP(MyTestModule().to(device_type))
+        model = FSDP(MyTestModule().to(device))
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(torch.rand(8, 8, device=dist.get_rank())).sum().backward()
+        model(torch.rand(8, 8, device=self.device)).sum().backward()
         optim.step()
 
         with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
@@ -123,7 +121,7 @@ class TestFSSpec(ShardedTensorTestBase):
                 planner=dcp.DefaultSavePlanner(),
             )
 
-        model_2 = FSDP(MyTestModule().to(device_type))
+        model_2 = FSDP(MyTestModule().to(device))
         optim_2 = torch.optim.Adam(model_2.parameters(), lr=0.1)
 
         with FSDP.summon_full_params(model):
@@ -173,14 +171,14 @@ class TestFSSpec(ShardedTensorTestBase):
             opt_at(optim, 0)["exp_avg_sq"], opt_at(optim_2, 0)["exp_avg_sq"]
         )
 
-    @with_comms(backend=BACKEND, init_rpc=False)
     @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 2,
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_overwrite(self):
+    def test_overwrite(self, device):
+        self._dev = torch.device(device)
         t1, t2 = torch.randn(10), torch.randn(10)
 
         dcp.save(
@@ -271,6 +269,12 @@ class TestFileSystem(TestCase):
         # os.sync() may be called on backends that don't support per-file fsync
         self.assertLessEqual(mock_os_sync.call_count, 2)
 
+
+instantiate_device_type_tests(
+    TestFSSpec,
+    globals(),
+    except_for=("cpu",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -23,11 +23,12 @@ from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_
 from torch.distributed.checkpoint.utils import CheckpointException
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -92,11 +93,11 @@ class TestFSSpec(ShardedTensorTestBase):
         return 2
 
     @with_comms(init_rpc=False)
-    @requires_accelerator_dist_backend()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_fsspec(self, device):
-        device_type = torch.accelerator.current_accelerator().type
+        device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
 
         model = FSDP(MyTestModule().to(device_type))
@@ -167,7 +168,7 @@ class TestFSSpec(ShardedTensorTestBase):
         )
 
     @with_comms(init_rpc=False)
-    @requires_accelerator_dist_backend()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_overwrite(self, device):

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -26,20 +26,17 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
-    skip_but_pass_in_sandcastle_if,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
 )
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-BACKEND = torch.distributed.get_default_backend_for_device(device_type)
 
 
 def with_temp_dir(
@@ -94,15 +91,12 @@ class TestFSSpec(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(backend=BACKEND, init_rpc=False)
+    @with_comms(init_rpc=False)
     @requires_accelerator_dist_backend()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_fsspec(self, device):
-        device_type = torch.device(device).type
+        device_type = torch.accelerator.current_accelerator().type
         CHECKPOINT_DIR = self.temp_dir
 
         model = FSDP(MyTestModule().to(device_type))
@@ -172,12 +166,9 @@ class TestFSSpec(ShardedTensorTestBase):
             opt_at(optim, 0)["exp_avg_sq"], opt_at(optim_2, 0)["exp_avg_sq"]
         )
 
-    @with_comms(backend=BACKEND, init_rpc=False)
+    @with_comms(init_rpc=False)
     @requires_accelerator_dist_backend()
-    @skip_but_pass_in_sandcastle_if(
-        torch.accelerator.device_count() < 2,
-        "test requires 2+ accelerators",
-    )
+    @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_overwrite(self, device):
         t1, t2 = torch.randn(10), torch.randn(10)

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -25,13 +25,19 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TestCase,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
 )
+
+
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
@@ -84,13 +90,18 @@ class MyTestModule(torch.nn.Module):
 
 
 class TestFSSpec(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
 
     @with_comms(backend=BACKEND, init_rpc=False)
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @with_temp_dir
     def test_fsspec(self):
         CHECKPOINT_DIR = self.temp_dir
@@ -164,7 +175,10 @@ class TestFSSpec(ShardedTensorTestBase):
 
     @with_comms(backend=BACKEND, init_rpc=False)
     @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(2)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 2,
+        "test requires 2+ accelerators",
+    )
     @with_temp_dir
     def test_overwrite(self):
         t1, t2 = torch.randn(10), torch.randn(10)
@@ -190,6 +204,8 @@ class TestFSSpec(ShardedTensorTestBase):
 
 
 class TestFileSystem(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_temp_dir
     def test_remove_on_fail(self):
         fs = FileSystem()

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -267,6 +267,7 @@ instantiate_device_type_tests(
     TestFSSpec,
     globals(),
     except_for=("cpu",),
+    allow_xpu=True,
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -101,10 +101,10 @@ class TestFSSpec(ShardedTensorTestBase):
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_fsspec(self, device):
+    def test_fsspec(self):
         CHECKPOINT_DIR = self.temp_dir
 
-        model = FSDP(MyTestModule().to(device))
+        model = FSDP(MyTestModule().to(device_type))
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
         model(torch.rand(8, 8, device=dist.get_rank())).sum().backward()
         optim.step()
@@ -121,7 +121,7 @@ class TestFSSpec(ShardedTensorTestBase):
                 planner=dcp.DefaultSavePlanner(),
             )
 
-        model_2 = FSDP(MyTestModule().to(device))
+        model_2 = FSDP(MyTestModule().to(device_type))
         optim_2 = torch.optim.Adam(model_2.parameters(), lr=0.1)
 
         with FSDP.summon_full_params(model):
@@ -178,7 +178,7 @@ class TestFSSpec(ShardedTensorTestBase):
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_overwrite(self, device):
+    def test_overwrite(self):
         t1, t2 = torch.randn(10), torch.randn(10)
 
         dcp.save(

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -101,7 +101,8 @@ class TestFSSpec(ShardedTensorTestBase):
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_fsspec(self):
+    def test_fsspec(self, device):
+        device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
 
         model = FSDP(MyTestModule().to(device_type))
@@ -178,7 +179,7 @@ class TestFSSpec(ShardedTensorTestBase):
         "test requires 2+ accelerators",
     )
     @with_temp_dir
-    def test_overwrite(self):
+    def test_overwrite(self, device):
         t1, t2 = torch.randn(10), torch.randn(10)
 
         dcp.save(

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -25,7 +25,6 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
-    MultiProcContinuousTest,
     requires_accelerator_dist_backend,
 )
 from torch.testing._internal.common_utils import (
@@ -34,8 +33,13 @@ from torch.testing._internal.common_utils import (
     skip_but_pass_in_sandcastle_if,
     TestCase,
 )
+from torch.testing._internal.distributed._shard.sharded_tensor import (
+    ShardedTensorTestBase,
+    with_comms,
+)
 
-
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+BACKEND = torch.distributed.get_default_backend_for_device(device_type)
 
 
 def with_temp_dir(
@@ -83,17 +87,14 @@ class MyTestModule(torch.nn.Module):
         return self.net4(self.net3(self.net2(self.net1(x))))
 
 
-class TestFSSpec(MultiProcContinuousTest):
+class TestFSSpec(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @classmethod
-    def backend_str(cls) -> str:
-        return dist.get_default_backend_for_device(cls.device_type)
-
     @property
-    def device(self) -> torch.device:
-        return self._dev
+    def world_size(self) -> int:
+        return 2
 
+    @with_comms(backend=BACKEND, init_rpc=False)
     @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 2,
@@ -101,12 +102,11 @@ class TestFSSpec(MultiProcContinuousTest):
     )
     @with_temp_dir
     def test_fsspec(self, device):
-        self._dev = torch.device(device)
         CHECKPOINT_DIR = self.temp_dir
 
         model = FSDP(MyTestModule().to(device))
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
-        model(torch.rand(8, 8, device=self.device)).sum().backward()
+        model(torch.rand(8, 8, device=dist.get_rank())).sum().backward()
         optim.step()
 
         with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
@@ -171,6 +171,7 @@ class TestFSSpec(MultiProcContinuousTest):
             opt_at(optim, 0)["exp_avg_sq"], opt_at(optim_2, 0)["exp_avg_sq"]
         )
 
+    @with_comms(backend=BACKEND, init_rpc=False)
     @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 2,
@@ -178,7 +179,6 @@ class TestFSSpec(MultiProcContinuousTest):
     )
     @with_temp_dir
     def test_overwrite(self, device):
-        self._dev = torch.device(device)
         t1, t2 = torch.randn(10), torch.randn(10)
 
         dcp.save(


### PR DESCRIPTION
## Summary

Add `hw_classification` labels to both test classes in
`test/distributed/checkpoint/test_fsspec.py` and replace
`@skip_if_lt_x_gpu(2)` with accelerator-agnostic device count checks.

## Changes

- **Import `HardwareClassification`, `skip_but_pass_in_sandcastle_if`.**
  Remove unused `skip_if_lt_x_gpu` import.
- **Add `hw_classification = HardwareClassification.ACCELERATOR`** to
  `TestFSSpec`, which exercises FSDP checkpoint save/load/overwrite over
  an fsspec storage backend — cross-accelerator behavior.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `TestFileSystem`, which tests file stream lifecycle and fsspec
  memory protocol handling — pure I/O, no accelerator dependency.
- **Replace `@skip_if_lt_x_gpu(2)`** on `test_fsspec` and
  `test_overwrite` with
  `@skip_but_pass_in_sandcastle_if(torch.accelerator.device_count() < 2, ...)`.

## Not changed

- No test logic or assertions are modified.
- `@requires_accelerator_dist_backend()` is preserved on both
  `TestFSSpec` methods.

## Test plan

- `python test/distributed/checkpoint/test_fsspec.py` — TODO: run on
  a 2+ GPU CUDA build with fsspec installed to confirm
  `test_fsspec` and `test_overwrite` pass.
- `python test/distributed/checkpoint/test_fsspec.py` — TODO: run on
  CPU to confirm `test_remove_on_fail` and
  `test_fsspec_without_fileno_support` pass.