### PR TITLE
[ROCm] Reject unregistered host pointers in getDeviceFromPtr

### DIFF
--- a/aten/src/ATen/cuda/CUDADevice.h
+++ b/aten/src/ATen/cuda/CUDADevice.h
@@ -12,7 +12,7 @@ inline Device getDeviceFromPtr(void* ptr) {
 
   AT_CUDA_CHECK(cudaPointerGetAttributes(&attr, ptr));
 
-#if !defined(USE_ROCM)
+#if !defined(USE_ROCM) || HIP_VERSION_MAJOR >= 6
   TORCH_CHECK(attr.type != cudaMemoryTypeUnregistered,
     "The specified pointer resides on host memory and is not registered with any CUDA device.");
 #endif

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -86,6 +86,7 @@ list(APPEND ATen_HIP_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_apply_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_math_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_device_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_distributions_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_dlconvertor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_generator_test.hip

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -85,6 +85,7 @@ list(APPEND ATen_HIP_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_apply_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_math_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_device_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_distributions_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_dlconvertor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_generator_test.hip


### PR DESCRIPTION
 Fixes #192056

I reviewed the two-file patch and the compatibility results across ROCm 5.x,
6.x, and 7.x. The change is limited to pointer classification and HIP test
registration, with CUDA and HIP 5 behavior unchanged.

> ## Issue
>
>
> ## Summary
>
> ROCm 6.0 changed `hipPointerGetAttributes()` to return success plus
> `hipMemoryTypeUnregistered` for ordinary host pointers. PyTorch still skips
> that semantic check under `USE_ROCM`, so `getDeviceFromPtr()` can construct
> `cuda:-2` from `hipInvalidDeviceId`.
>
> Extend the existing check to HIP 6 and newer while preserving the HIP 5
> error-return path, whose headers do not define the new enum. Register the
> existing `cuda_device_test.cpp` as generated `hip_device_test.cpp` so ROCm CI
> exercises the same host-memory contract as CUDA.
>
> Focused validation used the official
> `torch 2.14.0.dev20260804+rocm7.2` wheel and HIP 7.2.53211 on gfx1201 dGPU
> and gfx1151 APU. Both reproduced `cuda:-2` before the change and rejected the
> ordinary host pointer after it. `hipHostMalloc`, `hipHostRegister`,
> `hipMallocManaged`, and `hipMalloc` controls remained `cuda:0`.
>
> The full HIPified header also compiles against official ROCm 5.4, 5.5, 5.6,
> 5.7, and 6.0 headers. Representative ROCm 6.0-7.2 HIP/CLR releases retain
> the enum and success-plus-sentinel contract. CUDA and HIP 5 preprocessing
> remain unchanged. A full editable PyTorch build, NVIDIA, and Windows ROCm CI
> were not run.
>
> ## Checklist
>
> - [x] Passes lint (`spin quicklint`) - `ok No lint issues.`
> - [x] Added/updated tests - existing device test is now registered for HIP;
>   the generated test built and ran 1/1 passing with the CMake-equivalent host
>   compiler path.
> - [x] Updated documentation (not applicable; no user-facing documentation
>   change).
> - [x] Included benchmark results (not applicable; no performance-sensitive
>   code changes).
>
> ## BC-breaking?
>
> No. CUDA and HIP 5 behavior remain unchanged. HIP 6 and newer now reject an
> ordinary host pointer immediately instead of exposing the invalid `cuda:-2`
> device.
>
> **AI usage disclosure:** The quoted technical summary and two-line code
> change were prepared with GitHub Copilot and reviewed by the human submitter
> before submission.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
