### PR TITLE
[Testcase Refactoring]Add hw_classification to test_quantized_hf_storage.py

### DIFF
--- a/test/distributed/checkpoint/test_quantized_hf_storage.py
+++ b/test/distributed/checkpoint/test_quantized_hf_storage.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
 
 class TestQuantizedHfStorage(TestCase):
     hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         """Set up common test fixtures."""

--- a/test/distributed/checkpoint/test_quantized_hf_storage.py
+++ b/test/distributed/checkpoint/test_quantized_hf_storage.py
@@ -10,10 +10,15 @@ from torch.distributed.checkpoint.planner import LoadItemType, ReadItem
 from torch.distributed.checkpoint.quantized_hf_storage import (
     QuantizedHuggingFaceStorageReader,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestQuantizedHfStorage(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         """Set up common test fixtures."""


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to
`TestQuantizedHfStorage` in
`test/distributed/checkpoint/test_quantized_hf_storage.py`.  Both
tests in this class use mocks to exercise quantized weight
dequantization logic and have no device dependency.

## Changes

- **Import `HardwareClassification`** from `common_utils`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `TestQuantizedHfStorage`.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/checkpoint/test_quantized_hf_storage.py` —
  TODO: confirm both tests pass on CPU.