### PR TITLE
[Dynamo] derive device Stream/Event/tensor types from DeviceInterface

### DIFF
--- a/test/dynamo/test_device_interface.py
+++ b/test/dynamo/test_device_interface.py
@@ -10,11 +10,11 @@ from torch._dynamo.device_interface import (
     CpuInterface,
     CudaInterface,
     DeviceInterface,
+    get_registered_device_interfaces,
     MpsInterface,
     MtiaInterface,
-    XpuInterface,
-    get_registered_device_interfaces,
     register_interface_for_device,
+    XpuInterface,
 )
 from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 

--- a/test/dynamo/test_device_interface.py
+++ b/test/dynamo/test_device_interface.py
@@ -1,0 +1,159 @@
+# Owner(s): ["module: dynamo"]
+
+import unittest
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+from torch._dynamo import device_interface
+from torch._dynamo.device_interface import (
+    CpuInterface,
+    CudaInterface,
+    DeviceInterface,
+    MpsInterface,
+    MtiaInterface,
+    XpuInterface,
+    get_registered_device_interfaces,
+    register_interface_for_device,
+)
+from torch._dynamo.variables.user_defined import UserDefinedClassVariable
+
+
+class _StubStream(torch.Stream):
+    """A well-behaved backend stream: subclasses torch.Stream."""
+
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+
+class _StubEvent(torch.Event):
+    """A well-behaved backend event: subclasses torch.Event."""
+
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+
+class _StubTensorType:
+    """Stand-in for a backend tensor constructor such as torch.foo.FloatTensor."""
+
+
+class GoodStubInterface(DeviceInterface):
+    Stream = _StubStream
+    Event = _StubEvent
+    tensor_types = frozenset({_StubTensorType})
+
+
+class BadStubInterface(DeviceInterface):
+    """A backend that forgot to subclass torch.Stream/torch.Event.
+
+    It inherits DeviceInterface's placeholders, which only raise
+    NotImplementedError, so they must never reach _in_graph_classes().
+    """
+
+
+class InGraphClassesTests(torch._dynamo.test_case.TestCase):
+    def tearDown(self):
+        for name in ("stub", "badstub"):
+            device_interface.device_interfaces.pop(name, None)
+        UserDefinedClassVariable._in_graph_classes.cache_clear()
+        super().tearDown()
+
+    def _register(self, name, iface):
+        register_interface_for_device(name, iface)
+        self.assertIs(
+            dict(get_registered_device_interfaces())[name],
+            iface,
+        )
+
+    def test_registered_interface_stream_event_in_graph(self):
+        # Prime the cache first: this is the out-of-tree backend's situation,
+        # where registration happens lazily, after Dynamo has already run.
+        before = UserDefinedClassVariable._in_graph_classes()
+        self.assertNotIn(_StubStream, before)
+        self.assertNotIn(_StubEvent, before)
+
+        self._register("stub", GoodStubInterface)
+
+        after = UserDefinedClassVariable._in_graph_classes()
+        self.assertIn(_StubStream, after)
+        self.assertIn(_StubEvent, after)
+
+    def test_registered_interface_tensor_types_in_graph(self):
+        self.assertNotIn(_StubTensorType, UserDefinedClassVariable._in_graph_classes())
+
+        self._register("stub", GoodStubInterface)
+
+        self.assertIn(_StubTensorType, UserDefinedClassVariable._in_graph_classes())
+
+    def test_base_class_placeholders_never_in_graph(self):
+        self._register("badstub", BadStubInterface)
+
+        in_graph = UserDefinedClassVariable._in_graph_classes()
+        # The placeholders raise NotImplementedError with a message telling the
+        # backend to subclass torch.Stream/torch.Event.  Putting them in this
+        # set would trade that message for an opaque tracing failure.
+        self.assertNotIn(DeviceInterface.Stream, in_graph)
+        self.assertNotIn(DeviceInterface.Event, in_graph)
+        self.assertNotIn(BadStubInterface.Stream, in_graph)
+        self.assertNotIn(BadStubInterface.Event, in_graph)
+
+        for cls in in_graph:
+            self.assertIsInstance(cls, type)
+
+    def test_tensor_types_defaults_to_empty(self):
+        # The base-class default must be inert, so declaring it changes nothing
+        # for backends that do not opt in.  Checked against the in-tree
+        # interfaces specifically: an out-of-tree backend may well be
+        # registered, and is entitled to declare tensor_types.
+        self.assertEqual(DeviceInterface.tensor_types, frozenset())
+        for iface in (
+            CudaInterface,
+            XpuInterface,
+            MtiaInterface,
+            CpuInterface,
+            MpsInterface,
+        ):
+            self.assertEqual(iface.tensor_types, frozenset())
+            self.assertNotIn("tensor_types", vars(iface))
+
+    def test_late_registration_invalidates_cache(self):
+        # _in_graph_classes() is functools.cache'd over a mutable registry, so
+        # register_interface_for_device() has to invalidate it.
+        UserDefinedClassVariable._in_graph_classes()
+        self._register("stub", GoodStubInterface)
+        self.assertIn(_StubStream, UserDefinedClassVariable._in_graph_classes())
+
+    def test_stream_construction_traced_after_registration(self):
+        self._register("stub", GoodStubInterface)
+
+        counter = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=counter, fullgraph=True)
+        def fn(x):
+            _StubStream()
+            return x + 1
+
+        fn(torch.ones(2))
+        self.assertEqual(counter.frame_count, 1)
+
+    @unittest.skipIf(not torch.cuda._is_compiled(), "CUDA not compiled in")
+    def test_cuda_stream_event_still_in_graph(self):
+        # torch.cuda.Stream/Event used to be listed here by hand.  CudaInterface
+        # supplies them now, so the set must be unchanged for a CUDA build.
+        # _CudaStreamBase's tp_base is torch.Stream, so the issubclass() check
+        # in the loop admits them.
+        in_graph = UserDefinedClassVariable._in_graph_classes()
+        self.assertIn(torch.cuda.Stream, in_graph)
+        self.assertIn(torch.cuda.Event, in_graph)
+
+    @unittest.skipIf(not torch.xpu._is_compiled(), "XPU not compiled in")
+    def test_xpu_stream_event_still_in_graph(self):
+        in_graph = UserDefinedClassVariable._in_graph_classes()
+        self.assertIn(torch.xpu.Stream, in_graph)
+        self.assertIn(torch.xpu.Event, in_graph)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -43,6 +43,13 @@ class DeviceInterface:
     backends to be integrated with Inductor in a device-agnostic semantic.
     """
 
+    # Device-specific tensor types (e.g. torch.cuda.FloatTensor). Dynamo traces
+    # calls to these as in-graph tensor constructors rather than treating them
+    # as opaque user-defined classes; see
+    # UserDefinedClassVariable._in_graph_classes(). Backends that expose such
+    # types should override this with a frozenset containing them.
+    tensor_types: frozenset[type] = frozenset()
+
     class device:
         def __new__(cls, device: torch.types.Device) -> Any:
             raise NotImplementedError
@@ -642,6 +649,11 @@ def register_interface_for_device(
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
+    # _in_graph_classes() snapshots this registry, so a late registration
+    # (the common case for out-of-tree backends) must invalidate it.
+    from .variables.user_defined import UserDefinedClassVariable
+
+    UserDefinedClassVariable._in_graph_classes.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -401,6 +401,16 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 }
             )
 
+        from ..device_interface import get_registered_device_interfaces
+
+        for _, iface in get_registered_device_interfaces():
+            stream_cls = getattr(iface, "Stream", None)
+            event_cls = getattr(iface, "Event", None)
+            if stream_cls is not None and stream_cls is not torch.Stream:
+                _in_graph_class_list.add(stream_cls)
+            if event_cls is not None and event_cls is not torch.Event:
+                _in_graph_class_list.add(event_cls)
+
         return set(tensortype_to_dtype.keys()) | _in_graph_class_list
 
     @staticmethod

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -378,7 +378,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
     @staticmethod
     @functools.cache
     def _in_graph_classes() -> set[type[object]]:
-        _in_graph_class_list = {
+        _in_graph_class_set = {
             torch.Tensor,
             torch.cuda.FloatTensor,  # type: ignore[attr-defined]
             torch.cuda.DoubleTensor,  # type: ignore[attr-defined]
@@ -391,20 +391,28 @@ class UserDefinedClassVariable(UserDefinedVariable):
             torch.cuda.LongTensor,  # type: ignore[attr-defined]
             torch.Stream,
             torch.Event,
-            torch.cuda.Stream,
-            torch.cuda.Event,
-            torch.xpu.Stream,
-            torch.xpu.Event,
         }
         if hasattr(torch, "hpu"):
-            _in_graph_class_list.update(
+            _in_graph_class_set.update(
                 {
                     torch.hpu.Stream,
                     torch.hpu.Event,
                 }
             )
 
-        return set(tensortype_to_dtype.keys()) | _in_graph_class_list
+        from ..device_interface import get_registered_device_interfaces
+
+        for _, iface in get_registered_device_interfaces():
+            for base, cls in ((torch.Stream, iface.Stream), (torch.Event, iface.Event)):
+                # DeviceInterface's Stream/Event placeholders only raise
+                # NotImplementedError, so they must not land in this set --
+                # keeping them out preserves the friendly error message for
+                # backends that forget to subclass torch.Stream/torch.Event.
+                if isinstance(cls, type) and issubclass(cls, base):
+                    _in_graph_class_set.add(cls)
+            _in_graph_class_set.update(iface.tensor_types)
+
+        return set(tensortype_to_dtype.keys()) | _in_graph_class_set
 
     @staticmethod
     @functools.cache


### PR DESCRIPTION
# Summary

`_in_graph_classes()` hardcoded `torch.cuda.Stream`/`Event` and `torch.xpu.Stream`/`Event`, so out-of-tree backends had no way to get their own Stream/Event traced as in-graph constructors. This PR iterates the registered `DeviceInterface`s instead, and lets a backend declare its device tensor types via a new `tensor_types` slot on `DeviceInterface`.

## Why the hardcoded cuda/xpu entries can be dropped

- `CudaInterface.Stream is torch.cuda.Stream` (same object, pure Python attribute assignment), and `torch/csrc/cuda/Stream.cpp:219` sets `THCPStreamType.tp_base = THPStreamClass`, so on a CUDA build `issubclass(torch.cuda.Stream, torch.Stream)` holds and the loop re-adds the identical objects. There is no `#ifdef` around that assignment.
- On a CPU-only build `torch.cuda.Stream()` already raises `RuntimeError: torch.cuda.Stream requires CUDA support` in eager, so nothing usable is lost by removing it from the set.

## PR3 folded in

The original PR3 (#192195) dispatched out-of-tree tensor types via a new branch in `builder.py._wrap`. Review pointed out four problems sharing one root cause: a new, weaker side path (no guard installed, FakeTensor stacking special case bypassed, wrong VariableTracker type, hot-path overhead). Instead `tensor_types` now flows into `_in_graph_classes()`, reusing the existing guard installation and stacking logic. PR3 is closed.

## Note on CI

This change was developed and tested on a CPU-only build (`torch.cuda._is_compiled() == False`). The CUDA/XPU assertions (`test_cuda_stream_event_still_in_graph`, `test_xpu_stream_event_still_in_graph`) are gated on `torch.cuda._is_compiled()` / `torch.xpu._is_compiled()` and will actually run on the CUDA/XPU CI machines.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98