### PR TITLE
[Dynamo] support out-of-tree device autocast via DeviceInterface

### DIFF
--- a/test/dynamo/test_device_autocast.py
+++ b/test/dynamo/test_device_autocast.py
@@ -1,0 +1,65 @@
+# Owner(s): ["module: dynamo"]
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+from torch._dynamo import device_interface
+from torch._dynamo.device_interface import DeviceInterface, register_interface_for_device
+from torch._dynamo.variables.torch import _matches_device_autocast_class
+
+
+class _StubAutocast(torch.amp.autocast_mode.autocast):
+    """An out-of-tree backend's autocast, whose device_type is implicit in
+    the class itself (omitted from the constructor)."""
+
+    def __init__(self, dtype=torch.float16, enabled=True, cache_enabled=None):
+        super().__init__("cpu", dtype=dtype, enabled=enabled, cache_enabled=cache_enabled)
+
+
+class AutocastInterface(DeviceInterface):
+    autocast_classes = {_StubAutocast: "cpu"}
+
+
+class DeviceAutocastTests(torch._dynamo.test_case.TestCase):
+    def tearDown(self):
+        device_interface.device_interfaces.pop("stubac", None)
+        super().tearDown()
+
+    def test_matches_only_when_registered(self):
+        # Positive source-file matching is deliberately not issubclass-based:
+        # an arbitrary autocast subclass must not be picked up unless its
+        # owning device registered it.
+        self.assertFalse(_matches_device_autocast_class(_StubAutocast))
+
+        register_interface_for_device("stubac", AutocastInterface)
+        self.assertTrue(_matches_device_autocast_class(_StubAutocast))
+
+    def test_registered_autocast_class_traced(self):
+        register_interface_for_device("stubac", AutocastInterface)
+
+        counter = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=counter, fullgraph=True)
+        def fn(x):
+            with _StubAutocast():
+                pass
+            return x + 1
+
+        fn(torch.ones(2))
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_internal_autocast_subclass_not_matched(self):
+        # _UnmanagedAutocast is the class _enter_autocast() constructs during
+        # pre-dispatch tracing.  It subclasses autocast but belongs to no
+        # device, so a too-broad match would route it to AutocastModeVariable
+        # and blow up test__enter__exit_autocast with "setattr() on
+        # unsupported type".  This pins the positive source-file matching.
+        from torch.amp.autocast_mode import _UnmanagedAutocast
+
+        self.assertFalse(_matches_device_autocast_class(_UnmanagedAutocast))
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/test/dynamo/test_device_autocast.py
+++ b/test/dynamo/test_device_autocast.py
@@ -1,11 +1,18 @@
 # Owner(s): ["module: dynamo"]
 
+import importlib.util
+import sys
+import types
+import unittest.mock as mock
+
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import device_interface
 from torch._dynamo.device_interface import (
+    _autocast_class_location,
     DeviceInterface,
+    get_device_autocast_class_locations,
     get_device_autocast_classes,
     register_interface_for_device,
 )
@@ -27,16 +34,124 @@ class _StubAutocast(torch.amp.autocast_mode.autocast):
         )
 
 
+class _NarrowStubAutocast(torch.amp.autocast_mode.autocast):
+    """An out-of-tree autocast that narrows __init__ to no arguments."""
+
+    def __init__(self):
+        super().__init__(STUB_DEVICE)
+
+
+class _ReorderedStubAutocast(torch.amp.autocast_mode.autocast):
+    """An out-of-tree autocast whose parameters differ from the base.
+
+    Modelled on ``torch.npu.amp.autocast``, whose signature is
+    ``(enabled=True, dtype=torch.float16, cache_enabled=True)`` -- a different
+    order and different defaults than the base class.
+    """
+
+    def __init__(self, enabled=True, dtype=torch.float16, cache_enabled=True):
+        super().__init__(
+            STUB_DEVICE, enabled=enabled, dtype=dtype, cache_enabled=cache_enabled
+        )
+
+
+class _UnregisteredSiblingAutocast(torch.amp.autocast_mode.autocast):
+    """Defined in this same file, but deliberately never registered.
+
+    Guards the difference between keying on the defining file alone (which would
+    match this) and keying on file plus qualified name (which does not).
+    """
+
+    def __init__(self):
+        super().__init__(STUB_DEVICE)
+
+
 class AutocastInterface(DeviceInterface):
-    autocast_classes = frozenset({_StubAutocast})
+    autocast_classes = frozenset(
+        {_StubAutocast, _NarrowStubAutocast, _ReorderedStubAutocast}
+    )
+
+
+DUPLICATE_MODULE_NAME = "_dup_device_autocast"
 
 
 class DeviceAutocastTests(torch._dynamo.test_case.TestCase):
-    def tearDown(self):
-        for device in (STUB_DEVICE, f"{STUB_DEVICE}:3"):
-            device_interface.device_interfaces.pop(device, None)
+    def setUp(self):
+        super().setUp()
+        # Register the built-in interfaces before snapshotting device_interfaces,
+        # so restoring the snapshot cannot undo init_device_reg() for the rest
+        # of the process.
+        device_interface.get_registered_device_interfaces()
+        # Cleanups run LIFO, so clearing the cache is registered first in order
+        # to run after the snapshot is restored.
+        self.addCleanup(get_device_autocast_classes.cache_clear)
+        self.addCleanup(get_device_autocast_class_locations.cache_clear)
+        patcher = mock.patch.dict(device_interface.device_interfaces)
+        patcher.start()
+        self.addCleanup(patcher.stop)
         get_device_autocast_classes.cache_clear()
-        super().tearDown()
+        get_device_autocast_class_locations.cache_clear()
+        self._register_stub_device_module()
+
+    def _register_stub_device_module(self):
+        """Give STUB_DEVICE an AMP-capable device module.
+
+        ``torch.amp.autocast_mode.autocast.__init__`` requires the privateuse1
+        backend to expose ``get_amp_supported_dtype()``.  When the backend has
+        been renamed by a real out-of-tree backend, ``STUB_DEVICE`` is no longer
+        that backend's name and the check does not apply.
+        """
+        if torch._C._get_privateuse1_backend_name() != STUB_DEVICE:
+            return
+        if hasattr(torch, STUB_DEVICE):
+            return
+        module = types.ModuleType(f"torch.{STUB_DEVICE}")
+        module.get_amp_supported_dtype = lambda: [torch.float16]
+        torch._register_device_module(STUB_DEVICE, module)
+
+        def _unregister():
+            delattr(torch, STUB_DEVICE)
+            sys.modules.pop(f"torch.{STUB_DEVICE}", None)
+
+        self.addCleanup(_unregister)
+
+    def _reimport_this_file(self):
+        """Load this file again under a second module name.
+
+        An out-of-tree backend commonly ends up importable under two dotted names
+        (``torch_foo.foo.amp.autocast_mode`` and ``torch.foo.amp.autocast_mode``),
+        which loads two module objects from one file and runs the class body
+        twice.  This reproduces that, including the ``sys.modules`` entry a real
+        import would leave behind: the returned module's classes are *different*
+        objects from this module's, defined in the same file.
+        """
+        spec = importlib.util.spec_from_file_location(DUPLICATE_MODULE_NAME, __file__)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[DUPLICATE_MODULE_NAME] = module
+        self.addCleanup(sys.modules.pop, DUPLICATE_MODULE_NAME, None)
+        spec.loader.exec_module(module)
+        return module
+
+    def _compile_autocast_region(self, autocast_class, *ctor_args):
+        """Trace ``with autocast_class(*ctor_args):`` and return the enter nodes."""
+        graphs = []
+
+        def backend(gm, example_inputs):
+            graphs.append(gm)
+            return gm.forward
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def fn(x):
+            with autocast_class(*ctor_args):
+                return x + 1
+
+        fn(torch.ones(2))
+        self.assertEqual(len(graphs), 1)
+        return [
+            node
+            for node in graphs[0].graph.nodes
+            if node.op == "call_function" and node.target is torch.amp._enter_autocast
+        ]
 
     def test_slot_defaults_to_empty(self):
         self.assertEqual(DeviceInterface.autocast_classes, frozenset())
@@ -74,29 +189,135 @@ class DeviceAutocastTests(torch._dynamo.test_case.TestCase):
             _matches_device_autocast_class(torch.amp.autocast_mode.autocast)
         )
 
+    def test_non_class_never_matches(self):
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertFalse(_matches_device_autocast_class(torch.sin))
+        self.assertIsNone(device_type_for_autocast_class(torch.sin))
+
+    def test_unregistered_subclass_not_matched(self):
+        """Matching is by exact registration, not by inheritance or location."""
+
+        class _SiblingAutocast(_StubAutocast):
+            pass
+
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertFalse(_matches_device_autocast_class(_SiblingAutocast))
+        self.assertIsNone(device_type_for_autocast_class(_SiblingAutocast))
+
+    def test_same_file_unregistered_class_not_matched(self):
+        """A class sharing the defining file with a registered one must not match.
+
+        This is what keying on (file, qualname) buys over keying on the file.
+        """
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertEqual(
+            _autocast_class_location(_UnregisteredSiblingAutocast)[0],
+            _autocast_class_location(_StubAutocast)[0],
+        )
+        self.assertIsNone(device_type_for_autocast_class(_UnregisteredSiblingAutocast))
+
+    def test_class_reimported_under_another_name_matches(self):
+        """The registered class, reached through a second import of its file.
+
+        Real out-of-tree backends hit this: the interface captures the class from
+        one module object while traced code reaches the copy created by a second
+        import, so identity alone silently stops matching.
+        """
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+        duplicate = self._reimport_this_file()._StubAutocast
+
+        self.assertIsNot(duplicate, _StubAutocast)
+        self.assertNotIn(duplicate, get_device_autocast_classes())
+        self.assertTrue(_matches_device_autocast_class(duplicate))
+        self.assertEqual(device_type_for_autocast_class(duplicate), STUB_DEVICE)
+
+    def test_reimported_unregistered_class_not_matched(self):
+        """The second import must not widen what matches."""
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+        duplicate = self._reimport_this_file()._UnregisteredSiblingAutocast
+
+        self.assertIsNot(duplicate, _UnregisteredSiblingAutocast)
+        self.assertIsNone(device_type_for_autocast_class(duplicate))
+
+    def test_class_without_a_source_file_matches_by_identity(self):
+        """A registered class that has no file to key on still matches."""
+        fileless = type(
+            "_FilelessAutocast",
+            (_StubAutocast,),
+            {"__module__": "builtins"},  # builtins has no __file__
+        )
+
+        class FilelessInterface(DeviceInterface):
+            autocast_classes = frozenset({fileless})
+
+        self.assertIsNone(_autocast_class_location(fileless))
+        register_interface_for_device(STUB_DEVICE, FilelessInterface)
+
+        self.assertEqual(device_type_for_autocast_class(fileless), STUB_DEVICE)
+
+    def test_reimported_class_traced(self):
+        """End to end: the duplicate class still produces an autocast node."""
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+        duplicate = self._reimport_this_file()._StubAutocast
+
+        nodes = self._compile_autocast_region(duplicate)
+
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].args[0], STUB_DEVICE)
+
     def test_registered_autocast_class_traced(self):
         register_interface_for_device(STUB_DEVICE, AutocastInterface)
 
-        graphs = []
+        enters = self._compile_autocast_region(_StubAutocast)
 
-        def backend(gm, example_inputs):
-            graphs.append(gm)
-            return gm.forward
-
-        @torch.compile(backend=backend, fullgraph=True)
-        def fn(x):
-            with _StubAutocast():
-                return x + 1
-
-        fn(torch.ones(2))
-        self.assertEqual(len(graphs), 1)
-        enters = [
-            node
-            for node in graphs[0].graph.nodes
-            if node.op == "call_function" and node.target is torch.amp._enter_autocast
-        ]
         self.assertEqual(len(enters), 1)
         self.assertEqual(enters[0].args[0], STUB_DEVICE)
+        self.assertEqual(enters[0].args[1], torch.float16)
+
+    def test_narrowed_constructor_traced(self):
+        """A subclass need not accept every base parameter."""
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        enters = self._compile_autocast_region(_NarrowStubAutocast)
+
+        self.assertEqual(len(enters), 1)
+        device_type, dtype, enabled, cache_enabled = enters[0].args
+        self.assertEqual(device_type, STUB_DEVICE)
+        # Parameters the subclass does not accept fall back to the defaults of
+        # torch.amp.autocast_mode.autocast, which is what its super().__init__
+        # call gets when it does not pass them either.
+        self.assertIsNone(dtype)
+        self.assertEqual(enabled, True)
+        self.assertIsNone(cache_enabled)
+
+    def test_subclass_defaults_are_used_not_base_defaults(self):
+        """apply_defaults() must come from the subclass signature."""
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        enters = self._compile_autocast_region(_ReorderedStubAutocast)
+
+        self.assertEqual(len(enters), 1)
+        device_type, dtype, enabled, cache_enabled = enters[0].args
+        self.assertEqual(device_type, STUB_DEVICE)
+        self.assertEqual(dtype, torch.float16)
+        self.assertEqual(enabled, True)
+        self.assertEqual(cache_enabled, True)
+
+    def test_positional_arg_binds_to_subclass_signature(self):
+        """A subclass may order its parameters differently than the base."""
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        # First positional parameter is `enabled`, not the base's `dtype`.
+        enters = self._compile_autocast_region(_ReorderedStubAutocast, False)
+
+        self.assertEqual(len(enters), 1)
+        device_type, dtype, enabled, cache_enabled = enters[0].args
+        self.assertEqual(device_type, STUB_DEVICE)
+        self.assertEqual(dtype, torch.float16)
+        self.assertEqual(enabled, False)
 
     def test_internal_autocast_subclass_not_matched(self):
         from torch.amp.autocast_mode import _UnmanagedAutocast
@@ -104,6 +325,33 @@ class DeviceAutocastTests(torch._dynamo.test_case.TestCase):
         register_interface_for_device(STUB_DEVICE, AutocastInterface)
 
         self.assertFalse(_matches_device_autocast_class(_UnmanagedAutocast))
+
+    def test_registration_rejects_non_autocast_class(self):
+        class NotAutocastInterface(DeviceInterface):
+            autocast_classes = frozenset({int})
+
+        with self.assertRaisesRegex(TypeError, "is not a subclass"):
+            register_interface_for_device(STUB_DEVICE, NotAutocastInterface)
+
+    def test_registration_rejects_base_autocast(self):
+        class BaseAutocastInterface(DeviceInterface):
+            autocast_classes = frozenset({torch.amp.autocast_mode.autocast})
+
+        with self.assertRaisesRegex(ValueError, "must not contain"):
+            register_interface_for_device(STUB_DEVICE, BaseAutocastInterface)
+
+    def test_conflicting_device_types_raise(self):
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+        register_interface_for_device("meta", AutocastInterface)
+
+        with self.assertRaisesRegex(RuntimeError, "exactly one device_type"):
+            get_device_autocast_classes()
+
+    def test_indexed_keys_are_not_a_conflict(self):
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+        register_interface_for_device(f"{STUB_DEVICE}:0", AutocastInterface)
+
+        self.assertEqual(device_type_for_autocast_class(_StubAutocast), STUB_DEVICE)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_device_autocast.py
+++ b/test/dynamo/test_device_autocast.py
@@ -4,57 +4,104 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import device_interface
-from torch._dynamo.device_interface import DeviceInterface, register_interface_for_device
-from torch._dynamo.variables.torch import _matches_device_autocast_class
+from torch._dynamo.device_interface import (
+    DeviceInterface,
+    get_device_autocast_classes,
+    register_interface_for_device,
+)
+from torch._dynamo.variables.torch import (
+    _matches_device_autocast_class,
+    device_type_for_autocast_class,
+)
+
+
+STUB_DEVICE = "privateuseone"
 
 
 class _StubAutocast(torch.amp.autocast_mode.autocast):
-    """An out-of-tree backend's autocast, whose device_type is implicit in
-    the class itself (omitted from the constructor)."""
+    """An out-of-tree backend's autocast with an implicit device_type."""
 
     def __init__(self, dtype=torch.float16, enabled=True, cache_enabled=None):
-        super().__init__("cpu", dtype=dtype, enabled=enabled, cache_enabled=cache_enabled)
+        super().__init__(
+            STUB_DEVICE, dtype=dtype, enabled=enabled, cache_enabled=cache_enabled
+        )
 
 
 class AutocastInterface(DeviceInterface):
-    autocast_classes = {_StubAutocast: "cpu"}
+    autocast_classes = frozenset({_StubAutocast})
 
 
 class DeviceAutocastTests(torch._dynamo.test_case.TestCase):
     def tearDown(self):
-        device_interface.device_interfaces.pop("stubac", None)
+        for device in (STUB_DEVICE, f"{STUB_DEVICE}:3"):
+            device_interface.device_interfaces.pop(device, None)
+        get_device_autocast_classes.cache_clear()
         super().tearDown()
 
+    def test_slot_defaults_to_empty(self):
+        self.assertEqual(DeviceInterface.autocast_classes, frozenset())
+
     def test_matches_only_when_registered(self):
-        # Positive source-file matching is deliberately not issubclass-based:
-        # an arbitrary autocast subclass must not be picked up unless its
-        # owning device registered it.
         self.assertFalse(_matches_device_autocast_class(_StubAutocast))
 
-        register_interface_for_device("stubac", AutocastInterface)
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
         self.assertTrue(_matches_device_autocast_class(_StubAutocast))
 
+    def test_device_type_derived_from_registration_key(self):
+        self.assertIsNone(device_type_for_autocast_class(_StubAutocast))
+
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertEqual(device_type_for_autocast_class(_StubAutocast), STUB_DEVICE)
+
+    def test_device_type_strips_index_from_key(self):
+        register_interface_for_device(f"{STUB_DEVICE}:3", AutocastInterface)
+
+        self.assertEqual(device_type_for_autocast_class(_StubAutocast), STUB_DEVICE)
+
+    def test_late_registration_invalidates_cache(self):
+        get_device_autocast_classes()
+
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertIn(_StubAutocast, get_device_autocast_classes())
+
+    def test_base_autocast_never_matches(self):
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
+
+        self.assertFalse(
+            _matches_device_autocast_class(torch.amp.autocast_mode.autocast)
+        )
+
     def test_registered_autocast_class_traced(self):
-        register_interface_for_device("stubac", AutocastInterface)
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
 
-        counter = torch._dynamo.testing.CompileCounter()
+        graphs = []
 
-        @torch.compile(backend=counter, fullgraph=True)
+        def backend(gm, example_inputs):
+            graphs.append(gm)
+            return gm.forward
+
+        @torch.compile(backend=backend, fullgraph=True)
         def fn(x):
             with _StubAutocast():
-                pass
-            return x + 1
+                return x + 1
 
         fn(torch.ones(2))
-        self.assertEqual(counter.frame_count, 1)
+        self.assertEqual(len(graphs), 1)
+        enters = [
+            node
+            for node in graphs[0].graph.nodes
+            if node.op == "call_function" and node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enters), 1)
+        self.assertEqual(enters[0].args[0], STUB_DEVICE)
 
     def test_internal_autocast_subclass_not_matched(self):
-        # _UnmanagedAutocast is the class _enter_autocast() constructs during
-        # pre-dispatch tracing.  It subclasses autocast but belongs to no
-        # device, so a too-broad match would route it to AutocastModeVariable
-        # and blow up test__enter__exit_autocast with "setattr() on
-        # unsupported type".  This pins the positive source-file matching.
         from torch.amp.autocast_mode import _UnmanagedAutocast
+
+        register_interface_for_device(STUB_DEVICE, AutocastInterface)
 
         self.assertFalse(_matches_device_autocast_class(_UnmanagedAutocast))
 

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -15,6 +15,7 @@ The abstraction layer enables device-agnostic code in TorchDynamo while allowing
 specialized implementations for each hardware backend's unique features.
 """
 
+import functools
 import inspect
 import time
 from collections import namedtuple
@@ -42,6 +43,8 @@ class DeviceInterface:
     This is a simple device runtime interface for Inductor. It enables custom
     backends to be integrated with Inductor in a device-agnostic semantic.
     """
+
+    autocast_classes: frozenset[type] = frozenset()
 
     class device:
         def __new__(cls, device: torch.types.Device) -> Any:
@@ -636,12 +639,23 @@ device_interfaces: dict[str, type[DeviceInterface]] = {}
 _device_initialized = False
 
 
+@functools.cache
+def get_device_autocast_classes() -> dict[type, str]:
+    result: dict[type, str] = {}
+    for device, device_interface in get_registered_device_interfaces():
+        device_type = device.split(":")[0]
+        for autocast_class in device_interface.autocast_classes:
+            result.setdefault(autocast_class, device_type)
+    return result
+
+
 def register_interface_for_device(
     device: str | torch.device, device_interface: type[DeviceInterface]
 ) -> None:
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
+    get_device_autocast_classes.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -19,7 +19,7 @@ import functools
 import inspect
 import time
 from collections import namedtuple
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -40,10 +40,16 @@ caching_worker_current_devices: dict[str, int] = {}
 
 class DeviceInterface:
     """
-    This is a simple device runtime interface for Inductor. It enables custom
-    backends to be integrated with Inductor in a device-agnostic semantic.
+    This is a simple device runtime interface for Dynamo and Inductor. It
+    enables custom backends to be integrated with them in a device-agnostic
+    semantic.
     """
 
+    # Autocast classes this device provides, e.g. ``torch.foo.amp.autocast``.
+    # Dynamo uses these to route an out-of-tree autocast class to the
+    # device_type it was registered under; see
+    # ``device_type_for_autocast_class``.  Entries must be strict subclasses of
+    # ``torch.amp.autocast_mode.autocast``.
     autocast_classes: frozenset[type] = frozenset()
 
     class device:
@@ -639,14 +645,110 @@ device_interfaces: dict[str, type[DeviceInterface]] = {}
 _device_initialized = False
 
 
-@functools.cache
-def get_device_autocast_classes() -> dict[type, str]:
-    result: dict[type, str] = {}
+def _iter_registered_autocast_classes() -> Iterator[tuple[type, str]]:
     for device, device_interface in get_registered_device_interfaces():
         device_type = device.split(":")[0]
         for autocast_class in device_interface.autocast_classes:
-            result.setdefault(autocast_class, device_type)
+            yield autocast_class, device_type
+
+
+def _autocast_class_location(autocast_class: type) -> tuple[str, str] | None:
+    """A class identity that survives the class being imported twice.
+
+    An out-of-tree backend usually installs itself as a ``torch`` submodule, so
+    the same file is reachable under two dotted names, e.g.
+    ``torch_npu.npu.amp.autocast_mode`` and ``torch.npu.amp.autocast_mode``.
+    Importing both names loads two module objects, runs the class body twice and
+    yields two class objects; which one traced code reaches depends on import
+    order, so ``is`` against the registered one is not reliable.  The defining
+    file plus the qualified name is the same for both.
+
+    This is deliberately narrower than matching on the file alone: a *different*
+    class defined in that same file has a different ``__qualname__`` and so
+    still does not match.
+
+    ``None`` means the class has no source file to key on (C extension, exec'd
+    code), in which case only identity matching applies to it.
+    """
+    try:
+        file = inspect.getfile(autocast_class)
+    except (TypeError, OSError):
+        return None
+    return file, autocast_class.__qualname__
+
+
+def _conflict(key: object, previous: str, device_type: str) -> RuntimeError:
+    # Iteration order over device_interfaces is not something a caller
+    # controls, so first-wins would make the device_type non-deterministic.
+    return RuntimeError(
+        f"Autocast class {key} is registered by both device_type "
+        f"{previous!r} and {device_type!r}; each autocast class must belong "
+        f"to exactly one device_type."
+    )
+
+
+@functools.cache
+def get_device_autocast_classes() -> dict[type, str]:
+    """Map every registered autocast class to the device_type providing it."""
+    result: dict[type, str] = {}
+    for autocast_class, device_type in _iter_registered_autocast_classes():
+        previous = result.setdefault(autocast_class, device_type)
+        if previous != device_type:
+            raise _conflict(autocast_class, previous, device_type)
     return result
+
+
+@functools.cache
+def get_device_autocast_class_locations() -> dict[tuple[str, str], str]:
+    """``get_device_autocast_classes`` keyed by ``_autocast_class_location``."""
+    result: dict[tuple[str, str], str] = {}
+    for autocast_class, device_type in _iter_registered_autocast_classes():
+        location = _autocast_class_location(autocast_class)
+        if location is None:
+            continue
+        previous = result.setdefault(location, device_type)
+        if previous != device_type:
+            raise _conflict(location, previous, device_type)
+    return result
+
+
+def device_type_for_autocast_class(autocast_class: Any) -> str | None:
+    """Return the device_type that registered ``autocast_class``, else ``None``.
+
+    A device opts in by listing the class in ``DeviceInterface.autocast_classes``;
+    nothing it did not list can match.  Registered classes are recognised by
+    identity, or failing that by ``_autocast_class_location`` so that a second
+    import of the defining module still resolves.
+    """
+    if not isinstance(autocast_class, type):
+        return None
+    device_type = get_device_autocast_classes().get(autocast_class)
+    if device_type is not None:
+        return device_type
+    location = _autocast_class_location(autocast_class)
+    if location is None:
+        return None
+    return get_device_autocast_class_locations().get(location)
+
+
+def _validate_autocast_classes(
+    device: str, device_interface: type[DeviceInterface]
+) -> None:
+    base = torch.amp.autocast_mode.autocast
+    for autocast_class in device_interface.autocast_classes:
+        if not (isinstance(autocast_class, type) and issubclass(autocast_class, base)):
+            raise TypeError(
+                f"{device_interface.__name__}.autocast_classes entry "
+                f"{autocast_class!r} registered for device {device!r} is not a "
+                f"subclass of torch.amp.autocast_mode.autocast."
+            )
+        if autocast_class is base:
+            raise ValueError(
+                f"{device_interface.__name__}.autocast_classes registered for "
+                f"device {device!r} must not contain "
+                f"torch.amp.autocast_mode.autocast itself; list the "
+                f"device-specific subclass instead."
+            )
 
 
 def register_interface_for_device(
@@ -654,8 +756,10 @@ def register_interface_for_device(
 ) -> None:
     if isinstance(device, torch.device):
         device = device.type
+    _validate_autocast_classes(device, device_interface)
     device_interfaces[device] = device_interface
     get_device_autocast_classes.cache_clear()
+    get_device_autocast_class_locations.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1073,6 +1073,19 @@ class DisabledSavedTensorsHooksVariable(ContextWrappingVariable):
         return contextlib._GeneratorContextManager
 
 
+def _autocast_base_defaults() -> dict[str, Any]:
+    """Defaults of torch.amp.autocast_mode.autocast.__init__, by name."""
+    parameters = inspect.signature(torch.amp.autocast_mode.autocast).parameters
+    return {
+        name: parameter.default
+        for name, parameter in parameters.items()
+        if parameter.default is not inspect.Parameter.empty
+    }
+
+
+_AUTOCAST_BASE_DEFAULTS = _autocast_base_defaults()
+
+
 class AutocastModeVariable(ContextWrappingVariable):
     @staticmethod
     def create(
@@ -1082,20 +1095,13 @@ class AutocastModeVariable(ContextWrappingVariable):
     ) -> "AutocastModeVariable":
         from .torch import device_type_for_autocast_class
 
-        if func not in [
-            torch.amp.autocast_mode.autocast,
-            torch.cuda.amp.autocast,
-            torch.cpu.amp.autocast,
-        ]:
-            # Also accept autocast subclasses registered via
-            # DeviceInterface.  issubclass handles multi-path import
-            # aliasing where the same class acquires different Python
-            # identities.
-            if not (
-                isinstance(func, type)
-                and issubclass(func, torch.amp.autocast_mode.autocast)
-            ):
-                raise AssertionError(f"unexpected autocast function: {func}")
+        # Subclasses registered via DeviceInterface.autocast_classes are
+        # accepted alongside the in-tree entry points.
+        if not (
+            isinstance(func, type)
+            and issubclass(func, torch.amp.autocast_mode.autocast)
+        ):
+            raise AssertionError(f"unexpected autocast function: {func}")
         # device_type : str,
         # dtype : Optional[_dtype] = None,
         # enabled : bool = True,
@@ -1118,6 +1124,17 @@ class AutocastModeVariable(ContextWrappingVariable):
                     raise AssertionError(
                         f"Cannot determine device_type for autocast class: {func}"
                     )
+            elif key not in bound_args.arguments:
+                # A subclass may narrow the constructor and not accept every
+                # base parameter, e.g. ``def __init__(self, dtype=None)``.
+                # Use the base default for whatever it does not accept, which
+                # is what its super().__init__ call gets when it does not pass
+                # that parameter either.  Note the binding above must stay
+                # against func's own signature: a subclass may order its
+                # parameters differently than the base (torch.npu.amp.autocast
+                # takes `enabled` first), so binding to the base signature
+                # would misread positional arguments.
+                arg = _AUTOCAST_BASE_DEFAULTS[key]
             else:
                 arg = bound_args.arguments[key]
             if isinstance(arg, VariableTracker):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,7 +1080,7 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
-        from ..device_interface import get_registered_device_interfaces
+        from .torch import device_type_for_autocast_class
 
         if func not in [
             torch.amp.autocast_mode.autocast,
@@ -1113,17 +1113,7 @@ class AutocastModeVariable(ContextWrappingVariable):
                 # pyrefly: ignore [unnecessary-comparison]
                 arg = "cuda" if func is torch.cuda.amp.autocast else "cpu"
             elif key == "device_type" and key not in bound_args.arguments:
-                # Out-of-tree device autocast subclass: device_type
-                # is implicit in the subclass constructor.  Resolve
-                # from the DeviceInterface registration by name.
-                arg = None
-                for _, iface in get_registered_device_interfaces():
-                    for ac_cls, dt in getattr(iface, "autocast_classes", {}).items():
-                        if func.__name__ == ac_cls.__name__:
-                            arg = dt
-                            break
-                    if arg is not None:
-                        break
+                arg = device_type_for_autocast_class(func)
                 if arg is None:
                     raise AssertionError(
                         f"Cannot determine device_type for autocast class: {func}"

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,12 +1080,22 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
+        from ..device_interface import get_registered_device_interfaces
+
         if func not in [
             torch.amp.autocast_mode.autocast,
             torch.cuda.amp.autocast,
             torch.cpu.amp.autocast,
         ]:
-            raise AssertionError(f"unexpected autocast function: {func}")
+            # Also accept autocast subclasses registered via
+            # DeviceInterface.  issubclass handles multi-path import
+            # aliasing where the same class acquires different Python
+            # identities.
+            if not (
+                isinstance(func, type)
+                and issubclass(func, torch.amp.autocast_mode.autocast)
+            ):
+                raise AssertionError(f"unexpected autocast function: {func}")
         # device_type : str,
         # dtype : Optional[_dtype] = None,
         # enabled : bool = True,
@@ -1102,6 +1112,22 @@ class AutocastModeVariable(ContextWrappingVariable):
             ]:
                 # pyrefly: ignore [unnecessary-comparison]
                 arg = "cuda" if func is torch.cuda.amp.autocast else "cpu"
+            elif key == "device_type" and key not in bound_args.arguments:
+                # Out-of-tree device autocast subclass: device_type
+                # is implicit in the subclass constructor.  Resolve
+                # from the DeviceInterface registration by name.
+                arg = None
+                for _, iface in get_registered_device_interfaces():
+                    for ac_cls, dt in getattr(iface, "autocast_classes", {}).items():
+                        if func.__name__ == ac_cls.__name__:
+                            arg = dt
+                            break
+                    if arg is not None:
+                        break
+                if arg is None:
+                    raise AssertionError(
+                        f"Cannot determine device_type for autocast class: {func}"
+                    )
             else:
                 arg = bound_args.arguments[key]
             if isinstance(arg, VariableTracker):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -197,6 +197,56 @@ supported_ctx_manager_classes = dict.fromkeys(
 )
 
 
+def _get_device_autocast_classes() -> dict[type, str]:
+    """Autocast classes registered by out-of-tree DeviceInterfaces.
+
+    Not cached: device interfaces may be registered lazily, so we
+    query each time.
+    """
+    from ..device_interface import get_registered_device_interfaces
+
+    result: dict[type, str] = {}
+    for _, iface in get_registered_device_interfaces():
+        ac = getattr(iface, "autocast_classes", None)
+        if ac:
+            result.update(ac)
+    return result
+
+
+def _matches_device_autocast_class(value) -> bool:
+    """Check if `value` is an autocast class belonging to a registered device.
+
+    Handles the multi-path import identity mismatch where the same class
+    loaded via ``torch.npu.amp`` and ``torch_npu.npu.amp`` has different
+    Python identities.  Falls back to comparing source files when the
+    exact object reference does not match.
+    """
+    if not isinstance(value, type):
+        return False
+    if not issubclass(value, torch.amp.autocast_mode.autocast):
+        return False
+    if value is torch.amp.autocast_mode.autocast:
+        return False
+
+    registered = _get_device_autocast_classes()
+    if value in registered:
+        return True
+
+    if not registered:
+        return False
+
+    import inspect
+
+    for ac_cls in registered:
+        try:
+            if inspect.getfile(value) == inspect.getfile(ac_cls):
+                return True
+        except (TypeError, OSError):
+            pass
+
+    return False
+
+
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
     [
         torch._shape_as_tensor,
@@ -689,7 +739,10 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             callable(value)
             and (
                 hashable(value)  # accesses value.__hash__()
-                and value in supported_ctx_manager_classes
+                and (
+                    value in supported_ctx_manager_classes
+                    or _matches_device_autocast_class(value)
+                )
             )
         )
 
@@ -812,6 +865,14 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             torch.cuda.amp.autocast,
             torch.cpu.amp.autocast,
         ):
+            # pyrefly: ignore [bad-argument-type]
+            return AutocastModeVariable.create(self.value, args, kwargs)
+        elif _matches_device_autocast_class(self.value):
+            # Autocast class registered via DeviceInterface.
+            # Handles both exact reference match and multi-path
+            # import identity mismatch (e.g. torch.npu.amp vs
+            # torch_npu.npu.amp returning different Python objects
+            # for the same class).
             # pyrefly: ignore [bad-argument-type]
             return AutocastModeVariable.create(self.value, args, kwargs)
         elif self.value in (

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -197,51 +197,21 @@ supported_ctx_manager_classes = dict.fromkeys(
 )
 
 
-def _matches_device_autocast_class(value) -> bool:
+def device_type_for_autocast_class(value: Any) -> str | None:
+    """Return the device_type that registered ``value`` as its autocast class.
+
+    ``None`` means ``value`` is not a registered autocast class.  See
+    ``device_interface.device_type_for_autocast_class`` for how a class is
+    matched against what a device registered.
+    """
+    from ..device_interface import device_type_for_autocast_class as lookup
+
+    return lookup(value)
+
+
+def _matches_device_autocast_class(value: Any) -> bool:
     """Check whether value is an autocast class registered by a device."""
-    from ..device_interface import get_device_autocast_classes
-
-    if not isinstance(value, type):
-        return False
-    if not issubclass(value, torch.amp.autocast_mode.autocast):
-        return False
-    if value is torch.amp.autocast_mode.autocast:
-        return False
-
-    registered = get_device_autocast_classes()
-    if value in registered:
-        return True
-    if not registered:
-        return False
-    return _autocast_class_by_file(value) is not None
-
-
-def _autocast_class_by_file(value: type) -> type | None:
-    """Return the registered autocast class defined in value's source file."""
-    from ..device_interface import get_device_autocast_classes
-
-    try:
-        value_file = inspect.getfile(value)
-    except (TypeError, OSError):
-        return None
-    for autocast_class in get_device_autocast_classes():
-        try:
-            if inspect.getfile(autocast_class) == value_file:
-                return autocast_class
-        except (TypeError, OSError):
-            pass
-    return None
-
-
-def device_type_for_autocast_class(value: type) -> str | None:
-    from ..device_interface import get_device_autocast_classes
-
-    registered = get_device_autocast_classes()
-    device_type = registered.get(value)
-    if device_type is not None:
-        return device_type
-    autocast_class = _autocast_class_by_file(value)
-    return None if autocast_class is None else registered[autocast_class]
+    return device_type_for_autocast_class(value) is not None
 
 
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
@@ -861,15 +831,8 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             torch.amp.autocast_mode.autocast,
             torch.cuda.amp.autocast,
             torch.cpu.amp.autocast,
-        ):
-            # pyrefly: ignore [bad-argument-type]
-            return AutocastModeVariable.create(self.value, args, kwargs)
-        elif _matches_device_autocast_class(self.value):
-            # Autocast class registered via DeviceInterface.
-            # Handles both exact reference match and multi-path
-            # import identity mismatch (e.g. torch.npu.amp vs
-            # torch_npu.npu.amp returning different Python objects
-            # for the same class).
+            # An autocast class registered via DeviceInterface.autocast_classes.
+        ) or _matches_device_autocast_class(self.value):
             # pyrefly: ignore [bad-argument-type]
             return AutocastModeVariable.create(self.value, args, kwargs)
         elif self.value in (

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -197,30 +197,10 @@ supported_ctx_manager_classes = dict.fromkeys(
 )
 
 
-def _get_device_autocast_classes() -> dict[type, str]:
-    """Autocast classes registered by out-of-tree DeviceInterfaces.
-
-    Not cached: device interfaces may be registered lazily, so we
-    query each time.
-    """
-    from ..device_interface import get_registered_device_interfaces
-
-    result: dict[type, str] = {}
-    for _, iface in get_registered_device_interfaces():
-        ac = getattr(iface, "autocast_classes", None)
-        if ac:
-            result.update(ac)
-    return result
-
-
 def _matches_device_autocast_class(value) -> bool:
-    """Check if `value` is an autocast class belonging to a registered device.
+    """Check whether value is an autocast class registered by a device."""
+    from ..device_interface import get_device_autocast_classes
 
-    Handles the multi-path import identity mismatch where the same class
-    loaded via ``torch.npu.amp`` and ``torch_npu.npu.amp`` has different
-    Python identities.  Falls back to comparing source files when the
-    exact object reference does not match.
-    """
     if not isinstance(value, type):
         return False
     if not issubclass(value, torch.amp.autocast_mode.autocast):
@@ -228,23 +208,40 @@ def _matches_device_autocast_class(value) -> bool:
     if value is torch.amp.autocast_mode.autocast:
         return False
 
-    registered = _get_device_autocast_classes()
+    registered = get_device_autocast_classes()
     if value in registered:
         return True
-
     if not registered:
         return False
+    return _autocast_class_by_file(value) is not None
 
-    import inspect
 
-    for ac_cls in registered:
+def _autocast_class_by_file(value: type) -> type | None:
+    """Return the registered autocast class defined in value's source file."""
+    from ..device_interface import get_device_autocast_classes
+
+    try:
+        value_file = inspect.getfile(value)
+    except (TypeError, OSError):
+        return None
+    for autocast_class in get_device_autocast_classes():
         try:
-            if inspect.getfile(value) == inspect.getfile(ac_cls):
-                return True
+            if inspect.getfile(autocast_class) == value_file:
+                return autocast_class
         except (TypeError, OSError):
             pass
+    return None
 
-    return False
+
+def device_type_for_autocast_class(value: type) -> str | None:
+    from ..device_interface import get_device_autocast_classes
+
+    registered = get_device_autocast_classes()
+    device_type = registered.get(value)
+    if device_type is not None:
+        return device_type
+    autocast_class = _autocast_class_by_file(value)
+    return None if autocast_class is None else registered[autocast_class]
 
 
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(


### PR DESCRIPTION
Add _get_device_autocast_classes() to query DeviceInterface registrations for autocast classes. Extend is_matching_cls with an issubclass fallback for device autocast subclasses that may be loaded through different import paths. Extend call_function to route registered device autocast classes to AutocastModeVariable.create.

In AutocastModeVariable.create, accept autocast subclasses via issubclass and resolve device_type from DeviceInterface when the subclass constructor omits it (meaning device_type is implicit in the class itself).

Test Plan:
python -m unittest test_dynamo_patches.TestAutocast -v
@pytorchbot label "module: tests/distributed" "module: tests/graph" "module: tests/core" "module: tests/others"
cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98