### PR TITLE
[TEST] Refactor complex tests with hw_classification

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -32,7 +32,11 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
 )
-from torch.testing._internal.common_utils import run_tests, unMarkDynamoStrictTest
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    unMarkDynamoStrictTest,
+)
 
 
 if TYPE_CHECKING:
@@ -128,6 +132,7 @@ EXTRA_KWARGS = {
 
 
 class TestComplexTensor(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     _default_dtype_check_enabled = True
 
     @ops(
@@ -141,6 +146,10 @@ class TestComplexTensor(TestCase):
     @ops(force_test_op_db, allowed_dtypes=list(COMPLEX_DTYPES))
     def test_maybe_error(self, device, dtype, op: OpInfo):
         self.check_consistency(device, dtype, op, Variant.Op)
+
+
+class TestComplexTensorGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_set_components(self):
         from torch._subclasses.complex_tensor import ComplexTensor
@@ -182,6 +191,7 @@ class TestComplexTensor(TestCase):
 
 @unMarkDynamoStrictTest
 class TestComplexBwdGradients(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     _default_dtype_check_enabled = True
 
     @ops(
@@ -202,6 +212,8 @@ if dist.is_available():
 
     @unMarkDynamoStrictTest
     class TestComplexDistributed(TestCase, MultiProcessTestCase):
+        hw_classification = HardwareClassification.ACCELERATOR
+
         @ops(implemented_op_db, allowed_dtypes=list(COMPLEX_DTYPES))
         def test_distributed(self, device, dtype, op: OpInfo):
             self.check_consistency(device, dtype, op, Variant.Distributed)

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -8,13 +8,17 @@ from torch.testing._internal.common_device_type import (
     onlyCPU,
 )
 from torch.testing._internal.common_dtype import complex_types
-from torch.testing._internal.common_utils import run_tests, set_default_dtype, TestCase
-
-
-devices = (torch.device("cpu"), torch.device("cuda:0"))
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    set_default_dtype,
+    TestCase,
+)
 
 
 class TestComplexTensor(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @dtypes(*complex_types())
     def test_to_list(self, device, dtype):
         # test that the complex float tensor has expected values and


### PR DESCRIPTION
## Summary

Apply hardware classification to complex-number tests following #186918 guidelines.

**`test/complex_tensor/test_complex_tensor.py`**
- **TestComplexTensor**: `ACCELERATOR` (device op consistency)
- **TestComplexTensorGeneric**: `GENERIC` (CPU-only component/API tests split out)
- **TestComplexBwdGradients**, **TestComplexDistributed**: `ACCELERATOR`

**`test/test_complex.py`**
- **TestComplexTensor**: `ACCELERATOR` (device op numerics via `instantiate_device_type_tests`)
- Keep `@onlyCPU` on `test_eq`/`test_ne` (historical filter; not a GENERIC split)
- Remove unused hardcoded `devices` tuple

cc @mansiag05 @RiyaP2508

## Test plan

```
lintrunner -a test/complex_tensor/test_complex_tensor.py test/test_complex.py
# ok No lint issues.

python -c "import ast; ast.parse(open('test/complex_tensor/test_complex_tensor.py').read()); print('OK')"
python -c "import ast; ast.parse(open('test/test_complex.py').read()); print('OK')"

python test/complex_tensor/test_complex_tensor.py --hw-classification GENERIC -v
# Ran 3 tests — OK

python test/complex_tensor/test_complex_tensor.py --hw-classification ACCELERATOR -k abs_cpu_complex64 -v
# Ran 2 tests — OK

python test/test_complex.py -v
# Ran 30 tests — OK (skipped=4)

python test/test_complex.py --hw-classification ACCELERATOR -v
# HW classification: total=30, passed=30, unclassified=0, mismatched=0
```

Authored with an AI assistant.