### PR TITLE
[Testcase Refactoring]Add hw_classification to elastic multiprocessing errors api_test.py

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -15,6 +15,11 @@ from torch.distributed.elastic.multiprocessing.errors import (
     record,
 )
 from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class SentinelError(Exception):
@@ -54,7 +59,8 @@ def read_resource_file(resource_file: str) -> str:
         return "".join(fp.readlines())
 
 
-class ApiTest(unittest.TestCase):
+class ApiTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
@@ -283,3 +289,7 @@ class ApiTest(unittest.TestCase):
         error_msg = str(ex)
         self.assertIn("(SIGSEGV)", error_msg)
         self.assertIn(f"exitcode  : {-signal.SIGSEGV}", error_msg)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -110,6 +110,7 @@ def read_resource_file(resource_file: str) -> str:
 
 class ApiTest(TestCase):
     hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)

--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -16,6 +16,11 @@ from torch.distributed.elastic.multiprocessing.errors import (
     record,
 )
 from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class SentinelError(Exception):
@@ -103,7 +108,8 @@ def read_resource_file(resource_file: str) -> str:
         return "".join(fp.readlines())
 
 
-class ApiTest(unittest.TestCase):
+class ApiTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
@@ -461,3 +467,7 @@ class ApiTest(unittest.TestCase):
                 wrapped()
 
         error_handler.record_exception.assert_not_called()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import signal
 import tempfile
-import unittest
 from unittest import mock
 
 from torch.distributed.elastic.multiprocessing.errors import (


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `ApiTest`
in `test/distributed/elastic/multiprocessing/errors/api_test.py`, and
replace `unittest.TestCase` with `TestCase` so the test participates in
the hardware classification framework.

## Changes

- **Import `HardwareClassification`, `run_tests`, `TestCase`** from
  `common_utils`.
- **Replace `unittest.TestCase` with `TestCase`** as the base class.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `ApiTest`.  All tests exercise pure CPU error-handling logic
  (`ProcessFailure` parsing, signal name mapping, `@record`
  decorator behavior) without any device dependency.
- **Add `if __name__ == "__main__": run_tests()`** at the end.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/multiprocessing/errors/api_test.py` —
  TODO: confirm all tests pass on CPU.