### PR TITLE
[Testcase Refactoring]Add hw_classification to elastic multiprocessing error_handler_test.py

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
@@ -6,23 +6,30 @@ import json
 import os
 import shutil
 import tempfile
-import unittest
 from unittest.mock import patch
 
 from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
 from torch.distributed.elastic.multiprocessing.errors.handlers import get_error_handler
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def raise_exception_fn():
     raise RuntimeError("foobar")
 
 
-class GetErrorHandlerTest(unittest.TestCase):
+class GetErrorHandlerTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_error_handler(self):
         self.assertTrue(isinstance(get_error_handler(), ErrorHandler))
 
 
-class ErrorHandlerTest(unittest.TestCase):
+class ErrorHandlerTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
@@ -106,3 +113,7 @@ class ErrorHandlerTest(unittest.TestCase):
         with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": dst_error_file}):
             eh.dump_error_file(src_error_file)
             self.assertTrue(filecmp.cmp(src_error_file, dst_error_file))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
@@ -30,6 +30,7 @@ class GetErrorHandlerTest(TestCase):
 
 class ErrorHandlerTest(TestCase):
     hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to both test
classes in `test/distributed/elastic/multiprocessing/errors/error_handler_test.py`,
and switch from `unittest.TestCase` to `TestCase` so they participate
in the hardware classification framework.

## Changes

- **Import `HardwareClassification`, `run_tests`, `TestCase`** from
  `common_utils`.  Remove `import unittest`.
- **Switch `GetErrorHandlerTest` and `ErrorHandlerTest`** from
  `unittest.TestCase` to `TestCase`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to both
  classes.  All tests exercise pure CPU error handler logic
  (faulthandler initialization, JSON error file recording, and error
  file dump) without any device dependency.
- **Add `if __name__ == "__main__": run_tests()`** at the end.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/multiprocessing/errors/error_handler_test.py` —
  TODO: confirm all tests pass on CPU.