### PR TITLE
[Testcase Refactoring]  Add hw_classification in test_dce_pass.py

### DIFF
--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 import torch.fx
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     raise_on_run_directly,
     TestCase,
@@ -12,6 +13,8 @@ from torch.testing._internal.common_utils import (
 
 
 class TestDCE(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _custom_is_impure_node(self, node: torch.fx.Node) -> bool:
         if node.is_impure():
             return True


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestDCEPass class, enabling hardware-based test classification and filtering.

## Changes
test/fx/test_dce_pass.py : import HardwareClassification and add hw_classification to TestDCEPass class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_dce_pass.py

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian