### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to 5 dynamo test files

### DIFF
--- a/test/dynamo/test_nops.py
+++ b/test/dynamo/test_nops.py
@@ -4,6 +4,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import eval_frame
 from torch._dynamo.hooks import Hooks
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 c = 10
@@ -38,6 +39,8 @@ with_debug_nops = eval_frame._optimize_catch_errors(
 
 
 class NopTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_debug_nops
     def test1(self):
         self.assertEqual(fn1(1, 2), -7)

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -11,6 +11,7 @@ import torch._dynamo
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch.nn import Parameter
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class MyOptimizer(torch.optim.Optimizer):
@@ -35,6 +36,8 @@ class MyOptimizer(torch.optim.Optimizer):
 
 
 class End2EndTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # https://github.com/pytorch/torchdynamo/issues/1604
     def test_optimizing_over_tensor_with_requires_grad(self):
         class Net(torch.nn.Module):

--- a/test/dynamo/test_pgo.py
+++ b/test/dynamo/test_pgo.py
@@ -18,10 +18,12 @@ from torch._dynamo.testing import (
 )
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.utils import clear_caches, fresh_cache
-from torch.testing._internal.common_utils import IS_WINDOWS
+from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS
 
 
 class PgoTest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._test_stack = contextlib.ExitStack()
@@ -398,7 +400,7 @@ def run(cnt):
         # Windows can't create unification temp path:
         #   hash(a18a3259)C:/Users/Xuhan/AppData/Local/Temp/tmpx3hfkuqa/example.py
         # Skip hash check
-        self.assertTrue("hash" if IS_WINDOWS else "hash(390fe689)" in state)
+        self.assertTrue(("hash" if IS_WINDOWS else "hash(390fe689)") in state)
         self.assertTrue("/example.py:4:func:" in state)
         self.assertTrue(" L['x']: tensor size=[?] stride=[1]" in state)
         # We should compile this only once due to PGO.

--- a/test/dynamo/test_pgo.py
+++ b/test/dynamo/test_pgo.py
@@ -18,10 +18,12 @@ from torch._dynamo.testing import (
 )
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.utils import clear_caches, fresh_cache
-from torch.testing._internal.common_utils import IS_WINDOWS
+from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS
 
 
 class PgoTest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._test_stack = contextlib.ExitStack()

--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -3,10 +3,13 @@
 import torch
 import torch._dynamo.testing
 from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestGroupTensorsByDeviceAndDtype(TestCase):
     """Tests for the group_tensors_by_device_and_dtype polyfill."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_polyfill_matches_cpp_single_list(self):
         """Test that polyfill matches C++ implementation for a single list."""

--- a/test/dynamo/test_pre_dispatch.py
+++ b/test/dynamo/test_pre_dispatch.py
@@ -2,9 +2,12 @@
 import torch
 import torch._dynamo
 import torch._dynamo.test_case
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class PreDispatchTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_no_grad_simple(self):
         def f(a):
             b = a.sin()


### PR DESCRIPTION
## Summary

This PR classifies 5 `test/dynamo` test classes as `HardwareClassification.GENERIC`, enabling device-aware test infrastructure to correctly categorize these tests as device-generic rather than backend-specific.

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` and the corresponding import to:
  - `test/dynamo/test_nops.py` — `NopTests`
  - `test/dynamo/test_optimizers.py` — `End2EndTests`
  - `test/dynamo/test_pgo.py` — `PgoTest`
  - `test/dynamo/test_polyfills.py` — `TestGroupTensorsByDeviceAndDtype`
  - `test/dynamo/test_pre_dispatch.py` — `PreDispatchTests`
- test/dynamo/test_pgo.py:403 has a misplaced ternary:
`self.assertTrue("hash" if IS_WINDOWS else "hash(390fe689)" in state)`
Python parses this as `"hash" if IS_WINDOWS else ("hash(390fe689)" in state)`. On Windows the assertion is `assertTrue("hash") `— a non-empty string, always true, `state` never inspected. The intent was almost certainly:
`self.assertTrue(("hash" if IS_WINDOWS else "hash(390fe689)") in state)`

## Test plan

`python test/dynamo/test_nops.py --hw-classification GENERIC -v`
`python test/dynamo/test_optimizers.py --hw-classification GENERIC -v`
`python test/dynamo/test_pgo.py --hw-classification GENERIC -v`
`python test/dynamo/test_polyfills.py --hw-classification GENERIC -v`
`python test/dynamo/test_pre_dispatch.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98