### PR TITLE
[Testcase Refactoring] Add CPU hw_classification to AOTI arrayref host tests

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: inductor"]
+import copy
+import functools
 import sys
 import unittest
 
@@ -7,6 +9,7 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_cpp_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_CI,
@@ -32,7 +35,7 @@ try:
             check_model_with_multiple_inputs,
             code_check_count,
         )
-        from .test_torchinductor import copy_tests, TestFailure
+        from .test_torchinductor import TestFailure
     except ImportError:
         from test_aot_inductor import (  # @manual
             AOTInductorTestsTemplate,
@@ -42,7 +45,6 @@ try:
             code_check_count,
         )
         from test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-            copy_tests,
             TestFailure,
         )
 except (unittest.SkipTest, ImportError):
@@ -66,6 +68,32 @@ def fail_minimal_arrayref_interface(is_skip=False):
         ("cpu_with_stack_allocation_and_minimal_arrayref_interface",),
         is_skip=is_skip,
     )
+
+
+def _attach_aoti_template_tests(
+    template_cls, host_cls, failure_suffix, test_failures=None
+):
+    for name, value in template_cls.__dict__.items():
+        if not name.startswith("test_"):
+            continue
+
+        @functools.wraps(value)
+        def new_test(self, value=value):
+            return value(self)
+
+        new_test.__dict__ = copy.deepcopy(value.__dict__)
+
+        tf = test_failures and test_failures.get(name)
+        if tf and failure_suffix in tf.suffixes:
+            skip_func = (
+                unittest.skip("Skipped!") if tf.is_skip else unittest.expectedFailure
+            )
+            new_test = skip_func(new_test)
+
+        setattr(host_cls, name, new_test)
+
+    if hasattr(template_cls, "is_dtype_supported"):
+        host_cls.is_dtype_supported = template_cls.is_dtype_supported
 
 
 class AOTInductorArrayRefTestsTemplate(AOTInductorTestsTemplate):
@@ -332,11 +360,14 @@ class AOTInductorTestABICompatibleCpuWithStackAllocation(TestCase):
     use_minimal_arrayref_interface = False
 
 
-copy_tests(
+_attach_aoti_template_tests(
     AOTInductorTestsTemplate,
     AOTInductorTestABICompatibleCpuWithStackAllocation,
     "cpu_with_stack_allocation",
     CPU_TEST_FAILURES,
+)
+instantiate_device_type_tests(
+    AOTInductorTestABICompatibleCpuWithStackAllocation, globals(), only_for="cpu"
 )
 
 
@@ -358,24 +389,29 @@ if IS_FBCODE:
     # and terminal output say pass), but the process will segfault.  This only
     # happens in OSS CI and is fine internally.
     # See https://github.com/pytorch/pytorch/issues/123691
-    copy_tests(
+    _attach_aoti_template_tests(
         AOTInductorTestsTemplate,
         AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface,
         "cpu_with_stack_allocation_and_minimal_arrayref_interface",
         CPU_TEST_FAILURES,
     )
-    copy_tests(
+    _attach_aoti_template_tests(
         AOTInductorArrayRefTestsTemplate,
         AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface,
         "cpu_with_stack_allocation_and_minimal_arrayref_interface",
         CPU_TEST_FAILURES,
+    )
+    instantiate_device_type_tests(
+        AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface,
+        globals(),
+        only_for="cpu",
     )
 
 
 class TestCppWrapperCpuSelection(TestCase):
     hw_classification = HardwareClassification.CPU
 
-    def test_cpu_cpp_wrapper_follows_current_stack_allocation_config(self):
+    def test_cpu_cpp_wrapper_follows_current_stack_allocation_config(self, device):
         # Regression test: the CPU cpp wrapper class (CppWrapperCpu vs
         # CppWrapperCpuArrayRef) must track the current allow_stack_allocation
         # config at each compile. It used to be frozen at the process's first
@@ -394,14 +430,17 @@ class TestCppWrapperCpuSelection(TestCase):
         init_backend_registration()
         with config.patch({"aot_inductor.allow_stack_allocation": True}):
             self.assertIs(
-                get_wrapper_codegen_for_device("cpu", cpp_wrapper=True),
+                get_wrapper_codegen_for_device(device, cpp_wrapper=True),
                 CppWrapperCpuArrayRef,
             )
         with config.patch({"aot_inductor.allow_stack_allocation": False}):
             self.assertIs(
-                get_wrapper_codegen_for_device("cpu", cpp_wrapper=True),
+                get_wrapper_codegen_for_device(device, cpp_wrapper=True),
                 CppWrapperCpu,
             )
+
+
+instantiate_device_type_tests(TestCppWrapperCpuSelection, globals(), only_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -7,7 +7,12 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_cpp_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_CI, IS_FBCODE, IS_WINDOWS
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_CI,
+    IS_FBCODE,
+    IS_WINDOWS,
+)
 
 
 if IS_WINDOWS and IS_CI:
@@ -317,6 +322,8 @@ CPU_TEST_FAILURES = {
 
 
 class AOTInductorTestABICompatibleCpuWithStackAllocation(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -337,6 +344,8 @@ copy_tests(
 class AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface(
     TestCase
 ):
+    hw_classification = HardwareClassification.CPU
+
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -366,6 +375,8 @@ if IS_FBCODE:
 
 
 class TestCppWrapperCpuSelection(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def test_cpu_cpp_wrapper_follows_current_stack_allocation_config(self):
         # Regression test: the CPU cpp wrapper class (CppWrapperCpu vs
         # CppWrapperCpuArrayRef) must track the current allow_stack_allocation

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -323,7 +323,6 @@ CPU_TEST_FAILURES = {
 
 class AOTInductorTestABICompatibleCpuWithStackAllocation(TestCase):
     hw_classification = HardwareClassification.CPU
-
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -345,7 +344,6 @@ class AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterf
     TestCase
 ):
     hw_classification = HardwareClassification.CPU
-
     device = "cpu"
     device_type = "cpu"
     check_model = check_model

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -82,6 +82,8 @@ def _attach_aoti_template_tests(
             return value(self)
 
         new_test.__dict__ = copy.deepcopy(value.__dict__)
+        # Template parametrization was expanded before this module imported it.
+        new_test.__dict__.pop("parametrize_fn", None)
 
         tf = test_failures and test_failures.get(name)
         if tf and failure_suffix in tf.suffixes:

--- a/test/slow_tests.json
+++ b/test/slow_tests.json
@@ -213,7 +213,7 @@
   "test_run2run_determinism_model_name_GoogleFnet_training_or_inference_training_precision_float16 (__main__.DeterministicTest)": 118.3158327738444,
   "test_run2run_determinism_model_name_GoogleFnet_training_or_inference_training_precision_float32 (__main__.DeterministicTest)": 119.6198336283366,
   "test_runtime_checks_large_cpu (__main__.AOTInductorTestABICompatibleCpu)": 70.40016682942708,
-  "test_runtime_checks_large_cpu_with_stack_allocation (__main__.AOTInductorTestABICompatibleCpuWithStackAllocation)": 70.30955590142145,
+  "test_runtime_checks_large_cpu (__main__.AOTInductorTestABICompatibleCpuWithStackAllocationCPU)": 70.30955590142145,
   "test_runtime_checks_large_cuda (__main__.AOTInductorTestABICompatibleGpu)": 171.0409952799479,
   "test_sdpa_kernel_ctx_manager2_dynamic_shapes (__main__.DynamicShapesCtxManagerTests)": 106.9195556640625,
   "test_searchsorted_cuda (__main__.GPUTests)": 82.54333392779033,

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -6,16 +6,11 @@ import unittest
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    parametrize,
-    run_tests,
-    TestCase,
-    TEST_SCIPY,
-    set_default_dtype,
-)
+from torch.testing._internal.common_utils import (parametrize, run_tests, TestCase, TEST_SCIPY,
+                                                  set_default_dtype)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyCUDA,
     dtypes,
     OpDTypes,
 )
@@ -40,7 +35,75 @@ NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
 class TestPrims(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim(self, device, dtype):
+        def _wrapper(a, b, broadcast_dimensions):
+            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            # Same shape
+            shape = (5, 5)
+            a = make_arg(shape)
+            b = make_arg(shape, low=0.0, high=0.0)
+            result = fn(a, b, (0, 1))
+
+            self.assertEqual(result.shape, a.shape)
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(a, result)
+
+            # Error input: reordering dims
+            with self.assertRaises(Exception):
+                result = fn(a, b, (1, 0))
+
+            # Adding outermost dimensions
+            a = make_arg((5, 5))
+            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
+            result = fn(a, b, (2, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.broadcast_to(b.shape), result)
+
+            # Expands
+            a = make_arg((1, 5, 1))
+            b = make_arg((3, 5, 7), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 2))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.expand_as(result), result)
+
+            # Unsqueezes
+            a = make_arg((1, 2, 3))
+            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.unsqueeze(2), result)
+
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim_sum(self, device, dtype):
+        def _wrapper(a):
+            a_sum = prims.sum(a, [0, 1])
+            a_bc = prims.broadcast_in_dim(a_sum, [], [])
+            return a_bc
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
 
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     @dtypes(torch.float64, torch.long)
@@ -91,6 +154,7 @@ class TestPrims(TestCase):
                 with self.assertRaises(AssertionError):
                     fn(t, start, end)
 
+
     def test_aten_overload_to_prims(self, device):
         # This test is to ensure that the torch.ops.aten calls are replaced with refs
         from torch.fx.experimental.proxy_tensor import make_fx
@@ -110,6 +174,26 @@ class TestPrims(TestCase):
             node.target.name().startswith("prims") for node in call_function_nodes
         )
         self.assertTrue(all_prims_namespace)
+
+    @onlyCUDA
+    @dtypes(torch.float32)
+    @parametrize("correction", [0, 1])
+    def test_var(self, device, dtype, correction):
+        def _wrapper(a):
+            return prims.var(a, [0, 1], correction=correction)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
 
     @dtypes(torch.float32)
     def test_memory_format_strides(self, device, dtype):
@@ -187,6 +271,36 @@ class TestPrims(TestCase):
         result_refs = refs.view(a, *new_shape)
         self.assertEqual(result_eager, result_refs)
 
+
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_philox_rand(self, device, dtype):
+        sizes = (1000, 1000000)  # offsets of 4 and 8
+        repeats = 2  # Checks multiple rand calls results with multiple philox_rand calls
+        for size in sizes:
+            torch.cuda.manual_seed(123)
+            references = []
+            results = []
+            rng_states = []
+            for _ in range(repeats):
+                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
+                references.append(torch.rand(size, device=device, dtype=dtype))
+
+            torch.cuda.manual_seed(123)
+            for idx in range(repeats):
+                seed, offset = rng_states[idx]
+                result, _ = torch.ops.rngprims.philox_rand((size,),
+                                                           seed=seed,
+                                                           offset=offset,
+                                                           stride=None,
+                                                           device=device,
+                                                           dtype=dtype)
+                results.append(result)
+
+            for a, b in zip(references, results):
+                self.assertEqual(a, b)
+
+
     @dtypes(torch.float32)
     def test_functional_rng_wrappers(self, device, dtype):
 
@@ -218,133 +332,7 @@ class TestPrims(TestCase):
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(result.shape, (1,))
 
-
-instantiate_device_type_tests(TestPrims, globals())
-
-
-class TestPrimsCuda(TestCase):
-    hw_classification = HardwareClassification.CUDA
-
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim(self, device, dtype):
-        def _wrapper(a, b, broadcast_dimensions):
-            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            # Same shape
-            shape = (5, 5)
-            a = make_arg(shape)
-            b = make_arg(shape, low=0.0, high=0.0)
-            result = fn(a, b, (0, 1))
-
-            self.assertEqual(result.shape, a.shape)
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(a, result)
-
-            # Error input: reordering dims
-            with self.assertRaises(Exception):
-                result = fn(a, b, (1, 0))
-
-            # Adding outermost dimensions
-            a = make_arg((5, 5))
-            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
-            result = fn(a, b, (2, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.broadcast_to(b.shape), result)
-
-            # Expands
-            a = make_arg((1, 5, 1))
-            b = make_arg((3, 5, 7), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 2))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.expand_as(result), result)
-
-            # Unsqueezes
-            a = make_arg((1, 2, 3))
-            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.unsqueeze(2), result)
-
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim_sum(self, device, dtype):
-        def _wrapper(a):
-            a_sum = prims.sum(a, [0, 1])
-            a_bc = prims.broadcast_in_dim(a_sum, [], [])
-            return a_bc
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
-
-    @dtypes(torch.float32)
-    @parametrize("correction", [0, 1])
-    def test_var(self, device, dtype, correction):
-        def _wrapper(a):
-            return prims.var(a, [0, 1], correction=correction)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
-
-    @dtypes(torch.float32)
-    def test_philox_rand(self, device, dtype):
-        sizes = (1000, 1000000)  # offsets of 4 and 8
-        repeats = 2  # Checks multiple rand calls results with multiple philox_rand calls
-        for size in sizes:
-            torch.cuda.manual_seed(123)
-            references = []
-            results = []
-            rng_states = []
-            for _ in range(repeats):
-                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
-                references.append(torch.rand(size, device=device, dtype=dtype))
-
-            torch.cuda.manual_seed(123)
-            for idx in range(repeats):
-                seed, offset = rng_states[idx]
-                result, _ = torch.ops.rngprims.philox_rand((size,),
-                                                           seed=seed,
-                                                           offset=offset,
-                                                           stride=None,
-                                                           device=device,
-                                                           dtype=dtype)
-                results.append(result)
-
-            for a, b in zip(references, results):
-                self.assertEqual(a, b)
-
-
-instantiate_device_type_tests(TestPrimsCuda, globals(), only_for="cuda")
-
 class TestPrimsBasic(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def test_torch_ops(self):
         r = make_tensor((2,), device='cpu', dtype=torch.float)
         self.assertEqual(torch.ops.prims.sin(r), torch.sin(r))
@@ -380,10 +368,10 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             torch._prims_common.check(True, lambda: 'message')
 
 
+instantiate_device_type_tests(TestPrims, globals())
+
 
 class TestRefs(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
     @dtypes(torch.float32)
     def test_constant_pad_nd_memory_format(self, device, dtype):
         # Test memory format is preserved in unambiguous cases
@@ -452,8 +440,6 @@ instantiate_device_type_tests(TestRefs, globals())
 
 
 class TestDecomp(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
     @ops([op for op in op_db if op.supports_varargs], dtypes=OpDTypes.any_one)
     def test_decomposition_method_vararg(self, device, dtype, op):
         # some ops have vararg variants for the methods. this tests it.

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -6,11 +6,16 @@ import unittest
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import (parametrize, run_tests, TestCase, TEST_SCIPY,
-                                                  set_default_dtype)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+    TestCase,
+    TEST_SCIPY,
+    set_default_dtype,
+)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyCUDA,
     dtypes,
     OpDTypes,
 )
@@ -35,75 +40,7 @@ NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
 class TestPrims(TestCase):
-    @onlyCUDA
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim(self, device, dtype):
-        def _wrapper(a, b, broadcast_dimensions):
-            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            # Same shape
-            shape = (5, 5)
-            a = make_arg(shape)
-            b = make_arg(shape, low=0.0, high=0.0)
-            result = fn(a, b, (0, 1))
-
-            self.assertEqual(result.shape, a.shape)
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(a, result)
-
-            # Error input: reordering dims
-            with self.assertRaises(Exception):
-                result = fn(a, b, (1, 0))
-
-            # Adding outermost dimensions
-            a = make_arg((5, 5))
-            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
-            result = fn(a, b, (2, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.broadcast_to(b.shape), result)
-
-            # Expands
-            a = make_arg((1, 5, 1))
-            b = make_arg((3, 5, 7), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 2))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.expand_as(result), result)
-
-            # Unsqueezes
-            a = make_arg((1, 2, 3))
-            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.unsqueeze(2), result)
-
-    @onlyCUDA
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim_sum(self, device, dtype):
-        def _wrapper(a):
-            a_sum = prims.sum(a, [0, 1])
-            a_bc = prims.broadcast_in_dim(a_sum, [], [])
-            return a_bc
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     @dtypes(torch.float64, torch.long)
@@ -154,7 +91,6 @@ class TestPrims(TestCase):
                 with self.assertRaises(AssertionError):
                     fn(t, start, end)
 
-
     def test_aten_overload_to_prims(self, device):
         # This test is to ensure that the torch.ops.aten calls are replaced with refs
         from torch.fx.experimental.proxy_tensor import make_fx
@@ -174,26 +110,6 @@ class TestPrims(TestCase):
             node.target.name().startswith("prims") for node in call_function_nodes
         )
         self.assertTrue(all_prims_namespace)
-
-    @onlyCUDA
-    @dtypes(torch.float32)
-    @parametrize("correction", [0, 1])
-    def test_var(self, device, dtype, correction):
-        def _wrapper(a):
-            return prims.var(a, [0, 1], correction=correction)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
 
     @dtypes(torch.float32)
     def test_memory_format_strides(self, device, dtype):
@@ -271,36 +187,6 @@ class TestPrims(TestCase):
         result_refs = refs.view(a, *new_shape)
         self.assertEqual(result_eager, result_refs)
 
-
-    @onlyCUDA
-    @dtypes(torch.float32)
-    def test_philox_rand(self, device, dtype):
-        sizes = (1000, 1000000)  # offsets of 4 and 8
-        repeats = 2  # Checks multiple rand calls results with multiple philox_rand calls
-        for size in sizes:
-            torch.cuda.manual_seed(123)
-            references = []
-            results = []
-            rng_states = []
-            for _ in range(repeats):
-                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
-                references.append(torch.rand(size, device=device, dtype=dtype))
-
-            torch.cuda.manual_seed(123)
-            for idx in range(repeats):
-                seed, offset = rng_states[idx]
-                result, _ = torch.ops.rngprims.philox_rand((size,),
-                                                           seed=seed,
-                                                           offset=offset,
-                                                           stride=None,
-                                                           device=device,
-                                                           dtype=dtype)
-                results.append(result)
-
-            for a, b in zip(references, results):
-                self.assertEqual(a, b)
-
-
     @dtypes(torch.float32)
     def test_functional_rng_wrappers(self, device, dtype):
 
@@ -332,7 +218,133 @@ class TestPrims(TestCase):
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(result.shape, (1,))
 
+
+instantiate_device_type_tests(TestPrims, globals())
+
+
+class TestPrimsCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim(self, device, dtype):
+        def _wrapper(a, b, broadcast_dimensions):
+            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            # Same shape
+            shape = (5, 5)
+            a = make_arg(shape)
+            b = make_arg(shape, low=0.0, high=0.0)
+            result = fn(a, b, (0, 1))
+
+            self.assertEqual(result.shape, a.shape)
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(a, result)
+
+            # Error input: reordering dims
+            with self.assertRaises(Exception):
+                result = fn(a, b, (1, 0))
+
+            # Adding outermost dimensions
+            a = make_arg((5, 5))
+            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
+            result = fn(a, b, (2, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.broadcast_to(b.shape), result)
+
+            # Expands
+            a = make_arg((1, 5, 1))
+            b = make_arg((3, 5, 7), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 2))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.expand_as(result), result)
+
+            # Unsqueezes
+            a = make_arg((1, 2, 3))
+            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.unsqueeze(2), result)
+
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim_sum(self, device, dtype):
+        def _wrapper(a):
+            a_sum = prims.sum(a, [0, 1])
+            a_bc = prims.broadcast_in_dim(a_sum, [], [])
+            return a_bc
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
+
+    @dtypes(torch.float32)
+    @parametrize("correction", [0, 1])
+    def test_var(self, device, dtype, correction):
+        def _wrapper(a):
+            return prims.var(a, [0, 1], correction=correction)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
+
+    @dtypes(torch.float32)
+    def test_philox_rand(self, device, dtype):
+        sizes = (1000, 1000000)  # offsets of 4 and 8
+        repeats = 2  # Checks multiple rand calls results with multiple philox_rand calls
+        for size in sizes:
+            torch.cuda.manual_seed(123)
+            references = []
+            results = []
+            rng_states = []
+            for _ in range(repeats):
+                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
+                references.append(torch.rand(size, device=device, dtype=dtype))
+
+            torch.cuda.manual_seed(123)
+            for idx in range(repeats):
+                seed, offset = rng_states[idx]
+                result, _ = torch.ops.rngprims.philox_rand((size,),
+                                                           seed=seed,
+                                                           offset=offset,
+                                                           stride=None,
+                                                           device=device,
+                                                           dtype=dtype)
+                results.append(result)
+
+            for a, b in zip(references, results):
+                self.assertEqual(a, b)
+
+
+instantiate_device_type_tests(TestPrimsCuda, globals(), only_for="cuda")
+
 class TestPrimsBasic(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_torch_ops(self):
         r = make_tensor((2,), device='cpu', dtype=torch.float)
         self.assertEqual(torch.ops.prims.sin(r), torch.sin(r))
@@ -368,10 +380,10 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             torch._prims_common.check(True, lambda: 'message')
 
 
-instantiate_device_type_tests(TestPrims, globals())
-
 
 class TestRefs(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @dtypes(torch.float32)
     def test_constant_pad_nd_memory_format(self, device, dtype):
         # Test memory format is preserved in unambiguous cases
@@ -440,6 +452,8 @@ instantiate_device_type_tests(TestRefs, globals())
 
 
 class TestDecomp(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @ops([op for op in op_db if op.supports_varargs], dtypes=OpDTypes.any_one)
     def test_decomposition_method_vararg(self, device, dtype, op):
         # some ops have vararg variants for the methods. this tests it.


### PR DESCRIPTION
## Summary

Label the AOTI arrayref CPU hosts with `hw_classification = HardwareClassification.CPU` so `--hw-classification` filtering does not drop them. Register those hosts through `instantiate_device_type_tests(..., only_for="cpu")` instead of `copy_tests`, so the CPU dimension uses the same entry point as other device-type tests.

## Changes

- `test/inductor/test_aot_inductor_arrayref.py`
  - `AOTInductorTestABICompatibleCpuWithStackAllocation` → `CPU`, `only_for="cpu"`
  - `AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface` → `CPU`, `only_for="cpu"` (still FBcode-only)
  - `TestCppWrapperCpuSelection` → `CPU`, takes `device`, `only_for="cpu"`
  - Replace `copy_tests` with `_attach_aoti_template_tests` so template methods can be instantiated. Drop copied `parametrize_fn` because `AOTInductorTestsTemplate` has already expanded parametrization before this module imports it; keeping that metadata would expand the leaves a second time.
- `test/slow_tests.json`: update the slow-test id to the instantiated name `test_runtime_checks_large_cpu (__main__.AOTInductorTestABICompatibleCpuWithStackAllocationCPU)`.

Discovered names change from `test_*_cpu_with_stack_allocation` on the host class to `test_*_cpu` on the generated `*CPU` class. Failure-map suffixes (`cpu_with_stack_allocation`, ...) are unchanged and still applied at attach time.

Sibling `test/inductor/test_aot_inductor.py` is intentionally unlabeled here.

## Test Plan
```bash
python test/inductor/test_aot_inductor_arrayref.py -v -k TestCppWrapperCpuSelection
python test/inductor/test_aot_inductor_arrayref.py --hw-classification CPU -v -k TestCppWrapperCpuSelection
python test/inductor/test_aot_inductor_arrayref.py --hw-classification GENERIC -v -k TestCppWrapperCpuSelection
```
<img width="884" height="166" alt="image" src="https://github.com/user-attachments/assets/ec829ecf-4636-499c-96f7-52fc15fcb505" />

<img width="885" height="182" alt="image" src="https://github.com/user-attachments/assets/8ca00048-cd50-4616-8b6f-3b938f107bdb" />

<img width="885" height="171" alt="image" src="https://github.com/user-attachments/assets/a5ba7deb-67db-4b8a-a1cc-c29721e3cc44" />


@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo