### PR TITLE
[Testcase Refactoring] Add hw_classification in test_dynamism.py

### DIFF
--- a/test/fx/test_dynamism.py
+++ b/test/fx/test_dynamism.py
@@ -2,10 +2,15 @@
 
 import torch
 from torch.fx.experimental._dynamism import track_dynamism_across_examples
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import (
+    TestCase,
+    HardwareClassification,
+)
 
 
 class TestDynamism(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dynamic_tensor(self):
         ex1 = {"x": 1, "y": torch.ones(1, 1), "z": {0: torch.ones(1)}}
         ex2 = {"x": 2, "y": torch.ones(2, 1), "z": {0: torch.ones(2)}}

--- a/test/fx/test_dynamism.py
+++ b/test/fx/test_dynamism.py
@@ -2,10 +2,7 @@
 
 import torch
 from torch.fx.experimental._dynamism import track_dynamism_across_examples
-from torch.testing._internal.common_utils import (
-    TestCase,
-    HardwareClassification,
-)
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestDynamism(TestCase):


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestDynamism class, enabling hardware-based test classification and filtering.

## Changes
test/fx/test_dynamism.py : import HardwareClassification and add hw_classification to TestDynamism class.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_dynamism.py

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian