### PR TITLE
[Testcase Refactoring] Migrate test_pg_transport.py to capability-based gating

### DIFF
--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -218,12 +218,19 @@ class PgTransportCPU(MultiProcContinuousTest):
         return "gloo"
 
     @classmethod
-    def device_type(cls) -> str:
+    def _device_type_str(cls) -> str:
+        # Do NOT name this `device_type`: `instantiate_device_type_tests` looks
+        # up `cls.device_type` on the generated subclass expecting the plain
+        # string set by its device-specific base (e.g. CPUTestBase). A
+        # same-named classmethod defined directly on this class wins that MRO
+        # lookup instead, crashing with "can only concatenate str (not
+        # 'method')" during collection -- the same conflict `PgTransportGPU`
+        # below already works around.
         return "cpu"
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self.device_type())
+        return torch.device(self._device_type_str())
 
     def test_pg_transport(self, device) -> None:
         _test_pg_transport(self, self.device)

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import (
     init_from_local_shards,
@@ -600,7 +599,7 @@ class TestPGTransportEdgeCases(TestCase):
     # `TEST_CUDA or TEST_HPU or TEST_XPU` and so does not recognise PrivateUse1.
     # No capability is declared in its place: the test mocks the process group
     # outright, so what it needs is an accelerator device to exist, not a working
-    # distributed backend. `instantiate_device_type_tests(..., except_for="cpu")`
+    # distributed backend. `instantiate_device_type_tests(..., except_for="cpu", allow_xpu=True)`
     # below already guarantees that, generating this test only for accelerator
     # device classes.
     @unittest.skipIf(not TEST_ACCELERATOR, "No accelerator")
@@ -630,9 +629,13 @@ class TestPGTransportEdgeCases(TestCase):
 
 
 instantiate_device_type_tests(PgTransportCPU, globals(), only_for="cpu")
-instantiate_device_type_tests(PgTransportGPU, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    PgTransportGPU, globals(), except_for="cpu", allow_xpu=True
+)
 instantiate_device_type_tests(TestPrepareStateDict, globals(), only_for="cpu")
 instantiate_device_type_tests(TestPGTransportMocked, globals(), only_for="cpu")
-instantiate_device_type_tests(TestPGTransportEdgeCases, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestPGTransportEdgeCases, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -645,7 +645,7 @@ class TestPGTransportEdgeCases(TestCase):
     @unittest.skipIf(not TEST_ACCELERATOR, "No accelerator")
     def test_send_checkpoint_with_cpu_tensors(self, device):
         """Test send_checkpoint with CPU tensors when device is accelerator."""
-        device = torch.device(f"{device_type}:0")
+        device = torch.device(device)
 
         # Create a state dict with CPU tensors
         state_dict = {

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -29,7 +29,9 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     requires_capabilities,
 )
-from torch.testing._internal.common_distributed import MultiProcContinuousTest
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousForInstantiateTest,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -39,8 +41,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 logger = logging.getLogger(__name__)
 
@@ -207,68 +207,30 @@ def _test_pg_transport_with_sharded_tensor(self, device) -> None:
     torch.testing.assert_close(expected_local_tensor, received_local_tensor)
 
 
-class PgTransportCPU(MultiProcContinuousTest):
+class PgTransportCPU(MultiProcContinuousForInstantiateTest):
     hw_classification = HardwareClassification.CPU
 
     world_size = 8
     timeout: timedelta = timedelta(seconds=20)
 
-    @classmethod
-    def backend_str(cls) -> str | None:
-        return "gloo"
-
-    @classmethod
-    def _device_type_str(cls) -> str:
-        # Do NOT name this `device_type`: `instantiate_device_type_tests` looks
-        # up `cls.device_type` on the generated subclass expecting the plain
-        # string set by its device-specific base (e.g. CPUTestBase). A
-        # same-named classmethod defined directly on this class wins that MRO
-        # lookup instead, crashing with "can only concatenate str (not
-        # 'method')" during collection -- the same conflict `PgTransportGPU`
-        # below already works around.
-        return "cpu"
-
-    @property
-    def device(self) -> torch.device:
-        return torch.device(self._device_type_str())
-
     def test_pg_transport(self, device) -> None:
-        _test_pg_transport(self, self.device)
+        _test_pg_transport(self, device)
 
     def test_pg_transport_with_mixed_content(self, device) -> None:
-        _test_pg_transport_with_mixed_content(self, self.device)
+        _test_pg_transport_with_mixed_content(self, torch.device(device))
 
     def test_pg_transport_with_sharded_tensor(self, device) -> None:
-        _test_pg_transport_with_sharded_tensor(self, self.device)
+        _test_pg_transport_with_sharded_tensor(self, torch.device(device))
 
 
 @skip_but_pass_in_sandcastle_if(
     not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
 )
-class PgTransportGPU(MultiProcContinuousTest):
+class PgTransportGPU(MultiProcContinuousForInstantiateTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
     world_size = 2
     timeout: timedelta = timedelta(seconds=20)
-
-    @classmethod
-    def _device_type_str(cls) -> str:
-        # `MultiProcContinuousTest` defines `device_type` as a classmethod, but in
-        # the class `instantiate_device_type_tests` generates, `PrivateUse1TestBase`
-        # sits earlier in the MRO and shadows it with a string class attribute.
-        # Accept either form; calling the string would raise
-        # "'str' object is not callable". `MultiProcContinuousTest`
-        # `._ensure_processes_spawned` makes the same accommodation.
-        device_type_attr = cls.device_type
-        return device_type_attr() if callable(device_type_attr) else device_type_attr
-
-    @classmethod
-    def backend_str(cls) -> str | None:
-        return dist.get_default_backend_for_device(cls._device_type_str())
-
-    @property
-    def device(self) -> torch.device:
-        return torch.device(f"{self._device_type_str()}:{self.rank}")
 
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
@@ -277,7 +239,7 @@ class PgTransportGPU(MultiProcContinuousTest):
         Capability.distributed.backend,
     )
     def test_pg_transport(self, device) -> None:
-        _test_pg_transport(self, self.device)
+        _test_pg_transport(self, self.current_device)
 
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
@@ -286,7 +248,7 @@ class PgTransportGPU(MultiProcContinuousTest):
         Capability.distributed.backend,
     )
     def test_pg_transport_with_mixed_content(self, device) -> None:
-        _test_pg_transport_with_mixed_content(self, self.device)
+        _test_pg_transport_with_mixed_content(self, self.current_device)
 
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
@@ -295,7 +257,7 @@ class PgTransportGPU(MultiProcContinuousTest):
         Capability.distributed.backend,
     )
     def test_pg_transport_with_sharded_tensor(self, device) -> None:
-        _test_pg_transport_with_sharded_tensor(self, self.device)
+        _test_pg_transport_with_sharded_tensor(self, self.current_device)
 
 
 class TestCastTensor(TestCase):

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -225,13 +225,13 @@ class PgTransportCPU(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(self.device_type())
 
-    def test_pg_transport(self) -> None:
+    def test_pg_transport(self, device) -> None:
         _test_pg_transport(self, self.device)
 
-    def test_pg_transport_with_mixed_content(self) -> None:
+    def test_pg_transport_with_mixed_content(self, device) -> None:
         _test_pg_transport_with_mixed_content(self, self.device)
 
-    def test_pg_transport_with_sharded_tensor(self) -> None:
+    def test_pg_transport_with_sharded_tensor(self, device) -> None:
         _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
@@ -392,7 +392,7 @@ class TestPrepareStateDict(TestCase):
     # by construction. GENERIC is for logic that references no device at all.
     hw_classification = HardwareClassification.CPU
 
-    def test_prepare_state_dict_basic(self):
+    def test_prepare_state_dict_basic(self, device):
         """Test basic state dict preparation."""
         state_dict = {"weight": torch.randn(3, 4), "bias": torch.randn(4)}
         device = torch.device("cpu")
@@ -408,7 +408,7 @@ class TestPrepareStateDict(TestCase):
         for leaf in meta.non_tensor_leaves:
             self.assertIsInstance(leaf, _TensorMeta)
 
-    def test_prepare_state_dict_nested(self):
+    def test_prepare_state_dict_nested(self, device):
         """Test preparing nested state dict."""
         state_dict = {
             "layer1": {"weight": torch.randn(3, 4), "bias": torch.randn(4)},
@@ -423,7 +423,7 @@ class TestPrepareStateDict(TestCase):
         self.assertEqual(len(meta.non_tensor_leaves), 4)
         self.assertEqual(len(tensors), 4)
 
-    def test_prepare_state_dict_with_non_tensor_values(self):
+    def test_prepare_state_dict_with_non_tensor_values(self, device):
         """Test preparing state dict with non-tensor values."""
         state_dict = {
             "weight": torch.randn(3, 4),
@@ -467,7 +467,7 @@ class TestPGTransportMocked(TestCase):
         self.pg.send = MagicMock(return_value=self.mock_work)
         self.pg.recv = MagicMock(return_value=self.mock_work)
 
-    def test_send_checkpoint_basic(self):
+    def test_send_checkpoint_basic(self, device):
         """Test basic send_checkpoint functionality with mocked process group."""
         transport = PGTransport(self.pg, self.timeout, self.device)
         state_dict = {"weight": torch.randn(3, 4), "bias": torch.randn(4)}
@@ -483,7 +483,7 @@ class TestPGTransportMocked(TestCase):
         # Check that wait was called on all work objects
         self.assertEqual(self.mock_work.wait.call_count, expected_calls)
 
-    def test_recv_checkpoint_basic(self):
+    def test_recv_checkpoint_basic(self, device):
         """Test basic recv_checkpoint functionality with mocked process group."""
         # Setup mock for pickle.loads to return a valid _StateDictMeta
         with patch("pickle.loads") as mock_loads:
@@ -532,7 +532,7 @@ class TestPGTransportMocked(TestCase):
             # Check that wait was called
             self.assertGreaterEqual(self.mock_work.wait.call_count, 2)
 
-    def test_send_checkpoint_empty_state_dict(self):
+    def test_send_checkpoint_empty_state_dict(self, device):
         """Test send_checkpoint with empty state dict."""
         transport = PGTransport(self.pg, self.timeout, self.device)
         state_dict = {}
@@ -546,7 +546,7 @@ class TestPGTransportMocked(TestCase):
         # Check that wait was called
         self.assertEqual(self.mock_work.wait.call_count, 2)
 
-    def test_send_checkpoint_with_non_tensor_values(self):
+    def test_send_checkpoint_with_non_tensor_values(self, device):
         """Test send_checkpoint with non-tensor values in state dict."""
         transport = PGTransport(self.pg, self.timeout, self.device)
         state_dict = {"weight": torch.randn(3, 4), "config": {"lr": 0.01}}
@@ -560,7 +560,7 @@ class TestPGTransportMocked(TestCase):
         # Check that wait was called
         self.assertEqual(self.mock_work.wait.call_count, 3)
 
-    def test_recv_checkpoint_with_state_dict_callback(self):
+    def test_recv_checkpoint_with_state_dict_callback(self, device):
         """Test recv_checkpoint with state_dict callback."""
         # Setup mock for pickle.loads to return a valid _StateDictMeta
         with patch("pickle.loads") as mock_loads:
@@ -636,7 +636,7 @@ class TestPGTransportEdgeCases(TestCase):
     # below already guarantees that, generating this test only for accelerator
     # device classes.
     @unittest.skipIf(not TEST_ACCELERATOR, "No accelerator")
-    def test_send_checkpoint_with_cpu_tensors(self):
+    def test_send_checkpoint_with_cpu_tensors(self, device):
         """Test send_checkpoint with CPU tensors when device is accelerator."""
         device = torch.device(f"{device_type}:0")
 
@@ -661,7 +661,10 @@ class TestPGTransportEdgeCases(TestCase):
         self.assertGreaterEqual(self.mock_work.wait.call_count, 4)
 
 
+instantiate_device_type_tests(PgTransportCPU, globals(), only_for="cpu")
 instantiate_device_type_tests(PgTransportGPU, globals(), except_for="cpu")
+instantiate_device_type_tests(TestPrepareStateDict, globals(), only_for="cpu")
+instantiate_device_type_tests(TestPGTransportMocked, globals(), only_for="cpu")
 instantiate_device_type_tests(TestPGTransportEdgeCases, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -655,11 +655,7 @@ class TestPGTransportEdgeCases(TestCase):
         self.assertGreaterEqual(self.mock_work.wait.call_count, 4)
 
 
-instantiate_device_type_tests(
-    PgTransportGPU, globals(), except_for="cpu", allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestPGTransportEdgeCases, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(PgTransportGPU, globals(), except_for="cpu")
+instantiate_device_type_tests(TestPGTransportEdgeCases, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -387,7 +387,10 @@ class TestPrepareTensor(TestCase):
 
 
 class TestPrepareStateDict(TestCase):
-    hw_classification = HardwareClassification.GENERIC
+    # Every case builds its target device as torch.device("cpu") rather than
+    # deriving it from whatever accelerator is present, so this is tied to CPU
+    # by construction. GENERIC is for logic that references no device at all.
+    hw_classification = HardwareClassification.CPU
 
     def test_prepare_state_dict_basic(self):
         """Test basic state dict preparation."""
@@ -445,7 +448,10 @@ class TestPrepareStateDict(TestCase):
 
 
 class TestPGTransportMocked(TestCase):
-    hw_classification = HardwareClassification.GENERIC
+    # `setUp` pins the transport to torch.device("cpu"); the process group is
+    # mocked, so nothing here adapts to the accelerator that happens to be
+    # present. That is CPU, not GENERIC.
+    hw_classification = HardwareClassification.CPU
 
     def setUp(self):
         super().setUp()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
-import logging
 import unittest
+import logging
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -24,15 +24,18 @@ from torch.distributed.checkpoint._pg_transport import (
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.tensor import DTensor
-from torch.testing._internal.common_distributed import (
-    at_least_x_gpu,
-    HAS_ACCELERATOR,
-    MultiProcContinuousTest,
-    requires_accelerator_dist_backend,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
+from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_ACCELERATOR,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 
@@ -205,6 +208,8 @@ def _test_pg_transport_with_sharded_tensor(self, device) -> None:
 
 
 class PgTransportCPU(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CPU
+
     world_size = 8
     timeout: timedelta = timedelta(seconds=20)
 
@@ -230,42 +235,65 @@ class PgTransportCPU(MultiProcContinuousTest):
         _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
-@skip_but_pass_in_sandcastle_if(not at_least_x_gpu(2), "test requires 2+ accelerators")
+@skip_but_pass_in_sandcastle_if(
+    not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
+)
 class PgTransportGPU(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     world_size = 2
     timeout: timedelta = timedelta(seconds=20)
 
     @classmethod
+    def _device_type_str(cls) -> str:
+        # `MultiProcContinuousTest` defines `device_type` as a classmethod, but in
+        # the class `instantiate_device_type_tests` generates, `PrivateUse1TestBase`
+        # sits earlier in the MRO and shadows it with a string class attribute.
+        # Accept either form; calling the string would raise
+        # "'str' object is not callable". `MultiProcContinuousTest`
+        # `._ensure_processes_spawned` makes the same accommodation.
+        device_type_attr = cls.device_type
+        return device_type_attr() if callable(device_type_attr) else device_type_attr
+
+    @classmethod
     def backend_str(cls) -> str | None:
-        return dist.get_default_backend_for_device(cls.device_type())
+        return dist.get_default_backend_for_device(cls._device_type_str())
 
     @property
     def device(self) -> torch.device:
-        return torch.device(f"{self.device_type()}:{self.rank}")
+        return torch.device(f"{self._device_type_str()}:{self.rank}")
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
-        not at_least_x_gpu(2), "test requires 2+ accelerators"
+        not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
     )
-    def test_pg_transport(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_pg_transport(self, device) -> None:
         _test_pg_transport(self, self.device)
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
-        not at_least_x_gpu(2), "test requires 2+ accelerators"
+        not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
     )
-    def test_pg_transport_with_mixed_content(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_pg_transport_with_mixed_content(self, device) -> None:
         _test_pg_transport_with_mixed_content(self, self.device)
 
-    @requires_accelerator_dist_backend()
     @skip_but_pass_in_sandcastle_if(
-        not at_least_x_gpu(2), "test requires 2+ accelerators"
+        not TEST_MULTIACCELERATOR, "test requires 2+ accelerators"
     )
-    def test_pg_transport_with_sharded_tensor(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_pg_transport_with_sharded_tensor(self, device) -> None:
         _test_pg_transport_with_sharded_tensor(self, self.device)
 
 
 class TestCastTensor(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_cast_tensor_different_dtypes(self):
         """Test casting tensors of different dtypes."""
         dtypes = [torch.float32, torch.float64, torch.int32, torch.int64, torch.bool]
@@ -310,6 +338,8 @@ class TestCastTensor(TestCase):
 
 
 class TestPrepareTensor(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_prepare_tensor_basic(self):
         """Test basic tensor preparation."""
         tensor = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
@@ -357,6 +387,8 @@ class TestPrepareTensor(TestCase):
 
 
 class TestPrepareStateDict(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_prepare_state_dict_basic(self):
         """Test basic state dict preparation."""
         state_dict = {"weight": torch.randn(3, 4), "bias": torch.randn(4)}
@@ -413,6 +445,8 @@ class TestPrepareStateDict(TestCase):
 
 
 class TestPGTransportMocked(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.device = torch.device("cpu")
@@ -572,6 +606,8 @@ class TestPGTransportMocked(TestCase):
 
 
 class TestPGTransportEdgeCases(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         self.device = torch.device("cpu")
@@ -586,7 +622,14 @@ class TestPGTransportEdgeCases(TestCase):
         self.pg.send = MagicMock(return_value=self.mock_work)
         self.pg.recv = MagicMock(return_value=self.mock_work)
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    # This was gated on `HAS_ACCELERATOR`, which is
+    # `TEST_CUDA or TEST_HPU or TEST_XPU` and so does not recognise PrivateUse1.
+    # No capability is declared in its place: the test mocks the process group
+    # outright, so what it needs is an accelerator device to exist, not a working
+    # distributed backend. `instantiate_device_type_tests(..., except_for="cpu")`
+    # below already guarantees that, generating this test only for accelerator
+    # device classes.
+    @unittest.skipIf(not TEST_ACCELERATOR, "No accelerator")
     def test_send_checkpoint_with_cpu_tensors(self):
         """Test send_checkpoint with CPU tensors when device is accelerator."""
         device = torch.device(f"{device_type}:0")
@@ -612,5 +655,11 @@ class TestPGTransportEdgeCases(TestCase):
         self.assertGreaterEqual(self.mock_work.wait.call_count, 4)
 
 
+instantiate_device_type_tests(
+    PgTransportGPU, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestPGTransportEdgeCases, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
-import unittest
 import logging
+import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 

--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -623,7 +623,6 @@ class TestPGTransportEdgeCases(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.device = torch.device("cpu")
         self.pg = MagicMock()
         self.timeout = timedelta(seconds=10)
 


### PR DESCRIPTION
## Summary

Makes the PG transport tests device-instantiable, replaces CUDA/HPU/XPU-only
predicates with accelerator predicates, and reuses the common continuous-test
base introduced by #195000.

## Changes

- `PgTransportCPU` and `PgTransportGPU` inherit
  `MultiProcContinuousForInstantiateTest`;
- both classes reuse the common `backend_str()` and `current_device` behavior;
- the local `PgTransportBase`, `_device_type_str`, `backend_str`, and duplicate
  device properties are removed;
- the class/method device-count predicates use `TEST_MULTIACCELERATOR`;
- the accelerator transport tests declare
  `Capability.distributed.backend` where the original code already had the
  matching accelerator-backend gate;
- CPU-bound and device-free test classes receive their corresponding
  `CPU`/`GENERIC` classifications.

## Test Plan

The previous head passed 21 NPU tests. The current head will be revalidated
after stacking #195000; until that common PR is available on the target branch,
this PR intentionally cannot import the new base class by itself.

## Dependencies

- #191919 provides `Capability.distributed`;
- #195000 provides `MultiProcContinuousForInstantiateTest`.

Part of #185590.