### PR TITLE
[inductor] Allow disabling mkldnn fusion passes on cpu/xpu

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -331,6 +331,41 @@ class TestPatternMatcherGeneric(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
+    def test_mkldnn_fusion_pass_config_disables_fusion_only(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, kernel_size=3, stride=1)
+
+            def forward(self, x):
+                return torch.relu(self.conv(x))
+
+        v = torch.randn((1, 3, 56, 56), dtype=torch.float32).add(1)
+
+        def default_matcher_check_fn():
+            self.assertEqual(
+                counters["inductor"]["mkldnn_unary_fusion_matcher_count"],
+                0 if TEST_ACL else 1,
+            )
+            self.assertEqual(
+                counters["inductor"]["mkldnn_conv_weight_pack_matcher_count"], 1
+            )
+
+        self._test_common(M().eval(), (v,), default_matcher_check_fn)
+
+        def disabled_matcher_check_fn():
+            self.assertEqual(
+                counters["inductor"]["mkldnn_unary_fusion_matcher_count"], 0
+            )
+            self.assertEqual(
+                counters["inductor"]["mkldnn_conv_weight_pack_matcher_count"], 1
+            )
+
+        with config.patch({"mkldnn.enable_fusion_passes": False}):
+            self._test_common(M().eval(), (v,), disabled_matcher_check_fn)
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
     @reduced_f32_on_and_off()
     def test_conv3d_unary(self, device):
         self.device = device

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1166,6 +1166,16 @@ disabled_passes: str = Config(
 )
 
 
+class mkldnn:
+    # Controls MKLDNN/oneDNN graph rewrite patterns in the post-grad fusion pass.
+    # This does not affect eager-mode torch.backends.mkldnn behavior. Future
+    # MKLDNN rewrite pattern knobs shared by CPU and XPU should live here.
+    enable_fusion_passes = Config(
+        env_name_force="TORCHINDUCTOR_MKLDNN_ENABLE_FUSION_PASSES",
+        default=True,
+    )
+
+
 # The multiprocessing start method to use for inductor workers in the codecache.
 def decide_worker_start_method() -> str:
     if "TORCHINDUCTOR_WORKER_START" in os.environ:

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -9,7 +9,7 @@ from torch._dynamo.utils import counters
 from torch.fx.experimental.symbolic_shapes import has_free_symbols, optimization_hint
 from torch.utils._ordered_set import OrderedSet
 
-from .. import ir, mkldnn_ir
+from .. import config, ir, mkldnn_ir
 from ..lowering import lowerings as L
 from ..pattern_matcher import (
     Arg,
@@ -463,12 +463,20 @@ if torch._C._has_mkldnn:
 
         return fn
 
+    def _mkldnn_fusion_pass_enabled(extra_check):
+        def fn(match):
+            return config.mkldnn.enable_fusion_passes and extra_check(match)
+
+        return fn
+
     def _register_unary_fusion_lowering(
         pattern, unary_attr, computation_op, lowp_dtype=None
     ):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_valid_computation_unary_fusion(computation_op, lowp_dtype),
+            extra_check=_mkldnn_fusion_pass_enabled(
+                _is_valid_computation_unary_fusion(computation_op, lowp_dtype)
+            ),
             output_metadata_ignores_input_storage=True,
         )
         def fn(match, *args, **kwargs):
@@ -488,7 +496,9 @@ if torch._C._has_mkldnn:
     def _register_leaky_relu_fusion_lowering(pattern, computation_op, lowp_dtype=None):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_single_computation_op(computation_op, lowp_dtype),
+            extra_check=_mkldnn_fusion_pass_enabled(
+                _is_single_computation_op(computation_op, lowp_dtype)
+            ),
             output_metadata_ignores_input_storage=True,
         )
         def fn(match, *args, **kwargs):
@@ -536,7 +546,9 @@ if torch._C._has_mkldnn:
     def _register_hardtanh_fusion_lowering(pattern, computation_op, lowp_dtype=None):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_single_computation_op(computation_op, lowp_dtype),
+            extra_check=_mkldnn_fusion_pass_enabled(
+                _is_single_computation_op(computation_op, lowp_dtype)
+            ),
             output_metadata_ignores_input_storage=True,
         )
         def fn(match, *args, **kwargs):
@@ -766,7 +778,9 @@ if torch._C._has_mkldnn:
     ):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_valid_computation_binary(computation_op, binary_op),
+            extra_check=_mkldnn_fusion_pass_enabled(
+                _is_valid_computation_binary(computation_op, binary_op)
+            ),
             output_metadata_ignores_input_storage=True,
         )
         def fn(match, *args, **kwargs):
@@ -846,8 +860,10 @@ if torch._C._has_mkldnn:
     ):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_valid_computation_binary_inplace(
-                computation_op, binary_op, other_index
+            extra_check=_mkldnn_fusion_pass_enabled(
+                _is_valid_computation_binary_inplace(
+                    computation_op, binary_op, other_index
+                )
             ),
             output_metadata_ignores_input_storage=True,
         )


### PR DESCRIPTION
Currently for all cpu inductor backends mkldnn fusion passes are always applied. This PR introduces a config option that allows the user to disable these fusion passes. Additionally, there are different types of fx passes that can be applied for mkldnn:
- register_woq_lowerings
- register_quantization_lowerings
- weight prepacking (controlled by cpp.weight_prepack)

`cpp.weight_prepack` is also used for the xpu backend, despite the `cpp` config class being primarily for the CPU C++ backend. Ideally this `weight_prepack` option should be placed under the new `mkldnn` config class, together with any future mkldnn patterns, but it is kept there to preserve BC.

Added a unit test to ensure that the current default behaviour of enabling mkldnn fusion patterns is preserved.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo