### PR TITLE
[Test] Move device-dependent tests in test_stateless.py to a device-generic class

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,6 +9,7 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -16,12 +17,6 @@ from torch.testing._internal.common_utils import (
     subtest,
     TestCase,
     TEST_MULTIACCELERATOR,
-)
-
-device_type = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
 )
 
 
@@ -48,37 +43,37 @@ class MockTiedModule(torch.nn.Module):
         return self.l1(x) + self.tied_bias + self.buffer + self.tied_buffer
 
 
+def _run_call_with_mock_module(test, module, functional_call, device='cpu', prefix=''):
+    x = torch.rand((1, 1), device=device)
+    weight = torch.tensor([[1.0]], device=device)
+    bias = torch.tensor([0.0], device=device)
+    buffer = torch.tensor([0.0], device=device)
+    if prefix != '':
+        parameters = {f'{prefix}.l1.weight': weight,
+                      f'{prefix}.l1.bias': bias,
+                      f'{prefix}.buffer': buffer}
+    else:
+        parameters = {'l1.weight': weight,
+                      'l1.bias': bias,
+                      'buffer': buffer}
+    to_check = module
+    if prefix != '':
+        to_check = getattr(module, prefix)
+    prev_weight = to_check.l1.weight.clone()
+    prev_buffer = to_check.buffer.clone()
+    # the parameters represent an identity function contrary to the
+    # existing params in module. So here we expect the result to be the
+    # same as the input if the weight swapping went well.
+    res = functional_call(module, parameters, x)
+    test.assertEqual(x, res)
+    # check that the weight remain unmodified
+    cur_weight = to_check.l1.weight
+    cur_buffer = to_check.buffer
+    test.assertEqual(cur_weight, prev_weight)
+    test.assertEqual(cur_buffer, prev_buffer)
+
+
 class TestStatelessFunctionalAPI(TestCase):
-    def _run_call_with_mock_module(self, module, functional_call, device='cpu', prefix=''):
-
-        x = torch.rand((1, 1)).to(device)
-        weight = torch.tensor([[1.0]], device=device)
-        bias = torch.tensor([0.0], device=device)
-        buffer = torch.tensor([0.0], device=device)
-        if prefix != '':
-            parameters = {f'{prefix}.l1.weight': weight,
-                          f'{prefix}.l1.bias': bias,
-                          f'{prefix}.buffer': buffer}
-        else:
-            parameters = {'l1.weight': weight,
-                          'l1.bias': bias,
-                          'buffer': buffer}
-        to_check = module
-        if prefix != '':
-            to_check = getattr(module, prefix)
-        prev_weight = to_check.l1.weight.clone()
-        prev_buffer = to_check.buffer.clone()
-        # the parameters represent an identity function contrary to the
-        # existing params in module. So here we expect the result to be the
-        # same as the input if the weight swapping went well.
-        res = functional_call(module, parameters, x)
-        self.assertEqual(x, res)
-        # check that the weight remain unmodified
-        cur_weight = to_check.l1.weight
-        cur_buffer = to_check.buffer
-        self.assertEqual(cur_weight, prev_weight)
-        self.assertEqual(cur_buffer, prev_buffer)
-
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
         orig_parameters, orig_buffers = tuple(module.parameters()), tuple(module.buffers())
@@ -108,7 +103,7 @@ class TestStatelessFunctionalAPI(TestCase):
     ])
     def test_functional_call(self, functional_call):
         module = MockModule()
-        self._run_call_with_mock_module(module, functional_call)
+        _run_call_with_mock_module(self, module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -121,41 +116,14 @@ class TestStatelessFunctionalAPI(TestCase):
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(jit_module, functional_call)
+            _run_call_with_mock_module(self, jit_module, functional_call)
         x = torch.rand((1, 1))
         traced_module = torch.jit.trace(module, x)
         with self.assertRaisesRegex(
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(traced_module, functional_call)
-
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
-    @unittest.skip("This doesn't work right now")
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_call_with_data_parallel(self, functional_call):
-        module = MockModule()
-        module.to(device_type)
-        dp_module = torch.nn.DataParallel(module, [0, 1])
-        self._run_call_with_mock_module(dp_module, functional_call, device=device_type, prefix='module')
-
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_call_with_data_parallel_error(self, functional_call):
-        module = MockModule()
-        module.to(device_type)
-        dp_module = torch.nn.DataParallel(module, [0, 1])
-        with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
-            functional_call(
-                dp_module,
-                {'module.weight': torch.zeros(5, device=device_type)},
-                (torch.ones(2, 5, device=device_type),))
+            _run_call_with_mock_module(self, traced_module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -886,6 +854,33 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertTrue(all(t1 is t2 for t1, t2 in zip(buffers, (module.buffer,))))
 
 
+class TestStatelessFunctionalAPIDevice(TestCase):
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @unittest.skip("This doesn't work right now")
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_call_with_data_parallel(self, device, functional_call):
+        module = MockModule().to(device)
+        dp_module = torch.nn.DataParallel(module, [0, 1])
+        _run_call_with_mock_module(self, dp_module, functional_call, device=device, prefix='module')
+
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_call_with_data_parallel_error(self, device, functional_call):
+        module = MockModule().to(device)
+        dp_module = torch.nn.DataParallel(module, [0, 1])
+        with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
+            functional_call(
+                dp_module,
+                {'module.weight': torch.zeros(5, device=device)},
+                (torch.ones(2, 5, device=device),))
+
+
 class TestStatelessDeprecation(TestCase):
     def test_private_stateless_warns(self):
         script = """
@@ -933,6 +928,7 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
+instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals())
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,7 +9,10 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -866,7 +869,8 @@ class TestStatelessFunctionalAPIDevice(TestCase):
         dp_module = torch.nn.DataParallel(module, [0, 1])
         _run_call_with_mock_module(self, dp_module, functional_call, device=device, prefix='module')
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @onlyAccelerator
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multiple accelerator devices not available')
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
@@ -928,7 +932,7 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
-instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals())
+instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals(), allow_xpu=True)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -77,6 +78,8 @@ def _run_call_with_mock_module(test, module, functional_call, device='cpu', pref
 
 
 class TestStatelessFunctionalAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
         orig_parameters, orig_buffers = tuple(module.parameters()), tuple(module.buffers())
@@ -858,6 +861,8 @@ class TestStatelessFunctionalAPI(TestCase):
 
 
 class TestStatelessFunctionalAPIDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
     @unittest.skip("This doesn't work right now")
     @parametrize("functional_call", [
@@ -886,6 +891,8 @@ class TestStatelessFunctionalAPIDevice(TestCase):
 
 
 class TestStatelessDeprecation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_private_stateless_warns(self):
         script = """
 import torch
@@ -916,6 +923,8 @@ exit(len(w))
             stateless.functional_call(m, params, x)
 
 class TestPythonOptimizeMode(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_runs_with_optimize_flag(self):
         script = "import torch; import torch._functorch.deprecated"
         try:


### PR DESCRIPTION
### Summary

Prepares `test/test_stateless.py` for accelerator coverage and adds hardware classification. Nothing in this file previously exercised an accelerator: the only device-aware tests were the two DataParallel ones, which read a module-level `device_type` global.

Three commits, in review order:

1. **Refactor** – move `test_functional_call_with_data_parallel` and `test_functional_call_with_data_parallel_error` into a new `TestStatelessFunctionalAPIDevice` instantiated via `instantiate_device_type_tests`, taking `device` instead of the global; drop the now-unused `device_type`; make `_run_call_with_mock_module` a module-level helper shared by both classes. Pure move, no behavior change.
2. **Enable XPU** – `allow_xpu=True` on the `instantiate_device_type_tests` call, plus `@onlyAccelerator` and a reworded skip message on `test_functional_call_with_data_parallel_error`.
3. **Classify** – `hw_classification` on all four classes. `TestStatelessFunctionalAPIDevice` is `ACCELERATOR`; the other three are `GENERIC`, since none tests device-specific behavior.

The remaining tests in `TestStatelessFunctionalAPI` allocate on CPU only and were never device-parameterized, so they stay put.

Part of #142029.

### Test plan
```
  python test/test_stateless.py -v
  python test/test_stateless.py --hw-classification ACCELERATOR
  python test/test_stateless.py --hw-classification GENERIC
```

On a single-XPU machine:
Before: 50 tests / 4 skipped
After: 54 tests / 8 skipped

The +4 are the XPU variants of the DataParallel tests. Classification partitions the file exactly: 8 ACCELERATOR + 46 GENERIC = 54, with no class classified CPU.

Note that all 8 ACCELERATOR tests skip on a single-device host -- `test_functional_call_with_data_parallel` is permanently disabled by a pre-existing `@unittest.skip`, and `..._error` needs a second device. So this stack adds no executing XPU coverage on one device; it is the plumbing that lets these tests run on a multi-XPU host.