### PR TITLE
[TEST] Refactor test_complex.py with hw_classification

### DIFF
--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -8,13 +8,17 @@ from torch.testing._internal.common_device_type import (
     onlyCPU,
 )
 from torch.testing._internal.common_dtype import complex_types
-from torch.testing._internal.common_utils import run_tests, set_default_dtype, TestCase
-
-
-devices = (torch.device("cpu"), torch.device("cuda:0"))
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    set_default_dtype,
+    TestCase,
+)
 
 
 class TestComplexTensor(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @dtypes(*complex_types())
     def test_to_list(self, device, dtype):
         # test that the complex float tensor has expected values and


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestComplexTensor`: `ACCELERATOR` (device op numerics via `instantiate_device_type_tests`)
- Keep `@onlyCPU` on `test_eq`/`test_ne` (historical filter; not a GENERIC class)
- Remove unused hardcoded `devices` tuple

## Test Plan
```
python test/test_complex.py -v
# Ran 30 tests — OK (skipped=4)

python test/test_complex.py --hw-classification ACCELERATOR -v
# HW classification: total=30, passed=30, unclassified=0, mismatched=0
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508