### PR TITLE
[Testcase Refactoring] Add hw_classification in test_shape_inference.py

### DIFF
--- a/test/fx/test_shape_inference.py
+++ b/test/fx/test_shape_inference.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: fx"]
 
 import copy
-import unittest
 from collections import defaultdict
 
 import torch
@@ -12,10 +11,10 @@ from torch.fx.experimental.shape_inference.infer_symbol_values import (
     infer_symbol_values,
 )
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
-from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
-class TestShapeInference(unittest.TestCase):
+class TestShapeInference(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_infer_symbol_values(self):

--- a/test/fx/test_shape_inference.py
+++ b/test/fx/test_shape_inference.py
@@ -12,9 +12,12 @@ from torch.fx.experimental.shape_inference.infer_symbol_values import (
     infer_symbol_values,
 )
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestShapeInference(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_infer_symbol_values(self):
         def mksym(shape_env, value, source, dynamic_dim) -> None:
             return shape_env.create_symintnode(


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestShapeInference class, enabling hardware-based test classification and filtering.

## Changes
test/fx/test_shape_inference.py : import HardwareClassification and add hw_classification to TestShapeInference class.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_shape_inference.py

## Notes
This is part of the test case refactoring initiative tracked in [#185590](https://github.com/pytorch/pytorch/issues/185590).

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian