### PR TITLE
[MPS] Enable mpp conv3d for no bias terms

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -712,25 +712,32 @@ kernel void conv3d_mpp(
       GNAME,                          \
       GROUPED)
 
-#define INSTANTIATE_CONV3D_MPP_STANDARD(KD, KH, KW, SZ, SY, SX, CNAME, SRCC) \
-  INSTANTIATE_CONV3D_MPP_TILES(                                              \
-      KD,                                                                    \
-      KH,                                                                    \
-      KW,                                                                    \
-      SZ,                                                                    \
-      SY,                                                                    \
-      SX,                                                                    \
-      1,                                                                     \
-      1,                                                                     \
-      1,                                                                     \
-      CNAME,                                                                 \
-      SRCC,                                                                  \
-      bias,                                                                  \
-      true,                                                                  \
-      ncdhw,                                                                 \
-      true,                                                                  \
-      ungrouped,                                                             \
+#define INSTANTIATE_CONV3D_MPP_STANDARD_VARIANT(          \
+    KD, KH, KW, SZ, SY, SX, CNAME, SRCC, BNAME, HAS_BIAS) \
+  INSTANTIATE_CONV3D_MPP_TILES(                           \
+      KD,                                                 \
+      KH,                                                 \
+      KW,                                                 \
+      SZ,                                                 \
+      SY,                                                 \
+      SX,                                                 \
+      1,                                                  \
+      1,                                                  \
+      1,                                                  \
+      CNAME,                                              \
+      SRCC,                                               \
+      BNAME,                                              \
+      HAS_BIAS,                                           \
+      ncdhw,                                              \
+      true,                                               \
+      ungrouped,                                          \
       false)
+
+#define INSTANTIATE_CONV3D_MPP_STANDARD(KD, KH, KW, SZ, SY, SX, CNAME, SRCC) \
+  INSTANTIATE_CONV3D_MPP_STANDARD_VARIANT(                                   \
+      KD, KH, KW, SZ, SY, SX, CNAME, SRCC, bias, true)                       \
+  INSTANTIATE_CONV3D_MPP_STANDARD_VARIANT(                                   \
+      KD, KH, KW, SZ, SY, SX, CNAME, SRCC, nobias, false)
 
 #define INSTANTIATE_CONV3D_MPP_GROUPED(KD, KH, KW, SZ, SY, SX) \
   INSTANTIATE_CONV3D_MPP_TILES(                                \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14359,21 +14359,21 @@ class TestConvolutionMPS(TestCaseMPS):
 
     @parametrize("case", ["catalog", "simd_miss"])
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_conv3d_precompiled_and_simd_miss(self, dtype, case):
+    @parametrize("with_bias", [False, True])
+    def test_conv3d_precompiled_and_simd_miss(self, dtype, case, with_bias):
         torch.manual_seed(0)
         if case == "catalog":
             input_shape = (2, 3, 7, 9, 11)
             weight_shape = (8, 3, 3, 3, 3)
             stride, padding = (1, 1, 1), (1, 1, 1)
-            bias = torch.randn(weight_shape[0]).to(dtype).float()
         else:
             input_shape = (2, 5, 8, 10, 12)
             weight_shape = (7, 5, 2, 3, 2)
             stride, padding = (1, 2, 1), (0, 1, 0)
-            bias = None
 
         x = torch.randn(input_shape).to(dtype).float()
         weight = torch.randn(weight_shape).to(dtype).float()
+        bias = torch.randn(weight_shape[0]).to(dtype).float() if with_bias else None
         expected = F.conv3d(x, weight, bias, stride=stride, padding=padding)
         actual = F.conv3d(
             x.to(device="mps", dtype=dtype),


### PR DESCRIPTION
Fixes #192213 

Shapes we were instantiating conv3d mpp kernels for was for kernels which had bias term. If it didn't have bias term it would go to the simd version, this PR enables mpp kernels for the no bias cases as well.

Perf before and after:
## SIMD fallback versus precompiled MPP

| Kernel | Output | SIMD | MPP | Speedup | SIMD throughput | MPP throughput |
|---|---:|---:|---:|---:|---:|---:|
| `3x3x3` | `(1, 512, 5, 128, 512)` | 2375.326 ms | 231.687 ms | 10.25x | 1.95 TFLOP/s | 20.02 TFLOP/s |
| `1x3x3` | `(1, 512, 7, 128, 512)` | 1063.425 ms | 111.698 ms | 9.52x | 2.04 TFLOP/s | 19.38 TFLOP/s |

Reference measurements from the above issue:

| Operation | Time | Throughput |
|---|---:|---:|
| `8192x8192` matmul | 46.556 ms | 23.62 TFLOP/s |
| `512 -> 512` Conv2d, `3x3` | 52.026 ms | 23.59 TFLOP/s |
| `512 -> 512` Conv3d, `3x3x3` | 231.687 ms | 20.02 TFLOP/s (85% of matmul) |
| `512 -> 512` Conv3d, `1x3x3` | 111.698 ms | 19.38 TFLOP/s (82% of matmul) |