### PR TITLE
[Test] Refactored test_record_function.py to include hw_classification

### DIFF
--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -15,7 +15,11 @@ from torch.autograd import (
 )
 from torch.autograd.profiler import profile as _profile
 from torch.profiler import kineto_available, record_function
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # if tqdm is not shutdown properly, it will leave the monitor thread alive.
@@ -35,6 +39,8 @@ Json = dict[str, Any]
 
 
 class TestRecordFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _record_function_with_param(self):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with _profile(


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = GENERIC to TestRecordFunction — 9 profiler infrastructure tests. No device references; all tests exercise CPU-side profiler/framework logic.

## Test Plan

```bash
python test/profiler/test_record_function.py -v
# Ran 9 tests in 0.485s — OK

python test/profiler/test_record_function.py -v --hw-classification GENERIC
# Ran 9 tests in 0.486s — OK
```

CC: @mansiag05 @RiyaP2508 @vishalgoyal316 