### PR TITLE
Fix flattened optimizer state dict loading so  raises the same clear missing-state error as the non-flattened path

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -422,6 +422,62 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             self._test_strict,
         )
 
+    def _test_optimizer_missing_state_strict(
+        self, *, flatten_optimizer_state_dict: bool
+    ) -> None:
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Linear(2, 2, device=device_type, bias=False),
+            nn.Linear(2, 2, device=device_type, bias=False),
+        )
+        optim = torch.optim.AdamW(model.parameters())
+        model(torch.rand(2, 2, device=device_type)).sum().backward()
+        optim.step()
+        optim.zero_grad()
+
+        options = StateDictOptions(
+            flatten_optimizer_state_dict=flatten_optimizer_state_dict
+        )
+        osd = get_optimizer_state_dict(model, optim, options=options)
+        if flatten_optimizer_state_dict:
+            for key in list(osd):
+                if key.startswith("state.1.weight."):
+                    del osd[key]
+        else:
+            del osd["state"]["1.weight"]
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Missing optimizer state for parameter '1.weight'"
+        ):
+            set_optimizer_state_dict(
+                model,
+                torch.optim.AdamW(model.parameters()),
+                osd,
+                options=options,
+            )
+
+        strict_false_optim = torch.optim.AdamW(model.parameters())
+        set_optimizer_state_dict(
+            model,
+            strict_false_optim,
+            osd,
+            options=StateDictOptions(
+                flatten_optimizer_state_dict=flatten_optimizer_state_dict,
+                strict=False,
+            ),
+        )
+        strict_false_state = strict_false_optim.state_dict()["state"]
+        self.assertEqual(set(strict_false_state), {0})
+        self.assertEqual(strict_false_state[0], optim.state_dict()["state"][0])
+
+    @with_comms
+    @skip_if_lt_x_gpu(1)
+    def test_optimizer_missing_state_strict(self) -> None:
+        self.run_subtests(
+            {"flatten_optimizer_state_dict": [False, True]},
+            self._test_optimizer_missing_state_strict,
+        )
+
     def _test_cpu_offload_full_state_dict(
         self, optimizer_class: type[Optimizer]
     ) -> None:

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -863,27 +863,34 @@ def _unflatten_optim_state_dict(
                 if not param.requires_grad:
                     continue
 
-                # Reconstruct state for this parameter
-                # pyrefly: ignore [unsupported-operation]
-                state[fqn] = {}
-                for state_name in optim.state[param]:
+                # Reconstruct state for this parameter.
+                param_state_names = optim.state[param]
+                if not param_state_names:
+                    continue
+
+                param_state: DictValueType = {}
+                for state_name in param_state_names:
                     flattened_state_key = f"{_STATE}.{fqn}.{state_name}"
 
-                    if flattened_state_key not in state_dict:
-                        # Try to reconstruct the value
-                        reconstructed_value = _reconstruct_nested_dict(
-                            flattened_state_key, state_dict
-                        )
-                        # pyrefly: ignore [bad-index]
-                        cast(DictValueType, state[fqn])[state_name] = (
-                            reconstructed_value
-                        )
-                    else:
+                    if flattened_state_key in state_dict:
                         # Existing keys mean no nesting, directly use the value.
-                        # pyrefly: ignore [bad-index]
-                        cast(DictValueType, state[fqn])[state_name] = state_dict[
-                            flattened_state_key
-                        ]
+                        param_state[state_name] = state_dict[flattened_state_key]
+                        continue
+
+                    reconstructed_value = _reconstruct_nested_dict(
+                        flattened_state_key, state_dict
+                    )
+                    if reconstructed_value:
+                        param_state[state_name] = reconstructed_value
+
+                if param_state:
+                    state[fqn] = param_state
+                elif info.strict:
+                    raise RuntimeError(
+                        f"Missing optimizer state for parameter '{fqn}' in checkpoint. "
+                        "The parameter requires gradients but has no saved optimizer state. "
+                        "To load anyway, use StateDictOptions(strict=False)."
+                    )
 
         first_param_fqn = cast(list[str], pg_state[-1][_PARAMS])[0]
         for k in param_group:

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -835,7 +835,7 @@ def _unflatten_optim_state_dict(
     for param_group in optim.param_groups:
         pg_state.append({_PARAMS: []})
         for param in param_group[_PARAMS]:
-            for fqn in info.fqn_param_mapping[param]:
+            for fqn in cast(FQNS_T, info.fqn_param_mapping[param]):
                 # If a parameter is shared, only one of the FQN will be used.
                 # So we need to verify which if this fqn is actually used in
                 # the state_dict.
@@ -1018,7 +1018,7 @@ def _split_optim_state_dict(
     for param_group in optim.param_groups:
         pg_state.append({_PARAMS: []})
         for param in param_group[_PARAMS]:
-            for fqn in info.fqn_param_mapping[param]:
+            for fqn in cast(FQNS_T, info.fqn_param_mapping[param]):
                 if fqn in info.shared_params_mapping:
                     in_params = False
                     for loaded_param_group in cast(


### PR DESCRIPTION
Fixes #192224 

Fix flattened optimizer state dict loading so `strict=True` raises the same clear missing-state error as the non-flattened path instead of constructing invalid empty state and failing later in `optimizer.load_state_dict()`.

Add regression coverage for flattened and non-flattened missing-state loads.