### PR TITLE
[Test][XPU] Refactor reuse_ir tests to device-type harness and enable XPU

### DIFF
--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: jit"]
 
-import os
 import unittest
 
 import torch
@@ -9,6 +8,7 @@ import torch._lazy.config
 import torch._lazy.ir_cache
 import torch._lazy.metrics as metrics
 import torch._lazy.ts_backend
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 
@@ -16,14 +16,9 @@ torch._lazy.ts_backend.init()
 torch._lazy.config.set_reuse_ir(True)
 
 
-def get_test_device():
-    return "cuda" if "LTC_TS_CUDA" in os.environ else "cpu"
-
-
 @unittest.skipIf(IS_WINDOWS, "To be fixed")
-class TestLazyReuseIr(TestCase):
-    def testAdd(self):
-        device = get_test_device()
+class TestLazyReuseIrDevice(TestCase):
+    def testAdd(self, device):
         x = torch.randn(2, 3, 4, device=device)
         y = torch.randn(2, 3, 4, device=device)
         z = torch.zeros(2, 3, 4, device=device)
@@ -49,8 +44,7 @@ class TestLazyReuseIr(TestCase):
         metrics.reset()
         torch._lazy.ir_cache.reset()
 
-    def testAddSub(self):
-        device = get_test_device()
+    def testAddSub(self, device):
         x = torch.randn(2, 3, 4, device=device)
         y = torch.randn(2, 3, 4, device=device)
         z = torch.zeros(2, 3, 4, device=device)
@@ -82,9 +76,8 @@ class TestLazyReuseIr(TestCase):
         metrics.reset()
         torch._lazy.ir_cache.reset()
 
-    def testAddSubFallback(self):
+    def testAddSubFallback(self, device):
         torch._lazy.config.set_force_fallback("aten::sub")
-        device = get_test_device()
         x = torch.randn(2, 3, 4, device=device)
         y = torch.randn(2, 3, 4, device=device)
         z = torch.zeros(2, 3, 4, device=device)
@@ -117,8 +110,7 @@ class TestLazyReuseIr(TestCase):
         torch._lazy.ir_cache.reset()
         torch._lazy.config.set_force_fallback("")
 
-    def testBatchNorm(self):
-        device = get_test_device()
+    def testBatchNorm(self, device):
         x = torch.randn(16, 3, 224, 224, device=device)
         weight = torch.randn(3, device=device)
         bias = torch.randn(3, device=device)
@@ -155,6 +147,11 @@ class TestLazyReuseIr(TestCase):
             )
         metrics.reset()
         torch._lazy.ir_cache.reset()
+
+
+instantiate_device_type_tests(
+    TestLazyReuseIrDevice, globals(), only_for=("cpu", "cuda")
+)
 
 
 if __name__ == "__main__":

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -150,7 +150,10 @@ class TestLazyReuseIrDevice(TestCase):
 
 
 instantiate_device_type_tests(
-    TestLazyReuseIrDevice, globals(), only_for=("cpu", "cuda")
+    TestLazyReuseIrDevice,
+    globals(),
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
 )
 
 

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -9,7 +9,12 @@ import torch._lazy.ir_cache
 import torch._lazy.metrics as metrics
 import torch._lazy.ts_backend
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+)
 
 
 torch._lazy.ts_backend.init()
@@ -18,6 +23,8 @@ torch._lazy.config.set_reuse_ir(True)
 
 @unittest.skipIf(IS_WINDOWS, "To be fixed")
 class TestLazyReuseIrDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def testAdd(self, device):
         x = torch.randn(2, 3, 4, device=device)
         y = torch.randn(2, 3, 4, device=device)

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -23,7 +23,7 @@ torch._lazy.config.set_reuse_ir(True)
 
 @unittest.skipIf(IS_WINDOWS, "To be fixed")
 class TestLazyReuseIrDevice(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.GENERIC
 
     def testAdd(self, device):
         x = torch.randn(2, 3, 4, device=device)


### PR DESCRIPTION
- Refactors `test/lazy/test_reuse_ir.py` to use `instantiate_device_type_tests` instead of the legacy env-based `get_test_device` pattern.
- Converts tests to device-parameterized form (`self, device`) and keeps existing test intent/coverage.
- Enables execution for `cpu`, `cuda`, and `xpu` (`allow_xpu=True`).
- Adds `hw_classification = HardwareClassification.ACCELERATOR` for the refactored device test class.