### PR TITLE
[TEST] Refactored test_xpu_profiler.py to have hw_classification

### DIFF
--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -9,13 +9,20 @@ from collections import defaultdict
 
 import torch
 from torch.profiler import DeviceType
-from torch.testing._internal.common_utils import run_tests, TEST_XPU, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_XPU,
+    TestCase,
+)
 
 
 Verbose = False
 
 
 class XpuProfilerTest(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     @unittest.skipIf(not TEST_XPU, "test requires XPU")
     def test_profiler(self):
         t = torch.empty(1000, dtype=torch.int, device="xpu")


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = HardwareClassification.XPU to XpuProfilerTest — 2 XPU-specific profiler tests

## Test Plan
```bash
python test/profiler/test_xpu_profiler.py -v

python test/profiler/test_xpu_profiler.py -v --hw-classification XPU
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
