### PR TITLE
[TEST] Refactor tests with hw_classification

### DIFF
--- a/test/profiler/test_kineto.py
+++ b/test/profiler/test_kineto.py
@@ -6,10 +6,16 @@ from unittest.mock import patch
 
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class SimpleKinetoInitializationTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @patch.dict(os.environ, {"KINETO_USE_DAEMON": "1"})
     def test_kineto_profiler_with_environment_variable(self, device):
         """

--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -7,6 +7,7 @@ import time
 
 from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfPythonVersionMismatch,
     TemporaryFileName,
@@ -15,6 +16,8 @@ from torch.testing._internal.common_utils import (
 
 
 class TestPythonTracer(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_method_with_c_function(self):
         class A:

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -8,11 +8,17 @@ import torch
 from typing import Any
 from functools import wraps
 import unittest
-from torch.testing._internal.common_utils import skipIfTorchDynamo
 
-
-from torch.testing._internal.common_utils import \
-    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    skipIfTorchDynamo,
+    suppress_warnings,
+    _TestParametrizer,
+    run_tests,
+)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
@@ -264,6 +270,7 @@ class mask_layouts(_TestParametrizer):
 
 
 class TestMasked(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def assertEqualMasked(self, actual, expected, mask):
         strided = to_strided(actual)
@@ -316,6 +323,10 @@ class TestMasked(TestCase):
                 outmask = torch.masked._output_mask(op.op, r_inp, *r_args, **r_kwargs)
             expected = op.op(r_inp, *r_args, **r_kwargs)
             self.assertEqualMasked(actual, expected, outmask)
+
+
+class TestMaskedGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfTorchDynamo("https://github.com/pytorch/torchdynamo/issues/1992")
     @parametrize("sparse_kind,fill_value", [('coo', 0), ('hybrid_coo', 0),
@@ -432,6 +443,7 @@ class TestMasked(TestCase):
 
 
 instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_parametrized_tests(TestMaskedGeneric)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Apply hardware classification following #186918 guidelines across three test files.

**`test/profiler/test_kineto.py`**
- **SimpleKinetoInitializationTest**: `ACCELERATOR` — device-typed via `instantiate_device_type_tests`; `only_for=("cuda",)` preserved

**`test/profiler/test_python_tracer.py`**
- **TestPythonTracer**: `GENERIC` — Python tracer / `ProfilerActivity.CPU` only; no accelerator paths

**`test/test_masked.py`**
- **TestMasked**: `ACCELERATOR` — op-numerics via `instantiate_device_type_tests`
- **TestMaskedGeneric**: `GENERIC` — CPU-only sparse `where` tests split out

Note: `test/nn/attention/test_fa4.py` (#192249) and `test/nn/test_init.py` (#192306) were already merged to `main` independently, so they are not included in this PR.

cc @mansiag05 @RiyaP2508

## Test plan

```
lintrunner -a test/profiler/test_kineto.py test/profiler/test_python_tracer.py test/test_masked.py
# ok No lint issues.

python test/profiler/test_kineto.py -v
python test/profiler/test_kineto.py --hw-classification ACCELERATOR -v

python test/profiler/test_python_tracer.py -v
python test/profiler/test_python_tracer.py --hw-classification GENERIC -v

python test/test_masked.py --hw-classification GENERIC -v
python test/test_masked.py --hw-classification ACCELERATOR -v
```

Authored with an AI assistant.