### PR TITLE
[TEST] Refactor test_python_tracer.py with hw_classification

### DIFF
--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -7,6 +7,7 @@ import time
 
 from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfPythonVersionMismatch,
     TemporaryFileName,
@@ -15,6 +16,8 @@ from torch.testing._internal.common_utils import (
 
 
 class TestPythonTracer(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfPythonVersionMismatch(lambda major, minor, micro: major == 3 and minor == 12)
     def test_method_with_c_function(self):
         class A:


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestPythonTracer`: `GENERIC` — all tests use `ProfilerActivity.CPU` / Python tracer (`sys.monitoring`); no accelerator paths
- No class split; no `instantiate_device_type_tests`
- Preserve `skipIfPythonVersionMismatch`

## Test Plan
```
python test/profiler/test_python_tracer.py -v
# Ran 3 — OK

python test/profiler/test_python_tracer.py --hw-classification GENERIC -v
# Ran 3 — OK; unclassified=0, mismatched=0
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508