### PR TITLE
[Inductor][CuTeDSL] CSE repeated captured loads

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -623,6 +623,42 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
             self.assertIn("tmp0 = cute.make_rmem_tensor(1, cutlass.Float32)", body)
             self.assertIn("tmp2 = cute.TensorSSA(-tmp1, tmp1.shape, tmp1.dtype)", body)
 
+    def test_repeated_captured_load_reuses_generated_fragments(self):
+        import sympy
+
+        from torch._inductor.codegen.cutedsl.cutedsl_kernel import (
+            ModificationWrapperCuteDSL,
+        )
+
+        buffers = {}
+        for name in ("buf0", "buf1"):
+            buffer = MagicMock()
+            buffer.dtype = torch.float32
+            buffer.get_size.return_value = (16,)
+            buffers[name] = buffer
+        mock_graph = MockGraphHandler(buffers)
+
+        with V.set_graph_handler(mock_graph):
+            kernel = CuteDSLTemplateKernel(
+                kernel_name="test_repeated_captured_load",
+                input_nodes=[],
+                output_node=None,
+            )
+            handler = ModificationWrapperCuteDSL(kernel, 0, {}, None)
+            with V.set_kernel_handler(kernel):
+                first = handler.load("buf0", sympy.Integer(0))
+                repeated = handler.load("buf0", sympy.Integer(0))
+                different_index = handler.load("buf0", sympy.Integer(1))
+                different_buffer = handler.load("buf1", sympy.Integer(0))
+
+        self.assertIs(first, repeated)
+        self.assertIsNot(first, different_index)
+        self.assertIsNot(first, different_buffer)
+        self.assertEqual(
+            kernel.body.getvalue().count("cute.make_rmem_tensor(1, cutlass.Float32)"),
+            3,
+        )
+
     def test_cutedsl_op_overrides(self):
         """Test the new CuteDSLOpOverrides class."""
         import torch

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -649,6 +649,9 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         # Maps generated CSE names to their semantic provenance so vector-load
         # analysis can reason about the source indexing semantics.
         self._index_symbol_info: dict[sympy.Symbol, IndexSymbolInfo] = {}
+        # Captured modifications are read-only, so repeated loads from the same
+        # semantic location can share the generated index and value fragments.
+        self._captured_load_cache: dict[tuple[str, sympy.Expr], CuteDSLCSEVariable] = {}
 
     def _get_input_dtype(self, name: str) -> torch.dtype:
         """Get the dtype for an input from the kernel's named_input_nodes."""
@@ -662,6 +665,11 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         from torch._inductor.kernel.flex.flex_flash_attention import HierarchicalIndex
 
         if name not in self.fixed_inputs:
+            cache_key = (name, index)
+            cached = self._captured_load_cache.get(cache_key)
+            if cached is not None:
+                return self.kernel.cse.generate(self.kernel.body, cached)
+
             var = self._add_kernel_input(name)
             buffer = self.kernel._get_capture_input_node(name)
             if buffer is None:
@@ -707,6 +715,7 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
                 bounds=ValueRanges.unknown(),
                 shape=(1,),
             )
+            self._captured_load_cache[cache_key] = out
             return out
 
         value = self.fixed_inputs[name]


### PR DESCRIPTION
## Issue

Fixes #192246.

## Summary

`ModificationWrapperCuteDSL.load()` currently emits captured-tensor index/value fragments before the existing expression CSE sees the final `.load()`. This change adds a per-modification cache keyed by `(buffer name, symbolic index)`, so exact repeated reads reuse the first generated value while different indices and buffers remain distinct. The cache is scoped to one modification handler, whose subgraph is read-only.

### Compile performance

An A/B of the equivalent generated-source transformation used an exact production-shaped GB300 FlexAttention workload: BF16, Q `, deterministic 2K block-sparse window, and 2,559 partial tiles.

| Measurement | Before | With early CSE | Change |
|---|---:|---:|---:|
| First forward compile + call | 8,484.8 ms | 7,993.5 ms | -5.8% |
| First backward compile + call | 6,907.2 ms | 6,359.0 ms | -7.9% |
| Forward main MLIR pipeline | 3,223.8 ms | 2,975.3 ms | -7.7% |
| Backward main MLIR pipeline | 1,210.3 ms | 1,202.0 ms | -0.7% |

Pre-pipeline MLIR size decreased 2.2% forward and 9.2% backward. Post-pipeline MLIR, PTX, cubin, and disassembled SASS were byte-identical, so this PR intentionally makes no runtime-performance claim.

### Validation

- `test/inductor/test_cutedsl_template.py`: 23 passed on GB300.
- PyTorch linters for both changed files: clean.
- Lowering fuzz: 5,000 randomized requests across 1,119 unique rank-1/rank-2, positive/negative, and multi-buffer keys; all 3,881 expected hits reused the original value and every distinct key remained distinct.
- Compiled GB300 fuzz: 11 baseline-vs-patched FLASH forward/backward cases spanning BF16/FP16, B=1/2, H=2/4, MHA/GQA, sequence lengths 256/384/512, score/mask modifications, rank-1/rank-2/rank-3 captures, distinct indices, distinct buffers, aliased views, negative indices, and bool captures. Output, dQ, dK, and dV were bitwise identical in every case.
- Exact production-shaped forward/backward replay passed and emitted one midpoint physical load per direction instead of two.

## Checklist

- [x] Passes lint (targeted `lintrunner` checks)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results

## BC-breaking?

No.

> **AI assistance disclosure:** An AI coding assistant helped inspect the lowering path, draft the implementation and test harnesses, and assemble the initial description. I reviewed the final code, generated CuTeDSL, fuzz coverage, and benchmark results.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo