### PR TITLE
[S615805][RecSysCheckpointing][PyTorch] Add strides to TensorProperties (#192248)

### DIFF
--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed.checkpoint as dcp
+from torch.distributed._shard.sharded_tensor.metadata import (
+    MEM_FORMAT_ENCODING as SHARDED_MEM_FORMAT_ENCODING,
+    TensorProperties as ShardedTensorProperties,
+)
 from torch.distributed.checkpoint.metadata import (
+    _MEM_FORMAT_ENCODING,
     BytesStorageMetadata,
     ChunkStorageMetadata,
     Metadata,
@@ -94,6 +99,83 @@ class TestDCPCompatbility(TestCase):
         dcp._version._act_like_version = None
         dcp.load(load_sd, checkpoint_id=self.temp_dir)
         self.assertEqual(sd, load_sd)
+
+    def test_tensor_properties_backward_compat_without_strides(self) -> None:
+        """Ensure TensorProperties pickled before the strides field was added can still be loaded."""
+        import pickle
+
+        # Simulate an old checkpoint's pickled TensorProperties (5-element state, no strides).
+        props = TensorProperties(dtype=torch.float32)
+        old_state = (
+            torch.float32,
+            torch.strided,
+            False,
+            _MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT,
+            False,
+        )
+
+        # Verify the current round-trip works (6-element state).
+        props_bytes = pickle.dumps(props)
+        restored_new = pickle.loads(props_bytes)
+        self.assertIsNone(restored_new.strides)
+
+        # Directly test __setstate__ with a 5-element tuple.
+        restored_old = TensorProperties.__new__(TensorProperties)
+        restored_old.__setstate__(old_state)
+        self.assertIsNone(restored_old.strides)
+        self.assertEqual(restored_old.dtype, torch.float32)
+        self.assertEqual(restored_old.memory_format, torch.contiguous_format)
+
+    def test_tensor_properties_strides_survive_pickle_roundtrip(self) -> None:
+        """Ensure strides survive a pickle round-trip (as used by torch.save/load)."""
+        import pickle
+
+        tensor = torch.rand(3, 4)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (4, 1))
+
+        restored = pickle.loads(pickle.dumps(props))
+        self.assertEqual(restored.strides, (4, 1))
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_sharded_tensor_properties_backward_compat_without_strides(self) -> None:
+        """Ensure sharded tensor TensorProperties also handles old pickles without strides."""
+        old_state = (
+            torch.float32,
+            torch.strided,
+            False,
+            SHARDED_MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT,
+            False,
+        )
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(old_state)
+        self.assertIsNone(restored.strides)
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_sharded_tensor_properties_strides_roundtrip(self) -> None:
+        """Ensure sharded tensor TensorProperties preserves strides through getstate/setstate."""
+        tensor = torch.rand(3, 4)
+        props = ShardedTensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (4, 1))
+
+        state = props.__getstate__()
+        self.assertEqual(len(state), 6)
+
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(state)
+        self.assertEqual(restored.strides, (4, 1))
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_sharded_tensor_properties_non_contiguous_strides(self) -> None:
+        """Ensure sharded tensor TensorProperties captures non-contiguous strides."""
+        tensor = torch.rand(5, 10).t()  # shape [10, 5], strides (1, 10)
+        props = ShardedTensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (1, 10))
+
+        state = props.__getstate__()
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(state)
+        self.assertEqual(restored.strides, (1, 10))
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -30,6 +30,7 @@ from torch.distributed.checkpoint.default_planner import (
 )
 from torch.distributed.checkpoint.filesystem import CURRENT_DCP_VERSION
 from torch.distributed.checkpoint.metadata import (
+    _MEM_FORMAT_ENCODING,
     BytesStorageMetadata,
     ChunkStorageMetadata,
     Metadata,
@@ -163,6 +164,58 @@ class TestCheckpointableTensorDistributed(DTensorTestBase):
         self.assertEqual((self.world_size * shard_size,), loaded.global_shape)
         self.assertEqual(((start,),), loaded.global_offsets)
         self.assertEqual(expected, loaded)
+
+
+class TestTensorPropertiesStrides(TestCase):
+    def test_create_from_tensor_populates_strides(self):
+        tensor = torch.rand(4, 8)  # shape [4, 8], strides (8, 1)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (8, 1))
+
+    def test_create_from_tensor_non_contiguous_strides(self):
+        tensor = torch.rand(5, 10).t()  # shape [10, 5], strides (1, 10)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (1, 10))
+
+    def test_create_from_tensor_transposed_strides(self):
+        tensor = torch.rand(2, 1).t()  # shape [1, 2], strides (1, 1)
+        self.assertEqual(tensor.shape, (1, 2))
+        self.assertEqual(tensor.stride(), (1, 1))
+
+        props = TensorProperties.create_from_tensor(tensor)
+        # Test that even though (2, 1) is a valid stride,
+        # but we still retain the original strides (1, 1)
+        self.assertEqual(props.strides, tensor.stride())
+        self.assertNotEqual(props.strides, (2, 1))
+
+    def test_strides_default_none(self):
+        props = TensorProperties(dtype=torch.float32)
+        self.assertIsNone(props.strides)
+
+    def test_getstate_setstate_roundtrip_with_strides(self):
+        props = TensorProperties.create_from_tensor(torch.rand(3, 4))
+        state = props.__getstate__()
+        self.assertEqual(len(state), 6)
+
+        restored = TensorProperties.__new__(TensorProperties)
+        restored.__setstate__(state)
+        self.assertEqual(restored.strides, (4, 1))
+        self.assertEqual(restored.dtype, props.dtype)
+
+    def test_setstate_backward_compat_without_strides(self):
+        # Old checkpoints have 5-element state tuples (no strides field).
+        old_state = (
+            torch.float32,
+            torch.strided,
+            False,
+            _MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT,
+            False,
+        )
+        restored = TensorProperties.__new__(TensorProperties)
+        restored.__setstate__(old_state)
+        self.assertIsNone(restored.strides)
+        self.assertEqual(restored.dtype, torch.float32)
+        self.assertEqual(restored.memory_format, torch.contiguous_format)
 
 
 class TestSavePlan(TestCase):

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -97,8 +97,9 @@ class ShardedTensorBase(torch.Tensor):
         if dtype is None:
             dtype = torch.get_default_dtype()
 
+        strides = kwargs.get("strides")
         tensor_properties = TensorProperties(
-            dtype, layout, requires_grad, pin_memory=pin_memory
+            dtype, layout, requires_grad, pin_memory=pin_memory, strides=strides
         )
         sharded_tensor_metadata = sharding_spec.build_metadata(
             sizes, tensor_properties=tensor_properties
@@ -171,6 +172,7 @@ class ShardedTensorBase(torch.Tensor):
             layout=tensor_properties.layout,
             pin_memory=tensor_properties.pin_memory,
             requires_grad=tensor_properties.requires_grad,
+            strides=tensor_properties.strides,
         )
 
         # check if shards_metadata have overlap shards
@@ -995,6 +997,7 @@ class ShardedTensor(ShardedTensorBase):
             layout=tensor_properties.layout,
             pin_memory=tensor_properties.pin_memory,
             requires_grad=tensor_properties.requires_grad,
+            strides=tensor_properties.strides,
         )
 
         def _raise_if_mismatch(expected, actual, prop_name, rank, is_property=False):

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -23,6 +23,8 @@ class TensorProperties:
     memory_format: torch.memory_format = field(default=torch.contiguous_format)
     pin_memory: bool = False
 
+    strides: tuple[int, ...] | None = None
+
     def __getstate__(self):
         # Since torch.memory_format cannot be pickled!
         memory_format = self.memory_format
@@ -41,19 +43,31 @@ class TensorProperties:
             self.requires_grad,
             mem_format_encoding,
             self.pin_memory,
+            self.strides,
         )
 
     def __setstate__(
         self,
         state,
     ):
-        (
-            self.dtype,
-            self.layout,
-            self.requires_grad,
-            mem_format_encoding,
-            self.pin_memory,
-        ) = state
+        if len(state) == 5:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+            ) = state
+            self.strides = None
+        else:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+                self.strides,
+            ) = state
 
         if mem_format_encoding == MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT:
             memory_format = torch.contiguous_format
@@ -76,6 +90,7 @@ class TensorProperties:
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
             pin_memory=tensor.is_pinned(),
+            strides=tensor.stride(),
         )
 
 

--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -54,6 +54,8 @@ class TensorProperties:
     # This field is deprecated.
     pin_memory: bool = False
 
+    strides: tuple[int, ...] | None = None
+
     def __getstate__(self):
         # Since torch.memory_format cannot be pickled!
         memory_format = self.memory_format
@@ -72,19 +74,31 @@ class TensorProperties:
             self.requires_grad,
             mem_format_encoding,
             self.pin_memory,
+            self.strides,
         )
 
     def __setstate__(
         self,
         state,
     ):
-        (
-            self.dtype,
-            self.layout,
-            self.requires_grad,
-            mem_format_encoding,
-            self.pin_memory,
-        ) = state
+        if len(state) == 5:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+            ) = state
+            self.strides = None
+        else:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+                self.strides,
+            ) = state
 
         if mem_format_encoding == _MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT:
             memory_format = torch.contiguous_format
@@ -107,6 +121,7 @@ class TensorProperties:
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
             pin_memory=tensor.is_pinned(),
+            strides=tensor.stride(),
         )
 
 

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -171,6 +171,7 @@ def _sharded_tensor_metadata(
         requires_grad=shard_properties.requires_grad,
         memory_format=shard_properties.memory_format,
         pin_memory=shard_properties.pin_memory,
+        strides=shard_properties.strides,
     )
 
     return TensorWriteData(


### PR DESCRIPTION
Summary:


Root Cause Analysis: https://www.internalfb.com/intern/phabricator/paste/markdown/P2165832658/

This diff adds stride information to `TensorProperties` in core PyTorch DCP metadata and sharded tensor metadata. This preserves the actual tensor stride information (e.g., from unsqueeze, transpose, or broadcasting) rather than assuming all tensors are contiguous. The field is optional (`None` by default) for backward compatibility with existing checkpoints.

The `planner_helpers.py` change ensures strides are propagated when constructing `TensorWriteData` from shard properties.

Also adds tests for code changes.

Test Plan:
```
buck test fbcode//mode/opt \
    fbcode//caffe2/test/distributed/checkpoint:test_planner \
    fbcode//caffe2/test/distributed/checkpoint:test_compatibility
```

https://www.internalfb.com/intern/testinfra/testrun/14355223975802360

Reviewed By: meetv18

Differential Revision: D92474857


