### PR TITLE
[TEST] Refactor test_fa4.py with hw_classification

### DIFF
--- a/test/nn/attention/test_fa4.py
+++ b/test/nn/attention/test_fa4.py
@@ -11,7 +11,12 @@ import torch.nn.functional as F
 from torch.backends.cuda import SDPBackend
 from torch.nn.attention import activate_flash_attention_impl, sdpa_kernel
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 def _fa4_dependencies_available() -> bool:
@@ -28,6 +33,8 @@ def _fa4_dependencies_available() -> bool:
 
 
 class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # Mixin configuration
     impl_name = "FA4"
     fwd_kernel_patterns = ["flash_attncute", "flash_fwd"]


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestFlashAttentionFA4`: `CUDA` — FA4 uses `flash_attn.cute`, SM90/SM100, CUDA-only dispatch; `only_for="cuda"` preserved
- Tests already take and use `device` arg for future portability
- All CUDA-specific skip gates preserved

## Test Plan
```
python test/nn/attention/test_fa4.py -v
# Ran 80 — OK (skipped=80; flash_attn not installed)

python test/nn/attention/test_fa4.py --hw-classification CUDA -v
# Ran 80 — OK; unclassified=0, mismatched=0
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508