### PR TITLE
[inductor] Guard CompiledTritonKernels._cache with its own lock

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pickle
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -28,6 +29,7 @@ from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._inductor import config, config_comms, metrics
+from torch._inductor.async_compile import CompiledTritonKernels
 from torch._inductor.cache_key import (
     AUTOTUNE_CACHE_KEY_STRATEGY,
     CacheKeyStrategy,
@@ -503,6 +505,195 @@ class TestPyCodeCache(TestCase):
 
         generated_source = load_async.call_args.args[0]
         self.assertIn("Py_NewRef(Py_None)", generated_source)
+
+
+class TestCompiledTritonKernels(TestCase):
+    def setUp(self):
+        super().setUp()
+        CompiledTritonKernels.cache_clear()
+
+    def test_accessors_hold_the_lock(self):
+        """Every _cache accessor must serialize on _lock.
+
+        Megacache population (TritonBundler.load_autotuners) runs on a
+        background thread while compilation saves to and clears this cache.
+        An unguarded accessor lets dict_dealloc run the values' finalizers
+        re-entrantly while the other thread mutates the dict, which corrupts
+        the interpreter heap and surfaces as a SIGSEGV somewhere unrelated
+        (S686093).
+        """
+        acquired = []
+        real_lock = CompiledTritonKernels._lock
+
+        class TrackingLock:
+            def __enter__(self):
+                acquired.append(True)
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc_info):
+                return real_lock.__exit__(*exc_info)
+
+        with mock.patch.object(CompiledTritonKernels, "_lock", TrackingLock()):
+            CompiledTritonKernels.save("kernel_src", mock.sentinel.future)
+            self.assertEqual(
+                CompiledTritonKernels.get("kernel_src"), mock.sentinel.future
+            )
+            CompiledTritonKernels.save_with_key("key", mock.sentinel.other)
+            CompiledTritonKernels.remove_future("kernel_src")
+            CompiledTritonKernels.cache_clear()
+
+        self.assertEqual(len(acquired), 5)
+        self.assertEqual(CompiledTritonKernels._cache, {})
+
+    def test_concurrent_save_and_clear(self):
+        """Saving and clearing from two threads must not corrupt the heap.
+
+        Exercises the unhashed save_with_key() path that TritonBundler uses,
+        which inserts fast enough to hit the race. Needs values with a __del__
+        but no GPU or Triton. Runs in a subprocess because the failure mode
+        kills the interpreter rather than raising.
+        """
+        script = textwrap.dedent(
+            """
+            import threading
+
+            from torch._inductor.async_compile import CompiledTritonKernels
+
+            class Finalized:
+                __slots__ = ("payload",)
+
+                def __init__(self):
+                    self.payload = b"x" * 512
+
+                def __del__(self):
+                    total = 0
+                    for i in range(50):
+                        total += i
+
+            TOTAL = 200000
+            pool = [Finalized() for _ in range(TOTAL)]
+            stop = threading.Event()
+            gate = threading.Event()
+            errors = []
+            saved = []
+
+            def saver():
+                try:
+                    n = 0
+                    while pool:
+                        try:
+                            value = pool.pop()
+                        except IndexError:
+                            break
+                        # Event ops take a lock, so the GIL can be yielded next
+                        # to the insert -- as TritonBundler.load_autotuners does
+                        # via reload_cubin_path()'s file IO between its inserts.
+                        gate.set()
+                        CompiledTritonKernels.save_with_key(f"k{n}", value)
+                        gate.clear()
+                        n += 1
+                    saved.append(n)
+                except BaseException as e:
+                    errors.append(repr(e))
+
+            def clearer():
+                try:
+                    while not stop.is_set():
+                        CompiledTritonKernels.cache_clear()
+                except BaseException as e:
+                    errors.append(repr(e))
+
+            t_save = threading.Thread(target=saver)
+            t_clear = threading.Thread(target=clearer, daemon=True)
+            t_save.start()
+            t_clear.start()
+            t_save.join()
+            stop.set()
+            t_clear.join(timeout=5)
+
+            # A thread dying must fail the test, not silently look like success.
+            if errors:
+                raise SystemExit("thread errors: " + "; ".join(errors))
+            if saved != [TOTAL]:
+                raise SystemExit(f"saver completed {saved}, expected [{TOTAL}]")
+            print("SURVIVED")
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, timeout=600
+        )
+        self.assertNotEqual(
+            proc.returncode,
+            -signal.SIGSEGV,
+            f"save/clear race crashed: {proc.stderr.decode()[-2000:]}",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr.decode()[-2000:])
+
+
+class TestCacheArtifactManagerLocking(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Artifact types register on import; record_artifact() asserts otherwise.
+        CacheArtifactManager._ensure_cache_artifacts_registered()
+        CacheArtifactManager.clear()
+        PrecompileContext.clear()
+
+    def test_accessors_hold_the_artifact_lock(self):
+        """CacheArtifactManager/PrecompileContext state needs its own lock.
+
+        The class comments claim compile_lock protection, but two writers run
+        with no compile in progress and so cannot hold it: first-launch
+        autotuning (AutotuneCache.save -> _record_artifact) and the
+        lazy-backward AOTAutogradCache save, which fires after
+        compile_fx_backward has already released compile_lock.
+        """
+        acquired = []
+        real_lock = torch.compiler._cache._artifact_lock
+
+        class TrackingLock:
+            def __enter__(self):
+                acquired.append(True)
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc_info):
+                return real_lock.__exit__(*exc_info)
+
+        with mock.patch.object(torch.compiler._cache, "_artifact_lock", TrackingLock()):
+            CacheArtifactManager.record_artifact("autotune", "key", {"cfg": 1})
+            CacheArtifactManager.need_serialize()
+            CacheArtifactManager.serialize()
+            CacheArtifactManager.clear()
+            PrecompileContext.record_dynamo_cache_entry(mock.sentinel.entry, "key")
+            PrecompileContext.clear()
+
+        self.assertEqual(len(acquired), 6)
+
+    def test_save_cache_artifacts_is_atomic(self):
+        """save_cache_artifacts() must hold the lock across both halves.
+
+        save_to_dynamo_cache() records into _new_cache_artifacts via
+        DynamoCache.write, and serialize() then drains and clears it. Two
+        separate critical sections would let a concurrent compile's artifacts
+        land in the gap and get swept up by this save.
+        """
+        depth = []
+        real_lock = torch.compiler._cache._artifact_lock
+
+        class DepthLock:
+            def __enter__(self):
+                depth.append(len(depth))
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc_info):
+                return real_lock.__exit__(*exc_info)
+
+        CacheArtifactManager.record_artifact("autotune", "key", {"cfg": 1})
+        with mock.patch.object(torch.compiler._cache, "_artifact_lock", DepthLock()):
+            torch.compiler.save_cache_artifacts()
+
+        # serialize() must have run nested inside the outer acquisition, not
+        # after it was released.
+        self.assertGreaterEqual(len(depth), 2)
 
 
 @instantiate_parametrized_tests

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -14,6 +14,7 @@ from torch._dynamo.package import (
     DynamoCache,
     PrecompileCacheEntry,
 )
+from torch.compiler import _cache
 
 
 """
@@ -86,7 +87,7 @@ class PrecompileContext:
 
     """
 
-    # Protected by the compile_lock
+    # Protected by torch.compiler._cache._artifact_lock
     # _backend_artifacts_by_key organizes results by the key of each artifact.
     # Each object here must be serializable
     _backend_artifacts_by_key: dict[_BackendId, BackendCacheArtifact[Any]] = {}
@@ -97,8 +98,9 @@ class PrecompileContext:
 
     @classmethod
     def clear(cls) -> None:
-        cls._backend_artifacts_by_key.clear()
-        cls._dynamo_cache_entries.clear()
+        with _cache._artifact_lock:
+            cls._backend_artifacts_by_key.clear()
+            cls._dynamo_cache_entries.clear()
 
     @classmethod
     def record_artifact(
@@ -114,24 +116,26 @@ class PrecompileContext:
         from torch.utils._mode_utils import no_dispatch
 
         with no_dispatch():
-            cls._backend_artifacts_by_key[_BackendId(artifact.key)] = copy.deepcopy(
-                artifact
-            )
+            copied = copy.deepcopy(artifact)
+        with _cache._artifact_lock:
+            cls._backend_artifacts_by_key[_BackendId(artifact.key)] = copied
 
     @classmethod
     def record_dynamo_cache_entry(
         cls, cache_entry: _DynamoCacheEntry, key: str
     ) -> None:
-        cls._dynamo_cache_entries[key] = cache_entry
+        with _cache._artifact_lock:
+            cls._dynamo_cache_entries[key] = cache_entry
 
     @classmethod
     def edit_artifact(cls, key: str, edit_fn: Callable[..., Any]) -> None:
         """
         Edit the content of an existing artifact
         """
-        if key not in cls._backend_artifacts_by_key:
-            raise AssertionError(f"Key {key} not found in artifacts")
-        artifact = cls._backend_artifacts_by_key[_BackendId(key)]
+        with _cache._artifact_lock:
+            if key not in cls._backend_artifacts_by_key:
+                raise AssertionError(f"Key {key} not found in artifacts")
+            artifact = cls._backend_artifacts_by_key[_BackendId(key)]
         artifact.edit_contents(edit_fn)
 
     @classmethod
@@ -139,7 +143,8 @@ class PrecompileContext:
         """
         Return the backend cache artifact with the associated key
         """
-        return cls._backend_artifacts_by_key.get(_BackendId(key), None)
+        with _cache._artifact_lock:
+            return cls._backend_artifacts_by_key.get(_BackendId(key), None)
 
     @staticmethod
     def dump_debug_info(
@@ -164,10 +169,11 @@ class PrecompileContext:
 
     @classmethod
     def save_to_dynamo_cache(cls) -> dict[str, Any]:
-        precompile_cache_entries, debug_info = cls.create_cache_entries()
-        for key, entry in precompile_cache_entries.items():
-            DynamoCache.write(entry, key)
-        return debug_info
+        with _cache._artifact_lock:
+            precompile_cache_entries, debug_info = cls.create_cache_entries()
+            for key, entry in precompile_cache_entries.items():
+                DynamoCache.write(entry, key)
+            return debug_info
 
     @classmethod
     def create_cache_entries(
@@ -177,8 +183,9 @@ class PrecompileContext:
         Grabs all the cache entries in the precompile context and
         stitches them together into full PrecompileCacheEntries.
         """
-        dynamo_entries = cls._dynamo_cache_entries
-        backend_artifacts = cls._backend_artifacts_by_key
+        with _cache._artifact_lock:
+            dynamo_entries = dict(cls._dynamo_cache_entries)
+            backend_artifacts = dict(cls._backend_artifacts_by_key)
 
         num_artifacts = len(dynamo_entries)
 

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import re
 import sys
+import threading
 from concurrent.futures import (
     Future,
     ThreadPoolExecutor,
@@ -236,6 +237,11 @@ class CompiledTritonKernels:
     """
 
     _cache: dict[str, CodeCacheFuture] = {}
+    # Megacache population (TritonBundler.load_autotuners) runs on a background
+    # thread while compilation saves to and clears this cache, so all _cache
+    # access must go through the accessors below and hold this lock. Reentrant
+    # because clearing runs the values' finalizers.
+    _lock = threading.RLock()
 
     @staticmethod
     def key(kernel_src: str):
@@ -257,25 +263,34 @@ class CompiledTritonKernels:
         TODO: Source code here is not just the kernel's source code, but also includes the inductor preamble, etc.
         so it could be less strict.
         """
-        key = CompiledTritonKernels.key(kernel_src)
-        CompiledTritonKernels._cache[key] = future
+        # key() hashes, so compute it outside the lock
+        CompiledTritonKernels.save_with_key(
+            CompiledTritonKernels.key(kernel_src), future
+        )
+
+    @staticmethod
+    def save_with_key(key: str, future: CodeCacheFuture) -> None:
+        """Save under an already-computed key, for callers that have one."""
+        with CompiledTritonKernels._lock:
+            CompiledTritonKernels._cache[key] = future
 
     @staticmethod
     def get(kernel_src: str) -> CodeCacheFuture | None:
         key = CompiledTritonKernels.key(kernel_src)
-        return CompiledTritonKernels._cache.get(key, None)
+        with CompiledTritonKernels._lock:
+            return CompiledTritonKernels._cache.get(key, None)
 
     @staticmethod
     def cache_clear():
-        CompiledTritonKernels._cache = {}
+        with CompiledTritonKernels._lock:
+            CompiledTritonKernels._cache = {}
 
     @staticmethod
     def remove_future(kernel_src: str) -> None:
         key = CompiledTritonKernels.key(kernel_src)
-
-        # Delete the LambdaFuture if there is one
-        if key in CompiledTritonKernels._cache:
-            del CompiledTritonKernels._cache[key]
+        with CompiledTritonKernels._lock:
+            # Delete the LambdaFuture if there is one
+            CompiledTritonKernels._cache.pop(key, None)
 
 
 class AsyncCompile:

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -254,8 +254,8 @@ class TritonBundler:
                 # kernels that are not statically launchable (i.e. cache miss)
                 # can launch a worker without waiting on the blocking step of
                 # StaticAutotunerFuture.result().
-                CompiledTritonKernels._cache[result.cache_key] = StaticAutotunerFuture(
-                    result.kernel
+                CompiledTritonKernels.save_with_key(
+                    result.cache_key, StaticAutotunerFuture(result.kernel)
                 )
                 counters["inductor"]["triton_bundler_load_static_autotuner"] += 1
                 kernel_names.append(result.kernel_name)

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -760,14 +760,19 @@ def save_cache_artifacts() -> tuple[bytes, CacheInfo] | None:
     - Execute torch.compile
     - Call torch.compiler.save_cache_artifacts()
     """
-    from ._cache import CacheArtifactManager
+    from ._cache import _artifact_lock, CacheArtifactManager
 
-    if torch._dynamo.config.caching_precompile:
-        from torch._dynamo.precompile_context import PrecompileContext
+    # One critical section across both halves: save_to_dynamo_cache() records
+    # into _new_cache_artifacts (via DynamoCache.write) and serialize() then
+    # drains and clears it, so a gap would let a concurrent compile's artifacts
+    # be swept up by this save.
+    with _artifact_lock:
+        if torch._dynamo.config.caching_precompile:
+            from torch._dynamo.precompile_context import PrecompileContext
 
-        PrecompileContext.save_to_dynamo_cache()
+            PrecompileContext.save_to_dynamo_cache()
 
-    return CacheArtifactManager.serialize()
+        return CacheArtifactManager.serialize()
 
 
 def load_cache_artifacts(serialized_artifacts: bytes) -> CacheInfo | None:

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import logging
+import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Generator
@@ -17,6 +18,15 @@ from torch.utils._ordered_set import OrderedSet
 
 
 log = logging.getLogger(__name__)
+
+
+# Guards CacheArtifactManager and PrecompileContext class state. Not the Dynamo
+# compile_lock: artifacts are recorded from paths that run with no compile in
+# progress -- first-launch autotuning, and the lazy-backward AOTAutogradCache
+# save, which fires after compile_fx_backward has released compile_lock -- so
+# compile_lock could never cover them. Reentrant because save_cache_artifacts()
+# nests recording inside serialization.
+_artifact_lock = threading.RLock()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -205,7 +215,7 @@ class CacheArtifactManager:
           used unless code version matches.
     """
 
-    # Protected by the compile_lock
+    # Protected by _artifact_lock
     _new_cache_artifacts: CacheArtifactsResult = defaultdict(list)
     # Keep a separate seen artifacts list to avoid unnecessary duplicates
     # This list will not be cleared between serialize() calls
@@ -220,30 +230,39 @@ class CacheArtifactManager:
 
     @classmethod
     def clear(cls) -> None:
-        cls._new_cache_artifacts.clear()
-        cls._seen_artifacts.clear()
-        cls._serializer.clear()
-        cls._cache_info.clear()
+        with _artifact_lock:
+            cls._new_cache_artifacts.clear()
+            cls._seen_artifacts.clear()
+            cls._serializer.clear()
+            cls._cache_info.clear()
 
     @classmethod
     @contextmanager
     def with_fresh_cache(cls) -> Generator[None, None, None]:
-        original_new_cache_artifacts = cls._new_cache_artifacts
-        original_seen_artifacts = cls._seen_artifacts
-        original_serializer = cls._serializer
-        original_cache_info = cls._cache_info
+        # NOTE: the lock is only held across the swap and the restore, never
+        # across the yield. It makes each half atomic, but this remains a
+        # process-wide swap: artifacts another thread records inside the body
+        # land in the throwaway state and are dropped on restore.
+        with _artifact_lock:
+            original_new_cache_artifacts = cls._new_cache_artifacts
+            original_seen_artifacts = cls._seen_artifacts
+            original_serializer = cls._serializer
+            original_cache_info = cls._cache_info
 
-        cls._new_cache_artifacts = defaultdict(list)
-        cls._seen_artifacts = OrderedSet()
-        cls._serializer = AppendingByteSerializer(serialize_fn=_serialize_single_cache)
-        cls._cache_info = cls._cache_info.__class__()
+            cls._new_cache_artifacts = defaultdict(list)
+            cls._seen_artifacts = OrderedSet()
+            cls._serializer = AppendingByteSerializer(
+                serialize_fn=_serialize_single_cache
+            )
+            cls._cache_info = cls._cache_info.__class__()
         try:
             yield
         finally:
-            cls._new_cache_artifacts = original_new_cache_artifacts
-            cls._seen_artifacts = original_seen_artifacts
-            cls._serializer = original_serializer
-            cls._cache_info = original_cache_info
+            with _artifact_lock:
+                cls._new_cache_artifacts = original_new_cache_artifacts
+                cls._seen_artifacts = original_seen_artifacts
+                cls._serializer = original_serializer
+                cls._cache_info = original_cache_info
 
     @classmethod
     def record_artifact(
@@ -256,45 +275,49 @@ class CacheArtifactManager:
         Called from each caching operation to record the artifact in this
         "mega" list
         """
+        # encode_create() can be expensive, so keep it out of the lock
         artifact = CacheArtifactFactory.encode_create(artifact_type, key, content)
-        if artifact in cls._seen_artifacts:
-            return
-        log.debug("Recording %s", artifact)
-        cls._new_cache_artifacts[artifact_type].append(artifact)
-        cls._seen_artifacts.add(artifact)
+        with _artifact_lock:
+            if artifact in cls._seen_artifacts:
+                return
+            log.debug("Recording %s", artifact)
+            cls._new_cache_artifacts[artifact_type].append(artifact)
+            cls._seen_artifacts.add(artifact)
 
     @classmethod
     def need_serialize(cls) -> bool:
         """
         Have we seen new artifacts since last serialize call?
         """
-        return len(cls._new_cache_artifacts) != 0
+        with _artifact_lock:
+            return len(cls._new_cache_artifacts) != 0
 
     @classmethod
     def serialize(cls) -> tuple[bytes, CacheInfo] | None:
         """
         Converts the "mega" list into portable format
         """
-        for artifact in chain(*cls._new_cache_artifacts.values()):
-            log.debug("saving: %s", artifact)
-            cls._cache_info.add(artifact)
+        with _artifact_lock:
+            for artifact in chain(*cls._new_cache_artifacts.values()):
+                log.debug("saving: %s", artifact)
+                cls._cache_info.add(artifact)
 
-        if cls._cache_info.empty():
-            # If there are no artifacts, don't just return bytes with
-            # version.
+            if cls._cache_info.empty():
+                # If there are no artifacts, don't just return bytes with
+                # version.
+                return None
+
+            try:
+                # We deep copy cls._cache_info since later compilations
+                # can keep adding to cache_info
+                info = copy.deepcopy(cls._cache_info)
+                cls._serializer.extend(cls._new_cache_artifacts.items())
+                artifact_bytes = cls._serializer.to_bytes()
+                cls._new_cache_artifacts.clear()
+                return artifact_bytes, info
+            except Exception:
+                log.warning("Failed to pickle cache artifacts", exc_info=True)
             return None
-
-        try:
-            # We deep copy cls._cache_info since later compilations
-            # can keep adding to cache_info
-            info = copy.deepcopy(cls._cache_info)
-            cls._serializer.extend(cls._new_cache_artifacts.items())
-            artifact_bytes = cls._serializer.to_bytes()
-            cls._new_cache_artifacts.clear()
-            return artifact_bytes, info
-        except Exception:
-            log.warning("Failed to pickle cache artifacts", exc_info=True)
-        return None
 
     @staticmethod
     def deserialize(serialized_artifacts: bytes) -> CacheArtifactsResult | None:


### PR DESCRIPTION
Summary:
CompiledTritonKernels._cache is a process-global dict shared between
compilation and MegaCache population. PytorchController starts the MegaCache
load on a non-blocking daemon thread during trainer construction, so
TritonBundler.load_autotuners() inserts into _cache on that thread while the
first Inductor compile of the Shampoo optimizer runs cache_clear() on the main
thread.

Rebinding _cache drops the old dict, so dict_dealloc runs the values'
finalizers re-entrantly while the loading thread is still mutating that same
dict. That corrupts the interpreter heap and surfaces as a SIGSEGV in unrelated
interpreter code: the reported crash faulted in PyObject_SetItem on one attempt
and dict_dealloc on the other (S686093). Neither CUDA nor cuModuleUnload is
required -- a value whose __del__ runs any Python at all is enough, and the
same race reproduces in about thirty lines of pure CPython on both 3.10 and
3.12.

Every _cache accessor now serializes on a dedicated RLock. load_autotuners was
writing _cache directly, bypassing the class API, so it goes through a new
save_with_key(); without that the lock would be decorative. key() stays outside
the critical section because it hashes the kernel source and get()/save() are
on the hot compile path. The lock is reentrant because clearing runs the
values' finalizers while holding it.

An in-place _cache.clear() also fixes the crash by itself, because PyDict_Clear
empties the dict before decref'ing the values so re-entrant finalizers never
observe it mid-teardown. It was dropped once the lock was in place: the lock
already excludes concurrent observers, and one mechanism is easier to reason
about than two.

Test Plan:
The fbsource tree has no built torch, so these were run from a built PyTorch
checkout with the identical change applied.

Both new tests fail before the change and pass after:

```
python -m pytest test/inductor/test_codecache.py -q -k TestCompiledTritonKernels
```

test_accessors_hold_the_lock is deterministic and needs no GPU; it patches
_lock with a tracking wrapper and asserts all five accessors acquire it.
test_concurrent_save_and_clear races save_with_key() against cache_clear() in a
subprocess and asserts the child is not killed by SIGSEGV; it captures thread
exceptions and asserts the saver drained its pool, so a dead thread fails
rather than silently looking like success.

Memory safety, 8 consecutive runs of that stress workload: 0 SIGSEGV. The same
workload written the way load_autotuners used to write _cache (direct
subscript assignment, no lock) segfaults 5 out of 5.

Regressions, all pre-existing failures confirmed by re-running with the change
reverted:

```
python -m pytest test/inductor/test_static_triton_launcher.py -q
python -m pytest test/inductor/test_triton_launcher_integration.py -q
python -m pytest test/inductor/test_codecache.py -q -k "bundle or autotuner or static_launch or triton_bundler"
```

28 passed; 5 passed and 1 failed; 70 passed and 4 failed.

```
arc lint -a caffe2/torch/_inductor/async_compile.py caffe2/torch/_inductor/triton_bundler.py caffe2/test/inductor/test_codecache.py
```

Authored with Claude.

Differential Revision: D114901960




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98