### PR TITLE
[TEST] Refactor test_open_registry.py with hw_classification

### DIFF
--- a/test/nn/attention/test_open_registry.py
+++ b/test/nn/attention/test_open_registry.py
@@ -2,7 +2,11 @@
 
 import torch.nn.attention as attention
 from torch.nn.attention import _registry
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class FakeHandle:
@@ -11,6 +15,8 @@ class FakeHandle:
 
 
 class TestFlashAttentionRegistry(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._saved_impls = dict(_registry._FLASH_ATTENTION_IMPLS)


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestFlashAttentionRegistry`: `GENERIC` — both tests are pure Python registry/mock paths with no hardware dependency
- No `instantiate_device_type_tests` needed

## Test Plan
```
python test/nn/attention/test_open_registry.py -v
# Ran 2 — OK

python test/nn/attention/test_open_registry.py --hw-classification GENERIC -v
# Ran 2 — OK; unclassified=0, mismatched=0
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508