### PR TITLE
Enable C++ stack traces with distributed DETAIL debugging

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1930,6 +1930,28 @@ class CommTest(AbstractCommTest, MultiProcessTestCase):
             ):
                 dist.set_debug_level_from_env()
 
+    def test_debug_detail_enables_cpp_stacktraces(self):
+        original_debug = os.environ.get("TORCH_DISTRIBUTED_DEBUG")
+        original_stacktraces = os.environ.get("TORCH_SHOW_CPP_STACKTRACES")
+        try:
+            os.environ["TORCH_DISTRIBUTED_DEBUG"] = "detail"
+            os.environ.pop("TORCH_SHOW_CPP_STACKTRACES", None)
+            dist.set_debug_level_from_env()
+            self.assertEqual(os.environ["TORCH_SHOW_CPP_STACKTRACES"], "1")
+
+            os.environ["TORCH_SHOW_CPP_STACKTRACES"] = "0"
+            dist.set_debug_level_from_env()
+            self.assertEqual(os.environ["TORCH_SHOW_CPP_STACKTRACES"], "0")
+        finally:
+            if original_debug is None:
+                os.environ.pop("TORCH_DISTRIBUTED_DEBUG", None)
+            else:
+                os.environ["TORCH_DISTRIBUTED_DEBUG"] = original_debug
+            if original_stacktraces is None:
+                os.environ.pop("TORCH_SHOW_CPP_STACKTRACES", None)
+            else:
+                os.environ["TORCH_SHOW_CPP_STACKTRACES"] = original_stacktraces
+
 
 class DummyWork(dist._Work):
     def wait(self, timeout=5.0):

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
+import os
 import sys
 import traceback
 import typing
@@ -89,7 +90,7 @@ if is_available():
         ProcessGroup as ProcessGroup,
         Reducer,
         set_debug_level,
-        set_debug_level_from_env,
+        set_debug_level_from_env as _set_debug_level_from_env,
         Store,
         TCPStore,
         Work as _Work,
@@ -192,6 +193,12 @@ if is_available():
         register_rendezvous_handler,
         rendezvous,
     )
+
+    def set_debug_level_from_env():
+        """Set the distributed debug level from environment variables."""
+        if os.environ.get("TORCH_DISTRIBUTED_DEBUG", "").upper() == "DETAIL":
+            os.environ.setdefault("TORCH_SHOW_CPP_STACKTRACES", "1")
+        _set_debug_level_from_env()
 
     set_debug_level_from_env()
 


### PR DESCRIPTION
## Summary

Closes #78842.

When `TORCH_DISTRIBUTED_DEBUG=DETAIL` is active, automatically enable C++ stack traces unless the user explicitly set `TORCH_SHOW_CPP_STACKTRACES`. This aligns distributed detail diagnostics with the requested debugging level while preserving an explicit opt-out.

## Checklist

- [ ] I have run `spin fixlint` and all lint checks pass (not reported in the original PR body)
- [x] I have added or updated tests
- [x] I have updated documentation (not applicable; this changes an existing debug-mode behavior)
- [x] I have included benchmark results (not applicable; this is diagnostic configuration)

## BC-breaking?

No. Users who explicitly set `TORCH_SHOW_CPP_STACKTRACES` retain control; otherwise DETAIL mode gains the expected C++ stack traces.

## Validation

- `python3 -m compileall -q torch/distributed/__init__.py test/distributed/test_c10d_common.py`
- `git diff --check`
- Runtime distributed tests could not run locally because this checkout has no built PyTorch extension.

## Changes

- `torch/distributed/__init__.py`: apply the DETAIL-mode default.
- `test/distributed/test_c10d_common.py`: add/update coverage for the behavior.
