### PR TITLE
[ROCm 7.14] Install libatomic in the manywheel builder image

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -192,6 +192,9 @@ ARG ROCM_VERSION
 # repair_wheel.py discover ROCM_HOME from there. No /opt/rocm symlink.
 ARG THEROCK_INDEX_URL
 ENV MKLROOT /opt/intel
+# torch's extensions link libatomic.so.1, which the plain AlmaLinux base lacks and
+# which no ROCm OS package pulls in on this path (unlike rocm_final_legacy).
+RUN yum install -y libatomic
 # cmake-3.28.4 from pip to get enable_language(HIP)
 RUN python3 -m pip install --upgrade pip && \
     python3 -mpip install cmake==3.28.4


### PR DESCRIPTION
Fixes the `manywheel-py3_11-rocm7_14-test` smoke test, which fails on `nightly`
at `check_binary.sh`'s `python -c 'import torch'`
([job](https://github.com/pytorch/pytorch/actions/runs/30988588492/job/92407265826#step:8:1322)):

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../site-packages/torch/__init__.py", line 496, in <module>
    from torch._C import *  # noqa: F403
ImportError: libatomic.so.1: cannot open shared object file: No such file or directory
```

The `ldd` dump earlier in the same log reports `libatomic.so.1 => not found` for
a dozen libraries under `torch/lib`.

## Why only ROCm 7.14

`rocm_final` — the ROCm 7.14 stage — builds `FROM` a plain `amd64/almalinux:8`
and installs ROCm entirely as pip wheels from the TheRock multi-arch index, so no
OS package pulls `libatomic` in. `rocm_final_legacy` (7.2 and earlier) is based on
`rocm/dev-almalinux-8`, which ships it, which is why only the 7.14 leg fails.

The build succeeds because gcc-toolset-13 provides `libatomic` under `/opt/rh`,
but that directory is not on the runtime loader path — so the gap only surfaces
when the test job imports torch.

`libatomic` is in AlmaLinux 8 BaseOS (verified: `libatomic-8.5.0-24.el8_10` in
`BaseOS/x86_64/os/Packages/`) and provides `/usr/lib64/libatomic.so.1`. The
`RUN yum install -y libatomic` follows the existing convention in this file
(e.g. `RUN yum install -y libdrm-devel` in `rocm_final_legacy`).

## Note: the wheel itself does not carry libatomic

Worth deciding separately. On the 7.14 path `repair_wheel.py` takes the TheRock
branch, which resolves ROCm libs via RPATH and does **not** call `rocm_bundle()`,
so neither the ROCm libs nor `rocm_os_deps()` (libnuma, libelf, libtinfo, libdw,
libdrm) are bundled — and `libatomic.so.1` is not in that list anyway. This PR
makes the *CI image* provide the library, so the smoke test passes, but a user
installing the wheel on a host without `libatomic` (a slim container image, say)
would still hit the same ImportError.

If we want the wheel self-contained, the natural fix is to bundle
`libatomic.so.1` into `torch/lib/` for the ROCm path, exactly as `libgomp` is
bundled today via `detect_libgomp()`. That is a wheel-content change, so I left
it out of this PR — happy to add it here or as a follow-up.

## Test plan

Requires a rebuild of `pytorch/manylinux2_28-builder:rocm7.14` via
`build-manywheel-images.yml` before the nightly test leg picks it up.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang