### PR TITLE
[BE] Drop ROCm < 7.1 support from CI/CD

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -154,11 +154,6 @@ Pin: release o=repo.radeon.com
 Pin-Priority: 600
 EOF
 
-    # we want the patch version of 6.4 instead
-    if [[ $(ver $ROCM_VERSION) -eq $(ver 6.4) ]]; then
-        ROCM_VERSION="${ROCM_VERSION}.2"
-    fi
-
     # we want the patch version of 7.2 instead
     if [[ $(ver $ROCM_VERSION) -eq $(ver 7.2) ]]; then
         ROCM_VERSION="${ROCM_VERSION}.3"
@@ -182,59 +177,13 @@ EOF
                    roctracer-dev \
                    amd-smi-lib
 
-    if [[ $(ver $ROCM_VERSION) -ge $(ver 6.1) ]]; then
-        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated rocm-llvm-dev
-    fi
-
-    if [[ $(ver $ROCM_VERSION) -lt $(ver 7.1) ]]; then
-      # precompiled miopen kernels added in ROCm 3.5, renamed in ROCm 5.5, removed in ROCm 7.1
-      # search for all unversioned packages
-      # if search fails it will abort this script; use true to avoid case where search fails
-      MIOPENHIPGFX=$(apt-cache search --names-only miopen-hip-gfx | awk '{print $1}' | grep -F -v . || true)
-      if [[ "x${MIOPENHIPGFX}" = x ]]; then
-        echo "miopen-hip-gfx package not available" && exit 1
-      else
-        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated ${MIOPENHIPGFX}
-      fi
-    fi
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated rocm-llvm-dev
 
     # ROCm 6.0 had a regression where journal_mode was enabled on the kdb files resulting in permission errors at runtime
     for kdb in /opt/rocm/share/miopen/db/*.kdb
     do
         sqlite3 $kdb "PRAGMA journal_mode=off; PRAGMA VACUUM;"
     done
-
-    # ROCm 6.3 had a regression where initializing static code objects had significant overhead
-    # CI no longer builds for ROCm 6.3, but
-    # ROCm 6.4 did not yet fix the regression, also HIP branch names are different
-    if [[ $(ver $ROCM_VERSION) -ge $(ver 6.4) ]] && [[ $(ver $ROCM_VERSION) -lt $(ver 7.0) ]]; then
-        if [[ $(ver $ROCM_VERSION) -eq $(ver 6.4.2) ]]; then
-            HIP_TAG=rocm-6.4.2
-            CLR_HASH=74d78ba3ac4bac235d02bcb48511c30b5cfdd457  # branch release/rocm-rel-6.4.2-statco-hotfix
-        elif [[ $(ver $ROCM_VERSION) -eq $(ver 6.4.1) ]]; then
-            HIP_TAG=rocm-6.4.1
-            CLR_HASH=efe6c35790b9206923bfeed1209902feff37f386  # branch release/rocm-rel-6.4.1-statco-hotfix
-        elif [[ $(ver $ROCM_VERSION) -eq $(ver 6.4) ]]; then
-            HIP_TAG=rocm-6.4.0
-            CLR_HASH=600f5b0d2baed94d5121e2174a9de0851b040b0c  # branch release/rocm-rel-6.4-statco-hotfix
-        fi
-        # clr build needs CppHeaderParser but can only find it using conda's python
-        python -m pip install CppHeaderParser
-        git clone https://github.com/ROCm/HIP -b $HIP_TAG
-        HIP_COMMON_DIR=$(readlink -f HIP)
-        git clone https://github.com/jeffdaily/clr
-        pushd clr
-        git checkout $CLR_HASH
-        popd
-        mkdir -p clr/build
-        pushd clr/build
-        # Need to point CMake to the correct python installation to find CppHeaderParser
-        cmake .. -DPython3_EXECUTABLE=/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}/bin/python3 -DCLR_BUILD_HIP=ON -DHIP_COMMON_DIR=$HIP_COMMON_DIR
-        make -j
-        cp hipamd/lib/libamdhip64.so.6.4.* /opt/rocm/lib/libamdhip64.so.6.4.*
-        popd
-        rm -rf HIP clr
-    fi
 
     # Note: rocm-composable-kernel (ck4inductor) is now built as a wheel
     # alongside PyTorch in .ci/pytorch/build.sh and installed at test time

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -152,7 +152,7 @@ RUN ln -sf /usr/local/cuda-${BASE_CUDA_VERSION} /usr/local/cuda
 ENV PATH=/usr/local/cuda/bin:$PATH
 
 FROM cpu_final as rocm_final_legacy
-ARG ROCM_VERSION=6.0
+ARG ROCM_VERSION
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ARG DEVTOOLSET_VERSION=13

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -96,14 +96,6 @@ case ${image} in
             if [[ "$GPU_ARCH_VERSION" == *"7.1"* ]]; then
                 GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.1"
             fi
-            # we want the patch version of 7.0 instead
-            if [[ "$GPU_ARCH_VERSION" == *"7.0"* ]]; then
-                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.2"
-            fi
-            # we want the patch version of 6.4 instead
-            if [[ "$GPU_ARCH_VERSION" == *"6.4"* ]]; then
-                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.4"
-            fi
             TARGET=rocm_final_legacy
             GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
             # Legacy images also cover the older gfx900/gfx906 targets.

--- a/.ci/magma-rocm/README.md
+++ b/.ci/magma-rocm/README.md
@@ -4,14 +4,14 @@ This folder contains the scripts and configurations to build libmagma.so, linked
 
 ## Building
 
-Look in the `Makefile` for available targets to build. To build any target, for example `magma-rocm63`, run
+Look in the `Makefile` for available targets to build. To build any target, for example `magma-rocm72`, run
 
 ```
 # Using `docker`
-make magma-rocm63
+make magma-rocm72
 
 # Using `podman`
-DOCKER_CMD=podman make magma-rocm63
+DOCKER_CMD=podman make magma-rocm72
 ```
 
 This spawns a `pytorch/manylinux-rocm<version>` docker image, which has the required `devtoolset` and ROCm versions installed.

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2341,7 +2341,7 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
         BASELINE_INDEX_URL="https://download.pytorch.org/whl/nightly/cu130"
       elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
         # Keep in sync with the ROCm version in the benchmarks docker image
-        BASELINE_INDEX_URL="https://download.pytorch.org/whl/nightly/rocm6.4"
+        BASELINE_INDEX_URL="https://download.pytorch.org/whl/nightly/rocm7.2"
       else
         echo "ERROR: cannot infer BASELINE_INDEX_URL from BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
         exit 1


### PR DESCRIPTION
Companion to #192257 (CUDA < 12.6). `ROCM_ARCHES = ["7.2", "7.14"]`, so nothing
below 7.1 is built or shipped any more.

## Changes

| file | change |
|---|---|
| `.ci/docker/manywheel/Dockerfile_2_28` | `ARG ROCM_VERSION=6.0` → bare `ARG ROCM_VERSION` |
| `.ci/docker/manywheel/build.sh` | drop the 7.0 and 6.4 patch-version fixups |
| `.ci/docker/common/install_rocm.sh` | drop 4 dead version-gated blocks (see below) |
| `.ci/pytorch/test.sh` | ROCm benchmark baseline `rocm6.4` → `rocm7.2` |
| `.ci/magma-rocm/README.md` | example target `magma-rocm63` → `magma-rocm72` |

### `install_rocm.sh`

- the **6.4 patch-version fixup** (`ver == 6.4 → 6.4.2`);
- **`rocm-llvm-dev` is now installed unconditionally** — the `>= 6.1` guard can
  no longer be false;
- the **`< 7.1` precompiled-MIOpen-kernel branch**, which is dead by the
  comment's own admission ("removed in ROCm 7.1");
- the **6.4-only clr/HIP rebuild** (~30 lines gated on `>= 6.4 && < 7.0`) that
  worked around the ROCm 6.3/6.4 static-code-object regression, including the
  pinned `HIP_TAG`/`CLR_HASH` values and the `libamdhip64.so.6.4.*` copy.

### The two that are not pure deletions

- **`ARG ROCM_VERSION=6.0`** — the value you flagged. Dropped the default rather
  than bumping it, so it matches the `rocm_final` stage in the same file;
  `manywheel/build.sh` always passes `--build-arg ROCM_VERSION`.
- **`.ci/pytorch/test.sh`** — this one was a live bug, not just cruft. The ROCm
  benchmark baseline installed nightlies from `whl/nightly/rocm6.4`, while the
  comment directly above says to keep the version in sync with the benchmarks
  docker image — and that image is `ROCM_VERSION=7.2` (`.ci/docker/build.sh`,
  `pytorch-linux-jammy-rocm-n-py3-benchmarks`). Now points at `rocm7.2`.

## Deliberately left alone

- The **C++ `ROCM_VERSION` preprocessor guards**: 37 lines below `70100` in
  `aten/`, `torch/`, `c10/` (23 × `70000`, 6 × `60500`, 6 × `60300`, 2 ×
  `60400`). Same reasoning as the CUDA PR — separate, larger change.
- The **MIOpen kdb `journal_mode` loop.** Its comment calls it a ROCm 6.0
  workaround, so it looks like a candidate, but it is *not* version-gated — it
  runs for 7.x too, so deleting it would change current behaviour rather than
  remove dead code. Worth a follow-up if ROCm folks confirm it is obsolete.
- There is **no cmake ROCm minimum** to raise (no `ROCM_VERSION VERSION_LESS`
  check exists), so this PR has no source-build-narrowing counterpart to the
  CUDA one.

## Test plan

`bash -n` and `shellcheck -S error` clean on all three edited shell scripts. No
references to ROCm 6.x or 7.0 remain in the touched files. Remaining `rocm6.x`
strings elsewhere in `.ci/` are illustrative comments and docstrings
(e.g. "`e.g. manylinux2_28-builder:rocm6.2.4 returns 6.2.4`").


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang