### PR TITLE
[dynamo] Exclude aten.bernoulli.default from decomposition under fallback_random

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11459,6 +11459,26 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             rtol=0.06,
         )
 
+    @config.patch(fallback_random=True)
+    def test_bernoulli_default_fallback_random(self):
+        # aten.bernoulli.default must stay excluded from decomposition under
+        # fallback_random=True, like bernoulli_/bernoulli.p already are: its
+        # core decomp (rand + compare) consumes RNG state in a different
+        # order than the ATen kernel, so the two diverge on CUDA even with
+        # the same seed. See https://github.com/pytorch/pytorch/issues/188074
+        def fn(x):
+            return torch.bernoulli(x)
+
+        x = torch.full((200, 200), 0.3, device=self.device)
+        compiled = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(0)
+        expected = fn(x)
+        torch.manual_seed(0)
+        actual = compiled(x)
+
+        self.assertEqual(actual, expected)
+
     def test_narrow(self):
         def fn(x):
             return (

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -270,4 +270,16 @@ def bernoulli_p(self, p=0.5, *, generator=None):
     return torch.rand_like(self, dtype=torch.float32) < p
 
 
+@register_extra_random_decomp([aten.bernoulli.default])
+def bernoulli_default(self, *, generator=None):
+    # Unlike bernoulli_/bernoulli.p above, this has no dedicated Inductor
+    # lowering to fall back on for CPU, so (unlike its siblings) it must
+    # keep decomposing on CPU too to stay fused in the default (non
+    # fallback_random) path.
+    raw_p = torch.rand(
+        self.size(), generator=generator, dtype=torch.float32, device=self.device
+    )
+    return (raw_p < self).to(self.dtype)
+
+
 rng_decompositions.update(extra_random_decomps)  # type: ignore[arg-type]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -146,6 +146,11 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten._foreach_addcdiv_,
     aten.lerp,
     aten.lerp_,
+    # Excluded so it stays unfused (like bernoulli_/bernoulli.p in
+    # extra_random_decomps) under fallback_random=True. Its core decomp
+    # consumes Philox RNG state in a different order than the ATen kernel,
+    # producing outputs that diverge from eager even with the same seed.
+    aten.bernoulli.default,
 ]
 
 remove_decompositions(decompositions, decomps_to_exclude)


### PR DESCRIPTION
## Summary

When `fallback_random=True`, `torch.bernoulli(x)` diverges from eager even with the same seed, because `aten.bernoulli.default`'s decomposition (`rand() < x`) consumes RNG state in a different order than the native ATen kernel. `bernoulli_`/`bernoulli.p` already avoid this via `extra_random_decomps`, which is excluded whenever `fallback_random=True`. `bernoulli.default`'s decomp was instead registered directly on the shared `core_aten_decompositions()` table, so it kept decomposing regardless of the flag.

Adds `bernoulli.default` to `decomps_to_exclude` in `torch/_inductor/decomposition.py`, and re-registers an identical decomposition via `register_extra_random_decomp` in `torch/_decomp/decompositions_for_rng.py`, so the normal (non-fallback) fast compile path is unaffected. Unlike `bernoulli_`/`bernoulli.p`, the re-registered decomp keeps applying on CPU too, since `bernoulli.default` has no dedicated Inductor lowering to fall back on there.

Fixes #188074

## Test plan

Added `test_bernoulli_default_fallback_random` to `test/inductor/test_torchinductor.py`, asserting `torch.compile(fn, backend="inductor")(x)` exactly matches eager under `fallback_random=True`.

No CUDA or MSVC `cl.exe` available in my dev environment to run `torch.compile` end-to-end, so I verified the decomp-table selection mechanism directly via `make_fx` tracing against `select_decomp_table()`:

```
fallback_random=True:  bernoulli.default excluded, traced graph keeps
                        a single unfused aten.bernoulli.default call
fallback_random=False: bernoulli.default still decomposes into
                        rand()+lt()+convert_element_type(), unchanged
                        from before this diff
```

```
ruff check torch/_inductor/decomposition.py torch/_decomp/decompositions_for_rng.py test/inductor/test_torchinductor.py
ruff format --diff torch/_inductor/decomposition.py torch/_decomp/decompositions_for_rng.py
```
Both clean on the diff.

Marking as draft since I wasn't able to run the new test against CUDA locally — would appreciate a CI run / review before merge.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo