### PR TITLE
[inductor] Don't assume alignment of saved user inputs in backward

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2197,6 +2197,39 @@ class CudaReproTests(TestCase):
         self.assertEqual(foo_c(t[1:]), foo(t_orig[1:]))
         self.assertEqual(t, t_orig)
 
+    def test_misaligned_saved_for_backward_input(self):
+        # A user input saved for backward but unused in forward compute reaches
+        # the backward graph as a primal. The backward compile must not assume
+        # it is aligned just because the first call's example was: unlike
+        # params/buffers, its address changes every call.
+        N = 1024
+
+        class ScaleGradient(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, value, weight):
+                ctx.save_for_backward(weight)
+                return value.expand(N).clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (weight,) = ctx.saved_tensors
+                return (grad_output * weight).sum().reshape(1), None
+
+        compiled = torch.compile(ScaleGradient.apply, dynamic=False)
+
+        def run(weight):
+            value = torch.ones(1, device=device_type, requires_grad=True)
+            compiled(value, weight).sum().backward()
+            self.assertEqual(value.grad, weight.sum().to(value.dtype).reshape(1))
+
+        aligned = torch.ones(N, device=device_type, dtype=torch.int32)
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        run(aligned)
+
+        misaligned = torch.ones(N + 1, device=device_type, dtype=torch.int32)[1:]
+        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
+        run(misaligned)
+
     def test_non_commutative_scan_op(self):
         from torch._higher_order_ops.associative_scan import associative_scan
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1370,6 +1370,15 @@ def _extract_fwd_bwd_modules(
     )
     placeholders = joint_module.graph.find_nodes(op="placeholder")
     primal_inputs = [*filter(_is_primal, placeholders)]
+    # Record which primals have static addresses (params/buffers/
+    # mark_static_address inputs). Saved primals that are plain user inputs
+    # get a fresh tensor every call, and the backward compiler must not
+    # bake in address-derived properties (e.g. alignment) for them. The
+    # meta dict is shared with the extracted fwd/bwd placeholder nodes, so
+    # this is visible on bw_module's placeholders.
+    if static_lifetime_input_nodes is not None:
+        for node in primal_inputs:
+            node.meta["is_static_input"] = node in static_lifetime_input_nodes
     tangent_inputs = (
         [] if omit_aot_autograd_runtime else [*filter(_is_tangent, placeholders)]
     )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1370,31 +1370,16 @@ def _extract_fwd_bwd_modules(
     )
     placeholders = joint_module.graph.find_nodes(op="placeholder")
     primal_inputs = [*filter(_is_primal, placeholders)]
-    # Note: [is_static_input on backward placeholders]
-    #
-    # Whether an input has a static address (params/buffers/
-    # mark_static_address) is tracked positionally, as indices into the flat
-    # forward inputs (fw_metadata.static_input_indices), not as node
-    # metadata. Positional lookup stops working past this point: the
-    # backward graph's input list is (saved symints, saved values in
-    # partitioner-chosen order, tangents, ...), so a forward input index is
-    # meaningless there. Historically the backward compiler guessed from
-    # placeholder names instead ("primals_*" == static, see count_tangents),
-    # which wrongly classifies a saved-for-backward plain user input as
-    # static: its address changes every call, and e.g. baking the example
-    # input's alignment into backward codegen then crashes with a misaligned
-    # address when a later call passes a misaligned tensor.
-    #
-    # So convert the positional info to node metadata here, while primals
-    # are still 1:1 with flat forward inputs. The meta dict is shared by
+    # Stamp is_static_input on primal placeholders for the backward
+    # compiler; see Note: [is_static_input on backward placeholders] in
+    # torch/_inductor/compile_fx.py. This must happen here, while primals
+    # are still 1:1 with flat forward inputs, because staticness is tracked
+    # positionally (static_lifetime_input_nodes derives from
+    # fw_metadata.static_input_indices) and the backward graph's input
+    # ordering destroys that correspondence. The meta dict is shared by
     # reference with the extracted fwd/bwd placeholder nodes
     # (_extract_graph_with_inputs_outputs), so the stamp is visible on
     # bw_module's placeholders regardless of how saving reorders them.
-    # For static inputs the backward compiler may keep baking
-    # address-derived properties into generated code; their address never
-    # changes without a recompile. Saved activations are not stamped: they
-    # are inductor-allocated and handled separately (see
-    # get_static_bw_input_idxs for the partitioned-forward case).
     #
     # TODO: staticness arguably belongs on the AOTInput descriptors
     # (meta["desc"]); today those cannot express it (the dynamo frontend

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1370,12 +1370,36 @@ def _extract_fwd_bwd_modules(
     )
     placeholders = joint_module.graph.find_nodes(op="placeholder")
     primal_inputs = [*filter(_is_primal, placeholders)]
-    # Record which primals have static addresses (params/buffers/
-    # mark_static_address inputs). Saved primals that are plain user inputs
-    # get a fresh tensor every call, and the backward compiler must not
-    # bake in address-derived properties (e.g. alignment) for them. The
-    # meta dict is shared with the extracted fwd/bwd placeholder nodes, so
-    # this is visible on bw_module's placeholders.
+    # Note: [is_static_input on backward placeholders]
+    #
+    # Whether an input has a static address (params/buffers/
+    # mark_static_address) is tracked positionally, as indices into the flat
+    # forward inputs (fw_metadata.static_input_indices), not as node
+    # metadata. Positional lookup stops working past this point: the
+    # backward graph's input list is (saved symints, saved values in
+    # partitioner-chosen order, tangents, ...), so a forward input index is
+    # meaningless there. Historically the backward compiler guessed from
+    # placeholder names instead ("primals_*" == static, see count_tangents),
+    # which wrongly classifies a saved-for-backward plain user input as
+    # static: its address changes every call, and e.g. baking the example
+    # input's alignment into backward codegen then crashes with a misaligned
+    # address when a later call passes a misaligned tensor.
+    #
+    # So convert the positional info to node metadata here, while primals
+    # are still 1:1 with flat forward inputs. The meta dict is shared by
+    # reference with the extracted fwd/bwd placeholder nodes
+    # (_extract_graph_with_inputs_outputs), so the stamp is visible on
+    # bw_module's placeholders regardless of how saving reorders them.
+    # For static inputs the backward compiler may keep baking
+    # address-derived properties into generated code; their address never
+    # changes without a recompile. Saved activations are not stamped: they
+    # are inductor-allocated and handled separately (see
+    # get_static_bw_input_idxs for the partitioned-forward case).
+    #
+    # TODO: staticness arguably belongs on the AOTInput descriptors
+    # (meta["desc"]); today those cannot express it (the dynamo frontend
+    # emits PlainAOTInput even for lifted params, and mark_static_address
+    # lives on the tensor object), so we use a dedicated meta key.
     if static_lifetime_input_nodes is not None:
         for node in primal_inputs:
             node.meta["is_static_input"] = node in static_lifetime_input_nodes

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1371,7 +1371,7 @@ def _extract_fwd_bwd_modules(
     placeholders = joint_module.graph.find_nodes(op="placeholder")
     primal_inputs = [*filter(_is_primal, placeholders)]
     # Stamp is_static_input on primal placeholders for the backward
-    # compiler; see Note: [is_static_input on backward placeholders] in
+    # compiler; see Note: [static_input_idxs semantics] in
     # torch/_inductor/compile_fx.py. This must happen here, while primals
     # are still 1:1 with flat forward inputs, because staticness is tracked
     # positionally (static_lifetime_input_nodes derives from

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2802,6 +2802,25 @@ def compile_fx_backward(
             static_input_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
         else:
             static_input_idxs = list(range(fixed))
+
+        # Saved primals that are plain user inputs (not params/buffers/
+        # mark_static_address) get a fresh tensor every call, so they are not
+        # address-stable and may not match the example input's alignment.
+        # Demote them so get_input_idxs_to_check gives them the same runtime
+        # copy_if_misaligned treatment as tangents. Saved activations stay
+        # static: inductor allocates them aligned.
+        context = torch._guards.TracingContext.try_get()
+        if context is not None and context.fw_metadata is not None:
+            fw_static = OrderedSet(context.fw_metadata.static_input_indices)
+            placeholders = gm.graph.find_nodes(op="placeholder")
+
+            def is_static_bw_input(idx: int) -> bool:
+                name = placeholders[idx].name
+                if name.startswith("primals_"):
+                    return int(name[len("primals_") :]) - 1 in fw_static
+                return True
+
+            static_input_idxs = [i for i in static_input_idxs if is_static_bw_input(i)]
         with (
             (
                 config.patch(get_cpp_wrapper_config())

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -284,8 +284,8 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   backward input                    | addr-stable    | align-stable
 #   ----------------------------------+----------------+------------------
 #   saved fw input                    | same as that input in the forward
-#   saved inductor intermediate       | cudagraphs [2] | yes [2]
-#   saved fallback (custom) op output | cudagraphs     | NO: KNOWN HOLE [3]
+#   saved inductor intermediate       | pool-owned [2] | yes [2]
+#   saved fallback (custom) op output | pool-owned [2] | NO: KNOWN HOLE [3]
 #   tangent                           | no             | no
 #
 # [1] per-recompile: may legally move under inline_inbuilt_nn_modules
@@ -293,13 +293,22 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #     misaligned, alignment baked into existing kernels is wrong and we
 #     IMA; dynamo needs an alignment guard on unguarded statics so a
 #     misaligned swap recompiles instead.
-# [2] allocator-aligned base + deterministic codegen offsets: even a saved
-#     odd-offset view is stably misaligned, so bw codegen makes no
-#     assumption for it. Under cudagraphs, activations from inline code
-#     between graph partitions are NOT pool-allocated and get demoted
-#     (get_static_bw_input_idxs, see compile_fx_backward). A saved alias
-#     of a user input takes the "saved fw input" row: the partitioner
-#     saves the base primal and recomputes the view in backward.
+# [2] align: allocator-aligned base + deterministic codegen offsets; even
+#     a saved odd-offset view is stably misaligned, so bw codegen makes no
+#     assumption for it. addr: "cudagraphs on" is NOT sufficient --
+#     address-stability holds only for tensors allocated inside a region a
+#     CUDA graph actually owns. With piecewise/partitioned forwards
+#     (graph_partition, cudagraph-unsafe ops), code between partitions
+#     runs eagerly, so its allocations move per call even though
+#     "cudagraphs is on"; those saved activations are demoted wholesale
+#     (forward_is_partitioned -> get_static_bw_input_idxs, see
+#     compile_fx_backward -- conservative: partition-owned activations are
+#     demoted too). Same caveat at the dynamo level: graph breaks make
+#     each compiled region its own cudagraph (trees), and staticness only
+#     transfers within a region's pool lineage (cudagraph_managed_idxs).
+#     A saved alias of a user input takes the "saved fw input" row: the
+#     partitioner saves the base primal and recomputes the view in
+#     backward.
 # [3] allocated by arbitrary user code, so alignment may vary call to
 #     call, but it is classified static (unstamped, non-primal) and gets
 #     no runtime check: an alignment flip IMAs in the backward. Inductor

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2009,6 +2009,22 @@ def get_input_idxs_to_check(
         with maybe_get_suppress_shape_guards_ctx():
             # suppress guards so that tensor_is_aligned and should_assume_input_aligned
             # do not add guards on input's storage offset
+            #
+            # A static input is weight-like: address-stable across calls, and
+            # the compiled artifact must never copy it per call (cudagraphs
+            # records its address; see cudagraphify_impl). So if the example
+            # is aligned, every call's input is aligned and the runtime check
+            # is skippable; cloning would also break the address the
+            # cudagraph recorded. This is why misclassifying a non-static
+            # input as static crashes rather than deoptimizes -- see
+            # Note: [is_static_input on backward placeholders].
+            #
+            # TODO: "address-stable" is per-recompile, not absolute: with
+            # inline_inbuilt_nn_modules (#126822) an unguarded static input
+            # may legally move (cudagraphs re-records), and if the new
+            # address is misaligned the baked-in alignment here is wrong and
+            # we IMA. Dynamo needs an alignment guard on unguarded static
+            # inputs so a misaligned swap recompiles instead.
             if i in static_input_idxs and tensor_is_aligned(input):
                 continue
             if not should_assume_input_aligned(input):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2811,20 +2811,35 @@ def compile_fx_backward(
         if compiler_config_extra.cudagraphs_bwd_override is not None:
             cudagraphs = BoxedBool(compiler_config_extra.cudagraphs_bwd_override)
 
-        # Static backward inputs are the saved tensors, minus two
+        # Note: [is_static_input on backward placeholders]
+        #
+        # A backward placeholder may carry meta["is_static_input"], declaring
+        # whether its runtime tensor is address-stable across calls (a param/
+        # buffer/mark_static_address input, as opposed to e.g. a plain user
+        # input that was saved for backward and gets a fresh tensor every
+        # call). Inductor uses this to decide which inputs may have
+        # address-derived properties (alignment) baked into generated code
+        # versus needing the runtime copy_if_misaligned treatment; a wrong
+        # "static" here is a misaligned-address crash, not a deoptimization.
+        #
+        # Whoever produces the backward graph is responsible for stamping,
+        # because only the producer can map staticness (tracked positionally
+        # over the flat forward inputs, fw_metadata.static_input_indices)
+        # onto its choice and ordering of saved tensors; by the time the
+        # graph reaches us here, that correspondence is gone. AOTAutograd's
+        # partitioner stamps in _extract_fwd_bwd_modules, where primals are
+        # still 1:1 with flat forward inputs. Unstamped placeholders fall
+        # back to the historical name-based classification below (all
+        # "primals_*" static), so producers that do not stamp (custom
+        # partition_fns) keep the old, less safe behavior.
+        #
+        # Static backward inputs are thus the saved tensors, minus two
         # over-approximations of the name-based classification:
         # 1. When the forward was partitioned, saved activations from inline
         #    code between partitions are NOT at fixed addresses; keep only
         #    "primals_*" (get_static_bw_input_idxs).
-        # 2. A saved-for-backward plain user input is a "primals_*" but is
-        #    NOT address-stable (fresh tensor every call), so it must get
-        #    the same runtime copy_if_misaligned treatment as tangents
-        #    rather than having the example input's alignment baked in. The
-        #    partitioner records true staticness on saved primal
-        #    placeholders; see Note: [is_static_input on backward
-        #    placeholders]. Unstamped nodes (saved activations, or graphs
-        #    from custom partitioners) default to static, preserving the
-        #    name-based classification.
+        # 2. Saved-for-backward plain user inputs, demoted via the stamp as
+        #    described above.
         if compiler_config_extra.forward_is_partitioned.value:
             candidate_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
         else:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2808,19 +2808,17 @@ def compile_fx_backward(
         # address-stable and may not match the example input's alignment.
         # Demote them so get_input_idxs_to_check gives them the same runtime
         # copy_if_misaligned treatment as tangents. Saved activations stay
-        # static: inductor allocates them aligned.
-        context = torch._guards.TracingContext.try_get()
-        if context is not None and context.fw_metadata is not None:
-            fw_static = OrderedSet(context.fw_metadata.static_input_indices)
-            placeholders = gm.graph.find_nodes(op="placeholder")
-
-            def is_static_bw_input(idx: int) -> bool:
-                name = placeholders[idx].name
-                if name.startswith("primals_"):
-                    return int(name[len("primals_") :]) - 1 in fw_static
-                return True
-
-            static_input_idxs = [i for i in static_input_idxs if is_static_bw_input(i)]
+        # static: inductor allocates them aligned. The partitioner stamps
+        # is_static_input on saved primal placeholders (see
+        # _extract_fwd_bwd_modules); nodes without the stamp (activations,
+        # tangents, or graphs from partitioners that predate it) keep their
+        # existing classification.
+        placeholders = gm.graph.find_nodes(op="placeholder")
+        static_input_idxs = [
+            i
+            for i in static_input_idxs
+            if placeholders[i].meta.get("is_static_input", True)
+        ]
         with (
             (
                 config.patch(get_cpp_wrapper_config())

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -268,9 +268,14 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   address cudagraphs recorded.
 # Codegen itself does NOT consult staticness: triton code assumes the
 # alignment of the example inputs (see Note: [Input Alignment handling in
-# Inductor]). An input whose example was misaligned gets no-assumption code
-# and never needs a check or copy; an aligned example bakes in the fast
-# path, with the runtime check as the safety net for non-static inputs.
+# Inductor]). Per input, at compile time:
+#
+#   example input      | generated code      | later misaligned call
+#   -------------------+---------------------+--------------------------
+#   misaligned         | no assumption       | runs fine, no check/copy
+#   aligned, nonstatic | assumes aligned     | runtime check -> clone
+#   aligned, static    | assumes aligned     | (contract: cannot happen)
+#
 # Consequently a misclassified static input is a correctness bug,
 # not a missed optimization: kernels may run with a baked-in alignment the
 # runtime tensor doesn't satisfy (CUDA misaligned address), and cudagraph
@@ -283,16 +288,24 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 # needs an alignment guard on unguarded static inputs so a misaligned swap
 # recompiles instead.
 #
-# In the backward, staticness cannot be looked up positionally: the
-# backward's input list is (saved values in partitioner-chosen order,
-# tangents, ...), so forward input indices don't apply there. Instead, the
-# producer of the backward graph stamps meta["is_static_input"] on
-# placeholders it knows to be address-stable; AOTAutograd's partitioner
-# does this in _extract_fwd_bwd_modules, where primals are still 1:1 with
-# flat forward inputs. Unstamped placeholders fall back to name-based
-# classification (all "primals_*" static; see compile_fx_backward), so
-# producers that do not stamp (custom partition_fns) keep the historical,
-# less safe behavior.
+# The backward graph's inputs are tangents plus saved tensors, and a saved
+# tensor's staticness derives from what it is: a saved activation is
+# allocated by the compiled forward (address-stable while cudagraphs owns
+# the pool, and always aligned), while a saved forward *input* is exactly
+# as static as it was in the forward -- a saved param is address-stable, a
+# saved plain user input is not. So classifying backward inputs requires
+# mapping each saved primal back to the forward input it came from and
+# consulting the forward's static_input_indices. That mapping cannot be
+# done positionally from here: the backward's input list is (saved values
+# in partitioner-chosen order, tangents, ...), so forward input indices
+# don't apply to it. Instead, the producer of the backward graph -- the
+# only party that still knows the correspondence -- stamps
+# meta["is_static_input"] on placeholders it knows to be address-stable;
+# AOTAutograd's partitioner does this in _extract_fwd_bwd_modules, where
+# primals are still 1:1 with flat forward inputs. Unstamped placeholders
+# fall back to name-based classification (all "primals_*" static; see
+# compile_fx_backward), so producers that do not stamp (custom
+# partition_fns) keep the historical, less safe behavior.
 def get_static_input_idxs(num_fixed: int) -> list[int]:
     # If we are inlining NNModules, we treat all torch.nn.Parameters as static for the purposes
     # of cudagraphs. Rather than copying these into cudagraph-owned memory

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -282,13 +282,24 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   bw: tangent                        | no
 #
 #   * for the consumer that's active: without cudagraphs its address is
-#     fresh each call but only alignment is consumed, and inductor
-#     allocations are always 16-byte aligned; with cudagraphs it lives at
-#     a stable offset in the graph pool -- except activations from inline
-#     code between graph partitions, which are demoted
-#     (get_static_bw_input_idxs, see compile_fx_backward). A saved alias
-#     of a user input takes the "saved forward input" row: the partitioner
-#     saves the base primal and recomputes the view in the backward.
+#     fresh each call but only alignment is consumed, and that is stable
+#     for inductor-lowered intermediates (allocator-aligned base plus
+#     deterministic codegen offsets -- a saved odd-offset view is stably
+#     misaligned, so bw codegen makes no assumption for it). With
+#     cudagraphs it lives at a stable offset in the graph pool -- except
+#     activations from inline code between graph partitions, which are
+#     demoted (get_static_bw_input_idxs, see compile_fx_backward). A saved
+#     alias of a user input takes the "saved forward input" row: the
+#     partitioner saves the base primal and recomputes the view in
+#     backward. KNOWN HOLE: a saved *fallback op* output (e.g. a custom
+#     op) is allocated by arbitrary user code, so its alignment may vary
+#     call to call; it is classified static here (unstamped, non-primal)
+#     and gets no runtime check, so an alignment flip IMAs in the
+#     backward. Inductor judges fallback output alignment from the fake
+#     tensor (ir.py, V.graph.unaligned_buffers), which cannot express
+#     "sometimes misaligned"; TORCHINDUCTOR_ALIGNMENT_ASSERTS (default on
+#     in OSS) catches the fake-vs-real mismatch in the forward, and
+#     TORCHINDUCTOR_ASSUME_UNALIGNED_FALLBACK_OUTPUT=1 is the workaround.
 #
 # and what each combination does, where "aligned" means statically known
 # 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that cannot

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -248,6 +248,49 @@ static_inputs_log = torch._logging.getArtifactLogger(
 inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metrics")
 
 
+# Note: [static_input_idxs semantics]
+#
+# static_input_idxs marks inputs whose tensors are address-stable: the same
+# tensor (same data_ptr) is expected on every call, as opposed to a fresh
+# allocation per call. In the forward these are params, buffers, and
+# mark_static_address inputs (fw_metadata.static_input_indices); in the
+# backward, saved tensors (see below).
+#
+# Two mechanisms consume this:
+# - cudagraphs records static inputs at their own addresses instead of
+#   allocating graph-owned buffers and copying into them per replay
+#   (cudagraphify_impl). Copying a weight per call is unacceptable, so an
+#   address change must be handled by re-recording (cudagraph trees,
+#   #126822), never by copying.
+# - The alignment fixup (get_input_idxs_to_check) exempts static inputs that
+#   were aligned at compile time from the runtime copy_if_misaligned check:
+#   a stable address implies stable alignment, and cloning would break the
+#   address cudagraphs recorded.
+# Codegen itself does NOT consult staticness: triton code assumes the
+# alignment of the example inputs (see Note: [Input Alignment handling in
+# Inductor]), with the runtime check as the safety net for non-static
+# inputs. Consequently a misclassified static input is a correctness bug,
+# not a missed optimization: kernels may run with a baked-in alignment the
+# runtime tensor doesn't satisfy (CUDA misaligned address), and cudagraph
+# replay may read a stale address.
+#
+# "Address-stable" is per-recompile, not absolute: with
+# inline_inbuilt_nn_modules (#126822) an unguarded static input may legally
+# move, and cudagraphs re-records. TODO: if the new address is misaligned,
+# the alignment baked into existing kernels is wrong and we IMA; dynamo
+# needs an alignment guard on unguarded static inputs so a misaligned swap
+# recompiles instead.
+#
+# In the backward, staticness cannot be looked up positionally: the
+# backward's input list is (saved values in partitioner-chosen order,
+# tangents, ...), so forward input indices don't apply there. Instead, the
+# producer of the backward graph stamps meta["is_static_input"] on
+# placeholders it knows to be address-stable; AOTAutograd's partitioner
+# does this in _extract_fwd_bwd_modules, where primals are still 1:1 with
+# flat forward inputs. Unstamped placeholders fall back to name-based
+# classification (all "primals_*" static; see compile_fx_backward), so
+# producers that do not stamp (custom partition_fns) keep the historical,
+# less safe behavior.
 def get_static_input_idxs(num_fixed: int) -> list[int]:
     # If we are inlining NNModules, we treat all torch.nn.Parameters as static for the purposes
     # of cudagraphs. Rather than copying these into cudagraph-owned memory
@@ -2010,21 +2053,9 @@ def get_input_idxs_to_check(
             # suppress guards so that tensor_is_aligned and should_assume_input_aligned
             # do not add guards on input's storage offset
             #
-            # A static input is weight-like: address-stable across calls, and
-            # the compiled artifact must never copy it per call (cudagraphs
-            # records its address; see cudagraphify_impl). So if the example
-            # is aligned, every call's input is aligned and the runtime check
-            # is skippable; cloning would also break the address the
-            # cudagraph recorded. This is why misclassifying a non-static
-            # input as static crashes rather than deoptimizes -- see
-            # Note: [is_static_input on backward placeholders].
-            #
-            # TODO: "address-stable" is per-recompile, not absolute: with
-            # inline_inbuilt_nn_modules (#126822) an unguarded static input
-            # may legally move (cudagraphs re-records), and if the new
-            # address is misaligned the baked-in alignment here is wrong and
-            # we IMA. Dynamo needs an alignment guard on unguarded static
-            # inputs so a misaligned swap recompiles instead.
+            # Static inputs are address-stable, so compile-time alignment
+            # holds for every call and cloning would break the address
+            # cudagraphs recorded; see Note: [static_input_idxs semantics].
             if i in static_input_idxs and tensor_is_aligned(input):
                 continue
             if not should_assume_input_aligned(input):
@@ -2811,35 +2842,17 @@ def compile_fx_backward(
         if compiler_config_extra.cudagraphs_bwd_override is not None:
             cudagraphs = BoxedBool(compiler_config_extra.cudagraphs_bwd_override)
 
-        # Note: [is_static_input on backward placeholders]
-        #
-        # A backward placeholder may carry meta["is_static_input"], declaring
-        # whether its runtime tensor is address-stable across calls (a param/
-        # buffer/mark_static_address input, as opposed to e.g. a plain user
-        # input that was saved for backward and gets a fresh tensor every
-        # call). Inductor uses this to decide which inputs may have
-        # address-derived properties (alignment) baked into generated code
-        # versus needing the runtime copy_if_misaligned treatment; a wrong
-        # "static" here is a misaligned-address crash, not a deoptimization.
-        #
-        # Whoever produces the backward graph is responsible for stamping,
-        # because only the producer can map staticness (tracked positionally
-        # over the flat forward inputs, fw_metadata.static_input_indices)
-        # onto its choice and ordering of saved tensors; by the time the
-        # graph reaches us here, that correspondence is gone. AOTAutograd's
-        # partitioner stamps in _extract_fwd_bwd_modules, where primals are
-        # still 1:1 with flat forward inputs. Unstamped placeholders fall
-        # back to the historical name-based classification below (all
-        # "primals_*" static), so producers that do not stamp (custom
-        # partition_fns) keep the old, less safe behavior.
-        #
-        # Static backward inputs are thus the saved tensors, minus two
-        # over-approximations of the name-based classification:
+        # Static backward inputs (see Note: [static_input_idxs semantics])
+        # are the saved tensors, minus two over-approximations of the
+        # name-based classification:
         # 1. When the forward was partitioned, saved activations from inline
         #    code between partitions are NOT at fixed addresses; keep only
         #    "primals_*" (get_static_bw_input_idxs).
-        # 2. Saved-for-backward plain user inputs, demoted via the stamp as
-        #    described above.
+        # 2. A saved-for-backward plain user input is a "primals_*" but gets
+        #    a fresh tensor every call; the partitioner stamps
+        #    meta["is_static_input"] to demote it to the runtime
+        #    copy_if_misaligned treatment. Unstamped placeholders default to
+        #    static, preserving the name-based classification.
         if compiler_config_extra.forward_is_partitioned.value:
             candidate_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
         else:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -277,9 +277,18 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   mark_static_address(guard=True)    | yes, guarded (data_ptr guard)
 #   mark_static_address(guard=False)   | yes, unguarded
 #   plain user input                   | no
-#   bw: saved activation               | yes (inductor-allocated)
+#   bw: saved activation               | yes*
 #   bw: saved forward input            | same as it was in the forward
 #   bw: tangent                        | no
+#
+#   * for the consumer that's active: without cudagraphs its address is
+#     fresh each call but only alignment is consumed, and inductor
+#     allocations are always 16-byte aligned; with cudagraphs it lives at
+#     a stable offset in the graph pool -- except activations from inline
+#     code between graph partitions, which are demoted
+#     (get_static_bw_input_idxs, see compile_fx_backward). A saved alias
+#     of a user input takes the "saved forward input" row: the partitioner
+#     saves the base primal and recomputes the view in the backward.
 #
 # and what each combination does, where "aligned" means statically known
 # 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that cannot

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -250,60 +250,69 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 
 # Note: [static_input_idxs semantics]
 #
-# static_input_idxs marks inputs whose tensors are address-stable: the same
-# tensor (same data_ptr) is expected on every call, as opposed to a fresh
-# allocation per call. In the forward these are params, buffers, and
-# mark_static_address inputs (fw_metadata.static_input_indices); in the
-# backward, saved tensors (see below).
+# static_input_idxs is one bit standing in for two distinct properties of
+# an input, consumed by two different mechanisms:
 #
-# Two mechanisms consume this:
-# - cudagraphs records static inputs at their own addresses instead of
-#   allocating graph-owned buffers and copying into them per replay
-#   (cudagraphify_impl). Copying a weight per call is unacceptable, so an
-#   address change must be handled by re-recording (cudagraph trees,
-#   #126822), never by copying.
-# - The alignment fixup (get_input_idxs_to_check) exempts static inputs that
-#   were aligned at compile time from the runtime copy_if_misaligned check:
-#   a stable address implies stable alignment, and cloning would break the
-#   address cudagraphs recorded.
-# Codegen itself does NOT consult staticness: triton code assumes the
-# alignment of the example inputs (see Note: [Input Alignment handling in
-# Inductor]), and staticness only decides whether that assumption gets a
-# runtime safety net. What makes an input static:
+# - ADDRESS-stable: the same data_ptr every call. Consumed by cudagraphs
+#   only: static inputs are recorded at their own addresses instead of
+#   being copied into graph-owned buffers per replay (cudagraphify_impl).
+#   Copying a weight per call is unacceptable, so an address change must
+#   be handled by re-recording (cudagraph trees, #126822), never copying.
+# - ALIGNMENT-stable: data_ptr % 16 is the same every call. Consumed by
+#   the alignment fixup (get_input_idxs_to_check): static inputs whose
+#   example was aligned are exempted from the runtime copy_if_misaligned
+#   check, because re-checking a tensor whose alignment cannot change is
+#   waste and cloning it would break the address cudagraphs recorded.
 #
-#   input                              | static?
-#   -----------------------------------+---------------------------------
-#   nn.Module param/buffer             | yes, unguarded (auto, #130391)
-#   mark_static_address(guard=True)    | yes, guarded (data_ptr guard)
-#   mark_static_address(guard=False)   | yes, unguarded
-#   plain user input                   | no
-#   bw: saved activation               | yes*
-#   bw: saved forward input            | same as it was in the forward
-#   bw: tangent                        | no
+# Address-stable implies alignment-stable, and for forward inputs the two
+# coincide, so one bit suffices there. They diverge for backward saved
+# activations (alignment-stable always; address-stable only under
+# cudagraphs) -- see the backward rows below.
 #
-#   * for the consumer that's active: without cudagraphs its address is
-#     fresh each call but only alignment is consumed, and that is stable
-#     for inductor-lowered intermediates (allocator-aligned base plus
-#     deterministic codegen offsets -- a saved odd-offset view is stably
-#     misaligned, so bw codegen makes no assumption for it). With
-#     cudagraphs it lives at a stable offset in the graph pool -- except
-#     activations from inline code between graph partitions, which are
-#     demoted (get_static_bw_input_idxs, see compile_fx_backward). A saved
-#     alias of a user input takes the "saved forward input" row: the
-#     partitioner saves the base primal and recomputes the view in
-#     backward. KNOWN HOLE: a saved *fallback op* output (e.g. a custom
-#     op) is allocated by arbitrary user code, so its alignment may vary
-#     call to call; it is classified static here (unstamped, non-primal)
-#     and gets no runtime check, so an alignment flip IMAs in the
-#     backward. Inductor judges fallback output alignment from the fake
-#     tensor (ir.py, V.graph.unaligned_buffers), which cannot express
-#     "sometimes misaligned"; TORCHINDUCTOR_ALIGNMENT_ASSERTS (default on
-#     in OSS) catches the fake-vs-real mismatch in the forward, and
+# Codegen itself consumes NEITHER: triton code assumes the alignment of
+# the example inputs (see Note: [Input Alignment handling in Inductor]),
+# and staticness only decides whether that assumption gets a runtime
+# safety net. Per input kind:
+#
+#   forward input                     | addr-stable    | align-stable
+#   ----------------------------------+----------------+------------------
+#   nn.Module param/buffer            | yes [1]        | yes
+#   mark_static_address(guard=True)   | yes, ptr guard | yes
+#   mark_static_address(guard=False)  | yes [1]        | yes
+#   plain user input                  | no             | no
+#
+#   backward input                    | addr-stable    | align-stable
+#   ----------------------------------+----------------+------------------
+#   saved fw input                    | same as that input in the forward
+#   saved inductor intermediate       | cudagraphs [2] | yes [2]
+#   saved fallback (custom) op output | cudagraphs     | NO: KNOWN HOLE [3]
+#   tangent                           | no             | no
+#
+# [1] per-recompile: may legally move under inline_inbuilt_nn_modules
+#     (#126822); cudagraphs re-records. TODO: if the new address is
+#     misaligned, alignment baked into existing kernels is wrong and we
+#     IMA; dynamo needs an alignment guard on unguarded statics so a
+#     misaligned swap recompiles instead.
+# [2] allocator-aligned base + deterministic codegen offsets: even a saved
+#     odd-offset view is stably misaligned, so bw codegen makes no
+#     assumption for it. Under cudagraphs, activations from inline code
+#     between graph partitions are NOT pool-allocated and get demoted
+#     (get_static_bw_input_idxs, see compile_fx_backward). A saved alias
+#     of a user input takes the "saved fw input" row: the partitioner
+#     saves the base primal and recomputes the view in backward.
+# [3] allocated by arbitrary user code, so alignment may vary call to
+#     call, but it is classified static (unstamped, non-primal) and gets
+#     no runtime check: an alignment flip IMAs in the backward. Inductor
+#     judges fallback output alignment from the fake tensor (ir.py,
+#     V.graph.unaligned_buffers), which cannot express "sometimes
+#     misaligned". TORCHINDUCTOR_ALIGNMENT_ASSERTS (default on in OSS)
+#     catches the fake-vs-real mismatch in the forward;
 #     TORCHINDUCTOR_ASSUME_UNALIGNED_FALLBACK_OUTPUT=1 is the workaround.
 #
-# and what each combination does, where "aligned" means statically known
-# 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that cannot
-# be proven aligned counts as misaligned even if the example happens to be):
+# What each combination does at runtime, where "aligned" means statically
+# known 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that
+# cannot be proven aligned counts as misaligned even if the example
+# happens to be):
 #
 #   example input       | codegen         | runtime (no cudagraphs)
 #   --------------------+-----------------+------------------------------
@@ -330,31 +339,19 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 # runtime tensor doesn't satisfy (CUDA misaligned address), and cudagraph
 # replay may read a stale address.
 #
-# "Address-stable" is per-recompile, not absolute: with
-# inline_inbuilt_nn_modules (#126822) an unguarded static input may legally
-# move, and cudagraphs re-records. TODO: if the new address is misaligned,
-# the alignment baked into existing kernels is wrong and we IMA; dynamo
-# needs an alignment guard on unguarded static inputs so a misaligned swap
-# recompiles instead.
-#
-# The backward graph's inputs are tangents plus saved tensors, and a saved
-# tensor's staticness derives from what it is: a saved activation is
-# allocated by the compiled forward (address-stable while cudagraphs owns
-# the pool, and always aligned), while a saved forward *input* is exactly
-# as static as it was in the forward -- a saved param is address-stable, a
-# saved plain user input is not. So classifying backward inputs requires
-# mapping each saved primal back to the forward input it came from and
-# consulting the forward's static_input_indices. That mapping cannot be
-# done positionally from here: the backward's input list is (saved values
-# in partitioner-chosen order, tangents, ...), so forward input indices
-# don't apply to it. Instead, the producer of the backward graph -- the
-# only party that still knows the correspondence -- stamps
-# meta["is_static_input"] on placeholders it knows to be address-stable;
-# AOTAutograd's partitioner does this in _extract_fwd_bwd_modules, where
-# primals are still 1:1 with flat forward inputs. Unstamped placeholders
-# fall back to name-based classification (all "primals_*" static; see
-# compile_fx_backward), so producers that do not stamp (custom
-# partition_fns) keep the historical, less safe behavior.
+# Per the backward table, classifying a saved fw input requires mapping it
+# back to the forward input it came from and consulting the forward's
+# static_input_indices. That mapping cannot be done positionally from
+# here: the backward's input list is (saved values in partitioner-chosen
+# order, tangents, ...), so forward input indices don't apply to it.
+# Instead, the producer of the backward graph -- the only party that still
+# knows the correspondence -- stamps meta["is_static_input"] on
+# placeholders it knows to be address-stable; AOTAutograd's partitioner
+# does this in _extract_fwd_bwd_modules, where primals are still 1:1 with
+# flat forward inputs. Unstamped placeholders fall back to name-based
+# classification (all "primals_*" static; see compile_fx_backward), so
+# producers that do not stamp (custom partition_fns) keep the historical,
+# less safe behavior.
 def get_static_input_idxs(num_fixed: int) -> list[int]:
     # If we are inlining NNModules, we treat all torch.nn.Parameters as static for the purposes
     # of cudagraphs. Rather than copying these into cudagraph-owned memory

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -268,13 +268,42 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   address cudagraphs recorded.
 # Codegen itself does NOT consult staticness: triton code assumes the
 # alignment of the example inputs (see Note: [Input Alignment handling in
-# Inductor]). Per input, at compile time:
+# Inductor]), and staticness only decides whether that assumption gets a
+# runtime safety net. What makes an input static:
 #
-#   example input      | generated code      | later misaligned call
-#   -------------------+---------------------+--------------------------
-#   misaligned         | no assumption       | runs fine, no check/copy
-#   aligned, nonstatic | assumes aligned     | runtime check -> clone
-#   aligned, static    | assumes aligned     | (contract: cannot happen)
+#   input                              | static?
+#   -----------------------------------+---------------------------------
+#   nn.Module param/buffer             | yes, unguarded (auto, #130391)
+#   mark_static_address(guard=True)    | yes, guarded (data_ptr guard)
+#   mark_static_address(guard=False)   | yes, unguarded
+#   plain user input                   | no
+#   bw: saved activation               | yes (inductor-allocated)
+#   bw: saved forward input            | same as it was in the forward
+#   bw: tangent                        | no
+#
+# and what each combination does, where "aligned" means statically known
+# 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that cannot
+# be proven aligned counts as misaligned even if the example happens to be):
+#
+#   example input       | codegen         | runtime (no cudagraphs)
+#   --------------------+-----------------+------------------------------
+#   misaligned          | no assumption   | any alignment ok, no check
+#   aligned, nonstatic  | assumes aligned | check -> clone if misaligned
+#   aligned, static     | assumes aligned | no check; contract says the
+#                       |                 | address (hence alignment)
+#                       |                 | never changes
+#
+#   with cudagraphs     | additionally
+#   --------------------+---------------------------------------------
+#   nonstatic           | copied into graph-owned (aligned) buffer
+#                       | every replay
+#   static, aligned     | recorded at its own address; address change
+#                       | -> re-record (unguarded) / recompile (guarded)
+#   static, misaligned  | demoted to nonstatic at record time
+#                       | (remove_unaligned_input_idxs)
+#
+# (config.assume_aligned_inputs, non-default, removes the "misaligned" row:
+# everything is assumed aligned and nonstatics are checked at runtime.)
 #
 # Consequently a misclassified static input is a correctness bug,
 # not a missed optimization: kernels may run with a baked-in alignment the

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -268,8 +268,10 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 #   address cudagraphs recorded.
 # Codegen itself does NOT consult staticness: triton code assumes the
 # alignment of the example inputs (see Note: [Input Alignment handling in
-# Inductor]), with the runtime check as the safety net for non-static
-# inputs. Consequently a misclassified static input is a correctness bug,
+# Inductor]). An input whose example was misaligned gets no-assumption code
+# and never needs a check or copy; an aligned example bakes in the fast
+# path, with the runtime check as the safety net for non-static inputs.
+# Consequently a misclassified static input is a correctness bug,
 # not a missed optimization: kernels may run with a baked-in alignment the
 # runtime tensor doesn't satisfy (CUDA misaligned address), and cudagraph
 # replay may read a stale address.

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -250,117 +250,140 @@ inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metr
 
 # Note: [static_input_idxs semantics]
 #
-# static_input_idxs is one bit standing in for two distinct properties of
-# an input, consumed by two different mechanisms:
+# static_input_idxs, confusingly, describes the compiler's expectations about
+# inputs sent to the compiled function in two ways:
 #
-# - ADDRESS-stable: the same data_ptr every call. Consumed by cudagraphs
-#   only: static inputs are recorded at their own addresses instead of
-#   being copied into graph-owned buffers per replay (cudagraphify_impl).
-#   Copying a weight per call is unacceptable, so an address change must
-#   be handled by re-recording (cudagraph trees, #126822), never copying.
-# - ALIGNMENT-stable: data_ptr % 16 is the same every call. Consumed by
-#   the alignment fixup (get_input_idxs_to_check): static inputs whose
-#   example was aligned are exempted from the runtime copy_if_misaligned
-#   check, because re-checking a tensor whose alignment cannot change is
-#   waste and cloning it would break the address cudagraphs recorded.
+# - ADDRESS-stable: we expect the same data_ptr every call. cudagraphs cares
+#   about this, since stable inputs can be burned into the recorded cudagraph
+#   instead of being copied into graph-owned buffers.
 #
-# Address-stable implies alignment-stable, and for forward inputs the two
-# coincide, so one bit suffices there. They diverge for backward saved
-# activations (alignment-stable always; address-stable only under
-# cudagraphs) -- see the backward rows below.
+# - ALIGNMENT-stable: we expect data_ptr % 16 is the same every call. Most Triton
+#   kernels are more efficient if they can assume alignment, and if we chose to
+#   compile kernels for aligned inputs (because the input to be compiled
+#   happened to be aligned), if we run into an unaligned input we will
+#   copy_if_misaligned at runtime (nonstatic inputs only -- see the tables).
 #
-# Codegen itself consumes NEITHER: triton code assumes the alignment of
-# the example inputs (see Note: [Input Alignment handling in Inductor]),
-# and staticness only decides whether that assumption gets a runtime
-# safety net. Per input kind:
+# Note that an ADDRESS-stable input doesn't have to be aligned, but it will
+# be ALIGNMENT-stable (since the alignment will always be the same each
+# time around.)
 #
-#   forward input                     | addr-stable    | align-stable
-#   ----------------------------------+----------------+------------------
-#   nn.Module param/buffer            | yes [1]        | yes
-#   mark_static_address(guard=True)   | yes, ptr guard | yes
-#   mark_static_address(guard=False)  | yes [1]        | yes
-#   plain user input                  | no             | no
+# Both of these properties are tracked together via `static_input_idxs`.
+# However, this is mostly for the benefit of the wrapper code (in this file);
+# when we do triton codegen, whether or not it gets to do aligned or unaligned
+# code simply depends on the precise real tensors it happens to get
+# JIT-compiled with (see Note: [Input Alignment handling in Inductor]).
+# Although traditional triton launcher would check (and recompile) a kernel if
+# alignment on inputs changed, for performance reasons Inductor bypasses this:
+# the wrapper code here is responsible for safety checks / recompiling if
+# necessary.
 #
-#   backward input                    | addr-stable    | align-stable
-#   ----------------------------------+----------------+------------------
-#   saved fw input                    | same as that input in the forward
-#   saved inductor intermediate       | pool-owned [2] | yes [2]
-#   saved fallback (custom) op output | pool-owned [2] | NO: KNOWN HOLE [3]
-#   tangent                           | no             | no
+# Another confusing thing about these properties is that in some cases, a user
+# can SAFELY violate the compiler expectation.  If you obey the expectation you
+# get good performance, but the runtime wrapper can (inefficiently) fix things
+# up if you had got it wrong.  For example, if a param's address changes
+# (because you used one torch.compile for multiple instances, e.g.,
+# inline_inbuilt_nn_modules, #126822).  But there's quite a lot of variation
+# of WHO notices and WHAT repairs the problem, and it has also been a bit
+# of a bug farm (thus this comment!)
 #
-# [1] per-recompile: may legally move under inline_inbuilt_nn_modules
-#     (#126822); cudagraphs re-records. TODO: if the new address is
-#     misaligned, alignment baked into existing kernels is wrong and we
-#     IMA; dynamo needs an alignment guard on unguarded statics so a
-#     misaligned swap recompiles instead.
-# [2] align: allocator-aligned base + deterministic codegen offsets; even
-#     a saved odd-offset view is stably misaligned, so bw codegen makes no
-#     assumption for it. addr: "cudagraphs on" is NOT sufficient --
-#     address-stability holds only for tensors allocated inside a region a
-#     CUDA graph actually owns. With piecewise/partitioned forwards
-#     (graph_partition, cudagraph-unsafe ops), code between partitions
-#     runs eagerly, so its allocations move per call even though
-#     "cudagraphs is on"; those saved activations are demoted wholesale
-#     (forward_is_partitioned -> get_static_bw_input_idxs, see
-#     compile_fx_backward -- conservative: partition-owned activations are
-#     demoted too). Same caveat at the dynamo level: graph breaks make
-#     each compiled region its own cudagraph (trees), and staticness only
-#     transfers within a region's pool lineage (cudagraph_managed_idxs).
-#     A saved alias of a user input takes the "saved fw input" row: the
-#     partitioner saves the base primal and recomputes the view in
-#     backward.
-# [3] allocated by arbitrary user code, so alignment may vary call to
-#     call, but it is classified static (unstamped, non-primal) and gets
-#     no runtime check: an alignment flip IMAs in the backward. Inductor
-#     judges fallback output alignment from the fake tensor (ir.py,
+# Every input is classified into one of three classes:
+#
+#   STATIC-G  static, guarded:
+#       Only explicitly via mark_static_address(guard=True).
+#   STATIC-U  static, unguarded:
+#       Inferred from nn.Module params/buffers (#130391),
+#       some saved-for-backward tensors (see the backward table) and
+#       explicitly via mark_static_address(guard=False).
+#   NONSTATIC everything else:
+#       plain user inputs, tangents.
+#
+# We now enumerate the detector/repair apparatus for each property under
+# certain situations:
+#
+# ADDRESS changes. Addresses are only baked in where a CUDA graph records
+# the input (no cudagraphs => addresses are passed fresh to every kernel
+# launch and nothing needs detecting). Under cudagraphs:
+#
+#   class     | detector on address change               | repair
+#   ----------+------------------------------------------+-----------
+#   STATIC-U  | data_ptr comparison at replay            | re-record
+#             | (check_invariants /                      |
+#             | cudagraphify_impl assert)                |
+#             |                                          |
+#   STATIC-G  | dynamo data_ptr guard                    | recompile
+#             |                                          |
+#   NONSTATIC | no detector needed: copied into graph-owned buffer
+#             | every replay
+#
+# Without cudagraphs, we do nothing (but the alignment checks, see below.)
+#
+# ALIGNMENT changes. Alignment is only baked in if the example input was
+# statically known 16-byte aligned (tensor_is_aligned; a symbolic
+# storage_offset that cannot be proven aligned counts as misaligned even
+# if the example happens to be). A misaligned example produces
+# no-assumption codegen: correct for any alignment, nothing to detect.
+# (config.assume_aligned_inputs, non-default, disables that escape:
+# everything is assumed aligned.) For an aligned example:
+#
+#   class     | detector on align change                 | repair
+#   ----------+------------------------------------------+-----------
+#   STATIC-U  | NOBODY: misaligned-address crash.        | (TODO: needs
+#             | A misaligned static at cudagraph record  | a dynamo
+#             | time is demoted to NONSTATIC             | alignment
+#             | (remove_unaligned_input_idxs), but that  | guard ->
+#             | only helps if the flip happens to        | recompile)
+#             | coincide with a record                   |
+#             |                                          |
+#   STATIC-G  | dynamo data_ptr guard                    | recompile
+#             | (same ptr => same alignment)             |
+#             |                                          |
+#   NONSTATIC | per-call check emitted before first use  | clone
+#             | (copy_if_misaligned)                     |
+#
+# BACKWARD inputs are tangents plus saved tensors.  We infer a class
+# for these as follows:
+#
+#   backward input                    | class
+#   ----------------------------------+------------------------------------
+#   saved fw input                    | same class as that input in the
+#                                     | forward (requires the
+#                                     | is_static_input stamp; see below)
+#                                     |
+#   saved inductor intermediate       | STATIC-U; sound with NO detector [1]
+#                                     |
+#   saved fallback (custom) op output | STATIC-U, but alignment can
+#                                     | genuinely vary: detector is NOBODY.
+#                                     | KNOWN HOLE [2]
+#                                     |
+#   tangent                           | NONSTATIC
+#
+# [1] Alignment cannot change: allocator-aligned base + deterministic
+#     codegen offsets (a saved odd-offset view is *stably* misaligned and
+#     gets no-assumption codegen). Address is baked in only where a CUDA
+#     graph records the backward, and then the same pool serves the
+#     forward, so replay keeps pool offsets stable. Piecewise caveat:
+#     "cudagraphs is on" does not imply pool-owned. Tensors allocated by
+#     eager code BETWEEN graph partitions (graph_partition mode) or
+#     between dynamo graphs move per call; partitioned forwards therefore
+#     demote ALL saved activations, conservatively including pool-owned
+#     ones (forward_is_partitioned -> get_static_bw_input_idxs, see
+#     compile_fx_backward), and across dynamo graph breaks staticness only
+#     transfers within a pool lineage (cudagraph_managed_idxs, cudagraph
+#     trees).
+# [2] Allocated by arbitrary user code, so alignment may differ call to
+#     call with no address-stability contract to lean on; but it is
+#     classified static (unstamped, non-primal) and gets no runtime check,
+#     so an alignment flip IMAs in the backward. Inductor judges fallback
+#     output alignment from the fake tensor (ir.py,
 #     V.graph.unaligned_buffers), which cannot express "sometimes
 #     misaligned". TORCHINDUCTOR_ALIGNMENT_ASSERTS (default on in OSS)
 #     catches the fake-vs-real mismatch in the forward;
 #     TORCHINDUCTOR_ASSUME_UNALIGNED_FALLBACK_OUTPUT=1 is the workaround.
 #
-# What each combination does at runtime, where "aligned" means statically
-# known 16-byte aligned (tensor_is_aligned; a symbolic storage_offset that
-# cannot be proven aligned counts as misaligned even if the example
-# happens to be):
-#
-#   example input       | codegen         | runtime (no cudagraphs)
-#   --------------------+-----------------+------------------------------
-#   misaligned          | no assumption   | any alignment ok, no check
-#   aligned, nonstatic  | assumes aligned | check -> clone if misaligned
-#   aligned, static     | assumes aligned | no check; contract says the
-#                       |                 | address (hence alignment)
-#                       |                 | never changes
-#
-#   with cudagraphs     | additionally
-#   --------------------+---------------------------------------------
-#   nonstatic           | copied into graph-owned (aligned) buffer
-#                       | every replay
-#   static, aligned     | recorded at its own address; address change
-#                       | -> re-record (unguarded) / recompile (guarded)
-#   static, misaligned  | demoted to nonstatic at record time
-#                       | (remove_unaligned_input_idxs)
-#
-# (config.assume_aligned_inputs, non-default, removes the "misaligned" row:
-# everything is assumed aligned and nonstatics are checked at runtime.)
-#
-# Consequently a misclassified static input is a correctness bug,
-# not a missed optimization: kernels may run with a baked-in alignment the
-# runtime tensor doesn't satisfy (CUDA misaligned address), and cudagraph
-# replay may read a stale address.
-#
-# Per the backward table, classifying a saved fw input requires mapping it
-# back to the forward input it came from and consulting the forward's
-# static_input_indices. That mapping cannot be done positionally from
-# here: the backward's input list is (saved values in partitioner-chosen
-# order, tangents, ...), so forward input indices don't apply to it.
-# Instead, the producer of the backward graph -- the only party that still
-# knows the correspondence -- stamps meta["is_static_input"] on
-# placeholders it knows to be address-stable; AOTAutograd's partitioner
-# does this in _extract_fwd_bwd_modules, where primals are still 1:1 with
-# flat forward inputs. Unstamped placeholders fall back to name-based
-# classification (all "primals_*" static; see compile_fx_backward), so
-# producers that do not stamp (custom partition_fns) keep the historical,
-# less safe behavior.
+# A part of the bug farm is that static_input_idxs covers both address changes
+# and alignment changes.  In particular, it's easy to elide a test for
+# alignment which is OK assuming the address checks are on (cudagraphs), but
+# then forget to restore this test when cudagraphs are off.
 def get_static_input_idxs(num_fixed: int) -> list[int]:
     # If we are inlining NNModules, we treat all torch.nn.Parameters as static for the purposes
     # of cudagraphs. Rather than copying these into cudagraph-owned memory

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2795,28 +2795,28 @@ def compile_fx_backward(
         if compiler_config_extra.cudagraphs_bwd_override is not None:
             cudagraphs = BoxedBool(compiler_config_extra.cudagraphs_bwd_override)
 
-        # When the forward was partitioned, saved activations from inline
-        # code between partitions are NOT at fixed addresses. Only mark
-        # primals (params/buffers) as static.
+        # Static backward inputs are the saved tensors, minus two
+        # over-approximations of the name-based classification:
+        # 1. When the forward was partitioned, saved activations from inline
+        #    code between partitions are NOT at fixed addresses; keep only
+        #    "primals_*" (get_static_bw_input_idxs).
+        # 2. A saved-for-backward plain user input is a "primals_*" but is
+        #    NOT address-stable (fresh tensor every call), so it must get
+        #    the same runtime copy_if_misaligned treatment as tangents
+        #    rather than having the example input's alignment baked in. The
+        #    partitioner records true staticness on saved primal
+        #    placeholders; see Note: [is_static_input on backward
+        #    placeholders]. Unstamped nodes (saved activations, or graphs
+        #    from custom partitioners) default to static, preserving the
+        #    name-based classification.
         if compiler_config_extra.forward_is_partitioned.value:
-            static_input_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
+            candidate_idxs: Sequence[int] = get_static_bw_input_idxs(gm)
         else:
-            static_input_idxs = list(range(fixed))
-
-        # Saved primals that are plain user inputs (not params/buffers/
-        # mark_static_address) get a fresh tensor every call, so they are not
-        # address-stable and may not match the example input's alignment.
-        # Demote them so get_input_idxs_to_check gives them the same runtime
-        # copy_if_misaligned treatment as tangents. Saved activations stay
-        # static: inductor allocates them aligned. The partitioner stamps
-        # is_static_input on saved primal placeholders (see
-        # _extract_fwd_bwd_modules); nodes without the stamp (activations,
-        # tangents, or graphs from partitioners that predate it) keep their
-        # existing classification.
+            candidate_idxs = range(fixed)
         placeholders = gm.graph.find_nodes(op="placeholder")
         static_input_idxs = [
             i
-            for i in static_input_idxs
+            for i in candidate_idxs
             if placeholders[i].meta.get("is_static_input", True)
         ]
         with (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192263

A user input that is saved for backward but unused in forward compute
(e.g. via a custom autograd.Function's save_for_backward) reaches the
backward graph as a primal. count_tangents marks every non-tangent
backward placeholder as static, so get_input_idxs_to_check skipped the
runtime copy_if_misaligned fixup for it whenever the compile-time
example was aligned. Since a plain user input gets a fresh address
every call, a later call with a misaligned tensor (e.g. storage[1:])
ran an alignment-assuming triton kernel on a misaligned pointer:

    RuntimeError: CUDA driver error: misaligned address

The backward has no dynamo guard re-dispatch point, so the fix gives
these inputs the same runtime copy_if_misaligned treatment as tangents.
Staticness is tracked positionally (fw_metadata.static_input_indices),
which is uninterpretable against the backward's reordered input list,
so the partitioner converts it to node metadata while primals are still
1:1 with flat forward inputs: _extract_fwd_bwd_modules stamps
is_static_input on primal placeholders, and compile_fx_backward filters
the name-based static classification against the stamp. Unstamped
placeholders default to static, preserving existing behavior for saved
activations and custom partitioners.

Most of the diff is a new Note: [static_input_idxs semantics] in
torch/_inductor/compile_fx.py; read it first, it is the real
explanation of what static_input_idxs means and why the backward got
this wrong. Rather than restate it here, note only that it documents
two gaps this PR does NOT fix: saved fallback-op outputs are classified
static even though their alignment can genuinely vary call to call, and
unguarded static inputs (params/buffers under inline_inbuilt_nn_modules)
can legally move to a misaligned address with no detector. Both need
work beyond this fix.

Alternative considered: parsing "primals_j" names and indexing
fw_metadata.static_input_indices from compile_fx_backward directly.
Rejected: it re-derives the primal-to-forward-input correspondence by
string arithmetic (fragile against index-shifting conventions like
effect tokens, cf. #175904) and depends on TracingContext being
restored at lazy backward compile time; the stamp travels with the
graph.

History: the misclassification dates to the original dynamo merge
(#86461), when every saved tensor really was a param or an
inductor-allocated activation. It was unexploitable for years because
the forward cloned all misaligned non-static inputs at the call
boundary, so the backward only ever saw aligned saved tensors. #179039
(defer copy_misaligned_inputs to first use) removed that accidental
firewall for inputs with no forward reader, making the day-one hole
reachable. Precedent for the fix shape: #176620 already refined
backward static classification for saved activations under partitioned
forwards; this does the same for user-input primals.

AOTAutogradCache keys include static_input_indices and inputs_to_check
feeds FxGraphHashDetails, so cached wrappers cannot go stale under this
change.

Test Plan:

New test fails before the fix with "CUDA error: misaligned address" and
passes after:

```
python -m pytest test/inductor/test_cuda_repro.py -k test_misaligned_saved_for_backward_input
```

Verified the generated backward wrapper now emits
copy_if_misaligned(primals_2), while a compiled nn.Linear's weight
primal still gets no runtime alignment check (static treatment for
params preserved). Regression suites:

```
python -m pytest test/inductor/test_cuda_repro.py
python -m pytest test/inductor/test_cudagraph_trees.py -k backward
python -m pytest test/dynamo/test_aot_autograd_cache.py -k "backward or bwd"
python -m pytest test/functorch/test_aotdispatch.py -k partitioner
```

All pass except test_input_channels_last, which fails identically on
the base commit (pre-existing).

Authored with Claude.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo