### PR TITLE
[c10] Make c10::Error header-only

### DIFF
--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -23,16 +23,8 @@ bool IsGoogleLoggingInitialized();
 
 namespace c10 {
 
-Error::Error(std::string msg, Backtrace backtrace, const void* caller)
-    : msg_(std::move(msg)), backtrace_(std::move(backtrace)), caller_(caller) {
-  refresh_what();
-}
-
-// PyTorch-style error message
-// Error::Error(SourceLocation source_location, const std::string& msg)
-// NB: This is defined in Logging.cpp for access to GetFetchStackTrace
-
-// Caffe2-style error message
+// Caffe2-style error message. The only out-of-line Error constructor: it is
+// the one that needs detail::StripBasename().
 Error::Error(
     const char* file,
     const uint32_t line,
@@ -51,107 +43,6 @@ Error::Error(
               msg),
           std::move(backtrace),
           caller) {}
-
-std::string Error::compute_what(bool include_backtrace) const {
-  std::ostringstream oss;
-
-  oss << msg_;
-
-  if (context_.size() == 1) {
-    // Fold error and context in one line
-    oss << " (" << context_[0] << ')';
-  } else {
-    for (const auto& c : context_) {
-      oss << "\n  " << c;
-    }
-  }
-
-  if (include_backtrace && backtrace_) {
-    oss << '\n' << backtrace_->get();
-  }
-
-  return std::move(oss).str();
-}
-
-const Backtrace& Error::backtrace() const {
-  return backtrace_;
-}
-
-const char* Error::what() const noexcept {
-  return what_
-      .ensure([this] {
-        try {
-          return compute_what(/*include_backtrace*/ true);
-        } catch (...) {
-          // what() is noexcept, we need to return something here.
-          return std::string{"<Error computing Error::what()>"};
-        }
-      })
-      .c_str();
-}
-
-void Error::refresh_what() {
-  // Do not compute what_ eagerly, as it would trigger the computation of the
-  // backtrace. Instead, invalidate it, it will be computed on first access.
-  // refresh_what() is only called by non-const public methods which are not
-  // supposed to be called concurrently with any other method, so it is safe to
-  // invalidate here.
-  what_.reset();
-  what_without_backtrace_ = compute_what(/*include_backtrace*/ false);
-}
-
-void Error::add_context(std::string new_msg) {
-  context_.push_back(std::move(new_msg));
-  // TODO: Calling add_context O(n) times has O(n^2) cost.  We can fix
-  // this perf problem by populating the fields lazily... if this ever
-  // actually is a problem.
-  // NB: If you do fix this, make sure you do it in a thread safe way!
-  // what() is almost certainly expected to be thread safe even when
-  // accessed across multiple threads
-  refresh_what();
-}
-
-namespace detail {
-
-void torchCheckFail(
-    const char* func,
-    const char* file,
-    uint32_t line,
-    const std::string& msg) {
-  // NOLINTNEXTLINE(modernize-use-designated-initializers)
-  throw ::c10::Error({func, file, line}, msg);
-}
-
-void torchCheckFail(
-    const char* func,
-    const char* file,
-    uint32_t line,
-    const char* msg) {
-  // NOLINTNEXTLINE(modernize-use-designated-initializers)
-  throw ::c10::Error({func, file, line}, msg);
-}
-
-void torchInternalAssertFail(
-    const char* func,
-    const char* file,
-    uint32_t line,
-    const char* condMsg,
-    const char* userMsg) {
-  torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
-}
-
-// This should never be called. It is provided in case of compilers
-// that don't do any dead code stripping in debug builds.
-void torchInternalAssertFail(
-    const char* func,
-    const char* file,
-    uint32_t line,
-    const char* condMsg,
-    const std::string& userMsg) {
-  torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
-}
-
-} // namespace detail
 
 namespace WarningUtils {
 

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -10,7 +10,9 @@
 
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
@@ -22,6 +24,61 @@
 
 namespace c10 {
 
+namespace detail {
+
+/// Backtrace capture for c10::Error, empty by default so that Error stays
+/// header-only; libc10 installs a symbolizing fetcher on load (Logging.cpp).
+/// Without one an Error still carries its message, just no C++ stack.
+///
+/// C10_HEADERONLY_EXPORT is load-bearing: `fetcher` is shared mutable state,
+/// and under -fvisibility-inlines-hidden each DSO would get its own copy,
+/// making libc10's fetcher invisible elsewhere and silently dropping
+/// backtraces. Windows has that gap regardless of annotation; see Logging.cpp.
+C10_HEADERONLY_EXPORT inline std::function<::c10::Backtrace()>&
+getBacktraceFetcher() {
+  static std::function<::c10::Backtrace()> fetcher;
+  return fetcher;
+}
+
+/// Prefixes the backtrace with "Exception raised from <location>". Lazy, so
+/// symbolization only happens if what() is actually called.
+class PyTorchStyleBacktrace : public OptimisticLazyValue<std::string> {
+ public:
+  PyTorchStyleBacktrace(
+      SourceLocation source_location,
+      ::c10::Backtrace backtrace)
+      : backtrace_(std::move(backtrace)), source_location_(source_location) {}
+
+ private:
+  std::string compute() const override {
+    return str(
+        "Exception raised from ",
+        source_location_,
+        " (most recent call first):\n",
+        backtrace_->get());
+  }
+
+  ::c10::Backtrace backtrace_;
+  SourceLocation source_location_;
+};
+
+/// Captures a backtrace for `source_location`, or nullptr when no fetcher has
+/// been installed.
+inline ::c10::Backtrace makeBacktrace(SourceLocation source_location) {
+  const auto& fetcher = getBacktraceFetcher();
+  if (!fetcher) {
+    return nullptr;
+  }
+  ::c10::Backtrace backtrace = fetcher();
+  if (!backtrace) {
+    return nullptr;
+  }
+  return std::make_shared<PyTorchStyleBacktrace>(
+      source_location, std::move(backtrace));
+}
+
+} // namespace detail
+
 /// The primary ATen error class.
 /// Provides a complete error message with source location information via
 /// `what()`, and a more concise message via `what_without_backtrace()`.
@@ -29,7 +86,14 @@ namespace c10 {
 ///
 /// NB: c10::Error is handled specially by the default torch to suppress the
 /// backtrace, see torch/csrc/Exceptions.h
-class C10_API Error : public std::exception {
+///
+/// Keep this header-only: TORCH_CHECK throws it, so any c10 header using
+/// TORCH_CHECK would otherwise force its consumers to link libc10.
+///
+/// Hence C10_HEADERONLY_EXPORT rather than C10_API, which is dllimport for
+/// consumers and would reintroduce that dependency on Windows. It still gives
+/// the type a single vtable/typeinfo, so it crosses DSO boundaries.
+class C10_HEADERONLY_EXPORT Error : public std::exception {
  private:
   // The actual error message.
   std::string msg_;
@@ -60,12 +124,24 @@ class C10_API Error : public std::exception {
   const void* caller_;
 
  public:
-  // PyTorch-style Error constructor.  NB: the implementation of this
-  // is actually in Logging.cpp
-  Error(SourceLocation source_location, std::string msg);
+  // Base constructor
+  /* implicit */ Error(
+      std::string msg,
+      Backtrace backtrace = nullptr,
+      const void* caller = nullptr)
+      : msg_(std::move(msg)),
+        backtrace_(std::move(backtrace)),
+        caller_(caller) {
+    refresh_what();
+  }
 
-  // Caffe2-style error message
-  Error(
+  // PyTorch-style Error constructor.
+  Error(SourceLocation source_location, std::string msg)
+      : Error(std::move(msg), detail::makeBacktrace(source_location)) {}
+
+  // Caffe2-style error message. Out-of-line: the only constructor needing
+  // detail::StripBasename(), and only CAFFE_ENFORCE uses it.
+  C10_API Error(
       const char* file,
       const uint32_t line,
       const char* condition,
@@ -73,17 +149,20 @@ class C10_API Error : public std::exception {
       Backtrace backtrace,
       const void* caller = nullptr);
 
-  // Base constructor
-  Error(
-      std::string msg,
-      Backtrace backtrace = nullptr,
-      const void* caller = nullptr);
-
   // Add some new context to the message stack.  The last added context
   // will be formatted at the end of the context list upon printing.
   // WARNING: This method is O(n) in the size of the stack, so don't go
   // wild adding a ridiculous amount of context to error messages.
-  void add_context(std::string msg);
+  void add_context(std::string new_msg) {
+    context_.push_back(std::move(new_msg));
+    // TODO: Calling add_context O(n) times has O(n^2) cost.  We can fix
+    // this perf problem by populating the fields lazily... if this ever
+    // actually is a problem.
+    // NB: If you do fix this, make sure you do it in a thread safe way!
+    // what() is almost certainly expected to be thread safe even when
+    // accessed across multiple threads
+    refresh_what();
+  }
 
   const std::string& msg() const {
     return msg_;
@@ -93,12 +172,25 @@ class C10_API Error : public std::exception {
     return context_;
   }
 
-  const Backtrace& backtrace() const;
+  const Backtrace& backtrace() const {
+    return backtrace_;
+  }
 
   /// Returns the complete error message, including the source location.
   /// The returned pointer is invalidated if you call add_context() on
   /// this object.
-  const char* what() const noexcept override;
+  const char* what() const noexcept override {
+    return what_
+        .ensure([this] {
+          try {
+            return compute_what(/*include_backtrace*/ true);
+          } catch (...) {
+            // what() is noexcept, we need to return something here.
+            return std::string{"<Error computing Error::what()>"};
+          }
+        })
+        .c_str();
+  }
 
   const void* caller() const noexcept {
     return caller_;
@@ -112,8 +204,36 @@ class C10_API Error : public std::exception {
   }
 
  private:
-  void refresh_what();
-  std::string compute_what(bool include_backtrace) const;
+  void refresh_what() {
+    // Do not compute what_ eagerly, as it would trigger the computation of the
+    // backtrace. Instead, invalidate it, it will be computed on first access.
+    // refresh_what() is only called by non-const public methods which are not
+    // supposed to be called concurrently with any other method, so it is safe
+    // to invalidate here.
+    what_.reset();
+    what_without_backtrace_ = compute_what(/*include_backtrace*/ false);
+  }
+
+  std::string compute_what(bool include_backtrace) const {
+    std::ostringstream oss;
+
+    oss << msg_;
+
+    if (context_.size() == 1) {
+      // Fold error and context in one line
+      oss << " (" << context_[0] << ')';
+    } else {
+      for (const auto& c : context_) {
+        oss << "\n  " << c;
+      }
+    }
+
+    if (include_backtrace && backtrace_) {
+      oss << '\n' << backtrace_->get();
+    }
+
+    return std::move(oss).str();
+  }
 };
 
 class C10_API Warning {
@@ -237,10 +357,9 @@ struct C10_API WarnAlways {
 
 // Like Error, but we always report the C++ backtrace, instead of only
 // reporting when TORCH_SHOW_CPP_STACKTRACES
-class C10_API ErrorAlwaysShowCppStacktrace : public Error {
+class C10_HEADERONLY_EXPORT ErrorAlwaysShowCppStacktrace : public Error {
  public:
   using Error::Error;
-  ErrorAlwaysShowCppStacktrace(SourceLocation source_location, std::string msg);
   const char* what_without_backtrace() const noexcept override {
     return what();
   }
@@ -249,86 +368,76 @@ class C10_API ErrorAlwaysShowCppStacktrace : public Error {
 // Used in ATen for out-of-bound indices that can reasonably only be detected
 // lazily inside a kernel (See: advanced indexing).  These turn into
 // IndexError when they cross to Python.
-class C10_API IndexError : public Error {
+class C10_HEADERONLY_EXPORT IndexError : public Error {
  public:
   using Error::Error;
-  IndexError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for invalid values.  These turn into
 // ValueError when they cross to Python.
-class C10_API ValueError : public Error {
+class C10_HEADERONLY_EXPORT ValueError : public Error {
  public:
   using Error::Error;
-  ValueError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for invalid types.  These turn into
 // TypeError when they cross to Python.
-class C10_API TypeError : public Error {
+class C10_HEADERONLY_EXPORT TypeError : public Error {
  public:
   using Error::Error;
-  TypeError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for functionality that is not implemented.  These turn into
 // NotImplementedError when they cross to Python.
-class C10_API NotImplementedError : public Error {
+class C10_HEADERONLY_EXPORT NotImplementedError : public Error {
  public:
   using Error::Error;
-  NotImplementedError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for buffer-related errors, e.g. trying to create a DLPack of
 // an unsupported device.  These turn into BufferError when they cross to
 // Python.
-class C10_API BufferError : public Error {
+class C10_HEADERONLY_EXPORT BufferError : public Error {
  public:
   using Error::Error;
-  BufferError(SourceLocation source_location, std::string msg);
 };
 
 // Used in ATen for non finite indices.  These turn into
 // ExitException when they cross to Python.
-class C10_API EnforceFiniteError : public Error {
+class C10_HEADERONLY_EXPORT EnforceFiniteError : public Error {
  public:
   using Error::Error;
-  EnforceFiniteError(SourceLocation source_location, std::string msg);
 };
 
 // Used in Onnxifi backend lowering.  These turn into
 // ExitException when they cross to Python.
-class C10_API OnnxfiBackendSystemError : public Error {
+class C10_HEADERONLY_EXPORT OnnxfiBackendSystemError : public Error {
  public:
   using Error::Error;
-  OnnxfiBackendSystemError(SourceLocation source_location, std::string msg);
 };
 
 // Used for numerical errors from the linalg module. These
 // turn into LinAlgError when they cross into Python.
-class C10_API LinAlgError : public Error {
+class C10_HEADERONLY_EXPORT LinAlgError : public Error {
  public:
   using Error::Error;
-  LinAlgError(SourceLocation source_location, std::string msg);
 };
 
-class C10_API OutOfMemoryError : public Error {
+class C10_HEADERONLY_EXPORT OutOfMemoryError : public Error {
  public:
   using Error::Error;
-  OutOfMemoryError(SourceLocation source_location, std::string msg);
 };
 
 // Used for handling syntactic errors in input arguments.
 // These turn into SyntaxError when the cross into Python.
-class C10_API SyntaxError : public Error {
+class C10_HEADERONLY_EXPORT SyntaxError : public Error {
  public:
   using Error::Error;
-  SyntaxError(SourceLocation source_location, std::string msg);
 };
 
 // Raised when accelerator API call hits an error.
 // These turn into AcceleratorError when the cross into Python
-class C10_API AcceleratorError : public Error {
+class C10_HEADERONLY_EXPORT AcceleratorError : public Error {
   int32_t error_code;
 
  public:
@@ -341,42 +450,37 @@ class C10_API AcceleratorError : public Error {
 
 // Base error type for all distributed errors.
 // These turn into DistError when they cross into Python.
-class C10_API DistError : public Error {
+class C10_HEADERONLY_EXPORT DistError : public Error {
  public:
   using Error::Error;
-  DistError(SourceLocation source_location, std::string msg);
 };
 
 // Used for collective communication library errors from the distributed module.
 // These turn into DistBackendError when they cross into Python.
-class C10_API DistBackendError : public DistError {
+class C10_HEADERONLY_EXPORT DistBackendError : public DistError {
  public:
   using DistError::DistError;
-  DistBackendError(SourceLocation source_location, std::string msg);
 };
 
 // Used for errors originating from the store.
 // These turn into DistStoreError when they cross into Python.
-class C10_API DistStoreError : public DistError {
+class C10_HEADERONLY_EXPORT DistStoreError : public DistError {
  public:
   using DistError::DistError;
-  DistStoreError(SourceLocation source_location, std::string msg);
 };
 
 // Used for errors originating from the TCP/IP stack and not from collective
 // libraries. These turn into DistNetworkError when they cross into Python.
-class C10_API DistNetworkError : public DistError {
+class C10_HEADERONLY_EXPORT DistNetworkError : public DistError {
  public:
   using DistError::DistError;
-  DistNetworkError(SourceLocation source_location, std::string msg);
 };
 
 // Raised when a queue is empty and a non-blocking pop is called.
 // Translated to torch.distributed.QueueEmptyError in Python
-class C10_API DistQueueEmptyError : public DistStoreError {
+class C10_HEADERONLY_EXPORT DistQueueEmptyError : public DistStoreError {
  public:
   using DistStoreError::DistStoreError;
-  DistQueueEmptyError(SourceLocation source_location, std::string msg);
 };
 
 // A utility function to return an exception std::string by prepending its
@@ -536,29 +640,40 @@ inline C10_API const char* torchCheckMsgImpl(
 
 namespace c10::detail {
 
-[[noreturn]] C10_API void torchCheckFail(
+// Inline so TORCH_CHECK needs no libc10 at link time; C10_NOINLINE keeps the
+// cold throw path out of the caller, which matters given how many TORCH_CHECK
+// sites ATen has.
+[[noreturn]] C10_NOINLINE inline void torchCheckFail(
     const char* func,
     const char* file,
     uint32_t line,
-    const std::string& msg);
-[[noreturn]] C10_API void torchCheckFail(
+    const std::string& msg) {
+  // NOLINTNEXTLINE(modernize-use-designated-initializers)
+  throw ::c10::Error({func, file, line}, msg);
+}
+[[noreturn]] C10_NOINLINE inline void torchCheckFail(
     const char* func,
     const char* file,
     uint32_t line,
-    const char* msg);
+    const char* msg) {
+  // NOLINTNEXTLINE(modernize-use-designated-initializers)
+  throw ::c10::Error({func, file, line}, msg);
+}
 
 // The c10::str() call that creates userMsg can have 1 of 3 return
 // types depending on the number and types of arguments passed to
 // TORCH_INTERNAL_ASSERT.  0 arguments will get a
 // CompileTimeEmptyString, 1 const char * will be passed straight
 // through, and anything else will get converted to std::string.
-[[noreturn]] C10_API void torchInternalAssertFail(
+[[noreturn]] C10_NOINLINE inline void torchInternalAssertFail(
     const char* func,
     const char* file,
     uint32_t line,
     const char* condMsg,
-    const char* userMsg);
-[[noreturn]] inline C10_API void torchInternalAssertFail(
+    const char* userMsg) {
+  torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
+}
+[[noreturn]] inline void torchInternalAssertFail(
     const char* func,
     const char* file,
     uint32_t line,
@@ -566,12 +681,16 @@ namespace c10::detail {
     ::c10::detail::CompileTimeEmptyString /*userMsg*/) {
   torchCheckFail(func, file, line, condMsg);
 }
-[[noreturn]] C10_API void torchInternalAssertFail(
+// This should never be called. It is provided in case of compilers
+// that don't do any dead code stripping in debug builds.
+[[noreturn]] C10_NOINLINE inline void torchInternalAssertFail(
     const char* func,
     const char* file,
     uint32_t line,
     const char* condMsg,
-    const std::string& userMsg);
+    const std::string& userMsg) {
+  torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
+}
 
 } // namespace c10::detail
 

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -26,12 +26,32 @@ C10_DEFINE_bool(
 namespace c10 {
 
 namespace {
+
+// getBacktraceFetcher() defaults to empty so c10::Error stays header-only.
+// Symbolization needs get_lazy_backtrace() from libc10, so install it here:
+// anything linking libc10 gets symbolized backtraces. Callers that install
+// their own (torch's Python-aware one) run later and still win.
+//
+// On Windows an inline function's static local is per-module regardless of
+// annotation, so this only reaches libc10's own c10::Error uses. Other modules
+// see an empty fetcher and get no backtrace at all -- Error::compute_what()
+// skips the section when the pointer is null. That is a regression there
+// against the out-of-line GetFetchStackTrace() this replaced. ELF shares one
+// instance, so no such gap.
+struct InstallDefaultStackTraceFetcher {
+  InstallDefaultStackTraceFetcher() {
+    ::c10::detail::getBacktraceFetcher() = []() {
+      return get_lazy_backtrace(/*frames_to_skip=*/1);
+    };
+  }
+};
+
+const InstallDefaultStackTraceFetcher g_install_default_stack_trace_fetcher;
+
 std::function<::c10::Backtrace()>& GetFetchStackTrace() {
-  static std::function<::c10::Backtrace()> func = []() {
-    return get_lazy_backtrace(/*frames_to_skip=*/1);
-  };
-  return func;
+  return ::c10::detail::getBacktraceFetcher();
 }
+
 } // namespace
 
 void SetStackTraceFetcher(std::function<::c10::Backtrace()> fetcher) {
@@ -84,93 +104,6 @@ void ThrowEnforceFiniteNotMet(
     const void* caller) {
   ThrowEnforceFiniteNotMet(file, line, condition, std::string(msg), caller);
 }
-
-namespace {
-
-class PyTorchStyleBacktrace : public OptimisticLazyValue<std::string> {
- public:
-  PyTorchStyleBacktrace(SourceLocation source_location)
-      : backtrace_(GetFetchStackTrace()()), source_location_(source_location) {}
-
- private:
-  std::string compute() const override {
-    return str(
-        "Exception raised from ",
-        source_location_,
-        " (most recent call first):\n",
-        backtrace_->get());
-  }
-
-  ::c10::Backtrace backtrace_;
-  SourceLocation source_location_;
-};
-
-} // namespace
-
-// PyTorch-style error message
-// (This must be defined here for access to GetFetchStackTrace)
-Error::Error(SourceLocation source_location, std::string msg)
-    : Error(
-          std::move(msg),
-          std::make_shared<PyTorchStyleBacktrace>(source_location)) {}
-
-// Explicit constructor definitions for Error subclasses. Required because
-// clang-cl does not emit dllexport symbols for constructors inherited via
-// `using Base::Base;` (llvm/llvm-project#162640), which causes LNK2019 in
-// any DLL that links against c10 from outside (torch_hip.dll, inline C++
-// extensions, etc.). Each definition just delegates to the base class
-// constructor so behavior is unchanged.
-ErrorAlwaysShowCppStacktrace::ErrorAlwaysShowCppStacktrace(
-    SourceLocation loc,
-    std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-IndexError::IndexError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-ValueError::ValueError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-TypeError::TypeError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-NotImplementedError::NotImplementedError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-BufferError::BufferError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-EnforceFiniteError::EnforceFiniteError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-OnnxfiBackendSystemError::OnnxfiBackendSystemError(
-    SourceLocation loc,
-    std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-LinAlgError::LinAlgError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-OutOfMemoryError::OutOfMemoryError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-SyntaxError::SyntaxError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-DistError::DistError(SourceLocation loc, std::string msg)
-    : Error(loc, std::move(msg)) {}
-
-DistBackendError::DistBackendError(SourceLocation loc, std::string msg)
-    : DistError(loc, std::move(msg)) {}
-
-DistStoreError::DistStoreError(SourceLocation loc, std::string msg)
-    : DistError(loc, std::move(msg)) {}
-
-DistNetworkError::DistNetworkError(SourceLocation loc, std::string msg)
-    : DistError(loc, std::move(msg)) {}
-
-DistQueueEmptyError::DistQueueEmptyError(SourceLocation loc, std::string msg)
-    : DistStoreError(loc, std::move(msg)) {}
 
 using APIUsageLoggerType = std::function<void(const std::string&)>;
 using APIUsageMetadataLoggerType = std::function<void(

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -128,11 +128,6 @@ std::ostream& _str(std::ostream& ss, const std::wstring& wString) {
 
 } // namespace detail
 
-std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
-  out << loc.function << " at " << loc.file << ':' << loc.line;
-  return out;
-}
-
 size_t ReplaceAll(std::string& s, std::string_view from, std::string_view to) {
   if (from.empty()) {
     return 0;

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -171,7 +171,14 @@ struct C10_API SourceLocation {
   }
 };
 
-std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
+// Inline so the header-only c10::Error can format a SourceLocation without
+// linking libc10.
+inline std::ostream& operator<<(
+    std::ostream& out,
+    const SourceLocation& loc) {
+  out << loc.function << " at " << loc.file << ':' << loc.line;
+  return out;
+}
 
 // unix isprint but insensitive to locale
 [[nodiscard]] inline bool isPrint(char s) {

--- a/torch/headeronly/macros/Export.h
+++ b/torch/headeronly/macros/Export.h
@@ -93,6 +93,21 @@
 #define C10_API C10_IMPORT
 #endif
 
+// For header-only entities that must still resolve to a single instance
+// across DSO boundaries: an exception type thrown in one shared library and
+// caught in another (one vtable/typeinfo), or an inline function whose static
+// local is shared state (one copy, despite -fvisibility-inlines-hidden).
+// Same mechanism as FOLLY_EXPORT, spelled here so c10 need not depend on
+// folly.
+//
+// Unlike C10_API this never becomes dllimport/dllexport, so the entity stays
+// usable without linking libc10.
+#if defined(_WIN32) || !defined(__GNUC__)
+#define C10_HEADERONLY_EXPORT
+#else
+#define C10_HEADERONLY_EXPORT __attribute__((__visibility__("default")))
+#endif
+
 // This one is being used by libtorch.so
 #ifdef CAFFE2_BUILD_MAIN_LIB
 #define TORCH_API C10_EXPORT


### PR DESCRIPTION
Summary:
## Why

A binary that links both ExecuTorch and libtorch carries **multiple ODR
violations**, each settled by link order. This diff is the prerequisite for
removing them; the next diff in the stack does the removal. On its own it
changes no behaviour.

They come from `-DSTANDALONE_TORCH_HEADER`, which gives `TORCH_CHECK` two
expansions: it either throws `std::runtime_error` inline, or calls
`torchCheckFail()`, which throws `c10::Error`. `TORCH_CHECK` is a macro, so that
difference is compiled into the body of every header-inline c10 function that
calls it -- `ArrayRef::slice`, `Scalar::to*`, the `TensorImpl` accessors,
`IValue`, and many more. The flag is *exported* by the builds that set it, so it
reaches the own-compile of every transitive dependent, and any binary linking
both a flag-setting consumer and libtorch ends up holding two definitions of
each of those inline functions.

The flag exists for one reason: `c10::Error` cannot be used without linking
libc10. This diff removes that reason.

## How

`Error`, `torchCheckFail()`, `torchInternalAssertFail()` and
`operator<<(SourceLocation)` move into `Exception.h`. The blocker was the eager
backtrace: `Error(SourceLocation, ...)` lived in `Logging.cpp` to reach
`GetFetchStackTrace()`, whose default dragged in the symbolizer. That hook is now
`c10::detail::getBacktraceFetcher()` -- inline, empty by default, with libc10
installing the symbolizing one on load, so on ELF linking libc10 behaves as
before. Windows does not; see below.

`Error` and its subclasses use a new `C10_HEADERONLY_EXPORT` rather than
`C10_API`, which is `dllimport` for consumers and would reintroduce the libc10
dependency on Windows. Dropping `dllexport` also retires 16 per-subclass
constructors that only worked around clang-cl and inherited constructors
(llvm/llvm-project#162640).

## Regression this introduces, on Windows

`GetFetchStackTrace()` used to be a file-local function in `Logging.cpp` with a
symbolizing default, reached through libc10's out-of-line `Error` constructor,
so every module linking libc10 got a backtrace on every platform. The
replacement is inline, and on Windows an inline function's static local is
per-module whatever the annotation, so there any module other than libc10 sees
an empty fetcher and gets an `Error` with **no backtrace at all** --
`compute_what()` skips the section when the pointer is null. ELF is unaffected:
one shared instance, libc10 installs the fetcher on load.

I do not see a way to close this that keeps `Error` header-only on Windows, so
it is a real trade against the ODR fix rather than an oversight. Flagging for
owners.

Test Plan:
Behaviour-neutral by construction, so the checks target what could actually
regress: backtraces, and the visibility change.

**Backtraces still work, and are shorter.** A binary linking c10 and tripping
`TORCH_CHECK(false, ...)` still prints
`Exception raised from main at ...:7 (most recent call first):` followed by a
symbolized stack. `main` lands at frame 9 where master puts it at frame 17 --
the capture is no longer buried in a `make_shared` member-init chain.

**Builds:** c10, libtorch CPU and CUDA, the ExecuTorch runtime and its
extensions, and the downstream consumers of both. This diff keeps
`STANDALONE_TORCH_HEADER` alive, so both `TORCH_CHECK` expansions are compiled.

**Tests:** c10, the ExecuTorch runtime / tensor / portable-kernel suites, and
model-loading tests -- 635 pass, 0 fail. One pre-existing failure is excluded: a
c10 test target does not build because `safe_conv_test.cpp` cannot find
`c10/util/TypeCast.h`, identically on unmodified master.

Differential Revision: D114894423


