### PR TITLE
[Inductor] Support Triton cache key encoding across versions

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -46,6 +46,7 @@ from torch._inductor.runtime.hints import (
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
+from torch._inductor.runtime.runtime_utils import triton_hash_to_path_key
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _check_max_grid_x,
@@ -94,6 +95,33 @@ def get_autotuned_amd_sqr_kernel():
 @instantiate_parametrized_tests
 class TestTritonHeuristics(TestCase):
     device_type = GPU_TYPE
+
+    def test_triton_hash_to_path_key_prefers_base64(self):
+        with (
+            patch.object(
+                triton.runtime.cache, "_base64", return_value="base64", create=True
+            ),
+            patch.object(
+                triton.runtime.cache, "_base32", return_value="base32", create=True
+            ),
+        ):
+            self.assertEqual(triton_hash_to_path_key("key"), "base64")
+
+    def test_triton_hash_to_path_key_falls_back_to_base32(self):
+        with (
+            patch.object(triton.runtime.cache, "_base64", None, create=True),
+            patch.object(
+                triton.runtime.cache, "_base32", return_value="base32", create=True
+            ),
+        ):
+            self.assertEqual(triton_hash_to_path_key("key"), "base32")
+
+    def test_triton_hash_to_path_key_falls_back_to_key(self):
+        with (
+            patch.object(triton.runtime.cache, "_base64", None, create=True),
+            patch.object(triton.runtime.cache, "_base32", None, create=True),
+        ):
+            self.assertEqual(triton_hash_to_path_key("key"), "key")
 
     def test_triton_config(self):
         """

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -189,21 +189,20 @@ def triton_hash_to_path_key(key: str) -> str:
     # Later, the hash is converted to base64 before being used in the path name.
     # Later, the base64 conversion was replaced to the base32
     #
-    # This code tries to import _base64 and falls back to _base32 if _base64 is unavailable.
-    #
-    # To handle this, try to import the to-base64-conversion function.
-    # If it exists, use it; otherwise, try using _base32; if both are unavailable, use the hash directly.
+    # Avoid from-import probes for removed private attributes. Some Python
+    # runtimes can fail while constructing the resulting ImportError.
     try:
-        from triton.runtime.cache import _base64
-
-        return _base64(key)
+        from triton.runtime import cache
     except Exception:
-        try:
-            from triton.runtime.cache import _base32
+        return key
 
-            return _base32(key)
-        except Exception:
-            return key
+    base64_fn = getattr(cache, "_base64", None)
+    if base64_fn is not None:
+        return base64_fn(key)
+    base32_fn = getattr(cache, "_base32", None)
+    if base32_fn is not None:
+        return base32_fn(key)
+    return key
 
 
 def compile_mps_shader(source: str) -> Any:


### PR DESCRIPTION
Summary:
Avoid probing removed Triton cache helpers with from-imports. Use module attribute lookup instead, preserving compatibility with base64, base32, and unencoded cache keys.

Add focused coverage for all three Triton API generations.

Test Plan:
- Lint passed.
- Changed-target type checking reported no errors.
- All focused triton_hash_to_path_key tests passed, covering base64, base32, and unencoded keys.

Differential Revision: D114672331


