### PR TITLE
[dynamo] Graph-break on UntypedStorage._cdata to avoid reading freed memory

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13704,6 +13704,22 @@ def ___make_guard_fn():
         self.assertEqual(x.untyped_storage().size(), 0)
         self.assertIs(s, x.untyped_storage())
 
+    def test_storage_cdata_use_count(self):
+        # https://github.com/pytorch/pytorch/issues/156059: `_cdata` is a raw
+        # StorageImpl pointer. Tracing left it as a lazy attribute access; it
+        # was the bytecode generated at the graph break that read the pointer
+        # out and only then ran the DELETE_FAST dropping the last reference to
+        # the tensor, so the use count was read back off freed memory.
+        def fn():
+            a = torch.randn(10)
+            return torch._C._storage_Use_Count(a.untyped_storage()._cdata)
+
+        self.assertEqual(torch.compile(fn, backend="eager")(), fn())
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(Unsupported, "UntypedStorage._cdata"):
+            torch.compile(fn, backend="eager", fullgraph=True)()
+
     def test_flat_name_to_original_fqn(self):
         class FooBarModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -605,6 +605,16 @@
       ]
     }
   ],
+  "GB4440": [
+    {
+      "Gb_type": "Attempted to access UntypedStorage._cdata",
+      "Context": "{self}._cdata",
+      "Explanation": "Dynamo does not preserve the lifetime of the traced storage, so the raw pointer `_cdata` returns could dangle by the time the compiled code uses it.",
+      "Hints": [
+        "This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround."
+      ]
+    }
+  ],
   "GB0043": [
     {
       "Gb_type": "Encountered non-PT2-compliant op",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -3461,6 +3461,29 @@ class UntypedStorageVariable(VariableTracker):
     def python_type(self) -> type:
         return torch.UntypedStorage
 
+    # `_cdata` is a raw StorageImpl pointer, so the int it produces is only
+    # meaningful while something else keeps the storage alive. Dynamo drops dead
+    # locals as soon as the graph returns, which frees the storage before the
+    # generated code gets to use the pointer, so letting the access through
+    # yields a dangling pointer rather than the value eager would compute.
+    # Break instead: LOAD_ATTR is not wrapped in break_graph_if_unsupported, so
+    # this unwinds to step(), which either restarts tracing from the last
+    # checkpoint at which the Python stack was empty, or -- with no usable
+    # checkpoint -- skips the frame altogether. Either way the code reading
+    # `_cdata` ends up running as uninstrumented CPython, under normal
+    # object lifetimes.
+    def _get_cdata(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        unimplemented(
+            gb_type="Attempted to access UntypedStorage._cdata",
+            context=f"{self}._cdata",
+            explanation="Dynamo does not preserve the lifetime of the traced "
+            "storage, so the raw pointer `_cdata` returns could dangle by the "
+            "time the compiled code uses it.",
+            hints=[*graph_break_hints.FUNDAMENTAL],
+        )
+
+    tp_getset = {"_cdata": GetSet(_get_cdata, None)}
+
     def call_method(
         self,
         tx: "InstructionTranslatorBase",


### PR DESCRIPTION
## Summary

`_cdata` is a raw `StorageImpl` pointer (an unowned `int`). When a tensor's storage is created inside a compiled region and only `.untyped_storage()._cdata` is used afterward, Dynamo's liveness analysis frees the tensor before the generated bytecode consumes that pointer -- `torch._C._storage_Use_Count(a.untyped_storage()._cdata)` then reads freed memory and returns garbage, silently, with no error.

Root cause: tracing leaves `._cdata` as a lazy, unresolved attribute access. At the graph break that forces, Dynamo reconstructs the storage and reads the pointer into the generated bytecode, then runs `DELETE_FAST` on the tensor's last reference -- before that pointer is actually used -- since the tensor is dead per Dynamo's liveness analysis. Eager mode never does this because CPython keeps locals alive until their last real use.

Fix: register `_cdata` as an explicit `tp_getset` entry on `UntypedStorageVariable` (`torch/_dynamo/variables/tensor.py`) that raises a clean, explicit graph break instead of silently tracing through. This isn't just a better error message -- moving the break to the attribute access itself (rather than the later call site) means `LOAD_ATTR` isn't a fine-grained resume point, so this unwinds to Dynamo's `step()`, which either restarts from the last checkpoint with an empty stack or skips the frame to eager entirely. Either way, the code touching `_cdata` ends up running as normal, uninstrumented CPython with correct object lifetimes -- so the value becomes correct, not just the error.

Scope: deliberately narrow. `DataPtrVariable` (`tensor.py:3533+`) goes through the same codegen path with the same theoretical window for `data_ptr()`, but is far lower severity since that int is typically compared/printed rather than fed back into a torch API that dereferences it. Not addressed here.

Fixes #156059

## Test plan

Added `test_storage_cdata_use_count` to `test/dynamo/test_misc.py`, checking both the corrected value and (with `fullgraph=True`) the explicit graph break.

No C/C++ compiler and uninitialized git submodules in my dev environment, so I could not build this checkout to run its own test suite. I validated the failure mechanism and the fix's logical correctness by backporting the fix to an installed torch 2.12.1+cpu wheel (structurally different attribute-resolution path, but same underlying mechanism) -- pre-fix `FAILED` (`0 != 2`), post-fix `OK`. I statically verified against this checkout's actual current source that `tp_getset` is consulted before the generic attribute-resolution fallback (`torch/_dynamo/variables/base.py`, `torch/_dynamo/variables/object_protocol.py`), and confirmed `torch/_dynamo/graph_break_registry.json`'s new `GB4440` entry is in sync by running `tools/linter/adapters/gb_registry_linter.py` directly (pure Python, doesn't need a build) -- no output, meaning in sync.

`ruff check` and `ruff format --check` clean on both changed Python files.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98