### PR TITLE
[inductor][overlap] Prevent recursive handle_wait

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1131,6 +1131,7 @@ class TestOverlapPreservingBucketing(InductorTestCase):
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+@instantiate_parametrized_tests
 class TestCrossPGOverlap(InductorTestCase):
     """
     Tests for cross-PG overlap scheduling.
@@ -1228,6 +1229,47 @@ class TestCrossPGOverlap(InductorTestCase):
         ).check("%wait_tensor").run(str(out.graph))
 
         self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
+
+    @parametrize("wait_a_first", [False, True])
+    def test_active_wait_is_not_scheduled_recursively(self, wait_a_first):
+        pg1_name = self.pg1_name
+        pg2_name = self.pg2_name
+
+        def func(a, b):
+            start_a = torch.ops._c10d_functional.all_gather_into_tensor(a, 2, pg1_name)
+            start_b = torch.ops._c10d_functional.all_gather_into_tensor(b, 2, pg1_name)
+            if wait_a_first:
+                wait_a = torch.ops._c10d_functional.wait_tensor(start_a)
+                wait_b = torch.ops._c10d_functional.wait_tensor(start_b)
+            else:
+                wait_b = torch.ops._c10d_functional.wait_tensor(start_b)
+                wait_a = torch.ops._c10d_functional.wait_tensor(start_a)
+            start_c = torch.ops._c10d_functional.all_gather_into_tensor(
+                wait_b, 2, pg2_name
+            )
+            wait_c = torch.ops._c10d_functional.wait_tensor(start_c)
+            return wait_a.sum() + wait_c.sum()
+
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(4, 4, device=self.device)
+            traced = make_fx(func)(a, b)
+
+        def custom_runtime(node: fx.Node, override_size: int | None) -> float | None:
+            if "all_gather" in str(node.target):
+                return 10.0 if override_size == 0 else 3.0
+            return 0.0
+
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        schedule_overlap_bucketing(
+            traced,
+            custom_runtime_estimation=custom_runtime,
+            pre_bucketing_fsdp_collectives=False,
+        )
+        traced.graph.lint()
 
     def test_two_queue_scheduling_off_path_nodes(self):
         """

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -577,6 +577,9 @@ class OverlapScheduler:
 
         self.in_flight: dict[fx.Node, CollectiveInfo] = {}  # start -> info
         self.in_flight_bytes = 0
+        # Coalesced collectives can have multiple waits for the same collective.
+        # We track coll_starts in handling.
+        self.wait_starts_being_handled: OrderedSet[fx.Node] = OrderedSet()
         self.scheduled: OrderedSet[fx.Node] = OrderedSet()
         self.max_compute_pre_fetch = max_compute_pre_fetch
 
@@ -1083,6 +1086,9 @@ class OverlapScheduler:
         }
 
         for start_node, info in self.in_flight.items():
+            # Do not let a nested wait hide an outer active wait.
+            if start_node in self.wait_starts_being_handled:
+                continue
             if info.exposed_time_ms == 0:
                 continue
 
@@ -1238,6 +1244,16 @@ class OverlapScheduler:
         if node not in self.wait_to_start:
             raise AssertionError(f"wait node {node} has no associated start")
         coll_start = self.wait_to_start[node]
+        if coll_start in self.wait_starts_being_handled:
+            raise AssertionError(f"wait node {node} is already being handled")
+        self.wait_starts_being_handled.add(coll_start)
+        try:
+            self._handle_wait_impl(node, coll_start)
+        finally:
+            # Keep active state scoped to this handler on every exit.
+            self.wait_starts_being_handled.remove(coll_start)
+
+    def _handle_wait_impl(self, node: fx.Node, coll_start: fx.Node) -> None:
         # For coalesced collectives, multiple waits share the same start node.
         # The first wait completes the collective; subsequent waits just schedule.
         if coll_start not in self.in_flight:
@@ -1248,14 +1264,7 @@ class OverlapScheduler:
         # of every node enqueued prior to the collective on the
         # same process group
         group_name = get_group_name(coll_start)
-        to_schedule: list[fx.Node] = []
-        for in_flight_coll in self.in_flight:
-            if in_flight_coll == coll_start:
-                break
-            if get_group_name(in_flight_coll) == group_name:
-                to_schedule.append(in_flight_coll)
-
-        for coll_to_schedule in to_schedule:
+        for coll_to_schedule in self._get_prior_in_flight_collectives(coll_start):
             self._handle_wait(self.collective_info[coll_to_schedule].wait_node)
 
         # If we are waiting on an exposed collective, use this time to
@@ -1275,6 +1284,33 @@ class OverlapScheduler:
         self.in_flight_bytes -= self.in_flight[coll_start].size_bytes
         del self.in_flight[coll_start]
         self._schedule(node)
+
+    def _get_prior_in_flight_collectives(self, coll_start: fx.Node) -> list[fx.Node]:
+        """Return earlier in-flight collectives on the same process group."""
+        if coll_start not in self.in_flight:
+            return []
+
+        group_name = get_group_name(coll_start)
+        prior_collectives: list[fx.Node] = []
+        for in_flight_coll in self.in_flight:
+            if in_flight_coll == coll_start:
+                break
+            if get_group_name(in_flight_coll) == group_name:
+                prior_collectives.append(in_flight_coll)
+        return prior_collectives
+
+    def _would_reenter_wait(self, coll_start: fx.Node) -> bool:
+        # Check if we are in handle_wait and scheduling this coll_start will result
+        # in recursive handle_wait.
+        active_starts = self.wait_starts_being_handled
+        if not active_starts:
+            return False
+        if coll_start in active_starts:
+            return True
+        return any(
+            prior in active_starts
+            for prior in self._get_prior_in_flight_collectives(coll_start)
+        )
 
     def _schedule_collectives_for_overlap(
         self,
@@ -1366,6 +1402,9 @@ class OverlapScheduler:
                 candidates.extend(group)
 
         for collective in candidates:
+            if collective not in self.unscheduled_collectives:
+                continue
+
             pg_name = get_group_name(collective)
             pg_available_time = remaining_time_per_pg[pg_name]
 
@@ -1388,9 +1427,19 @@ class OverlapScheduler:
             while (
                 self.in_flight
                 and (self.max_in_flight_bytes - self.in_flight_bytes) < info.size_bytes
-                and self._wait_is_hidden(self._get_oldest_wait(), overlap_node)
             ):
+                oldest_wait = self._get_oldest_wait()
+                oldest_start = self.wait_to_start[oldest_wait]
+                # Forcing this wait would re-enter an active handler.
+                if self._would_reenter_wait(oldest_start):
+                    break
+                if not self._wait_is_hidden(oldest_wait, overlap_node):
+                    break
                 self._force_oldest_wait()
+
+            # Forcing a wait may recursively schedule this candidate.
+            if collective not in self.unscheduled_collectives:
+                continue
 
             if (self.max_in_flight_bytes - self.in_flight_bytes) < info.size_bytes:
                 why("in-flight memory limit")
@@ -1491,7 +1540,12 @@ class OverlapScheduler:
             # thus forcing it to be exposed.
             # however, if it is already hidden it's fine to schedule it
             if _schedulable_wait_node(node):
-                info = self.collective_info[self.wait_to_start[node]]
+                coll_start = self.wait_to_start[node]
+                # Defer paths that would recurse through an active wait.
+                if self._would_reenter_wait(coll_start):
+                    why("path blocked by active wait node %s", node.name)
+                    return None
+                info = self.collective_info[coll_start]
                 if (not info.is_exposed) and (
                     curr_overlap_node not in info.hiding_nodes
                 ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

handle_wait(W_A) could lead to stackoverflow handle_wait(W_A)
This was catched by internal training job.

Prevent this by tracking waits being handled - self.wait_starts_being_handled

We skip handling recursive waits with this PR,
the main check is "if self._would_reenter_wait(coll_start): return None"
in _find_schedulable_path.

Scheduling of wait forces all previous in_flight collectives on the same
pg to be scheduled - we check not only self.wait_starts_being_handled
but also self._get_prior_in_flight_collectives(coll_start).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo