### PR TITLE
[c10][cuda] Per-stream expandable-segment reserve downsizing (#192269)

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -1,6 +1,10 @@
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 
+#include <cmath>
+#include <locale>
+#include <sstream>
+
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #endif
@@ -97,6 +101,12 @@ void CUDAAllocatorConfig::parseArgs(const std::string& env) {
       used_native_specific_option = true;
     } else if (key == "throw_on_cudamalloc_oom") {
       i = parseThrowOnCudaMallocOom(tokenizer, i);
+      used_native_specific_option = true;
+    } else if (key == "expandable_segments_reserve") {
+      i = parseExpandableSegmentsReserve(tokenizer, i);
+      used_native_specific_option = true;
+    } else if (key == "expandable_segments_reserve_by_class") {
+      i = parseExpandableSegmentsReserveByClass(tokenizer, i);
       used_native_specific_option = true;
     } else {
       const auto& keys =
@@ -197,6 +207,77 @@ size_t CUDAAllocatorConfig::parseThrowOnCudaMallocOom(
   // would likely fail due to insufficient memory.
   tokenizer.checkToken(++i, ":");
   m_throw_on_cudamalloc_oom = tokenizer.toBool(++i);
+  return i;
+}
+
+std::optional<ExpandableSegmentReserveSpec> CUDAAllocatorConfig::
+    parseReserveSpec(const std::string& token) {
+  // A trailing 'G' means the value is absolute GiB; otherwise it is a fraction
+  // of total GPU memory. Malformed or non-positive values are intentionally
+  // non-fatal: we log and return nullopt so the caller keeps its default rather
+  // than aborting the process over a bad PYTORCH_CUDA_ALLOC_CONF entry.
+  bool is_gib = !token.empty() && (token.back() == 'G' || token.back() == 'g');
+  const std::string num = is_gib ? token.substr(0, token.size() - 1) : token;
+  // Parse in the classic (C) locale so a non-C process locale cannot change how
+  // the decimal separator is interpreted, and reject non-finite values (inf/nan
+  // would otherwise slip past the range check and poison resolveBytes).
+  double value = 0.0;
+  std::istringstream iss(num);
+  iss.imbue(std::locale::classic());
+  iss >> value;
+  const bool ok = !num.empty() && !iss.fail() && iss.eof() &&
+      std::isfinite(value) && value > 0.0;
+  if (!ok) {
+    TORCH_WARN(
+        "Ignoring invalid expandable-segment reserve value '",
+        token,
+        "' in PYTORCH_CUDA_ALLOC_CONF (expected a positive, finite fraction "
+        "like 0.5 or an absolute size like 40G); using default.");
+    return std::nullopt;
+  }
+  return ExpandableSegmentReserveSpec{/*is_fraction=*/!is_gib, value};
+}
+
+size_t CUDAAllocatorConfig::parseExpandableSegmentsReserve(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  // Bad value -> keep the default (leave m_expandable_segments_reserve_set
+  // false so untagged streams stay on the historical reserve).
+  auto spec = parseReserveSpec(tokenizer[++i]);
+  if (spec) {
+    std::lock_guard<std::mutex> lock(m_reserve_mutex);
+    m_expandable_segments_reserve = *spec;
+    m_expandable_segments_reserve_set = true;
+  }
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parseExpandableSegmentsReserveByClass(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  // Format: expandable_segments_reserve_by_class:[name:val,name:val,...]
+  tokenizer.checkToken(++i, ":");
+  tokenizer.checkToken(++i, "[");
+  // Build into a local map, then publish under the lock so readers on the
+  // segment-creation path never observe a partially-updated map.
+  ska::flat_hash_map<std::string, ExpandableSegmentReserveSpec> parsed;
+  while (!tokenizer.checkToken(i + 1, "]")) {
+    const std::string& name = tokenizer[++i];
+    tokenizer.checkToken(++i, ":");
+    // A malformed entry is skipped (logged); other entries still apply.
+    if (auto spec = parseReserveSpec(tokenizer[++i])) {
+      parsed[name] = *spec;
+    }
+    if (tokenizer.checkToken(i + 1, ",")) {
+      ++i;
+    }
+  }
+  ++i; // consume ']'
+  {
+    std::lock_guard<std::mutex> lock(m_reserve_mutex);
+    m_expandable_segments_reserve_by_class = std::move(parsed);
+  }
   return i;
 }
 

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -1,6 +1,10 @@
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 
+#include <cmath>
+#include <locale>
+#include <sstream>
+
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #endif
@@ -97,6 +101,15 @@ void CUDAAllocatorConfig::parseArgs(const std::string& env) {
       used_native_specific_option = true;
     } else if (key == "throw_on_cudamalloc_oom") {
       i = parseThrowOnCudaMallocOom(tokenizer, i);
+      used_native_specific_option = true;
+    } else if (key == "expandable_segments_reserve") {
+      i = parseExpandableSegmentsReserve(tokenizer, i);
+      used_native_specific_option = true;
+    } else if (key == "expandable_segments_reserve_by_class") {
+      i = parseExpandableSegmentsReserveByClass(tokenizer, i);
+      used_native_specific_option = true;
+    } else if (key == "expandable_segments_min_reserve") {
+      i = parseExpandableSegmentsMinReserve(tokenizer, i);
       used_native_specific_option = true;
     } else {
       const auto& keys =
@@ -197,6 +210,89 @@ size_t CUDAAllocatorConfig::parseThrowOnCudaMallocOom(
   // would likely fail due to insufficient memory.
   tokenizer.checkToken(++i, ":");
   m_throw_on_cudamalloc_oom = tokenizer.toBool(++i);
+  return i;
+}
+
+std::optional<ExpandableSegmentReserveSpec> CUDAAllocatorConfig::
+    parseReserveSpec(const std::string& token) {
+  // A trailing 'G' means the value is absolute GiB; otherwise it is a fraction
+  // of total GPU memory. Malformed or non-positive values are intentionally
+  // non-fatal: we log and return nullopt so the caller keeps its default rather
+  // than aborting the process over a bad PYTORCH_CUDA_ALLOC_CONF entry.
+  bool is_gib = !token.empty() && (token.back() == 'G' || token.back() == 'g');
+  const std::string num = is_gib ? token.substr(0, token.size() - 1) : token;
+  // Parse in the classic (C) locale so a non-C process locale cannot change how
+  // the decimal separator is interpreted, and reject non-finite values (inf/nan
+  // would otherwise slip past the range check and poison resolveBytes).
+  double value = 0.0;
+  std::istringstream iss(num);
+  iss.imbue(std::locale::classic());
+  iss >> value;
+  const bool ok = !num.empty() && !iss.fail() && iss.eof() &&
+      std::isfinite(value) && value > 0.0;
+  if (!ok) {
+    TORCH_WARN(
+        "Ignoring invalid expandable-segment reserve value '",
+        token,
+        "' in PYTORCH_CUDA_ALLOC_CONF (expected a positive, finite fraction "
+        "like 0.5 or an absolute size like 40G); using default.");
+    return std::nullopt;
+  }
+  return ExpandableSegmentReserveSpec{/*is_fraction=*/!is_gib, value};
+}
+
+size_t CUDAAllocatorConfig::parseExpandableSegmentsReserve(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  // Bad value -> keep the default (leave m_expandable_segments_reserve_set
+  // false so untagged streams stay on the historical reserve).
+  auto spec = parseReserveSpec(tokenizer[++i]);
+  if (spec) {
+    std::lock_guard<std::mutex> lock(m_reserve_mutex);
+    m_expandable_segments_reserve = *spec;
+    m_expandable_segments_reserve_set = true;
+  }
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parseExpandableSegmentsMinReserve(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  auto spec = parseReserveSpec(tokenizer[++i]);
+  if (spec) {
+    std::lock_guard<std::mutex> lock(m_reserve_mutex);
+    m_expandable_segments_min_reserve = *spec;
+  }
+  return i;
+}
+
+size_t CUDAAllocatorConfig::parseExpandableSegmentsReserveByClass(
+    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+    size_t i) {
+  // Format: expandable_segments_reserve_by_class:[name:val,name:val,...]
+  tokenizer.checkToken(++i, ":");
+  tokenizer.checkToken(++i, "[");
+  // Build into a local map, then publish under the lock so readers on the
+  // segment-creation path never observe a partially-updated map.
+  std::unordered_map<std::string, ExpandableSegmentReserveSpec> parsed;
+  while (!tokenizer.checkToken(i + 1, "]")) {
+    const std::string& name = tokenizer[++i];
+    tokenizer.checkToken(++i, ":");
+    // A malformed entry is skipped (logged); other entries still apply.
+    if (auto spec = parseReserveSpec(tokenizer[++i])) {
+      parsed[name] = *spec;
+    }
+    if (tokenizer.checkToken(i + 1, ",")) {
+      ++i;
+    }
+  }
+  ++i; // consume ']'
+  {
+    std::lock_guard<std::mutex> lock(m_reserve_mutex);
+    m_expandable_segments_reserve_by_class = std::move(parsed);
+  }
   return i;
 }
 

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -6,6 +6,13 @@
 #include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
+#include <c10/util/flat_hash_map.h>
+
+#include <algorithm>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <string>
 
 namespace c10::cuda::CUDACachingAllocator {
 
@@ -13,6 +20,39 @@ enum class Expandable_Segments_Handle_Type : int {
   UNSPECIFIED = 0,
   POSIX_FD = 1,
   FABRIC_HANDLE = 2,
+};
+
+// A per-segment virtual-address reserve size, expressed either as a fraction of
+// a device's total memory (e.g. 0.5) or as an absolute number of GiB (config
+// suffix 'G', e.g. 40G). Resolved to an absolute byte count against a device's
+// total memory.
+struct ExpandableSegmentReserveSpec {
+  bool is_fraction = true;
+  double value = 0.0;
+
+  size_t resolveBytes(size_t total_global_mem) const {
+    double bytes = is_fraction ? value * static_cast<double>(total_global_mem)
+                               : value * static_cast<double>(size_t{1} << 30);
+    // Saturate before narrowing: converting a double that exceeds SIZE_MAX to
+    // size_t is undefined behavior, and a pathological config value (e.g.
+    // expandable_segments_reserve:1e20G) can produce such a double.
+    // clamp_reserve_bytes() bounds the reserve to the full reserve, so a
+    // saturated value here can never reach numSegments().
+    if (bytes >= static_cast<double>(std::numeric_limits<size_t>::max())) {
+      return std::numeric_limits<size_t>::max();
+    }
+    return static_cast<size_t>(bytes);
+  }
+};
+
+// A consistent snapshot of the reserve decision for a class, read under a
+// single lock so a concurrent config re-parse cannot compose an inconsistent
+// view.
+struct ExpandableSegmentReserveDecision {
+  // nullopt => no override configured; caller keeps the full historical
+  // reserve.
+  std::optional<size_t> reserve_bytes;
+  bool class_known = false; // the class had an explicit per-class entry
 };
 
 // Environment config parser
@@ -64,6 +104,63 @@ class C10_CUDA_API CUDAAllocatorConfig {
 
   static double per_process_memory_fraction() {
     return instance().m_per_process_memory_fraction;
+  }
+
+  // Single-lock snapshot of the reserve decision for reserve_class, so the
+  // segment-creation path composes (reserve, class_known) consistently even if
+  // setAllocatorSettings() re-parses concurrently.
+  static ExpandableSegmentReserveDecision expandable_segments_reserve_decision(
+      const std::string& reserve_class,
+      size_t total_global_mem) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    ExpandableSegmentReserveDecision d;
+    auto it = self.m_expandable_segments_reserve_by_class.find(reserve_class);
+    if (it != self.m_expandable_segments_reserve_by_class.end()) {
+      d.reserve_bytes = it->second.resolveBytes(total_global_mem);
+      d.class_known = true;
+    } else if (self.m_expandable_segments_reserve_set) {
+      d.reserve_bytes =
+          self.m_expandable_segments_reserve.resolveBytes(total_global_mem);
+    }
+    return d;
+  }
+
+  // Final per-segment reserve for a decision snapshot, given the device's full
+  // historical reserve (9/8 of total memory). Returns full_reserve unchanged
+  // when no override is configured, so the untagged path is byte-for-byte
+  // identical. Otherwise the configured reserve is capped at full_reserve: no
+  // single allocation can exceed physical memory, so a larger reservation is
+  // never needed, and the cap also keeps a saturated reserve (a pathological
+  // expandable_segments_reserve) from overflowing numSegments(). Pure, so it is
+  // unit-testable without a device.
+  static size_t clamp_reserve_bytes(
+      const ExpandableSegmentReserveDecision& decision,
+      size_t full_reserve) {
+    if (!decision.reserve_bytes.has_value()) {
+      return full_reserve;
+    }
+    return std::min(*decision.reserve_bytes, full_reserve);
+  }
+
+  // Registers a code-side default reserve for a class, letting serving layers
+  // opt their stream classes into a downsized reserve by default. Prefer the
+  // setDefaultExpandableSegmentReserveFractionForClass() free function over
+  // calling this directly. Precedence is resolved at call time: this is a no-op
+  // if a global reserve (expandable_segments_reserve) has been set, or if
+  // reserve_class already has an explicit per-class entry. Call only after
+  // config is parsed (touching instance() forces that); a later runtime
+  // re-parse that sets only a global reserve does not retroactively remove an
+  // already-seeded default.
+  static void set_default_reserve_for_class(
+      const std::string& reserve_class,
+      ExpandableSegmentReserveSpec spec) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    if (self.m_expandable_segments_reserve_set) {
+      return;
+    }
+    self.m_expandable_segments_reserve_by_class.emplace(reserve_class, spec);
   }
 
   // When enabled, throws OOM error before calling cudaMalloc if the allocation
@@ -171,7 +268,9 @@ class C10_CUDA_API CUDAAllocatorConfig {
         "pinned_num_register_threads",
         "per_process_memory_fraction",
         "pinned_free_catch_all",
-        "throw_on_cudamalloc_oom"};
+        "throw_on_cudamalloc_oom",
+        "expandable_segments_reserve",
+        "expandable_segments_reserve_by_class"};
     return keys;
   }
 
@@ -205,6 +304,17 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parseThrowOnCudaMallocOom(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
+  size_t parseExpandableSegmentsReserve(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
+  size_t parseExpandableSegmentsReserveByClass(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
+  // Parses a reserve value ("<fraction>" or "<n>G"). Returns nullopt on a
+  // malformed or non-positive value (logged, non-fatal) so callers keep
+  // defaults.
+  static std::optional<ExpandableSegmentReserveSpec> parseReserveSpec(
+      const std::string& token);
 
   std::atomic<size_t> m_pinned_num_register_threads{1};
   std::atomic<size_t> m_pinned_reserve_segment_size_mb{0};
@@ -221,6 +331,22 @@ class C10_CUDA_API CUDAAllocatorConfig {
   // When true, throw OOM error before calling cudaMalloc if allocation would
   // fail
   std::atomic<bool> m_throw_on_cudamalloc_oom{false};
+  // Per-stream expandable-segment reserve config. Parsed once at init (like the
+  // rest of PYTORCH_CUDA_ALLOC_CONF); read on the segment-creation path.
+  // Default reserve, applied to untagged streams and to classes with no
+  // override. 1.125 mirrors the historical "1 1/8" reserve that the
+  // ExpandableSegment ctor computes as (total + total/8); it is only consulted
+  // when explicitly set via config, so the untagged path stays byte-for-byte
+  // identical when unset.
+  ExpandableSegmentReserveSpec m_expandable_segments_reserve{
+      /*is_fraction=*/true,
+      1.125};
+  bool m_expandable_segments_reserve_set{false};
+  ska::flat_hash_map<std::string, ExpandableSegmentReserveSpec>
+      m_expandable_segments_reserve_by_class;
+  // Guards the reserve fields above: they are read on the segment-creation path
+  // and can be rewritten at runtime by a setAllocatorSettings() re-parse.
+  std::mutex m_reserve_mutex;
 };
 
 // Keep this for backwards compatibility

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -7,12 +7,52 @@
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
 
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
 namespace c10::cuda::CUDACachingAllocator {
 
 enum class Expandable_Segments_Handle_Type : int {
   UNSPECIFIED = 0,
   POSIX_FD = 1,
   FABRIC_HANDLE = 2,
+};
+
+// A per-segment virtual-address reserve size, expressed either as a fraction of
+// a device's total memory (e.g. 0.5) or as an absolute number of GiB (config
+// suffix 'G', e.g. 40G). Resolved to an absolute byte count against a device's
+// total memory.
+struct ExpandableSegmentReserveSpec {
+  bool is_fraction = true;
+  double value = 0.0;
+
+  size_t resolveBytes(size_t total_global_mem) const {
+    double bytes = is_fraction ? value * static_cast<double>(total_global_mem)
+                               : value * static_cast<double>(size_t{1} << 30);
+    // Saturate before narrowing: converting a double that exceeds SIZE_MAX to
+    // size_t is undefined behavior, and a pathological config value (e.g.
+    // expandable_segments_min_reserve:1e20G) can produce such a double. The
+    // caller further clamps the reserve to the full reserve, so saturating here
+    // is safe.
+    if (bytes >= static_cast<double>(std::numeric_limits<size_t>::max())) {
+      return std::numeric_limits<size_t>::max();
+    }
+    return static_cast<size_t>(bytes);
+  }
+};
+
+// A consistent snapshot of the reserve decision for a class, read under a
+// single lock so a concurrent config re-parse cannot compose an inconsistent
+// view.
+struct ExpandableSegmentReserveDecision {
+  // nullopt => no override configured; caller keeps the full historical
+  // reserve.
+  std::optional<size_t> reserve_bytes;
+  bool class_known = false; // the class had an explicit per-class entry
+  size_t min_reserve_bytes = 0; // floor
 };
 
 // Environment config parser
@@ -64,6 +104,90 @@ class C10_CUDA_API CUDAAllocatorConfig {
 
   static double per_process_memory_fraction() {
     return instance().m_per_process_memory_fraction;
+  }
+
+  // Per-segment reserve in bytes for a given reserve class, resolved against
+  // total_global_mem. Returns nullopt when neither a per-class override
+  // (expandable_segments_reserve_by_class) nor an explicit default reserve
+  // (expandable_segments_reserve) is set, so callers fall back to the
+  // historical reserve unchanged. An empty class name resolves to the default
+  // reserve.
+  static std::optional<size_t> expandable_segments_reserve_bytes(
+      const std::string& reserve_class,
+      size_t total_global_mem) {
+    auto& self = instance();
+    // Guards against a concurrent setAllocatorSettings() re-parse mutating the
+    // reserve config while a segment is being created on another thread.
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    auto it = self.m_expandable_segments_reserve_by_class.find(reserve_class);
+    if (it != self.m_expandable_segments_reserve_by_class.end()) {
+      return it->second.resolveBytes(total_global_mem);
+    }
+    if (self.m_expandable_segments_reserve_set) {
+      return self.m_expandable_segments_reserve.resolveBytes(total_global_mem);
+    }
+    return std::nullopt;
+  }
+
+  // True if reserve_class has an explicit per-class override.
+  static bool expandable_segments_has_reserve_class(
+      const std::string& reserve_class) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    return self.m_expandable_segments_reserve_by_class.find(reserve_class) !=
+        self.m_expandable_segments_reserve_by_class.end();
+  }
+
+  // Floor on the per-segment reserve, resolved against total_global_mem. This
+  // is the expected largest single allocation: a single allocation cannot span
+  // expandable segments, so a downsized reserve must not fall below it.
+  static size_t expandable_segments_min_reserve_bytes(size_t total_global_mem) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    return self.m_expandable_segments_min_reserve.resolveBytes(
+        total_global_mem);
+  }
+
+  // Single-lock snapshot of the reserve decision for reserve_class, so the
+  // segment-creation path composes (reserve, class_known, floor) consistently
+  // even if setAllocatorSettings() re-parses concurrently.
+  static ExpandableSegmentReserveDecision expandable_segments_reserve_decision(
+      const std::string& reserve_class,
+      size_t total_global_mem) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    ExpandableSegmentReserveDecision d;
+    auto it = self.m_expandable_segments_reserve_by_class.find(reserve_class);
+    if (it != self.m_expandable_segments_reserve_by_class.end()) {
+      d.reserve_bytes = it->second.resolveBytes(total_global_mem);
+      d.class_known = true;
+    } else if (self.m_expandable_segments_reserve_set) {
+      d.reserve_bytes =
+          self.m_expandable_segments_reserve.resolveBytes(total_global_mem);
+    }
+    d.min_reserve_bytes =
+        self.m_expandable_segments_min_reserve.resolveBytes(total_global_mem);
+    return d;
+  }
+
+  // Registers a code-side default reserve for a class, letting serving layers
+  // opt their stream classes into a downsized reserve by default. Prefer the
+  // setDefaultExpandableSegmentReserveFractionForClass() free function over
+  // calling this directly. Precedence is resolved at call time: this is a no-op
+  // if a global reserve (expandable_segments_reserve) has been set, or if
+  // reserve_class already has an explicit per-class entry. Call only after
+  // config is parsed (touching instance() forces that); a later runtime
+  // re-parse that sets only a global reserve does not retroactively remove an
+  // already-seeded default.
+  static void set_default_reserve_for_class(
+      const std::string& reserve_class,
+      ExpandableSegmentReserveSpec spec) {
+    auto& self = instance();
+    std::lock_guard<std::mutex> lock(self.m_reserve_mutex);
+    if (self.m_expandable_segments_reserve_set) {
+      return;
+    }
+    self.m_expandable_segments_reserve_by_class.emplace(reserve_class, spec);
   }
 
   // When enabled, throws OOM error before calling cudaMalloc if the allocation
@@ -171,7 +295,10 @@ class C10_CUDA_API CUDAAllocatorConfig {
         "pinned_num_register_threads",
         "per_process_memory_fraction",
         "pinned_free_catch_all",
-        "throw_on_cudamalloc_oom"};
+        "throw_on_cudamalloc_oom",
+        "expandable_segments_reserve",
+        "expandable_segments_reserve_by_class",
+        "expandable_segments_min_reserve"};
     return keys;
   }
 
@@ -205,6 +332,20 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parseThrowOnCudaMallocOom(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
+  size_t parseExpandableSegmentsReserve(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
+  size_t parseExpandableSegmentsReserveByClass(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
+  size_t parseExpandableSegmentsMinReserve(
+      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
+      size_t i);
+  // Parses a reserve value ("<fraction>" or "<n>G"). Returns nullopt on a
+  // malformed or non-positive value (logged, non-fatal) so callers keep
+  // defaults.
+  static std::optional<ExpandableSegmentReserveSpec> parseReserveSpec(
+      const std::string& token);
 
   std::atomic<size_t> m_pinned_num_register_threads{1};
   std::atomic<size_t> m_pinned_reserve_segment_size_mb{0};
@@ -221,6 +362,26 @@ class C10_CUDA_API CUDAAllocatorConfig {
   // When true, throw OOM error before calling cudaMalloc if allocation would
   // fail
   std::atomic<bool> m_throw_on_cudamalloc_oom{false};
+  // Per-stream expandable-segment reserve config. Parsed once at init (like the
+  // rest of PYTORCH_CUDA_ALLOC_CONF); read on the segment-creation path.
+  // Default reserve, applied to untagged streams and to classes with no
+  // override. 1.125 mirrors the historical "1 1/8" reserve that the
+  // ExpandableSegment ctor computes as (total + total/8); it is only consulted
+  // when explicitly set via config, so the untagged path stays byte-for-byte
+  // identical when unset.
+  ExpandableSegmentReserveSpec m_expandable_segments_reserve{
+      /*is_fraction=*/true,
+      1.125};
+  bool m_expandable_segments_reserve_set{false};
+  std::unordered_map<std::string, ExpandableSegmentReserveSpec>
+      m_expandable_segments_reserve_by_class;
+  // Floor / expected largest single allocation. Default 16 GiB.
+  ExpandableSegmentReserveSpec m_expandable_segments_min_reserve{
+      /*is_fraction=*/false,
+      16.0};
+  // Guards the reserve fields above: they are read on the segment-creation path
+  // and can be rewritten at runtime by a setAllocatorSettings() re-parse.
+  std::mutex m_reserve_mutex;
 };
 
 // Keep this for backwards compatibility

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -421,7 +421,40 @@ struct ExpandableSegment {
     // we allocate enough address space for 1 1/8 the total memory on the GPU.
     // This allows for some cases where we have to unmap pages earlier in the
     // segment to put them at the end.
-    max_handles_ = numSegments(prop.totalGlobalMem + prop.totalGlobalMem / 8);
+    const size_t full_reserve = prop.totalGlobalMem + prop.totalGlobalMem / 8;
+    size_t reserve = full_reserve;
+    // Serving streams may be tagged with a reserve class to downsize their VA
+    // reservation (see PYTORCH_CUDA_ALLOC_CONF expandable_segments_reserve*).
+    // Untagged streams and IPC-imported segments (no stream) keep the full
+    // reserve, so this path is a byte-for-byte no-op unless reserve config is
+    // set. A single allocation cannot span segments, so the reserve is raised
+    // to the floor, and the result is capped at the historical full reserve
+    // (see clamp_reserve_bytes).
+    if (stream.has_value()) {
+      const std::string reserve_class =
+          getExpandableSegmentReserveClassForStream(*stream);
+      // Single locked snapshot so a concurrent setAllocatorSettings() re-parse
+      // cannot compose an inconsistent (reserve, class_known, floor) view.
+      const auto decision =
+          CUDAAllocatorConfig::expandable_segments_reserve_decision(
+              reserve_class, prop.totalGlobalMem);
+      if (decision.reserve_bytes.has_value() && !reserve_class.empty() &&
+          !decision.class_known) {
+        static std::mutex warn_mutex;
+        static ska::flat_hash_set<std::string> warned;
+        std::lock_guard<std::mutex> lock(warn_mutex);
+        if (warned.insert(reserve_class).second) {
+          TORCH_WARN(
+              "expandable_segments reserve class '",
+              reserve_class,
+              "' has no configured reserve in "
+              "expandable_segments_reserve_by_class; using the default reserve.");
+        }
+      }
+      reserve =
+          CUDAAllocatorConfig::clamp_reserve_bytes(decision, full_reserve);
+    }
+    max_handles_ = numSegments(reserve);
 #ifdef USE_ROCM
     C10_CUDA_CHECK(hipMemAddressReserve(
         &ptr_, segment_size_ * max_handles_, 0ULL, 0, 0ULL));
@@ -1924,6 +1957,37 @@ class DeviceCachingAllocator {
       // Note that at this point free_cached_blocks has already returned all
       // possible "cached" memory to the driver. The only remaining "cached"
       // memory is split from a larger block that is partially in-use.
+      //
+      // With expandable segments a single allocation cannot span segments, so a
+      // request larger than this stream's per-segment reserve fails even when
+      // the device has room -- which is otherwise baffling, since the message
+      // above will report plenty free. Only advise raising the reserve when the
+      // request would actually fit on the device; for a genuinely oversized
+      // request the reserve is not the problem.
+      std::string expandable_reserve_msg;
+      if (CUDAAllocatorConfig::expandable_segments() &&
+          alloc_size <= device_prop.totalGlobalMem) {
+        const std::string reserve_class =
+            getExpandableSegmentReserveClassForStream(stream);
+        const size_t total = device_prop.totalGlobalMem;
+        const size_t reserve = CUDAAllocatorConfig::clamp_reserve_bytes(
+            CUDAAllocatorConfig::expandable_segments_reserve_decision(
+                reserve_class, total),
+            total + total / 8);
+        if (reserve < alloc_size) {
+          expandable_reserve_msg =
+              " This allocation exceeds the expandable-segment reserve of " +
+              format_size(reserve) +
+              (reserve_class.empty()
+                   ? std::string(" for this stream")
+                   : " for stream reserve class '" + reserve_class + "'") +
+              ", and a single allocation cannot span expandable segments."
+              " Raise PYTORCH_CUDA_ALLOC_CONF expandable_segments_reserve or"
+              " expandable_segments_reserve_by_class (or unset it) so that a"
+              " segment is at least " +
+              format_size(alloc_size) + ".";
+        }
+      }
       TORCH_CHECK_WITH(
           OutOfMemoryError,
           false,
@@ -1951,7 +2015,8 @@ class DeviceCachingAllocator {
               : " If reserved but unallocated memory is large try setting"
                 " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
                 " fragmentation.  See documentation for Memory Management "
-                " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
+                " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)",
+          expandable_reserve_msg);
     }
 
     bool split_remainder = should_split(
@@ -3341,6 +3406,8 @@ class DeviceCachingAllocator {
   // returns the smallest possible address in any segment
   // where there is enough free address space to fit size
   // may be composed of free and unmapped segments
+  // returns nullptr if no segment can ever be large enough to fit size, i.e.
+  // size exceeds the per-stream expandable-segment reserve
   Block* find_expandable_block(
       c10::DeviceIndex device,
       cudaStream_t stream,
@@ -3381,6 +3448,17 @@ class DeviceCachingAllocator {
         device, stream, segment_size, devices_with_peer_access_));
 
     ExpandableSegment* es = expandable_segments_.back();
+    // A single allocation cannot span expandable segments, so if even a fresh
+    // segment is smaller than `size` no segment can ever satisfy the request.
+    // Report "no block" rather than returning a candidate that violates the
+    // contract above: the caller then fails the allocation through the normal
+    // OOM path, which notifies out-of-memory observers, counts the OOM, and
+    // retries after releasing cached blocks.
+    if (es->size() < size) {
+      expandable_segments_.pop_back();
+      delete es;
+      return nullptr;
+    }
     Block* candidate = new Block(device, stream, es->size(), pool, es->ptr());
     candidate->mapped = false;
     candidate->expandable_segment_ = es;
@@ -3472,6 +3550,11 @@ class DeviceCachingAllocator {
       size_t size,
       const std::shared_ptr<GatheredContext>& ctx) {
     Block* candidate = find_expandable_block(device, stream, pool, size);
+    if (!candidate) {
+      // No segment can ever be large enough for this allocation; fail the same
+      // way an exhausted device does so the caller runs the normal OOM path.
+      return nullptr;
+    }
     // Candidate is now a list free/unmapped blocks with at least size room:
     // unmapped -> null
     // unmapped -> free -> *
@@ -5397,5 +5480,43 @@ struct BackendStaticInitializer {
 
 std::atomic<CUDAAllocator*> allocator;
 static BackendStaticInitializer backend_static_initializer;
+
+namespace {
+std::mutex& expandableSegmentReserveClassMutex() {
+  static std::mutex m;
+  return m;
+}
+ska::flat_hash_map<cudaStream_t, std::string>&
+expandableSegmentReserveClassMap() {
+  static ska::flat_hash_map<cudaStream_t, std::string> m;
+  return m;
+}
+} // namespace
+
+void setExpandableSegmentReserveClassForStream(
+    cudaStream_t stream,
+    const std::string& reserve_class) {
+  std::lock_guard<std::mutex> lock(expandableSegmentReserveClassMutex());
+  if (reserve_class.empty()) {
+    expandableSegmentReserveClassMap().erase(stream);
+  } else {
+    expandableSegmentReserveClassMap()[stream] = reserve_class;
+  }
+}
+
+std::string getExpandableSegmentReserveClassForStream(cudaStream_t stream) {
+  std::lock_guard<std::mutex> lock(expandableSegmentReserveClassMutex());
+  auto& map = expandableSegmentReserveClassMap();
+  auto it = map.find(stream);
+  return it != map.end() ? it->second : std::string{};
+}
+
+void setDefaultExpandableSegmentReserveFractionForClass(
+    const std::string& reserve_class,
+    double fraction) {
+  CUDAAllocatorConfig::set_default_reserve_for_class(
+      reserve_class,
+      ExpandableSegmentReserveSpec{/*is_fraction=*/true, fraction});
+}
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -421,7 +421,44 @@ struct ExpandableSegment {
     // we allocate enough address space for 1 1/8 the total memory on the GPU.
     // This allows for some cases where we have to unmap pages earlier in the
     // segment to put them at the end.
-    max_handles_ = numSegments(prop.totalGlobalMem + prop.totalGlobalMem / 8);
+    const size_t full_reserve = prop.totalGlobalMem + prop.totalGlobalMem / 8;
+    size_t reserve = full_reserve;
+    // Serving streams may be tagged with a reserve class to downsize their VA
+    // reservation (see PYTORCH_CUDA_ALLOC_CONF expandable_segments_reserve*).
+    // Untagged streams and IPC-imported segments (no stream) keep the full
+    // reserve, so this path is a byte-for-byte no-op unless reserve config is
+    // set. A single allocation cannot span segments, so the reserve is never
+    // lowered below the floor; when the floor exceeds the historical full
+    // reserve (e.g. a small GPU) the floor wins.
+    if (stream.has_value()) {
+      const std::string reserve_class =
+          getExpandableSegmentReserveClassForStream(*stream);
+      // Single locked snapshot so a concurrent setAllocatorSettings() re-parse
+      // cannot compose an inconsistent (reserve, class_known, floor) view.
+      const auto decision =
+          CUDAAllocatorConfig::expandable_segments_reserve_decision(
+              reserve_class, prop.totalGlobalMem);
+      if (decision.reserve_bytes.has_value()) {
+        if (!reserve_class.empty() && !decision.class_known) {
+          static std::mutex warn_mutex;
+          static ska::flat_hash_set<std::string> warned;
+          std::lock_guard<std::mutex> lock(warn_mutex);
+          if (warned.insert(reserve_class).second) {
+            TORCH_WARN(
+                "expandable_segments reserve class '",
+                reserve_class,
+                "' has no configured reserve in "
+                "expandable_segments_reserve_by_class; using the default reserve.");
+          }
+        }
+        // Cap the downsize target at the historical full reserve, but never
+        // below the floor (which may exceed full on a small GPU).
+        reserve = std::max(
+            decision.min_reserve_bytes,
+            std::min(*decision.reserve_bytes, full_reserve));
+      }
+    }
+    max_handles_ = numSegments(reserve);
 #ifdef USE_ROCM
     C10_CUDA_CHECK(hipMemAddressReserve(
         &ptr_, segment_size_ * max_handles_, 0ULL, 0, 0ULL));
@@ -5396,5 +5433,43 @@ struct BackendStaticInitializer {
 
 std::atomic<CUDAAllocator*> allocator;
 static BackendStaticInitializer backend_static_initializer;
+
+namespace {
+std::mutex& expandableSegmentReserveClassMutex() {
+  static std::mutex m;
+  return m;
+}
+ska::flat_hash_map<cudaStream_t, std::string>&
+expandableSegmentReserveClassMap() {
+  static ska::flat_hash_map<cudaStream_t, std::string> m;
+  return m;
+}
+} // namespace
+
+void setExpandableSegmentReserveClassForStream(
+    cudaStream_t stream,
+    const std::string& reserve_class) {
+  std::lock_guard<std::mutex> lock(expandableSegmentReserveClassMutex());
+  if (reserve_class.empty()) {
+    expandableSegmentReserveClassMap().erase(stream);
+  } else {
+    expandableSegmentReserveClassMap()[stream] = reserve_class;
+  }
+}
+
+std::string getExpandableSegmentReserveClassForStream(cudaStream_t stream) {
+  std::lock_guard<std::mutex> lock(expandableSegmentReserveClassMutex());
+  auto& map = expandableSegmentReserveClassMap();
+  auto it = map.find(stream);
+  return it != map.end() ? it->second : std::string{};
+}
+
+void setDefaultExpandableSegmentReserveFractionForClass(
+    const std::string& reserve_class,
+    double fraction) {
+  CUDAAllocatorConfig::set_default_reserve_for_class(
+      reserve_class,
+      ExpandableSegmentReserveSpec{/*is_fraction=*/true, fraction});
+}
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -568,6 +568,36 @@ inline void annotateMemory(const void* ptr, const std::string& metadata) {
   get()->annotateMemory(ptr, metadata);
 }
 
+// Tag (or, with an empty class, untag) a CUDA stream with an opaque reserve
+// class. Expandable segments created for a tagged stream size their virtual
+// address reservation from the per-class reserve in PYTORCH_CUDA_ALLOC_CONF
+// (see expandable_segments_reserve_by_class / expandable_segments_reserve). The
+// class string is opaque to core: downstream callers own the vocabulary. An
+// untagged stream (or the empty class) uses the full historical reserve.
+//
+// Contract: the tag is keyed by the raw cudaStream_t handle and persists until
+// overwritten or cleared. Streams from getStreamFromPool come from a shared,
+// round-robin pool, so tagging such a stream applies the class to every user of
+// that handle and to the (shared) expandable segments created on it. Tag only
+// streams whose (device, stream) identity you control for the intended
+// lifetime, and clear the tag (empty class) if the handle may later be reused
+// for an unrelated purpose.
+C10_CUDA_API void setExpandableSegmentReserveClassForStream(
+    cudaStream_t stream,
+    const std::string& reserve_class);
+C10_CUDA_API std::string getExpandableSegmentReserveClassForStream(
+    cudaStream_t stream);
+
+// Registers a code-side default reserve, expressed as a fraction of total
+// device memory, for a reserve class. Lets serving layers opt their stream
+// classes into a downsized reserve by default without depending on
+// CUDAAllocatorConfig. Explicit operator config (via PYTORCH_CUDA_ALLOC_CONF)
+// wins; see the precedence note on
+// CUDAAllocatorConfig::set_default_reserve_for_class.
+C10_CUDA_API void setDefaultExpandableSegmentReserveFractionForClass(
+    const std::string& reserve_class,
+    double fraction);
+
 } // namespace c10::cuda::CUDACachingAllocator
 
 namespace c10::cuda {

--- a/c10/cuda/test/CMakeLists.txt
+++ b/c10/cuda/test/CMakeLists.txt
@@ -9,6 +9,8 @@ set(C10_CUDA_ALL_TEST_FILES
     impl/CUDAAssertionsTest_multiple_writes_from_multiple_blocks.cu
     impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu
     impl/CUDATest.cpp
+    impl/CUDACachingAllocatorReserveTest.cpp
+    impl/CUDACachingAllocatorReserveDeviceTest.cpp
 )
 if(BUILD_TEST)
   foreach(test_src ${C10_CUDA_ALL_TEST_FILES})

--- a/c10/cuda/test/build.bzl
+++ b/c10/cuda/test/build.bzl
@@ -20,6 +20,28 @@ def define_targets(rules, gtest_deps):
         ] + gtest_deps,
     )
 
+    rules.cc_test(
+        name = "expandable_segment_reserve_test",
+        srcs = [
+            "impl/CUDACachingAllocatorReserveTest.cpp",
+        ],
+        target_compatible_with = rules.requires_cuda_enabled(),
+        deps = [
+            "//c10/cuda",
+        ] + gtest_deps,
+    )
+
+    rules.cc_test(
+        name = "expandable_segment_reserve_device_test",
+        srcs = [
+            "impl/CUDACachingAllocatorReserveDeviceTest.cpp",
+        ],
+        target_compatible_with = rules.requires_cuda_enabled(),
+        deps = [
+            "//c10/cuda",
+        ] + gtest_deps,
+    )
+
     for src in dsa_tests:
         name = src.replace("impl/", "").replace(".cu", "")
         rules.cuda_library(

--- a/c10/cuda/test/build.bzl
+++ b/c10/cuda/test/build.bzl
@@ -20,6 +20,17 @@ def define_targets(rules, gtest_deps):
         ] + gtest_deps,
     )
 
+    rules.cc_test(
+        name = "expandable_segment_reserve_test",
+        srcs = [
+            "impl/CUDACachingAllocatorReserveTest.cpp",
+        ],
+        target_compatible_with = rules.requires_cuda_enabled(),
+        deps = [
+            "//c10/cuda",
+        ] + gtest_deps,
+    )
+
     for src in dsa_tests:
         name = src.replace("impl/", "").replace(".cu", "")
         rules.cuda_library(

--- a/c10/cuda/test/impl/CUDACachingAllocatorReserveDeviceTest.cpp
+++ b/c10/cuda/test/impl/CUDACachingAllocatorReserveDeviceTest.cpp
@@ -1,0 +1,165 @@
+#include <c10/core/AllocatorConfig.h>
+#include <c10/cuda/CUDAAllocatorConfig.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/util/Exception.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+
+// Device tests for allocations that no expandable segment can ever satisfy,
+// because a single allocation cannot span segments. They must fail through the
+// allocator's normal out-of-memory path -- notifying OOM observers -- and not
+// crash or bypass it. Live in their own binary because they mutate the
+// process-global allocator config and tag streams.
+
+namespace {
+
+// Set by the OOM observer. A namespace-scope flag (rather than a captured
+// local) because observers cannot be detached and outlive the test that
+// attached them.
+std::atomic<bool> g_oom_observed{false};
+
+// Attaches the observer exactly once for the whole binary; every test then just
+// resets the flag.
+void attachOomObserverOnce() {
+  static const bool attached = [] {
+    c10::cuda::CUDACachingAllocator::attachOutOfMemoryObserver(
+        [](int64_t, size_t, size_t, size_t) { g_oom_observed = true; });
+    return true;
+  }();
+  (void)attached;
+}
+
+// Returns false (and skips) when the host has no GPU.
+bool initDeviceOrSkip() {
+  if (c10::cuda::device_count() == 0) {
+    return false;
+  }
+  c10::cuda::set_device(0);
+  c10::cuda::CUDACachingAllocator::init(c10::cuda::device_count());
+  attachOomObserverOnce();
+  g_oom_observed = false;
+  return true;
+}
+
+// Runs an allocation expected to OOM and returns the error message.
+std::string expectOomMessage(size_t request) {
+  try {
+    auto blk = c10::cuda::CUDACachingAllocator::get()->allocate(request);
+  } catch (const c10::OutOfMemoryError& e) {
+    return e.what();
+  }
+  ADD_FAILURE() << "expected an OutOfMemoryError for a " << request
+                << "-byte allocation";
+  return {};
+}
+
+size_t deviceTotalBytes() {
+  cudaDeviceProp prop{};
+  C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, 0));
+  return prop.totalGlobalMem;
+}
+
+} // namespace
+
+TEST(
+    ExpandableSegmentReserveDeviceTest,
+    DownsizedReserveAllocLargerThanReserve) {
+  if (!initDeviceOrSkip()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const size_t device_total = deviceTotalBytes();
+
+  // Reserve ~5% of the device for the tagged class, then ask for 4x that. The
+  // request is far below total device memory, so it fails only because a single
+  // allocation cannot span expandable segments.
+  c10::CachingAllocator::setAllocatorSettings(
+      "expandable_segments:True,"
+      "expandable_segments_reserve_by_class:[tiny:0.05]");
+  ASSERT_TRUE(c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::
+                  expandable_segments())
+      << "expandable_segments must be enabled for this test to be meaningful";
+
+  auto stream = c10::cuda::getCurrentCUDAStream(0);
+  c10::cuda::CUDACachingAllocator::setExpandableSegmentReserveClassForStream(
+      stream.stream(), "tiny");
+
+  const size_t request = (device_total / 20) * 4;
+  ASSERT_LT(request, device_total)
+      << "request must be satisfiable if segments could span";
+
+  const std::string msg = expectOomMessage(request);
+  // The allocation must fail through the normal OOM path, not a bespoke throw
+  // that skips observers, the OOM counter and the release-and-retry step.
+  EXPECT_TRUE(g_oom_observed)
+      << "out-of-memory observers must be notified for an unsatisfiable "
+         "allocation";
+  // ...and that path must explain why an allocation failed on a device that
+  // still has plenty of memory free.
+  EXPECT_NE(msg.find("expandable-segment"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("expandable_segments_reserve_by_class"), std::string::npos)
+      << msg;
+  EXPECT_NE(msg.find("tiny"), std::string::npos) << msg;
+
+  c10::cuda::CUDACachingAllocator::setExpandableSegmentReserveClassForStream(
+      stream.stream(), "");
+}
+
+TEST(ExpandableSegmentReserveDeviceTest, GlobalReserveUntaggedStream) {
+  if (!initDeviceOrSkip()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const size_t device_total = deviceTotalBytes();
+
+  // Same failure via the global knob on an untagged stream -- i.e. what a user
+  // hits with only PYTORCH_CUDA_ALLOC_CONF set and no code change.
+  c10::CachingAllocator::setAllocatorSettings(
+      "expandable_segments:True,expandable_segments_reserve:0.05");
+
+  // A stream with no reserve class resolves to the global reserve. Clear the
+  // tag explicitly so this does not depend on another test having cleaned up.
+  auto stream = c10::cuda::getCurrentCUDAStream(0);
+  c10::cuda::CUDACachingAllocator::setExpandableSegmentReserveClassForStream(
+      stream.stream(), "");
+  ASSERT_EQ(
+      c10::cuda::CUDACachingAllocator::
+          getExpandableSegmentReserveClassForStream(stream.stream()),
+      "");
+
+  const size_t request = (device_total / 20) * 4;
+  const std::string msg = expectOomMessage(request);
+  EXPECT_TRUE(g_oom_observed)
+      << "out-of-memory observers must be notified for an unsatisfiable "
+         "allocation";
+  EXPECT_NE(msg.find("expandable-segment"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("expandable_segments_reserve"), std::string::npos) << msg;
+}
+
+TEST(ExpandableSegmentReserveDeviceTest, OversizedAllocNotifiesOomObserver) {
+  if (!initDeviceOrSkip()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const size_t device_total = deviceTotalBytes();
+
+  // Regression guard for the no-downsizing path: an allocation larger than the
+  // whole device exceeds even the default 9/8 reserve, so it takes the same
+  // "no segment can ever fit this" branch. It must still behave exactly like a
+  // stock OOM (this is the C++ analogue of test_cuda.py's test_notifies_oom,
+  // which caught an earlier revision that threw from inside the allocator and
+  // silently skipped the observers).
+  c10::CachingAllocator::setAllocatorSettings("expandable_segments:True");
+
+  const size_t request = device_total * 100;
+  const std::string msg = expectOomMessage(request);
+  EXPECT_TRUE(g_oom_observed)
+      << "out-of-memory observers must be notified for an allocation larger "
+         "than the device";
+  // The reserve is not why this failed -- the request does not fit on the
+  // device at all -- so the message must not send the user chasing the reserve
+  // knobs.
+  EXPECT_EQ(msg.find("expandable-segment"), std::string::npos) << msg;
+}

--- a/c10/cuda/test/impl/CUDACachingAllocatorReserveTest.cpp
+++ b/c10/cuda/test/impl/CUDACachingAllocatorReserveTest.cpp
@@ -1,0 +1,178 @@
+#include <c10/core/AllocatorConfig.h>
+#include <c10/cuda/CUDAAllocatorConfig.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+using c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig;
+using c10::cuda::CUDACachingAllocator::ExpandableSegmentReserveDecision;
+using c10::cuda::CUDACachingAllocator::
+    getExpandableSegmentReserveClassForStream;
+using c10::cuda::CUDACachingAllocator::
+    setDefaultExpandableSegmentReserveFractionForClass;
+using c10::cuda::CUDACachingAllocator::
+    setExpandableSegmentReserveClassForStream;
+
+namespace {
+constexpr size_t kTotal = size_t{100} << 30; // 100 GiB device
+constexpr size_t kGiB = size_t{1} << 30;
+// Sentinel for "no reserve configured" that no test expects as a real reserve
+// (a configured reserve is always > 0). Using value_or keeps optional access
+// total, which clang-tidy's bugprone-unchecked-optional-access requires.
+constexpr size_t kUnset = 0;
+
+void setConf(const std::string& conf) {
+  c10::CachingAllocator::setAllocatorSettings(conf);
+}
+
+// The reserve bytes a class resolves to, via the production snapshot API;
+// kUnset when no reserve is configured for the class.
+size_t reserveBytes(const std::string& reserve_class) {
+  return CUDAAllocatorConfig::expandable_segments_reserve_decision(
+             reserve_class, kTotal)
+      .reserve_bytes.value_or(kUnset);
+}
+} // namespace
+
+// Note: the "unset => nullopt" no-op path (keeps the historical 9/8 reserve
+// byte-for-byte) is guaranteed structurally by
+// m_expandable_segments_reserve_set defaulting to false; it is not unit-tested
+// here because the config singleton cannot be reset to its unset state once
+// another test sets a reserve.
+
+TEST(ExpandableSegmentReserveTest, DefaultFractionAndGiB) {
+  setConf("expandable_segments_reserve:0.5");
+  EXPECT_EQ(reserveBytes(""), kTotal / 2);
+
+  setConf("expandable_segments_reserve:40G");
+  EXPECT_EQ(reserveBytes("any"), 40 * kGiB);
+}
+
+TEST(ExpandableSegmentReserveTest, PerClassOverrideAndFallback) {
+  setConf(
+      "expandable_segments_reserve:0.9,"
+      "expandable_segments_reserve_by_class:[serving:0.25,ads_sparse:8G]");
+  EXPECT_EQ(reserveBytes("serving"), kTotal / 4);
+  EXPECT_EQ(reserveBytes("ads_sparse"), 8 * kGiB);
+  // Unknown class falls back to the default reserve (0.9 of total).
+  EXPECT_EQ(reserveBytes("other"), (kTotal / 10) * 9);
+  EXPECT_TRUE(CUDAAllocatorConfig::expandable_segments_reserve_decision(
+                  "serving", kTotal)
+                  .class_known);
+  EXPECT_FALSE(
+      CUDAAllocatorConfig::expandable_segments_reserve_decision("other", kTotal)
+          .class_known);
+}
+
+TEST(ExpandableSegmentReserveTest, ReserveDecisionSnapshot) {
+  setConf(
+      "expandable_segments_reserve:0.9,"
+      "expandable_segments_reserve_by_class:[serving:0.25]");
+  auto known = CUDAAllocatorConfig::expandable_segments_reserve_decision(
+      "serving", kTotal);
+  EXPECT_TRUE(known.reserve_bytes.has_value());
+  EXPECT_EQ(known.reserve_bytes.value_or(kUnset), kTotal / 4);
+  EXPECT_TRUE(known.class_known);
+  // Unknown class falls back to the global default (0.9) and is not "known".
+  auto fallback = CUDAAllocatorConfig::expandable_segments_reserve_decision(
+      "other", kTotal);
+  EXPECT_TRUE(fallback.reserve_bytes.has_value());
+  EXPECT_EQ(fallback.reserve_bytes.value_or(kUnset), (kTotal / 10) * 9);
+  EXPECT_FALSE(fallback.class_known);
+}
+
+TEST(ExpandableSegmentReserveTest, HugeValueSaturatesInsteadOfUB) {
+  // A pathological config must saturate at SIZE_MAX rather than invoke UB in
+  // the double->size_t narrowing (1e20 GiB far exceeds SIZE_MAX). The saturated
+  // value is bounded later by clamp_reserve_bytes (see ClampReserveBytes).
+  setConf("expandable_segments_reserve:1e20G");
+  EXPECT_EQ(reserveBytes(""), std::numeric_limits<size_t>::max());
+}
+
+TEST(ExpandableSegmentReserveTest, InvalidValuesAreIgnoredNotFatal) {
+  // Establish a known-good default.
+  setConf("expandable_segments_reserve:0.5");
+  ASSERT_EQ(reserveBytes(""), kTotal / 2);
+  // Malformed / out-of-range values must not throw or abort; they are logged
+  // and ignored, leaving the previously-set value intact.
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:abc"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:G"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:-1"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:0"));
+  EXPECT_EQ(reserveBytes(""), kTotal / 2);
+  // A malformed per-class entry is skipped; valid entries in the same list
+  // still apply.
+  EXPECT_NO_THROW(
+      setConf("expandable_segments_reserve_by_class:[serving:0.25,bad:12X]"));
+  EXPECT_EQ(reserveBytes("serving"), kTotal / 4);
+  EXPECT_FALSE(
+      CUDAAllocatorConfig::expandable_segments_reserve_decision("bad", kTotal)
+          .class_known);
+}
+
+TEST(ExpandableSegmentReserveTest, ClampReserveBytes) {
+  // Pure clamp arithmetic (the production ExpandableSegment ctor path), tested
+  // without a device. full_reserve models 9/8 of an ~80 GiB GPU.
+  constexpr size_t kFull = size_t{90} << 30;
+
+  // No override configured -> the full reserve is kept unchanged.
+  ExpandableSegmentReserveDecision none;
+  EXPECT_EQ(CUDAAllocatorConfig::clamp_reserve_bytes(none, kFull), kFull);
+
+  // Configured below full -> used as-is.
+  ExpandableSegmentReserveDecision below;
+  below.reserve_bytes = 40 * kGiB;
+  EXPECT_EQ(CUDAAllocatorConfig::clamp_reserve_bytes(below, kFull), 40 * kGiB);
+
+  // Configured above full -> capped at full.
+  ExpandableSegmentReserveDecision above;
+  above.reserve_bytes = kFull + (32 * kGiB);
+  EXPECT_EQ(CUDAAllocatorConfig::clamp_reserve_bytes(above, kFull), kFull);
+
+  // Saturated reserve (pathological config) -> capped at full, never SIZE_MAX,
+  // so the reserve fed to numSegments() cannot overflow to 0.
+  ExpandableSegmentReserveDecision saturated;
+  saturated.reserve_bytes = std::numeric_limits<size_t>::max();
+  EXPECT_EQ(CUDAAllocatorConfig::clamp_reserve_bytes(saturated, kFull), kFull);
+}
+
+TEST(ExpandableSegmentReserveTest, StreamReserveClassTagRoundTrip) {
+  // The tag map is keyed by the raw cudaStream_t handle, so a fake, never
+  // dereferenced handle exercises set/get without a device. Take the address of
+  // a local (a distinct, non-null pointer) rather than casting an integer,
+  // which clang-tidy's performance-no-int-to-ptr flags.
+  char storage = 0;
+  const auto stream = reinterpret_cast<cudaStream_t>(&storage);
+
+  // Untagged handle -> empty class.
+  EXPECT_EQ(getExpandableSegmentReserveClassForStream(stream), "");
+  // Tag, then read back.
+  setExpandableSegmentReserveClassForStream(stream, "serving");
+  EXPECT_EQ(getExpandableSegmentReserveClassForStream(stream), "serving");
+  // Overwrite.
+  setExpandableSegmentReserveClassForStream(stream, "lrm_sparse");
+  EXPECT_EQ(getExpandableSegmentReserveClassForStream(stream), "lrm_sparse");
+  // Clear via the empty class.
+  setExpandableSegmentReserveClassForStream(stream, "");
+  EXPECT_EQ(getExpandableSegmentReserveClassForStream(stream), "");
+}
+
+TEST(ExpandableSegmentReserveTest, SetDefaultReserveFractionPrecedence) {
+  // An explicit per-class config entry wins over a code-side default.
+  setConf("expandable_segments_reserve_by_class:[serving:0.25]");
+  setDefaultExpandableSegmentReserveFractionForClass("serving", 0.9);
+  EXPECT_EQ(reserveBytes("serving"), kTotal / 4);
+
+  // Once a global reserve is set via config, a code-side default is a no-op: an
+  // unseeded class falls back to the global default, not the code-side
+  // fraction.
+  setConf("expandable_segments_reserve:0.5");
+  setDefaultExpandableSegmentReserveFractionForClass("telemetry", 0.9);
+  auto d = CUDAAllocatorConfig::expandable_segments_reserve_decision(
+      "telemetry", kTotal);
+  EXPECT_FALSE(d.class_known);
+  EXPECT_EQ(d.reserve_bytes.value_or(kUnset), kTotal / 2);
+}

--- a/c10/cuda/test/impl/CUDACachingAllocatorReserveTest.cpp
+++ b/c10/cuda/test/impl/CUDACachingAllocatorReserveTest.cpp
@@ -1,0 +1,127 @@
+#include <c10/core/AllocatorConfig.h>
+#include <c10/cuda/CUDAAllocatorConfig.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig;
+
+namespace {
+constexpr size_t kTotal = size_t{100} << 30; // 100 GiB device
+constexpr size_t kGiB = size_t{1} << 30;
+
+void setConf(const std::string& conf) {
+  c10::CachingAllocator::setAllocatorSettings(conf);
+}
+} // namespace
+
+// Note: the "unset => nullopt" no-op path (keeps the historical 9/8 reserve
+// byte-for-byte) is guaranteed structurally by
+// m_expandable_segments_reserve_set defaulting to false; it is not unit-tested
+// here because the config singleton cannot be reset to its unset state once
+// another test sets a reserve.
+
+TEST(ExpandableSegmentReserveTest, DefaultFractionAndGiB) {
+  setConf("expandable_segments_reserve:0.5");
+  auto frac =
+      CUDAAllocatorConfig::expandable_segments_reserve_bytes("", kTotal);
+  ASSERT_TRUE(frac.has_value());
+  EXPECT_EQ(*frac, kTotal / 2);
+
+  setConf("expandable_segments_reserve:40G");
+  auto gib =
+      CUDAAllocatorConfig::expandable_segments_reserve_bytes("any", kTotal);
+  ASSERT_TRUE(gib.has_value());
+  EXPECT_EQ(*gib, 40 * kGiB);
+}
+
+TEST(ExpandableSegmentReserveTest, PerClassOverrideAndFallback) {
+  setConf(
+      "expandable_segments_reserve:0.9,"
+      "expandable_segments_reserve_by_class:[serving:0.25,ads_sparse:8G]");
+  EXPECT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes(
+          "serving", kTotal),
+      kTotal / 4);
+  EXPECT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes(
+          "ads_sparse", kTotal),
+      8 * kGiB);
+  // Unknown class falls back to the default reserve (0.9 of total).
+  EXPECT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes("other", kTotal),
+      (kTotal / 10) * 9);
+  EXPECT_TRUE(
+      CUDAAllocatorConfig::expandable_segments_has_reserve_class("serving"));
+  EXPECT_FALSE(
+      CUDAAllocatorConfig::expandable_segments_has_reserve_class("other"));
+}
+
+TEST(ExpandableSegmentReserveTest, MinReserveOverride) {
+  // The 16 GiB default is a construction-time default; it is not asserted here
+  // because the config singleton cannot be reset between tests (a prior test
+  // may have set min_reserve). Verify explicit overrides in both GiB and
+  // fraction.
+  setConf("expandable_segments_min_reserve:32G");
+  EXPECT_EQ(
+      CUDAAllocatorConfig::expandable_segments_min_reserve_bytes(kTotal),
+      32 * kGiB);
+  setConf("expandable_segments_min_reserve:0.1");
+  EXPECT_EQ(
+      CUDAAllocatorConfig::expandable_segments_min_reserve_bytes(kTotal),
+      kTotal / 10);
+}
+
+TEST(ExpandableSegmentReserveTest, ReserveDecisionSnapshot) {
+  setConf(
+      "expandable_segments_reserve:0.9,"
+      "expandable_segments_reserve_by_class:[serving:0.25]");
+  auto known = CUDAAllocatorConfig::expandable_segments_reserve_decision(
+      "serving", kTotal);
+  ASSERT_TRUE(known.reserve_bytes.has_value());
+  EXPECT_EQ(*known.reserve_bytes, kTotal / 4);
+  EXPECT_TRUE(known.class_known);
+  // Unknown class falls back to the global default (0.9) and is not "known".
+  auto fallback = CUDAAllocatorConfig::expandable_segments_reserve_decision(
+      "other", kTotal);
+  ASSERT_TRUE(fallback.reserve_bytes.has_value());
+  EXPECT_EQ(*fallback.reserve_bytes, (kTotal / 10) * 9);
+  EXPECT_FALSE(fallback.class_known);
+}
+
+TEST(ExpandableSegmentReserveTest, HugeValueSaturatesInsteadOfUB) {
+  // A pathological config must saturate at SIZE_MAX rather than invoke UB in
+  // the double->size_t narrowing (1e20 GiB far exceeds SIZE_MAX).
+  setConf("expandable_segments_reserve:1e20G");
+  auto b = CUDAAllocatorConfig::expandable_segments_reserve_bytes("", kTotal);
+  ASSERT_TRUE(b.has_value());
+  EXPECT_EQ(*b, std::numeric_limits<size_t>::max());
+}
+
+TEST(ExpandableSegmentReserveTest, InvalidValuesAreIgnoredNotFatal) {
+  // Establish a known-good default.
+  setConf("expandable_segments_reserve:0.5");
+  ASSERT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes("", kTotal),
+      kTotal / 2);
+  // Malformed / out-of-range values must not throw or abort; they are logged
+  // and ignored, leaving the previously-set value intact.
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:abc"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:G"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:-1"));
+  EXPECT_NO_THROW(setConf("expandable_segments_reserve:0"));
+  EXPECT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes("", kTotal),
+      kTotal / 2);
+  // A malformed per-class entry is skipped; valid entries in the same list
+  // still apply.
+  EXPECT_NO_THROW(
+      setConf("expandable_segments_reserve_by_class:[serving:0.25,bad:12X]"));
+  EXPECT_EQ(
+      *CUDAAllocatorConfig::expandable_segments_reserve_bytes(
+          "serving", kTotal),
+      kTotal / 4);
+  EXPECT_FALSE(
+      CUDAAllocatorConfig::expandable_segments_has_reserve_class("bad"));
+}


### PR DESCRIPTION
Summary:

Adds an opt-in mechanism to shrink the virtual-address (VA) reservation of CUDA
expandable segments per stream, so serving streams can reserve less than the
historical `9/8 * totalGlobalMem` while loading/replication streams keep the full
reserve. The savings are in VA/VSZ, not physical memory (an expandable segment
reserves VA up front and only maps physical pages on demand).

Design:
- Values live in `PYTORCH_CUDA_ALLOC_CONF`, parsed once in `CUDAAllocatorConfig`:
  `expandable_segments_reserve` (default reserve) and
  `expandable_segments_reserve_by_class` (per-class map, `ska::flat_hash_map`).
  Each value is a fraction of GPU memory (bare number, e.g. `0.5`) or an absolute
  size in GiB (suffix `G`, e.g. `40G`). Fractions are portable across GPU types;
  `G` is for operators who reason in absolute terms.
- Selection is an imperative, opt-in per-stream tag:
  `setExpandableSegmentReserveClassForStream(stream, reserve_class)`. The class is
  an opaque string owned by downstream callers, so core carries no enum and takes
  no dependency on downstream vocabularies.
- The `ExpandableSegment` ctor takes a single locked snapshot of the reserve
  decision and resolves the final reserve via the pure, unit-tested
  `CUDAAllocatorConfig::clamp_reserve_bytes`: the configured reserve is capped at
  `9/8 * total`. It is a byte-for-byte no-op when no reserve config is set:
  untagged streams and IPC-imported segments (no stream) keep the full reserve.

Guarding against too-small reserves: a single allocation cannot span expandable
segments (the allocator spills to additional segments only across allocations),
so an over-aggressively downsized reserve can make a large single allocation
unsatisfiable. Instead of a separate floor knob, the allocator detects this
directly: when a single allocation exceeds the stream's per-segment reserve,
`try_allocate_expandable_block` raises a clear `OutOfMemoryError` that names the
allocation size, the resolved per-segment reserve, the stream's reserve class, and
the `expandable_segments_reserve` / `expandable_segments_reserve_by_class` knobs to
raise (previously this path would dereference a null next-block). The `9/8 * total`
cap also keeps a saturated reserve (a pathological `expandable_segments_reserve`,
which `resolveBytes` clamps to `SIZE_MAX`) from overflowing `numSegments()`.

This is built on the parent of D112698246 (an earlier VA-budget cap diff); that
diff was used only as inspiration and is not modified here. All config keys and
APIs added here are new.

Follow-up (separate diff): tag serving streams at their creation sites (LRM
stream-split, Ads sparse runner, GPUTaskRunner merge/remote) so the feature has
effect once enabled via config.

Authored with the assistance of an AI agent (Claude Code); all changes reviewed by
the author.

Test Plan:
```
buck2 build //caffe2/c10/cuda:cuda
buck2 test //caffe2/c10/cuda/test:expandable_segment_reserve_test
```
Result: `Pass 8. Fail 0.` (no GPU required -- this binary only exercises config
resolution.) Coverage: fraction and `G` value resolution; the per-class map with
default fallback; `class_known`; hard-error handling of malformed values;
`clamp_reserve_bytes` arithmetic (cap-at-full and a saturated reserve capped at
full so `numSegments()` cannot overflow); the per-stream reserve-class tag
set/overwrite/clear round-trip; and
`setDefaultExpandableSegmentReserveFractionForClass` precedence.

Device tests (need a real GPU, so they are a separate binary that also isolates
the process-global allocator config). Plain `buck2 test` SKIPS them: the default
dev mode is ASAN, which disables CUDA init, and RE workers have no GPU. On a GPU
host use either:
```
buck2 run  fbcode//mode/dev-nosan              //caffe2/c10/cuda/test:expandable_segment_reserve_device_test
buck2 test fbcode//mode/dev-nosan --local-only //caffe2/c10/cuda/test:expandable_segment_reserve_device_test
```
Result: `Pass 3. Fail 0.` on an A100-40GB.
- `DownsizedReserveAllocLargerThanReserve`: `expandable_segments_reserve_by_class:[tiny:0.05]`,
  stream tagged `tiny` (~2 GiB reserve), requests ~7.9 GiB -- far below the device,
  so it fails only because a single allocation cannot span segments.
- `GlobalReserveUntaggedStream`: same via the global
  `expandable_segments_reserve:0.05` on an untagged stream, i.e. what a user hits
  with only `PYTORCH_CUDA_ALLOC_CONF` set and no code change.
- `OversizedAllocNotifiesOomObserver`: no downsizing at all -- an allocation
  larger than the whole device, which exceeds even the default 9/8 reserve and so
  takes the same branch. Guards the unconfigured path.

All three assert both that `c10::OutOfMemoryError` is raised AND that
out-of-memory observers were notified. Counterfactual: reintroducing a direct
throw from the allocator makes all three fail on exactly the observer assertion.

Behavior on an unsatisfiable allocation: `find_expandable_block` returns `nullptr`
(documented in its contract) after destroying the too-small segment it just
created, so no VA is leaked on a caught-OOM retry loop. `try_allocate_expandable_block`
propagates the `nullptr`, `alloc_block` returns false, and `malloc` runs its
normal OOM path -- release-cached-blocks-and-retry, `num_ooms`, OOM observers, and
the standard error. An earlier revision instead threw an `OutOfMemoryError`
directly from the allocator; that skipped all of the above and broke
`test_cuda.py::TestCudaAllocator::test_notifies_oom` under
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on ROCm CI (the observer never
fired). Doing the check here also keeps `find_expandable_block`'s "enough free
address space to fit size" contract -- and the caller's `at least size room`
comment -- true by construction, instead of having the caller cope with a
violated invariant.

Both test files are also registered in `c10/cuda/test/CMakeLists.txt`
(`C10_CUDA_ALL_TEST_FILES`); that list is explicit, not a glob, so without this the
files were linted upstream but never compiled. OSS CI will now BUILD both binaries
(catching a compile break, including the ROCm hipify path) but will not RUN them:
`.ci/pytorch/test.sh` invokes C++ tests only through explicit `-i cpp/<name>`
allowlists, no `c10_*` binary appears in any of them (the pre-existing
`c10_cuda_CUDATest` is likewise built but never run), and CI does not use `ctest`.
The device tests self-skip when `device_count() == 0`, so they are safe on
CPU-only hosts.

Reviewed By: banitag1, ngimel

Differential Revision: D114156494
