### PR TITLE
[AI Codemod][PerfAICT-General] Prefetch random gather source rows in index_select_out_cpu_dim1_

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1560,6 +1560,14 @@ static void check_indexarray_range(
   }
 }
 
+// __builtin_prefetch is a GCC/Clang builtin; MSVC lacks it. Provide a portable
+// no-op fallback so this translation unit still compiles on Windows.
+#if defined(__GNUC__) || defined(__clang__)
+#define AT_INDEX_SELECT_PREFETCH(addr) __builtin_prefetch((addr), 0, 0)
+#else
+#define AT_INDEX_SELECT_PREFETCH(addr) ((void)0)
+#endif
+
 static Tensor& index_select_out_cpu_dim1_(
     Tensor& result_contig,
     const Tensor& self,
@@ -1604,20 +1612,30 @@ static Tensor& index_select_out_cpu_dim1_(
           // outer_dims_product specifies how many times we repeat inner
           // dimensions, so we just iterate over it to cover all outer
           // dimensions.
+          // Prefetch the randomly-gathered source read this many iterations
+          // ahead to hide its cache-miss latency behind the current copy.
+          constexpr int64_t kPrefetchDistance = 8;
           for (const auto batch : c10::irange(outer_dims_product)) {
+            const auto* src_batch_base = src_base + batch * src_batch_bytesize;
+            auto* dst_batch_base = out + batch * gathered_batch_bytesize;
             for (const auto i : c10::irange(N)) {
-              auto idx = idxs[i];
-              auto src =
-                  src_base + batch * src_batch_bytesize + idx * block_bytesize;
-              auto dst =
-                  out + batch * gathered_batch_bytesize + i * block_bytesize;
-              memcpy(dst, src, block_bytesize);
+              if (i + kPrefetchDistance < N) {
+                AT_INDEX_SELECT_PREFETCH(
+                    src_batch_base +
+                    idxs[i + kPrefetchDistance] * block_bytesize);
+              }
+              memcpy(
+                  dst_batch_base + i * block_bytesize,
+                  src_batch_base + idxs[i] * block_bytesize,
+                  block_bytesize);
             }
           }
         }
       });
   return result_contig;
 }
+
+#undef AT_INDEX_SELECT_PREFETCH
 
 Tensor& index_select_out_cpu_(
     const Tensor& self,


### PR DESCRIPTION
The `at::native::index_select_cpu_` showed up in internal profiles. This is an AI agent generated performance improvement that was reviewed by a human:

`index_select_out_cpu_dim1_` gathers source rows from random offsets `idxs[i]`. For the general `block_size > 1` path, each iteration copies an entire gathered row with `memcpy`, and random source rows can miss cache. This diff prefetches the source row for `i + 8` before copying the current row, so cache-miss latency can overlap with current copy work.

The scalar `Float` / `block_size == 1` path is intentionally left in its original shape. The companion microbenchmark showed that prefetching this 4-byte scalar load is neutral to slightly negative, so the updated diff avoids adding overhead there.

The change also hoists per-batch source/destination base pointers in the general path. The prefetch address is guarded by `i + kPrefetchDistance < N`, and all indices are validated by the existing `check_indexarray_range` before the gather loop, so output bytes and bounds behavior are unchanged.

Differential Revision: D114833263


