### PR TITLE
[SDPA] Enable fused CUDA backends for rank-3 inputs

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
@@ -689,6 +689,14 @@ _scaled_dot_product_cudnn_attention_batch_rule(
         value_bdim.has_value() || attn_bias_bdim.has_value();
     check_randomness(randomness, any_tensor_batched);
   }
+  // BatchedTensor wrappers hide requires_grad from the composite SDPA wrapper.
+  // Recompute it after unwrapping so training forwards produce LSE for backward.
+  compute_log_sumexp =
+      compute_log_sumexp ||
+      (at::GradMode::is_enabled() &&
+       (query.requires_grad() || key.requires_grad() || value.requires_grad() ||
+        (attn_bias.has_value() && attn_bias->defined() &&
+         attn_bias->requires_grad())));
   auto batch_size = attn_bias.has_value() && attn_bias->defined()
       ? get_bdim_size4(query, query_bdim, key, key_bdim, value, value_bdim, *attn_bias, attn_bias_bdim)
       : get_bdim_size3(query, query_bdim, key, key_bdim, value, value_bdim);

--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -263,8 +263,15 @@ int64_t _fused_sdp_choice_xpu(
     bool is_causal,
     std::optional<double> scale,
     bool enable_gqa) {
-  sdp::sdp_params kernel_params{
-      query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+  auto kernel_params = sdp::normalize_unbatched_input({
+      .query = query_,
+      .key = key,
+      .value = value,
+      .attn_mask = attn_mask_,
+      .dropout = dropout_p,
+      .is_causal = is_causal,
+      .enable_gqa = enable_gqa,
+  });
   auto backend = select_sdp_backend_xpu(kernel_params);
 
   if (backend == sdp::SDPBackend::error) {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -736,6 +736,26 @@ Tensor scaled_dot_product_attention(
     bool is_causal,
     std::optional<double> scale,
     bool enable_gqa) {
+  // Give fused CUDA backends a batch dimension for unbatched inputs.
+  if (query_.is_cuda() && !query_.is_nested() && !key.is_nested() &&
+      !value.is_nested() && query_.dim() == 3 && key.dim() == 3 &&
+      value.dim() == 3) {
+    std::optional<Tensor> attn_mask = attn_mask_;
+    while (attn_mask.has_value() && attn_mask->dim() < 4) {
+      attn_mask = attn_mask->unsqueeze(0);
+    }
+    return scaled_dot_product_attention(
+               query_.unsqueeze(0),
+               key.unsqueeze(0),
+               value.unsqueeze(0),
+               attn_mask,
+               dropout_p,
+               is_causal,
+               scale,
+               enable_gqa)
+        .squeeze(0);
+  }
+
   using sdp::SDPBackend;
   validate_sdpa_input(query_, key, value, attn_mask_, dropout_p, is_causal, scale);
   // NB: This op is CompositeImplicitAutograd -- autograd traces through the

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -737,23 +737,21 @@ Tensor scaled_dot_product_attention(
     std::optional<double> scale,
     bool enable_gqa) {
   // Give fused CUDA backends a batch dimension for unbatched inputs.
-  if (query_.is_cuda() && !query_.is_nested() && !key.is_nested() &&
-      !value.is_nested() && query_.dim() == 3 && key.dim() == 3 &&
-      value.dim() == 3) {
-    std::optional<Tensor> attn_mask = attn_mask_;
-    while (attn_mask.has_value() && attn_mask->dim() < 4) {
-      attn_mask = attn_mask->unsqueeze(0);
+  if (query_.is_cuda() && query_.dim() == 3) {
+    auto normalized_params = sdp::normalize_unbatched_cuda_input(
+        {query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa});
+    if (normalized_params.query.dim() != query_.dim()) {
+      return scaled_dot_product_attention(
+                 normalized_params.query,
+                 normalized_params.key,
+                 normalized_params.value,
+                 normalized_params.attn_mask,
+                 dropout_p,
+                 is_causal,
+                 scale,
+                 enable_gqa)
+          .squeeze(0);
     }
-    return scaled_dot_product_attention(
-               query_.unsqueeze(0),
-               key.unsqueeze(0),
-               value.unsqueeze(0),
-               attn_mask,
-               dropout_p,
-               is_causal,
-               scale,
-               enable_gqa)
-        .squeeze(0);
   }
 
   using sdp::SDPBackend;

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -741,7 +741,7 @@ Tensor scaled_dot_product_attention(
     auto normalized_params = sdp::normalize_unbatched_cuda_input(
         {query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa});
     if (normalized_params.query.dim() != query_.dim()) {
-      return scaled_dot_product_attention(
+      return at::native::scaled_dot_product_attention(
                  normalized_params.query,
                  normalized_params.key,
                  normalized_params.value,

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -432,7 +432,15 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
 
 int64_t _fused_sdp_choice_cpp(const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+  auto kernel_params = sdp::normalize_unbatched_input({
+      .query = query_,
+      .key = key,
+      .value = value,
+      .attn_mask = attn_mask_,
+      .dropout = dropout_p,
+      .is_causal = is_causal,
+      .enable_gqa = enable_gqa,
+  });
   auto backend = sdp::select_sdp_backend_cpp(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(
@@ -736,10 +744,18 @@ Tensor scaled_dot_product_attention(
     bool is_causal,
     std::optional<double> scale,
     bool enable_gqa) {
-  // Give fused CUDA backends a batch dimension for unbatched inputs.
-  if (query_.is_cuda() && query_.dim() == 3) {
-    auto normalized_params = sdp::normalize_unbatched_cuda_input(
-        {query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa});
+  // Give fused backends a batch dimension for unbatched inputs.
+  if ((query_.is_cpu() || query_.is_cuda() || query_.is_xpu()) &&
+      query_.dim() == 3) {
+    auto normalized_params = sdp::normalize_unbatched_input({
+        .query = query_,
+        .key = key,
+        .value = value,
+        .attn_mask = attn_mask_,
+        .dropout = dropout_p,
+        .is_causal = is_causal,
+        .enable_gqa = enable_gqa,
+    });
     if (normalized_params.query.dim() != query_.dim()) {
       return at::native::scaled_dot_product_attention(
                  normalized_params.query,

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -463,15 +463,24 @@ int64_t _fused_sdp_choice_meta(
     bool is_causal,
     std::optional<double> scale,
     bool enable_gqa) {
-  auto query_key_set = query_.key_set();
+  auto kernel_params = sdp::normalize_unbatched_input({
+      .query = query_,
+      .key = key,
+      .value = value,
+      .attn_mask = attn_mask_,
+      .dropout = dropout_p,
+      .is_causal = is_causal,
+      .enable_gqa = enable_gqa,
+  });
+  auto query_key_set = kernel_params.query.key_set();
   bool has_hpu = query_key_set.has(c10::DispatchKey::HPU);
   if (has_hpu) {
     auto choice_int = at::_ops::_fused_sdp_choice::redispatch(
         c10::DispatchKeySet(DispatchKey::HPU),
-        query_,
-        key,
-        value,
-        attn_mask_,
+        kernel_params.query,
+        kernel_params.key,
+        kernel_params.value,
+        kernel_params.attn_mask,
         dropout_p,
         is_causal,
         scale,
@@ -481,7 +490,16 @@ int64_t _fused_sdp_choice_meta(
 #if defined(USE_ROCM)
   bool has_rocm = query_key_set.has(c10::DispatchKey::HIP);
   if (has_rocm) {
-    auto choice_int = _fused_sdp_choice_stub(at::kHIP, query_, key, value, attn_mask_, dropout_p, is_causal, scale, enable_gqa);
+    auto choice_int = _fused_sdp_choice_stub(
+        at::kHIP,
+        kernel_params.query,
+        kernel_params.key,
+        kernel_params.value,
+        kernel_params.attn_mask,
+        dropout_p,
+        is_causal,
+        scale,
+        enable_gqa);
     return choice_int;
   }
 #else
@@ -489,10 +507,10 @@ int64_t _fused_sdp_choice_meta(
   if (has_cuda) {
     auto choice_int = _fused_sdp_choice_stub(
         at::kCUDA,
-        query_,
-        key,
-        value,
-        attn_mask_,
+        kernel_params.query,
+        kernel_params.key,
+        kernel_params.value,
+        kernel_params.attn_mask,
         dropout_p,
         is_causal,
         scale,
@@ -504,10 +522,10 @@ int64_t _fused_sdp_choice_meta(
   if (has_xpu) {
     auto choice_int = _fused_sdp_choice_stub(
         at::kXPU,
-        query_,
-        key,
-        value,
-        attn_mask_,
+        kernel_params.query,
+        kernel_params.key,
+        kernel_params.value,
+        kernel_params.attn_mask,
         dropout_p,
         is_causal,
         scale,
@@ -745,8 +763,7 @@ Tensor scaled_dot_product_attention(
     std::optional<double> scale,
     bool enable_gqa) {
   // Give fused backends a batch dimension for unbatched inputs.
-  if ((query_.is_cpu() || query_.is_cuda() || query_.is_xpu()) &&
-      query_.dim() == 3) {
+  if (query_.dim() == 3) {
     auto normalized_params = sdp::normalize_unbatched_input({
         .query = query_,
         .key = key,

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1400,7 +1400,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _scaled_dot_product_efficient_attenti
 
 int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+  auto kernel_params = sdp::normalize_unbatched_cuda_input(
+      {query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa});
   auto backend = select_sdp_backend(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1400,8 +1400,15 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _scaled_dot_product_efficient_attenti
 
 int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
-  auto kernel_params = sdp::normalize_unbatched_cuda_input(
-      {query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa});
+  auto kernel_params = sdp::normalize_unbatched_input({
+      .query = query_,
+      .key = key,
+      .value = value,
+      .attn_mask = attn_mask_,
+      .dropout = dropout_p,
+      .is_causal = is_causal,
+      .enable_gqa = enable_gqa,
+  });
   auto backend = select_sdp_backend(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -44,6 +44,23 @@ struct sdp_params {
   bool enable_gqa;
 };
 
+// Fused CUDA backends require a batch dimension. Give unbatched inputs a
+// singleton batch dimension before selecting or running a fused backend.
+inline sdp_params normalize_unbatched_cuda_input(sdp_params params) {
+  if (params.query.is_cuda() && !params.query.is_nested() &&
+      !params.key.is_nested() && !params.value.is_nested() &&
+      params.query.dim() == 3 && params.key.dim() == 3 &&
+      params.value.dim() == 3) {
+    params.query = params.query.unsqueeze(0);
+    params.key = params.key.unsqueeze(0);
+    params.value = params.value.unsqueeze(0);
+    while (params.attn_mask.has_value() && params.attn_mask->dim() < 4) {
+      params.attn_mask = params.attn_mask->unsqueeze(0);
+    }
+  }
+  return params;
+}
+
 SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params);
 
 inline c10::SymFloat calculate_scale(

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -44,14 +44,11 @@ struct sdp_params {
   bool enable_gqa;
 };
 
-// Fused CPU, CUDA, and XPU backends require a batch dimension. Give
-// unbatched inputs a singleton batch dimension before selecting or running a
-// fused backend.
+// Fused backends require a batch dimension. Give unbatched inputs a singleton
+// batch dimension before selecting or running a fused backend.
 inline sdp_params normalize_unbatched_input(sdp_params params) {
-  const bool supports_fused_attention = params.query.is_cpu() ||
-      params.query.is_cuda() || params.query.is_xpu();
-  if (supports_fused_attention && !params.query.is_nested() &&
-      !params.key.is_nested() && !params.value.is_nested() &&
+  if (!params.query.is_nested() && !params.key.is_nested() &&
+      !params.value.is_nested() &&
       params.query.layout() == at::kStrided &&
       params.key.layout() == at::kStrided &&
       params.value.layout() == at::kStrided && params.query.dim() == 3 &&

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -44,13 +44,18 @@ struct sdp_params {
   bool enable_gqa;
 };
 
-// Fused CUDA backends require a batch dimension. Give unbatched inputs a
-// singleton batch dimension before selecting or running a fused backend.
-inline sdp_params normalize_unbatched_cuda_input(sdp_params params) {
-  if (params.query.is_cuda() && !params.query.is_nested() &&
+// Fused CPU, CUDA, and XPU backends require a batch dimension. Give
+// unbatched inputs a singleton batch dimension before selecting or running a
+// fused backend.
+inline sdp_params normalize_unbatched_input(sdp_params params) {
+  const bool supports_fused_attention = params.query.is_cpu() ||
+      params.query.is_cuda() || params.query.is_xpu();
+  if (supports_fused_attention && !params.query.is_nested() &&
       !params.key.is_nested() && !params.value.is_nested() &&
-      params.query.dim() == 3 && params.key.dim() == 3 &&
-      params.value.dim() == 3) {
+      params.query.layout() == at::kStrided &&
+      params.key.layout() == at::kStrided &&
+      params.value.layout() == at::kStrided && params.query.dim() == 3 &&
+      params.key.dim() == 3 && params.value.dim() == 3) {
     params.query = params.query.unsqueeze(0);
     params.key = params.key.unsqueeze(0);
     params.value = params.value.unsqueeze(0);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4043,9 +4043,11 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         if device == "cpu":
             raise unittest.SkipTest("This test is only for CUDA for now")
 
-        query = torch.randn(3, 4, 32, 64, dtype=torch.float16, device=device)
-        key = torch.randn_like(query)
-        value = torch.randn_like(query)
+        query = torch.randn(
+            3, 4, 32, 64, dtype=torch.float16, device=device, requires_grad=True
+        )
+        key = torch.randn_like(query, requires_grad=True)
+        value = torch.randn_like(query, requires_grad=True)
 
         def loss(q, k, v):
             return F.scaled_dot_product_attention(q, k, v).sum()
@@ -4054,10 +4056,18 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         with sdpa_kernel([backend]):
             expected = F.scaled_dot_product_attention(query, key, value)
             actual = vmap(F.scaled_dot_product_attention)(query, key, value)
+            grad_output = torch.randn_like(expected)
+            expected_backward_grads = torch.autograd.grad(
+                expected, (query, key, value), grad_output
+            )
+            actual_backward_grads = torch.autograd.grad(
+                actual, (query, key, value), grad_output
+            )
             expected_grads = loss_grad(query, key, value)
             actual_grads = vmap(loss_grad)(query, key, value)
 
         self.assertEqual(actual, expected)
+        self.assertEqual(actual_backward_grads, expected_backward_grads)
         self.assertEqual(actual_grads, expected_grads)
 
     @parametrize(

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4039,6 +4039,53 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
             )
 
     @parametrize("backend", PLATFORM_SPECIFIC_SDPA)
+    def test_sdpa_unbatched_inputs(self, device, backend):
+        if device == "cpu":
+            raise unittest.SkipTest("This test is only for CUDA for now")
+
+        query = torch.randn(3, 4, 32, 64, dtype=torch.float16, device=device)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        def loss(q, k, v):
+            return F.scaled_dot_product_attention(q, k, v).sum()
+
+        loss_grad = grad(loss, argnums=(0, 1, 2))
+        with sdpa_kernel([backend]):
+            expected = F.scaled_dot_product_attention(query, key, value)
+            actual = vmap(F.scaled_dot_product_attention)(query, key, value)
+            expected_grads = loss_grad(query, key, value)
+            actual_grads = vmap(loss_grad)(query, key, value)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_grads, expected_grads)
+
+    @parametrize(
+        "backend",
+        [
+            backend
+            for backend in PLATFORM_SPECIFIC_SDPA
+            if backend != SDPBackend.FLASH_ATTENTION
+        ],
+    )
+    def test_sdpa_unbatched_inputs_with_mask(self, device, backend):
+        if device == "cpu":
+            raise unittest.SkipTest("This test is only for CUDA for now")
+
+        query = torch.randn(3, 4, 32, 64, dtype=torch.float16, device=device)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        attn_mask = torch.randn(3, 1, 32, 32, dtype=torch.float16, device=device)
+
+        with sdpa_kernel([backend]):
+            expected = F.scaled_dot_product_attention(query, key, value, attn_mask)
+            actual = vmap(F.scaled_dot_product_attention)(
+                query, key, value, attn_mask[:, 0]
+            )
+
+        self.assertEqual(actual, expected)
+
+    @parametrize("backend", PLATFORM_SPECIFIC_SDPA)
     @parametrize("randomness", ["error", "same", "different"])
     def test_randomness(self, device, randomness, backend):
         if device == "cpu":

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4070,6 +4070,37 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         self.assertEqual(actual_backward_grads, expected_backward_grads)
         self.assertEqual(actual_grads, expected_grads)
 
+    def test_sdpa_unbatched_inputs_cpu(self, device):
+        if device != "cpu":
+            raise unittest.SkipTest("This test is only for CPU")
+
+        query = torch.randn(3, 4, 32, 64, device=device, requires_grad=True)
+        key = torch.randn_like(query, requires_grad=True)
+        value = torch.randn_like(query, requires_grad=True)
+
+        def loss(q, k, v):
+            return F.scaled_dot_product_attention(q, k, v).sum()
+
+        loss_grad = grad(loss, argnums=(0, 1, 2))
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=FALLBACK_REGEX)
+            with sdpa_kernel([SDPBackend.FLASH_ATTENTION]):
+                expected = F.scaled_dot_product_attention(query, key, value)
+                actual = vmap(F.scaled_dot_product_attention)(query, key, value)
+                grad_output = torch.randn_like(expected)
+                expected_backward_grads = torch.autograd.grad(
+                    expected, (query, key, value), grad_output
+                )
+                actual_backward_grads = torch.autograd.grad(
+                    actual, (query, key, value), grad_output
+                )
+                expected_grads = loss_grad(query, key, value)
+                actual_grads = vmap(loss_grad)(query, key, value)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_backward_grads, expected_backward_grads)
+        self.assertEqual(actual_grads, expected_grads)
+
     @parametrize(
         "backend",
         [

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1746,17 +1746,27 @@ class TestSDPAFailureModes(NNTestCase):
         "kernel",
         PLATFORM_SPECIFIC_SDPA,
     )
-    def test_invalid_fused_inputs_dim_3(self, device, kernel: SDPBackend):
+    def test_fused_inputs_dim_3(self, device, kernel: SDPBackend):
+        size = (2, 3, 8)
+        dtype = torch.float16
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+        attn_mask = (
+            None
+            if kernel == SDPBackend.FLASH_ATTENTION
+            else torch.randn(3, 3, device=device, dtype=dtype)
+        )
+
         with sdpa_kernel(backends=[kernel]):
-            # Dim is not 4
-            size = (2, 3, 8)
-            dtype = torch.float16
-            q = torch.randn(size, device=device, dtype=dtype)
-            k = torch.randn(size, device=device, dtype=dtype)
-            v = torch.randn(size, device=device, dtype=dtype)
-            with self.assertWarnsRegex(UserWarning, "All fused kernels requires query, key and value to be 4 dimensional"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
+            expected = torch.nn.functional.scaled_dot_product_attention(
+                q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), attn_mask
+            ).squeeze(0)
+            actual = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask
+            )
+
+        self.assertEqual(actual, expected)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1759,6 +1759,9 @@ class TestSDPAFailureModes(NNTestCase):
         )
 
         with sdpa_kernel(backends=[kernel]):
+            self.assertEqual(
+                torch._fused_sdp_choice(q, k, v, attn_mask), kernel.value
+            )
             expected = torch.nn.functional.scaled_dot_product_attention(
                 q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), attn_mask
             ).squeeze(0)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2558,6 +2558,36 @@ class TestSDPACpuOnly(NNTestCase):
             if torch._fused_sdp_choice(q, k, v, dropout_p=dropout) != SDPBackend.FLASH_ATTENTION.value:
                 raise AssertionError("expected FLASH_ATTENTION backend")
 
+    def test_fused_inputs_dim_3_cpu(self, device):
+        size = (2, 3, 8)
+        q = torch.randn(size, device=device)
+        k = torch.randn(size, device=device)
+        v = torch.randn(size, device=device)
+        masks = (
+            None,
+            torch.randn(3, 3, device=device),
+            torch.randn(2, 3, 3, device=device),
+        )
+
+        for attn_mask in masks:
+            normalized_mask = attn_mask
+            while normalized_mask is not None and normalized_mask.dim() < 4:
+                normalized_mask = normalized_mask.unsqueeze(0)
+            with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+                self.assertEqual(
+                    torch._fused_sdp_choice(q, k, v, attn_mask),
+                    SDPBackend.FLASH_ATTENTION.value,
+                )
+                expected = F.scaled_dot_product_attention(
+                    q.unsqueeze(0),
+                    k.unsqueeze(0),
+                    v.unsqueeze(0),
+                    normalized_mask,
+                ).squeeze(0)
+                actual = F.scaled_dot_product_attention(q, k, v, attn_mask)
+
+            self.assertEqual(actual, expected)
+
     def _generate_fixed_qkv_helper(
         self,
         device,
@@ -5640,6 +5670,36 @@ class TestSDPAXpuOnly(NNTestCase):
         else:
             if torch._fused_sdp_choice(q, k, v, dropout_p=dropout) != SDPBackend.OVERRIDEABLE.value:
                 raise AssertionError("expected OVERRIDEABLE backend")
+
+    def test_fused_inputs_dim_3_xpu(self, device):
+        size = (2, 3, 8)
+        q = torch.randn(size, device=device)
+        k = torch.randn(size, device=device)
+        v = torch.randn(size, device=device)
+        masks = (
+            None,
+            torch.randn(3, 3, device=device),
+            torch.randn(2, 3, 3, device=device),
+        )
+
+        for attn_mask in masks:
+            normalized_mask = attn_mask
+            while normalized_mask is not None and normalized_mask.dim() < 4:
+                normalized_mask = normalized_mask.unsqueeze(0)
+            with sdpa_kernel(backends=[SDPBackend.OVERRIDEABLE]):
+                self.assertEqual(
+                    torch._fused_sdp_choice(q, k, v, attn_mask),
+                    SDPBackend.OVERRIDEABLE.value,
+                )
+                expected = F.scaled_dot_product_attention(
+                    q.unsqueeze(0),
+                    k.unsqueeze(0),
+                    v.unsqueeze(0),
+                    normalized_mask,
+                ).squeeze(0)
+                actual = F.scaled_dot_product_attention(q, k, v, attn_mask)
+
+            self.assertEqual(actual, expected)
 
     def test_backends_set_to_math(self, device):
         dtype = torch.bfloat16


### PR DESCRIPTION
## Human Note
Okay this is techinally a policy change. I for the longest time wanted people to run unsqueeze(0).
The motivation for vmap but it just felt really weird to add this extra support for vmap and not to 
just do in generiacllly. As well although our docs very exiplicty say we dont support this for fused impl
we do for math. So in that spirit i think this more aligns impls and is net net fine.

## Agent Report
# Summary

`scaled_dot_product_attention` selected the math backend when `torch.vmap` mapped over CUDA query/key/value tensors that were logically rank 3, even though the hidden mapped dimension made the physical workload suitable for fused attention.

The final prototype normalizes every dense rank-3 CPU, CUDA/ROCm, and XPU SDPA call to rank 4 by adding a singleton batch dimension, running the existing implementation, and removing that dimension from the result. This removes the dependency on functorch's dynamic-layer stack, fixes the reported CUDA `vmap` and `vmap(grad(...))` fallback, and enables each device's eligible fused backends for ordinary rank-3 calls.

# Documented and implemented shape behavior

The current Python documentation presents the canonical shapes as `(N, ..., Hq, L, E)`, `(N, ..., H, S, E)`, and `(N, ..., H, S, Ev)`. Read literally, that notation suggests a minimum rank of 4 and does not explicitly describe the unbatched rank-3 form.

Rank-3 SDPA is nevertheless intentional high-level behavior rather than an accidental math-kernel property:

- native input validation accepts query/key/value tensors with rank 2 or greater;
- the SDPA OpInfo contains explicit rank-3 samples;
- the documented reference calculation applies matrix operations to the final dimensions and supports arbitrary leading dimensions.

The rank-4 restriction belonged specifically to the fused backend selectors. This change accelerates an existing high-level input form rather than introducing a previously rejected input form. The documentation could be clarified separately to spell out lower-rank/unbatched forms.

# Root cause

The composite SDPA implementation performs fused-backend selection before the low-level fused attention batching rules unwrap and flatten `BatchedTensor` inputs. The selector therefore observed logical shapes `(H, L, D)` and rejected every fused backend because their low-level interfaces require rank-4 query/key/value tensors. It then decomposed through the math implementation despite the physical tensors already containing the mapped batch dimension.

A promotion only in the `FuncTorchVmapMode` registration fixed ordinary `vmap(SDPA)` but not `vmap(grad(SDPA))`: the inner grad transform can decompose this CompositeImplicitAutograd operator before the vmap registration sees it. Inspecting functorch's dynamic-layer stack in generic SDPA code worked, but introduced an undesirable functorch dependency and special-case transform logic.

# Fix

At the composite SDPA entry point, when dense strided CPU, CUDA/ROCm, or XPU query/key/value tensors are all rank 3, the implementation now:

1. adds a singleton leading batch dimension to query, key, and value;
2. left-pads an optional attention mask to rank 4 so that 2D masks remain eligible for cuDNN as well as memory-efficient attention;
3. invokes the existing SDPA implementation, whose selector now sees canonical rank-4 inputs;
4. removes the singleton dimension from the result.

The CPU, CUDA/HIP, and XPU `_fused_sdp_choice` implementations use the same shared normalization helper. The public backend-choice API therefore reports the backend that high-level rank-3 SDPA can actually execute, including under forced fused-backend policies.

The cuDNN forward batching rule now mirrors memory-efficient attention by recomputing `compute_log_sumexp` from the unwrapped physical inputs. This ensures training forwards materialize the auxiliary required by eager and compiled backward even though the outer `BatchedTensor` wrappers hide `requires_grad`.

`unsqueeze` and `squeeze` are views, so the normalization does not copy tensor data. Nested or non-strided tensors, unsupported device types, mixed input ranks, and already rank-4 inputs retain their existing paths.

The existing transformer test that expected forced fused rank-3 inputs to fail is now a rank-3 versus explicit rank-4 equivalence test. Vmap tests force every available backend, compare outputs, direct autograd-through-vmap Q/K/V gradients, and `vmap(grad(...))` results, and cover mapped 2D masks with math, memory-efficient, and cuDNN attention.

# Validation

## Build

The final incremental C++ rebuild completed successfully:

```text
bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260805-pytorch-187266/pytorch
Built torch ...
Installed torch==2.14.0a0+gitd962d11
```

A no-ops GCC CI configuration exposed an ambiguous recursive call in `attention.cpp`: argument-dependent lookup considered both the native implementation and the generated public `at::scaled_dot_product_attention` wrapper. The corrected head explicitly calls `at::native::scaled_dot_product_attention`. The exact rebuild then passed with local GCC 11.5, matching the compiler family that reported the failure. Both replacement GCC jobs—including the exact `linux-jammy-py3.10-gcc11-no-ops / build` configuration—completed successfully. AArch64, Clang 21, ASAN, Python 3.14/free-threaded, CUDA 13.0/13.2, ROCm, mobile lightweight-dispatch, docs, and Dynamo CPython builds also passed for the corrected head.

## Focused tests

```text
gpu-run 1 -- ../.venv/bin/python -m pytest -q test/functorch/test_vmap.py \
  -k "TestVmapBatchedGradientCUDA and (test_sdpa or test_randomness)"
23 passed, 4096 deselected in 5.01s
```

This covers math, flash, memory-efficient, and cuDNN forward and `vmap(grad(...))` cases, mapped masks for all applicable backends, and existing SDPA randomness tests.

```text
gpu-run 0 -- ../.venv/bin/python -m pytest -q test/test_transformers.py \
  -k "fused_inputs_dim_3 or vmap_attn_mask or vmap_gqa_backward"
7 passed, 3 skipped, 15975 deselected in 5.26s
```

Manual direct rank-3 forward/backward comparisons against explicit rank-4 inputs passed for math, flash, memory-efficient, and cuDNN attention, including 2D/3D masks where supported and GQA. An explicit vmapped cuDNN 2D-mask probe passed. A forced-flash rank-3 `torch.compile(..., backend="aot_eager", fullgraph=True)` smoke test also passed.

After sharing normalization with `_fused_sdp_choice`, the exact incremental rebuild succeeded and the focused transformer/no-backend/vmap selection produced `8 passed, 4 skipped`; the functorch SDPA/randomness selection produced `23 passed`. A standalone selector reproduction now reports cuDNN by default and the requested flash, memory-efficient, or cuDNN backend under forced policies. Fresh-cache direct rank-3 AOT eager and masked Inductor forward/backward probes also passed after the refactor.

## Expanded existing-test sweep

All ten targeted existing-test selections passed, totaling 56 tests:

- direct rank-3 fused equivalence: `3 passed`;
- rank-3 mask/causal/dropout/reference matrix: `30 passed`;
- rank-3 no-backend behavior: `1 passed`;
- existing memory-efficient mask/GQA vmap regressions: `4 passed`;
- OpInfo eager coverage: `1 passed`;
- rank-3 vmap forward/grad: `4 passed`;
- rank-3 vmap masks: `3 passed`;
- existing all-backend SDPA vmap coverage: `4 passed`;
- OpInfo gradcheck: `2 passed`;
- nested-tensor exclusion coverage: `4 passed`.

The canonical `test/run_test.py` wrapper could not start because this job environment lacks `pytest-rerunfailures`, so the same full files were run directly with the job Python and pytest:

- `test/test_transformers.py`: `12412 passed, 3571 skipped, 1 xfailed, 1 failed` in 29m11s. The sole failure was the already-known unrelated CPU Inductor compiler mismatch: local `g++` rejects `-march=armv9-a+sve2+...`.
- `test/functorch/test_vmap.py`: `3368 passed, 307 skipped, 438 xfailed, 102142 subtests passed, 6 failed` in 21m07s. All six failures were CPU linear-algebra tests requiring LAPACK, which this build lacks (`geqrf`, `lu_factor`, SVD, and eig); no CUDA or SDPA test failed.

## Compile/export triple-check

Direct rank-3 compilation is healthy. Fresh-cache, fullgraph checks passed for AOTAutograd eager and Inductor, with forward and backward, under math, flash, memory-efficient, and cuDNN backends. Standard 2D masks and GQA passed. Dynamic masked cross-attention passed for four `(L, S)` pairs; Dynamo specialized this into three graphs. Export decomposition produced the expected `unsqueeze -> _scaled_dot_product_cudnn_attention -> squeeze` graph. Existing Dynamo, Inductor, CUDA export, compiled-autograd, and ProxyTensor selections also passed (`7`, `1`, `1`, `1`, and `3` tests respectively, with two ProxyTensor skips).

The transform-heavy cuDNN training composition is now clean for the tested cases. Before the batching-rule fix, `BatchedTensor` wrappers hid `requires_grad`, the cuDNN forward omitted logsumexp, eager `vmap(SDPA)` backward produced NaN/zero gradients, and AOTAutograd received `None` where it needed to save a tensor. Mirroring memory-efficient attention's post-unwrapping `compute_log_sumexp` recomputation fixes the shared root cause.

After the fix, a same-input eager comparison matched direct cuDNN exactly for the output and all Q/K/V gradients. All eight cache-disabled outer-compile combinations passed forward and backward: AOT eager and Inductor, each with masked/unmasked inputs and default/forced-cuDNN backend selection. Compiling `vmap(grad(SDPA))` also continues to pass. Like flash and memory-efficient attention, cuDNN has no dedicated batching rule for its fused backward operator, so `vmap(grad(...))` uses the generic per-example fallback; this is now only a performance warning rather than a correctness or saved-output failure.

## Requested 32-worker runs

The full transformer suite and focused vmap suite were launched concurrently on separate GPUs with `pytest -n 32` as requested.

- The focused vmap selection completed with `21 passed`; xdist replaced one worker after a collection-time segfault caused by spawning 32 copies of the large test module.
- The full transformer run reported `12096 passed, 3571 skipped, 317 failed, 1 xfailed`. The failures were dominated by 32 CUDA workers sharing one GPU rather than failures in the changed rank-3 path. Rerunning all 316 cached CUDA failures serially produced `316 passed` in 16.80 seconds.
- The remaining cached CPU failure is unrelated to SDPA: local Inductor compilation passes `-march=armv9-a...` to a `g++` that supports only up to `armv8.6-a`.

## Lint

- `spin quicklint`: no changed-file lint issues.
- `git diff --check`: passed.
- Required `spin fixlint` applied all available patches, then its repository-wide lint phase exited nonzero on unrelated pre-existing ShellCheck findings in packaging and CI shell scripts.

## Global-promotion tradeoffs

The singleton views themselves are cheap and copy no data. A GB200 inference microbenchmark showed strong steady-state wins: promoted rank-3 fused calls took roughly 25–37 microseconds versus 245–313 microseconds for the old direct math path over tested shapes. However, the first call for a new cuDNN shape took roughly 29–46 milliseconds while its execution plan was created; this can be a regression for one-off calls or workloads that continually introduce new shapes.

Global promotion also changes more than performance. The tested rank-3 default selected cuDNN, and second derivatives then failed because flash, memory-efficient, and cuDNN SDPA backward operators do not implement their own derivatives; the old rank-3 math path and an explicitly forced math backend support this grad-grad case. The final `squeeze(0)` also makes the returned rank-3 tensor a view, whereas the old direct math result was not a view. Numerics, dropout RNG consumption, determinism, workspace use, and backend-specific corner-case support can likewise change whenever automatic selection moves from math to fused.

These are reasons to treat unconditional rank-3 promotion as a broader backend-policy/API decision rather than merely a vmap bug fix. If the intended scope is only the reported vmap fallback, a vmap-scoped normalization has less compatibility risk. If global support is desired, the implementation could validate first and use promoted local aliases only for backend selection and fused branches, while leaving the original rank-3 tensors on a selected math path; that avoids recursive-call/view overhead and preserves the old forced-math result behavior.

A review identified a concrete consistency bug in the original global prototype: public `torch._fused_sdp_choice` still received the original rank-3 tensors. This is now fixed by sharing rank/mask normalization with CPU, CUDA/HIP, and XPU `_fused_sdp_choice`. Direct fused rank-3 tests assert selector parity with high-level execution.

# Review follow-up: CPU/XPU support and designated initialization

Review correctly identified that CPU flash and XPU fused selectors had the same rank-4 restriction. The shared normalization now covers dense strided CPU, CUDA/ROCm, and XPU tensors, and the corresponding device selectors all use it so `_fused_sdp_choice` remains consistent with high-level execution. CPU rank-3 calls now select `_scaled_dot_product_flash_attention_for_cpu`; XPU rank-3 calls can select the oneDNN overrideable backend or XPU flash when otherwise eligible. Device-specific tests compare rank-3 execution and selector results with explicitly normalized rank-4 calls, including 2D and 3D masks.

CPU output and first-order gradients matched explicit rank-4 CPU flash for direct calls, backward through `vmap(SDPA)`, and `vmap(grad(...))`. CPU SDPA OpInfo, composite-compliance, gradient, and functorch selections passed. AOT eager passed masked/unmasked forward and backward under default and forced CPU flash. Local Inductor validation remains blocked by the pre-existing host compiler mismatch that passes an unsupported Armv9 `-march` option. CPU flash has no dedicated vmap rule and therefore emits the generic per-example fallback warning, but measured promoted vmap cases were still approximately 1.8–12x faster than the old math path; direct rank-3 CPU flash was approximately 5–13x faster over sampled shapes.

Two duplicate review comments requested C++20 member/designated initialization. Every normalization call site now names each `sdp_params` field explicitly. The exact rebuild, focused CPU/CUDA tests, `spin quicklint`, and `git diff --check` passed. `spin fixlint` applied all changed-file patches and then failed only on unrelated repository-wide ShellCheck findings.

# Remaining uncertainty

Validation used CPU and an NVIDIA GB200 with CUDA 13.1. ROCm and XPU hardware were unavailable. XPU source/build coverage and the added XPU regression test should therefore be exercised by XPU CI or a backend owner before merge.

Ordinary rank-3 CPU, CUDA/ROCm, and XPU calls can now select a fused backend instead of math, so floating-point numerics, higher-order derivative availability, output view status, and backend-specific corner cases can change in the same way as other SDPA backend-selection changes. Explicit same-backend rank-3 versus rank-4 output, first-order gradient, mask, GQA, and supported-dropout checks passed on available hardware.

CUDA flash, memory-efficient, and cuDNN fused backward operators currently have no dedicated vmap batching rules, so `vmap(grad(SDPA))` uses the generic per-example fallback. CPU flash also lacks a dedicated forward or backward batching rule and currently uses the generic fallback under vmap. Both tested transform orders produced correct gradients; dedicated CPU and fused-backward batching rules remain performance follow-ups.

<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.profiler import ProfilerActivity, profile


def sdpa_ops(fn):
    torch.cuda.synchronize()
    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
        output = fn()
        torch.cuda.synchronize()
    ops = sorted(
        event.key
        for event in prof.key_averages()
        if "scaled_dot_product" in event.key
    )
    return output, ops


torch.manual_seed(0)
device = "cuda"
dtype = torch.float16
batch, heads, sequence, head_dim = 4, 4, 128, 64
query = torch.randn(batch, heads, sequence, head_dim, device=device, dtype=dtype)
key = torch.randn_like(query)
value = torch.randn_like(query)

# Warm up lazy CUDA initialization before profiling.
F.scaled_dot_product_attention(query, key, value)
F.scaled_dot_product_attention(query[0], key[0], value[0])
torch.vmap(F.scaled_dot_product_attention)(query, key, value)

direct_output, direct_ops = sdpa_ops(
    lambda: F.scaled_dot_product_attention(query, key, value)
)
unbatched_output, unbatched_ops = sdpa_ops(
    lambda: F.scaled_dot_product_attention(query[0], key[0], value[0])
)
vmapped_output, vmapped_ops = sdpa_ops(
    lambda: torch.vmap(F.scaled_dot_product_attention)(query, key, value)
)

outputs_match = torch.allclose(
    direct_output, vmapped_output, atol=1e-3, rtol=1e-3
)
unbatched_output_matches = torch.allclose(
    direct_output[0], unbatched_output, atol=1e-3, rtol=1e-3
)
print(f"device: {torch.cuda.get_device_name()}")
print(f"direct 4D SDPA ops: {direct_ops}")
print(f"direct 3D SDPA ops: {unbatched_ops}")
print(f"vmap over logical 3D SDPA ops: {vmapped_ops}")
print(f"direct 3D output matches direct 4D slice: {unbatched_output_matches}")
print(f"vmap output matches direct 4D: {outputs_match}")

fused_backends = ("flash", "efficient", "cudnn")
assert any(backend in op for backend in fused_backends for op in direct_ops)
assert any(backend in op for backend in fused_backends for op in unbatched_ops)
assert not any("_math" in op for op in unbatched_ops)
assert any(backend in op for backend in fused_backends for op in vmapped_ops)
assert not any("_math" in op for op in vmapped_ops)
assert unbatched_output_matches
assert outputs_match
```

```text
device: NVIDIA GB200
direct 4D SDPA ops: ['aten::_scaled_dot_product_cudnn_attention', 'aten::scaled_dot_product_attention']
direct 3D SDPA ops: ['aten::_scaled_dot_product_cudnn_attention', 'aten::scaled_dot_product_attention']
vmap over logical 3D SDPA ops: ['aten::_scaled_dot_product_cudnn_attention', 'aten::scaled_dot_product_attention']
direct 3D output matches direct 4D slice: True
vmap output matches direct 4D: True
```

</details>


Fixes #187266


<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.profiler import ProfilerActivity, profile


def sdpa_ops(fn):
    torch.cuda.synchronize()
    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
        output = fn()
        torch.cuda.synchronize()
    ops = sorted(
        event.key
        for event in prof.key_averages()
        if "scaled_dot_product" in event.key
    )
    return output, ops


torch.manual_seed(0)
device = "cuda"
dtype = torch.float16
batch, heads, sequence, head_dim = 4, 4, 128, 64
query = torch.randn(batch, heads, sequence, head_dim, device=device, dtype=dtype)
key = torch.randn_like(query)
value = torch.randn_like(query)

# Warm up lazy CUDA initialization before profiling.
F.scaled_dot_product_attention(query, key, value)
F.scaled_dot_product_attention(query[0], key[0], value[0])
torch.vmap(F.scaled_dot_product_attention)(query, key, value)

direct_output, direct_ops = sdpa_ops(
    lambda: F.scaled_dot_product_attention(query, key, value)
)
unbatched_output, unbatched_ops = sdpa_ops(
    lambda: F.scaled_dot_product_attention(query[0], key[0], value[0])
)
vmapped_output, vmapped_ops = sdpa_ops(
    lambda: torch.vmap(F.scaled_dot_product_attention)(query, key, value)
)

outputs_match = torch.allclose(
    direct_output, vmapped_output, atol=1e-3, rtol=1e-3
)
unbatched_output_matches = torch.allclose(
    direct_output[0], unbatched_output, atol=1e-3, rtol=1e-3
)
print(f"device: {torch.cuda.get_device_name()}")
print(f"direct 4D SDPA ops: {direct_ops}")
print(f"direct 3D SDPA ops: {unbatched_ops}")
print(f"vmap over logical 3D SDPA ops: {vmapped_ops}")
print(f"direct 3D output matches direct 4D slice: {unbatched_output_matches}")
print(f"vmap output matches direct 4D: {outputs_match}")

fused_backends = ("flash", "efficient", "cudnn")
assert any(backend in op for backend in fused_backends for op in direct_ops)
assert any(backend in op for backend in fused_backends for op in unbatched_ops)
assert not any("_math" in op for op in unbatched_ops)
assert any(backend in op for backend in fused_backends for op in vmapped_ops)
assert not any("_math" in op for op in vmapped_ops)
assert unbatched_output_matches
assert outputs_match
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced the backend fallback

Created `repro.py` and ran it on an NVIDIA GB200 with the job's editable PyTorch build (`2.14.0a0+gitaa8abcb`). A direct 4D SDPA call selected `aten::_scaled_dot_product_cudnn_attention`, while `torch.vmap` over the same inputs as logical 3D examples selected `aten::_scaled_dot_product_attention_math`. The outputs matched.

Command:

```bash
gpu-run 0 -- ~/.ptq_workspace/jobs/20260805-pytorch-187266/.venv/bin/python ~/.ptq_workspace/jobs/20260805-pytorch-187266/repro.py
```

### Located the logical-rank eligibility failure

`scaled_dot_product_attention` is decomposed while its arguments are still `BatchedTensor`s. The fused selector in `sdp_utils_cpp.h` therefore sees each mapped query/key/value at logical rank 3 and rejects every fused backend, even though the hidden vmap dimension makes the physical tensors rank 4. The existing low-level flash, efficient, and cuDNN batching rules can already flatten and execute the physical batch correctly.

A Python prototype that adds a singleton logical batch dimension around the composite SDPA call selected cuDNN without a mask and memory-efficient attention with a mapped mask. Because this promotion occurs inside vmap, direct 3D SDPA behavior remains unchanged.

### Added failing fused-backend regression coverage

Added CUDA vmap tests that compare logical-3D mapped SDPA with the equivalent direct 4D call under each available backend, plus a mapped-mask memory-efficient case. Before the fix, math passed while flash, memory-efficient, cuDNN, and the mask case all failed with `RuntimeError: No available kernel` (`4 failed, 1 passed, 5 skipped`).

The job-local `pytest` script has a stale shebang pointing at the shared PTQ environment, so tests are invoked with the required job Python via `../.venv/bin/python -m pytest`.

### Implemented vmap-scoped 3D promotion

The first implementation placed the promotion in the `FuncTorchVmapMode` SDPA decomposition. It fixed ordinary `vmap(SDPA)`, but a focused `vmap(grad(SDPA))` probe still failed: the inner grad transform decomposes this CompositeImplicitAutograd operator before the vmap dispatch registration sees it.

Moved the promotion to the composite SDPA entry point and gate it on an active vmap layer in functorch's dynamic-layer stack. For dense CUDA query/key/value tensors that are all logically 3D, SDPA recursively executes with a singleton logical batch dimension (and the same dimension on an optional mask), then removes that dimension from the result. Calls outside vmap, CPU calls, nested tensors, and inputs of other ranks retain their existing path.

### Rebuilt and validated fused forward and gradients

The incremental C++ rebuild completed successfully. The new test selection passes all available CUDA backends and the mapped-mask case (`5 passed, 5 skipped`). Extended the backend test through `vmap(grad(...))`; math, flash, memory-efficient, and cuDNN outputs and Q/K/V gradients match the equivalent direct 4D calls. A nested-vmap probe also passes all four backends.

The updated profiler repro now selects cuDNN for both the direct 4D call and logical-3D vmap call, with matching outputs. Fused backward currently emits the existing batching-fallback warning tracked separately by the issue's referenced backward work; this change fixes forward backend eligibility and preserves gradient correctness.

### Final validation and simplification

Rebuilt the final C++ source successfully and reduced the regression matrix to the representative all-backend forward/gradient case plus one mapped-mask case. Final results:

- `test/functorch/test_vmap.py` SDPA/randomness selection: `21 passed`.
- Existing memory-efficient vmap mask/GQA tests in `test/test_transformers.py`: `4 passed`.
- Profiler repro: direct 3D remains math, direct 4D and logical-3D vmap both select cuDNN, and outputs match.
- `torch.compile(..., backend="aot_eager", fullgraph=True)` vmap smoke test passes with forced flash attention.
- Manual nested-vmap and zero-size input probes pass.
- `spin quicklint` reports no issues and `git diff --check` passes.

`spin fixlint` applied all available patches but its full-repository prerequisite lint exits nonzero on unrelated pre-existing ShellCheck findings in packaging and CI scripts; changed-file `spin quicklint` is clean.

### Final artifacts

Wrote `report.md`, `pr_title.txt`, and `pr_labels.txt`, then generated `fix.diff` from the final two-file source diff.

## Run 2

### Prototyped unconditional dense rank-3 CUDA promotion

After design discussion, removed the functorch dynamic-layer dependency and made the singleton-batch normalization apply to every dense CUDA call where query, key, and value are all rank 3. This broadens direct rank-3 CUDA SDPA from math-only execution to fused-backend eligibility and naturally retains the vmap fix. Converted the existing transformer failure-mode test, which expected forced fused rank-3 SDPA to fail, into a rank-3 versus explicit rank-4 equivalence test.

The current Python documentation gives only the canonical `(N, ..., H, L, E)` shape, which literally suggests rank 4 or greater. However, native validation explicitly accepts rank-2-and-higher inputs and the SDPA OpInfo has intentional rank-3 samples. Rank-3 high-level SDPA is therefore tested behavior but is not clearly described by the current shape documentation; only fused execution was explicitly restricted to rank 4.

### Found and fixed mask-rank normalization issue

The first global prototype added one leading dimension to every mask. A 2D mask consequently became rank 3, which memory-efficient attention accepted but cuDNN's selector rejected (it accepts 2D or 4D masks). Left-padding masks below rank 4 fixes both direct and vmapped 2D-mask cases while preserving broadcasting. Added direct rank-3 mask coverage for fused backends and parameterized the vmap mask regression across math, memory-efficient, and cuDNN backends.

### Rebuilt and tested the broader prototype

Both incremental rebuilds completed successfully. Focused final results:

- Direct rank-3 fused and existing vmap transformer selection: `7 passed, 3 skipped`.
- Functorch SDPA/randomness selection with all applicable masked backends: `23 passed`.
- Manual direct rank-3 forward/backward checks passed for math, flash, memory-efficient, and cuDNN with no mask, 2D/3D masks where supported, and GQA.
- Explicit vmapped cuDNN 2D-mask probe passed.
- `spin quicklint` and `git diff --check` passed.

As requested, the full transformer suite and focused vmap suite were also launched concurrently with `pytest -n 32` on separate GPUs. The vmap selection ultimately completed with `21 passed`, though xdist replaced one worker after a collection-time segfault. The full transformer run reported `12096 passed, 3571 skipped, 317 failed`; 32 CUDA workers oversubscribed one GPU. Rerunning all 316 cached CUDA failures serially produced `316 passed`. The remaining cached CPU failure is an unrelated local Inductor compiler configuration error (`g++` rejects `-march=armv9-a...`).

### Updated final artifacts for the broader behavior

Updated the profiler repro and report to show direct rank-3, direct rank-4, and vmapped logical-rank-3 calls all selecting cuDNN with matching outputs. Changed the suggested title to `[SDPA] Enable fused CUDA backends for rank-3 inputs`, selected `release notes: nn`, and regenerated `fix.diff` from the final three-file source diff.

## Run 3

### Located existing regression coverage

Fanned out ten read-only test-discovery scouts across direct tests, symbol matches, callers, history, OpInfo, compile, backend, C++, test-infrastructure, and CI facets. The strongest coverage is the new direct fused rank-3 test, the two new logical-rank-3 vmap tests, the existing CUDA rank-3 math/reference matrix, and the existing rank-3 no-backend failure case. OpInfo supplies additional rank-3 causal/dropout/GQA and gradient coverage.

No existing C++ test directly exercises high-level SDPA rank promotion. Existing compile/export SDPA tests use rank-4 CUDA tensors, and no checked-in test directly combines rank-3 fused execution with dropout, GQA, mask gradients, or `torch.compile`.

### Ran the discovered test matrix

Ran all ten focused and broader selections across two GPUs without xdist. All 56 selected tests passed, including direct fused rank-3 equivalence, the rank-3 semantics matrix, no-backend behavior, vmap forward/grad/mask cases, OpInfo eager and gradient checks, existing mask/GQA vmap regressions, and nested-tensor coverage.

The canonical `test/run_test.py` wrapper stopped at preflight because `pytest-rerunfailures` is absent from the job venv, so equivalent full-file pytest runs were used. `test_transformers.py` produced `12412 passed, 3571 skipped, 1 xfailed, 1 failed`; the sole failure is the known unrelated CPU Inductor `-march=armv9-a...` compiler mismatch. `test/functorch/test_vmap.py` produced `3368 passed, 307 skipped, 438 xfailed, 102142 subtests passed, 6 failed`; every failure was a CPU linear-algebra case requiring LAPACK, which this build lacks. No CUDA or SDPA test failed.

## Run 4

### Assessed global-promotion compatibility and performance risk

Confirmed that the view normalization itself performs no copies, and measured substantial steady-state speedups on GB200: automatic fused rank-3 SDPA took about 25–37 microseconds over the sampled shapes, versus roughly 245–313 microseconds for the old direct math implementation. The non-obvious cost is first-use latency: new cuDNN shapes took about 29–46 milliseconds to create/initialize an execution plan, so one-off or highly dynamic-shape rank-3 workloads can regress despite much faster steady-state execution.

Also confirmed a broader semantic change. The default promoted rank-3 call selected cuDNN. Math supported second derivatives, but forced flash, memory-efficient, and cuDNN paths all failed grad-grad because their backward operators do not implement derivatives. Forced math still passed. The promoted result is also a view due to the final `squeeze(0)`, whereas the old direct math result was not a view. Standard 0D–3D broadcastable masks matched the old math behavior; a rank-4 singleton mask that previously errored became accepted.

This makes unconditional promotion a backend-policy/API expansion, not only a vmap fix. A narrower vmap gate avoids those direct-call changes. If retaining global support, a cleaner implementation would validate the original inputs first, use promoted local aliases for selector/fused branches, and leave a selected math branch on the original rank-3 tensors instead of recursively wrapping every rank-3 CUDA call.

## Run 5

### Triple-checked compile and export behavior

Ran a fresh-cache compile matrix rather than relying on the earlier single forced-flash smoke test. Direct rank-3 fullgraph compilation passed under AOT eager and Inductor with forward/backward for math, flash, memory-efficient, and cuDNN, plus 2D masks and GQA. Dynamic masked cross-attention passed at four shape pairs and specialized into three graphs. Export decomposition contains the expected `unsqueeze`, low-level cuDNN SDPA, and `squeeze`. Existing Dynamo, Inductor, export, compiled-autograd, and ProxyTensor selections passed.

The outer `torch.compile(torch.vmap(SDPA))` training case exposes an existing cuDNN/AOT limitation. With compiler caches force-disabled, grad-enabled cuDNN inputs fail under both AOT eager and Inductor because AOT expects the saved cuDNN logsumexp output to be a tensor but receives `None`. Forward-only inputs pass; math, flash, and memory-efficient compiled vmap paths pass; and explicitly compiling `vmap(grad(SDPA))` passes, including a mapped mask. This is not a view-normalization failure, but enabling cuDNN makes the pre-existing backward-batching/AOT issue reachable where rank-3 previously fell back to math.

### Reproduced `_fused_sdp_choice` review finding

Fetched and verified review comment `discussion_r3725014772`. With default backend policy, `torch._fused_sdp_choice` reports math for rank-3 tensors while the high-level SDPA call executes cuDNN. Under forced flash, memory-efficient, or cuDNN contexts, `_fused_sdp_choice` throws `No available kernel` while SDPA succeeds. The comment is valid: if global rank-3 promotion remains, CUDA/HIP backend-choice dispatch must share the same Q/K/V and mask normalization, with a regression assertion added to the direct rank-3 backend test.

## Run 6

### Fixed `_fused_sdp_choice` parity

Moved the unbatched CUDA Q/K/V and attention-mask normalization into a shared `sdp_utils_cpp.h` helper. The high-level composite SDPA path and CUDA/HIP `_fused_sdp_choice` now pass the same canonical rank-4 views to fused backend selection. Extended `test_fused_inputs_dim_3` to assert that `_fused_sdp_choice` returns each forced flash, memory-efficient, or cuDNN backend, including the existing rank-2-mask cases.

The exact incremental rebuild succeeded. Focused transformer/no-backend/vmap coverage produced `8 passed, 4 skipped`; the functorch SDPA/randomness selection produced `23 passed`. The standalone reproduction now reports cuDNN by default and the requested backend under each forced fused policy, matching successful high-level execution. Fresh-cache direct rank-3 compilation was rechecked after the refactor: AOT eager passed unmasked forward/backward and Inductor passed masked forward/backward.

`spin quicklint` and `git diff --check` are clean. `spin fixlint` applied all available changed-file patches and then failed only on the same unrelated repository-wide ShellCheck findings.

### Root-caused the compiled-vmap cuDNN caveat

The failure is not caused by `unsqueeze`/`squeeze`. The cuDNN forward vmap rule receives `compute_log_sumexp=False` because the outer `BatchedTensor` wrappers hide `requires_grad` from the composite SDPA wrapper. Unlike the memory-efficient vmap rule immediately above it, the cuDNN rule does not recompute that flag after unwrapping the physical tensors. It therefore returns no logsumexp even though AOTAutograd needs that tensor for backward; AOT eager reports a `None` in its saved-tensor list, and Inductor expects a Tensor at the corresponding generated-code slot.

An isolated fresh-cache probe that invokes the same vmapped low-level cuDNN operation while forcing `compute_log_sumexp=True` passed forward and backward under both `aot_eager` and Inductor. A same-input eager comparison was even more conclusive: current high-level cuDNN `vmap(SDPA)` matched the direct output but produced a NaN query-gradient norm and zero key/value-gradient norms, whereas the forced-logsumexp low-level vmap matched the direct output and all three gradients exactly. This confirms the missing saved auxiliary as both the immediate compile failure and an eager-backward correctness issue. The cuDNN backward op still lacks a dedicated batching rule and uses the generic fallback, which is a separate performance warning rather than the cause of the missing auxiliary.

## Run 7

### Mirrored the memory-efficient training-forward handling for cuDNN

Extended `test_sdpa_unbatched_inputs` to differentiate directly through the output of `vmap(SDPA)` and compare those Q/K/V gradients with direct rank-4 SDPA, while retaining the existing `vmap(grad(...))` coverage. Before the C++ fix, the forced-cuDNN case failed on every query-gradient element with NaNs.

Copied the memory-efficient batching rule's `compute_log_sumexp` recomputation into `_scaled_dot_product_cudnn_attention_batch_rule`. Once the batching rule has the unwrapped physical tensors, it now requests logsumexp whenever grad mode is enabled and query, key, value, or a defined attention bias requires gradients.

The incremental rebuild succeeded. The formerly failing cuDNN test now passes, and the full focused functorch SDPA/randomness selection remains `23 passed`; transformer selector/vmap coverage remains `8 passed, 4 skipped`. A same-input eager probe now matches direct cuDNN exactly for the output and all Q/K/V gradients.

All eight fresh-cache outer-compile combinations passed: AOT eager and Inductor, each with masked/unmasked inputs and default/forced-cuDNN selection. This resolves both the eager-backward correctness issue and the saved-logsumexp AOT/Inductor failure. A warning probe confirmed that flash, memory-efficient, and cuDNN alike lack dedicated fused-backward batching rules: `vmap(grad(...))` uses the generic per-example fallback for each, while backward through the result of a completed `vmap(SDPA)` uses the flattened forward graph without fallback.

`spin quicklint` and `git diff --check` pass. `spin fixlint` applied all changed-file patches and then failed only on the same unrelated repository-wide ShellCheck findings.

## Run 8

### Fixed the no-ops GCC build failure

The `linux-jammy-py3.10-gcc11-no-ops` CI build failed while compiling `attention.cpp`. The recursive SDPA call was unqualified, so GCC's argument-dependent lookup considered both the native implementation and the generated public `at::scaled_dot_product_attention` wrapper and diagnosed an ambiguous overload. This was a source failure, not infrastructure noise.

The PR head was updated at `d962d111f62` to explicitly call `at::native::scaled_dot_product_attention`, which selects the intended recursion and prevents ADL from adding the public wrapper. The exact incremental rebuild succeeded with local GCC 11.5. Focused transformer coverage passed (`8 passed, 4 skipped`), focused functorch SDPA coverage passed (`7 passed, 7 skipped, 4 xfailed, 8 subtests passed`), `spin quicklint` passed, and `git diff --check` remained clean. The replacement `linux-jammy-py3.10-gcc11 / build` GitHub CI job completed successfully for the corrected head. The exact `linux-jammy-py3.10-gcc11-no-ops / build` configuration subsequently passed as well. The corrected head also passed AArch64, Clang 21, ASAN, Python 3.14/free-threaded, CUDA 13.0/13.2, ROCm, mobile lightweight-dispatch, docs, and Dynamo CPython builds; no current-head CI failure was present when rechecked.

## Run 9

### Investigated CPU/XPU review feedback

The selector-side rank-4 restriction also exists outside CUDA, but high-level rank-3 CPU/XPU SDPA remains correct through the math fallback. A CPU probe showed rank-3 `_fused_sdp_choice` returning math while the explicit rank-4 equivalent returned CPU flash; forced CPU flash failed for rank 3 and succeeded for rank 4. Explicit promotion under `vmap` reached CPU flash but emitted the generic batching-fallback warning because `_scaled_dot_product_flash_attention_for_cpu` has no dedicated vmap rule, so it processes mapped examples separately rather than flattening them as the CUDA fused rules do.

Source inspection found the analogous XPU rank-4 gate in `check_tensor_shapes`, an explicit rank-4 assertion in the oneDNN overrideable implementation, and separate/incomplete XPU training support. XPU hardware was unavailable. Extending promotion to CPU/XPU would therefore be another backend-policy change requiring backend-specific behavior and performance validation, not merely widening `query_.is_cuda()`. The recommended review response is to acknowledge the analogous missed fused optimization while keeping this PR intentionally CUDA/ROCm-scoped and treating CPU/XPU as follow-up work.

### Applied the C++20 designated-initializer suggestion

The two initializer review comments were duplicates on the same expression. Converted both newly added `sdp_params` helper call sites—the composite implementation and CUDA selector—to C++20 designated initializers, making field assignment explicit. The exact rebuild passed, transformer coverage remained `8 passed, 4 skipped`, and focused functorch SDPA/randomness coverage remained `23 passed`. `spin quicklint` and `git diff --check` passed. `spin fixlint` applied all changed-file patches and then failed only on the same unrelated repository-wide ShellCheck findings.

## Run 10

### Extended rank-3 normalization to CPU and XPU

After deciding to address the backend-scope review directly, renamed the shared helper to `normalize_unbatched_input` and extended it to dense strided CPU and XPU tensors in addition to CUDA/ROCm. The composite entry point and CPU, CUDA/HIP, and XPU `_fused_sdp_choice` implementations now use the same normalization. All call sites use C++20 designated initializers. Sparse, nested, mixed-rank, unsupported-device, and already rank-4 inputs remain on their existing paths.

Added CPU and XPU rank-3 tests that force the native fused backend, assert `_fused_sdp_choice` parity, and compare against explicitly normalized rank-4 inputs with no mask, a 2D mask, and a 3D mask. Added a CPU vmap regression covering output, backward through completed `vmap(SDPA)`, and `vmap(grad(SDPA))`. CPU flash currently uses functorch's generic batching fallback, so the test suppresses the expected performance warning.

The exact rebuild passed twice during the prototype. Final focused results included `77 passed` for CPU rank-3/reference and selector coverage, `1 passed, 1 skipped` for the new CPU vmap selection, `9 passed, 4 skipped` for focused transformer coverage across the available devices, and `23 passed, 1 skipped` for the CUDA functorch SDPA/randomness selection. CPU SDPA OpInfo/composite coverage produced `12 passed, 8 skipped`; CPU gradient coverage produced `1 passed, 4 skipped`; and CPU functorch OpInfo coverage produced `2 passed, 8 skipped, 4 xfailed`. Mask, GQA, first-order gradient, empty-sequence, no-backend, and dropout-RNG probes passed.

Fresh-cache AOT eager passed all four tested CPU combinations (masked/unmasked and default/forced flash) with forward and backward. Inductor reached the known unrelated local compiler failure where `g++` rejects the configured Armv9 `-march` option. CPU microbenchmarks measured roughly 5–13x direct rank-3 speedups and roughly 1.8–12x vmapped speedups versus the previous math path over sampled shapes, despite the generic vmap fallback. XPU hardware was unavailable, so the added XPU test still requires XPU CI/backend-owner execution.

`spin quicklint` and `git diff --check` pass. `spin fixlint` applied all changed-file patches and failed only on the same unrelated repository-wide ShellCheck findings.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01