### PR TITLE
[c10d][nccl2] Serialize communicator lifecycle transitions

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -2,6 +2,7 @@
 #
 # Tests specific to the in-tree torchcomms NCCL backends.
 
+import concurrent.futures
 import ctypes
 import os
 import subprocess
@@ -72,6 +73,22 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
         opts.config.max_ctas = 4
         self.assertEqual(opts.config.cga_cluster_size, 2)
         self.assertEqual(opts.config.max_ctas, 4)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_concurrent_lazy_initialization(self) -> None:
+        backend = dist.get_backend_impl(device=self.device)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [
+                executor.submit(backend.eager_connect_single_device, self.device)
+                for _ in range(4)
+            ]
+            for future in futures:
+                future.result()
+
+        tensor = torch.ones(1, device=self.device)
+        dist.all_reduce(tensor)
+        self.assertEqual(tensor, torch.full_like(tensor, self.world_size))
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/test_c10d_suspend_resume.py
+++ b/test/distributed/test_c10d_suspend_resume.py
@@ -20,7 +20,7 @@ if not dist.is_available():
     sys.exit(0)
 
 from torch.testing._internal.common_distributed import MultiProcessTestCase
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.common_utils import get_cycles_per_ms, run_tests, TEST_CUDA
 
 
 SUSPEND_RESUME_BACKENDS = [
@@ -125,6 +125,41 @@ class AbstractSuspendResumeTest:
         self.assertEqual(tensor, expected)
         if self.create_pair_channel:
             self._exchange_with_peer()
+
+    def test_operations_rejected_while_suspended(self):
+        if self.backend_name != "nccl2":
+            self.skipTest("nccl2 lifecycle serialization")
+        self._init_pg()
+        self.backend.suspend()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "communicator is suspended"):
+                dist.all_reduce(torch.ones(1, device=self.device))
+        finally:
+            self.backend.resume()
+
+    def test_suspend_rejects_pending_work(self):
+        if self.backend_name != "nccl2":
+            self.skipTest("nccl2 lifecycle serialization")
+        self._init_pg()
+        torch.cuda._sleep(int(500 * get_cycles_per_ms()))
+        work = dist.all_reduce(torch.ones(1, device=self.device), async_op=True)
+        with self.assertRaisesRegex(RuntimeError, "work is pending"):
+            self.backend.suspend()
+        work.wait()
+        torch.cuda.synchronize()
+        self.backend.suspend()
+        self.backend.resume()
+
+    def test_suspend_rejects_active_coalescing_batch(self):
+        if self.backend_name != "nccl2":
+            self.skipTest("nccl2 lifecycle serialization")
+        self._init_pg()
+        self.backend._start_coalescing()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "coalescing batch is active"):
+                self.backend.suspend()
+        finally:
+            self.backend._end_coalescing().wait()
 
 
 def _make_suspend_resume_test_class(backend_name, device_type, create_pair_channel):

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -313,6 +313,7 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
     const c10::intrusive_ptr<::c10d::Store>& store,
     const std::vector<int>& ranks,
     const c10::intrusive_ptr<::c10d::Backend::Options>& opts) {
+  auto commUseGuard = acquireCommUse();
   // Validate the requested ranks (in range, no duplicates). Port of the
   // validation in TorchCommNCCL::split.
   std::unordered_set<int> seen;
@@ -412,6 +413,10 @@ void ProcessGroupNCCL::abort() {
   // watchdog detects on its own.
   TC_LOG(INFO, this) << "abort() requested on rank " << rank_
                      << "; aborting the NCCL communicator";
+  if (!options_c10d_->enable_reconfigure) {
+    stopWatchdog();
+  }
+  std::unique_lock lifecycleLock(comm_lifecycle_mutex_);
   if (options_c10d_->enable_reconfigure) {
     comm_state_ = CommState::ERROR;
     revokeNcclComm();
@@ -422,33 +427,49 @@ void ProcessGroupNCCL::abort() {
     // the comm is revoked rather than destroyed and the watchdog is needed
     // again after reconfigure(). The error is still published before the
     // teardown, so work in flight reports it instead of completing.
-    stopWatchdog();
     comm_state_ = CommState::ERROR;
     abortNcclComm();
   }
 }
 
 void ProcessGroupNCCL::suspend() {
+  std::unique_lock lifecycleLock(comm_lifecycle_mutex_);
   checkInitialized();
+  TORCH_CHECK(
+      !comm_suspended_.load(), "ProcessGroupNCCL communicator is suspended");
+  TORCH_CHECK(
+      !coalescing_batch_.has_value(),
+      "ProcessGroupNCCL communicator cannot be suspended while a coalescing "
+      "batch is active");
+  TORCH_CHECK(
+      workq_.garbageCollect() == WorkNCCL::WorkStatus::COMPLETED,
+      "ProcessGroupNCCL communicator cannot be suspended while work is "
+      "pending");
   c10::cuda::CUDAGuard gpuGuard(device_);
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,
       nccl_api_->commSuspend(nccl_comm_, NCCL_SUSPEND_MEM),
       "NCCL Suspend failed (requires NCCL 2.29.7+)");
+  comm_suspended_ = true;
 }
 
 void ProcessGroupNCCL::resume() {
+  std::unique_lock lifecycleLock(comm_lifecycle_mutex_);
   checkInitialized();
+  TORCH_CHECK(
+      comm_suspended_.load(), "ProcessGroupNCCL communicator is not suspended");
   c10::cuda::CUDAGuard gpuGuard(device_);
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,
       nccl_api_->commResume(nccl_comm_),
       "NCCL Resume failed (requires NCCL 2.29.7+)");
+  comm_suspended_ = false;
 }
 
 std::unordered_map<std::string, uint64_t> ProcessGroupNCCL::getMemoryStats() {
+  std::shared_lock lifecycleLock(comm_lifecycle_mutex_);
   checkInitialized();
   c10::cuda::CUDAGuard gpuGuard(device_);
   // Stat indices follow ncclCommMemStat_t: suspend=0, suspended=1, persist=2,
@@ -480,17 +501,17 @@ std::unordered_map<std::string, uint64_t> ProcessGroupNCCL::getMemoryStats() {
 }
 
 void ProcessGroupNCCL::finalize() {
+  // Stop the watchdog first: draining the work queue below may surface a
+  // timeout, which is a teardown result to report to the caller, not a reason
+  // to terminate the process.
+  stopWatchdog();
+  std::unique_lock lifecycleLock(comm_lifecycle_mutex_);
   if (init_state_ == InitializationState::UNINITIALIZED) {
     throw std::runtime_error("ProcessGroupNCCL not initialized");
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("ProcessGroupNCCL already finalized");
   }
   init_state_ = InitializationState::FINALIZED;
-
-  // Stop the watchdog first: draining the work queue below may surface a
-  // timeout, which is a teardown result to report to the caller, not a reason
-  // to terminate the process.
-  stopWatchdog();
 
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -22,6 +22,7 @@
 #include <optional>
 #include <queue>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -363,6 +364,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       ncclResult_t status,
       std::chrono::milliseconds timeout,
       std::string_view operation);
+  [[nodiscard]] std::shared_lock<std::shared_mutex> acquireCommUse() const;
   // Tears the NCCL communicator down. This NEVER terminates the process --
   // a user-initiated abort()/shutdown() must be survivable, matching
   // ::c10d::ProcessGroupNCCL::abort(). Callers that are handling a
@@ -594,7 +596,12 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     UNINITIALIZED,
     INITIALIZED,
     FINALIZED,
-  } init_state_{InitializationState::UNINITIALIZED};
+  };
+  std::atomic<InitializationState> init_state_{
+      InitializationState::UNINITIALIZED};
+  std::mutex initialization_mutex_;
+  mutable std::shared_mutex comm_lifecycle_mutex_;
+  std::atomic<bool> comm_suspended_{false};
 
   c10::intrusive_ptr<::c10d::Store> store_;
   uint64_t bootstrap_generation_{0};

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -108,6 +108,7 @@ std::chrono::milliseconds ProcessGroupNCCL::operationTimeout(
 void ProcessGroupNCCL::ensureInitialized(at::Device device) {
   TORCH_CHECK(
       device.is_cuda(), "ProcessGroupNCCL requires CUDA tensors/devices");
+  std::lock_guard initializationLock(initialization_mutex_);
   if (init_state_ == InitializationState::INITIALIZED) {
     TORCH_CHECK(
         device_.index() == device.index(),
@@ -239,6 +240,7 @@ c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const ::c10d::BroadcastOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   auto tensor = tensors.at(0);
   if (tensor.is_complex()) {
@@ -258,6 +260,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::broadcast(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce(
     std::vector<at::Tensor>& tensors,
     const ::c10d::AllreduceOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   auto tensor = tensors.at(0);
   if (tensor.is_complex()) {
@@ -279,6 +282,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce_coalesced(
     std::vector<at::Tensor>& tensors,
     const ::c10d::AllreduceCoalescedOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(!tensors.empty(), "Tensor list must be nonempty");
   ensureInitialized(tensors.at(0).device());
   ++sequence_number_;
@@ -298,6 +302,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce_coalesced(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ::c10d::ReduceOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   auto tensor = tensors.at(0);
   if (tensor.is_complex()) {
@@ -324,6 +329,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ::c10d::AllgatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       outputTensors.size() == 1 && inputTensors.size() == 1,
       "Only single tensor / single list supported");
@@ -367,6 +373,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allgather_coalesced(
     std::vector<std::vector<at::Tensor>>& outputTensorLists,
     std::vector<at::Tensor>& inputTensors,
     const ::c10d::AllgatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       !inputTensors.empty() && outputTensorLists.size() == inputTensors.size(),
       "Input and output tensor lists must have the same nonzero size");
@@ -398,6 +405,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::
         std::vector<at::Tensor>& outputs,
         std::vector<at::Tensor>& inputs,
         const ::c10d::AllgatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       !inputs.empty() && outputs.size() == inputs.size(),
       "Input and output tensor lists must have the same nonzero size");
@@ -423,6 +431,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::_allgather_base(
     at::Tensor& outputBuffer,
     at::Tensor& inputBuffer,
     const ::c10d::AllgatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   ensureInitialized(inputBuffer.device());
   ++sequence_number_;
   auto work = allGatherSingleImpl(
@@ -435,6 +444,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ::c10d::GatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(inputTensors.size() == 1, "Only single input tensor supported");
   ensureInitialized(inputTensors.at(0).device());
   if (getRank() == opts.rootRank) {
@@ -459,6 +469,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::gather_single(
     at::Tensor& outputBuffer,
     at::Tensor& inputBuffer,
     const ::c10d::GatherOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       opts.rootRank >= 0 && opts.rootRank < getSize(),
       "invalid root rank: ",
@@ -498,6 +509,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ::c10d::ScatterOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(outputTensors.size() == 1, "Only single output tensor supported");
   ensureInitialized(outputTensors.at(0).device());
   if (getRank() == opts.rootRank) {
@@ -521,6 +533,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reduce_scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ::c10d::ReduceScatterOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       outputTensors.size() == 1 && inputTensors.size() == 1,
       "Only single tensor / single list supported");
@@ -541,6 +554,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::
         std::vector<at::Tensor>& outputs,
         std::vector<at::Tensor>& inputs,
         const ::c10d::ReduceScatterOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       !outputs.empty() && inputs.size() == outputs.size(),
       "Input and output tensor lists must have the same nonzero size");
@@ -567,6 +581,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::_reduce_scatter_base(
     at::Tensor& outputBuffer,
     at::Tensor& inputBuffer,
     const ::c10d::ReduceScatterOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   ensureInitialized(outputBuffer.device());
   ++sequence_number_;
   auto work = reduceScatterSingleImpl(
@@ -585,6 +600,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall_base(
     std::vector<int64_t>& outputSplitSizes,
     std::vector<int64_t>& inputSplitSizes,
     const ::c10d::AllToAllOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   ensureInitialized(outputBuffer.device());
   ++sequence_number_;
   auto timeout = operationTimeout(opts.timeout);
@@ -611,6 +627,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const ::c10d::AllToAllOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(!inputTensors.empty(), "alltoall requires input tensors");
   ensureInitialized(inputTensors.at(0).device());
   ++sequence_number_;
@@ -625,6 +642,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall(
 
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::barrier(
     const ::c10d::BarrierOptions& opts) {
+  auto commUseGuard = acquireCommUse();
   // Resolve a device for lazy init: prefer an explicit device id, then the
   // bound device, then the conventional rank-to-device mapping.
   if (init_state_ != InitializationState::INITIALIZED) {
@@ -647,6 +665,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::send(
     std::vector<at::Tensor>& tensors,
     int dstRank,
     [[maybe_unused]] int tag) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
   if (coalescing_batch_.has_value()) {
@@ -663,6 +682,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::recv(
     std::vector<at::Tensor>& tensors,
     int srcRank,
     [[maybe_unused]] int tag) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
   if (coalescing_batch_.has_value()) {
@@ -676,6 +696,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::recv(
 }
 
 void ProcessGroupNCCL::startCoalescing() {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       !coalescing_batch_.has_value(),
       "startCoalescing called while a batch is already active");
@@ -684,6 +705,7 @@ void ProcessGroupNCCL::startCoalescing() {
 }
 
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::endCoalescing() {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       coalescing_batch_.has_value(),
       "endCoalescing called without a matching startCoalescing");

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -367,6 +367,15 @@ void ProcessGroupNCCL::checkInitialized() const {
   }
 }
 
+std::shared_lock<std::shared_mutex> ProcessGroupNCCL::acquireCommUse() const {
+  std::shared_lock lock(comm_lifecycle_mutex_);
+  TORCH_CHECK(
+      !comm_suspended_.load(),
+      "ProcessGroupNCCL communicator is suspended; call resume() before "
+      "issuing operations");
+  return lock;
+}
+
 void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
   // Nothing to check in graph capture mode
   if (getGraphCaptureMode()) {

--- a/torch/csrc/distributed/c10d/nccl2/ShrinkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ShrinkNCCL.cpp
@@ -33,6 +33,7 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::shrink(
     const std::vector<int64_t>& ranks_to_exclude,
     int shrink_flags,
     const c10::intrusive_ptr<::c10d::Backend::Options>& opts_override) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(supportsShrinking(), "nccl2 shrink requires NCCL 2.27 or later");
   TORCH_CHECK_VALUE(
       !ranks_to_exclude.empty(), "ranks_to_exclude cannot be empty");

--- a/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
@@ -28,6 +28,7 @@ WindowNCCL::WindowNCCL(c10::intrusive_ptr<ProcessGroupNCCL> pg)
 }
 
 void WindowNCCL::tensor_register(const at::Tensor& tensor, bool owning) {
+  auto commUseGuard = pg_->acquireCommUse();
   TORCH_CHECK(tensor.defined(), "WindowNCCL: a valid tensor is required");
   checkDeviceAndThrow(tensor);
   TORCH_CHECK(win_ == nullptr, "WindowNCCL: double registration");
@@ -78,6 +79,7 @@ c10::intrusive_ptr<::c10d::Work> WindowNCCL::put(
     int64_t targetOffsetNelems,
     bool asyncOp,
     const ::c10d::PutOptions& opts) {
+  auto commUseGuard = pg_->acquireCommUse();
   checkWindowAndThrow();
   checkDeviceAndThrow(tensor);
   TORCH_CHECK(
@@ -135,6 +137,7 @@ c10::intrusive_ptr<::c10d::Work> WindowNCCL::signal(
     int64_t peerRank,
     bool asyncOp,
     const ::c10d::SignalOptions& opts) {
+  auto commUseGuard = pg_->acquireCommUse();
   checkWindowAndThrow();
   c10::cuda::CUDAGuard device_guard(pg_->getDevice());
   cudaStream_t stream = pg_->getOperationStream(asyncOp);
@@ -160,6 +163,7 @@ c10::intrusive_ptr<::c10d::Work> WindowNCCL::wait_signal(
     int64_t peerRank,
     bool asyncOp,
     const ::c10d::WaitSignalOptions& opts) {
+  auto commUseGuard = pg_->acquireCommUse();
   checkWindowAndThrow();
   c10::cuda::CUDAGuard device_guard(pg_->getDevice());
   cudaStream_t stream = pg_->getOperationStream(asyncOp);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192281
* #192280
* #192279
* #192278
* #192277
* #192276
* #192275
* __->__ #192274
* #192273

nccl2 allowed lazy initialization, collectives, suspend/resume, finalize, abort, split, shrink, and window operations to race on the same communicator. Two host threads could also bootstrap duplicate communicators and watchdogs. Publish initialization state atomically, serialize one-time initialization, take shared use guards around operation launch, and take exclusive guards around lifecycle transitions. Suspend now rejects pending work and active coalescing batches instead of changing communicator state underneath them.

Test Plan:

```bash
BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_XNNPACK=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_DISTRIBUTED=1 USE_CUDA=1 .venv/bin/pip install -e . -v --no-build-isolation
```

```bash
VIRTUAL_ENV=.venv uv run --no-project python test/distributed/test_c10d_nccl2.py -k concurrent_lazy_initialization
VIRTUAL_ENV=.venv uv run --no-project python test/distributed/test_c10d_suspend_resume.py -k NCCL2
```

Authored with an AI assistant.