### PR TITLE
[c10d][nccl2] Make work and graph lifetimes safe

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -4,6 +4,7 @@
 
 import concurrent.futures
 import ctypes
+import gc
 import os
 import subprocess
 import sys
@@ -27,6 +28,7 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     run_tests,
     TEST_CUDA,
+    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -44,9 +46,10 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
 
-    def setUp(self) -> None:
-        super().setUp()
-        torch.cuda.set_device(self.rank)
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        torch.cuda.set_device(rank)
+        super()._init_pg(rank, world_size, rdvz_file)
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
@@ -62,6 +65,53 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
 
         torch.cuda.synchronize()
         time.sleep(2)
+        dist.barrier()
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_work_outlives_process_group(self) -> None:
+        group = dist.new_group(ranks=list(range(self.world_size)), backend="nccl2")
+        tensor = torch.tensor([self.rank + 1], device=self.device)
+        work = dist.all_reduce(tensor, group=group, async_op=True)
+        work.wait()
+        torch.cuda.synchronize(self.device)
+        self.assertEqual(
+            tensor,
+            torch.tensor([sum(range(1, self.world_size + 1))], device=self.device),
+        )
+
+        dist.destroy_process_group(group)
+        del group
+        gc.collect()
+        self.assertTrue(work.is_completed())
+        del work
+        gc.collect()
+        dist.barrier()
+
+    @unittest.skipIf(TEST_WITH_ROCM, "RCCL graph capture is not supported")
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_live_cuda_graph_blocks_process_group_destruction(self) -> None:
+        group = dist.new_group(ranks=list(range(self.world_size)), backend="nccl2")
+        tensor = torch.tensor([self.rank + 1], device=self.device)
+        dist.all_reduce(torch.ones(1, device=self.device), group=group)
+        torch.cuda.synchronize(self.device)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            dist.all_reduce(tensor, group=group)
+        graph.replay()
+        torch.cuda.synchronize(self.device)
+
+        with self.assertRaisesRegex(RuntimeError, "captured CUDA graph is alive"):
+            dist.destroy_process_group(group)
+        graph.replay()
+        torch.cuda.synchronize(self.device)
+        del graph
+        gc.collect()
+        dist.destroy_process_group(group)
+        del group
+        gc.collect()
         dist.barrier()
 
     @requires_nccl()
@@ -179,9 +229,10 @@ class _ProcessGroupNCCL2OptionsTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
 
-    def setUp(self) -> None:
-        super().setUp()
-        torch.cuda.set_device(self.rank)
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        torch.cuda.set_device(rank)
+        super()._init_pg(rank, world_size, rdvz_file)
 
     def _check_all_reduce(self) -> None:
         t = torch.full((4,), float(self.rank), device=self.device)
@@ -197,6 +248,7 @@ class ProcessGroupNCCL2EagerNewGroupTest(_ProcessGroupNCCL2OptionsTest):
     def _init_pg(cls, rank, world_size, rdvz_file) -> None:
         if rdvz_file is None:
             raise AssertionError("Expected rdvz_file to not be None")
+        torch.cuda.set_device(rank)
         os.environ["LOCAL_RANK"] = str(rank)
         store = dist.FileStore(rdvz_file, world_size)
         dist.init_process_group(
@@ -379,9 +431,10 @@ class _ProcessGroupNCCL2SubgroupTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
 
-    def setUp(self) -> None:
-        super().setUp()
-        torch.cuda.set_device(self.rank)
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        torch.cuda.set_device(rank)
+        super()._init_pg(rank, world_size, rdvz_file)
 
     def _new_subgroup(self, timeout=timedelta(seconds=60)):
         return dist.new_group(
@@ -476,12 +529,9 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
 
-    def setUp(self) -> None:
-        super().setUp()
-        torch.cuda.set_device(self.rank)
-
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        torch.cuda.set_device(rank)
         torch._C._accelerator_setAllocatorSettings("expandable_segments:True")
         super()._init_pg(rank, world_size, rdvz_file)
 
@@ -697,12 +747,9 @@ class _DeterministicNVLSTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device("cuda", self.rank)
 
-    def setUp(self) -> None:
-        super().setUp()
-        torch.cuda.set_device(self.rank)
-
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file) -> None:
+        torch.cuda.set_device(rank)
         if cls.preset_nccl_algo is not None:
             os.environ["NCCL_ALGO"] = cls.preset_nccl_algo
         else:

--- a/test/distributed/test_c10d_suspend_resume.py
+++ b/test/distributed/test_c10d_suspend_resume.py
@@ -6,6 +6,7 @@
 # 2.29.7+), but other backends can be enabled by extending
 # SUSPEND_RESUME_BACKENDS.
 
+import gc
 import os
 import sys
 import unittest
@@ -160,6 +161,24 @@ class AbstractSuspendResumeTest:
                 self.backend.suspend()
         finally:
             self.backend._end_coalescing().wait()
+
+    def test_suspend_rejects_live_cuda_graph(self):
+        if self.backend_name != "nccl2":
+            self.skipTest("nccl2 captured-work lifecycle")
+        if torch.version.hip is not None:
+            self.skipTest("RCCL graph capture is not supported")
+        self._init_pg()
+        tensor = torch.ones(1, device=self.device)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            dist.all_reduce(tensor)
+
+        with self.assertRaisesRegex(RuntimeError, "captured CUDA graph is alive"):
+            self.backend.suspend()
+        del graph
+        gc.collect()
+        self.backend.suspend()
+        self.backend.resume()
 
 
 def _make_suspend_resume_test_class(backend_name, device_type, create_pair_channel):

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -103,7 +103,8 @@ void waitForNcclChildComm(
         " timed out after ",
         timeout.count(),
         " ms");
-    return std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        deadline - now);
   };
   try {
     waitForNcclCompletion(
@@ -132,11 +133,7 @@ void waitForNcclChildComm(
     const auto abortComm = [&](ncclComm_t comm, std::string_view description) {
       try {
         waitForNcclCompletion(
-            nccl_api,
-            comm,
-            nccl_api.commAbort(comm),
-            timeout,
-            description);
+            nccl_api, comm, nccl_api.commAbort(comm), timeout, description);
       } catch (const std::exception& error) {
         LOG(ERROR) << error.what();
       }
@@ -171,6 +168,8 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
         << " was not finalized before destruction. "
         << "This may indicate a resource leak. Please call finalize() explicitly.";
 
+    work_state_->comm_state = CommState::ERROR;
+
     // Stop the watchdog so it cannot access this object after destruction. It
     // may be the caller (garbageCollect can pop a work item whose destruction
     // releases the last reference to this comm), which stopWatchdog handles.
@@ -204,6 +203,7 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
   // We need to detach the memory hook in case finalize is not called,
   // so that we don't encounter a memory corruption.
   detachMemoryHook();
+  work_state_->closeEventPool();
 }
 
 void ProcessGroupNCCL::init(at::Device device) {
@@ -273,8 +273,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  max_event_pool_size_ = kDefaultMaxEventPoolSize;
-
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,
@@ -287,9 +285,7 @@ void ProcessGroupNCCL::initNcclResources() {
       nccl_api_->commCount(nccl_comm_, &comm_size_),
       "NCCL Count failed");
 
-  if (!shutdown_) {
-    timeout_thread_ = std::thread(&ProcessGroupNCCL::timeoutWatchdog, this);
-  }
+  startWatchdog();
 
   attachMemoryHook();
   publishComm();
@@ -384,7 +380,7 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::split(
         ncclOpts->timeout,
         "NCCL split failed");
   } catch (...) {
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     nccl_comm_ = nullptr;
     throw;
   }
@@ -418,7 +414,7 @@ void ProcessGroupNCCL::abort() {
   }
   std::unique_lock lifecycleLock(comm_lifecycle_mutex_);
   if (options_c10d_->enable_reconfigure) {
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     revokeNcclComm();
   } else {
     // Stop the watchdog before publishing the error: this failure is one the
@@ -427,7 +423,7 @@ void ProcessGroupNCCL::abort() {
     // the comm is revoked rather than destroyed and the watchdog is needed
     // again after reconfigure(). The error is still published before the
     // teardown, so work in flight reports it instead of completing.
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     abortNcclComm();
   }
 }
@@ -441,6 +437,10 @@ void ProcessGroupNCCL::suspend() {
       !coalescing_batch_.has_value(),
       "ProcessGroupNCCL communicator cannot be suspended while a coalescing "
       "batch is active");
+  TORCH_CHECK(
+      !hasCapturedGraphs(),
+      "ProcessGroupNCCL communicator cannot be suspended while a captured "
+      "CUDA graph is alive");
   TORCH_CHECK(
       workq_.garbageCollect() == WorkNCCL::WorkStatus::COMPLETED,
       "ProcessGroupNCCL communicator cannot be suspended while work is "
@@ -490,7 +490,7 @@ std::unordered_map<std::string, uint64_t> ProcessGroupNCCL::getMemoryStats() {
 }
 
 ::c10d::ErrorType ProcessGroupNCCL::getError() {
-  switch (comm_state_.load()) {
+  switch (work_state_->comm_state.load()) {
     case CommState::TIMEOUT:
       return ::c10d::ErrorType::TIMEOUT;
     case CommState::ERROR:
@@ -511,6 +511,12 @@ void ProcessGroupNCCL::finalize() {
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("ProcessGroupNCCL already finalized");
   }
+  if (hasCapturedGraphs()) {
+    startWatchdog();
+    throw std::runtime_error(
+        "ProcessGroupNCCL cannot be finalized while a captured CUDA graph is "
+        "alive");
+  }
   init_state_ = InitializationState::FINALIZED;
 
   // Wait for all pending work objects to complete and get final status
@@ -522,13 +528,13 @@ void ProcessGroupNCCL::finalize() {
         "WorkQ finalize returned in progress or not started state");
   }
 
-  // Update comm_state_ based on the work status
+  // Update communicator state based on the work status.
   if (work_status == WorkNCCL::WorkStatus::TIMEDOUT) {
-    comm_state_ = CommState::TIMEOUT;
+    work_state_->comm_state = CommState::TIMEOUT;
     abortNcclComm();
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     if (!nccl_comm_) {
       throw std::runtime_error(
           "NCCL communicator was aborted after a previous error");
@@ -545,13 +551,7 @@ void ProcessGroupNCCL::finalize() {
     throw std::move(ncclException);
   }
 
-  // Clean up event pool
-  {
-    std::lock_guard<std::mutex> lock(event_pool_mutex_);
-    while (!event_pool_.empty()) {
-      event_pool_.pop();
-    }
-  }
+  work_state_->closeEventPool();
 
   barrier_buffer_.clear();
 
@@ -587,6 +587,14 @@ void ProcessGroupNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
+}
+
+void ProcessGroupNCCL::startWatchdog() {
+  if (timeout_thread_.joinable()) {
+    return;
+  }
+  shutdown_ = false;
+  timeout_thread_ = std::thread(&ProcessGroupNCCL::timeoutWatchdog, this);
 }
 
 void ProcessGroupNCCL::stopWatchdog() {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -278,6 +278,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   void suspend() override;
   void resume() override;
   std::unordered_map<std::string, uint64_t> getMemoryStats() override;
+  bool hasCapturedGraphs() const;
 
   // Fault tolerance / reconfigure API (see Backend.hpp). The handle encodes
   // "nccl2:<rank>:<uuid>:<store host:port>"; reconfigure() tears down the
@@ -349,21 +350,13 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Underlying host ncclComm_t as an opaque integer pointer.
   int64_t getCommPtr() const;
   bool collectivesTimingEnabled() const {
-    return timing_enabled_.load();
+    return work_state_->timing_enabled.load();
   }
 
   friend class WorkNCCL;
   friend class WindowNCCL;
 
  protected:
-  // Events are pooled per timing mode: an event created with timing disabled
-  // cannot serve a work that needs elapsed_time(), so `timing_enabled` must
-  // describe the work the event is taken for / returned from.
-  [[nodiscard]] std::unique_ptr<at::cuda::CUDAEvent> getEvent(
-      bool timing_enabled);
-  void returnEvent(
-      std::unique_ptr<at::cuda::CUDAEvent> event,
-      bool timing_enabled);
   void waitForNcclOperation(
       ncclResult_t status,
       std::chrono::milliseconds timeout,
@@ -379,18 +372,12 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // reconfigurable mode. `reason` is logged after "Aborting process on rank N
   // due to ", so it must describe the actual trigger.
   void abortProcess(const std::string& reason);
+  void startWatchdog();
   // Signals the watchdog thread to exit and reaps it. Detaches instead of
   // joining when called from the watchdog thread itself.
   void stopWatchdog();
   void revokeNcclComm();
 
-  enum class CommState {
-    NORMAL,
-    ERROR,
-    TIMEOUT,
-  };
-
-  std::atomic<CommState> comm_state_{CommState::NORMAL};
   std::atomic<bool> revoked_{false};
 
   ncclDataType_t getNcclDataType(const at::Tensor& tensor);
@@ -592,7 +579,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // NOTE: the rank is stored in the inherited c10d::Backend::rank_ (set in the
   // ctor and refreshed from NCCL in initNcclResources). The ported engine code
   // reads/writes `rank_` directly, which resolves to that protected member.
-  size_t max_event_pool_size_{};
   std::optional<at::cuda::CUDAStream> internal_stream_;
   std::optional<at::cuda::CUDAEvent> dependency_event_;
   at::DataPtr barrier_buffer_;
@@ -612,12 +598,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   uint64_t sequence_number_{0};
 
   std::shared_ptr<NcclApi> nccl_api_;
-
-  std::queue<std::unique_ptr<at::cuda::CUDAEvent>> event_pool_;
-  std::mutex event_pool_mutex_;
-  // Set by enableCollectivesTiming(); mutated under event_pool_mutex_ so the
-  // pool never holds events whose timing mode disagrees with it.
-  std::atomic<bool> timing_enabled_{false};
+  std::shared_ptr<WorkNCCLState> work_state_;
 
   WorkNCCLQueue workq_;
 
@@ -636,10 +617,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   const bool abort_process_on_timeout_or_error_;
 
   c10::intrusive_ptr<Options> options_c10d_;
-
-  std::mutex ephemeral_timeout_mutex_;
-  std::chrono::milliseconds ephemeral_timeout_active_{0};
-  std::chrono::milliseconds ephemeral_timeout_inflight_{0};
 
   // Identifies the current communicator generation in the reconfigure regime;
   // -1 until the first reconfigure(). Baked into the reconfigure handle so
@@ -677,17 +654,23 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::optional<BatchSendRecv> coalescing_batch_;
   c10::intrusive_ptr<WorkNCCL> coalesced_work_;
 
-  std::unordered_map<
-      unsigned long long,
-      std::vector<c10::intrusive_ptr<WorkNCCL>>>
-      graph_capture_work_refs_;
-  std::mutex graph_capture_work_mutex_;
+  struct GraphCaptureState {
+    std::unordered_map<
+        unsigned long long,
+        std::vector<c10::intrusive_ptr<WorkNCCL>>>
+        work_refs;
+    std::mutex mutex;
+  };
+  std::shared_ptr<GraphCaptureState> graph_capture_state_{
+      std::make_shared<GraphCaptureState>()};
 
   struct GraphCleanupData {
-    ProcessGroupNCCL* comm;
+    std::shared_ptr<GraphCaptureState> state;
     unsigned long long graph_id;
-    GraphCleanupData(ProcessGroupNCCL* comm_, unsigned long long id)
-        : comm(comm_), graph_id(id) {}
+    GraphCleanupData(
+        std::shared_ptr<GraphCaptureState> state_,
+        unsigned long long id)
+        : state(std::move(state_)), graph_id(id) {}
   };
   // NOTE: no CUDART_CB here -- it is empty on Linux CUDA and undefined under
   // HIP/ROCm; the plain void(void*) signature matches cuda/hipHostFn_t.

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -88,6 +88,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
+      work_state_(std::make_shared<WorkNCCLState>(kDefaultMaxEventPoolSize)),
       abort_process_on_timeout_or_error_(
           SHOULD_TEAR_DOWN(static_cast<::c10d::ErrorHandlingMode>(getCvarInt(
               ::c10d::TORCH_NCCL_ASYNC_ERROR_HANDLING,
@@ -175,13 +176,21 @@ void ProcessGroupNCCL::unregisterAbortHook(int64_t hook_id) {
 
 void ProcessGroupNCCL::shutdown() {
   // Called by destroy_process_group(). Drain in-flight work and close the comm
-  // gracefully. Idempotent: finalize-on-already-finalized throws, so swallow.
+  // gracefully. A live CUDA graph must retain the communicator until its graph
+  // object is released; ncclCommDestroy otherwise blocks indefinitely.
   if (init_state_ != InitializationState::INITIALIZED) {
     return;
   }
+  TORCH_CHECK(
+      !hasCapturedGraphs(),
+      "ProcessGroupNCCL cannot be destroyed while a captured CUDA graph is "
+      "alive");
   try {
     finalize();
   } catch (const std::exception& e) {
+    if (hasCapturedGraphs()) {
+      throw;
+    }
     TC_LOG(WARNING) << "ProcessGroupNCCL::shutdown: finalize() raised, "
                     << "treating as no-op: " << e.what();
   }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -243,10 +243,10 @@ void ProcessGroupNCCL::checkWorkQueue() {
 
   switch (status) {
     case WorkNCCL::WorkStatus::TIMEDOUT:
-      comm_state_ = CommState::TIMEOUT;
+      work_state_->comm_state = CommState::TIMEOUT;
       break;
     case WorkNCCL::WorkStatus::ERROR:
-      comm_state_ = CommState::ERROR;
+      work_state_->comm_state = CommState::ERROR;
       break;
     default:
       // For COMPLETED, NOT_STARTED, and INPROGRESS, no state change needed
@@ -294,19 +294,19 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
         break;
       }
       // With abort_process_on_timeout_or_error disabled this is a no-op and
-      // the loop keeps running: comm_state_ stays TIMEOUT/ERROR so getError()
+      // the loop keeps running: the state stays TIMEOUT/ERROR so getError()
       // reports it, and the next collective throws from
       // checkAndAbortIfTimedOutOrError().
-      if (comm_state_ != CommState::NORMAL) {
+      if (work_state_->comm_state != CommState::NORMAL) {
         abortProcess(
-            comm_state_ == CommState::TIMEOUT
+            work_state_->comm_state == CommState::TIMEOUT
                 ? "timeout - timeout watchdog detected operation timeout"
                 : "error - timeout watchdog detected operation error");
       }
 
       // Detect a communicator-level async error while the comm is still
       // healthy.
-      if (comm_state_ == CommState::NORMAL) {
+      if (work_state_->comm_state == CommState::NORMAL) {
         ncclResult_t asyncErr{};
         NCCL_CHECK(
             nccl_api_,
@@ -314,7 +314,7 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
             nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
             "failed to get async error");
         if (asyncErr != ncclSuccess && asyncErr != ncclInProgress) {
-          comm_state_ = CommState::ERROR;
+          work_state_->comm_state = CommState::ERROR;
           if (!options_c10d_->enable_reconfigure) {
             TC_LOG(ERROR, this) << "nccl hit async error on rank " << rank_
                                 << ": " << ncclGetErrorString(asyncErr);
@@ -342,12 +342,13 @@ void ProcessGroupNCCL::timeoutWatchdog() noexcept {
       // checkAndAbortIfTimedOutOrError(); isAborted() then reports the revoked
       // state to the caller. revokeNcclComm() is idempotent and the revoked_
       // check keeps the watchdog from logging every iteration.
-      if (comm_state_ != CommState::NORMAL &&
+      if (work_state_->comm_state != CommState::NORMAL &&
           options_c10d_->enable_reconfigure && !revoked_.load()) {
         TC_LOG(ERROR, this)
             << "Revoking communicator on rank " << rank_
             << " - watchdog detected "
-            << (comm_state_ == CommState::TIMEOUT ? "timeout" : "error")
+            << (work_state_->comm_state == CommState::TIMEOUT ? "timeout"
+                                                              : "error")
             << " (reconfigurable mode)";
         revokeNcclComm();
       }
@@ -385,7 +386,7 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
   // First, check work queue status
   checkWorkQueue();
 
-  if (comm_state_ == CommState::TIMEOUT) {
+  if (work_state_->comm_state == CommState::TIMEOUT) {
     if (options_c10d_->enable_reconfigure) {
       revokeNcclComm();
       throw std::runtime_error("NCCL operation timed out");
@@ -394,7 +395,7 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       abortProcess("timeout - collective operation timed out");
       throw std::runtime_error("NCCL operation timed out");
     }
-  } else if (comm_state_ == CommState::ERROR) {
+  } else if (work_state_->comm_state == CommState::ERROR) {
     // With abort_process_on_timeout_or_error disabled the watchdog aborts the
     // communicator on an async error and lets the process live, so a later
     // collective can reach here with no communicator left to query.
@@ -433,8 +434,15 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::createWork(
     const std::vector<at::Tensor>& inputTensors) {
   // Only create the work object without enqueuing it
   auto [workTimeout, ownedTimeout] = applyEphemeralTimeout(timeout);
-  auto work =
-      c10::make_intrusive<WorkNCCL>(this, stream, workTimeout, inputTensors);
+  auto work = c10::make_intrusive<WorkNCCL>(
+      work_state_,
+      device_,
+      rank_,
+      comm_size_,
+      name_,
+      stream,
+      workTimeout,
+      inputTensors);
   work->setOwnedEphemeralTimeout(ownedTimeout);
   work->setSequenceNumber(sequence_number_);
   return work;
@@ -446,8 +454,15 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::createWork(
     const at::Tensor& inputTensor) {
   // Single-tensor overload to avoid vector allocation
   auto [workTimeout, ownedTimeout] = applyEphemeralTimeout(timeout);
-  auto work =
-      c10::make_intrusive<WorkNCCL>(this, stream, workTimeout, inputTensor);
+  auto work = c10::make_intrusive<WorkNCCL>(
+      work_state_,
+      device_,
+      rank_,
+      comm_size_,
+      name_,
+      stream,
+      workTimeout,
+      inputTensor);
   work->setOwnedEphemeralTimeout(ownedTimeout);
   work->setSequenceNumber(sequence_number_);
   return work;
@@ -455,24 +470,17 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::createWork(
 
 std::pair<std::chrono::milliseconds, std::chrono::milliseconds>
 ProcessGroupNCCL::applyEphemeralTimeout(std::chrono::milliseconds timeout) {
-  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
-  timeout += ephemeral_timeout_active_;
-  auto ownedTimeout = ephemeral_timeout_active_ - ephemeral_timeout_inflight_;
-  ephemeral_timeout_inflight_ = ephemeral_timeout_active_;
-  return {timeout, ownedTimeout};
+  return work_state_->applyEphemeralTimeout(timeout);
 }
 
 void ProcessGroupNCCL::releaseEphemeralTimeout(
     std::chrono::milliseconds timeout) {
-  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
-  ephemeral_timeout_active_ -= timeout;
-  ephemeral_timeout_inflight_ -= timeout;
+  work_state_->releaseEphemeralTimeout(timeout);
 }
 
 void ProcessGroupNCCL::addEphemeralTimeout(
     const std::chrono::milliseconds& timeout) {
-  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
-  ephemeral_timeout_active_ += timeout;
+  work_state_->addEphemeralTimeout(timeout);
 }
 
 void ProcessGroupNCCL::enqueueWork(
@@ -483,20 +491,21 @@ void ProcessGroupNCCL::enqueueWork(
   if (getGraphCaptureMode()) {
     auto capture_info = c10::cuda::captureInfoMayInitCtx(stream);
     if (capture_info.status == c10::cuda::CaptureStatus::Active) {
-      std::lock_guard<std::mutex> lock(graph_capture_work_mutex_);
-
-      // Check if this is the first work object for this graph
-      bool is_first_work = graph_capture_work_refs_[capture_info.id].empty();
-
-      // Add work reference to the per-graph container
-      graph_capture_work_refs_[capture_info.id].push_back(work);
+      bool is_first_work = false;
+      {
+        std::lock_guard<std::mutex> lock(graph_capture_state_->mutex);
+        is_first_work =
+            graph_capture_state_->work_refs[capture_info.id].empty();
+        graph_capture_state_->work_refs[capture_info.id].push_back(work);
+      }
 
       // If this is the first work object for this graph, set up automatic
       // cleanup
       if (is_first_work) {
         c10::cuda::retainGraphUserObject(
             capture_info.graph,
-            std::make_unique<GraphCleanupData>(this, capture_info.id),
+            std::make_unique<GraphCleanupData>(
+                graph_capture_state_, capture_info.id),
             graphCleanupCallback);
       }
     }
@@ -509,14 +518,16 @@ void ProcessGroupNCCL::enqueueWork(
 // Static callback function for CUDA user object cleanup
 void ProcessGroupNCCL::graphCleanupCallback(void* userData) {
   auto* cleanup_data = static_cast<GraphCleanupData*>(userData);
-  if (cleanup_data == nullptr || cleanup_data->comm == nullptr) {
+  if (cleanup_data == nullptr || cleanup_data->state == nullptr) {
     throw std::runtime_error("Invalid cleanup data");
   }
 
   // Clear the work references for this graph
-  std::lock_guard<std::mutex> lock(
-      cleanup_data->comm->graph_capture_work_mutex_);
-  cleanup_data->comm->graph_capture_work_refs_.erase(cleanup_data->graph_id);
+  auto state = cleanup_data->state;
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->work_refs.erase(cleanup_data->graph_id);
+  }
 
   // Clean up the cleanup data itself
   delete cleanup_data;
@@ -563,40 +574,8 @@ void ProcessGroupNCCL::checkTensorsDevice(
   }
 }
 
-// Protected methods (not in the private section of the header)
-std::unique_ptr<at::cuda::CUDAEvent> ProcessGroupNCCL::getEvent(
-    bool timing_enabled) {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-
-  if (timing_enabled == timing_enabled_.load() && !event_pool_.empty()) {
-    auto event = std::move(event_pool_.front());
-    event_pool_.pop();
-    return event;
-  }
-
-  return std::make_unique<at::cuda::CUDAEvent>(
-      timing_enabled ? cudaEventDefault : cudaEventDisableTiming);
-}
-
-void ProcessGroupNCCL::returnEvent(
-    std::unique_ptr<at::cuda::CUDAEvent> event,
-    bool timing_enabled) {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-
-  if (timing_enabled == timing_enabled_.load() &&
-      event_pool_.size() < max_event_pool_size_) {
-    event_pool_.push(std::move(event));
-  }
-}
-
 void ProcessGroupNCCL::enableCollectivesTiming() {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-  if (timing_enabled_.exchange(true)) {
-    return;
-  }
-  // Pooled events were created with timing disabled and cannot serve
-  // getDuration(); drop them so later works get timing-capable events.
-  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+  work_state_->enableCollectivesTiming();
 }
 
 void ProcessGroupNCCL::attachMemoryHook() {
@@ -823,6 +802,11 @@ void ProcessGroupNCCL::deregisterMemPool(at::cuda::MemPool* pool) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     deregister_address(reinterpret_cast<void*>(segment.address));
   }
+}
+
+bool ProcessGroupNCCL::hasCapturedGraphs() const {
+  std::lock_guard<std::mutex> lock(graph_capture_state_->mutex);
+  return !graph_capture_state_->work_refs.empty();
 }
 
 } // namespace c10d::nccl2

--- a/torch/csrc/distributed/c10d/nccl2/ReconfigureNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ReconfigureNCCL.cpp
@@ -127,6 +127,10 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reconfigure(
       "ProcessGroupNCCL communicator is suspended; call resume() before "
       "reconfigure()");
   TORCH_CHECK(
+      !hasCapturedGraphs(),
+      "ProcessGroupNCCL communicator cannot be reconfigured while a captured "
+      "CUDA graph is alive");
+  TORCH_CHECK(
       init_state_ != InitializationState::FINALIZED,
       "ProcessGroupNCCL has been finalized");
   auto handles = getOrderedReconfigureHandles(opts);
@@ -209,7 +213,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reconfigure(
     nccl_api_ = std::make_shared<DefaultNcclApi>();
   }
 
-  comm_state_ = CommState::NORMAL;
+  work_state_->comm_state = CommState::NORMAL;
   shutdown_ = false;
   revoked_ = false;
 
@@ -293,7 +297,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reconfigure(
         LOG(ERROR) << e.what();
       }
     }
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     nccl_comm_ = nullptr;
     init_state_ = InitializationState::UNINITIALIZED;
     throw;

--- a/torch/csrc/distributed/c10d/nccl2/ShrinkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ShrinkNCCL.cpp
@@ -100,7 +100,7 @@ c10::intrusive_ptr<::c10d::Backend> ProcessGroupNCCL::shrink(
         childOptions->timeout,
         "NCCL commShrink failed");
   } catch (...) {
-    comm_state_ = CommState::ERROR;
+    work_state_->comm_state = CommState::ERROR;
     nccl_comm_ = nullptr;
     throw;
   }

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
@@ -19,48 +19,116 @@
 
 namespace c10d::nccl2 {
 
+std::unique_ptr<at::cuda::CUDAEvent> WorkNCCLState::getEvent(
+    bool event_timing_enabled) {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (event_pool_open_ && event_timing_enabled == timing_enabled.load() &&
+      !event_pool_.empty()) {
+    auto event = std::move(event_pool_.front());
+    event_pool_.pop();
+    return event;
+  }
+  return std::make_unique<at::cuda::CUDAEvent>(
+      event_timing_enabled ? cudaEventDefault : cudaEventDisableTiming);
+}
+
+void WorkNCCLState::returnEvent(
+    std::unique_ptr<at::cuda::CUDAEvent> event,
+    bool event_timing_enabled) {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (event_pool_open_ && event_timing_enabled == timing_enabled.load() &&
+      event_pool_.size() < max_event_pool_size_) {
+    event_pool_.push(std::move(event));
+  }
+}
+
+void WorkNCCLState::enableCollectivesTiming() {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (timing_enabled.exchange(true)) {
+    return;
+  }
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+}
+
+void WorkNCCLState::closeEventPool() {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  event_pool_open_ = false;
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+}
+
+std::pair<std::chrono::milliseconds, std::chrono::milliseconds> WorkNCCLState::
+    applyEphemeralTimeout(std::chrono::milliseconds timeout) {
+  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
+  timeout += ephemeral_timeout_active_;
+  auto owned_timeout = ephemeral_timeout_active_ - ephemeral_timeout_inflight_;
+  ephemeral_timeout_inflight_ = ephemeral_timeout_active_;
+  return {timeout, owned_timeout};
+}
+
+void WorkNCCLState::releaseEphemeralTimeout(std::chrono::milliseconds timeout) {
+  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
+  ephemeral_timeout_active_ -= timeout;
+  ephemeral_timeout_inflight_ -= timeout;
+}
+
+void WorkNCCLState::addEphemeralTimeout(std::chrono::milliseconds timeout) {
+  std::lock_guard<std::mutex> lock(ephemeral_timeout_mutex_);
+  ephemeral_timeout_active_ += timeout;
+}
+
 WorkNCCL::WorkNCCL(
-    ProcessGroupNCCL* comm,
+    std::shared_ptr<WorkNCCLState> state,
+    at::Device device,
+    int rank,
+    int size,
+    std::string comm_name,
     cudaStream_t stream,
     std::chrono::milliseconds timeout_ms,
     const std::vector<at::Tensor>& inputTensors)
     : inputTensors_(inputTensors),
-      comm_(comm),
-      stream_(
-          at::cuda::getStreamFromExternal(stream, comm->getDevice().index())),
+      state_(std::move(state)),
+      device_(device),
+      rank_(rank),
+      comm_size_(size),
+      comm_name_(std::move(comm_name)),
+      stream_(at::cuda::getStreamFromExternal(stream, device_.index())),
       work_start_time_(std::chrono::steady_clock::now()),
       timeout_ms_(timeout_ms),
-      timing_enabled_(comm->collectivesTimingEnabled()) {
-  start_event_ = comm_->getEvent(timing_enabled_);
-  end_event_ = comm_->getEvent(timing_enabled_);
+      timing_enabled_(state_->timing_enabled.load()) {
+  start_event_ = state_->getEvent(timing_enabled_);
+  end_event_ = state_->getEvent(timing_enabled_);
   future_work_result_ =
       c10::make_intrusive<c10::ivalue::Future>(c10::AnyEnumType::get());
 }
 
 WorkNCCL::WorkNCCL(
-    ProcessGroupNCCL* comm,
+    std::shared_ptr<WorkNCCLState> state,
+    at::Device device,
+    int rank,
+    int size,
+    std::string comm_name,
     cudaStream_t stream,
     std::chrono::milliseconds timeout_ms,
     at::Tensor inputTensor)
     : inputTensor_(std::move(inputTensor)),
-      comm_(comm),
-      stream_(
-          at::cuda::getStreamFromExternal(stream, comm->getDevice().index())),
+      state_(std::move(state)),
+      device_(device),
+      rank_(rank),
+      comm_size_(size),
+      comm_name_(std::move(comm_name)),
+      stream_(at::cuda::getStreamFromExternal(stream, device_.index())),
       work_start_time_(std::chrono::steady_clock::now()),
       timeout_ms_(timeout_ms),
-      timing_enabled_(comm->collectivesTimingEnabled()) {
-  start_event_ = comm_->getEvent(timing_enabled_);
-  end_event_ = comm_->getEvent(timing_enabled_);
+      timing_enabled_(state_->timing_enabled.load()) {
+  start_event_ = state_->getEvent(timing_enabled_);
+  end_event_ = state_->getEvent(timing_enabled_);
   future_work_result_ =
       c10::make_intrusive<c10::ivalue::Future>(c10::AnyEnumType::get());
 }
 
 WorkNCCL::~WorkNCCL() {
-  if (!comm_) {
-    return;
-  }
-  comm_->returnEvent(std::move(start_event_), timing_enabled_);
-  comm_->returnEvent(std::move(end_event_), timing_enabled_);
+  state_->returnEvent(std::move(start_event_), timing_enabled_);
+  state_->returnEvent(std::move(end_event_), timing_enabled_);
 }
 
 void WorkNCCL::recordFunctionStart(std::string_view coll_name) {
@@ -137,12 +205,12 @@ WorkNCCL::WorkStatus WorkNCCL::checkStatus(
     return current;
   }
 
-  auto comm_error = comm_->getError();
-  if (comm_error == ErrorType::TIMEOUT) {
+  auto comm_state = state_->comm_state.load();
+  if (comm_state == CommState::TIMEOUT) {
     setTerminalStatus(WorkStatus::TIMEDOUT);
     return status();
   }
-  if (comm_error != ErrorType::SUCCESS) {
+  if (comm_state != CommState::NORMAL) {
     setTerminalStatus(WorkStatus::ERROR);
     return status();
   }
@@ -155,8 +223,8 @@ WorkNCCL::WorkStatus WorkNCCL::checkStatus(
             expected, WorkStatus::INPROGRESS, std::memory_order_relaxed);
       }
     } catch (const std::exception& e) {
-      TC_LOG(ERROR, comm_) << "CUDA error during start event query: "
-                           << e.what();
+      LOG(ERROR) << "[TC][rank " << rank_ << "][comm " << comm_name_
+                 << "] CUDA error during start event query: " << e.what();
       setTerminalStatus(WorkStatus::ERROR);
     }
   }
@@ -170,12 +238,13 @@ WorkNCCL::WorkStatus WorkNCCL::checkStatus(
         if (setTerminalStatus(WorkStatus::COMPLETED) &&
             owned_ephemeral_timeout_.count() > 0 &&
             !ephemeral_timeout_released_.exchange(true)) {
-          comm_->releaseEphemeralTimeout(owned_ephemeral_timeout_);
+          state_->releaseEphemeralTimeout(owned_ephemeral_timeout_);
         }
         return status();
       }
     } catch (const std::exception& e) {
-      TC_LOG(ERROR, comm_) << "CUDA error during end event query: " << e.what();
+      LOG(ERROR) << "[TC][rank " << rank_ << "][comm " << comm_name_
+                 << "] CUDA error during end event query: " << e.what();
       setTerminalStatus(WorkStatus::ERROR);
       return status();
     }
@@ -185,8 +254,8 @@ WorkNCCL::WorkStatus WorkNCCL::checkStatus(
       std::chrono::steady_clock::now() - work_start_time_);
   auto work_timeout = timeout.value_or(timeout_ms_);
   if (elapsed >= work_timeout) {
-    TC_LOG(ERROR, comm_) << "Operation timed out after " << elapsed.count()
-                         << " ms";
+    LOG(ERROR) << "[TC][rank " << rank_ << "][comm " << comm_name_
+               << "] Operation timed out after " << elapsed.count() << " ms";
     setTerminalStatus(WorkStatus::TIMEDOUT);
   }
   return status();
@@ -210,16 +279,11 @@ void WorkNCCL::synchronizeInternal() {
     return;
   }
 
-  TracingGuard tracingGuard(
-      std::string(comm_->getCommName()),
-      comm_->getSize(),
-      "wait",
-      comm_->getRank());
+  TracingGuard tracingGuard(comm_name_, comm_size_, "wait", rank_);
 
   // Make the current stream wait for the end event recorded on the work's
   // stream, ordering subsequent current-stream ops after this collective.
-  auto current_stream =
-      at::cuda::getCurrentCUDAStream(comm_->getDevice().index());
+  auto current_stream = at::cuda::getCurrentCUDAStream(device_.index());
   end_event_->block(current_stream);
 
   // For a synchronous barrier, mirror stock ProcessGroupNCCL by host-blocking
@@ -245,8 +309,7 @@ void WorkNCCL::synchronizeInternal() {
 bool WorkNCCL::wait(std::chrono::milliseconds timeout) {
   synchronize();
 
-  auto current_stream =
-      at::cuda::getCurrentCUDAStream(comm_->getDevice().index());
+  auto current_stream = at::cuda::getCurrentCUDAStream(device_.index());
   if (timeout == kNoTimeout &&
       c10::cuda::isStreamCapturingMayInitCtx(current_stream)) {
     WorkStatus current = status();

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
@@ -10,8 +10,10 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <ATen/ATen.h>
@@ -26,14 +28,49 @@ namespace c10d::nccl2 {
 
 class ProcessGroupNCCL;
 
+enum class CommState {
+  NORMAL,
+  ERROR,
+  TIMEOUT,
+};
+
+class WorkNCCLState {
+ public:
+  explicit WorkNCCLState(size_t max_event_pool_size)
+      : max_event_pool_size_(max_event_pool_size) {}
+
+  [[nodiscard]] std::unique_ptr<at::cuda::CUDAEvent> getEvent(
+      bool timing_enabled);
+  void returnEvent(
+      std::unique_ptr<at::cuda::CUDAEvent> event,
+      bool timing_enabled);
+  void enableCollectivesTiming();
+  void closeEventPool();
+  std::pair<std::chrono::milliseconds, std::chrono::milliseconds>
+  applyEphemeralTimeout(std::chrono::milliseconds timeout);
+  void releaseEphemeralTimeout(std::chrono::milliseconds timeout);
+  void addEphemeralTimeout(std::chrono::milliseconds timeout);
+
+  std::atomic<CommState> comm_state{CommState::NORMAL};
+  std::atomic<bool> timing_enabled{false};
+
+ private:
+  const size_t max_event_pool_size_;
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>> event_pool_;
+  std::mutex event_pool_mutex_;
+  bool event_pool_open_{true};
+  std::mutex ephemeral_timeout_mutex_;
+  std::chrono::milliseconds ephemeral_timeout_active_{0};
+  std::chrono::milliseconds ephemeral_timeout_inflight_{0};
+};
+
 // Work object for the NCCL TorchComms backend. Ported from torchcomms'
 // WorkNCCL, but rebased onto c10d::Work (upstream subclassed
 // torchcomms::TorchWork). Completion is tracked with a pair of CUDA events;
 // the Future/result handling that BackendWrapper::WorkWrapper used to provide
-// is folded in here (see setOutputs/getFuture). The back-pointer to the owning
-// backend is non-owning: the backend drains its work queue in finalize()/dtor,
-// so a work never outlives its backend (upstream held a shared_ptr, which is
-// incompatible with c10d's intrusive_ptr ownership of the backend).
+// is folded in here (see setOutputs/getFuture). State needed after
+// process-group teardown is shared separately so Python may retain a Work
+// without retaining the backend or creating a backend-to-work reference cycle.
 class WorkNCCL : public c10d::Work {
  public:
   enum class WorkStatus {
@@ -45,12 +82,20 @@ class WorkNCCL : public c10d::Work {
   };
 
   WorkNCCL(
-      ProcessGroupNCCL* comm,
+      std::shared_ptr<WorkNCCLState> state,
+      at::Device device,
+      int rank,
+      int size,
+      std::string comm_name,
       cudaStream_t stream,
       std::chrono::milliseconds timeout_ms,
       const std::vector<at::Tensor>& inputTensors);
   WorkNCCL(
-      ProcessGroupNCCL* comm,
+      std::shared_ptr<WorkNCCLState> state,
+      at::Device device,
+      int rank,
+      int size,
+      std::string comm_name,
       cudaStream_t stream,
       std::chrono::milliseconds timeout_ms,
       at::Tensor inputTensor);
@@ -119,7 +164,11 @@ class WorkNCCL : public c10d::Work {
   std::vector<at::Tensor> outputs_;
   std::vector<c10::intrusive_ptr<WorkNCCL>> children_;
 
-  ProcessGroupNCCL* comm_; // non-owning; see class comment
+  std::shared_ptr<WorkNCCLState> state_;
+  at::Device device_;
+  int rank_;
+  int comm_size_;
+  std::string comm_name_;
   std::unique_ptr<at::cuda::CUDAEvent> start_event_;
   std::unique_ptr<at::cuda::CUDAEvent> end_event_;
   at::cuda::CUDAStream stream_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192281
* #192280
* #192279
* #192278
* __->__ #192277
* #192276
* #192275
* #192273
* #192274

Python Work handles can outlive ProcessGroupNCCL, but Work retained a raw process-group pointer and could dereference freed backend state during status queries. CUDA graph cleanup callbacks had the same raw-pointer lifetime, while ncclCommDestroy blocks indefinitely if finalization races a still-live captured graph.

Share only the event, timeout, communicator, and graph-capture state needed after teardown, snapshot immutable process-group metadata, and keep blocking-wait cleanup behind a weak backend reference to avoid a backend-to-work ownership cycle. Finalization, destruction, and suspend now reject a live captured graph without damaging the communicator, so callers can release the graph and retry. The nccl2 continuous-test fixtures also select each worker's rank-local device during process-group bootstrap so the graph and multi-GPU tests exercise the intended streams.

Test Plan:

```bash
BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_XNNPACK=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_DISTRIBUTED=1 USE_CUDA=1 .venv/bin/pip install -e . -v --no-build-isolation
```

```bash
CUDA_VISIBLE_DEVICES=1,2,3 NCCL_RAS_ENABLE=0 VIRTUAL_ENV=.venv uv run --no-project python test/distributed/test_c10d_nccl2.py ProcessGroupNCCL2Test.test_work_outlives_process_group ProcessGroupNCCL2Test.test_live_cuda_graph_blocks_process_group_destruction ProcessGroupNCCL2Test.test_concurrent_lazy_initialization
CUDA_VISIBLE_DEVICES=1,2 NCCL_RAS_ENABLE=0 VIRTUAL_ENV=.venv uv run --no-project python test/distributed/test_c10d_suspend_resume.py Nccl2SuspendResumeTest
```

Authored with an AI assistant.