### PR TITLE
c10d: make nccl2 window lifetime explicit

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -145,6 +145,57 @@ class AbstractFaultToleranceTest:
         recv_work.wait()
         self.assertEqual(recv_tensor.cpu(), torch.full((4,), recv_rank + 1.0))
 
+    def test_reconfigure_invalidates_windows(self):
+        self._create_reconfigured_pg("ft_window_generation", 1302)
+        if not self.backend.supports_window:
+            self.skipTest(f"{self.backend_name} does not support windows")
+        pool = torch.cuda.MemPool(self.backend.mem_allocator)
+        with torch.cuda.use_mem_pool(pool):
+            win_buf = torch.zeros(16, device=self.device)
+        try:
+            win = dist._new_window(win_buf)
+            unregistered_win = dist._new_window()
+        except RuntimeError as e:
+            self.skipTest(f"symmetric window registration unsupported: {e}")
+
+        handles = self._collect_handles("ft_window_generation_post")
+        self._reconfigure(1303, handles)
+        with self.assertRaisesRegex(RuntimeError, "stale communicator generation"):
+            win.signal((self.rank + 1) % self.world_size, False)
+        with self.assertRaisesRegex(RuntimeError, "stale communicator generation"):
+            unregistered_win.tensor_register(win_buf)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+
+    def test_reconfigure_timeout_with_live_window_is_retryable(self):
+        if self.backend_name != "nccl2":
+            self.skipTest("nccl2 window teardown behavior")
+        self._create_reconfigured_pg("ft_window_timeout", 1400)
+        if not self.backend.supports_window:
+            self.skipTest("nccl2 windows are unavailable")
+        pool = torch.cuda.MemPool(self.backend.mem_allocator)
+        with torch.cuda.use_mem_pool(pool):
+            win_buf = torch.zeros(16, device=self.device)
+        try:
+            win = dist._new_window(win_buf)
+        except RuntimeError as e:
+            self.skipTest(f"symmetric window registration unsupported: {e}")
+
+        handles = self._collect_handles("ft_window_timeout_initial")
+        if self.rank == 0:
+            with self.assertRaisesRegex(RuntimeError, "timed out"):
+                dist._reconfigure(
+                    1402,
+                    handles[:2],
+                    timeout=timedelta(milliseconds=500),
+                ).wait()
+        self._store_barrier("ft_window_timeout_observed")
+
+        handles = self._collect_handles("ft_window_timeout_current")
+        self._reconfigure(1403, handles)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        with self.assertRaisesRegex(RuntimeError, "stale communicator generation"):
+            win.signal((self.rank + 1) % self.world_size, False)
+
     def test_work_explicit_timeout_includes_prelaunch_stall(self):
         if not self.supports_work_result:
             self.skipTest(f"{self.backend_name} does not report work results")

--- a/test/distributed/test_c10d_suspend_resume.py
+++ b/test/distributed/test_c10d_suspend_resume.py
@@ -135,6 +135,8 @@ class AbstractSuspendResumeTest:
         try:
             with self.assertRaisesRegex(RuntimeError, "communicator is suspended"):
                 dist.all_reduce(torch.ones(1, device=self.device))
+            with self.assertRaisesRegex(RuntimeError, "communicator is suspended"):
+                dist._new_window()
         finally:
             self.backend.resume()
 

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -290,6 +290,27 @@ class AbstractWindowTest:
         win.tensor_deregister()
         del padding
 
+    def test_windows_sharing_allocator_segment_have_independent_lifetimes(self):
+        self._init_pg()
+        pool = self._make_pool()
+        self._probe_window_support(pool)
+        with torch.cuda.use_mem_pool(pool):
+            backing = torch.zeros(32, device=self.device)
+        first_buf = backing[:16]
+        second_buf = backing[16:]
+        second_buf.fill_(self.rank + 1.0)
+        first = dist._new_window(first_buf)
+        second = dist._new_window(second_buf)
+
+        first.tensor_deregister()
+        dst_rank = (self.rank + 1) % self.world_size
+        src_rank = (self.rank - 1 + self.world_size) % self.world_size
+        second.put(second_buf[:1], dst_rank, 0, False)
+        second.wait_signal(src_rank, False)
+        torch.cuda.synchronize()
+        self.assertEqual(second_buf[0], src_rank + 1.0)
+        second.tensor_deregister()
+
 
 def _make_window_test_class(backend_name, device_type):
     class WindowTest(AbstractWindowTest, MultiProcessTestCase):

--- a/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLCachingAllocatorHook.cpp
@@ -20,10 +20,8 @@ void ncclCachingAllocatorHookFn(
   NCCLCachingAllocatorHook::getInstance().regDeregMem(te);
 }
 
-// registeredComms_ is ordered by pointer, which differs between ranks. Any NCCL
-// call these hooks make that waits on peers (deregister_address tearing down a
-// symmetric window does so on NCCL builds that barrier there) must be issued in
-// the same order everywhere, so order by the group name instead.
+// registeredComms_ is ordered by process-local pointer. Use group name for
+// deterministic diagnostics and registration ordering instead.
 std::vector<ProcessGroupNCCL*> commsForDevice(
     const std::set<ProcessGroupNCCL*>& comms,
     c10::DeviceIndex device) {
@@ -130,7 +128,8 @@ void NCCLCachingAllocatorHook::deregisterComm(ProcessGroupNCCL* comm) {
   }
   for (const auto& [addr, mem_info] : registeredMemMap_) {
     if (mem_info.device == comm->getDevice().index()) {
-      comm->deregister_address(addr);
+      comm->deregister_address(
+          addr, /*from_allocator_hook=*/false, /*comm_teardown=*/true);
     }
   }
   registeredComms_.erase(comm);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -262,6 +262,7 @@ void ProcessGroupNCCL::init(at::Device device) {
 void ProcessGroupNCCL::initNcclResources() {
   c10::cuda::CUDAGuard gpuGuard(device_);
 
+  comm_generation_.fetch_add(1, std::memory_order_release);
   window_registration_counter_.store(0, std::memory_order_relaxed);
 
   is_high_priority_stream_ = options_c10d_->is_high_priority_stream;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -319,15 +319,22 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Caching-allocator segment registration (called by
   // NCCLCachingAllocatorHook, potentially from allocator threads).
   void register_address(void* addr, size_t len);
-  // from_allocator_hook only controls diagnostics: tearing a symmetric window
-  // down from the hook is the uncollective path worth warning about.
-  void deregister_address(void* addr, bool from_allocator_hook = false);
+  // Symmetric windows must be released collectively before an allocator hook
+  // observes the segment free. NCCLX may barrier while deregistering them.
+  void deregister_address(
+      void* addr,
+      bool from_allocator_hook = false,
+      bool comm_teardown = false);
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);
   // Registers the segment containing ptr as a NCCL_WIN_COLL_SYMMETRIC window
   // if it is not one already. Collective: all ranks must call it together.
-  ncclResult_t ensureSegmentWindow(const void* ptr);
+  ncclResult_t ensureSegmentWindow(
+      const void* ptr,
+      bool owned_by_mem_pool = false);
+  void retainSegmentWindow(const void* ptr);
+  void releaseSegmentWindow(const void* ptr);
 
   void registerAbortHook(int64_t hook_id, ::c10d::AbortHook hook) override;
   void unregisterAbortHook(int64_t hook_id) override;
@@ -593,6 +600,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
 
   c10::intrusive_ptr<::c10d::Store> store_;
   uint64_t bootstrap_generation_{0};
+  std::atomic<uint64_t> comm_generation_{0};
   std::atomic<uint64_t> window_registration_counter_{0};
   uint64_t sequence_number_{0};
 
@@ -629,6 +637,8 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     void* regHandle{nullptr};
     ncclWindow_t winHandle{nullptr};
     size_t len{0};
+    size_t windowRefCount{0};
+    bool windowOwnedByMemPool{false};
   };
   std::map<void*, RegistrationHandle, std::less<>> memoryRegistrationHandles_;
   // Guards memoryRegistrationHandles_ and registeredMemPools_:

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -226,6 +226,7 @@ std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
 
 c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
     const std::optional<at::Tensor>& tensor) {
+  auto commUseGuard = acquireCommUse();
   TORCH_CHECK(
       supportsWindow(),
       "ProcessGroupNCCL windows require NCCL 2.29 or later and are not "
@@ -246,7 +247,7 @@ c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
       c10::intrusive_ptr<ProcessGroupNCCL>::unsafe_reclaim_from_nonowning(
           this));
   if (tensor.has_value()) {
-    window->tensor_register(*tensor);
+    window->tensorRegisterImpl(*tensor, true);
   }
   return window;
 }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -583,6 +583,7 @@ void ProcessGroupNCCL::attachMemoryHook() {
 }
 
 void ProcessGroupNCCL::detachMemoryHook() {
+  comm_generation_.fetch_add(1, std::memory_order_release);
   NCCLCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
@@ -597,7 +598,7 @@ void ProcessGroupNCCL::registerAddressLocked(void* addr, size_t len) {
   // cannot run from the allocator hook, which fires on arbitrary threads. It
   // happens lazily in ensureSegmentWindow(), keyed by the base recorded here.
   memoryRegistrationHandles_.emplace(
-      addr, RegistrationHandle{handle, nullptr, len});
+      addr, RegistrationHandle{handle, nullptr, len, 0, false});
 }
 
 void ProcessGroupNCCL::register_address(void* addr, size_t len) {
@@ -613,7 +614,8 @@ void ProcessGroupNCCL::register_address(void* addr, size_t len) {
 
 void ProcessGroupNCCL::deregister_address(
     void* addr,
-    bool from_allocator_hook) {
+    bool from_allocator_hook,
+    bool comm_teardown) {
   if (nccl_comm_ == nullptr) {
     return;
   }
@@ -622,20 +624,23 @@ void ProcessGroupNCCL::deregister_address(
   if (it == memoryRegistrationHandles_.end()) {
     return;
   }
+  if (comm_teardown) {
+    // ncclCommAbort destroys communicator registrations. Window deregistration
+    // may barrier in NCCLX, so it cannot be called while failed ranks are
+    // absent from a fault-tolerance teardown.
+    memoryRegistrationHandles_.erase(it);
+    return;
+  }
   if (it->second.winHandle != nullptr) {
-    // Tearing the window down is still the least bad option -- the allocator is
-    // about to hand this address range back, and a later allocation reusing it
-    // would silently resolve to the stale window -- but say so loudly: on NCCL
-    // builds where ncclCommWindowDeregister barriers, a rank-divergent free
-    // hangs here, on an allocator thread, holding the allocator's mutex.
-    if (from_allocator_hook) {
-      TORCH_WARN_ONCE(
-          "A symmetric-window segment was freed without deregister_mem_pool() "
-          "being called first, so its NCCL window is being torn down from the "
-          "CUDA allocator hook. That is only safe if every rank frees the same "
-          "segment in the same order; call deregister_mem_pool() from every "
-          "rank before freeing.");
-    }
+    TORCH_CHECK(
+        !from_allocator_hook,
+        "A symmetric-window segment is being freed before its window was "
+        "deregistered. Call Window.tensor_deregister() or "
+        "backend.deregister_mem_pool() collectively before freeing it.");
+    TORCH_CHECK(
+        it->second.windowRefCount == 0,
+        "Cannot deregister a memory pool while a Window still uses one of its "
+        "segments");
     NCCL_CHECK_IGNORE(
         nccl_api_,
         nccl_api_->commWindowDeregister(nccl_comm_, it->second.winHandle),
@@ -667,7 +672,9 @@ std::pair<ncclWindow_t, size_t> ProcessGroupNCCL::lookupSegmentWindow(
   return {it->second.winHandle, target - base};
 }
 
-ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
+ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(
+    const void* ptr,
+    bool owned_by_mem_pool) {
   if (nccl_comm_ == nullptr) {
     return ncclInvalidUsage;
   }
@@ -683,6 +690,7 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
     return ncclInvalidArgument;
   }
   if (it->second.winHandle != nullptr) {
+    it->second.windowOwnedByMemPool |= owned_by_mem_pool;
     return ncclSuccess;
   }
   ncclWindow_t win = nullptr;
@@ -699,7 +707,47 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
     return ncclInvalidUsage;
   }
   it->second.winHandle = win;
+  it->second.windowOwnedByMemPool = owned_by_mem_pool;
   return ncclSuccess;
+}
+
+void ProcessGroupNCCL::retainSegmentWindow(const void* ptr) {
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  const auto target = reinterpret_cast<uintptr_t>(ptr);
+  auto it = memoryRegistrationHandles_.upper_bound(ptr);
+  TORCH_CHECK(
+      it != memoryRegistrationHandles_.begin(),
+      "Cannot retain an unregistered NCCL window");
+  --it;
+  const auto base = reinterpret_cast<uintptr_t>(it->first);
+  TORCH_CHECK(
+      target < base + it->second.len && it->second.winHandle != nullptr,
+      "Cannot retain an unregistered NCCL window");
+  ++it->second.windowRefCount;
+}
+
+void ProcessGroupNCCL::releaseSegmentWindow(const void* ptr) {
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  const auto target = reinterpret_cast<uintptr_t>(ptr);
+  auto it = memoryRegistrationHandles_.upper_bound(ptr);
+  TORCH_CHECK(
+      it != memoryRegistrationHandles_.begin(),
+      "Cannot release an unregistered NCCL window");
+  --it;
+  const auto base = reinterpret_cast<uintptr_t>(it->first);
+  TORCH_CHECK(
+      target < base + it->second.len && it->second.winHandle != nullptr &&
+          it->second.windowRefCount > 0,
+      "Cannot release an unregistered NCCL window");
+  if (it->second.windowRefCount == 1 && !it->second.windowOwnedByMemPool) {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commWindowDeregister(nccl_comm_, it->second.winHandle),
+        "ncclCommWindowDeregister failed for segment");
+    it->second.winHandle = nullptr;
+  }
+  --it->second.windowRefCount;
 }
 
 namespace {
@@ -761,7 +809,7 @@ void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
     // Only segments that exist now can be upgraded: the window call is
     // collective, so a segment another thread allocates concurrently must be
     // left to the next registerMemPool.
-    auto rc = ensureSegmentWindow(addr);
+    auto rc = ensureSegmentWindow(addr, /*owned_by_mem_pool=*/true);
     if (rc == ncclInvalidUsage) {
       // No symmetric-memory-capable transport (or NCCL predates
       // ncclCommWindowRegister). The stock backend keeps the plain

--- a/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
@@ -28,6 +28,7 @@ WindowNCCL::WindowNCCL(c10::intrusive_ptr<ProcessGroupNCCL> pg)
   TORCH_CHECK(pg_, "WindowNCCL: null ProcessGroupNCCL");
   nccl_api_ = pg_->getNcclApi();
   nccl_comm_ = pg_->nccl_comm_;
+  comm_generation_ = pg_->comm_generation_.load(std::memory_order_acquire);
   TORCH_CHECK(
       nccl_comm_ != nullptr && nccl_api_ != nullptr,
       "WindowNCCL: ProcessGroupNCCL is not initialized");
@@ -94,6 +95,14 @@ void WindowNCCL::exchangePeerMetadata(
 
 void WindowNCCL::tensor_register(const at::Tensor& tensor, bool owning) {
   auto commUseGuard = pg_->acquireCommUse();
+  tensorRegisterImpl(tensor, owning);
+}
+
+void WindowNCCL::tensorRegisterImpl(const at::Tensor& tensor, bool owning) {
+  TORCH_CHECK(
+      comm_generation_ == pg_->comm_generation_.load(std::memory_order_acquire),
+      "WindowNCCL: window belongs to a stale communicator generation; "
+      "create and register a new window after reconfigure");
   TORCH_CHECK(tensor.defined(), "WindowNCCL: a valid tensor is required");
   checkDeviceAndThrow(tensor);
   TORCH_CHECK(win_ == nullptr, "WindowNCCL: double registration");
@@ -123,24 +132,30 @@ void WindowNCCL::tensor_register(const at::Tensor& tensor, bool owning) {
       !c10::mul_overflows(numel, tensor.element_size(), &win_size),
       "WindowNCCL: tensor size overflows size_t");
   exchangePeerMetadata(seg_offset, win_size, tensor.scalar_type());
+  pg_->retainSegmentWindow(tensor.data_ptr());
   win_ = seg_win;
+  registered_ptr_ = tensor.data_ptr();
   if (owning) {
     buf_tensor_ = tensor;
   }
 }
 
 void WindowNCCL::tensor_deregister() {
-  // Segment-level deregistration happens automatically when the mempool frees
-  // the segment (via NCCLCachingAllocatorHook). Here we just forget the
-  // tensor; the barriers keep ranks aligned around the collective contract.
-  pg_->barrier();
-  TORCH_CHECK(win_ != nullptr, "WindowNCCL: double deregistration");
+  auto commUseGuard = pg_->acquireCommUse();
+  checkWindowAndThrow();
+  const auto barrier = [&] {
+    ++pg_->sequence_number_;
+    pg_->barrierImpl(/*async_op=*/false, pg_->options_c10d_->timeout)->wait();
+  };
+  barrier();
+  pg_->releaseSegmentWindow(registered_ptr_);
   win_ = nullptr;
   peer_win_offsets_.clear();
   peer_win_sizes_.clear();
   peer_dtypes_.clear();
+  registered_ptr_ = nullptr;
   buf_tensor_.reset();
-  pg_->barrier();
+  barrier();
 }
 
 c10::intrusive_ptr<::c10d::Work> WindowNCCL::put(
@@ -317,6 +332,10 @@ void WindowNCCL::checkWindowAndThrow() const {
   TORCH_CHECK(
       win_ != nullptr,
       "WindowNCCL: window not registered (call tensor_register first)");
+  TORCH_CHECK(
+      comm_generation_ == pg_->comm_generation_.load(std::memory_order_acquire),
+      "WindowNCCL: window belongs to a stale communicator generation; "
+      "create and register a new window after reconfigure");
 }
 
 void WindowNCCL::checkDeviceAndThrow(const at::Tensor& tensor) const {

--- a/torch/csrc/distributed/c10d/nccl2/WindowNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/WindowNCCL.hpp
@@ -63,6 +63,9 @@ class WindowNCCL : public ::c10d::Window {
   ::c10d::WindowAttr get_attr(int64_t peerRank) override;
 
  private:
+  friend class ProcessGroupNCCL;
+
+  void tensorRegisterImpl(const at::Tensor& tensor, bool owning);
   void checkWindowAndThrow() const;
   void checkDeviceAndThrow(const at::Tensor& tensor) const;
   void checkPeerRankAndThrow(int64_t rank) const;
@@ -74,6 +77,7 @@ class WindowNCCL : public ::c10d::Window {
   c10::intrusive_ptr<ProcessGroupNCCL> pg_;
   NcclApi* nccl_api_{nullptr};
   ncclComm_t nccl_comm_{nullptr};
+  uint64_t comm_generation_{0};
 
   // Destination window for this rank and each peer's logical tensor metadata.
   // The NCCL window is collective, but tensor offsets and sizes may differ.
@@ -81,6 +85,7 @@ class WindowNCCL : public ::c10d::Window {
   std::vector<size_t> peer_win_offsets_;
   std::vector<size_t> peer_win_sizes_;
   std::vector<at::ScalarType> peer_dtypes_;
+  const void* registered_ptr_{nullptr};
   std::optional<at::Tensor> buf_tensor_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192281
* #192280
* __->__ #192279
* #192278
* #192277
* #192276
* #192275
* #192273
* #192274

NCCLX's CTRAN window deregistration path executes a communicator-wide barrier. Keeping symmetric windows alive until allocator segment-free callbacks can therefore deadlock when ranks free segments at different times, and windows retain stale NCCL handles after communicator reconfiguration.

Reference-count windows that share an allocator segment and deregister the symmetric handle from the collective Window.tensor_deregister lifecycle. Allocator callbacks now reject premature symmetric-window frees instead of entering NCCLX communication. Communicator teardown remains allowed to retire live handles, increments a generation before doing so, and stale Window objects reject every operation after reconfigure.

Test Plan:

```

uv run --no-sync python -m py_compile test/distributed/test_c10d_window.py test/distributed/test_c10d_fault_tolerance.py

git diff --check

```

Authored with an AI assistant.