### PR TITLE
[inductor][refactor] Drop the dead num_stages axis from ROCm exhaustive mm configs

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -488,6 +488,27 @@ class TestTritonHeuristics(TestCase):
         res = torch.compile(fn)(x)
         self.assertEqual(ref, res)
 
+    @runOnRocm
+    def test_rocm_exhaustive_configs_do_not_enumerate_num_stages(self):
+        """ROCmConfigHeuristic._filter_configs forces num_stages to
+        default_num_stages, so enumerating num_stages in exhaustive_configs would
+        only yield duplicates that get deduped again in _finalize_mm_configs.
+        """
+        from torch._inductor.heuristics.template.triton import (
+            GemmConfig,
+            ROCmConfigHeuristic,
+        )
+
+        heuristic = ROCmConfigHeuristic()
+        self.assertEqual(
+            {c.num_stages for c in heuristic.exhaustive_configs},
+            {heuristic.default_num_stages},
+        )
+
+        # the invariant above is only safe because _filter_configs clobbers it
+        filtered = heuristic._filter_configs([GemmConfig(32, 32, 32, 1, 4, group_m=8)])
+        self.assertEqual(filtered[0].num_stages, heuristic.default_num_stages)
+
     @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
     @parametrize("do_pruning", [False, True])
     def test_prune_configs_over_shared_memory_limit(self, do_pruning):

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -1631,13 +1631,15 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             ROCmGemmConfig(256, 256, 64, self.default_num_stages, 8, group_m=4),
         ]
 
-        # Exhaustive search for mm configs
+        # Exhaustive search for mm configs. num_stages is deliberately not an axis
+        # here: _filter_configs forces every config to self.default_num_stages, so
+        # enumerating it would only produce duplicates that get deduped later.
         self.exhaustive_configs: list[BaseConfig] = [
             ROCmGemmConfig(
                 BLOCK_M,
                 BLOCK_N,
                 BLOCK_K,
-                num_stages,
+                self.default_num_stages,
                 num_warps,
                 group_m=group_m,
                 matrix_instr_nonkdim=matrix_instr_nonkdim,
@@ -1647,7 +1649,6 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
                 [16, 32, 64, 128, 256], repeat=3
             )
-            for num_stages in [1, self.default_num_stages]
             for num_warps in [4, 8]
             for group_m in [4, 8, 16]
             for matrix_instr_nonkdim in [0, 16]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #192286
* #192285

ROCmConfigHeuristic._filter_configs overwrites num_stages on every config with
self.default_num_stages -- this is intentional, and both the origami selection
path and its LDS pre-filter are written to match that post-filter state. But
exhaustive_configs also enumerated `for num_stages in [1, default_num_stages]`,
so half of the generated configs were byte-identical to the other half once
filtering ran, and num_stages=1 was never actually tried. The duplicates were
silently discarded later by the dedup key in _finalize_mm_configs, so this only
wasted work and made the search space look like it covered an axis it did not.

Halves the exhaustive candidate count before dedup with no change in the set of
configs actually benchmarked.

Authored with the assistance from an AI coding agent.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben