### PR TITLE
Use METH_FASTCALL for Inductor C++ Python bindings

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4063,24 +4063,24 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         // We manually link it below to workaround issues with fbcode build.
         static void* (*_torchinductor_pyobject_tensor_data_ptr)(PyObject* obj);
 
-        template <typename T> static inline T parse_arg(PyObject* args, size_t n) {{
+        template <typename T> static inline T parse_arg(PyObject* const* args, size_t n) {{
             static_assert(std::is_pointer_v<T>, "arg type must be pointer or long");
-            return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(PyTuple_GET_ITEM(args, n)));
+            return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(args[n]));
         }}
-        template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {{
-            auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
+        template <> inline int64_t parse_arg<int64_t>(PyObject* const* args, size_t n) {{
+            auto result = PyLong_AsSsize_t(args[n]);
             if(result == -1 && PyErr_Occurred()) [[unlikely]]
                 throw std::runtime_error("expected int arg");
             return result;
         }}
-        template <> inline uintptr_t parse_arg<uintptr_t>(PyObject* args, size_t n) {{
-            auto result = PyLong_AsVoidPtr(PyTuple_GET_ITEM(args, n));
+        template <> inline uintptr_t parse_arg<uintptr_t>(PyObject* const* args, size_t n) {{
+            auto result = PyLong_AsVoidPtr(args[n]);
             if(result == reinterpret_cast<void*>(-1) && PyErr_Occurred()) [[unlikely]]
                 throw std::runtime_error("expected int arg");
             return reinterpret_cast<uintptr_t>(result);
         }}
-        template <> inline float parse_arg<float>(PyObject* args, size_t n) {{
-            auto result = PyFloat_AsDouble(PyTuple_GET_ITEM(args, n));
+        template <> inline float parse_arg<float>(PyObject* const* args, size_t n) {{
+            auto result = PyFloat_AsDouble(args[n]);
             if(result == -1.0 && PyErr_Occurred()) [[unlikely]]
                 throw std::runtime_error("expected float arg");
             return static_cast<float>(result);
@@ -4088,11 +4088,9 @@ class CppPythonBindingsCodeCache(CppCodeCache):
 
         {extra_parse_arg}
 
-        static PyObject* {entry_func}_py(PyObject* self, PyObject* args) {{
+        static PyObject* {entry_func}_py(PyObject* self, PyObject* const* args, Py_ssize_t nargs) {{
             try {{
-                if(!PyTuple_CheckExact(args)) [[unlikely]]
-                    throw std::runtime_error("tuple args required");
-                if(PyTuple_GET_SIZE(args) != {arg_len}) [[unlikely]]
+                if(nargs != {arg_len}) [[unlikely]]
                     throw std::runtime_error("requires {arg_len} args");
                 {call_entry_func}
             }} catch(std::exception const& e) {{
@@ -4105,7 +4103,12 @@ class CppPythonBindingsCodeCache(CppCodeCache):
         }}
 
         static PyMethodDef py_methods[] = {{
-            {{"{entry_func}", {entry_func}_py, METH_VARARGS, ""}},
+            {{
+                "{entry_func}",
+                reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>({entry_func}_py)),
+                METH_FASTCALL,
+                ""
+            }},
             {{NULL, NULL, 0, NULL}}}};
 
         static struct PyModuleDef py_module =
@@ -4301,8 +4304,9 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
             return result;
         }}
 
-        template <> inline std::vector<AtenTensorHandle> parse_arg<std::vector<AtenTensorHandle>>(PyObject* args, size_t n) {{
-            return unpack_tensor_handle_list(PyTuple_GET_ITEM(args, n));
+        template <>
+        inline std::vector<AtenTensorHandle> parse_arg<std::vector<AtenTensorHandle>>(PyObject* const* args, size_t n) {{
+            return unpack_tensor_handle_list(args[n]);
         }}
 
         PyObject* inductor_entry_cpp(std::vector<AtenTensorHandle>&& input_handles) {{


### PR DESCRIPTION
This PR reduces the Python overhead for inductor generated python
bindings by replacing `METH_VARARGS` with `METH_FASTCALL`.

I used Codex to create a benchmark for Python bindings generated by
`CppPythonBindingsCodeCache.load_pybinding` it shows a consistent
reduction of 40-50% reduction in execution times of no-op kernels with
differing number of params and types.

Related-to: #49476

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo