### PR TITLE
[MPS] Add Metal cdist forward kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distance.h
+++ b/aten/src/ATen/native/mps/kernels/Distance.h
@@ -1,5 +1,13 @@
 #pragma once
 
+struct CdistFwdParams {
+  long B;
+  long P;
+  long R;
+  long D;
+  float p;
+};
+
 struct CdistBwdParams {
   long B;
   long P;

--- a/aten/src/ATen/native/mps/kernels/Distance.metal
+++ b/aten/src/ATen/native/mps/kernels/Distance.metal
@@ -4,6 +4,139 @@
 
 using namespace metal;
 
+// P_KIND: 0 = p==0, 1 = p==1, 2 = p==2, 3 = p==inf, 4 = generic.
+template <typename T, int P_KIND>
+kernel void cdist_forward_scalar(
+    constant T* x1 [[buffer(0)]],
+    constant T* x2 [[buffer(1)]],
+    device T* output [[buffer(2)]],
+    constant CdistFwdParams& params [[buffer(3)]],
+    uint2 pair [[thread_position_in_grid]]) {
+  const ulong row2 = pair.x;
+  const ulong batch_row = pair.y;
+  if (row2 >= ulong(params.R) ||
+      batch_row >= ulong(params.B) * ulong(params.P)) {
+    return;
+  }
+  const ulong batch = batch_row / ulong(params.P);
+  const ulong row1 = batch_row % ulong(params.P);
+  const ulong x1_base = (batch * ulong(params.P) + row1) * ulong(params.D);
+  const ulong x2_base = (batch * ulong(params.R) + row2) * ulong(params.D);
+
+  float value = 0.0f;
+  for (long dim = 0; dim < params.D; ++dim) {
+    const float distance = ::metal::precise::abs(
+        float(x1[x1_base + ulong(dim)]) - float(x2[x2_base + ulong(dim)]));
+    if IF_CONSTEXPR (P_KIND == 0) {
+      value += distance != 0.0f;
+    } else if IF_CONSTEXPR (P_KIND == 1) {
+      value += distance;
+    } else if IF_CONSTEXPR (P_KIND == 2) {
+      value += distance * distance;
+    } else if IF_CONSTEXPR (P_KIND == 3) {
+      value = isnan(value)
+          ? value
+          : (isnan(distance) ? distance : max(value, distance));
+    } else {
+      value += ::metal::precise::pow(distance, params.p);
+    }
+  }
+  if IF_CONSTEXPR (P_KIND == 2) {
+    value = ::metal::precise::sqrt(value);
+  } else if IF_CONSTEXPR (P_KIND == 4) {
+    value = ::metal::precise::pow(value, 1.0f / params.p);
+  }
+  output[batch_row * ulong(params.R) + row2] = T(value);
+}
+
+template <typename T, int P_KIND>
+kernel void cdist_forward_scalar4(
+    constant T* x1 [[buffer(0)]],
+    constant T* x2 [[buffer(1)]],
+    device T* output [[buffer(2)]],
+    constant CdistFwdParams& params [[buffer(3)]],
+    uint2 tile [[thread_position_in_grid]]) {
+  constexpr uint outputs_per_thread = 4;
+  const ulong batch_row = tile.y;
+  const ulong batch = batch_row / ulong(params.P);
+  const ulong row1 = batch_row % ulong(params.P);
+  const ulong row2_base = ulong(tile.x) * outputs_per_thread;
+  if (row2_base >= ulong(params.R) || batch >= ulong(params.B)) {
+    return;
+  }
+  const ulong x1_base = (batch * ulong(params.P) + row1) * ulong(params.D);
+  const ulong x2_batch = batch * ulong(params.R) * ulong(params.D);
+  float values[outputs_per_thread] = {};
+
+  for (long dim = 0; dim < params.D; ++dim) {
+    const float a = float(x1[x1_base + ulong(dim)]);
+    for (uint item = 0; item < outputs_per_thread; ++item) {
+      const ulong row2 = row2_base + item;
+      if (row2 >= ulong(params.R)) {
+        continue;
+      }
+      const float distance = ::metal::precise::abs(
+          a - float(x2[x2_batch + row2 * ulong(params.D) + ulong(dim)]));
+      if IF_CONSTEXPR (P_KIND == 0) {
+        values[item] += distance != 0.0f;
+      } else if IF_CONSTEXPR (P_KIND == 1) {
+        values[item] += distance;
+      } else if IF_CONSTEXPR (P_KIND == 2) {
+        values[item] += distance * distance;
+      } else if IF_CONSTEXPR (P_KIND == 3) {
+        values[item] = isnan(values[item])
+            ? values[item]
+            : (isnan(distance) ? distance : max(values[item], distance));
+      } else {
+        values[item] += ::metal::precise::pow(distance, params.p);
+      }
+    }
+  }
+  for (uint item = 0; item < outputs_per_thread; ++item) {
+    const ulong row2 = row2_base + item;
+    if (row2 >= ulong(params.R)) {
+      continue;
+    }
+    float value = values[item];
+    if IF_CONSTEXPR (P_KIND == 2) {
+      value = ::metal::precise::sqrt(value);
+    } else if IF_CONSTEXPR (P_KIND == 4) {
+      value = ::metal::precise::pow(value, 1.0f / params.p);
+    }
+    output[(batch * ulong(params.P) + row1) * ulong(params.R) + row2] =
+        T(value);
+  }
+}
+
+#define REGISTER_CDIST_FORWARD_SCALAR(T)                   \
+  template [[host_name("cdist_forward_scalar_" #T "_p4")]] \
+  kernel void cdist_forward_scalar<T, 4>(                  \
+      constant T * x1 [[buffer(0)]],                       \
+      constant T * x2 [[buffer(1)]],                       \
+      device T * output [[buffer(2)]],                     \
+      constant CdistFwdParams & params [[buffer(3)]],      \
+      uint2 pair [[thread_position_in_grid]]);
+
+#define REGISTER_CDIST_FORWARD_SCALAR4(T, P_KIND)                  \
+  template [[host_name("cdist_forward_scalar4_" #T "_p" #P_KIND)]] \
+  kernel void cdist_forward_scalar4<T, P_KIND>(                    \
+      constant T * x1 [[buffer(0)]],                               \
+      constant T * x2 [[buffer(1)]],                               \
+      device T * output [[buffer(2)]],                             \
+      constant CdistFwdParams & params [[buffer(3)]],              \
+      uint2 tile [[thread_position_in_grid]]);
+
+#define REGISTER_CDIST_FORWARD_FOR_TYPE(T) \
+  REGISTER_CDIST_FORWARD_SCALAR(T)         \
+  REGISTER_CDIST_FORWARD_SCALAR4(T, 0)     \
+  REGISTER_CDIST_FORWARD_SCALAR4(T, 1)     \
+  REGISTER_CDIST_FORWARD_SCALAR4(T, 2)     \
+  REGISTER_CDIST_FORWARD_SCALAR4(T, 3)
+
+REGISTER_CDIST_FORWARD_FOR_TYPE(float)
+REGISTER_CDIST_FORWARD_FOR_TYPE(half)
+REGISTER_CDIST_FORWARD_FOR_TYPE(bfloat)
+
 // P_KIND: 0 = p==1, 1 = p==inf, 2 = generic. The TG precomputes
 // `grad / cdist^(p-1)` per (b, i, j) into `s_reducer`, shared across c-threads.
 template <typename T, int P_KIND, uint TG_C>

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -24,18 +24,37 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #endif
 
 static void cdist_kernel_mps(Tensor& result, const Tensor& x1, const Tensor& x2, const double p) {
-  // Promote fp16/bf16 to fp32 internally so the max-norm argmax selection
-  // matches what the CPU reference does (which falls back to fp32 for
-  // these dtypes anyway).
-  const auto out_dtype = result.scalar_type();
-  const bool promote = at::isReducedFloatingType(out_dtype);
-  const auto compute_dtype = promote ? at::kFloat : out_dtype;
-  auto diff = x1.to(compute_dtype).unsqueeze(-2).sub(x2.to(compute_dtype).unsqueeze(-3));
-  auto out = at::linalg_vector_norm(diff, p, makeArrayRef<int64_t>(-1), /*keepdim=*/false, /*dtype=*/std::nullopt);
-  if (promote) {
-    out = out.to(out_dtype);
+  const int64_t batches = x1.size(0);
+  const int64_t x1_rows = x1.size(1);
+  const int64_t x2_rows = x2.size(1);
+  const int64_t dimensions = x1.size(2);
+  const int p_kind = p == 0.0 ? 0 : p == 1.0 ? 1 : p == 2.0 ? 2 : std::isinf(p) ? 3 : 4;
+  const bool scalar4 = p_kind != 4;
+  const auto kernel =
+      fmt::format("cdist_forward_{}{}_p{}", scalar4 ? "scalar4_" : "scalar_", scalarToMetalTypeString(x1), p_kind);
+  const CdistFwdParams params{
+      .B = batches,
+      .P = x1_rows,
+      .R = x2_rows,
+      .D = dimensions,
+      .p = static_cast<float>(p),
+  };
+  const NSUInteger inner = scalar4 ? c10::metal::ceil_div(x2_rows, int64_t{4}) : x2_rows;
+  const NSUInteger outer = batches * x1_rows;
+  auto stream = getCurrentMPSStream();
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(kernel);
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto encoder = stream->commandEncoder();
+        getMPSProfiler().beginProfileKernel(pso, "cdist_forward", {x1, x2});
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder, x1, x2, result, params);
+        mtl_dispatch2DJob(encoder, pso, inner, outer);
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    });
   }
-  result.copy_(out.reshape(result.sizes()));
 }
 
 static void cdist_backward_kernel_mps(Tensor& result,


### PR DESCRIPTION
## Summary

Add a native Metal kernel for the non-matmul `cdist` forward path on MPS.

The kernel computes each output distance directly instead of materializing the broadcasted pairwise difference tensor. It has specialized paths for `p = 0`, `p = 1`, `p = 2`, and `p = inf`, plus a generic `p` path.

On an M1 with float32 inputs of shape `[1024, 128]`, the `p = 1.5` case improved from 132.3 ms to 25.3 ms. The driver allocation increase for that case dropped from about 544 MiB to 32 MiB.

## Testing

```text
python test/test_mps.py -k cdist
python test/test_ops.py -k cdist
```
