### PR TITLE
[Elastic] Close file descriptor returned by tempfile.mkstemp in FileStore rendezvous

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,19 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    def test_create_backend_closes_mkstemp_fd(self, mock_mkstemp, mock_close) -> None:
+        fake_fd = 42
+        fake_path = tempfile.mktemp()
+        mock_mkstemp.return_value = (fake_fd, fake_path)
+        self._params_filestore.endpoint = ""
+        try:
+            with mock.patch("torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"):
+                create_backend(self._params_filestore)
+            mock_close.assert_called_once_with(fake_fd)
+        finally:
+            if os.path.exists(fake_path):
+                os.remove(fake_path)
+

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
## Summary

Fixes #191394.

In `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py`, `_create_file_store()` calls `tempfile.mkstemp()` when no endpoint is supplied but previously discarded the returned file descriptor without closing it. Because `FileStore` opens the path independently, the descriptor remained open for the lifetime of the process.

## Checklist

- [ ] I have run `spin fixlint` and all lint checks pass (not reported in the original PR body)
- [x] I have added or updated tests
- [x] I have updated documentation (not applicable; this is an internal resource-management fix)
- [x] I have included benchmark results (not applicable; no performance-sensitive behavior was changed)

## BC-breaking?

No. The change closes the descriptor immediately after creation with `os.close(fd)` and does not alter the `FileStore` interface or rendezvous behavior.

## Changes

- `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py`: close the `mkstemp()` descriptor immediately.
- `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py`: add `test_create_backend_closes_mkstemp_fd` to assert that `os.close()` receives the returned descriptor.
