### PR TITLE
[Tasks][Test Blame] Fix 2 broken tests caused by D114655096

### DIFF
--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -52,6 +52,7 @@ def define_targets(rules):
             ":complex_math_test_common",
             ":complex_test_common",
             "//c10/macros",
+            "//c10/util:TypeCast",
             "//c10/util:base",
             "@com_google_googletest//:gtest_main",
         ],


### PR DESCRIPTION
Summary: Adds missing dependency for header

Test Plan: Sandcastle

Differential Revision: D114715975


