### PR TITLE
Fail the job when a compile-worker result callback dies (#192301)

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import io
 import json
 import operator
 import os
@@ -10,19 +11,31 @@ import time
 import types
 import unittest
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures.process import BrokenProcessPool
 from threading import Event
 from unittest.mock import patch
 
 import torch._inductor.config as config
 from torch._inductor.compile_worker.subproc_pool import (
+    _recv_msg,
+    _SubprocExceptionInfo,
+    MsgHeader,
     raise_testexc,
     SubprocException,
     SubprocKind,
+    SubprocMain,
+    SubprocPickler,
     SubprocPool,
 )
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_LINUX, skipIfWindows
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    skipIfWindows,
+    subtest,
+)
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
@@ -139,8 +152,16 @@ class TestCompileWorker(TestCase):
         # but EOF never arrives" case: with that path dead, only _health_monitor
         # -> _on_sidecar_death can resolve pending futures. (The complementary
         # test_sidecar_death_eofs_without_watchdog covers the EOF path in
-        # isolation by disabling the watchdog instead.)
-        with patch.object(SubprocPool, "_read_thread", lambda self: None):
+        # isolation by disabling the watchdog instead.) The injected diagnostic
+        # failure proves pending futures are failed before best-effort reporting.
+        with (
+            patch.object(SubprocPool, "_read_thread", lambda self: None),
+            patch.object(
+                SubprocPool,
+                "_log_sidecar_death_diagnostics",
+                side_effect=SystemExit(3),
+            ),
+        ):
             pool = self.make_pool(2)
             try:
                 fut = pool.submit(time.sleep, 600)
@@ -321,6 +342,447 @@ class TestCompileWorker(TestCase):
 class TestCompileWorkerWithTimer(TestCompileWorker):
     def make_pool(self, size):
         return SubprocPool(size, quiesce=True)
+
+
+class TestSubprocPoolCallbackSafety(TestCase):
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_done_callback_can_submit_job(self):
+        code = textwrap.dedent(
+            """
+            import operator
+            import threading
+            import time
+
+            from torch._inductor.compile_worker.subproc_pool import SubprocPool
+
+            pool = SubprocPool(2)
+            callback_done = threading.Event()
+            chained = []
+
+            def callback(future):
+                chained.append(pool.submit(operator.add, 20, 22))
+                callback_done.set()
+
+            first = pool.submit(time.sleep, 1)
+            first.add_done_callback(callback)
+            assert first.result(timeout=60) is None
+            assert callback_done.wait(60), "done callback deadlocked in pool.submit()"
+            assert chained[0].result(timeout=60) == 42
+            pool.shutdown()
+            print("reentrant callback completed")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            lambda msg: f"{msg}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertIn("reentrant callback completed", result.stdout)
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_sidecar_death_completes_all_futures_after_callback_base_exception(self):
+        code = textwrap.dedent(
+            """
+            import threading
+            import time
+
+            from torch._inductor.compile_worker.subproc_pool import SubprocPool
+
+            pool = SubprocPool(2)
+            callback_done = threading.Event()
+            first = pool.submit(time.sleep, 600)
+            second = pool.submit(time.sleep, 600)
+
+            class BrokenWaitCounter:
+                def __exit__(
+                    self, exc_type=None, exc_value=None, traceback=None
+                ):
+                    raise SystemExit(3)
+
+            first_job_id = next(iter(pool.pending_jobs))
+            pool.pending_jobs[first_job_id].waitcounter = BrokenWaitCounter()
+
+            def reentrant_callback(future):
+                try:
+                    pool.submit(time.sleep, 0)
+                except RuntimeError:
+                    callback_done.set()
+                else:
+                    raise AssertionError("submit unexpectedly succeeded on dead pool")
+
+            def base_exception_callback(future):
+                raise SystemExit(3)
+
+            first.add_done_callback(reentrant_callback)
+            first.add_done_callback(base_exception_callback)
+            time.sleep(1)
+            pool.process.kill()
+
+            for future in (first, second):
+                try:
+                    future.result(timeout=60)
+                except Exception:
+                    pass
+                else:
+                    raise AssertionError("sidecar death unexpectedly succeeded")
+            assert callback_done.wait(60), "sidecar-death callback did not run"
+            pool.shutdown()
+            print("all pending futures completed")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            lambda msg: f"{msg}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertIn("all pending futures completed", result.stdout)
+
+
+class _UnpicklableError(Exception):
+    """Stands in for a job exception that the pickler cannot serialize."""
+
+
+class _FailingPickler(SubprocPickler):
+    def dumps(self, obj):
+        if isinstance(obj, _UnpicklableError):
+            raise RuntimeError("cannot pickle this exception")
+        return super().dumps(obj)
+
+
+class _RefusesFailurePickler(_FailingPickler):
+    """Also refuses the failure details, forcing the empty-payload last resort."""
+
+    def dumps(self, obj):
+        if isinstance(obj, _SubprocExceptionInfo):
+            raise RuntimeError("cannot pickle the failure payload either")
+        return super().dumps(obj)
+
+
+class _RaisesBaseExceptionPickler(SubprocPickler):
+    def dumps(self, obj):
+        raise SystemExit(3)
+
+
+class _RaisesOnBadLoadPickler(SubprocPickler):
+    def loads(self, data):
+        if data == b"bad":
+            raise SystemExit(3)
+        return super().loads(data)
+
+
+class _DoneFuture:
+    """
+    A finished future that runs done callbacks the way concurrent.futures does:
+    inline, swallowing anything they raise. That swallowing is what turned a
+    dead callback into a silent hang, so the fake has to reproduce it.
+    """
+
+    def __init__(self, result=None, exc=None, cancelled=False):
+        self._result = result
+        self._exc = exc
+        self._cancelled = cancelled
+
+    def cancelled(self):
+        return self._cancelled
+
+    def exception(self, timeout=None):
+        if self._cancelled:
+            raise AssertionError("exception() must not be called on a cancelled future")
+        return self._exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+    def add_done_callback(self, fn):
+        try:
+            fn(self)
+        except Exception:
+            pass
+
+
+class _FakePool:
+    def __init__(self, future):
+        self._future = future
+
+    def submit(self, fn, *args, **kwargs):
+        return self._future
+
+
+class _EmptyTolerantPickler(SubprocPickler):
+    """
+    Returns a value for empty input instead of raising. Custom picklers are a
+    supported hook (SubprocPool takes one), so "unpickling empty data throws"
+    is not something the parent gets to assume.
+    """
+
+    def loads(self, data):
+        return None if not data else super().loads(data)
+
+
+def _run_callback(future, job_id, pickler):
+    """
+    Run SubprocMain's result callback in-process for a finished job and return
+    the bytes it put on the wire, or b"" if it sent nothing.
+    """
+    read_fd, write_fd = os.pipe()
+    with os.fdopen(read_fd, "rb") as parent_read:
+        with os.fdopen(write_fd, "wb") as sidecar_write:
+            # SubprocMain only reads its command pipe from main(), which we
+            # bypass by calling _submit_inner directly.
+            main = SubprocMain(
+                pickler, SubprocKind.FORK, 1, io.BytesIO(), sidecar_write
+            )
+            # Presetting the pool keeps _start_pool from forking real workers.
+            main.pool = _FakePool(future)
+            with main._inflight_lock:
+                main._inflight[job_id] = time.monotonic()
+
+            main._submit_inner(job_id, b"")
+        # The callback ran inline above and the write end is closed now, so this
+        # reads whatever was sent and then hits EOF. A callback that sent nothing
+        # surfaces as no bytes rather than as a hang.
+        return parent_read.read()
+
+
+@instantiate_parametrized_tests
+class TestSubprocMainResultDelivery(TestCase):
+    # Drive SubprocMain's result callback in-process against a fake pool, so the
+    # two escapes in the pre-send work can be reproduced directly. Running the
+    # callback here rather than through a real sidecar is what lets these tests
+    # fail -- instead of hanging -- when it dies without sending anything.
+
+    @parametrize(
+        "future",
+        [
+            # The job raised and the pickler cannot serialize the exception.
+            subtest(
+                _DoneFuture(exc=_UnpicklableError("boom")),
+                name="unpicklable_exception",
+            ),
+            # A BaseException must become a job failure rather than a successful
+            # result containing the exception object.
+            subtest(_DoneFuture(exc=SystemExit(3)), name="base_exception"),
+            # Future.exception() raises on cancellation, so cancellation must be
+            # handled before reading the outcome.
+            subtest(_DoneFuture(cancelled=True), name="cancelled"),
+            # do_job is supposed to hand back bytes; anything else trips the
+            # isinstance check just before the send.
+            subtest(_DoneFuture(result="not bytes"), name="non_bytes_result"),
+        ],
+    )
+    def test_callback_escape_fails_the_job(self, future):
+        pickler = _FailingPickler()
+        delivered = _run_callback(future, 7, pickler)
+
+        self.assertTrue(
+            delivered, "callback sent nothing: the parent's future would hang forever"
+        )
+        msg_header, job_id, data = _recv_msg(io.BytesIO(delivered))
+        self.assertEqual(msg_header, MsgHeader.JOB)
+        self.assertEqual(job_id, 7)
+        result = pickler.loads(data)
+        self.assertIsInstance(result, _SubprocExceptionInfo)
+        self.assertIn(
+            "SubprocPool failed to deliver a result for job 7", result.details
+        )
+
+    def test_unpicklable_failure_sends_error_frame(self):
+        # Last resort: the pickler refuses even _SubprocExceptionInfo, so there
+        # is no way to describe the failure. Sending an empty payload is still
+        # better than sending nothing. A distinct header keeps an empty success
+        # payload unambiguous (see test_empty_payload_can_be_a_success).
+        delivered = _run_callback(
+            _DoneFuture(exc=_UnpicklableError("boom")), 7, _RefusesFailurePickler()
+        )
+
+        self.assertTrue(
+            delivered, "callback sent nothing: the parent's future would hang forever"
+        )
+        msg_header, job_id, data = _recv_msg(io.BytesIO(delivered))
+        self.assertEqual(msg_header, MsgHeader.JOB_ERROR)
+        self.assertEqual(job_id, 7)
+        self.assertEqual(data, b"")
+
+    def test_base_exception_from_failure_pickler_sends_error_frame(self):
+        delivered = _run_callback(
+            _DoneFuture(exc=_UnpicklableError("boom")),
+            7,
+            _RaisesBaseExceptionPickler(),
+        )
+
+        self.assertTrue(delivered)
+        msg_header, job_id, data = _recv_msg(io.BytesIO(delivered))
+        self.assertEqual(msg_header, MsgHeader.JOB_ERROR)
+        self.assertEqual(job_id, 7)
+        self.assertEqual(data, b"")
+
+    def test_failed_delivery_terminates_sidecar(self):
+        main = SubprocMain(
+            SubprocPickler(), SubprocKind.FORK, 1, io.BytesIO(), io.BytesIO()
+        )
+        main.pool = _FakePool(_DoneFuture(result=b"result"))
+        with main._inflight_lock:
+            main._inflight[7] = time.monotonic()
+
+        def fail_delivery(*args, **kwargs):
+            self.assertIn(7, main._inflight)
+            raise BrokenPipeError("closed result pipe")
+
+        with patch(
+            "torch._inductor.compile_worker.subproc_pool._send_msg",
+            side_effect=fail_delivery,
+        ):
+            with patch(
+                "torch._inductor.compile_worker.subproc_pool._exit_sidecar"
+            ) as exit_sidecar:
+                main._submit_inner(7, b"")
+
+        exit_sidecar.assert_called_once_with()
+        self.assertIn(7, main._inflight)
+
+    def test_broken_pool_submit_retries_are_bounded(self):
+        write_pipe = io.BytesIO()
+        main = SubprocMain(
+            SubprocPickler(), SubprocKind.FORK, 1, io.BytesIO(), write_pipe
+        )
+        with patch.object(
+            main,
+            "_submit_inner",
+            side_effect=BrokenProcessPool("pool is broken"),
+        ) as submit:
+            main.submit(7, b"")
+
+        self.assertEqual(submit.call_count, 3)
+        msg_header, job_id, data = _recv_msg(io.BytesIO(write_pipe.getvalue()))
+        self.assertEqual(msg_header, MsgHeader.JOB)
+        self.assertEqual(job_id, 7)
+        result = main.pickler.loads(data)
+        self.assertIsInstance(result, _SubprocExceptionInfo)
+        self.assertIn("3 consecutive submit attempts", result.details)
+        self.assertNotIn(7, main._inflight)
+
+
+class TestSubprocPoolResultHandling(TestCase):
+    # The job submitted in these tests is one that never finishes, so the
+    # sidecar has no real reply to race the payload injected for it. That lets
+    # the read thread keep running, so the follow-up jobs below are ordinary
+    # round trips through a real pool.
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_bookkeeping_failure_does_not_strand_result(self):
+        class BrokenWaitCounter:
+            def __exit__(self, exc_type=None, exc_value=None, traceback=None):
+                raise SystemExit(3)
+
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            pool.pending_jobs[job_id].waitcounter = BrokenWaitCounter()
+
+            pool._handle_job_result(job_id, pool.pickler.dumps(42))
+            self.assertEqual(fut.result(timeout=60), 42)
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_base_exception_payload_surfaces_as_subproc_exception(self):
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            delivered = _run_callback(
+                _DoneFuture(exc=SystemExit(3)), job_id, SubprocPickler()
+            )
+            _, _, data = _recv_msg(io.BytesIO(delivered))
+
+            pool._handle_job_result(job_id, data)
+            expected_error = "the job raised SystemExit"
+            with self.assertRaisesRegex(SubprocException, expected_error):
+                fut.result(timeout=60)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_failure_payload_surfaces_as_subproc_exception(self):
+        # Join the two halves: the exact bytes SubprocMain sends when its
+        # callback dies, handed to a real parent, must fail that job and leave
+        # the pool usable. Only the pipe between them is stubbed out, and every
+        # other test in this file runs a real one.
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            delivered = _run_callback(
+                _DoneFuture(exc=_UnpicklableError("boom")), job_id, _FailingPickler()
+            )
+            _, _, data = _recv_msg(io.BytesIO(delivered))
+
+            pool._handle_job_result(job_id, data)
+            with self.assertRaisesRegex(
+                SubprocException, "SubprocPool failed to deliver a result"
+            ):
+                fut.result(timeout=60)
+
+            # One failed delivery must not take the pool down.
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_empty_payload_can_be_a_success(self):
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            with patch.object(pool, "pickler", _EmptyTolerantPickler()):
+                pool._handle_job_result(job_id, b"")
+            self.assertIsNone(fut.result(timeout=60))
+
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_error_frame_fails_the_job_without_unpickling(self):
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            with patch.object(pool, "pickler", _EmptyTolerantPickler()):
+                pool._handle_job_result(job_id, b"", failed=True)
+            with self.assertRaisesRegex(
+                SubprocException, "SubprocPool failed to deliver a result"
+            ):
+                fut.result(timeout=60)
+
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_base_exception_from_load_fails_only_that_job(self):
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_jobs
+            with patch.object(pool, "pickler", _RaisesOnBadLoadPickler()):
+                pool._handle_job_result(job_id, b"bad")
+            with self.assertRaisesRegex(SubprocException, "pickler raised SystemExit"):
+                fut.result(timeout=60)
+
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
 
 
 class TestCompileWorkerWatchdog(TestCase):

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import io
 import json
 import operator
 import os
@@ -15,14 +16,25 @@ from unittest.mock import patch
 
 import torch._inductor.config as config
 from torch._inductor.compile_worker.subproc_pool import (
+    _recv_msg,
+    _SubprocExceptionInfo,
+    MsgHeader,
     raise_testexc,
     SubprocException,
     SubprocKind,
+    SubprocMain,
+    SubprocPickler,
     SubprocPool,
 )
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_LINUX, skipIfWindows
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    skipIfWindows,
+    subtest,
+)
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
@@ -321,6 +333,204 @@ class TestCompileWorker(TestCase):
 class TestCompileWorkerWithTimer(TestCompileWorker):
     def make_pool(self, size):
         return SubprocPool(size, quiesce=True)
+
+
+class _UnpicklableError(Exception):
+    """Stands in for a job exception that the pickler cannot serialize."""
+
+
+class _FailingPickler(SubprocPickler):
+    def dumps(self, obj):
+        if isinstance(obj, _UnpicklableError):
+            raise RuntimeError("cannot pickle this exception")
+        return super().dumps(obj)
+
+
+class _RefusesFailurePickler(_FailingPickler):
+    """Also refuses the failure details, forcing the empty-payload last resort."""
+
+    def dumps(self, obj):
+        if isinstance(obj, _SubprocExceptionInfo):
+            raise RuntimeError("cannot pickle the failure payload either")
+        return super().dumps(obj)
+
+
+class _DoneFuture:
+    """
+    A finished future that runs done callbacks the way concurrent.futures does:
+    inline, swallowing anything they raise. That swallowing is what turned a
+    dead callback into a silent hang, so the fake has to reproduce it.
+    """
+
+    def __init__(self, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+
+    def exception(self, timeout=None):
+        return self._exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+    def add_done_callback(self, fn):
+        try:
+            fn(self)
+        except Exception:
+            pass
+
+
+class _FakePool:
+    def __init__(self, future):
+        self._future = future
+
+    def submit(self, fn, *args, **kwargs):
+        return self._future
+
+
+class _EmptyTolerantPickler(SubprocPickler):
+    """
+    Returns a value for empty input instead of raising. Custom picklers are a
+    supported hook (SubprocPool takes one), so "unpickling empty data throws"
+    is not something the parent gets to assume.
+    """
+
+    def loads(self, data):
+        return None if not data else super().loads(data)
+
+
+def _run_callback(future, job_id, pickler):
+    """
+    Run SubprocMain's result callback in-process for a finished job and return
+    the bytes it put on the wire, or b"" if it sent nothing.
+    """
+    read_fd, write_fd = os.pipe()
+    with os.fdopen(read_fd, "rb") as parent_read:
+        with os.fdopen(write_fd, "wb") as sidecar_write:
+            # SubprocMain only reads its command pipe from main(), which we
+            # bypass by calling _submit_inner directly.
+            main = SubprocMain(
+                pickler, SubprocKind.FORK, 1, io.BytesIO(), sidecar_write
+            )
+            # Presetting the pool keeps _start_pool from forking real workers.
+            main.pool = _FakePool(future)
+            with main._inflight_lock:
+                main._inflight[job_id] = time.monotonic()
+
+            main._submit_inner(job_id, b"")
+        # The callback ran inline above and the write end is closed now, so this
+        # reads whatever was sent and then hits EOF. A callback that sent nothing
+        # surfaces as no bytes rather than as a hang.
+        return parent_read.read()
+
+
+@instantiate_parametrized_tests
+class TestSubprocMainResultDelivery(TestCase):
+    # Drive SubprocMain's result callback in-process against a fake pool, so the
+    # two escapes in the pre-send work can be reproduced directly. Running the
+    # callback here rather than through a real sidecar is what lets these tests
+    # fail -- instead of hanging -- when it dies without sending anything.
+
+    @parametrize(
+        "future",
+        [
+            # The job raised and the pickler cannot serialize the exception.
+            subtest(
+                _DoneFuture(exc=_UnpicklableError("boom")),
+                name="unpicklable_exception",
+            ),
+            # do_job is supposed to hand back bytes; anything else trips the
+            # isinstance check just before the send.
+            subtest(_DoneFuture(result="not bytes"), name="non_bytes_result"),
+        ],
+    )
+    def test_callback_escape_fails_the_job(self, future):
+        pickler = _FailingPickler()
+        delivered = _run_callback(future, 7, pickler)
+
+        self.assertTrue(
+            delivered, "callback sent nothing: the parent's future would hang forever"
+        )
+        msg_header, job_id, data = _recv_msg(io.BytesIO(delivered))
+        self.assertEqual(msg_header, MsgHeader.JOB)
+        self.assertEqual(job_id, 7)
+        result = pickler.loads(data)
+        self.assertIsInstance(result, _SubprocExceptionInfo)
+        self.assertIn(
+            "SubprocPool failed to deliver a result for job 7", result.details
+        )
+
+    def test_unpicklable_failure_sends_empty_payload(self):
+        # Last resort: the pickler refuses even _SubprocExceptionInfo, so there
+        # is no way to describe the failure. Sending an empty payload is still
+        # better than sending nothing -- the parent fails the job on the empty
+        # payload alone (see test_empty_payload_fails_the_job).
+        delivered = _run_callback(
+            _DoneFuture(exc=_UnpicklableError("boom")), 7, _RefusesFailurePickler()
+        )
+
+        self.assertTrue(
+            delivered, "callback sent nothing: the parent's future would hang forever"
+        )
+        msg_header, job_id, data = _recv_msg(io.BytesIO(delivered))
+        self.assertEqual(msg_header, MsgHeader.JOB)
+        self.assertEqual(job_id, 7)
+        self.assertEqual(data, b"")
+
+
+class TestSubprocPoolResultHandling(TestCase):
+    # The job submitted in these tests is one that never finishes, so the
+    # sidecar has no real reply to race the payload injected for it. That lets
+    # the read thread keep running, so the follow-up jobs below are ordinary
+    # round trips through a real pool.
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_failure_payload_surfaces_as_subproc_exception(self):
+        # Join the two halves: the exact bytes SubprocMain sends when its
+        # callback dies, handed to a real parent, must fail that job and leave
+        # the pool usable. Only the pipe between them is stubbed out, and every
+        # other test in this file runs a real one.
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_futures
+            delivered = _run_callback(
+                _DoneFuture(exc=_UnpicklableError("boom")), job_id, _FailingPickler()
+            )
+            _, _, data = _recv_msg(io.BytesIO(delivered))
+
+            pool._handle_job_result(job_id, data)
+            with self.assertRaisesRegex(
+                SubprocException, "SubprocPool failed to deliver a result"
+            ):
+                fut.result(timeout=60)
+
+            # One failed delivery must not take the pool down.
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
+
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_empty_payload_fails_the_job(self):
+        # An empty JOB payload is how the sidecar says it could not even pickle
+        # a failure for that job (SubprocMain._failure_payload). The parent has
+        # to fail the job on that alone; leaning on the unpickle to throw turns
+        # a hang into a bogus result for any pickler that tolerates empty input.
+        pool = SubprocPool(2)
+        try:
+            fut = pool.submit(time.sleep, 600)
+            (job_id,) = pool.pending_futures
+            with patch.object(pool, "pickler", _EmptyTolerantPickler()):
+                pool._handle_job_result(job_id, b"")
+            with self.assertRaisesRegex(
+                SubprocException, "SubprocPool failed to deliver a result"
+            ):
+                fut.result(timeout=60)
+
+            self.assertEqual(pool.submit(operator.add, 100, 1).result(timeout=60), 101)
+        finally:
+            pool.shutdown()
 
 
 class TestCompileWorkerWatchdog(TestCase):

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -16,6 +16,7 @@ import typing
 from collections.abc import Callable
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass
 from enum import Enum, IntEnum
 from pathlib import Path
 from typing import Any, IO, TypeVar
@@ -54,6 +55,10 @@ class MsgHeader(IntEnum):
     # Sidecar -> parent watchdog report about a still-running job (out-of-band,
     # low volume). Payload is a pickled status dict; does not affect the future.
     STATUS = 5
+    # Sidecar -> parent: the job failed, but even its failure details could not
+    # be serialized. Keeping this distinct from JOB makes an empty successful
+    # serialization unambiguous.
+    JOB_ERROR = 6
 
 
 def _current_compile_id() -> Any:
@@ -91,6 +96,12 @@ _SIDECAR_HEALTH_POLL_SECONDS = 2.0
 # whole shutdown.
 _WORKER_TERMINATE_GRACE_SECONDS = 10.0
 
+_BROKEN_POOL_MAX_SUBMIT_ATTEMPTS = 3
+
+
+def _exit_sidecar() -> Never:
+    os._exit(1)
+
 
 def _send_msg(
     write_pipe: IO[bytes], msg_header: MsgHeader, job_id: int = -1, data: bytes = b""
@@ -105,6 +116,10 @@ def _send_msg(
 def _recv_msg(read_pipe: IO[bytes]) -> tuple[MsgHeader, int, bytes]:
     msg_header, job_id, length = _unpack_msg(read_pipe.read(msg_bytes))
     data = read_pipe.read(length) if length > 0 else b""
+    if len(data) != length:
+        if msg_header in (MsgHeader.JOB, MsgHeader.JOB_ERROR):
+            return MsgHeader.JOB_ERROR, job_id, b""
+        return MsgHeader.ERROR, -1, b""
     return msg_header, job_id, data
 
 
@@ -150,6 +165,13 @@ class SubprocPickler:
 class SubprocKind(Enum):
     FORK = "fork"
     SPAWN = "spawn"
+
+
+@dataclass
+class _PendingJob:
+    future: Future[Any]
+    waitcounter: Any
+    compile_id: Any
 
 
 class SubprocPool:
@@ -243,12 +265,7 @@ class SubprocPool:
         )
 
         self.futures_lock = threading.Lock()
-        self.pending_futures: dict[int, Future[Any]] = {}
-        # Compile id captured at submit so watchdog STATUS reports (handled on the
-        # read thread) attribute to the right compile in tlparse. Keyed by job_id.
-        self._job_compile_id: dict[int, Any] = {}
-        # The pending waitcounter, is used to indicate the time when we have any specific job running.
-        self.pending_waitcounters: dict[int, Any] = {}
+        self.pending_jobs: dict[int, _PendingJob] = {}
         self.job_id_count = itertools.count()
 
         # The running waitcounter indicates the time when the SubProcPool object exists.
@@ -289,13 +306,16 @@ class SubprocPool:
         job_data = self.pickler.dumps(job_fn)
         future: Future[_T]
         with self.futures_lock:
+            if not self.running:
+                raise RuntimeError("Attempting to use a closed pool")
             job_id = next(self.job_id_count)
-            self.pending_futures[job_id] = future = Future()
-            self._job_compile_id[job_id] = _current_compile_id()
-            self.pending_waitcounters[job_id] = _WaitCounter(
-                "pytorch.wait_counter.subproc_pool.job"
-            ).guard()
-            self.pending_waitcounters[job_id].__enter__()
+            future = Future()
+            counter = _WaitCounter("pytorch.wait_counter.subproc_pool.job")
+            waitcounter = counter.guard()
+            waitcounter.__enter__()
+            self.pending_jobs[job_id] = _PendingJob(
+                future, waitcounter, _current_compile_id()
+            )
             if self.quiesce_waitcounter:
                 self.firstjob = True
                 self.quiesce_waitcounter.__exit__()
@@ -332,7 +352,7 @@ class SubprocPool:
                 self._handle_worker_status(job_id, data)
                 continue
 
-            if msg_header != MsgHeader.JOB:
+            if msg_header not in (MsgHeader.JOB, MsgHeader.JOB_ERROR):
                 # read_pipe returned None or got exception
                 if self.running:
                     log.warning("SubprocPool unclean exit")
@@ -343,37 +363,112 @@ class SubprocPool:
                 self.shutdown()
                 return
 
+            if not self._handle_job_result(
+                job_id, data, failed=msg_header == MsgHeader.JOB_ERROR
+            ):
+                return
+
+    def _handle_job_result(
+        self, job_id: int, data: bytes, *, failed: bool = False
+    ) -> bool:
+        """Resolve `job_id`'s future. Returns False once the pool has stopped."""
+        result = self._decode_job_result(job_id, data, failed=failed)
+
+        with self.futures_lock:
+            if not self.running:
+                return False
+            pending_job = self.pending_jobs.pop(job_id, None)
+            was_first_job = self.firstjob_id == job_id
+            if was_first_job:
+                self.firstjob_id = None
+        if pending_job is None:
+            log.error("Received result for unknown job %s; stopping pool", job_id)
+            self.shutdown()
+            return False
+        if self.timer:
+            self._run_job_bookkeeping(self.timer.record_call, "timer update")
+        self._run_job_bookkeeping(pending_job.waitcounter.__exit__, "waitcounter exit")
+        if was_first_job:
+            self._run_job_bookkeeping(
+                self.firstjob_waitcounter.__exit__, "first-job waitcounter exit"
+            )
+        self._resolve_future(pending_job.future, result)
+        return True
+
+    def _decode_job_result(self, job_id: int, data: bytes, *, failed: bool) -> object:
+        """Decode a result frame into a value or per-job failure; never raises."""
+        if failed:
+            return _SubprocExceptionInfo(
+                f"SubprocPool failed to deliver a result for job {job_id}. This "
+                "is an internal compile-worker error, not a failure of the code "
+                "being compiled. The sidecar could not serialize the details, "
+                "or the result pipe was truncated. If serialization failed, "
+                "re-run with TORCHINDUCTOR_WORKER_SUPPRESS_LOGGING=0 for the "
+                "sidecar traceback."
+            )
+        try:
+            return self.pickler.loads(data)
+        except BaseException as e:
             try:
-                result = self.pickler.loads(data)
-            except Exception as e:
-                # Something went wrong unpickling. We have a job_id so just
-                # notify that particular future and continue on.
                 log.exception("unpickle failure in SubprocPool._read_thread")
-                result = e
+            except BaseException:
+                pass
+            return _SubprocExceptionInfo(
+                "SubprocPool failed to deserialize the result for job "
+                f"{job_id}: the pickler raised {type(e).__name__}. This is "
+                "an internal compile-worker error, not a failure of the "
+                "code being compiled."
+            )
 
-            with self.futures_lock:
-                if not self.running:
-                    return
-                if self.timer:
-                    self.timer.record_call()
-                if isinstance(result, _SubprocExceptionInfo):
-                    # An exception occurred in the submitted job
-                    self.pending_futures[job_id].set_exception(
-                        SubprocException(result.details)
-                    )
-                elif isinstance(result, Exception):
-                    # An exception occurred in some of our subprocess machinery.
-                    self.pending_futures[job_id].set_exception(result)
-                else:
-                    self.pending_futures[job_id].set_result(result)
+    @staticmethod
+    def _resolve_future(future: Future[Any], result: object) -> None:
+        try:
+            if isinstance(result, _SubprocExceptionInfo):
+                future.set_exception(SubprocException(result.details))
+            elif isinstance(result, Exception):
+                future.set_exception(result)
+            else:
+                future.set_result(result)
+        except BaseException:
+            # Future callbacks run synchronously. A callback must not kill the
+            # sole result reader or prevent cleanup of the remaining futures.
+            try:
+                log.exception("compile-worker future callback failed")
+            except BaseException:
+                pass
 
-                self.pending_waitcounters[job_id].__exit__()
-                del self.pending_waitcounters[job_id]
-                if self.firstjob_id == job_id:
-                    self.firstjob_waitcounter.__exit__()
+    @staticmethod
+    def _run_job_bookkeeping(callback: Callable[[], object], description: str) -> None:
+        try:
+            callback()
+        except BaseException:
+            try:
+                log.exception("compile-worker %s failed", description)
+            except BaseException:
+                pass
 
-                del self.pending_futures[job_id]
-                self._job_compile_id.pop(job_id, None)
+    def _fail_pending_futures(self, exc: Exception) -> None:
+        with self.futures_lock:
+            pending_jobs = self.pending_jobs
+            firstjob_id = self.firstjob_id
+            self.pending_jobs = {}
+            self.firstjob_id = None
+        for job_id, pending_job in pending_jobs.items():
+            try:
+                if not pending_job.future.cancel():
+                    self._resolve_future(pending_job.future, exc)
+            except BaseException:
+                try:
+                    log.exception("compile-worker future callback failed")
+                except BaseException:
+                    pass
+            self._run_job_bookkeeping(
+                pending_job.waitcounter.__exit__, "waitcounter exit"
+            )
+            if firstjob_id == job_id:
+                self._run_job_bookkeeping(
+                    self.firstjob_waitcounter.__exit__, "first-job waitcounter exit"
+                )
 
     def _health_monitor(self) -> None:
         # Poll the sidecar for liveness. If it dies while we still think we are
@@ -392,35 +487,33 @@ class SubprocPool:
                 # Expected exit (shutdown) or already handled.
                 return
             self.running = False
-        # `running` is set under different locks across shutdown()/_read_thread/
-        # here, so this exit can race another for the same transition. That's
-        # safe: _WaitCounterTracker.__exit__ is idempotent (optional::reset()).
-        self.running_waitcounter.__exit__()
 
         pid = self.process.pid
-        log.error(
-            "Inductor compile worker sidecar (pid %s) exited unexpectedly with "
-            "code %s during compilation; failing pending compile jobs. Re-run "
-            "with TORCHINDUCTOR_COMPILE_THREADS=1 to compile in the main process.",
-            pid,
-            returncode,
-        )
-        self._log_sidecar_death_diagnostics(returncode)
-
         exc = RuntimeError(
             f"Inductor compile worker sidecar (pid {pid}) exited unexpectedly "
             f"with code {returncode} during compilation. Re-run with "
             "TORCHINDUCTOR_COMPILE_THREADS=1 to compile in the main process."
         )
-        with self.futures_lock:
-            for job_id, future in self.pending_futures.items():
-                if not future.cancel():
-                    future.set_exception(exc)
-                waitcounter = self.pending_waitcounters.pop(job_id, None)
-                if waitcounter is not None:
-                    waitcounter.__exit__()
-            self.pending_futures.clear()
-            self._job_compile_id.clear()
+        self._fail_pending_futures(exc)
+
+        try:
+            # `running` is set under different locks across shutdown() /
+            # `_read_thread` / here, so this exit can race another for the same
+            # transition. `_WaitCounterTracker.__exit__` is idempotent.
+            self.running_waitcounter.__exit__()
+            log.error(
+                "Inductor compile worker sidecar (pid %s) exited unexpectedly with "
+                "code %s during compilation; failing pending compile jobs. Re-run "
+                "with TORCHINDUCTOR_COMPILE_THREADS=1 to compile in the main process.",
+                pid,
+                returncode,
+            )
+            self._log_sidecar_death_diagnostics(returncode)
+        except BaseException:
+            try:
+                log.exception("failed to report compile worker sidecar death")
+            except BaseException:
+                pass
         # We intentionally do not close read_pipe here. _read_thread owns it and
         # may be mid-read; closing a buffered pipe out from under a concurrent
         # read can deadlock on the buffer lock. It is a daemon thread, so leaving
@@ -465,7 +558,9 @@ class SubprocPool:
             status = self.pickler.loads(data)
             if not isinstance(status, dict):
                 return
-            compile_id = self._job_compile_id.get(job_id)
+            with self.futures_lock:
+                pending_job = self.pending_jobs.get(job_id)
+            compile_id = pending_job.compile_id if pending_job is not None else None
             record = {**status, "compile_id": str(compile_id) if compile_id else None}
             trace_structured(
                 "artifact",
@@ -479,8 +574,11 @@ class SubprocPool:
                 suppress_context=True,
                 record_logging_overhead=False,
             )
-        except Exception:
-            log.warning("failed to report compile worker status", exc_info=True)
+        except BaseException:
+            try:
+                log.warning("failed to report compile worker status", exc_info=True)
+            except BaseException:
+                pass
 
     def quiesce(self) -> None:
         self._send(MsgHeader.QUIESCE)
@@ -523,12 +621,7 @@ class SubprocPool:
         except OSError:
             log.warning("Ignored OSError in pool shutdown", exc_info=True)
         finally:
-            with self.futures_lock:
-                for future in self.pending_futures.values():
-                    if not future.cancel():
-                        future.set_exception(RuntimeError("SubprocPool closed"))
-                self.pending_futures.clear()
-                self._job_compile_id.clear()
+            self._fail_pending_futures(RuntimeError("SubprocPool closed"))
 
 
 class SubprocMain:
@@ -613,41 +706,118 @@ class SubprocMain:
         # of the workers -- that wait is real and worth surfacing.
         with self._inflight_lock:
             self._inflight[job_id] = time.monotonic()
-        while self.running:
+        for _ in range(_BROKEN_POOL_MAX_SUBMIT_ATTEMPTS):
+            if not self.running:
+                return
             try:
                 self._submit_inner(job_id, data)
                 return
             except BrokenProcessPool:
                 # If any subprocess in the pool crashes, we get a BrokenProcessPool
-                # exception and the whole pool becomes unusable. Handle crashes by
-                # recreating the pool and resubmitting. Log it -- this was
-                # previously silent, hiding repeated worker crashes that can stall
-                # a job in this retry loop.
+                # exception and the whole pool becomes unusable. Reset it so the
+                # next attempt, or the next job after exhaustion, starts clean.
                 log.warning(
                     "Compile worker pool broke while submitting job %s; "
-                    "recreating the pool and retrying.",
+                    "resetting the pool.",
                     job_id,
                     exc_info=True,
                 )
-                self.pool = None
+                self._shutdown_pool(terminate_workers=True)
+        header, payload = self._failure_payload(
+            job_id,
+            f"worker pool broke on {_BROKEN_POOL_MAX_SUBMIT_ATTEMPTS} "
+            "consecutive submit attempts",
+        )
+        self._send_result(job_id, header, payload)
+
+    def _result_payload(self, job_id: int, fut: Future[Any]) -> tuple[MsgHeader, bytes]:
+        """
+        Bytes to send back for `job_id`. Never raises: returning without sending
+        would leave the parent's future pending forever, so each way this can go
+        wrong turns into a payload that fails just this job.
+        """
+        if fut.cancelled():
+            return self._failure_payload(job_id, "the job result was cancelled")
+
+        # exception() rather than result(): whatever the job raised is data the
+        # worker shipped back, and it need not be an Exception -- do_job only
+        # catches those, so a job calling sys.exit() lands a SystemExit here.
+        # Asking for it avoids re-raising it in this thread just to catch it.
+        if (exc := fut.exception()) is not None:
+            log.error("Error in subprocess", exc_info=exc)
+            if not isinstance(exc, Exception):
+                return self._failure_payload(
+                    job_id,
+                    f"the job raised {type(exc).__name__}, which the parent "
+                    "cannot surface as a job failure",
+                )
+            try:
+                return MsgHeader.JOB, self.pickler.dumps(exc)
+            except BaseException:
+                return self._failure_payload(
+                    job_id,
+                    f"could not pickle the {type(exc).__name__} raised by the job\n"
+                    f"{traceback.format_exc()}",
+                )
+        result = fut.result()
+        if not isinstance(result, bytes):
+            return self._failure_payload(
+                job_id, f"expected bytes result, got {type(result)}"
+            )
+        return MsgHeader.JOB, result
+
+    def _failure_payload(self, job_id: int, reason: str) -> tuple[MsgHeader, bytes]:
+        """A payload that fails `job_id` in the parent rather than hanging it."""
+        log.error("job %s: failing the job: %s", job_id, reason)
+        details = (
+            f"SubprocPool failed to deliver a result for job {job_id}: {reason}. "
+            "This is an internal compile-worker error, not a failure of the code "
+            "being compiled."
+        )
+        # Just in case a custom pickler doesn't like _SubprocExceptionInfo.
+        try:
+            return MsgHeader.JOB, self.pickler.dumps(_SubprocExceptionInfo(details))
+        except BaseException:
+            try:
+                log.exception("job %s: could not pickle the failure payload", job_id)
+            except BaseException:
+                pass
+            return MsgHeader.JOB_ERROR, b""
+
+    def _send_result(self, job_id: int, msg_header: MsgHeader, payload: bytes) -> None:
+        try:
+            with self.write_lock:
+                if not self.running:
+                    return
+                _send_msg(self.write_pipe, msg_header, job_id, payload)
+        except BaseException:
+            try:
+                log.exception(
+                    "job %s: failed to deliver a result to the parent", job_id
+                )
+            finally:
+                _exit_sidecar()
+            return
+        with self._inflight_lock:
+            self._inflight.pop(job_id, None)
 
     def _submit_inner(self, job_id: int, data: bytes) -> None:
         def callback(fut: Future[Any]) -> None:
-            with self._inflight_lock:
-                self._inflight.pop(job_id, None)
+            # concurrent.futures swallows anything raised out of a done
+            # callback (it logs to its own logger and moves on), so an escape
+            # here leaves the parent's future pending forever with nothing sent
+            # and nothing logged on the parent side.
             if not self.running:
                 return
             try:
-                result = fut.result()
-            except Exception as e:
-                log.exception("Error in subprocess")
-                result = self.pickler.dumps(e)
-            if not isinstance(result, bytes):
-                raise AssertionError(f"Expected bytes result, got {type(result)}")
-            with self.write_lock:
-                if self.running:
-                    _send_msg(self.write_pipe, MsgHeader.JOB, job_id, result)
-            return
+                msg_header, payload = self._result_payload(job_id, fut)
+            except BaseException:
+                try:
+                    log.exception("job %s: failed to construct result payload", job_id)
+                except BaseException:
+                    pass
+                msg_header, payload = MsgHeader.JOB_ERROR, b""
+            self._send_result(job_id, msg_header, payload)
 
         self._start_pool()
         if self.pool is None:

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -343,6 +343,26 @@ class SubprocPool:
                 self.shutdown()
                 return
 
+            if not self._handle_job_result(job_id, data):
+                return
+
+    def _handle_job_result(self, job_id: int, data: bytes) -> bool:
+        """Resolve `job_id`'s future. Returns False once the pool has stopped."""
+        result: object
+        if not data:
+            # The sidecar sends no payload when it could not even pickle a
+            # failure for this job (see SubprocMain._failure_payload). Fail the
+            # job on the empty payload itself: leaving it to the unpickle below
+            # to throw would resolve the future with whatever a pickler that
+            # tolerates empty input happens to return.
+            result = _SubprocExceptionInfo(
+                f"SubprocPool failed to deliver a result for job {job_id}. This "
+                f"is an internal compile-worker error, not a failure of the code "
+                f"being compiled. The sidecar could not serialize the details; "
+                f"re-run with TORCHINDUCTOR_WORKER_SUPPRESS_LOGGING=0 for its "
+                f"traceback."
+            )
+        else:
             try:
                 result = self.pickler.loads(data)
             except Exception as e:
@@ -351,29 +371,30 @@ class SubprocPool:
                 log.exception("unpickle failure in SubprocPool._read_thread")
                 result = e
 
-            with self.futures_lock:
-                if not self.running:
-                    return
-                if self.timer:
-                    self.timer.record_call()
-                if isinstance(result, _SubprocExceptionInfo):
-                    # An exception occurred in the submitted job
-                    self.pending_futures[job_id].set_exception(
-                        SubprocException(result.details)
-                    )
-                elif isinstance(result, Exception):
-                    # An exception occurred in some of our subprocess machinery.
-                    self.pending_futures[job_id].set_exception(result)
-                else:
-                    self.pending_futures[job_id].set_result(result)
+        with self.futures_lock:
+            if not self.running:
+                return False
+            if self.timer:
+                self.timer.record_call()
+            if isinstance(result, _SubprocExceptionInfo):
+                # An exception occurred in the submitted job
+                self.pending_futures[job_id].set_exception(
+                    SubprocException(result.details)
+                )
+            elif isinstance(result, Exception):
+                # An exception occurred in some of our subprocess machinery.
+                self.pending_futures[job_id].set_exception(result)
+            else:
+                self.pending_futures[job_id].set_result(result)
 
-                self.pending_waitcounters[job_id].__exit__()
-                del self.pending_waitcounters[job_id]
-                if self.firstjob_id == job_id:
-                    self.firstjob_waitcounter.__exit__()
+            self.pending_waitcounters[job_id].__exit__()
+            del self.pending_waitcounters[job_id]
+            if self.firstjob_id == job_id:
+                self.firstjob_waitcounter.__exit__()
 
-                del self.pending_futures[job_id]
-                self._job_compile_id.pop(job_id, None)
+            del self.pending_futures[job_id]
+            self._job_compile_id.pop(job_id, None)
+        return True
 
     def _health_monitor(self) -> None:
         # Poll the sidecar for liveness. If it dies while we still think we are
@@ -631,23 +652,73 @@ class SubprocMain:
                 )
                 self.pool = None
 
+    def _result_payload(self, job_id: int, fut: Future[Any]) -> bytes:
+        """
+        Bytes to send back for `job_id`. Never raises: returning without sending
+        would leave the parent's future pending forever, so each way this can go
+        wrong turns into a payload that fails just this job.
+        """
+        # exception() rather than result(): whatever the job raised is data the
+        # worker shipped back, and it need not be an Exception -- do_job only
+        # catches those, so a job calling sys.exit() lands a SystemExit here.
+        # Asking for it avoids re-raising it in this thread just to catch it.
+        if (exc := fut.exception()) is not None:
+            log.error("Error in subprocess", exc_info=exc)
+            try:
+                return self.pickler.dumps(exc)
+            except Exception:
+                return self._failure_payload(
+                    job_id,
+                    f"could not pickle the {type(exc).__name__} raised by the job\n"
+                    f"{traceback.format_exc()}",
+                )
+        result = fut.result()
+        if not isinstance(result, bytes):
+            return self._failure_payload(
+                job_id, f"expected bytes result, got {type(result)}"
+            )
+        return result
+
+    def _failure_payload(self, job_id: int, reason: str) -> bytes:
+        """A payload that fails `job_id` in the parent rather than hanging it."""
+        log.error("job %s: failing the job: %s", job_id, reason)
+        details = (
+            f"SubprocPool failed to deliver a result for job {job_id}: {reason}. "
+            f"This is an internal compile-worker error, not a failure of the code "
+            f"being compiled."
+        )
+        # Just in case a custom pickler doesn't like _SubprocExceptionInfo.
+        try:
+            return self.pickler.dumps(_SubprocExceptionInfo(details))
+        except Exception:
+            log.exception("job %s: could not pickle the failure payload", job_id)
+            # An empty payload is the pickler-independent way to say "this job
+            # failed": SubprocPool._handle_job_result fails the job on the empty
+            # payload alone, without unpickling anything.
+            return b""
+
     def _submit_inner(self, job_id: int, data: bytes) -> None:
         def callback(fut: Future[Any]) -> None:
+            # concurrent.futures swallows anything raised out of a done
+            # callback (it logs to its own logger and moves on), so an escape
+            # here leaves the parent's future pending forever with nothing sent
+            # and nothing logged on the parent side.
             with self._inflight_lock:
                 self._inflight.pop(job_id, None)
             if not self.running:
                 return
+            payload = self._result_payload(job_id, fut)
             try:
-                result = fut.result()
-            except Exception as e:
-                log.exception("Error in subprocess")
-                result = self.pickler.dumps(e)
-            if not isinstance(result, bytes):
-                raise AssertionError(f"Expected bytes result, got {type(result)}")
-            with self.write_lock:
-                if self.running:
-                    _send_msg(self.write_pipe, MsgHeader.JOB, job_id, result)
-            return
+                with self.write_lock:
+                    if self.running:
+                        _send_msg(self.write_pipe, MsgHeader.JOB, job_id, payload)
+            except Exception:
+                # Pipe gone or closing, so there is nothing left to try and the
+                # parent has to notice via the health monitor or EOF. Log it
+                # anyway: unlike a dropped STATUS report this hangs a job.
+                log.exception(
+                    "job %s: failed to deliver a result to the parent", job_id
+                )
 
         self._start_pool()
         if self.pool is None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3025,6 +3025,10 @@ _cache_config_ignore_prefix: list[str] = [
     # not relevant
     "worker_start_method",
     "compile_threads",
+    # only controls how often the sidecar watchdog reports a still-running job;
+    # it has no effect on compiled output, so including it would change the
+    # config hash and needlessly invalidate every cache entry
+    "compile_worker_watchdog_interval_seconds",
     # see CustomGraphPass; these are handled specially
     "post_grad_custom_post_pass",
     "post_grad_custom_pre_pass",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3019,6 +3019,10 @@ _cache_config_ignore_prefix: list[str] = [
     # not relevant
     "worker_start_method",
     "compile_threads",
+    # only controls how often the sidecar watchdog reports a still-running job;
+    # it has no effect on compiled output, so including it would change the
+    # config hash and needlessly invalidate every cache entry
+    "compile_worker_watchdog_interval_seconds",
     # see CustomGraphPass; these are handled specially
     "post_grad_custom_post_pass",
     "post_grad_custom_pre_pass",


### PR DESCRIPTION
Summary:

`concurrent.futures` runs done callbacks synchronously and only contains ordinary `Exception` values. A callback that raises a `BaseException`, re-enters the pool while internal locks are held, or fails while serializing a result can kill the only result-processing path and leave compile futures pending forever.

Make result delivery explicit and failure-safe. `SubprocMain` converts cancelled futures, non-`Exception` outcomes such as `SystemExit`, non-bytes results, and unpicklable exceptions into per-job failures. A new `JOB_ERROR` frame represents the last-resort failure case when even the diagnostic cannot be serialized, leaving an empty `JOB` payload available to custom picklers as a valid successful serialization. Truncated result frames also become `JOB_ERROR`.

Harden the parent result path. Store each pending job's future, wait counter, and compile ID in one `_PendingJob` record so submission, completion, status attribution, and bulk failure cannot drift across parallel maps. Catch `BaseException` from a caller-supplied `loads()`, remove the pending record while holding `futures_lock`, and resolve its future only after releasing the lock. Keep timer and wait-counter bookkeeping ahead of normal future completion, but contain failures from each bookkeeping operation so they cannot kill the reader or strand the result. During bulk failure, resolve each future before its per-job bookkeeping so one broken counter cannot prevent later futures from completing. A re-entrant done callback can therefore submit work without deadlocking, and a callback that raises `BaseException` cannot kill the reader thread or prevent the remaining pending futures from being failed after sidecar death.

On sidecar death, fail all pending futures before log-tail reads, logging, or structured diagnostics. Treat that reporting as best-effort and contain `BaseException`, so a blocked or broken diagnostic path cannot strand compile jobs.

Bound repeated `BrokenProcessPool` submission failures to three attempts and then fail that job. Keep sidecar-to-parent writes blocking: if a live parent stops draining the pipe, the parent is the failure site and its reader stack preserves the useful diagnosis. A closed pipe is still fatal to the sidecar. Remove a job from `_inflight` only after its result is written successfully.

Separately, add `compile_worker_watchdog_interval_seconds` to `_cache_config_ignore_prefix`. The watchdog interval does not affect compiled output and should not perturb FX graph cache keys, matching existing treatment of `compile_threads` and `worker_start_method`.

This closes silent-hang and stuck-job shapes observed while investigating an APS training job that remained in `async_compile.wait` with no compiler subprocess running.

Authored with Claude.

Test Plan:
`buck2 test fbcode//mode/dbgo fbcode//caffe2/test/inductor:compile_worker`

Result: Pass 60, Fail 0, Skip 2. The skips are `test_quiesce_repeatedly` in `TestCompileWorker` and `TestCompileWorkerWithTimer`.

Focused `TestSubprocMainResultDelivery`: Pass 9, Fail 0.

Focused `TestSubprocPoolResultHandling`: completed successfully.

Focused `test_watchdog_fails_futures_when_no_eof`: Pass 3, Fail 0.

Focused `test_bookkeeping_failure_does_not_strand_result`: pass.

Focused `test_sidecar_death_completes_all_futures_after_callback_base_exception`: Pass 2, Fail 0.

`arc pyre check-owning-targets` on the fbcode implementation and test: no type errors.

`arc lint -a` on the four synchronized Python files: no lint issues.

OSS changed-file lint in `/data/users/aorenste/worktrees/calm-sky`:
`lintrunner -a test/inductor/test_compile_worker.py torch/_inductor/compile_worker/subproc_pool.py torch/_inductor/config.py`
Result: no lint issues.

Regression coverage verifies:
- zero-length successful payloads remain valid while `JOB_ERROR` fails without invoking the custom pickler;
- `BaseException` values from custom serialization and deserialization fail only the affected job;
- re-entrant and `BaseException`-raising future callbacks do not deadlock or strand other pending futures;
- pending-job lifecycle and telemetry state remain atomic in one record;
- timer and wait-counter failures cannot strand a delivered result or stop bulk failure of later futures;
- sidecar-death diagnostic failure cannot prevent pending futures from resolving;
- repeated `BrokenProcessPool` submission failures are bounded and surfaced;
- a failed result-pipe write terminates the sidecar and retains `_inflight` bookkeeping until delivery succeeds;
- unpicklable exceptions, cancelled futures, and non-bytes results produce per-job failures; and
- the pool remains usable after a per-job result failure.

The cache-key exclusion is verified by reading `save_config_portable` in `torch/utils/_config_module.py`, which filters portable cache configuration by `_cache_config_ignore_prefix`.

Reviewed By: bobrenjc93

Differential Revision: D114834644




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo