### PR TITLE
[Test] Enable `test_ao_sparsity.py` for XPU

### DIFF
--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -57,9 +57,9 @@ from ao.sparsity.test_data_sparsifier import (  # noqa: F401
 from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F401
 
 
-instantiate_device_type_tests(TestSaliencyPruner, globals())
-instantiate_device_type_tests(TestBaseStructuredSparsifier, globals())
-instantiate_device_type_tests(TestFPGMPruner, globals())
+instantiate_device_type_tests(TestSaliencyPruner, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestBaseStructuredSparsifier, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestFPGMPruner, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `allow_xpu=True` to `instantiate_device_type_tests` for `TestSaliencyPruner`, `TestBaseStructuredSparsifier` and `TestFPGMPruner`

Test summary:
Before: 88 passed
After: 105 passed, 5 skipped
\-------------------------------
Delta: +17 passed

Newly passed tests (XPU instantiations):
- TestSaliencyPrunerXPU: 2 (saliency / LSTM saliency `update_mask`)
- TestBaseStructuredSparsifierXPU: 14 (constructor, prepare/step/prune for linear and conv2d)
- TestFPGMPrunerXPU: 1 (`test_update_mask`)

The 5 skipped XPU cases are held back by their existing `@onlyCPU`: the 4 LSTM fusion tests and `TestFPGMPruner::test_compute_distance`.