### PR TITLE
[Build] Throttle FlashAttention compilation with a Ninja job pool

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -183,12 +183,18 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* && -z "$TORCH_CUDA_ARCH_LIST" ]]; then
   exit 1
 fi
 
-# FlashAttention CUDA kernels (built for CUDA 8.0+) need large amounts of memory
-# to compile and can OOM at full build parallelism. The previous mitigation set
-# BUILD_CUSTOM_STEP to pre-build the flash_attention target at a reduced job
-# count; it was consumed by the setuptools build path removed in this stack, so
-# it is dropped here. Re-homing the throttle as a CMake JOB_POOLS constraint is
-# tracked in https://github.com/pytorch/pytorch/issues/190663.
+# FlashAttention kernels for CUDA architectures 8.0+ need large amounts of memory
+# to compile and can OOM at full build parallelism.
+if [[ "$BUILD_ENVIRONMENT" == *cuda* ]] && echo "${TORCH_CUDA_ARCH_LIST}" | tr ' ;' '\n' | sed 's/$/>= 8.0/' | bc | grep -q 1; then
+  FLASH_ATTENTION_MAX_JOBS=2
+  case "$RUNNER" in
+    linux.12xlarge.memory|linux.24xlarge.memory)
+      FLASH_ATTENTION_MAX_JOBS=24
+      ;;
+  esac
+  export FLASH_ATTENTION_MAX_JOBS
+  echo "Limiting FlashAttention compilation to ${FLASH_ATTENTION_MAX_JOBS} jobs"
+fi
 
 # TODO: Removeme once all the wrappers are gone
 if [[ "$BUILD_ENVIRONMENT" == *clang* ]] && [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -183,15 +183,14 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* && -z "$TORCH_CUDA_ARCH_LIST" ]]; then
   exit 1
 fi
 
-# FlashAttention kernels for CUDA architectures 8.0+ need large amounts of memory
-# to compile and can OOM at full build parallelism.
-if [[ "$BUILD_ENVIRONMENT" == *cuda* ]] && echo "${TORCH_CUDA_ARCH_LIST}" | tr ' ;' '\n' | sed 's/$/>= 8.0/' | bc | grep -q 1; then
+# FlashAttention kernels need large amounts of memory to compile and can OOM at
+# full build parallelism. Only workflows that select a reviewed high-memory
+# build runner should opt in to the larger target-specific pool.
+if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   FLASH_ATTENTION_MAX_JOBS=2
-  case "$RUNNER" in
-    linux.12xlarge.memory|linux.24xlarge.memory)
-      FLASH_ATTENTION_MAX_JOBS=24
-      ;;
-  esac
+  if [[ "${FLASH_ATTENTION_LARGE_MEMORY_BUILD:-false}" == "true" ]]; then
+    FLASH_ATTENTION_MAX_JOBS=24
+  fi
   export FLASH_ATTENTION_MAX_JOBS
   echo "Limiting FlashAttention compilation to ${FLASH_ATTENTION_MAX_JOBS} jobs"
 fi

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -46,6 +46,13 @@ on:
         default: "linux.c7i.2xlarge"
         description: |
           Label of the runner this job should run on.
+      flash-attention-large-memory-build:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Allow a larger FlashAttention compile pool. Only enable this for a
+          reviewed high-memory build runner.
       test-matrix:
         required: false
         type: string
@@ -229,11 +236,11 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
+          FLASH_ATTENTION_LARGE_MEMORY_BUILD: ${{ inputs.flash-attention-large-memory-build }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           OUR_GITHUB_JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
-          RUNNER: ${{ inputs.runner }}
           SKIP_SCCACHE_INITIALIZATION: 1
         shell: bash
         run: |

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -7,6 +7,13 @@ on:
         required: true
         type: string
         description: The runner to use.
+      flash_attention_large_memory_build:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Allow a larger FlashAttention compile pool. Only enable this for a
+          reviewed high-memory build runner.
       docker_image:
         required: true
         type: string
@@ -44,7 +51,7 @@ jobs:
         SCCACHE_REGION: us-east-1
         TORCH_CUDA_ARCH_LIST: ${{ inputs.torch_cuda_arch_list }}
         BUILD_ENVIRONMENT: ${{ inputs.build_environment }}
-        RUNNER: ${{ inputs.runner }}
+        FLASH_ATTENTION_LARGE_MEMORY_BUILD: ${{ inputs.flash_attention_large_memory_build }}
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/inductor-perf-test-b200.yml
+++ b/.github/workflows/inductor-perf-test-b200.yml
@@ -90,6 +90,7 @@ jobs:
       # from trunk. Also use a memory-intensive runner here because memory is
       # usually the bottleneck
       runner: l-x86iavx512-48-384
+      flash-attention-large-memory-build: true
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm100
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-inductor-benchmarks

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -114,6 +114,7 @@ jobs:
     uses: ./.github/workflows/_vllm-build.yml
     with:
       runner: mt-l-x86iavx512-94-768
+      flash_attention_large_memory_build: true
       docker_image: ${{ needs.set-parameters.outputs.docker_image }}
       build_environment: ${{ needs.set-parameters.outputs.build_environment }}
       pytorch_branch: ${{ inputs.pytorch_branch }}

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -353,6 +353,13 @@ if(USE_CUDA AND (USE_FLASH_ATTENTION OR USE_MEM_EFF_ATTENTION))
   )
 
   set_target_properties(flash_attention PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  if(FLASH_ATTENTION_MAX_JOBS)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS
+      flash_attention_compile=${FLASH_ATTENTION_MAX_JOBS})
+    set_property(TARGET flash_attention PROPERTY JOB_POOL_COMPILE
+      flash_attention_compile)
+  endif()
 endif()
 
 if(USE_FLASH_ATTENTION)

--- a/cmake/EnvVarForwarding.cmake
+++ b/cmake/EnvVarForwarding.cmake
@@ -19,6 +19,8 @@
 #   MAX_JOBS                 compile parallelism; aliased to
 #                            CMAKE_BUILD_PARALLEL_LEVEL by [tool.scikit-build.env]
 #                            in pyproject.toml
+#   FLASH_ATTENTION_MAX_JOBS max concurrent FlashAttention CUDA compilations;
+#                            unset by default, set by CUDA CI based on runner memory
 #   CC / CXX / CFLAGS        compiler and flags; read by CMake / scikit-build-core
 #                            directly (CFLAGS also applies to C++ unless CXXFLAGS
 #                            is set)
@@ -130,6 +132,7 @@ set(_ENV_PASSTHROUGH
   CUDNN_INCLUDE_DIR
   CUDNN_ROOT
   EXPERIMENTAL_SINGLE_THREAD_POOL
+  FLASH_ATTENTION_MAX_JOBS
   INSTALL_TEST
   INTEL_MKL_DIR
   INTEL_OMP_DIR


### PR DESCRIPTION
## Human Note
pretty much straight from the issue; restoring the job limitng for smaller build machines in ci

## Agent Report
# Restore the FlashAttention build-memory throttle

## Summary

The scikit-build-core migration removed the only consumer of `BUILD_CUSTOM_STEP`, so the vendored FlashAttention CUDA objects again compiled at the main build's full parallelism. The PR restores the historical 2/24-job throttle as a target-specific CMake/Ninja compile pool.

The review follow-up now keeps CI policy semantic rather than duplicating infrastructure details in shell: ordinary CUDA builds use a pool depth of 2, while reusable workflows explicitly opt reviewed high-memory build jobs into depth 24.

## Root cause

`flash_attention` remains an OBJECT library whose objects are included in `torch_cuda`. Before the migration, `.ci/pytorch/build.sh` set `BUILD_CUSTOM_STEP`, and `tools/build_pytorch_libs.py` pre-built that target with reduced global Ninja parallelism. Removing the setuptools helper removed the pre-build path without replacing its memory control.

Consequently, FlashAttention translation units became ordinary edges in the main Ninja build and could run up to `MAX_JOBS`, recreating the compiler OOM risk.

## Fix

- `.ci/pytorch/build.sh` exports `FLASH_ATTENTION_MAX_JOBS=2` for CUDA CI builds.
- A semantic `FLASH_ATTENTION_LARGE_MEMORY_BUILD=true` capability raises that value to 24. The numeric 2/24 policy exists only in `build.sh`.
- `_linux-build.yml` and `_vllm-build.yml` define boolean inputs that default to false and pass the capability to `build.sh`.
- The B200 performance build and vLLM benchmark build opt in next to their actual high-memory runner selections.
- `build.sh` no longer contains runner labels or parses `TORCH_CUDA_ARCH_LIST`. Runner identity remains where workflows select runners, and CUDA architecture grammar remains owned by CMake.
- The reusable workflows no longer forward a duplicate `RUNNER` environment variable. Their runner inputs remain the single value used by `runs-on`; the old environment transport had no consumer after removing runner inference from `build.sh`.
- `cmake/EnvVarForwarding.cmake` forwards the selected depth into the CMake cache.
- `aten/src/ATen/CMakeLists.txt` creates a `flash_attention_compile` pool and assigns it to `flash_attention` through `JOB_POOL_COMPILE`.
- When the depth is unset, no pool is defined, preserving normal local-build parallelism. Non-Ninja generators accept and ignore the target pool property.

Applying the target-specific pool to all CUDA CI builds is conservative for pre-SM80 configurations, but it avoids maintaining a second, incomplete CUDA architecture parser in shell. The separate binary-build `MAX_JOBS=12` cap remains unchanged because those paths do not currently export this target-pool setting.

## Reproduction

The issue is a missing build constraint rather than a deterministic runtime failure. The script compares the pinned unfixed revision with the working tree and verifies both the CMake scheduling contract and the workflow capability wiring.

<details>
<summary>Repro Script</summary>

```python
from pathlib import Path
import subprocess


JOB_DIR = Path(__file__).resolve().parent
SOURCE_DIR = JOB_DIR / "pytorch"
CMAKE_PATH = "aten/src/ATen/CMakeLists.txt"
BUILD_SCRIPT_PATH = ".ci/pytorch/build.sh"
ENV_FORWARDING_PATH = "cmake/EnvVarForwarding.cmake"
LINUX_BUILD_WORKFLOW_PATH = ".github/workflows/_linux-build.yml"
B200_WORKFLOW_PATH = ".github/workflows/inductor-perf-test-b200.yml"
VLLM_BUILD_WORKFLOW_PATH = ".github/workflows/_vllm-build.yml"
VLLM_BENCHMARK_WORKFLOW_PATH = ".github/workflows/vllm-benchmark.yml"
BASE_REV = "aa8abcb98c32ef307cba9fb67839925a73ba712b"


def read_baseline(path: str) -> str:
    """Read a tracked file from the unfixed checkout revision."""
    return subprocess.check_output(
        ["git", "show", f"{BASE_REV}:{path}"], cwd=SOURCE_DIR, text=True
    )


baseline_cmake = read_baseline(CMAKE_PATH)
baseline_build_script = read_baseline(BUILD_SCRIPT_PATH)
baseline_env_forwarding = read_baseline(ENV_FORWARDING_PATH)
current_cmake = (SOURCE_DIR / CMAKE_PATH).read_text()
current_build_script = (SOURCE_DIR / BUILD_SCRIPT_PATH).read_text()
current_env_forwarding = (SOURCE_DIR / ENV_FORWARDING_PATH).read_text()
current_linux_workflow = (SOURCE_DIR / LINUX_BUILD_WORKFLOW_PATH).read_text()
current_b200_workflow = (SOURCE_DIR / B200_WORKFLOW_PATH).read_text()
current_vllm_workflow = (SOURCE_DIR / VLLM_BUILD_WORKFLOW_PATH).read_text()
current_vllm_benchmark = (SOURCE_DIR / VLLM_BENCHMARK_WORKFLOW_PATH).read_text()

assert "JOB_POOL_COMPILE" not in baseline_cmake
assert "BUILD_CUSTOM_STEP" in baseline_build_script
assert "FLASH_ATTENTION_MAX_JOBS" not in baseline_env_forwarding
print("REPRODUCED: baseline has no compile pool on the flash_attention target")
print("REPRODUCED: baseline only documents the removed BUILD_CUSTOM_STEP throttle")

assert "JOB_POOL_COMPILE" in current_cmake
assert "export FLASH_ATTENTION_MAX_JOBS" in current_build_script
assert "FLASH_ATTENTION_MAX_JOBS" in current_env_forwarding
selection_block = current_build_script.split("# FlashAttention kernels", 1)[1].split(
    "# TODO:", 1
)[0]
assert "FLASH_ATTENTION_LARGE_MEMORY_BUILD" in selection_block
assert "TORCH_CUDA_ARCH_LIST" not in selection_block
assert "RUNNER" not in selection_block
assert "flash-attention-large-memory-build:" in current_linux_workflow
assert "flash-attention-large-memory-build: true" in current_b200_workflow
assert "RUNNER: ${{ inputs.runner }}" not in current_linux_workflow
assert "flash_attention_large_memory_build:" in current_vllm_workflow
assert "flash_attention_large_memory_build: true" in current_vllm_benchmark
assert "RUNNER: ${{ inputs.runner }}" not in current_vllm_workflow
print("FIXED: working tree assigns the FlashAttention compile pool")
print("FIXED: CUDA CI selects its depth through an explicit workflow capability")
print("FIXED: build.sh no longer duplicates runner labels or CUDA arch grammar")
print("FIXED: reusable workflows no longer forward the obsolete RUNNER environment")
```

Output:

```text
REPRODUCED: baseline has no compile pool on the flash_attention target
REPRODUCED: baseline only documents the removed BUILD_CUSTOM_STEP throttle
FIXED: working tree assigns the FlashAttention compile pool
FIXED: CUDA CI selects its depth through an explicit workflow capability
FIXED: build.sh no longer duplicates runner labels or CUDA arch grammar
FIXED: reusable workflows no longer forward the obsolete RUNNER environment
```

</details>

## Validation

### Focused behavioral checks

- Verified CUDA selection with an absent/false capability produces 2, true produces 24, and a non-CUDA build remains unset.
- Confirmed architecture spellings including `8.6+PTX`, `9.0a`, `9.0f`, `Ampere`, `Hopper`, `Blackwell`, and parenthesized forms no longer require shell parsing.
- Parsed both reusable workflows and callers, confirming boolean inputs default false, both high-memory jobs opt in, both build environments receive the capability, and neither forwards the obsolete `RUNNER` environment.
- Configured fresh Ninja smoke builds at depths 2 and 24; each generated the expected pool depth and attached the target compile edge.
- Confirmed an unset CMake variable generates no pool and a Unix Makefiles configure/build succeeds with the variable set.
- Ran the structural repro with the required job Python.

The complete passing output is in `validation.log`.

### Prerequisite and lint checks

- `bash -n .ci/pytorch/build.sh` passed.
- `git diff --check` passed.
- `spin quicklint` passed all changed files, including GitHub Actions validation, with no issues.
- Required `spin fixlint` was run after the final source edit. Its repository-wide pass exits 1 on unrelated existing all-file failures (`CLANGTIDY_EXECUTORCH_COMPATIBILITY` lacks a top-level compilation database and legacy scripts have shellcheck findings). It reports no issue in any changed file and creates no additional tracked changes. Full output is in `spin_fixlint.log`.

No full PyTorch rebuild was run because this follow-up changes shell/workflow policy only, the underlying CMake pool implementation is already in the PR, and a successful local build cannot establish absence of an OOM. The focused generator checks directly validate the scheduling contract.

## Low-resource build research

Parallel research of upstream FlashAttention/FA4, CUDA projects, package builders, and compiler controls is summarized in `fa_build_research.md`. The strongest findings are:

- upstream budgets roughly 3-5 GB per NVCC thread and uses `MAX_JOBS=1-2` plus `NVCC_THREADS=2` on constrained wheel builders;
- upstream's five-hour timeout plus cached partial build state validates timeout/resume as a useful broader CI strategy;
- architecture and feature pruning can reduce work substantially but change artifact coverage or functionality;
- FA4 now packages as pure Python/CuTeDSL and moves CUDA compilation to runtime JIT, so it has no directly transferable AOT packaging throttle.

These findings support a target pool as the narrow artifact-preserving fix for PyTorch's vendored AOT build.

## Remaining uncertainty

The pool constrains FlashAttention compilation but does not impose a total memory budget across unrelated targets. Only repeated CUDA CI runs can establish whether depths 2 and 24 leave sufficient whole-build memory headroom for every toolkit and runner combination.

The capability is deliberately fail-closed: new callsites receive 2 unless they explicitly opt in. Because the opt-in is adjacent to runner selection, runner changes are reviewable in one place, though a caller could still become stale if someone changes its runner without reconsidering the flag. Pre-SM80 CUDA jobs may also compile this target more conservatively than necessary; that is the explicit tradeoff for eliminating duplicate architecture grammar from shell.


Fixes #190663


<details>
<summary>Repro Script</summary>

```python
from pathlib import Path
import subprocess


JOB_DIR = Path(__file__).resolve().parent
SOURCE_DIR = JOB_DIR / "pytorch"
CMAKE_PATH = "aten/src/ATen/CMakeLists.txt"
BUILD_SCRIPT_PATH = ".ci/pytorch/build.sh"
ENV_FORWARDING_PATH = "cmake/EnvVarForwarding.cmake"
LINUX_BUILD_WORKFLOW_PATH = ".github/workflows/_linux-build.yml"
B200_WORKFLOW_PATH = ".github/workflows/inductor-perf-test-b200.yml"
VLLM_BUILD_WORKFLOW_PATH = ".github/workflows/_vllm-build.yml"
VLLM_BENCHMARK_WORKFLOW_PATH = ".github/workflows/vllm-benchmark.yml"
BASE_REV = "aa8abcb98c32ef307cba9fb67839925a73ba712b"


def read_baseline(path: str) -> str:
    """Read a tracked file from the unfixed checkout revision."""
    return subprocess.check_output(
        ["git", "show", f"{BASE_REV}:{path}"], cwd=SOURCE_DIR, text=True
    )


baseline_cmake = read_baseline(CMAKE_PATH)
baseline_build_script = read_baseline(BUILD_SCRIPT_PATH)
baseline_env_forwarding = read_baseline(ENV_FORWARDING_PATH)
current_cmake = (SOURCE_DIR / CMAKE_PATH).read_text()
current_build_script = (SOURCE_DIR / BUILD_SCRIPT_PATH).read_text()
current_env_forwarding = (SOURCE_DIR / ENV_FORWARDING_PATH).read_text()
current_linux_workflow = (SOURCE_DIR / LINUX_BUILD_WORKFLOW_PATH).read_text()
current_b200_workflow = (SOURCE_DIR / B200_WORKFLOW_PATH).read_text()
current_vllm_workflow = (SOURCE_DIR / VLLM_BUILD_WORKFLOW_PATH).read_text()
current_vllm_benchmark = (SOURCE_DIR / VLLM_BENCHMARK_WORKFLOW_PATH).read_text()

assert "JOB_POOL_COMPILE" not in baseline_cmake
assert "BUILD_CUSTOM_STEP" in baseline_build_script
assert "FLASH_ATTENTION_MAX_JOBS" not in baseline_env_forwarding
print("REPRODUCED: baseline has no compile pool on the flash_attention target")
print("REPRODUCED: baseline only documents the removed BUILD_CUSTOM_STEP throttle")

assert "JOB_POOL_COMPILE" in current_cmake
assert "export FLASH_ATTENTION_MAX_JOBS" in current_build_script
assert "FLASH_ATTENTION_MAX_JOBS" in current_env_forwarding
selection_block = current_build_script.split("# FlashAttention kernels", 1)[1].split(
    "# TODO:", 1
)[0]
assert "FLASH_ATTENTION_LARGE_MEMORY_BUILD" in selection_block
assert "TORCH_CUDA_ARCH_LIST" not in selection_block
assert "RUNNER" not in selection_block
assert "flash-attention-large-memory-build:" in current_linux_workflow
assert "flash-attention-large-memory-build: true" in current_b200_workflow
assert "RUNNER: ${{ inputs.runner }}" not in current_linux_workflow
assert "flash_attention_large_memory_build:" in current_vllm_workflow
assert "flash_attention_large_memory_build: true" in current_vllm_benchmark
assert "RUNNER: ${{ inputs.runner }}" not in current_vllm_workflow
print("FIXED: working tree assigns the FlashAttention compile pool")
print("FIXED: CUDA CI selects its depth through an explicit workflow capability")
print("FIXED: build.sh no longer duplicates runner labels or CUDA arch grammar")
print("FIXED: reusable workflows no longer forward the obsolete RUNNER environment")
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Context and structural reproduction

Read the PTQ context, repository policy, and relevant build files. The checkout is clean at detached `aa8abcb98c3`. The current `flash_attention` OBJECT target in `aten/src/ATen/CMakeLists.txt` has no `JOB_POOL_COMPILE` property, while `.ci/pytorch/build.sh` contains only a comment documenting that the old `BUILD_CUSTOM_STEP` throttle was removed. This reproduces the reported regression structurally: FlashAttention compile edges receive the main Ninja build's unrestricted parallelism.

Historical inspection confirmed that the removed logic selected 2 jobs by default and 24 on `linux.12xlarge.memory` / `linux.24xlarge.memory`. `cmake/EnvVarForwarding.cmake` is the current authoritative path for carrying non-`USE_*`/`BUILD_*` environment settings into the CMake cache.

### Initial fix and focused validation

Added a `FLASH_ATTENTION_MAX_JOBS` setting selected by CUDA CI with the historical 2/24 runner tiers, forwarded it into CMake, and assigned the `flash_attention` OBJECT target to a dedicated `flash_attention_compile` Ninja pool. With the variable unset, no pool is defined, preserving default local-build parallelism; non-Ninja generators ignore the target pool property.

A focused CMake smoke project confirmed that `FLASH_ATTENTION_MAX_JOBS=2` produces a Ninja pool with depth 2 and attaches the target's compile edge, while an unset variable produces neither the pool nor an assignment. A Unix Makefiles configure/build also succeeded with the setting present. Extracted CI selection logic produced 2 jobs for ordinary CUDA runners, 24 for both memory-runner tiers, and no setting for pre-SM80 or CPU builds. The architecture parser now accepts both space- and semicolon-separated `TORCH_CUDA_ARCH_LIST` values, matching formats already used by repository workflows.

Added and ran `repro.py`, which compares tracked HEAD with the working tree: it reproduces that HEAD has only the dead-throttle comment and no compile-pool property, then confirms the working tree exports, forwards, and applies the new setting. `shellcheck -e SC1091 .ci/pytorch/build.sh` and `git diff --check` pass. Required `spin fixlint` was run; its repository-wide pass failed on pre-existing shellcheck findings in unrelated legacy CI scripts, while the directly changed shell script passes targeted shellcheck and no extra tracked files were modified.

### Parallel low-resource build research

Started four independent research workers covering upstream FlashAttention/FA4 controls, comparable CUDA project CI patterns, package-builder/container experience, and authoritative CMake/Ninja/NVCC mechanisms. Results support the target pool as the correct transparent fix: upstream budgets approximately 3-5 GB per NVCC thread, uses `MAX_JOBS=1-2` plus `NVCC_THREADS=2` on constrained wheel builders, and recommends architecture/feature pruning only when reduced artifact coverage is acceptable. FA4 itself now ships as a small pure-Python CuTeDSL package, moving CUDA compilation to runtime, so its packaging no longer provides an AOT-build throttle precedent. Upstream also uses a five-hour timeout with cached partial build state to resume exceptionally long wheel builds; that is a broader CI strategy, not part of this focused PyTorch CMake fix. The claim-level synthesis and sources are in `fa_build_research.md`.

### Final validation and artifacts

Re-ran the complete focused validation after the final edit. The enabled Ninja configuration generated `flash_attention_compile` at depth 2 and attached the compile edge; the unset configuration generated no pool; both Ninja variants and the Unix Makefiles variant built successfully. All runner-selection cases, the structural repro, targeted shellcheck, and diff hygiene passed. Output is recorded in `validation.log`.

Ran final `spin fixlint`; the all-files command remains red because of unrelated clang-tidy setup and legacy shellcheck findings, with no issue reported for the changed files. Wrote `report.md`, `pr_title.txt`, `pr_labels.txt` (`release notes: build`), and regenerated `fix.diff` from the final three-file source diff.

### Follow-up design review

Reviewed the configuration path after a question about whether environment forwarding is sufficiently CMake-native. The scheduling mechanism itself is CMake's target-scoped `JOB_POOLS` / `JOB_POOL_COMPILE` facility. The environment variable is only the CI transport for a normal CMake cache variable, equivalent to passing `-DFLASH_ATTENTION_MAX_JOBS=N`; direct `-D` configuration already works. Keeping runner-memory policy in `build.sh` avoids embedding CI runner names or unreliable host-memory detection in project CMake, while PyTorch's scikit-build entry point makes the central `EnvVarForwarding.cmake` bridge the repository-standard way to carry dynamic CI settings. A possible nonessential hardening is explicit positive-integer validation of the cache value.

### PR review feedback fetched

Fetched all issue comments, reviews, inline comments, and review-thread states for PR #192305. Two inline threads remain unresolved. The first flags that legacy `linux.12xlarge.memory` / `linux.24xlarge.memory` values are logical test-runner labels, while `_linux-build.yml` actually places their build step on `l-x86iavx512-8-64`; selecting 24 from `RUNNER` can therefore weaken the cap on a 64-GB host. Source inspection confirms the workflow mapping and forwarded logical label differ. A reviewer reply also asks whether the separate global binary-build `MAX_JOBS` cap can be raised after introducing the targeted pool; the cap found in `binary_populate_env.sh` is 12 and would need separate plumbing before removal.

The second thread flags valid architecture spellings such as `8.6+PTX`, `9.0a`, and `9.0f`: feeding those directly to `bc` makes the condition fail, leaving the pool unset. Repository parsing and tests confirm those suffixes are supported. Skylion007 approved conditionally with “Looks good after you strip the suffix.” The PR currently has two CI failures, both classified as infrastructure failures (pod/image startup and the consequent missing artifact), not code failures. No GitHub state or source was changed while fetching this feedback.

### Review feedback addressed locally

After explicit user approval, updated `.ci/pytorch/build.sh` to grant the 24-job pool only to an exact, auditable allowlist of actual large-memory ARC build labels (`l-x86iavx512-48-384`, `l-x86iavx512-94-768`, and their `mt-` forms). The legacy logical memory labels now deliberately receive the safe 2-job default because their reusable-workflow build phase can run on `l-x86iavx512-8-64`. Unknown or renamed runners also fail closed to 2. The separate binary-build `MAX_JOBS=12` cap remains unchanged because binary builds do not yet export the target-pool setting.

Normalized supported CUDA architecture suffixes before the SM80 comparison: `+PTX` is removed first and trailing `a` / `f` second, including combined forms such as `9.0a+PTX`. Focused selection tests passed for all four allowlist entries, both legacy logical labels, small/unlisted/unknown labels, suffix variants, pre-SM80 variants, mixed delimiters, and CPU builds. Re-ran the structural repro, fresh enabled/unset Ninja generator builds, Unix Makefiles compatibility build, shell syntax, targeted shellcheck, and diff hygiene; all passed and are recorded in `validation.log`.

Re-ran required `spin fixlint` after the final formatting edit. It remains red only on the repository-wide pre-existing clang-tidy setup and legacy shellcheck findings, while targeted shellcheck for the changed script passes and no additional tracked files were modified. Updated `repro.py` to compare against the pinned unfixed merge base now that the original fix is committed on the PR branch, and refreshed `report.md` accordingly.

### Capability-based review redesign

After explicit user approval, replaced the local runner allowlist and CUDA suffix parser with a semantic workflow capability. CUDA builds now select the safe depth 2 by default; `FLASH_ATTENTION_LARGE_MEMORY_BUILD=true` selects 24. The 2/24 constants remain solely in `.ci/pytorch/build.sh`, which no longer knows runner labels or CUDA architecture grammar.

Added default-false boolean inputs to `_linux-build.yml` and `_vllm-build.yml`, passed them into the PyTorch build environment, and opted in only at the B200 performance and vLLM benchmark callsites next to their actual high-memory runner selections. This makes runner choice and memory capability reviewable together while unknown and new callsites fail closed to 2.

Fresh validation passed for false/unset/true capability selection, CPU behavior, named and suffixed CUDA architecture strings without shell parsing, reusable-workflow input/default/env wiring, Ninja pool depths 2 and 24, the unset-pool case, Unix Makefiles compatibility, the structural repro, shell syntax, diff hygiene, and `spin quicklint`. Required `spin fixlint` was rerun and remains red only on the unrelated repository-wide clang-tidy setup and legacy shellcheck findings; no changed file was flagged or unexpectedly modified. Refreshed `validation.log`, `spin_fixlint.log`, `repro.py`, `report.md`, and `fix.diff`. No commit, push, or GitHub mutation was performed.

### Code simplifier pass

Reviewed the final ownership and concept budget before changing more code. Retained the semantic boolean because a direct numeric input would duplicate the 24-job policy at both callers, runner inference would restore the brittle label coupling, and a generic arbitrary-environment input would be a speculative extension point. The boolean remains the narrow interface between workflow-owned memory capability and the single 2/24 policy in `build.sh`.

After explicit approval, removed the obsolete `RUNNER` environment export from `_linux-build.yml` and `_vllm-build.yml`. Both lines were introduced while the historical `case "$RUNNER"` throttle still existed; the working tree has no remaining build consumer, and the pinned vLLM source does not consume it. The runner inputs remain unchanged and continue to select `runs-on`.

Re-ran the full focused validation, including explicit assertions that neither reusable workflow exposes `RUNNER` to the build environment. Pool selection, workflow wiring, Ninja depths 2/24, unset and Makefiles cases, structural repro, diff hygiene, and `spin quicklint` all pass. Required `spin fixlint` again reports only unrelated repository-wide failures and makes no additional tracked changes. No commit, push, or GitHub mutation was performed.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*