### PR TITLE
[TEST] Refactor test_nn_init.py with hw_classification

### DIFF
--- a/test/nn/test_init.py
+++ b/test/nn/test_init.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 import torch.nn.init as init
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     parametrize as parametrize_test,
     run_tests,
     skipIfNoLapack,
@@ -46,6 +47,8 @@ ALL_INIT_FNS = [
 
 
 class TestNNInit(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         random.seed(123)
@@ -571,6 +574,8 @@ class TestNNInit(TestCase):
 
 
 class TestNNInitDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @torch._dynamo.disable
     def _is_trunc_normal(self, tensor, mean, std, a, b):
         z_samples = (tensor.view(-1) - mean) / std


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestNNInit`: `GENERIC` — all tests operate on CPU/meta tensors; no device param
- `TestNNInitDeviceType`: `ACCELERATOR` — every method takes `device`; already uses `instantiate_device_type_tests`
- 5 lines added, no logic changed

## Test Plan

```
python test/nn/test_init.py -v
# 53 passed, 1 skipped

python test/nn/test_init.py --hw-classification GENERIC -v
# 31 passed, unclassified=0

python test/nn/test_init.py --hw-classification ACCELERATOR -v
# 22 passed, unclassified=0
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508