### PR TITLE
[DCP] Preserve frozen-parameter optimizer state and initialize partially initialized state

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -47,7 +47,13 @@ from torch.testing._internal.common_dist_composable import (
     UnitModule,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MultiProcessTestCase,
@@ -1081,6 +1087,53 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             },
             _test_multi,
         )
+
+
+class TestFrozenParamOptimStateDict(TestCase):
+    """Tests optimizer state_dict handling of frozen parameters without comms."""
+
+    def _make_model_optim(self) -> tuple[nn.Module, torch.optim.Optimizer]:
+        model = nn.Sequential(nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False))
+        return model, torch.optim.AdamW(model.parameters())
+
+    def test_partial_optim_state_init_with_frozen_param(self) -> None:
+        # A trained-then-frozen param with existing optimizer state must not
+        # block state initialization of the other trainable params, and its
+        # own state must not be mutated by get_optimizer_state_dict().
+        model, optim = self._make_model_optim()
+        frozen = model[0].weight
+        frozen.sum().backward()
+        optim.step()
+        optim.zero_grad()
+        frozen.requires_grad_(False)
+        orig_frozen_state = copy.deepcopy(optim.state[frozen])
+
+        osd = get_optimizer_state_dict(model, optim)
+        self.assertEqual(set(osd["state"].keys()), {"0.weight", "1.weight"})
+        self.assertEqual(optim.state[frozen], orig_frozen_state)
+
+    @parametrize("flatten_optimizer_state_dict", [True, False])
+    def test_frozen_param_optim_state_round_trip(
+        self, flatten_optimizer_state_dict: bool
+    ) -> None:
+        # Optimizer state of a param frozen after training must survive a
+        # get_optimizer_state_dict()/set_optimizer_state_dict() round trip.
+        model, optim = self._make_model_optim()
+        model(torch.rand(2)).sum().backward()
+        optim.step()
+        optim.zero_grad()
+        model[0].weight.requires_grad_(False)
+
+        options = StateDictOptions(
+            flatten_optimizer_state_dict=flatten_optimizer_state_dict
+        )
+        osd = get_optimizer_state_dict(model, optim, options=options)
+        new_optim = torch.optim.AdamW(model.parameters())
+        set_optimizer_state_dict(model, new_optim, osd, options=options)
+        self.assertEqual(new_optim.state_dict(), optim.state_dict())
+
+
+instantiate_parametrized_tests(TestFrozenParamOptimStateDict)
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -630,7 +630,17 @@ def _init_optim_state(optim: torch.optim.Optimizer) -> None:
     """
     Initialize optim states by calling the step() with zero grads.
     """
-    if optim.state:
+    # Only initialize the state of trainable parameters that do not have any
+    # state yet. Parameters that already have state (e.g., previously trained
+    # but now frozen ones) must not be stepped again as that would mutate
+    # their state.
+    uninitialized_params = [
+        param
+        for param_group in optim.param_groups
+        for param in param_group[_PARAMS]
+        if param.requires_grad and not optim.state.get(param)
+    ]
+    if not uninitialized_params:
         # The optimizer state is initialized.
         return
 
@@ -643,10 +653,8 @@ def _init_optim_state(optim: torch.optim.Optimizer) -> None:
             if param.grad is not None:
                 return
 
-    for param_group in optim.param_groups:
-        for param in param_group[_PARAMS]:
-            if param.requires_grad:
-                param.grad = torch.zeros_like(param)
+    for param in uninitialized_params:
+        param.grad = torch.zeros_like(param)
 
     # Some optimizers will update parameters regardless of grads due to lr, so
     # make lr to zero when calling `step()`.
@@ -859,14 +867,26 @@ def _unflatten_optim_state_dict(
                     raise AssertionError(f"Expected list, got {type(params)}")
                 params.append(fqn)
 
-                # Only add state if param requires grad
-                if not param.requires_grad:
-                    continue
+                if param.requires_grad:
+                    state_names = list(optim.state[param].keys())
+                else:
+                    # Frozen params have no local optimizer state, so recover
+                    # the saved state names from the flattened keys.
+                    state_prefix = f"{_STATE}.{fqn}."
+                    state_names = sorted(
+                        {
+                            key[len(state_prefix) :].split(".")[0]
+                            for key in state_dict
+                            if key.startswith(state_prefix)
+                        }
+                    )
+                    if not state_names:
+                        continue
 
                 # Reconstruct state for this parameter
                 # pyrefly: ignore [unsupported-operation]
                 state[fqn] = {}
-                for state_name in optim.state[param]:
+                for state_name in state_names:
                     flattened_state_key = f"{_STATE}.{fqn}.{state_name}"
 
                     if flattened_state_key not in state_dict:
@@ -1029,15 +1049,14 @@ def _split_optim_state_dict(
                 if not isinstance(params, list):
                     raise AssertionError(f"Expected list, got {type(params)}")
                 params.append(fqn)
-                if param.requires_grad:
-                    if fqn in cast(DictValueType, optim_state_dict[_STATE]):
-                        state[fqn] = cast(DictValueType, optim_state_dict[_STATE])[fqn]
-                    elif info.strict:
-                        raise RuntimeError(
-                            f"Missing optimizer state for parameter '{fqn}' in checkpoint. "
-                            "The parameter requires gradients but has no saved optimizer state. "
-                            "To load anyway, use StateDictOptions(strict=False)."
-                        )
+                if fqn in cast(DictValueType, optim_state_dict[_STATE]):
+                    state[fqn] = cast(DictValueType, optim_state_dict[_STATE])[fqn]
+                elif param.requires_grad and info.strict:
+                    raise RuntimeError(
+                        f"Missing optimizer state for parameter '{fqn}' in checkpoint. "
+                        "The parameter requires gradients but has no saved optimizer state. "
+                        "To load anyway, use StateDictOptions(strict=False)."
+                    )
                 for loaded_param_group in cast(
                     ListDictValueType, optim_state_dict[_PG]
                 ):


### PR DESCRIPTION
`get_optimizer_state_dict()` treated any nonempty optimizer state as fully initialized: `_init_optim_state` returned early when `optim.state` was nonempty, so trainable parameters without state were never initialized or saved once any other parameter had state. On load, `set_optimizer_state_dict()` filtered parameters by `requires_grad` in `_unflatten_optim_state_dict` and `_split_optim_state_dict`, silently dropping saved state for parameters that were trained and later frozen.

`_init_optim_state` now initializes state per parameter, running the zero-grad step only for trainable parameters that have no state yet; parameters with existing state keep `grad=None`, so `step()` leaves their state untouched. The load paths now key state extraction on presence in the checkpoint instead of requires_grad. The strict-mode missing-state error still fires only for trainable parameters, since a never-trained frozen parameter legitimately has no state. In the flattened format, saved state names for frozen parameters are recovered from the flattened keys (`state.{fqn}.{name}`); an alternative was to reuse a trainable sibling's state names, but that fails when every parameter is frozen, and the flattened keys are the only actual record of what was saved.

Fixes #192202 