### PR TITLE
[symm_mem] Run alloc/rendezvous device ops on the current stream 

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -279,7 +279,11 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
             and "stream" in ev.get("args", {})
             and ev["ts"] < barrier_ts
         ]
-        self.assertGreater(len(mem_events), 0)
+        # ROCm records no memset/memcpy activities for these ops, most likely
+        # because HIP lowers a small fill and the pointer-array uploads to blit
+        # kernels, so there is nothing to check the stream of there.
+        if not TEST_WITH_ROCM:
+            self.assertGreater(len(mem_events), 0)
         for ev in mem_events:
             self.assertEqual(ev["args"]["stream"], user_stream, ev["name"])
 

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1,9 +1,11 @@
 # Owner(s): ["module: c10d"]
 
 import itertools
+import json
 import os
 import random
 import re
+import tempfile
 from contextlib import contextmanager, nullcontext
 from unittest import skip, skipIf, skipUnless
 
@@ -223,6 +225,63 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
     def test_large_alloc(self) -> None:
         t = symm_mem.empty(2 * 1024**3, dtype=torch.uint8, device="cuda")
         self.assertEqual(t.numel() * t.element_size(), 2 * 1024**3)
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_alloc_rendezvous_on_current_stream(self) -> None:
+        # Regression test for https://github.com/pytorch/pytorch/issues/181086:
+        # the memset issued by empty() and the memcpys issued by the first
+        # rendezvous() must follow the caller's current stream instead of
+        # implicitly using the default stream.
+        self._init_process()
+
+        # Only the CUDA backend is fixed; NCCL/NVSHMEM still issue these ops
+        # synchronously on the default stream.
+        if symm_mem.get_backend(self.device) != "CUDA":
+            self.skipTest("test applies to the CUDA symm mem backend")
+
+        stream = torch.cuda.Stream()
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA]
+        ) as prof:
+            with torch.cuda.stream(stream):
+                t = symm_mem.empty(1024, device="cuda")
+                symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+                symm_mem_hdl.barrier()
+            torch.cuda.synchronize()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_path = os.path.join(tmpdir, "trace.json")
+            prof.export_chrome_trace(trace_path)
+            with open(trace_path) as f:
+                events = json.load(f)["traceEvents"]
+
+        # Only GPU-track events carry args.stream. The barrier kernel launched
+        # on the current stream even before the fix, so its trace stream id
+        # identifies the user stream.
+        barrier_events = [
+            ev
+            for ev in events
+            if "barrier" in ev.get("name", "") and "stream" in ev.get("args", {})
+        ]
+        self.assertGreater(len(barrier_events), 0)
+        user_stream = barrier_events[0]["args"]["stream"]
+        # Restrict to the alloc/rendezvous window (everything before the
+        # barrier) so unrelated copies elsewhere in the profile cannot affect
+        # the result.
+        barrier_ts = min(ev["ts"] for ev in barrier_events)
+        mem_events = [
+            ev
+            for ev in events
+            if ev.get("name", "").startswith(("Memset", "Memcpy"))
+            and "stream" in ev.get("args", {})
+            and ev["ts"] < barrier_ts
+        ]
+        self.assertGreater(len(mem_events), 0)
+        for ev in mem_events:
+            self.assertEqual(ev["args"]["stream"], user_stream, ev["name"])
 
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -100,10 +100,21 @@ CUDAPeerAllocInfo::CUDAPeerAllocInfo(
       c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
 
   c10::cuda::CUDAGuard guard(local_device_idx);
-  AT_CUDA_CHECK(cudaMemcpy(
-      buffers_dev_, buffers_.data(), arr_size, cudaMemcpyHostToDevice));
-  AT_CUDA_CHECK(cudaMemcpy(
-      signal_pads_dev_, signal_pads_.data(), arr_size, cudaMemcpyHostToDevice));
+  // Upload on the current stream, then sync. The sync is required because
+  // callers may launch kernels that dereference these arrays on a stream other
+  // than the one the copies were issued on; same-stream consumers alone would
+  // be ordered by the async copies.
+  auto stream = at::cuda::getCurrentCUDAStream(
+      static_cast<c10::DeviceIndex>(local_device_idx));
+  AT_CUDA_CHECK(cudaMemcpyAsync(
+      buffers_dev_, buffers_.data(), arr_size, cudaMemcpyHostToDevice, stream));
+  AT_CUDA_CHECK(cudaMemcpyAsync(
+      signal_pads_dev_,
+      signal_pads_.data(),
+      arr_size,
+      cudaMemcpyHostToDevice,
+      stream));
+  AT_CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
 /* Start of CUDASymmetricMemory */
@@ -422,8 +433,12 @@ void* CUDASymmetricMemoryAllocator::alloc(
 
   // Zero the signal pad (at the front, [0, buffer_offset)) to initialize it for
   // the CAS-based barrier() protocol; the data buffer that follows does not need
-  // zeroing.
-  AT_CUDA_CHECK(cudaMemset(alloc_base, 0, buffer_offset));
+  // zeroing. Zero on the current stream, then sync so the signal pad is fully
+  // zeroed before rendezvous can expose it to peers.
+  auto stream = at::cuda::getCurrentCUDAStream(
+      static_cast<c10::DeviceIndex>(device_idx));
+  AT_CUDA_CHECK(cudaMemsetAsync(alloc_base, 0, buffer_offset, stream));
+  AT_CUDA_CHECK(cudaStreamSynchronize(stream));
 
   // Hand back the data buffer pointer, not alloc_base; the signal pad stays
   // hidden in front. Returning the data ptr (rather than the alloc ptr) is safe

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -2105,6 +2105,12 @@ def empty(  # type: ignore[misc]
     :func:`torch._distributed._symmetric_memory.rendezvous()` to establish a
     symmetric memory tensor among participating processes.
 
+    .. note::
+        This is a host-synchronous allocation. Together with
+        :func:`rendezvous`, it is intended as an initialization-time
+        operation: allocate a symmetric memory tensor once and reuse it,
+        rather than allocating in hot code paths.
+
     Args:
         size (int...): a sequence of integers defining the shape of the output tensor.
             Can be a variable number of arguments or a collection like a list or tuple.
@@ -2161,6 +2167,14 @@ def rendezvous(
 
     Establish a symmetric memory tensor among participating processes. This is
     a collective operation.
+
+    .. note::
+        This is a host-blocking initialization operation: the first rendezvous
+        of a tensor performs handle exchange and mapping across processes, and
+        synchronizes the host with the device. It cannot be ordered onto a
+        CUDA stream or captured in a CUDA graph. Rendezvous a buffer once and
+        reuse the returned handle rather than calling this in hot code paths;
+        subsequent calls on the same tensor return the cached handle.
 
     Args:
         tensor (:class:`torch.Tensor`): the local tensor used to establish the symmetric memory tensor.


### PR DESCRIPTION
`symm_mem.empty()` and the first `symm_mem.rendezvous()` each emit a bit of device work that ignores whatever stream you're on: `empty()` zeroes the signal pad with a plain `cudaMemset`, and rendezvous uploads the peer buffer/signal-pad pointer arrays with two `cudaMemcpy` calls in the `CUDAPeerAllocInfo` constructor. Being synchronous, all three run on the legacy default stream, which is what shows up in the trace in #181086 and is also why they serialize against every blocking stream in the process.

Everything else in those two calls is host-blocking driver or IPC work — `cuMemCreate`/`cuMemMap`, handle export/import, fd exchange, store barriers — so there's no stream to put it on in the first place.

This switches the three call sites to `cudaMemsetAsync`/`cudaMemcpyAsync` on `getCurrentCUDAStream(device_idx)` and follows each with an explicit `cudaStreamSynchronize`. The sync isn't leftover caution: the signal pad has to be fully zeroed before rendezvous makes it visible to peers, because `barrier()`'s CAS protocol assumes zeroed pads, and a peer can reach its first barrier as soon as the host-side store barrier completes. Same reasoning for the pointer arrays, which a kernel on any stream may dereference. So the work now lands on (and orders with) the caller's stream, and only the host blocks.

One behavior change worth calling out: `torch.cuda.Stream` creates non-blocking streams, which the legacy default stream never synchronized against. Synchronizing the caller's stream now waits for whatever is already queued on it, so allocating behind a deep queue of work will stall the host in a way it didn't before. That's inherent to moving the op onto the caller's stream, and these are init-time calls, so it seems like the right trade.

To be clear about what this doesn't do: `empty()`/`rendezvous()` are still host-synchronous and still not stream-ordered or capturable — the host-side IPC makes that impossible. I've added notes to both docstrings saying so, since the natural reading of the old docs was that they behave like ordinary allocations.

Two things left out of scope. `NCCLSymmetricMemory.cu` and `NVSHMEMSymmetricMemory.cpp` have the same synchronous memset/memcpy pattern; I've left them alone here and will follow up separately — I don't have a setup to validate those paths properly. And the repro in the issue allocates and rendezvouses a fresh buffer on every collective call, where the per-call alloc + handle exchange + store barrier cost dwarfs the memset; no stream fix helps with that part.

Fixes #181086

cc @ngimel @kapilsh @kwen2501

## Test Plan

New regression test allocates and rendezvouses under a non-default stream, then checks from the profiler trace that the Memset/Memcpy events in that window land on the caller's stream rather than the default one. I confirmed it fails against a build without the fix — the alloc `Memset` shows up on the default stream — and passes with it:

```
python test/distributed/test_symmetric_memory.py SymmetricMemoryTest.test_alloc_rendezvous_on_current_stream
```

Existing coverage:

```
python test/distributed/test_symmetric_memory.py -k SymmetricMemoryTest
```
