### PR TITLE
[TEST] Refactor test_trace_validator.py with hw_classification

### DIFF
--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -19,6 +19,7 @@ from torch.profiler._trace_validator import (
     _check_stream_wait_corr_id_populated,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -146,6 +147,8 @@ def _load_events(trace_path):
 class TestTraceValidatorRules(TestCase):
     """Synthetic tests for rules not exercised by real E2E payloads."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_nccl_metadata_pass(self):
         events = [
             {
@@ -186,6 +189,8 @@ class TestTraceValidatorRules(TestCase):
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
 @instantiate_parametrized_tests
 class TestTraceValidatorE2E(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     _trace_dir: str = ""
     _payloads: dict = {}
 


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- `TestTraceValidatorRules`: `GENERIC` — synthetic JSON event rules; no device
- `TestTraceValidatorE2E`: `CUDA` — hardcodes `ProfilerActivity.CUDA`, CUDA streams/events/sync
- No `instantiate_device_type_tests` (CUDA-specific E2E; skips preserved)

## Test Plan

```
python test/profiler/test_trace_validator.py -v
# 14 tests OK (skipped=12)

python test/profiler/test_trace_validator.py --hw-classification GENERIC -v
# 2 ran OK

python test/profiler/test_trace_validator.py --hw-classification CUDA -v
# 12 ran OK (skipped)
```

Authored with an AI assistant.

cc @mansiag05 @RiyaP2508
