### PR TITLE
Add Half support to the eager torch.polar kernel, pytorch/pytorch PR #192311 (#192311)

### DIFF
--- a/aten/src/ATen/native/cpu/ComplexKernel.cpp
+++ b/aten/src/ATen/native/cpu/ComplexKernel.cpp
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
@@ -16,11 +17,15 @@ void complex_kernel(TensorIterator& iter) {
 }
 
 void polar_kernel(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.input_dtype(), "polar_cpu", [&]() {
-    cpu_kernel(iter, [=](scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
-      return c10::complex<scalar_t>(a * std::cos(b), a * std::sin(b));
-    });
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      kHalf, iter.input_dtype(), "polar_cpu", [&]() {
+        using opmath_t = at::opmath_type<scalar_t>;
+        cpu_kernel(iter, [=](scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
+          return c10::complex<scalar_t>(
+              static_cast<scalar_t>(opmath_t(a) * std::cos(opmath_t(b))),
+              static_cast<scalar_t>(opmath_t(a) * std::sin(opmath_t(b))));
+        });
+      });
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/native/cuda/ComplexKernel.cu
+++ b/aten/src/ATen/native/cuda/ComplexKernel.cu
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
@@ -20,12 +21,17 @@ void complex_kernel_cuda(TensorIterator& iter) {
 }
 
 void polar_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.input_dtype(0), "polar_cuda", [&]() {
-    gpu_kernel(
-      iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
-        return c10::complex<scalar_t>(a * std::cos(b), a * std::sin(b));
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      kHalf, iter.input_dtype(0), "polar_cuda", [&]() {
+        using opmath_t = at::opmath_type<scalar_t>;
+        gpu_kernel(
+            iter,
+            [] GPU_LAMBDA(scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
+              return c10::complex<scalar_t>(
+                  static_cast<scalar_t>(opmath_t(a) * std::cos(opmath_t(b))),
+                  static_cast<scalar_t>(opmath_t(a) * std::sin(opmath_t(b))));
+            });
       });
-  });
 }
 
 } // anonymous namespace

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -251,6 +251,12 @@ inductor_expected_failures_single_sample["cpu"] = {
     "resize_": {b8, f16, f32, f64, i32, i64},
     "resize_as_": {b8, f16, f32, f64, i32, i64},
     "histc": {f16},
+    # Same reason as "complex"/"view_as_complex" above: check_model runs the
+    # reference with reference_in_float=True, and reference_to_expect only
+    # casts the reference back when y.dtype.is_floating_point -- which is
+    # False for complex, so the f16 reference stays complex64 while the actual
+    # is complex32 and the dtype comparison fails.
+    "polar": {f16},
     ("sparse.mm", "reduce"): {f32, f64, f16},
     "sparse.sampled_addmm": {f32, f64},
     "to_sparse": {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -447,17 +447,19 @@ class TestTensorCreation(TestCase):
         self.assertEqual(torch.tensor([1.0 + 3.0j, 2.0 + 4.0j], dtype=complex_dtype), z)
 
     @onlyNativeDeviceTypes
-    @dtypes(torch.float32, torch.float64)
+    @dtypes(torch.half, torch.float32, torch.float64)
     def test_torch_polar(self, device, dtype):
         abs = torch.tensor([1, 2, -3, -4.5, 1, 1], device=device, dtype=dtype)
         angle = torch.tensor([math.pi / 2, 5 * math.pi / 4, 0, -11 * math.pi / 6, math.pi, -math.pi],
                              device=device, dtype=dtype)
         z = torch.polar(abs, angle)
-        complex_dtype = torch.complex64 if dtype == torch.float32 else torch.complex128
+        complex_dtype = float_to_corresponding_complex_type_map[dtype]
+        # float16 loses precision in cos/sin and the interleaved storage; relax tol.
+        atol, rtol = (1e-2, 1e-2) if dtype == torch.half else (1e-5, 1e-5)
         self.assertEqual(torch.tensor([1j, -1.41421356237 - 1.41421356237j, -3,
                                        -3.89711431703 - 2.25j, -1, -1],
                                       dtype=complex_dtype),
-                         z, atol=1e-5, rtol=1e-5)
+                         z, atol=atol, rtol=rtol)
 
     @onlyNativeDeviceTypes
     @dtypes(torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19122,8 +19122,7 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
            )),
     BinaryUfuncInfo('polar',
-                    dtypes=floating_types(),
-                    dtypesIfMPS=floating_types_and(torch.float16),
+                    dtypes=floating_types_and(torch.half),
                     # this function is undefined if 'abs' values are <0
                     supports_forward_ad=True,
                     lhs_make_tensor_kwargs=dict(low=0),


### PR DESCRIPTION
Summary:

https://github.com/pytorch/pytorch/pull/192311

torch.polar's factory (complex_check_floating) already accepts Half, but the CPU
and CUDA polar kernels dispatched over AT_DISPATCH_FLOATING_TYPES (float/double
only), so torch.polar(half, half) raised "polar not implemented for 'Half'".
Switch the polar kernels to AT_DISPATCH_FLOATING_TYPES_AND(kHalf, ...) and compute
cos/sin in opmath (float) precision; float32/float64 numerics are unchanged. This
enables complex32 polar.

Test Plan:
Extended test_torch_polar in caffe2/test/test_tensor_creation_ops.py to cover
torch.half.

Reviewed By: nandesuka

Differential Revision: D115013192


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo