### PR TITLE
[Testcase Refactoring] Mark TestExportOpInfo CPU and TestExportOnFakeCuda CUDA

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -124,7 +124,7 @@ def _test_export_helper(self, dtype, op):
 
 
 class TestExportOpInfo(TestCase):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.CPU
 
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps(export_failures | fake_export_failures)

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_FBCODE,
     IS_WINDOWS,
     run_tests,
@@ -123,6 +124,8 @@ def _test_export_helper(self, dtype, op):
 
 
 class TestExportOpInfo(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps(export_failures | fake_export_failures)
     @unittest.skipIf(IS_FBCODE, "tests broken with unexpected successes internally")
@@ -146,6 +149,8 @@ selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
 class TestExportOnFakeCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # In CI, this test runs on a CUDA machine with cuda build
     # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build
     # Running this on all ops in op_db is too slow, so we only run on a selected subset

--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -14,6 +14,7 @@ import torch._inductor.config
 from torch._environment import is_fbcode
 from torch._inductor.cpp_builder import _ensure_mingw_cudart_import_lib
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
 
 
@@ -230,6 +231,8 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
     will auto-generate compile/load test methods.
     """
 
+    hw_classification = HardwareClassification.CUDA
+
     def _define_simple(self):
         """Define the Simple model and its test configuration."""
 
@@ -323,6 +326,8 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
 
 class TestEnsureMingwCudartImportLib(TestCase):
     """Unit tests for _ensure_mingw_cudart_import_lib."""
+
+    hw_classification = HardwareClassification.CUDA
 
     def setUp(self):
         super().setUp()

--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -327,7 +327,7 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
 class TestEnsureMingwCudartImportLib(TestCase):
     """Unit tests for _ensure_mingw_cudart_import_lib."""
 
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()

--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -14,8 +14,9 @@ import torch._inductor.config
 from torch._environment import is_fbcode
 from torch._inductor.cpp_builder import _ensure_mingw_cudart_import_lib
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
+from torch.testing._internal.inductor_utils import HAS_GPU
 
 
 @dataclass
@@ -76,7 +77,7 @@ class WindowsCrossCompilationTestFramework:
     def create_compile_test(cls, config: ModelTestConfig):
         """Create a compile test method for a model configuration."""
 
-        def compile_test(self):
+        def compile_test(self, device):
             if platform.system() == "Windows":
                 raise unittest.SkipTest(
                     "This test should run on Linux for cross-compilation"
@@ -90,11 +91,9 @@ class WindowsCrossCompilationTestFramework:
             with torch.no_grad():
                 # Windows cross-compilation is only used for GPU.
                 # AOTI for CPU should be able to work as native compilation on Windows.
-                device = GPU_TYPE
                 model = config.model_class().to(device=device)
                 example_inputs = config.example_inputs
 
-                # Inputs should already be on GPU_TYPE but ensure they are
                 example_inputs = tuple(inp.to(device) for inp in example_inputs)
 
                 # Export the model
@@ -132,7 +131,7 @@ class WindowsCrossCompilationTestFramework:
     def create_load_test(cls, config: ModelTestConfig):
         """Create a load test method for a model configuration."""
 
-        def load_test(self):
+        def load_test(self, device):
             if platform.system() != "Windows":
                 raise unittest.SkipTest("This test should run on Windows")
 
@@ -152,13 +151,9 @@ class WindowsCrossCompilationTestFramework:
             with torch.no_grad():
                 # Windows cross-compilation is only used for GPU.
                 # AOTI for CPU should be able to work as native compilation on Windows.
-                device = GPU_TYPE
-
-                # Create original model for comparison
                 original_model = config.model_class().to(device=device)
                 example_inputs = config.example_inputs
 
-                # Inputs should already be on GPU_TYPE but ensure they are
                 example_inputs = tuple(inp.to(device) for inp in example_inputs)
 
                 # Load the compiled package
@@ -208,7 +203,6 @@ def auto_generate_tests(test_class):
         )
         compile_method.__name__ = compile_method_name
         compile_method.__doc__ = f"Step 1: Cross-compile {model_name} model on Linux"
-        compile_method = requires_gpu()(compile_method)
         setattr(test_class, compile_method_name, compile_method)
 
         # Create load test method
@@ -216,7 +210,6 @@ def auto_generate_tests(test_class):
         load_method = WindowsCrossCompilationTestFramework.create_load_test(config)
         load_method.__name__ = load_method_name
         load_method.__doc__ = f"Step 2: Load and test {model_name} model on Windows"
-        load_method = requires_gpu()(load_method)
         setattr(test_class, load_method_name, load_method)
 
     return test_class
@@ -254,7 +247,7 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="simple",
             model_class=Simple,
-            example_inputs=(torch.randn(8, 10, device=GPU_TYPE),),
+            example_inputs=(torch.randn(8, 10),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=1024)}},
         )
 
@@ -280,7 +273,7 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="simple_cnn",
             model_class=SimpleCNN,
-            example_inputs=(torch.randn(2, 3, 32, 32, device=GPU_TYPE),),
+            example_inputs=(torch.randn(2, 3, 32, 32),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=16)}},
             rtol=1e-3,
             atol=1e-3,
@@ -317,11 +310,16 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="transformer",
             model_class=SimpleTransformer,
-            example_inputs=(torch.randn(4, 16, 128, device=GPU_TYPE),),
+            example_inputs=(torch.randn(4, 16, 128),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=32)}},
             rtol=1e-3,
             atol=1e-3,
         )
+
+
+instantiate_device_type_tests(
+    TestAOTInductorWindowsCrossCompilation, globals(), only_for="cuda"
+)
 
 
 class TestEnsureMingwCudartImportLib(TestCase):

--- a/test/inductor/test_aoti_cross_compile_windows.py
+++ b/test/inductor/test_aoti_cross_compile_windows.py
@@ -14,9 +14,7 @@ import torch._inductor.config
 from torch._environment import is_fbcode
 from torch._inductor.cpp_builder import _ensure_mingw_cudart_import_lib
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import HardwareClassification
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
 
 
 @dataclass
@@ -77,7 +75,7 @@ class WindowsCrossCompilationTestFramework:
     def create_compile_test(cls, config: ModelTestConfig):
         """Create a compile test method for a model configuration."""
 
-        def compile_test(self, device):
+        def compile_test(self):
             if platform.system() == "Windows":
                 raise unittest.SkipTest(
                     "This test should run on Linux for cross-compilation"
@@ -91,9 +89,11 @@ class WindowsCrossCompilationTestFramework:
             with torch.no_grad():
                 # Windows cross-compilation is only used for GPU.
                 # AOTI for CPU should be able to work as native compilation on Windows.
+                device = GPU_TYPE
                 model = config.model_class().to(device=device)
                 example_inputs = config.example_inputs
 
+                # Inputs should already be on GPU_TYPE but ensure they are
                 example_inputs = tuple(inp.to(device) for inp in example_inputs)
 
                 # Export the model
@@ -131,7 +131,7 @@ class WindowsCrossCompilationTestFramework:
     def create_load_test(cls, config: ModelTestConfig):
         """Create a load test method for a model configuration."""
 
-        def load_test(self, device):
+        def load_test(self):
             if platform.system() != "Windows":
                 raise unittest.SkipTest("This test should run on Windows")
 
@@ -151,9 +151,13 @@ class WindowsCrossCompilationTestFramework:
             with torch.no_grad():
                 # Windows cross-compilation is only used for GPU.
                 # AOTI for CPU should be able to work as native compilation on Windows.
+                device = GPU_TYPE
+
+                # Create original model for comparison
                 original_model = config.model_class().to(device=device)
                 example_inputs = config.example_inputs
 
+                # Inputs should already be on GPU_TYPE but ensure they are
                 example_inputs = tuple(inp.to(device) for inp in example_inputs)
 
                 # Load the compiled package
@@ -203,6 +207,7 @@ def auto_generate_tests(test_class):
         )
         compile_method.__name__ = compile_method_name
         compile_method.__doc__ = f"Step 1: Cross-compile {model_name} model on Linux"
+        compile_method = requires_gpu()(compile_method)
         setattr(test_class, compile_method_name, compile_method)
 
         # Create load test method
@@ -210,6 +215,7 @@ def auto_generate_tests(test_class):
         load_method = WindowsCrossCompilationTestFramework.create_load_test(config)
         load_method.__name__ = load_method_name
         load_method.__doc__ = f"Step 2: Load and test {model_name} model on Windows"
+        load_method = requires_gpu()(load_method)
         setattr(test_class, load_method_name, load_method)
 
     return test_class
@@ -223,8 +229,6 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
     Define test methods that return ModelTestConfig, and the decorator
     will auto-generate compile/load test methods.
     """
-
-    hw_classification = HardwareClassification.CUDA
 
     def _define_simple(self):
         """Define the Simple model and its test configuration."""
@@ -247,7 +251,7 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="simple",
             model_class=Simple,
-            example_inputs=(torch.randn(8, 10),),
+            example_inputs=(torch.randn(8, 10, device=GPU_TYPE),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=1024)}},
         )
 
@@ -273,7 +277,7 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="simple_cnn",
             model_class=SimpleCNN,
-            example_inputs=(torch.randn(2, 3, 32, 32),),
+            example_inputs=(torch.randn(2, 3, 32, 32, device=GPU_TYPE),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=16)}},
             rtol=1e-3,
             atol=1e-3,
@@ -310,22 +314,15 @@ class TestAOTInductorWindowsCrossCompilation(TestCase):
         return ModelTestConfig(
             name="transformer",
             model_class=SimpleTransformer,
-            example_inputs=(torch.randn(4, 16, 128),),
+            example_inputs=(torch.randn(4, 16, 128, device=GPU_TYPE),),
             dynamic_shapes={"x": {0: torch.export.Dim("batch", min=1, max=32)}},
             rtol=1e-3,
             atol=1e-3,
         )
 
 
-instantiate_device_type_tests(
-    TestAOTInductorWindowsCrossCompilation, globals(), only_for="cuda"
-)
-
-
 class TestEnsureMingwCudartImportLib(TestCase):
     """Unit tests for _ensure_mingw_cudart_import_lib."""
-
-    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

Add `hw_classification` so `--hw-classification` opts each suite into the correct bucket. Unlabeled classes are **unclassified and dropped** when the flag is set (they are not treated as GENERIC).


## Changes

- `test/export/test_export_opinfo.py`:
  - `TestExportOpInfo` → `CPU` (`only_for="cpu"`; FakeTensor export; CPU-only builds)
  - `TestExportOnFakeCuda` → `CUDA` (`@onlyCUDA`, `only_for="cuda"`)

## Test Plan

```bash
python -m py_compile test/export/test_export_opinfo.py test/inductor/test_aoti_cross_compile_windows.py

python test/export/test_export_opinfo.py --hw-classification CPU -v -k TestExportOpInfo
python test/export/test_export_opinfo.py --hw-classification CUDA -v -k TestExportOnFakeCuda

```



@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo