### PR TITLE
[CUDA][CUTLASS] Guard row-wise scaled MM kernels by architecture

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -418,11 +418,23 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
           cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
           MainloopScheduleType>::CollectiveOp;
 
-  using GemmKernel = at::cuda::detail::enable_3x_kernel_for_sm10_or_later<
-      cutlass::gemm::kernel::GemmUniversal<
-          cute::Shape<int, int, int>,
-          CollectiveMainloop,
-          CollectiveEpilogue>>;
+  using GemmKernelBase = cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue>;
+
+  static_assert(
+      std::is_same_v<ArchTag, cutlass::arch::Sm100> ||
+          std::is_same_v<ArchTag, cutlass::arch::Sm120>,
+      "RowwiseScaledMM only supports the Sm100 and Sm120 arch tags");
+
+  using GemmKernel = std::conditional_t<
+      std::is_same_v<ArchTag, cutlass::arch::Sm100>,
+      at::cuda::detail::enable_3x_kernel_for_sm10<GemmKernelBase>,
+      std::conditional_t<
+          std::is_same_v<ArchTag, cutlass::arch::Sm120>,
+          at::cuda::detail::enable_3x_kernel_for_sm12<GemmKernelBase>,
+          void>>;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 

--- a/aten/src/ATen/native/cuda/cutlass_common.cuh
+++ b/aten/src/ATen/native/cuda/cutlass_common.cuh
@@ -45,4 +45,14 @@ struct enable_3x_kernel_for_sm10_or_later : Kernel {
   }
 };
 
+template <typename Kernel>
+struct enable_3x_kernel_for_sm12 : Kernel {
+  template <typename... Args>
+  CUTLASS_DEVICE void operator()(Args&&... args) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 1200 && __CUDA_ARCH__ < 1300
+    Kernel::operator()(std::forward<Args>(args)...);
+#endif
+  }
+};
+
 }  // namespace at::cuda::detail


### PR DESCRIPTION
Summary:
`RowwiseScaledMM.cu` instantiates the SM100 and SM120 CUTLASS kernels through a shared template. The existing device guard admits both specializations when compiling SM120 PTX, even though runtime dispatch selects only the SM120 specialization.

This emits SM100 kernels, including multicast instructions unsupported by SM120, into the SM120 compilation and substantially increases compiler work.

Add an SM120-specific device guard and select the guard from `ArchTag`. SM100 uses the existing SM100-specific guard, while SM120 uses the new SM120-specific guard, so each architecture emits only its applicable kernels. Runtime dispatch and the set of supported architectures remain unchanged.

Test Plan:
- Built the ATen CUDA library with SM80, SM90, SM100, and SM120a enabled.
- Confirmed that the SM120a compilation no longer emits `.multicast::cluster` warnings and that the focused target builds successfully.
- Runtime tests were not run because this change only narrows compile-time device emission and leaves host dispatch unchanged.

Differential Revision: D114751947


