### PR TITLE
Fix gelu returning NaN for infinite inputs on CPU and MPS

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -44,6 +44,8 @@
 #include <ATen/ops/hardtanh_backward_native.h>
 #include <ATen/ops/hardtanh_native.h>
 #include <ATen/ops/infinitely_differentiable_gelu_backward_native.h>
+#include <ATen/ops/aminmax.h>
+#include <ATen/ops/isinf.h>
 #include <ATen/ops/leaky_relu.h>
 #include <ATen/ops/leaky_relu_backward.h>
 #include <ATen/ops/leaky_relu_backward_native.h>
@@ -77,6 +79,7 @@
 #include <ATen/ops/tanh.h>
 #include <ATen/ops/threshold_backward_native.h>
 #include <ATen/ops/threshold_native.h>
+#include <ATen/ops/where.h>
 
 #include <utility>
 #endif
@@ -388,6 +391,21 @@ static bool use_mkldnn(const Tensor& input) {
     ((input.scalar_type() == kHalf) && mkldnn_fp16_device_check()) ||
     (input.scalar_type() == kFloat))); // input is dense layout and bfloat16/float16/float32
 }
+
+// oneDNN gelu returns NaN for infinite inputs; overwrite them with the limits
+// (gelu(-inf) = 0, gelu(inf) = inf) so the result matches GeluKernel. The
+// aminmax detection is a single read-only pass; NaN inputs need no fixup since
+// oneDNN already propagates them.
+static void gelu_mkldnn_inf_fixup(const Tensor& self, const Tensor& result) {
+  auto [min, max] = at::aminmax(self);
+  constexpr auto kInfinity = std::numeric_limits<double>::infinity();
+  const auto mn = min.item<double>();
+  const auto mx = max.item<double>();
+  // NaN inputs poison aminmax, so a NaN min/max cannot rule out infs
+  if (mn == -kInfinity || mx == kInfinity || mn != mn || mx != mx) {
+    const_cast<Tensor&>(result).copy_(at::where(self.isinf(), at::clamp_min(self, 0), result));
+  }
+}
 #endif
 
 TORCH_IMPL_FUNC(gelu_out_cpu) (
@@ -400,12 +418,14 @@ auto approximate_type = get_gelutype_enum(approximate);
     ideep::tensor y = itensor_from_tensor(result);
     ideep::eltwise_forward::compute(
       x, y, ideep::algorithm::eltwise_gelu_erf, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
+    gelu_mkldnn_inf_fixup(self, result);
 #ifdef __aarch64__
   } else if (use_mkldnn(self) && (approximate_type == GeluType::Tanh)) {
     const ideep::tensor& x = itensor_from_tensor(self, /*from_const_data_ptr*/true);
     ideep::tensor y = itensor_from_tensor(result);
     ideep::eltwise_forward::compute(
       x, y, ideep::algorithm::eltwise_gelu_tanh, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
+    gelu_mkldnn_inf_fixup(self, result);
 #endif  // ifdef __aarch64__
   } else {
     GeluKernel(kCPU, *this, approximate_type);

--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -8,6 +8,9 @@
 #include <math.h>
 #endif // _WIN32
 
+#include <cmath>
+#include <limits>
+
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/BFloat16.h> // For c10::is_reduced_floating_point_v.
 
@@ -33,9 +36,20 @@ template <typename T>
 T scalar_gelu_approximated_with_tanh(T x) {
   using opmath_t = reduced_fp_to_float_t<T>;
   auto x_float = reduced_fp_to_float(x);
+  if (std::isinf(x_float)) {
+    return x_float > opmath_t(0) ? x : T(0);
+  }
   auto x_cube = x_float * x_float * x_float;
   auto inner = opmath_t(kGeluBeta) * (x_float + opmath_t(kGeluKappa) * x_cube);
   return opmath_t(0.5) * x_float * (opmath_t(1) + std::tanh(inner));
+}
+
+template <typename T>
+vec::Vectorized<T> fixup_gelu_inf(vec::Vectorized<T> res, vec::Vectorized<T> x) {
+  const vec::Vectorized<T> kInfVec(std::numeric_limits<T>::infinity());
+  const vec::Vectorized<T> kZeroVec(T(0));
+  res = vec::Vectorized<T>::blendv(res, kZeroVec, x == -kInfVec);
+  return vec::Vectorized<T>::blendv(res, kInfVec, x == kInfVec);
 }
 
 template <typename T, std::enable_if_t<!c10::is_reduced_floating_point_v<T>, bool> = true>
@@ -46,7 +60,7 @@ vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) 
   const vec::Vectorized<T> kGeluKappaVec((T(kGeluKappa)));
   auto x_cube = x * x * x;
   vec::Vectorized<T> inner_vec = kGeluBetaVec * (x + kGeluKappaVec * x_cube);
-  return kPointFiveVec * x * (kOneVec + inner_vec.tanh());
+  return fixup_gelu_inf(kPointFiveVec * x * (kOneVec + inner_vec.tanh()), x);
 }
 
 template <typename T, std::enable_if_t<c10::is_reduced_floating_point_v<T>, bool> = true>
@@ -62,7 +76,11 @@ template <typename T>
 T scalar_gelu(T x) {
   using opmath_t = reduced_fp_to_float_t<T>;
   const auto kAlpha = opmath_t(M_SQRT1_2);
-  return reduced_fp_to_float(x) * opmath_t(0.5) * (opmath_t(1) + std::erf(reduced_fp_to_float(x) * kAlpha));
+  auto x_float = reduced_fp_to_float(x);
+  if (std::isinf(x_float)) {
+    return x_float > opmath_t(0) ? x : T(0);
+  }
+  return x_float * opmath_t(0.5) * (opmath_t(1) + std::erf(x_float * kAlpha));
 }
 
 template<typename T, std::enable_if_t<!c10::is_reduced_floating_point_v<T>, bool> = true>
@@ -70,7 +88,7 @@ vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
   const vec::Vectorized<T> kAlphaVec(T(M_SQRT1_2));
   const vec::Vectorized<T> kOneVec(T(1));
   const vec::Vectorized<T> kPointFiveVec(T(0.5));
-  return x * kPointFiveVec * (kOneVec + (x * kAlphaVec).erf());
+  return fixup_gelu_inf(x * kPointFiveVec * (kOneVec + (x * kAlphaVec).erf()), x);
 }
 
 template<typename T, std::enable_if_t<c10::is_reduced_floating_point_v<T>, bool> = true>

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -275,6 +275,9 @@ struct gelu_functor {
   template <typename T>
   inline T operator()(const T x) {
     const float xf = float(x);
+    if (::metal::isinf(xf)) {
+      return xf > 0.0f ? x : T(0);
+    }
     return static_cast<T>(
         0.5f * xf * (1.0f + ::c10::metal::erf(xf * M_SQRT1_2_F)));
   }
@@ -284,6 +287,9 @@ struct gelu_tanh_functor {
   template <typename T>
   inline T operator()(const T x) {
     const float xf = float(x);
+    if (::metal::isinf(xf)) {
+      return xf > 0.0f ? x : T(0);
+    }
     constexpr float kBeta = M_SQRT2_F * M_2_SQRTPI_F * 0.5f;
     constexpr float kKappa = 0.044715f;
     const float inner = kBeta * (xf + kKappa * xf * xf * xf);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5159,6 +5159,16 @@ def sample_inputs_gelu(self, device, dtype, requires_grad, **kwargs):
                 approximate=approximate)
 
 
+def reference_inputs_gelu(op, device, dtype, requires_grad, **kwargs):
+    yield from sample_inputs_gelu(op, device, dtype, requires_grad, **kwargs)
+    # 64 elements so the extremal values also reach the vectorized kernel paths
+    extremals = [float('-inf'), float('inf'), float('nan'), 0.0] * 16
+    for approximate in ['none', 'tanh']:
+        yield SampleInput(
+            torch.tensor(extremals, device=device, dtype=dtype, requires_grad=requires_grad),
+            approximate=approximate)
+
+
 def error_inputs_gelu(op, device, **kwargs):
     # Tests that gelu errors out when passed an approximation we don't know.
     yield ErrorInput(SampleInput(make_tensor((), dtype=torch.float, device=device), kwargs={"approximate": "asdf"}),
@@ -11524,10 +11534,8 @@ def reference_gelu(X, *, approximate='none'):
         Z = M_SQRT_2_PI * (X + 0.044715 * np.power(X, 3.0))
         return 0.5 * X * (1.0 + np.tanh(Z))
 
-    if approximate == 'tanh':
-        return _tanh_gelu_ref(X)
-    else:
-        return _gelu_ref(X)
+    res = _tanh_gelu_ref(X) if approximate == 'tanh' else _gelu_ref(X)
+    return np.where(np.isinf(X), np.maximum(X, 0), res).astype(X.dtype)
 
 
 def reference_one_hot(a: npt.NDArray, num_classes: int = -1) -> npt.NDArray:
@@ -17806,6 +17814,7 @@ op_db: list[OpInfo] = [
            supports_autograd=True,
            assert_autodiffed=True,
            sample_inputs_func=sample_inputs_gelu,
+           reference_inputs_func=reference_inputs_gelu,
            dtypes=floating_types_and(torch.bfloat16, torch.half),
            supports_gradgrad=True,
            supports_forward_ad=True,
@@ -17815,7 +17824,8 @@ op_db: list[OpInfo] = [
                # AssertionError: Tensor-likes are not close!
                # May not replicate in CI
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_out'),
-               DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+               # CUDA kernel still returns NaN at inf (#187293)
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_numpy_ref', device_type='cuda'),
            )),
     UnaryUfuncInfo('nn.functional.relu6',
                    aten_name="relu6",
@@ -24517,6 +24527,13 @@ python_ref_db = [
     PythonRefInfo(  # TODO: Port this to an UnaryOpInfo
         "_refs.nn.functional.gelu",
         torch_opinfo_name="nn.functional.gelu",
+        skips=(
+            # ref returns NaN at inf, fixed CPU/MPS kernels do not (#187293)
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='cpu'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='cpu'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='mps'),
+        ),
     ),
     PythonRefInfo(
         "_refs.nn.functional.layer_norm",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5143,6 +5143,16 @@ def sample_inputs_gelu(self, device, dtype, requires_grad, **kwargs):
                 approximate=approximate)
 
 
+def reference_inputs_gelu(op, device, dtype, requires_grad, **kwargs):
+    yield from sample_inputs_gelu(op, device, dtype, requires_grad, **kwargs)
+    # 64 elements so the extremal values also reach the vectorized kernel paths
+    extremals = [float('-inf'), float('inf'), float('nan'), 0.0] * 16
+    for approximate in ['none', 'tanh']:
+        yield SampleInput(
+            torch.tensor(extremals, device=device, dtype=dtype, requires_grad=requires_grad),
+            approximate=approximate)
+
+
 def error_inputs_gelu(op, device, **kwargs):
     # Tests that gelu errors out when passed an approximation we don't know.
     yield ErrorInput(SampleInput(make_tensor((), dtype=torch.float, device=device), kwargs={"approximate": "asdf"}),
@@ -11508,10 +11518,8 @@ def reference_gelu(X, *, approximate='none'):
         Z = M_SQRT_2_PI * (X + 0.044715 * np.power(X, 3.0))
         return 0.5 * X * (1.0 + np.tanh(Z))
 
-    if approximate == 'tanh':
-        return _tanh_gelu_ref(X)
-    else:
-        return _gelu_ref(X)
+    res = _tanh_gelu_ref(X) if approximate == 'tanh' else _gelu_ref(X)
+    return np.where(np.isinf(X), np.maximum(X, 0), res).astype(X.dtype)
 
 
 def reference_one_hot(a: npt.NDArray, num_classes: int = -1) -> npt.NDArray:
@@ -17783,6 +17791,7 @@ op_db: list[OpInfo] = [
            supports_autograd=True,
            assert_autodiffed=True,
            sample_inputs_func=sample_inputs_gelu,
+           reference_inputs_func=reference_inputs_gelu,
            dtypes=floating_types_and(torch.bfloat16, torch.half),
            supports_gradgrad=True,
            supports_forward_ad=True,
@@ -17792,7 +17801,8 @@ op_db: list[OpInfo] = [
                # AssertionError: Tensor-likes are not close!
                # May not replicate in CI
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_out'),
-               DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+               # CUDA kernel still returns NaN at inf (#187293)
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_numpy_ref', device_type='cuda'),
            )),
     UnaryUfuncInfo('nn.functional.relu6',
                    aten_name="relu6",
@@ -24508,6 +24518,13 @@ python_ref_db = [
     PythonRefInfo(  # TODO: Port this to an UnaryOpInfo
         "_refs.nn.functional.gelu",
         torch_opinfo_name="nn.functional.gelu",
+        skips=(
+            # ref returns NaN at inf, fixed CPU/MPS kernels do not (#187293)
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='cpu'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='cpu'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='mps'),
+        ),
     ),
     PythonRefInfo(
         "_refs.nn.functional.layer_norm",


### PR DESCRIPTION
#187293, #185770

If you call `F.gelu` on infinite inputs (for example, `F.gelu(torch.tensor([float("-inf")]))`), it doesn't return 0, which is the mathematical limit. Instead, it returns NaN. This is because `erf` saturates to -1 at `-inf`, so `0.5 * x * (1 + erf(x/sqrt(2)))` evaluates `-inf * 0`, which is NaN. The `tanh` approximation has the same problem. The reports also show `+inf` returning NaN through the vectorized `erf` on x86. The MPS Metal kernels share the formula, so they have the same bug.

I read through PR #185790, which was closed when its fork was deleted. Building on the diagnosis there, this PR adds infinity guards to the scalar and vectorized helpers in `Gelu.h` and to the two MPS functors, so `gelu(+inf)` returns `inf`, `gelu(-inf)` returns 0, and NaN propagation is unchanged. CUDA has the same bug, but I don't have a CUDA machine. As such, this PR covers CPU and MPS, and CUDA is left as a follow-up. The same guard is applied around the oneDNN gelu call in Activation.cpp, which handles contiguous CPU inputs on Linux, until this is fixed in oneDNN itself. This is independent of #189234, which reworks the same expression for a different bug and does not cover infinities.

Per review, the extreme values are covered through the OpInfo reference inputs instead of a standalone test, with expected failures for the tests that depend on the still-unfixed python ref or CUDA kernel.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @mikaylagawarecki