### PR TITLE
[Testcase Refactoring] Tag test_state_dict_utils.py with hw_classification

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -36,103 +36,103 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
-def _build_state_dict_for_cpu_copy(self, buffer):
-    """Builds the mixed state dict used by the ``_create_cpu_state_dict`` tests.
-
-    Shared by the generic combinations in ``TestStateDictUtils`` and the
+class _CpuStateDictTestMixin:
+    """Shared by the generic combinations in ``TestStateDictUtils`` and the
     CUDA-only share+pin combination in ``TestStateDictUtilsOnCUDA``, which are
     separate classes so that each can carry an honest ``hw_classification``.
     """
-    device = torch.device(self.device_type)
-    rank = dist.get_rank()
-    # Scale tensors based on world size
-    # to fit in the tensor shards accurately.
-    scale_factor = self.world_size
-    return {
-        "tensor1": torch.arange(10, device=device),
-        "tensor2": torch.ones(10, device=device),
-        "sharded_tensor": init_from_local_shards(
-            [
-                ShardedTensorShard(
-                    tensor=torch.arange(
-                        50 * rank, 50 + 50 * rank, device=device
-                    ).reshape(5, 10),
-                    metadata=ShardMetadata(
-                        shard_offsets=[5 * rank, 0],
-                        shard_sizes=[5, 10],
-                        placement=f"rank:{rank}/{self.device_type}:{rank}",
-                    ),
-                )
-            ],
-            torch.Size([5 * scale_factor, 10]),
-        ),
-        "dtensor": distribute_tensor(
-            torch.arange(50 * scale_factor, device=device).reshape(
-                5 * scale_factor, 10
+
+    def _build_state_dict_for_cpu_copy(self, buffer, device_type):
+        """Builds the mixed state dict used by the ``_create_cpu_state_dict`` tests."""
+        device = torch.device(device_type)
+        rank = dist.get_rank()
+        # Scale tensors based on world size
+        # to fit in the tensor shards accurately.
+        scale_factor = self.world_size
+        return {
+            "tensor1": torch.arange(10, device=device),
+            "tensor2": torch.ones(10, device=device),
+            "sharded_tensor": init_from_local_shards(
+                [
+                    ShardedTensorShard(
+                        tensor=torch.arange(
+                            50 * rank, 50 + 50 * rank, device=device
+                        ).reshape(5, 10),
+                        metadata=ShardMetadata(
+                            shard_offsets=[5 * rank, 0],
+                            shard_sizes=[5, 10],
+                            placement=f"rank:{rank}/{device_type}:{rank}",
+                        ),
+                    )
+                ],
+                torch.Size([5 * scale_factor, 10]),
             ),
-            init_device_mesh(self.device_type, mesh_shape=(self.world_size,)),
-            [Shard(0)],
-        ),
-        "non_tensor_bytes_io": copy.deepcopy(buffer),
-        "non_tensor_bytes": buffer.read(),
-        "step": torch.tensor(7, dtype=torch.float),
-        "lr": 1.5,
-        "nested": {"list": [1, 2, 3, 4]},
-    }
+            "dtensor": distribute_tensor(
+                torch.arange(50 * scale_factor, device=device).reshape(
+                    5 * scale_factor, 10
+                ),
+                init_device_mesh(device_type, mesh_shape=(self.world_size,)),
+                [Shard(0)],
+            ),
+            "non_tensor_bytes_io": copy.deepcopy(buffer),
+            "non_tensor_bytes": buffer.read(),
+            "step": torch.tensor(7, dtype=torch.float),
+            "lr": 1.5,
+            "nested": {"list": [1, 2, 3, 4]},
+        }
+
+    def _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer):
+        rank = dist.get_rank()
+        # Verify the correctness of _check_state_dict_similarity()
+        self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
+        tensor1 = cpu_state_dict["tensor1"]
+        cpu_state_dict["tensor1"] = torch.arange(11)
+        self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
+        cpu_state_dict["tensor1"] = tensor1
+
+        _copy_state_dict(state_dict, cpu_state_dict)
+
+        # Verify if _copy_state_dict works
+        for v in cpu_state_dict.values():
+            if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
+                self.assertTrue(v.device == torch.device("cpu"))
+        self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
+        self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
+        self.assertEqual(
+            cpu_state_dict["sharded_tensor"].local_tensor(),
+            torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+        )
+        self.assertEqual(
+            cpu_state_dict["dtensor"].to_local(),
+            torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+        )
+        self.assertNotEqual(
+            cpu_state_dict["tensor1"].storage().data_ptr(),
+            state_dict["tensor1"].storage().data_ptr(),
+        )
+        self.assertNotEqual(
+            cpu_state_dict["tensor2"].storage().data_ptr(),
+            state_dict["tensor2"].storage().data_ptr(),
+        )
+        self.assertNotEqual(
+            cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+            state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+        )
+        self.assertNotEqual(
+            cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
+            state_dict["dtensor"].to_local().storage().data_ptr(),
+        )
+        buffer.seek(0)
+        cpu_state_dict["non_tensor_bytes_io"].seek(0)
+        self.assertEqual(cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read())
+        buffer.seek(0)
+        self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
+        self.assertEqual(cpu_state_dict["lr"], 1.5)
+        self.assertEqual(cpu_state_dict["step"], 7)
+        self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
 
 
-def _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer):
-    rank = dist.get_rank()
-    # Verify the correctness of _check_state_dict_similarity()
-    self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
-    tensor1 = cpu_state_dict["tensor1"]
-    cpu_state_dict["tensor1"] = torch.arange(11)
-    self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
-    cpu_state_dict["tensor1"] = tensor1
-
-    _copy_state_dict(state_dict, cpu_state_dict)
-
-    # Verify if _copy_state_dict works
-    for v in cpu_state_dict.values():
-        if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
-            self.assertTrue(v.device == torch.device("cpu"))
-    self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
-    self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
-    self.assertEqual(
-        cpu_state_dict["sharded_tensor"].local_tensor(),
-        torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-    )
-    self.assertEqual(
-        cpu_state_dict["dtensor"].to_local(),
-        torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-    )
-    self.assertNotEqual(
-        cpu_state_dict["tensor1"].storage().data_ptr(),
-        state_dict["tensor1"].storage().data_ptr(),
-    )
-    self.assertNotEqual(
-        cpu_state_dict["tensor2"].storage().data_ptr(),
-        state_dict["tensor2"].storage().data_ptr(),
-    )
-    self.assertNotEqual(
-        cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-        state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-    )
-    self.assertNotEqual(
-        cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
-        state_dict["dtensor"].to_local().storage().data_ptr(),
-    )
-    buffer.seek(0)
-    cpu_state_dict["non_tensor_bytes_io"].seek(0)
-    self.assertEqual(cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read())
-    buffer.seek(0)
-    self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
-    self.assertEqual(cpu_state_dict["lr"], 1.5)
-    self.assertEqual(cpu_state_dict["step"], 7)
-    self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
-
-
-class TestStateDictUtils(DTensorTestBase):
+class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @property
@@ -146,6 +146,7 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_gather_state_dict_dtensor(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
         torch.random.manual_seed(dist.get_rank())
@@ -158,7 +159,7 @@ class TestStateDictUtils(DTensorTestBase):
             dist_tensor.to_local(), gather_dim=0, group=(device_mesh, 0)
         )
         self.assertEqual(expected_gathered_dtensor, gathered_state_dict["dtensor"])
-        self.assertEqual(gathered_state_dict["dtensor"].device.type, self.device_type)
+        self.assertEqual(gathered_state_dict["dtensor"].device.type, device_type)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -167,6 +168,7 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_gather_with_cpu_and_ranks_only(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
         torch.random.manual_seed(dist.get_rank())
@@ -182,9 +184,7 @@ class TestStateDictUtils(DTensorTestBase):
         )
         if dist.get_rank() in (0, 2):
             self.assertEqual(expected_gathered_dtensor, gathered_state_dict["dtensor"])
-            self.assertNotEqual(
-                gathered_state_dict["dtensor"].device.type, self.device_type
-            )
+            self.assertNotEqual(gathered_state_dict["dtensor"].device.type, device_type)
         else:
             self.assertEqual(gathered_state_dict, {})
 
@@ -195,7 +195,8 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_cpu_and_ranks_only(self, device):
-        device = torch.device(self.device_type)
+        device_type = torch.device(device).type
+        device = torch.device(device)
         state_dict = {
             "tensor1": torch.arange(10, device=device),
             "tensor2": torch.ones(10, device=device),
@@ -204,7 +205,7 @@ class TestStateDictUtils(DTensorTestBase):
         cpu_state_dict = _offload_state_dict_to_cpu(state_dict, ranks_only=(0, 2))
         if dist.get_rank() in (0, 2):
             for v in cpu_state_dict.values():
-                self.assertNotEqual(v.device.type, self.device_type)
+                self.assertNotEqual(v.device.type, device_type)
             self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
             self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
         else:
@@ -217,6 +218,8 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_complicated_dict(self, device):
+        device_type = torch.device(device).type
+
         def create_dtensor():
             device_mesh = self.build_device_mesh()
             shard_spec = [Shard(0)]
@@ -232,20 +235,20 @@ class TestStateDictUtils(DTensorTestBase):
         for _ in range(10):
             tensor, dtensor = create_dtensor()
             ltensor.append(tensor)
-            ltensor.append(torch.ones(10, device=torch.device(self.device_type)))
+            ltensor.append(torch.ones(10, device=torch.device(device_type)))
             ldtensor.append(dtensor)
-            ldtensor.append(torch.ones(10, device=torch.device(self.device_type)))
+            ldtensor.append(torch.ones(10, device=torch.device(device_type)))
 
         tensor, dtensor = create_dtensor()
         dist_state_dict = {
             "local": dtensor,
             "list": ldtensor,
-            "arange": torch.arange(10, device=torch.device(self.device_type)),
+            "arange": torch.arange(10, device=torch.device(device_type)),
         }
         state_dict = {
             "local": tensor,
             "list": ltensor,
-            "arange": torch.arange(10, device=torch.device(self.device_type)),
+            "arange": torch.arange(10, device=torch.device(device_type)),
         }
         self.assertEqual(state_dict, _gather_state_dict(dist_state_dict))
 
@@ -256,10 +259,11 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_create_cpu_state_dict(self, device):
+        device_type = torch.device(device).type
         buffer = io.BytesIO()
         torch.save(torch.ones(10), buffer)
         buffer.seek(0)
-        state_dict = _build_state_dict_for_cpu_copy(self, buffer)
+        state_dict = self._build_state_dict_for_cpu_copy(buffer, device_type)
 
         # `share_memory` and `pin_memory` are only CUDA-coupled when *both* are
         # set: that path registers the memory through
@@ -270,7 +274,7 @@ class TestStateDictUtils(DTensorTestBase):
         # gate. The share+pin one lives in `TestStateDictUtilsOnCUDA`.
         for kwargs in ({}, {"pin_memory": True}, {"share_memory": True}):
             cpu_state_dict = _create_cpu_state_dict(state_dict, **kwargs)
-            _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer)
+            self._verify_cpu_state_dict(state_dict, cpu_state_dict, buffer)
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -279,10 +283,11 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_state_dict_util_distribute_tensors(self, device):
+        device_type = torch.device(device).type
         even_tensor = torch.randn(self.world_size, 2)
         uneven_tensor = torch.randn(1, 2)
 
-        mesh = init_device_mesh(self.device_type, mesh_shape=(self.world_size,))
+        mesh = init_device_mesh(device_type, mesh_shape=(self.world_size,))
         even_dtensor = distribute_tensor(
             torch.randn(self.world_size, 2), mesh, [Shard(0)]
         )
@@ -296,7 +301,7 @@ class TestStateDictUtils(DTensorTestBase):
         ref_local_state_dict = copy.deepcopy(local_state_dict)
         keys = ["even", "uneven"]
 
-        _distribute_tensors(local_state_dict, keys, self.device_type)
+        _distribute_tensors(local_state_dict, keys, device_type)
         for local_v, ref_v in zip(
             local_state_dict.values(), ref_local_state_dict.values()
         ):
@@ -314,10 +319,11 @@ class TestStateDictUtils(DTensorTestBase):
         Capability.distributed.dtensor,
     )
     def test_cpu_offload_for_dtensor(self, device):
-        device_mesh = init_device_mesh(self.device_type, mesh_shape=(self.world_size,))
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, mesh_shape=(self.world_size,))
         sd = {
             "k": DTensor.from_local(
-                torch.ones(8, 8, device=self.device_type), device_mesh, [Shard(0)]
+                torch.ones(8, 8, device=device_type), device_mesh, [Shard(0)]
             )
         }
         cpu_sd = _create_cpu_state_dict(sd)
@@ -340,7 +346,7 @@ class TestStateDictUtils(DTensorTestBase):
         self.assertTrue(torch.equal(sd["k"].cpu(), cpu_sd["k"]))
 
 
-class TestStateDictUtilsOnCUDA(DTensorTestBase):
+class TestStateDictUtilsOnCUDA(_CpuStateDictTestMixin, DTensorTestBase):
     """The ``share_memory`` + ``pin_memory`` combination of
     ``_create_cpu_state_dict``, which is the only one that is CUDA-specific.
 
@@ -371,15 +377,16 @@ class TestStateDictUtilsOnCUDA(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_create_cpu_state_dict_share_and_pin(self, device):
+        device_type = torch.device(device).type
         buffer = io.BytesIO()
         torch.save(torch.ones(10), buffer)
         buffer.seek(0)
-        state_dict = _build_state_dict_for_cpu_copy(self, buffer)
+        state_dict = self._build_state_dict_for_cpu_copy(buffer, device_type)
 
         cpu_state_dict = _create_cpu_state_dict(
             state_dict, share_memory=True, pin_memory=True
         )
-        _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer)
+        self._verify_cpu_state_dict(state_dict, cpu_state_dict, buffer)
 
         # The pinned pages are released by a weakref.finalize hook installed by
         # _create_cpu_state_dict; check that dropping the state dict runs it.

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -370,7 +370,7 @@ class TestStateDictUtilsOnCUDA(DTensorTestBase):
     )
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_create_cpu_state_dict_share_and_pin(self):
+    def test_create_cpu_state_dict_share_and_pin(self, device):
         buffer = io.BytesIO()
         torch.save(torch.ones(10), buffer)
         buffer.seek(0)
@@ -391,5 +391,6 @@ class TestStateDictUtilsOnCUDA(DTensorTestBase):
 
 
 instantiate_device_type_tests(TestStateDictUtils, globals(), except_for="cpu")
+instantiate_device_type_tests(TestStateDictUtilsOnCUDA, globals(), only_for="cuda")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -74,9 +74,7 @@ class TestStateDictUtils(DTensorTestBase):
         )
         if dist.get_rank() in (0, 2):
             self.assertEqual(expected_gathered_dtensor, gathered_state_dict["dtensor"])
-            self.assertNotEqual(
-                gathered_state_dict["dtensor"].device.type, device_type
-            )
+            self.assertNotEqual(gathered_state_dict["dtensor"].device.type, device_type)
         else:
             self.assertEqual(gathered_state_dict, {})
 
@@ -312,6 +310,8 @@ class TestStateDictUtils(DTensorTestBase):
         self.assertTrue(torch.equal(sd["k"].cpu(), cpu_sd["k"]))
 
 
-instantiate_device_type_tests(TestStateDictUtils, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestStateDictUtils, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 import io
-import unittest
 
 import torch
 import torch.distributed as dist
@@ -22,12 +21,7 @@ from torch.distributed._state_dict_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
-from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -36,103 +30,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
-class _CpuStateDictTestMixin:
-    """Shared by the generic combinations in ``TestStateDictUtils`` and the
-    CUDA-only share+pin combination in ``TestStateDictUtilsOnCUDA``, which are
-    separate classes so that each can carry an honest ``hw_classification``.
-    """
-
-    def _build_state_dict_for_cpu_copy(self, buffer, device_type):
-        """Builds the mixed state dict used by the ``_create_cpu_state_dict`` tests."""
-        device = torch.device(device_type)
-        rank = dist.get_rank()
-        # Scale tensors based on world size
-        # to fit in the tensor shards accurately.
-        scale_factor = self.world_size
-        return {
-            "tensor1": torch.arange(10, device=device),
-            "tensor2": torch.ones(10, device=device),
-            "sharded_tensor": init_from_local_shards(
-                [
-                    ShardedTensorShard(
-                        tensor=torch.arange(
-                            50 * rank, 50 + 50 * rank, device=device
-                        ).reshape(5, 10),
-                        metadata=ShardMetadata(
-                            shard_offsets=[5 * rank, 0],
-                            shard_sizes=[5, 10],
-                            placement=f"rank:{rank}/{device_type}:{rank}",
-                        ),
-                    )
-                ],
-                torch.Size([5 * scale_factor, 10]),
-            ),
-            "dtensor": distribute_tensor(
-                torch.arange(50 * scale_factor, device=device).reshape(
-                    5 * scale_factor, 10
-                ),
-                init_device_mesh(device_type, mesh_shape=(self.world_size,)),
-                [Shard(0)],
-            ),
-            "non_tensor_bytes_io": copy.deepcopy(buffer),
-            "non_tensor_bytes": buffer.read(),
-            "step": torch.tensor(7, dtype=torch.float),
-            "lr": 1.5,
-            "nested": {"list": [1, 2, 3, 4]},
-        }
-
-    def _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer):
-        rank = dist.get_rank()
-        # Verify the correctness of _check_state_dict_similarity()
-        self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
-        tensor1 = cpu_state_dict["tensor1"]
-        cpu_state_dict["tensor1"] = torch.arange(11)
-        self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
-        cpu_state_dict["tensor1"] = tensor1
-
-        _copy_state_dict(state_dict, cpu_state_dict)
-
-        # Verify if _copy_state_dict works
-        for v in cpu_state_dict.values():
-            if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
-                self.assertTrue(v.device == torch.device("cpu"))
-        self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
-        self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
-        self.assertEqual(
-            cpu_state_dict["sharded_tensor"].local_tensor(),
-            torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-        )
-        self.assertEqual(
-            cpu_state_dict["dtensor"].to_local(),
-            torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-        )
-        self.assertNotEqual(
-            cpu_state_dict["tensor1"].storage().data_ptr(),
-            state_dict["tensor1"].storage().data_ptr(),
-        )
-        self.assertNotEqual(
-            cpu_state_dict["tensor2"].storage().data_ptr(),
-            state_dict["tensor2"].storage().data_ptr(),
-        )
-        self.assertNotEqual(
-            cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-            state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-        )
-        self.assertNotEqual(
-            cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
-            state_dict["dtensor"].to_local().storage().data_ptr(),
-        )
-        buffer.seek(0)
-        cpu_state_dict["non_tensor_bytes_io"].seek(0)
-        self.assertEqual(cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read())
-        buffer.seek(0)
-        self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
-        self.assertEqual(cpu_state_dict["lr"], 1.5)
-        self.assertEqual(cpu_state_dict["step"], 7)
-        self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
-
-
-class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
+class TestStateDictUtils(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @property
@@ -141,10 +39,6 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_gather_state_dict_dtensor(self, device):
         device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
@@ -163,10 +57,6 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_gather_with_cpu_and_ranks_only(self, device):
         device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
@@ -184,16 +74,14 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
         )
         if dist.get_rank() in (0, 2):
             self.assertEqual(expected_gathered_dtensor, gathered_state_dict["dtensor"])
-            self.assertNotEqual(gathered_state_dict["dtensor"].device.type, device_type)
+            self.assertNotEqual(
+                gathered_state_dict["dtensor"].device.type, device_type
+            )
         else:
             self.assertEqual(gathered_state_dict, {})
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_cpu_and_ranks_only(self, device):
         device_type = torch.device(device).type
         device = torch.device(device_type)
@@ -213,10 +101,6 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_complicated_dict(self, device):
         device_type = torch.device(device).type
 
@@ -254,34 +138,120 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_create_cpu_state_dict(self, device):
         device_type = torch.device(device).type
+        device = torch.device(device_type)
+        rank = dist.get_rank()
+        # Scale tensors based on world size
+        # to fit in the tensor shards accurately.
+        scale_factor = self.world_size
         buffer = io.BytesIO()
         torch.save(torch.ones(10), buffer)
         buffer.seek(0)
-        state_dict = self._build_state_dict_for_cpu_copy(buffer, device_type)
+        state_dict = {
+            "tensor1": torch.arange(10, device=device),
+            "tensor2": torch.ones(10, device=device),
+            "sharded_tensor": init_from_local_shards(
+                [
+                    ShardedTensorShard(
+                        tensor=torch.arange(
+                            50 * rank, 50 + 50 * rank, device=device
+                        ).reshape(5, 10),
+                        metadata=ShardMetadata(
+                            shard_offsets=[5 * rank, 0],
+                            shard_sizes=[5, 10],
+                            placement=f"rank:{rank}/{device_type}:{rank}",
+                        ),
+                    )
+                ],
+                torch.Size([5 * scale_factor, 10]),
+            ),
+            "dtensor": distribute_tensor(
+                torch.arange(50 * scale_factor, device=device).reshape(
+                    5 * scale_factor, 10
+                ),
+                init_device_mesh(device_type, mesh_shape=(self.world_size,)),
+                [Shard(0)],
+            ),
+            "non_tensor_bytes_io": copy.deepcopy(buffer),
+            "non_tensor_bytes": buffer.read(),
+            "step": torch.tensor(7, dtype=torch.float),
+            "lr": 1.5,
+            "nested": {"list": [1, 2, 3, 4]},
+        }
 
-        # `share_memory` and `pin_memory` are only CUDA-coupled when *both* are
-        # set: that path registers the memory through
-        # `torch.cuda._pin_memory_utils`, which calls `cudaHostRegister`
-        # directly. Either flag on its own goes through
-        # `torch.Tensor.pin_memory()` / `share_memory_()`, which are backend
-        # agnostic, so these three combinations do not belong behind a CUDA
-        # gate. The share+pin one lives in `TestStateDictUtilsOnCUDA`.
-        for kwargs in ({}, {"pin_memory": True}, {"share_memory": True}):
-            cpu_state_dict = _create_cpu_state_dict(state_dict, **kwargs)
-            self._verify_cpu_state_dict(state_dict, cpu_state_dict, buffer)
+        def _verify(cpu_state_dict):
+            # Verify the correctness of _check_state_dict_similarity()
+            self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
+            tensor1 = cpu_state_dict["tensor1"]
+            cpu_state_dict["tensor1"] = torch.arange(11)
+            self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
+            cpu_state_dict["tensor1"] = tensor1
+
+            _copy_state_dict(state_dict, cpu_state_dict)
+
+            # Verify if _copy_state_dict works
+            for v in cpu_state_dict.values():
+                if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
+                    self.assertTrue(v.device == torch.device("cpu"))
+            self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
+            self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
+            self.assertEqual(
+                cpu_state_dict["sharded_tensor"].local_tensor(),
+                torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+            )
+            self.assertEqual(
+                cpu_state_dict["dtensor"].to_local(),
+                torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+            )
+            self.assertNotEqual(
+                cpu_state_dict["tensor1"].storage().data_ptr(),
+                state_dict["tensor1"].storage().data_ptr(),
+            )
+            self.assertNotEqual(
+                cpu_state_dict["tensor2"].storage().data_ptr(),
+                state_dict["tensor2"].storage().data_ptr(),
+            )
+            self.assertNotEqual(
+                cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+                state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+            )
+            self.assertNotEqual(
+                cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
+                state_dict["dtensor"].to_local().storage().data_ptr(),
+            )
+            buffer.seek(0)
+            cpu_state_dict["non_tensor_bytes_io"].seek(0)
+            self.assertEqual(
+                cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read()
+            )
+            buffer.seek(0)
+            self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
+            self.assertEqual(cpu_state_dict["lr"], 1.5)
+            self.assertEqual(cpu_state_dict["step"], 7)
+            self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
+
+        def _verify_weakref_finalize(cpu_state_dict):
+            import gc
+
+            del cpu_state_dict["tensor1"]
+            del cpu_state_dict
+            gc.collect()
+
+        cpu_state_dict = _create_cpu_state_dict(state_dict)
+        _verify(cpu_state_dict)
+        cpu_state_dict = _create_cpu_state_dict(state_dict, pin_memory=True)
+        _verify(cpu_state_dict)
+        cpu_state_dict = _create_cpu_state_dict(state_dict, share_memory=True)
+        _verify(cpu_state_dict)
+        cpu_state_dict = _create_cpu_state_dict(
+            state_dict, share_memory=True, pin_memory=True
+        )
+        _verify(cpu_state_dict)
+        _verify_weakref_finalize(cpu_state_dict)
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_state_dict_util_distribute_tensors(self, device):
         device_type = torch.device(device).type
         even_tensor = torch.randn(self.world_size, 2)
@@ -314,10 +284,6 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-    )
     def test_cpu_offload_for_dtensor(self, device):
         device_type = torch.device(device).type
         device_mesh = init_device_mesh(device_type, mesh_shape=(self.world_size,))
@@ -346,58 +312,6 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
         self.assertTrue(torch.equal(sd["k"].cpu(), cpu_sd["k"]))
 
 
-class TestStateDictUtilsOnCUDA(_CpuStateDictTestMixin, DTensorTestBase):
-    """The ``share_memory`` + ``pin_memory`` combination of
-    ``_create_cpu_state_dict``, which is the only one that is CUDA-specific.
-
-    That path registers pinned shared memory through
-    ``torch.cuda._pin_memory_utils``, i.e. ``cudaHostRegister``, so it cannot
-    run on any other backend. Keeping it in ``TestStateDictUtils`` -- which is
-    ``ACCELERATOR`` and whose other combinations run anywhere -- would either
-    mislabel that class or, as before, hide three working combinations behind a
-    CUDA gate they do not need.
-
-    The name must not be ``TestStateDictUtilsCUDA``:
-    ``instantiate_device_type_tests`` names what it generates
-    ``<generic class> + <device>.upper()`` and writes it straight into module
-    globals, so on a CUDA host it would produce that exact name and silently
-    replace this class.
-    """
-
-    hw_classification = HardwareClassification.CUDA
-
-    @property
-    def world_size(self):
-        return min(4, torch.accelerator.device_count())
-
-    @unittest.skipIf(
-        not TEST_CUDA,
-        "share_memory + pin_memory registers memory via cudaHostRegister",
-    )
-    @with_comms
-    @skip_if_lt_x_gpu(2)
-    def test_create_cpu_state_dict_share_and_pin(self, device):
-        device_type = torch.device(device).type
-        buffer = io.BytesIO()
-        torch.save(torch.ones(10), buffer)
-        buffer.seek(0)
-        state_dict = self._build_state_dict_for_cpu_copy(buffer, device_type)
-
-        cpu_state_dict = _create_cpu_state_dict(
-            state_dict, share_memory=True, pin_memory=True
-        )
-        self._verify_cpu_state_dict(state_dict, cpu_state_dict, buffer)
-
-        # The pinned pages are released by a weakref.finalize hook installed by
-        # _create_cpu_state_dict; check that dropping the state dict runs it.
-        import gc
-
-        del cpu_state_dict["tensor1"]
-        del cpu_state_dict
-        gc.collect()
-
-
 instantiate_device_type_tests(TestStateDictUtils, globals(), except_for="cpu")
-instantiate_device_type_tests(TestStateDictUtilsOnCUDA, globals(), only_for="cuda")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -196,7 +196,7 @@ class TestStateDictUtils(_CpuStateDictTestMixin, DTensorTestBase):
     )
     def test_cpu_and_ranks_only(self, device):
         device_type = torch.device(device).type
-        device = torch.device(device)
+        device = torch.device(device_type)
         state_dict = {
             "tensor1": torch.arange(10, device=device),
             "tensor2": torch.ones(10, device=device),

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -390,8 +390,6 @@ class TestStateDictUtilsOnCUDA(DTensorTestBase):
         gc.collect()
 
 
-instantiate_device_type_tests(
-    TestStateDictUtils, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestStateDictUtils, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -40,7 +40,7 @@ def _build_state_dict_for_cpu_copy(self, buffer):
     """Builds the mixed state dict used by the ``_create_cpu_state_dict`` tests.
 
     Shared by the generic combinations in ``TestStateDictUtils`` and the
-    CUDA-only share+pin combination in ``TestStateDictUtilsCUDA``, which are
+    CUDA-only share+pin combination in ``TestStateDictUtilsOnCUDA``, which are
     separate classes so that each can carry an honest ``hw_classification``.
     """
     device = torch.device(self.device_type)
@@ -267,7 +267,7 @@ class TestStateDictUtils(DTensorTestBase):
         # directly. Either flag on its own goes through
         # `torch.Tensor.pin_memory()` / `share_memory_()`, which are backend
         # agnostic, so these three combinations do not belong behind a CUDA
-        # gate. The share+pin one lives in `TestStateDictUtilsCUDA`.
+        # gate. The share+pin one lives in `TestStateDictUtilsOnCUDA`.
         for kwargs in ({}, {"pin_memory": True}, {"share_memory": True}):
             cpu_state_dict = _create_cpu_state_dict(state_dict, **kwargs)
             _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer)
@@ -340,7 +340,7 @@ class TestStateDictUtils(DTensorTestBase):
         self.assertTrue(torch.equal(sd["k"].cpu(), cpu_sd["k"]))
 
 
-class TestStateDictUtilsCUDA(DTensorTestBase):
+class TestStateDictUtilsOnCUDA(DTensorTestBase):
     """The ``share_memory`` + ``pin_memory`` combination of
     ``_create_cpu_state_dict``, which is the only one that is CUDA-specific.
 
@@ -350,6 +350,12 @@ class TestStateDictUtilsCUDA(DTensorTestBase):
     ``ACCELERATOR`` and whose other combinations run anywhere -- would either
     mislabel that class or, as before, hide three working combinations behind a
     CUDA gate they do not need.
+
+    The name must not be ``TestStateDictUtilsCUDA``:
+    ``instantiate_device_type_tests`` names what it generates
+    ``<generic class> + <device>.upper()`` and writes it straight into module
+    globals, so on a CUDA host it would produce that exact name and silently
+    replace this class.
     """
 
     hw_classification = HardwareClassification.CUDA

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 import io
+import unittest
 
 import torch
 import torch.distributed as dist
@@ -21,22 +22,130 @@ from torch.distributed._state_dict_utils import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
-    skip_if_lt_x_gpu,
     with_comms,
 )
 
 
+def _build_state_dict_for_cpu_copy(self, buffer):
+    """Builds the mixed state dict used by the ``_create_cpu_state_dict`` tests.
+
+    Shared by the generic combinations in ``TestStateDictUtils`` and the
+    CUDA-only share+pin combination in ``TestStateDictUtilsCUDA``, which are
+    separate classes so that each can carry an honest ``hw_classification``.
+    """
+    device = torch.device(self.device_type)
+    rank = dist.get_rank()
+    # Scale tensors based on world size
+    # to fit in the tensor shards accurately.
+    scale_factor = self.world_size
+    return {
+        "tensor1": torch.arange(10, device=device),
+        "tensor2": torch.ones(10, device=device),
+        "sharded_tensor": init_from_local_shards(
+            [
+                ShardedTensorShard(
+                    tensor=torch.arange(
+                        50 * rank, 50 + 50 * rank, device=device
+                    ).reshape(5, 10),
+                    metadata=ShardMetadata(
+                        shard_offsets=[5 * rank, 0],
+                        shard_sizes=[5, 10],
+                        placement=f"rank:{rank}/{self.device_type}:{rank}",
+                    ),
+                )
+            ],
+            torch.Size([5 * scale_factor, 10]),
+        ),
+        "dtensor": distribute_tensor(
+            torch.arange(50 * scale_factor, device=device).reshape(
+                5 * scale_factor, 10
+            ),
+            init_device_mesh(self.device_type, mesh_shape=(self.world_size,)),
+            [Shard(0)],
+        ),
+        "non_tensor_bytes_io": copy.deepcopy(buffer),
+        "non_tensor_bytes": buffer.read(),
+        "step": torch.tensor(7, dtype=torch.float),
+        "lr": 1.5,
+        "nested": {"list": [1, 2, 3, 4]},
+    }
+
+
+def _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer):
+    rank = dist.get_rank()
+    # Verify the correctness of _check_state_dict_similarity()
+    self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
+    tensor1 = cpu_state_dict["tensor1"]
+    cpu_state_dict["tensor1"] = torch.arange(11)
+    self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
+    cpu_state_dict["tensor1"] = tensor1
+
+    _copy_state_dict(state_dict, cpu_state_dict)
+
+    # Verify if _copy_state_dict works
+    for v in cpu_state_dict.values():
+        if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
+            self.assertTrue(v.device == torch.device("cpu"))
+    self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
+    self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
+    self.assertEqual(
+        cpu_state_dict["sharded_tensor"].local_tensor(),
+        torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+    )
+    self.assertEqual(
+        cpu_state_dict["dtensor"].to_local(),
+        torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
+    )
+    self.assertNotEqual(
+        cpu_state_dict["tensor1"].storage().data_ptr(),
+        state_dict["tensor1"].storage().data_ptr(),
+    )
+    self.assertNotEqual(
+        cpu_state_dict["tensor2"].storage().data_ptr(),
+        state_dict["tensor2"].storage().data_ptr(),
+    )
+    self.assertNotEqual(
+        cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+        state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
+    )
+    self.assertNotEqual(
+        cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
+        state_dict["dtensor"].to_local().storage().data_ptr(),
+    )
+    buffer.seek(0)
+    cpu_state_dict["non_tensor_bytes_io"].seek(0)
+    self.assertEqual(cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read())
+    buffer.seek(0)
+    self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
+    self.assertEqual(cpu_state_dict["lr"], 1.5)
+    self.assertEqual(cpu_state_dict["step"], 7)
+    self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
+
+
 class TestStateDictUtils(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return min(4, torch.accelerator.device_count())
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_gather_state_dict_dtensor(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_gather_state_dict_dtensor(self, device):
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
         torch.random.manual_seed(dist.get_rank())
@@ -53,7 +162,11 @@ class TestStateDictUtils(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_gather_with_cpu_and_ranks_only(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_gather_with_cpu_and_ranks_only(self, device):
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
         torch.random.manual_seed(dist.get_rank())
@@ -77,7 +190,11 @@ class TestStateDictUtils(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_cpu_and_ranks_only(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_cpu_and_ranks_only(self, device):
         device = torch.device(self.device_type)
         state_dict = {
             "tensor1": torch.arange(10, device=device),
@@ -95,7 +212,11 @@ class TestStateDictUtils(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_complicated_dict(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_complicated_dict(self, device):
         def create_dtensor():
             device_mesh = self.build_device_mesh()
             shard_spec = [Shard(0)]
@@ -130,120 +251,34 @@ class TestStateDictUtils(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_create_cpu_state_dict(self):
-        device = torch.device(self.device_type)
-        rank = dist.get_rank()
-        # Scale tensors based on world size
-        # to fit in the tensor shards accurately.
-        scale_factor = self.world_size
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_create_cpu_state_dict(self, device):
         buffer = io.BytesIO()
         torch.save(torch.ones(10), buffer)
         buffer.seek(0)
-        state_dict = {
-            "tensor1": torch.arange(10, device=device),
-            "tensor2": torch.ones(10, device=device),
-            "sharded_tensor": init_from_local_shards(
-                [
-                    ShardedTensorShard(
-                        tensor=torch.arange(
-                            50 * rank, 50 + 50 * rank, device=device
-                        ).reshape(5, 10),
-                        metadata=ShardMetadata(
-                            shard_offsets=[5 * rank, 0],
-                            shard_sizes=[5, 10],
-                            placement=f"rank:{rank}/{self.device_type}:{rank}",
-                        ),
-                    )
-                ],
-                torch.Size([5 * scale_factor, 10]),
-            ),
-            "dtensor": distribute_tensor(
-                torch.arange(50 * scale_factor, device=device).reshape(
-                    5 * scale_factor, 10
-                ),
-                init_device_mesh(self.device_type, mesh_shape=(self.world_size,)),
-                [Shard(0)],
-            ),
-            "non_tensor_bytes_io": copy.deepcopy(buffer),
-            "non_tensor_bytes": buffer.read(),
-            "step": torch.tensor(7, dtype=torch.float),
-            "lr": 1.5,
-            "nested": {"list": [1, 2, 3, 4]},
-        }
+        state_dict = _build_state_dict_for_cpu_copy(self, buffer)
 
-        def _verify(cpu_state_dict):
-            # Verify the correctness of _check_state_dict_similarity()
-            self.assertTrue(_check_state_dict_similarity(state_dict, cpu_state_dict))
-            tensor1 = cpu_state_dict["tensor1"]
-            cpu_state_dict["tensor1"] = torch.arange(11)
-            self.assertFalse(_check_state_dict_similarity(state_dict, cpu_state_dict))
-            cpu_state_dict["tensor1"] = tensor1
-
-            _copy_state_dict(state_dict, cpu_state_dict)
-
-            # Verify if _copy_state_dict works
-            for v in cpu_state_dict.values():
-                if isinstance(v, (torch.Tensor, DTensor, ShardedTensor)):
-                    self.assertTrue(v.device == torch.device("cpu"))
-            self.assertEqual(cpu_state_dict["tensor1"], torch.arange(10))
-            self.assertEqual(cpu_state_dict["tensor2"], torch.ones(10))
-            self.assertEqual(
-                cpu_state_dict["sharded_tensor"].local_tensor(),
-                torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-            )
-            self.assertEqual(
-                cpu_state_dict["dtensor"].to_local(),
-                torch.arange(50 * rank, 50 + 50 * rank).reshape(5, 10),
-            )
-            self.assertNotEqual(
-                cpu_state_dict["tensor1"].storage().data_ptr(),
-                state_dict["tensor1"].storage().data_ptr(),
-            )
-            self.assertNotEqual(
-                cpu_state_dict["tensor2"].storage().data_ptr(),
-                state_dict["tensor2"].storage().data_ptr(),
-            )
-            self.assertNotEqual(
-                cpu_state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-                state_dict["sharded_tensor"].local_tensor().storage().data_ptr(),
-            )
-            self.assertNotEqual(
-                cpu_state_dict["dtensor"].to_local().storage().data_ptr(),
-                state_dict["dtensor"].to_local().storage().data_ptr(),
-            )
-            buffer.seek(0)
-            cpu_state_dict["non_tensor_bytes_io"].seek(0)
-            self.assertEqual(
-                cpu_state_dict["non_tensor_bytes_io"].read(), buffer.read()
-            )
-            buffer.seek(0)
-            self.assertEqual(cpu_state_dict["non_tensor_bytes"], buffer.read())
-            self.assertEqual(cpu_state_dict["lr"], 1.5)
-            self.assertEqual(cpu_state_dict["step"], 7)
-            self.assertEqual(cpu_state_dict["nested"], {"list": [1, 2, 3, 4]})
-
-        def _verify_weakref_finalize(cpu_state_dict):
-            import gc
-
-            del cpu_state_dict["tensor1"]
-            del cpu_state_dict
-            gc.collect()
-
-        cpu_state_dict = _create_cpu_state_dict(state_dict)
-        _verify(cpu_state_dict)
-        cpu_state_dict = _create_cpu_state_dict(state_dict, pin_memory=True)
-        _verify(cpu_state_dict)
-        cpu_state_dict = _create_cpu_state_dict(state_dict, share_memory=True)
-        _verify(cpu_state_dict)
-        cpu_state_dict = _create_cpu_state_dict(
-            state_dict, share_memory=True, pin_memory=True
-        )
-        _verify(cpu_state_dict)
-        _verify_weakref_finalize(cpu_state_dict)
+        # `share_memory` and `pin_memory` are only CUDA-coupled when *both* are
+        # set: that path registers the memory through
+        # `torch.cuda._pin_memory_utils`, which calls `cudaHostRegister`
+        # directly. Either flag on its own goes through
+        # `torch.Tensor.pin_memory()` / `share_memory_()`, which are backend
+        # agnostic, so these three combinations do not belong behind a CUDA
+        # gate. The share+pin one lives in `TestStateDictUtilsCUDA`.
+        for kwargs in ({}, {"pin_memory": True}, {"share_memory": True}):
+            cpu_state_dict = _create_cpu_state_dict(state_dict, **kwargs)
+            _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer)
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_state_dict_util_distribute_tensors(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_state_dict_util_distribute_tensors(self, device):
         even_tensor = torch.randn(self.world_size, 2)
         uneven_tensor = torch.randn(1, 2)
 
@@ -274,7 +309,11 @@ class TestStateDictUtils(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_cpu_offload_for_dtensor(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+    )
+    def test_cpu_offload_for_dtensor(self, device):
         device_mesh = init_device_mesh(self.device_type, mesh_shape=(self.world_size,))
         sd = {
             "k": DTensor.from_local(
@@ -301,5 +340,52 @@ class TestStateDictUtils(DTensorTestBase):
         self.assertTrue(torch.equal(sd["k"].cpu(), cpu_sd["k"]))
 
 
+class TestStateDictUtilsCUDA(DTensorTestBase):
+    """The ``share_memory`` + ``pin_memory`` combination of
+    ``_create_cpu_state_dict``, which is the only one that is CUDA-specific.
+
+    That path registers pinned shared memory through
+    ``torch.cuda._pin_memory_utils``, i.e. ``cudaHostRegister``, so it cannot
+    run on any other backend. Keeping it in ``TestStateDictUtils`` -- which is
+    ``ACCELERATOR`` and whose other combinations run anywhere -- would either
+    mislabel that class or, as before, hide three working combinations behind a
+    CUDA gate they do not need.
+    """
+
+    hw_classification = HardwareClassification.CUDA
+
+    @property
+    def world_size(self):
+        return min(4, torch.accelerator.device_count())
+
+    @unittest.skipIf(
+        not TEST_CUDA,
+        "share_memory + pin_memory registers memory via cudaHostRegister",
+    )
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_create_cpu_state_dict_share_and_pin(self):
+        buffer = io.BytesIO()
+        torch.save(torch.ones(10), buffer)
+        buffer.seek(0)
+        state_dict = _build_state_dict_for_cpu_copy(self, buffer)
+
+        cpu_state_dict = _create_cpu_state_dict(
+            state_dict, share_memory=True, pin_memory=True
+        )
+        _verify_cpu_state_dict(self, state_dict, cpu_state_dict, buffer)
+
+        # The pinned pages are released by a weakref.finalize hook installed by
+        # _create_cpu_state_dict; check that dropping the state dict runs it.
+        import gc
+
+        del cpu_state_dict["tensor1"]
+        del cpu_state_dict
+        gc.collect()
+
+
+instantiate_device_type_tests(
+    TestStateDictUtils, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Tags `TestStateDictUtils` as `HardwareClassification.ACCELERATOR` and
instantiates it by device type while preserving the original test structure.

## Changes

- adds `hw_classification = HardwareClassification.ACCELERATOR`;
- adds `instantiate_device_type_tests(..., except_for=cpu)` and uses the
  injected `device` argument in test bodies;
- keeps every existing `skip_if_lt_x_gpu` world-size gate unchanged;
- keeps all four `_create_cpu_state_dict` option combinations in the original
  `test_create_cpu_state_dict` method, including
  `share_memory=True, pin_memory=True`;
- does not add a CUDA-only class, a split-out test method, or an NPU-specific
  skip.

No `requires_capabilities` declaration is added because the original file had
no matching capability-specific decorator. Missing pinned-memory support in a
downstream accelerator backend is tracked in that backend instead of being
encoded as a PyTorch test exception.

## Test Plan

The latest review follow-up will be revalidated on NPU, CPU, and GPU. A backend
failure in the pinned-memory combination will be reported separately with its
full traceback; it will not be converted into a skip in this PR.

## Related

Part of #185590. This replaces the broader CUDA-only approach from #190848.