### PR TITLE
[Testcase Refactoring] Migrate test_shard_utils.py to instantiate_device_type_tests

### DIFF
--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -7,9 +7,7 @@ from torch.distributed.fsdp._shard_utils import (
     _create_chunk_sharded_tensor,
 )
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
@@ -36,11 +34,6 @@ class TestShardUtilsDistributed(FSDPTest):
         return torch.rand(*size).to(device=device_type)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-        Capability.distributed.sharded_tensor,
-    )
     def test_create_chunk_sharded_tensor(self, device):
         for size in ((1,), (1, 6), (12,), (12, 6), (25,), (25, 6)):
             tensor = self._create_tensor(*size)
@@ -74,11 +67,6 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.dtensor,
-        Capability.distributed.fsdp1,
-    )
     def test_create_chunk_dtensor(self, device):
         device_mesh = self.build_device_mesh()
 

--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -38,7 +38,8 @@ class TestShardUtilsDistributed(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
+        Capability.distributed.sharded_tensor,
     )
     def test_create_chunk_sharded_tensor(self, device):
         for size in ((1,), (1, 6), (12,), (12, 6), (25,), (25, 6)):
@@ -76,7 +77,7 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
     @requires_capabilities(
         Capability.distributed.backend,
         Capability.distributed.dtensor,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_create_chunk_dtensor(self, device):
         device_mesh = self.build_device_mesh()

--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -6,9 +6,7 @@ from torch.distributed.fsdp._shard_utils import (
     _create_chunk_dtensor,
     _create_chunk_sharded_tensor,
 )
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -83,9 +81,11 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
                 self.assertEqual(self.rank >= len(tensor_chunks), True)
 
 
-instantiate_device_type_tests(TestShardUtilsDistributed, globals(), except_for="cpu")
 instantiate_device_type_tests(
-    TestShardUtilsDistributedDTensor, globals(), except_for="cpu"
+    TestShardUtilsDistributed, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardUtilsDistributedDTensor, globals(), except_for="cpu", allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -6,8 +6,13 @@ from torch.distributed.fsdp._shard_utils import (
     _create_chunk_dtensor,
     _create_chunk_sharded_tensor,
 )
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_fsdp import FSDPTest
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     skip_if_lt_x_gpu,
@@ -19,6 +24,8 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 
 
 class TestShardUtilsDistributed(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
@@ -29,7 +36,11 @@ class TestShardUtilsDistributed(FSDPTest):
         return torch.rand(*size).to(device=device_type)
 
     @skip_if_lt_x_gpu(2)
-    def test_create_chunk_sharded_tensor(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_create_chunk_sharded_tensor(self, device):
         for size in ((1,), (1, 6), (12,), (12, 6), (25,), (25, 6)):
             tensor = self._create_tensor(*size)
 
@@ -49,6 +60,8 @@ class TestShardUtilsDistributed(FSDPTest):
 
 
 class TestShardUtilsDistributedDTensor(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
@@ -60,7 +73,12 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_create_chunk_dtensor(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+        Capability.distributed.fsdp,
+    )
+    def test_create_chunk_dtensor(self, device):
         device_mesh = self.build_device_mesh()
 
         for size in ((1,), (1, 6), (12,), (12, 6), (25,), (25, 6)):
@@ -76,5 +94,11 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
                 self.assertEqual(self.rank >= len(tensor_chunks), True)
 
 
+instantiate_device_type_tests(
+    TestShardUtilsDistributed, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardUtilsDistributedDTensor, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_shard_utils.py
+++ b/test/distributed/fsdp/test_shard_utils.py
@@ -94,11 +94,9 @@ class TestShardUtilsDistributedDTensor(DTensorTestBase):
                 self.assertEqual(self.rank >= len(tensor_chunks), True)
 
 
+instantiate_device_type_tests(TestShardUtilsDistributed, globals(), except_for="cpu")
 instantiate_device_type_tests(
-    TestShardUtilsDistributed, globals(), except_for="cpu", allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestShardUtilsDistributedDTensor, globals(), except_for="cpu", allow_xpu=True
+    TestShardUtilsDistributedDTensor, globals(), except_for="cpu"
 )
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Runs `TestShardUtilsDistributed` and `TestShardUtilsDistributedDTensor`
through `instantiate_device_type_tests`.

## Motivation

Neither class had `hw_classification` bookkeeping despite both being
accelerator-only. This mirrors the pure-tagging pass #191909 did for other
files in this suite.

The existing `skip_if_lt_x_gpu` world-size gates are deliberately left alone.
Its device-agnostic implementation has already landed in #185184, so no
per-file rewrite is needed here.


## Changes

- The two tests sit in different base classes, so each class gets its own
  `instantiate_device_type_tests` call; the test methods gain the `device`
  parameter it injects.
- `@with_comms` stays outermost on the DTensor test, preserving the original
  decorator nesting.
- The existing `skip_if_lt_x_gpu` gates and their import from `common_dtensor`
  are left untouched. No `@requires_capabilities` is added to either test —
  per team review, a capability is only registered where an existing
  decorator already named it, and `skip_if_lt_x_gpu`/`@with_comms` are
  generic gates, not capability-specific ones.

This change is purely additive — no existing gate is removed or rewritten.


## Test Plan

Verified on an accelerator backend (4 devices): `Ran 2 tests ... OK`.

## Related

Part of #185590.

The world-size gates in this file are unchanged; their device-agnostic
implementation is provided by the landed #185184.
