### PR TITLE
[Testcase Refactoring] Migrate test_checkpoint.py to capability-based gating

### DIFF
--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -363,7 +363,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_save(state_dict, coordinator=1, fail_set_up_storage_writer=[1])
         self._test_save(state_dict, coordinator=1, fail_finish=[1])
 
-    def test_save_error_handling_no_dist(self) -> None:
+    def test_save_error_handling_no_dist(self, device) -> None:
         state_dict = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
 
         self.assertFalse(dist.is_initialized())
@@ -407,7 +407,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_load(state_dict, coordinator=3, fail_read_data_async=[2])
         self._test_load(state_dict, coordinator=1, fail_prepare_global_plan=[1])
 
-    def test_load_error_handling_no_dist(self) -> None:
+    def test_load_error_handling_no_dist(self, device) -> None:
         state_dict = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
         self._test_load(state_dict)
         self._test_load(state_dict, fail_set_up_storage_reader=[0])

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -113,7 +113,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         Capability.distributed.backend,
     )
     def test_default_metadata(self, device) -> None:
-        device = f"{device_type}:{dist.get_rank()}"
+        device = f"{torch.device(device).type}:{dist.get_rank()}"
         spec = ChunkShardingSpec(
             dim=0,
             placements=[

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -418,11 +418,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_load(state_dict, fail_read_data_async=[0])
 
 
-instantiate_device_type_tests(
-    TestDistributedCheckpointing, globals(), except_for="cpu", allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestDistributedFailure, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestDistributedCheckpointing, globals(), except_for="cpu")
+instantiate_device_type_tests(TestDistributedFailure, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -313,8 +313,7 @@ class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
         return ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:{r}/{self.device_type}:{r}"
-                for r in range(dist.get_world_size())
+                f"rank:{r}/{self.device_type}:{r}" for r in range(dist.get_world_size())
             ],
         )
 
@@ -434,7 +433,11 @@ class TestNoDistFailure(_FailureTestMixin, TestCase):
         self._test_load(state_dict, fail_read_data_async=[0])
 
 
-instantiate_device_type_tests(TestDistributedCheckpointing, globals(), except_for="cpu")
-instantiate_device_type_tests(TestDistributedFailure, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestDistributedCheckpointing, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDistributedFailure, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -32,11 +32,17 @@ from torch.distributed.checkpoint.planner import (
 )
 from torch.distributed.checkpoint.storage import WriteResult
 from torch.futures import Future
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
@@ -76,14 +82,18 @@ class TestModule(torch.nn.Module):
 
 
 class TestDistributedCheckpointing(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_tensor_metadata_with_missing_rank_spec(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_tensor_metadata_with_missing_rank_spec(self, device) -> None:
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -99,8 +109,10 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_default_metadata(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_default_metadata(self, device) -> None:
         device = f"{device_type}:{dist.get_rank()}"
         spec = ChunkShardingSpec(
             dim=0,
@@ -237,6 +249,8 @@ class FaultyStorageReader(TestStorageBase, StorageReader):
 
 
 class TestDistributedFailure(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def get_spec(self):
         return ChunkShardingSpec(
             dim=0,
@@ -247,8 +261,10 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_dummy_writer_works(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_dummy_writer_works(self, device) -> None:
         state_dict = {
             "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
             "replicated": torch.rand(10, 10),
@@ -259,8 +275,10 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_dummy_reader_works(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_dummy_reader_works(self, device) -> None:
         state_dict = {
             "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
             "replicated": torch.rand(10, 10),
@@ -324,8 +342,10 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend()
-    def test_save_error_handling(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_save_error_handling(self, device) -> None:
         state_dict = {
             "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
             "replicated": torch.rand(10, 10),
@@ -358,8 +378,10 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
-    @requires_accelerator_dist_backend()
-    def test_load_error_handling(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_load_error_handling(self, device) -> None:
         state_dict = {
             "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
             "replicated": torch.rand(10, 10),
@@ -396,5 +418,11 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_load(state_dict, fail_read_data_async=[0])
 
 
+instantiate_device_type_tests(
+    TestDistributedCheckpointing, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDistributedFailure, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -50,10 +50,6 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
 )
 
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = torch.distributed.get_default_backend_for_device(device_type)
-
-
 if TEST_WITH_DEV_DBG_ASAN:
     print(
         "Skip dev-asan as torch + multiprocessing spawn have known issues",
@@ -63,8 +59,9 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestModule(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, device) -> None:
         super().__init__()
+        self.device_type = torch.device(device).type
         self.sharded: ShardedTensor = sharded_tensor.zeros(self.spec(), 4, 4)
         self.regular = torch.nn.Parameter(torch.ones(4, 4))
         self.extra_sharded: ShardedTensor | None = None
@@ -76,8 +73,8 @@ class TestModule(torch.nn.Module):
         return ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:0/{device_type}:0",
-                f"rank:1/{device_type}:1",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
             ],
         )
 
@@ -89,7 +86,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
@@ -98,7 +95,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:1/{device_type}:1",
+                f"rank:1/{self.device_type}:1",
             ],
         )
 
@@ -108,18 +105,18 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
         self.assertEqual(1, len(st_md.chunks))
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
     )
     def test_default_metadata(self, device) -> None:
-        device = f"{torch.device(device).type}:{dist.get_rank()}"
+        device = self.current_device
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:0/{device_type}:0",
-                f"rank:1/{device_type}:1",
+                f"rank:0/{device.type}:0",
+                f"rank:1/{device.type}:1",
             ],
         )
 
@@ -316,11 +313,12 @@ class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
         return ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:{r}/{device_type}:{r}" for r in range(dist.get_world_size())
+                f"rank:{r}/{self.device_type}:{r}"
+                for r in range(dist.get_world_size())
             ],
         )
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
@@ -334,7 +332,7 @@ class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
 
         save_state_dict(state_dict, FaultyStorageWriter({}))
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
@@ -349,7 +347,7 @@ class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
 
         load_state_dict(state_dict, FaultyStorageReader(metadata, {}))
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(
         Capability.distributed.backend,
@@ -372,7 +370,7 @@ class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
         self._test_save(state_dict, coordinator=1, fail_set_up_storage_writer=[1])
         self._test_save(state_dict, coordinator=1, fail_finish=[1])
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(
         Capability.distributed.backend,

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -248,45 +249,12 @@ class FaultyStorageReader(TestStorageBase, StorageReader):
         return True
 
 
-class TestDistributedFailure(ShardedTensorTestBase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    def get_spec(self):
-        return ChunkShardingSpec(
-            dim=0,
-            placements=[
-                f"rank:{r}/{device_type}:{r}" for r in range(dist.get_world_size())
-            ],
-        )
-
-    @with_comms(init_rpc=False, backend=backend)
-    @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-    )
-    def test_dummy_writer_works(self, device) -> None:
-        state_dict = {
-            "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
-            "replicated": torch.rand(10, 10),
-            "bytes": [1, 2, 3, 4],
-        }
-
-        save_state_dict(state_dict, FaultyStorageWriter({}))
-
-    @with_comms(init_rpc=False, backend=backend)
-    @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-    )
-    def test_dummy_reader_works(self, device) -> None:
-        state_dict = {
-            "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
-            "replicated": torch.rand(10, 10),
-            "bytes": [1, 2, 3, 4],
-        }
-        metadata = _create_default_local_metadata(state_dict)
-
-        load_state_dict(state_dict, FaultyStorageReader(metadata, {}))
+class _FailureTestMixin:
+    """Drives the faulty save/load paths for both the distributed tests in
+    ``TestDistributedFailure`` and the no-dist ones in ``TestNoDistFailure``,
+    which are separate classes so that each can carry an honest
+    ``hw_classification``.
+    """
 
     def _test_dist_failure(self, callback, kwargs):
         bad_ranks = next(iter(kwargs.values())) if len(kwargs) > 0 else []
@@ -340,6 +308,47 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         self._test_dist_failure(_load, kwargs)
 
+
+class TestDistributedFailure(_FailureTestMixin, ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def get_spec(self):
+        return ChunkShardingSpec(
+            dim=0,
+            placements=[
+                f"rank:{r}/{device_type}:{r}" for r in range(dist.get_world_size())
+            ],
+        )
+
+    @with_comms(init_rpc=False, backend=backend)
+    @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_dummy_writer_works(self, device) -> None:
+        state_dict = {
+            "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
+            "replicated": torch.rand(10, 10),
+            "bytes": [1, 2, 3, 4],
+        }
+
+        save_state_dict(state_dict, FaultyStorageWriter({}))
+
+    @with_comms(init_rpc=False, backend=backend)
+    @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_dummy_reader_works(self, device) -> None:
+        state_dict = {
+            "sharded": sharded_tensor.rand(self.get_spec(), 20, 20),
+            "replicated": torch.rand(10, 10),
+            "bytes": [1, 2, 3, 4],
+        }
+        metadata = _create_default_local_metadata(state_dict)
+
+        load_state_dict(state_dict, FaultyStorageReader(metadata, {}))
+
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
     @requires_capabilities(
@@ -362,19 +371,6 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         self._test_save(state_dict, coordinator=1, fail_set_up_storage_writer=[1])
         self._test_save(state_dict, coordinator=1, fail_finish=[1])
-
-    def test_save_error_handling_no_dist(self, device) -> None:
-        state_dict = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
-
-        self.assertFalse(dist.is_initialized())
-
-        self._test_save(state_dict, fail_set_up_storage_writer=[0])
-        self._test_save(state_dict, fail_finish=[0])
-        self._test_save(state_dict, fail_prepare_global_plan=[0])
-
-        self._test_save(state_dict, fail_prepare_local_plan=[0])
-        self._test_save(state_dict, fail_write_data=[0])
-        self._test_save(state_dict, fail_write_data_async=[0])
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
@@ -407,7 +403,29 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_load(state_dict, coordinator=3, fail_read_data_async=[2])
         self._test_load(state_dict, coordinator=1, fail_prepare_global_plan=[1])
 
-    def test_load_error_handling_no_dist(self, device) -> None:
+
+class TestNoDistFailure(_FailureTestMixin, TestCase):
+    # These tests assert that no process group is initialized and reference no
+    # device at all, so they are GENERIC and stay un-instantiated. Keeping
+    # them in the ACCELERATOR class above would stop them from being
+    # generated (and run) on CPU-only hosts once ``except_for="cpu"`` filters
+    # that class out.
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_save_error_handling_no_dist(self) -> None:
+        state_dict = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
+
+        self.assertFalse(dist.is_initialized())
+
+        self._test_save(state_dict, fail_set_up_storage_writer=[0])
+        self._test_save(state_dict, fail_finish=[0])
+        self._test_save(state_dict, fail_prepare_global_plan=[0])
+
+        self._test_save(state_dict, fail_prepare_local_plan=[0])
+        self._test_save(state_dict, fail_write_data=[0])
+        self._test_save(state_dict, fail_write_data_async=[0])
+
+    def test_load_error_handling_no_dist(self) -> None:
         state_dict = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
         self._test_load(state_dict)
         self._test_load(state_dict, fail_set_up_storage_reader=[0])


### PR DESCRIPTION
[Testcase Refactoring] Migrate test_checkpoint.py to capability-based gating

## Summary

Tags the distributed checkpoint classes as `ACCELERATOR`, declares their
distributed-backend requirement, and takes device/backend selection from the
instantiated `ShardedTensorTestBase` context.

## Changes

- six distributed tests retain their existing `skip_if_lt_x_gpu` gates and use
  `requires_capabilities(Capability.distributed.backend)`;
- distributed test methods retain the injected `device` parameter required by
  device-type instantiation, while their bodies use
  `ShardedTensorTestBase.current_device`;
- the module-level backend is removed and the decorators use
  `@with_comms(init_rpc=False)`, allowing `ShardedTensorTestBase.backend` from
  #194992 to resolve the registered default backend;
- `TestModule` receives its device explicitly and does not call
  `current_accelerator()`;
- the two no-dist failure tests remain in a separate `GENERIC` class so CPU-only
  coverage is not lost.

The file contains no `current_accelerator()` call after this refactor.

## Test Plan

Validated the current head (`1a70fbc6f20`) with #194992 head `61a0cd84a32`
stacked on the same PyTorch source commit (`69231fe37ab`):

- NPU/HCCL: common-base contract 7/7 and `test_checkpoint.py` 8/8;
- CPU/Gloo: common-base contract 7/7 and the two generic no-dist tests 2/2;
- all four groups completed with zero skips and exit code 0;
- the validator restored the prepared source tree byte-for-byte after each run.

This stacked run is required because #194992 owns the bare `with_comms`
backend resolution and `current_device` used by this PR.

## Dependencies

- #191919 provides `Capability.distributed`;
- #194992 provides device-based `ShardedTensorTestBase.backend` and
  `current_device` resolution.

Part of #185590. The unchanged device-count gate uses the landed #185184.
