### PR TITLE
[Testcase Refactoring] Tag test_wrap.py with hw_classification

### DIFF
--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -1026,8 +1026,8 @@ class TestWrapUtils(TestCase):
         _validate_frozen_params(model, modules_to_wrap, ignored_params, use_orig_params)
 
 
-instantiate_device_type_tests(TestFSDPWrap, globals(), except_for="cpu")
-instantiate_device_type_tests(TestAutoWrap, globals(), except_for="cpu")
+instantiate_device_type_tests(TestFSDPWrap, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestAutoWrap, globals(), except_for="cpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -1098,8 +1098,8 @@ class TestWrapUtils(TestCase):
         _validate_frozen_params(model, modules_to_wrap, ignored_params, use_orig_params)
 
 
-instantiate_device_type_tests(TestFSDPWrap, globals(), except_for="cpu", allow_xpu=True)
-instantiate_device_type_tests(TestAutoWrap, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestFSDPWrap, globals(), except_for="cpu")
+instantiate_device_type_tests(TestAutoWrap, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -215,7 +215,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize("nested", [True, False])
     @parametrize(
@@ -243,7 +243,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize("use_or_policy", [True, False])
     def test_wrap_batchnorm_individually(self, device, use_or_policy):
@@ -274,7 +274,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_bn_always_wrapped_individually(self, device):
         """
@@ -334,7 +334,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     @skip_if_lt_x_gpu(2)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize(
         "cpu_offload",
@@ -427,7 +427,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     @skip_if_lt_x_gpu(1)
     @requires_capabilities(
         Capability.distributed.backend,
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_zero_argument(self, device):
         class ZeroArguModel(nn.Module):
@@ -454,7 +454,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_wrap(self, device, wrap_method):
@@ -479,7 +479,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_wrap_disabled_outside_context(self, device):
         pg = self.process_group
@@ -501,7 +501,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_wrap_override_defaults(self, device):
         new_process_group = DummyProcessGroup(rank=0, size=2)
@@ -528,7 +528,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_transformer_auto_wrap_policy(self, device):
         """Tests the ``transformer_auto_wrap_policy``."""
@@ -542,7 +542,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_module_wrap_policy(self, device):
         """Tests the ``ModuleWrapPolicy``."""
@@ -555,7 +555,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_module_wrap_policy_callable(self, device):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
@@ -590,7 +590,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_custom_policy(self, device):
         """
@@ -698,7 +698,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_api(self, device):
         """
@@ -721,7 +721,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_exclude_wrap(self, device):
         """
@@ -747,7 +747,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_exclude_wrap_include_children(self, device):
         """
@@ -771,7 +771,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_force_leaf(self, device):
         """
@@ -796,7 +796,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_force_leaf_custom(self, device):
         """
@@ -895,7 +895,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
@@ -925,7 +925,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
@@ -963,7 +963,7 @@ class TestAutoWrap(TestCase):
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
     @requires_capabilities(
-        Capability.distributed.fsdp,
+        Capability.distributed.fsdp1,
     )
     def test_frozen_params(self, device):
         """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -34,9 +34,7 @@ from torch.distributed.fsdp.wrap import (
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
@@ -213,10 +211,6 @@ class TestFSDPWrap(FSDPTestContinuous):
         return model
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-    )
     @parametrize("nested", [True, False])
     @parametrize(
         "device_init_mode", [DEVICEInitMode.DEVICE_AFTER, DEVICEInitMode.DEVICE_BEFORE]
@@ -241,10 +235,6 @@ class TestFSDPWrap(FSDPTestContinuous):
             FSDP(wrapped_fsdp, auto_wrap_policy=size_based_auto_wrap_policy)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-    )
     @parametrize("use_or_policy", [True, False])
     def test_wrap_batchnorm_individually(self, device, use_or_policy):
         def never_wrap_policy(*args, **kwargs):
@@ -272,10 +262,6 @@ class TestFSDPWrap(FSDPTestContinuous):
         self.assertFalse(isinstance(fsdp.lin, FSDP))
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-    )
     def test_bn_always_wrapped_individually(self, device):
         """
         Ensures that by using _or_policy with _wrap_module_cls_individually, even
@@ -332,10 +318,6 @@ class TestFSDPWrap(FSDPTestContinuous):
             self.assertFalse(isinstance(bn, FSDP))
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-    )
     @parametrize(
         "cpu_offload",
         [CPUOffload(offload_params=False), CPUOffload(offload_params=True)],
@@ -425,10 +407,6 @@ class TestFSDPWrap(FSDPTestContinuous):
             optim.step()
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp1,
-    )
     def test_zero_argument(self, device):
         class ZeroArguModel(nn.Module):
             def __init__(self) -> None:
@@ -453,9 +431,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_wrap(self, device, wrap_method):
         if wrap_method == WrapMethod.WRAP_API:
@@ -478,9 +453,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     def test_wrap_disabled_outside_context(self, device):
         pg = self.process_group
 
@@ -499,9 +471,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_wrap_override_defaults(self, device):
         new_process_group = DummyProcessGroup(rank=0, size=2)
@@ -527,9 +496,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     def test_transformer_auto_wrap_policy(self, device):
         """Tests the ``transformer_auto_wrap_policy``."""
         auto_wrap_policy = functools.partial(
@@ -541,9 +507,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     def test_module_wrap_policy(self, device):
         """Tests the ``ModuleWrapPolicy``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -553,9 +516,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_module_wrap_policy_callable(self, device):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
@@ -588,9 +548,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_custom_policy(self, device):
         """
@@ -697,9 +654,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     def test_auto_wrap_api(self, device):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
@@ -719,9 +673,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_exclude_wrap(self, device):
         """
@@ -746,9 +697,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     def test_auto_wrap_preset_exclude_wrap_include_children(self, device):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than
@@ -769,9 +717,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_force_leaf(self, device):
         """
@@ -794,9 +739,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_auto_wrap_preset_force_leaf_custom(self, device):
         """
@@ -894,9 +836,6 @@ class TestAutoWrap(TestCase):
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
     )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
-    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
         sequential = NestedSequentialModel.get_model(device=False)
@@ -923,9 +862,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
@@ -961,9 +897,6 @@ class TestAutoWrap(TestCase):
 
     @unittest.skipIf(
         not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
-    )
-    @requires_capabilities(
-        Capability.distributed.fsdp1,
     )
     def test_frozen_params(self, device):
         """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -33,9 +33,7 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _move_to_device,
@@ -55,10 +53,6 @@ from torch.testing._internal.common_utils import (
     TEST_MULTIACCELERATOR,
     TestCase,
 )
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = torch.distributed.get_default_backend_for_device(device_type)
 
 
 class BatchNormNet(nn.Module):
@@ -130,14 +124,14 @@ class WrapMethod(Enum):
 
 class NestedSequentialModel:
     @staticmethod
-    def get_model(device=True):
+    def get_model(device=None):
         sequential = nn.Sequential(
             nn.Linear(5, 5),
             nn.Linear(5, 5),
             nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)),
         )
-        if device:
-            sequential = sequential.to(device=device_type)
+        if device is not None:
+            sequential = sequential.to(device=device)
         return sequential
 
     @staticmethod
@@ -224,7 +218,7 @@ class TestFSDPWrap(FSDPTestContinuous):
             nested=nested, device_init_mode=device_init_mode
         )
         if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
-            wrapped_fsdp = wrapped_fsdp.to(device=device_type)
+            wrapped_fsdp = wrapped_fsdp.to(device=device)
 
         wrapped_module_name = "lin1.1" if nested else "lin1"
         with self.assertRaisesRegex(
@@ -380,7 +374,7 @@ class TestFSDPWrap(FSDPTestContinuous):
             forward_prefetch=forward_prefetch,
         )
         if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
-            wrapped_model = wrapped_model.to(device=device_type)
+            wrapped_model = wrapped_model.to(device=device)
 
         modules_in_fsdp_graph_order = [
             wrapped_model.module.lin1,
@@ -399,7 +393,7 @@ class TestFSDPWrap(FSDPTestContinuous):
 
         # Run model a few times for sanity check.
         optim = torch.optim.SGD(wrapped_model.parameters(), lr=1e-2, momentum=0.9)
-        inp = torch.ones(1).to(device=device_type)
+        inp = torch.ones(1).to(device=device)
         for _ in range(6):
             optim.zero_grad()
             loss = wrapped_model(inp).sum()
@@ -487,7 +481,7 @@ class TestAutoWrap(TestCase):
         Test to ensure that if `always_wrap_policy` is
         passed into FSDP, all submodules are wrapped.
         """
-        seq = NestedSequentialModel.get_model(device=True)
+        seq = NestedSequentialModel.get_model(device=device)
         model = FSDP(
             seq, process_group=self.process_group, auto_wrap_policy=always_wrap_policy
         )
@@ -659,7 +653,7 @@ class TestAutoWrap(TestCase):
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
         ``nn.Linear(5, 5)`` does not exceed the bucket size, but combined they do.
         """
-        sequential = NestedSequentialModel.get_model(device=False)
+        sequential = NestedSequentialModel.get_model()
         my_auto_wrap_policy = functools.partial(
             size_based_auto_wrap_policy, min_num_params=40
         )
@@ -783,10 +777,9 @@ class TestAutoWrap(TestCase):
         ):
             return
 
-        device = torch.device(device_type)
         torch.accelerator.set_device_index(0)
         device_id = (
-            torch.device(device_type, torch.accelerator.current_device_index())
+            torch.device(device, torch.accelerator.current_device_index())
             if use_device_id
             else None
         )
@@ -798,7 +791,7 @@ class TestAutoWrap(TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             file_name = f.name
             torch.distributed.init_process_group(
-                backend=backend,
+                backend=torch.distributed.get_default_backend_for_device(device),
                 init_method=f"{FILE_SCHEMA}_{file_name}",
                 rank=0,
                 world_size=1,
@@ -808,7 +801,9 @@ class TestAutoWrap(TestCase):
         # cases where full model cannot be loaded onto GPU, but their shards can.
         device_after_init = device_init_mode == DEVICEInitMode.DEVICE_AFTER
         try:
-            sequential = NestedSequentialModel.get_model(device=(not device_after_init))
+            sequential = NestedSequentialModel.get_model(
+                device=None if device_after_init else device
+            )
             my_auto_wrap_policy = functools.partial(
                 size_based_auto_wrap_policy, min_num_params=40
             )
@@ -820,7 +815,7 @@ class TestAutoWrap(TestCase):
             )
             NestedSequentialModel.verify_model(self, model)
             if device_after_init:
-                model = model.to(device=device_type)
+                model = model.to(device=device)
             input = torch.rand((1, 5), dtype=torch.float).to(device)
             output = model(input)
             loss = F.mse_loss(input, output)
@@ -838,7 +833,7 @@ class TestAutoWrap(TestCase):
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
-        sequential = NestedSequentialModel.get_model(device=False)
+        sequential = NestedSequentialModel.get_model()
         ignored_modules = [sequential[1], sequential[2][0]]
         fsdp_kwargs = {
             "process_group": self.process_group,
@@ -865,7 +860,7 @@ class TestAutoWrap(TestCase):
     )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
-        sequential = NestedSequentialModel.get_model(device=False)
+        sequential = NestedSequentialModel.get_model()
         ignored_modules = [sequential[1], sequential[2][0]]
         my_auto_wrap_policy = functools.partial(
             size_based_auto_wrap_policy,
@@ -927,10 +922,10 @@ class TestAutoWrap(TestCase):
                 lambda_wrap_policy_nonuniform,
             ],
         ):
-            self._test_frozen_params(use_orig_params, policy)
+            self._test_frozen_params(device, use_orig_params, policy)
 
-    def _test_frozen_params(self, use_orig_params: bool, policy: _Policy):
-        model = LoraModel().to(device=device_type)
+    def _test_frozen_params(self, device, use_orig_params: bool, policy: _Policy):
+        model = LoraModel().to(device=device)
         msg = "layers.0.attn has both parameters with requires_grad=True and False. "
         if use_orig_params:
             msg += "We do not recommend wrapping such modules"

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -1,10 +1,10 @@
 # Owner(s): ["oncall: distributed"]
 
+import unittest
 import functools
 import itertools
 import os
 import tempfile
-import unittest
 from collections.abc import Callable
 from enum import auto, Enum
 
@@ -33,7 +33,11 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _move_to_device,
@@ -46,11 +50,11 @@ from torch.testing._internal.common_fsdp import (
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
     find_free_port,
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
-    TEST_CUDA,
-    TEST_XPU,
+    TEST_ACCELERATOR,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 
@@ -126,45 +130,48 @@ class WrapMethod(Enum):
     WRAP_API = auto()
 
 
+class NestedSequentialModel:
+    @staticmethod
+    def get_model(device=True):
+        sequential = nn.Sequential(
+            nn.Linear(5, 5),
+            nn.Linear(5, 5),
+            nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)),
+        )
+        if device:
+            sequential = sequential.to(device=device_type)
+        return sequential
+
+    @staticmethod
+    def verify_model_all_wrapped(cls, model):
+        cls.assertTrue(isinstance(model, FSDP))
+        cls.assertTrue(isinstance(model.module[0], FSDP))
+        cls.assertTrue(isinstance(model.module[1], FSDP))
+        cls.assertTrue(isinstance(model.module[2], FSDP))
+        cls.assertTrue(isinstance(model.module[2].module[0], FSDP))
+        cls.assertTrue(isinstance(model.module[2].module[1], FSDP))
+
+    @staticmethod
+    def verify_model(cls, model):
+        cls.assertTrue(isinstance(model, FSDP))
+        cls.assertTrue(isinstance(model.module[0], nn.Linear))
+        cls.assertTrue(isinstance(model.module[1], nn.Linear))
+        cls.assertTrue(isinstance(model.module[2], FSDP))
+        # following modules were not wrapped by the policy.
+        cls.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
+        cls.assertTrue(isinstance(model.module[2].module[1], nn.Linear))
+
+
 class TestFSDPWrap(FSDPTestContinuous):
     """
     Tests main API for wrapping FSDP, which is to pass auto_wrap_policy into
     FSDP constructor.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self) -> None:
         super().setUp()
-
-    class NestedSequentialModel:
-        @staticmethod
-        def get_model(device=True):
-            sequential = nn.Sequential(
-                nn.Linear(5, 5),
-                nn.Linear(5, 5),
-                nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)),
-            )
-            if device:
-                sequential = sequential.to(device=device_type)
-            return sequential
-
-        @staticmethod
-        def verify_model_all_wrapped(cls, model):
-            cls.assertTrue(isinstance(model, FSDP))
-            cls.assertTrue(isinstance(model.module[0], FSDP))
-            cls.assertTrue(isinstance(model.module[1], FSDP))
-            cls.assertTrue(isinstance(model.module[2], FSDP))
-            cls.assertTrue(isinstance(model.module[2].module[0], FSDP))
-            cls.assertTrue(isinstance(model.module[2].module[1], FSDP))
-
-        @staticmethod
-        def verify_model(cls, model):
-            cls.assertTrue(isinstance(model, FSDP))
-            cls.assertTrue(isinstance(model.module[0], nn.Linear))
-            cls.assertTrue(isinstance(model.module[1], nn.Linear))
-            cls.assertTrue(isinstance(model.module[2], FSDP))
-            # following modules were not wrapped by the policy.
-            cls.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
-            cls.assertTrue(isinstance(model.module[2].module[1], nn.Linear))
 
     def _get_linear(self, fin, fout):
         return nn.Linear(fin, fout, bias=False)
@@ -206,11 +213,15 @@ class TestFSDPWrap(FSDPTestContinuous):
         return model
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize("nested", [True, False])
     @parametrize(
         "device_init_mode", [DEVICEInitMode.DEVICE_AFTER, DEVICEInitMode.DEVICE_BEFORE]
     )
-    def test_error_already_wrapped(self, nested, device_init_mode):
+    def test_error_already_wrapped(self, device, nested, device_init_mode):
         """
         Test that an error is raised if we attempt to wrap when submodules are
         already FSDP.
@@ -230,8 +241,12 @@ class TestFSDPWrap(FSDPTestContinuous):
             FSDP(wrapped_fsdp, auto_wrap_policy=size_based_auto_wrap_policy)
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize("use_or_policy", [True, False])
-    def test_wrap_batchnorm_individually(self, use_or_policy):
+    def test_wrap_batchnorm_individually(self, device, use_or_policy):
         def never_wrap_policy(*args, **kwargs):
             return False
 
@@ -257,7 +272,11 @@ class TestFSDPWrap(FSDPTestContinuous):
         self.assertFalse(isinstance(fsdp.lin, FSDP))
 
     @skip_if_lt_x_gpu(2)
-    def test_bn_always_wrapped_individually(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_bn_always_wrapped_individually(self, device):
         """
         Ensures that by using _or_policy with _wrap_module_cls_individually, even
         if the other policy results in a module containing a BN unit being
@@ -313,6 +332,10 @@ class TestFSDPWrap(FSDPTestContinuous):
             self.assertFalse(isinstance(bn, FSDP))
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize(
         "cpu_offload",
         [CPUOffload(offload_params=False), CPUOffload(offload_params=True)],
@@ -327,6 +350,7 @@ class TestFSDPWrap(FSDPTestContinuous):
     )
     def test_main_wrap_api(
         self,
+        device,
         cpu_offload: CPUOffload,
         backward_prefetch: BackwardPrefetch,
         forward_prefetch: bool,
@@ -401,7 +425,11 @@ class TestFSDPWrap(FSDPTestContinuous):
             optim.step()
 
     @skip_if_lt_x_gpu(1)
-    def test_zero_argument(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_zero_argument(self, device):
         class ZeroArguModel(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -415,14 +443,21 @@ class TestFSDPWrap(FSDPTestContinuous):
 
 
 class TestAutoWrap(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self) -> None:
         super().setUp()
         # For all the tests here, we use a fake group
         self.process_group = DummyProcessGroup(rank=0, size=1)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
-    def test_wrap(self, wrap_method):
+    def test_wrap(self, device, wrap_method):
         if wrap_method == WrapMethod.WRAP_API:
             with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group):
                 layer = wrap(nn.Linear(5, 5))
@@ -440,8 +475,13 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, self.process_group.rank())
         self.assertEqual(layer.world_size, self.process_group.size())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_wrap_disabled_outside_context(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_wrap_disabled_outside_context(self, device):
         pg = self.process_group
 
         class MyModel(nn.Module):
@@ -457,8 +497,13 @@ class TestAutoWrap(TestCase):
         self.assertFalse(isinstance(model.lin, FSDP))
         self.assertTrue(isinstance(model.lin, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_wrap_override_defaults(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_wrap_override_defaults(self, device):
         new_process_group = DummyProcessGroup(rank=0, size=2)
         with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group):
             layer = wrap(nn.Linear(5, 5), process_group=new_process_group)
@@ -467,20 +512,25 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
-    def test_always_wrap(self):
+    @unittest.skipIf(not TEST_ACCELERATOR, "Test Requires an accelerator")
+    def test_always_wrap(self, device):
         """
         Test to ensure that if `always_wrap_policy` is
         passed into FSDP, all submodules are wrapped.
         """
-        seq = TestFSDPWrap.NestedSequentialModel.get_model(device=True)
+        seq = NestedSequentialModel.get_model(device=True)
         model = FSDP(
             seq, process_group=self.process_group, auto_wrap_policy=always_wrap_policy
         )
-        TestFSDPWrap.NestedSequentialModel.verify_model_all_wrapped(self, model)
+        NestedSequentialModel.verify_model_all_wrapped(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_transformer_auto_wrap_policy(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_transformer_auto_wrap_policy(self, device):
         """Tests the ``transformer_auto_wrap_policy``."""
         auto_wrap_policy = functools.partial(
             transformer_auto_wrap_policy,
@@ -488,16 +538,26 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_module_wrap_policy(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_module_wrap_policy(self, device):
         """Tests the ``ModuleWrapPolicy``."""
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer}
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_module_wrap_policy_callable(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_module_wrap_policy_callable(self, device):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer}
@@ -526,8 +586,13 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_custom_policy(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_custom_policy(self, device):
         """
         Tests ``CustomPolicy`` with both a lambda function that uses uniform
         kwargs (so only returns ``False`` or ``True``) and a lambda function
@@ -629,13 +694,18 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_auto_wrap_api(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_auto_wrap_api(self, device):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
         ``nn.Linear(5, 5)`` does not exceed the bucket size, but combined they do.
         """
-        sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
+        sequential = NestedSequentialModel.get_model(device=False)
         my_auto_wrap_policy = functools.partial(
             size_based_auto_wrap_policy, min_num_params=40
         )
@@ -645,10 +715,15 @@ class TestAutoWrap(TestCase):
             auto_wrap_policy=my_auto_wrap_policy,
         )
 
-        TestFSDPWrap.NestedSequentialModel.verify_model(self, model)
+        NestedSequentialModel.verify_model(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_auto_wrap_preset_exclude_wrap(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_auto_wrap_preset_exclude_wrap(self, device):
         """
         Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
         min_num_params. the size_based_auto_wrap_policy excludes wrapping for {nn.ModuleList, nn.ModuleDict}
@@ -668,8 +743,13 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model[0], nn.Linear))
         self.assertTrue(isinstance(model[1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_auto_wrap_preset_exclude_wrap_include_children(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_auto_wrap_preset_exclude_wrap_include_children(self, device):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than
         min_num_params
@@ -687,8 +767,13 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model, FSDP))
         self.assertTrue(isinstance(model[0], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_auto_wrap_preset_force_leaf(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_auto_wrap_preset_force_leaf(self, device):
         """
         Test to ensure force-leaf modules are not wrapped, and children are not wrapped. The
         size_based_auto_wrap_policy forces leaf modules of type {nn.MultiheadAttention} to not be wrapped
@@ -707,8 +792,13 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[1], nn.MultiheadAttention))
         self.assertTrue(isinstance(model.module[1].out_proj, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_auto_wrap_preset_force_leaf_custom(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_auto_wrap_preset_force_leaf_custom(self, device):
         """
         Test to ensure force-leaf modules are not wrapped.
         """
@@ -732,7 +822,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[1], nn.ModuleList))
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "Test Requires an accelerator")
     @parametrize(
         "device_init_mode", [DEVICEInitMode.DEVICE_BEFORE, DEVICEInitMode.DEVICE_AFTER]
     )
@@ -741,7 +831,9 @@ class TestAutoWrap(TestCase):
         [CPUOffload(offload_params=False), CPUOffload(offload_params=True)],
     )
     @parametrize("use_device_id", [True, False])
-    def test_auto_wrap_smoke_test(self, device_init_mode, cpu_offload, use_device_id):
+    def test_auto_wrap_smoke_test(
+        self, device, device_init_mode, cpu_offload, use_device_id
+    ):
         # CPU offload and CUDA after don't work together as expected.
         if (
             cpu_offload.offload_params
@@ -774,9 +866,7 @@ class TestAutoWrap(TestCase):
         # cases where full model cannot be loaded onto GPU, but their shards can.
         device_after_init = device_init_mode == DEVICEInitMode.DEVICE_AFTER
         try:
-            sequential = TestFSDPWrap.NestedSequentialModel.get_model(
-                device=(not device_after_init)
-            )
+            sequential = NestedSequentialModel.get_model(device=(not device_after_init))
             my_auto_wrap_policy = functools.partial(
                 size_based_auto_wrap_policy, min_num_params=40
             )
@@ -786,7 +876,7 @@ class TestAutoWrap(TestCase):
                 auto_wrap_policy=my_auto_wrap_policy,
                 device_id=device_id,
             )
-            TestFSDPWrap.NestedSequentialModel.verify_model(self, model)
+            NestedSequentialModel.verify_model(self, model)
             if device_after_init:
                 model = model.to(device=device_type)
             input = torch.rand((1, 5), dtype=torch.float).to(device)
@@ -801,10 +891,15 @@ class TestAutoWrap(TestCase):
         except FileNotFoundError:
             pass
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
-    def test_always_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
-        sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
+    def test_always_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
+        sequential = NestedSequentialModel.get_model(device=False)
         ignored_modules = [sequential[1], sequential[2][0]]
         fsdp_kwargs = {
             "process_group": self.process_group,
@@ -826,10 +921,15 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[2].module[1], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
-    def test_auto_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
-        sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
+    def test_auto_wrap_with_ignored_modules(self, device, wrap_method: WrapMethod):
+        sequential = NestedSequentialModel.get_model(device=False)
         ignored_modules = [sequential[1], sequential[2][0]]
         my_auto_wrap_policy = functools.partial(
             size_based_auto_wrap_policy,
@@ -859,8 +959,13 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2][0], nn.Linear))
         self.assertTrue(isinstance(model.module[2][1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
-    def test_frozen_params(self):
+    @unittest.skipIf(
+        not TEST_MULTIACCELERATOR, "Requires at least 2 accelerator devices"
+    )
+    @requires_capabilities(
+        Capability.distributed.fsdp,
+    )
+    def test_frozen_params(self, device):
         """
         Tests that mixing frozen/non-frozen parameters in an FSDP instance
         raises for ``use_orig_params=False`` and warns for ``True``.
@@ -910,6 +1015,8 @@ class TestAutoWrap(TestCase):
 
 
 class TestWrapUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_validate_frozen_params(self):
         """Tests the method ``_validate_frozen_params()``."""
         for use_orig_params in [True, False]:
@@ -991,8 +1098,8 @@ class TestWrapUtils(TestCase):
         _validate_frozen_params(model, modules_to_wrap, ignored_params, use_orig_params)
 
 
-instantiate_parametrized_tests(TestFSDPWrap)
-instantiate_parametrized_tests(TestAutoWrap)
+instantiate_device_type_tests(TestFSDPWrap, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestAutoWrap, globals(), except_for="cpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -218,7 +218,7 @@ class TestFSDPWrap(FSDPTestContinuous):
             nested=nested, device_init_mode=device_init_mode
         )
         if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
-            wrapped_fsdp = wrapped_fsdp.to(device=device)
+            wrapped_fsdp = wrapped_fsdp.to(device=torch.device(device).type)
 
         wrapped_module_name = "lin1.1" if nested else "lin1"
         with self.assertRaisesRegex(
@@ -339,6 +339,7 @@ class TestFSDPWrap(FSDPTestContinuous):
             # they don't work together, expected
             return
 
+        device_type = torch.device(device).type
         move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
 
         class Nested(nn.Module):
@@ -374,7 +375,7 @@ class TestFSDPWrap(FSDPTestContinuous):
             forward_prefetch=forward_prefetch,
         )
         if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
-            wrapped_model = wrapped_model.to(device=device)
+            wrapped_model = wrapped_model.to(device=device_type)
 
         modules_in_fsdp_graph_order = [
             wrapped_model.module.lin1,
@@ -393,7 +394,7 @@ class TestFSDPWrap(FSDPTestContinuous):
 
         # Run model a few times for sanity check.
         optim = torch.optim.SGD(wrapped_model.parameters(), lr=1e-2, momentum=0.9)
-        inp = torch.ones(1).to(device=device)
+        inp = torch.ones(1).to(device=device_type)
         for _ in range(6):
             optim.zero_grad()
             loss = wrapped_model(inp).sum()
@@ -481,7 +482,7 @@ class TestAutoWrap(TestCase):
         Test to ensure that if `always_wrap_policy` is
         passed into FSDP, all submodules are wrapped.
         """
-        seq = NestedSequentialModel.get_model(device=device)
+        seq = NestedSequentialModel.get_model(device=torch.device(device).type)
         model = FSDP(
             seq, process_group=self.process_group, auto_wrap_policy=always_wrap_policy
         )
@@ -777,9 +778,10 @@ class TestAutoWrap(TestCase):
         ):
             return
 
+        device_type = torch.device(device).type
         torch.accelerator.set_device_index(0)
         device_id = (
-            torch.device(device, torch.accelerator.current_device_index())
+            torch.device(device_type, torch.accelerator.current_device_index())
             if use_device_id
             else None
         )
@@ -791,7 +793,7 @@ class TestAutoWrap(TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             file_name = f.name
             torch.distributed.init_process_group(
-                backend=torch.distributed.get_default_backend_for_device(device),
+                backend=torch.distributed.get_default_backend_for_device(device_type),
                 init_method=f"{FILE_SCHEMA}_{file_name}",
                 rank=0,
                 world_size=1,
@@ -802,7 +804,7 @@ class TestAutoWrap(TestCase):
         device_after_init = device_init_mode == DEVICEInitMode.DEVICE_AFTER
         try:
             sequential = NestedSequentialModel.get_model(
-                device=None if device_after_init else device
+                device=None if device_after_init else device_type
             )
             my_auto_wrap_policy = functools.partial(
                 size_based_auto_wrap_policy, min_num_params=40
@@ -815,8 +817,8 @@ class TestAutoWrap(TestCase):
             )
             NestedSequentialModel.verify_model(self, model)
             if device_after_init:
-                model = model.to(device=device)
-            input = torch.rand((1, 5), dtype=torch.float).to(device)
+                model = model.to(device=device_type)
+            input = torch.rand((1, 5), dtype=torch.float).to(device_type)
             output = model(input)
             loss = F.mse_loss(input, output)
             loss.backward()
@@ -922,10 +924,10 @@ class TestAutoWrap(TestCase):
                 lambda_wrap_policy_nonuniform,
             ],
         ):
-            self._test_frozen_params(device, use_orig_params, policy)
+            self._test_frozen_params(torch.device(device).type, use_orig_params, policy)
 
-    def _test_frozen_params(self, device, use_orig_params: bool, policy: _Policy):
-        model = LoraModel().to(device=device)
+    def _test_frozen_params(self, device_type, use_orig_params: bool, policy: _Policy):
+        model = LoraModel().to(device=device_type)
         msg = "layers.0.attn has both parameters with requires_grad=True and False. "
         if use_orig_params:
             msg += "We do not recommend wrapping such modules"

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -1,10 +1,10 @@
 # Owner(s): ["oncall: distributed"]
 
-import unittest
 import functools
 import itertools
 import os
 import tempfile
+import unittest
 from collections.abc import Callable
 from enum import auto, Enum
 


### PR DESCRIPTION
## Summary

Adds `hw_classification` to `TestFSDPWrap` and `TestAutoWrap`, runs both
through `instantiate_device_type_tests`, and replaces the CUDA-specific
predicates in `TestAutoWrap`'s skip conditions with the device-agnostic
equivalents already in `common_utils`.

## Motivation

Neither class had `hw_classification` bookkeeping despite both being
accelerator-only. This mirrors the pure-tagging pass #191909 did for other
files in this suite.

Separately, `TestAutoWrap` gates on `TEST_MULTIGPU`
(`TEST_CUDA and torch.cuda.device_count() >= 2`) and on
`TEST_CUDA and not TEST_XPU`, both of which name accelerators explicitly and so
skip silently on any other backend. `common_utils` already provides
device-agnostic equivalents — `TEST_MULTIACCELERATOR`
(`torch.accelerator.device_count() > 1`) and `TEST_ACCELERATOR`
(`torch.accelerator.is_available()`) — so the fix is to swap the predicate and
leave each decorator and its skip mechanism alone.

`TestFSDPWrap` gates on `skip_if_lt_x_gpu`, which is left untouched: its
device-agnostic implementation has already landed in #185184 and applies to
every call site.

## Changes

- `TestFSDPWrap`: five tests keep their `skip_if_lt_x_gpu` gates unchanged.
- `TestAutoWrap`: fifteen `@unittest.skipIf(not TEST_MULTIGPU, ...)` become
  `@unittest.skipIf(not TEST_MULTIACCELERATOR, ...)`, and two
  `@unittest.skipIf(not TEST_CUDA and not TEST_XPU, ...)` become
  `@unittest.skipIf(not TEST_ACCELERATOR, ...)`. The decorators themselves are
  unchanged.
- Both classes gain `hw_classification = HardwareClassification.ACCELERATOR`.
  No `@requires_capabilities` is added to either class — per team review, a
  capability is only registered where an existing decorator already named
  it, and these are all generic gates, not capability-specific ones.
- `instantiate_parametrized_tests(TestAutoWrap)` is **replaced** by
  `instantiate_device_type_tests`, not joined by it — running both
  double-expands `@parametrize` methods, because `@wraps` copies
  `parametrize_fn` onto the already-expanded test and the device-class
  generation expands it a second time.
- `NestedSequentialModel` moves from a nested class inside `TestFSDPWrap` to
  module level. `TestAutoWrap` refers to it by qualified name, and
  `instantiate_device_type_tests` deletes the generic class from module globals
  after generating the device subclasses, so those references would raise
  `NameError`.
- `TestWrapUtils` is untouched: no device gating.

`instantiate_device_type_tests` is added with `except_for="cpu"`, and the
test methods gain the `device` parameter it injects.

## Test Plan

Verified on an accelerator backend (4 devices): `Ran 52 tests ... OK`. Test count
unchanged.

## Related

Part of #185590.

`TestFSDPWrap`'s `skip_if_lt_x_gpu` gates are unchanged; their device-agnostic
implementation is provided by the landed #185184.
