### PR TITLE
[Testcase Refactoring] Migrate test_file_system_checkpoint.py to capability-based gating

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -23,12 +23,14 @@ from torch.distributed.checkpoint import (
 )
 from torch.distributed.checkpoint._extension import ZStandard
 from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -114,6 +116,8 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
@@ -167,15 +171,19 @@ class TestDistributedStateDictSaveLoad(TestCase):
 
 
 class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
     @parametrize("extensions", [None, [Rot13Example()], [ZStandard()]])
-    def test_read_write_shard_tensor(self, extensions) -> None:
+    def test_read_write_shard_tensor(self, device, extensions) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -224,6 +232,8 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
 
 
 class TestDistributedReshardOnLoad(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
@@ -244,8 +254,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_load_with_different_shard_plan(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_load_with_different_shard_plan(self, device) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -359,8 +371,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_load_rowwise_to_colwise(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_load_rowwise_to_colwise(self, device) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -410,8 +424,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_save_load_bytes(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_save_load_bytes(self, device) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
@@ -429,8 +445,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
-    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
+    def test_switch_between_sharded_tensor_to_tensor(self, device) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -515,15 +533,19 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 
 class TestDistributedStateDictSaveLoadWithCaching(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
-    @requires_accelerator_dist_backend()
+    @requires_capabilities(
+        Capability.distributed.backend,
+    )
     @with_temp_dir
-    def test_read_write_shard_tensor(self) -> None:
+    def test_read_write_shard_tensor(self, device) -> None:
         # pyre-fixme [28]: Unexpected keyword argument `dim` to call `dist._sharding_spec.api.ChunkShardingSpec.__init__`.
         spec = ChunkShardingSpec(
             dim=0,
@@ -600,7 +622,21 @@ class TestDistributedStateDictSaveLoadWithCaching(ShardedTensorTestBase):
         dist.barrier()
 
 
-instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
+instantiate_device_type_tests(
+    TestDistributedStateDictSaveLoadWithSharedTensor,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestDistributedReshardOnLoad, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDistributedStateDictSaveLoadWithCaching,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -626,16 +626,12 @@ instantiate_device_type_tests(
     TestDistributedStateDictSaveLoadWithSharedTensor,
     globals(),
     except_for="cpu",
-    allow_xpu=True,
 )
-instantiate_device_type_tests(
-    TestDistributedReshardOnLoad, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestDistributedReshardOnLoad, globals(), except_for="cpu")
 instantiate_device_type_tests(
     TestDistributedStateDictSaveLoadWithCaching,
     globals(),
     except_for="cpu",
-    allow_xpu=True,
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -626,12 +626,16 @@ instantiate_device_type_tests(
     TestDistributedStateDictSaveLoadWithSharedTensor,
     globals(),
     except_for="cpu",
+    allow_xpu=True,
 )
-instantiate_device_type_tests(TestDistributedReshardOnLoad, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestDistributedReshardOnLoad, globals(), except_for="cpu", allow_xpu=True
+)
 instantiate_device_type_tests(
     TestDistributedStateDictSaveLoadWithCaching,
     globals(),
     except_for="cpu",
+    allow_xpu=True,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Testcase Refactoring] Migrate test_file_system_checkpoint.py to capability-based gating

## Summary

Migrates the three `ShardedTensorTestBase` classes in this file to the
capability mechanism and tags them `HardwareClassification.ACCELERATOR`.

## Motivation

These tests state how many devices they need, but not what device
functionality they exercise, so a backend cannot tell whether it is expected to
support them. `requires_capabilities` makes that explicit: the test declares the
functionality it uses, and each backend declares what it provides, so a test runs
where it can and reports a specific reason where it cannot.

The existing `skip_if_lt_x_gpu` world-size gates are deliberately left alone.
Its device-agnostic implementation has already landed in #185184, so no
per-file rewrite is needed here.


## Changes

- Six `skip_if_lt_x_gpu(2)` gates across
  `TestDistributedStateDictSaveLoadWithSharedTensor`,
  `TestDistributedReshardOnLoad` and
  `TestDistributedStateDictSaveLoadWithCaching` keep their `skip_if_lt_x_gpu(2)` gate and gain
  `@requires_capabilities(distributed.backend)`. As in test_checkpoint.py only the
  backend capability applies — this is ShardedTensor and file-system checkpoint code.
- The existing `instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)`
  is **replaced** by `instantiate_device_type_tests`, not joined by it. Running
  both double-expands `@parametrize` methods, because `@wraps` copies
  `parametrize_fn` onto the already-expanded test and the device-class generation
  expands it again.
- `TestDistributedStateDictSaveLoad` is untouched: a plain `TestCase` with no
  device gating, still `GENERIC`.

`@requires_capabilities` resolves the capability map through the device class it
runs on, so it only works on classes `instantiate_device_type_tests` generates.
That call is added with `except_for="cpu"`, and the test method
gains the `device` parameter it injects.

This change is purely additive — no existing gate is removed or rewritten.


## Test Plan

Verified on the current head:

- NPU/HCCL (4 devices): 9/9 passed;
- CPU/Gloo: the unchanged generic class ran 1/1, while the accelerator classes
  were not instantiated by design;
- no failures, errors, or unexpected skips.

## Related

Depends on #191919 for the capability infrastructure and
`Capability.distributed.backend`, and on #192043 for the out-of-tree
PrivateUse1 capability-provider registry. Both dependencies are still open, so
this PR must be tested or landed with that stack in place.

#190846, cited by an earlier review, was closed without merge. Its relevant
capability work is now carried by #191919, so #190846 is no longer an actionable
prerequisite for this PR.

The change itself is complete and ready to review.
Part of #185590.

The world-size gates in this file are unchanged; their device-agnostic
implementation is provided by the landed #185184.
