### PR TITLE
[3/3][Test] Add hardware classification to test_stateless.py

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,6 +9,7 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -16,12 +17,6 @@ from torch.testing._internal.common_utils import (
     subtest,
     TestCase,
     TEST_MULTIACCELERATOR,
-)
-
-device_type = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
 )
 
 
@@ -48,37 +43,29 @@ class MockTiedModule(torch.nn.Module):
         return self.l1(x) + self.tied_bias + self.buffer + self.tied_buffer
 
 
+def _run_call_with_mock_module(test, module, functional_call, device='cpu'):
+    x = torch.rand((1, 1), device=device)
+    weight = torch.tensor([[1.0]], device=device)
+    bias = torch.tensor([0.0], device=device)
+    buffer = torch.tensor([0.0], device=device)
+    parameters = {'l1.weight': weight,
+                  'l1.bias': bias,
+                  'buffer': buffer}
+    prev_weight = module.l1.weight.clone()
+    prev_buffer = module.buffer.clone()
+    # the parameters represent an identity function contrary to the
+    # existing params in module. So here we expect the result to be the
+    # same as the input if the weight swapping went well.
+    res = functional_call(module, parameters, x)
+    test.assertEqual(x, res)
+    # check that the weight remain unmodified
+    cur_weight = module.l1.weight
+    cur_buffer = module.buffer
+    test.assertEqual(cur_weight, prev_weight)
+    test.assertEqual(cur_buffer, prev_buffer)
+
+
 class TestStatelessFunctionalAPI(TestCase):
-    def _run_call_with_mock_module(self, module, functional_call, device='cpu', prefix=''):
-
-        x = torch.rand((1, 1)).to(device)
-        weight = torch.tensor([[1.0]], device=device)
-        bias = torch.tensor([0.0], device=device)
-        buffer = torch.tensor([0.0], device=device)
-        if prefix != '':
-            parameters = {f'{prefix}.l1.weight': weight,
-                          f'{prefix}.l1.bias': bias,
-                          f'{prefix}.buffer': buffer}
-        else:
-            parameters = {'l1.weight': weight,
-                          'l1.bias': bias,
-                          'buffer': buffer}
-        to_check = module
-        if prefix != '':
-            to_check = getattr(module, prefix)
-        prev_weight = to_check.l1.weight.clone()
-        prev_buffer = to_check.buffer.clone()
-        # the parameters represent an identity function contrary to the
-        # existing params in module. So here we expect the result to be the
-        # same as the input if the weight swapping went well.
-        res = functional_call(module, parameters, x)
-        self.assertEqual(x, res)
-        # check that the weight remain unmodified
-        cur_weight = to_check.l1.weight
-        cur_buffer = to_check.buffer
-        self.assertEqual(cur_weight, prev_weight)
-        self.assertEqual(cur_buffer, prev_buffer)
-
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
         orig_parameters, orig_buffers = tuple(module.parameters()), tuple(module.buffers())
@@ -106,14 +93,6 @@ class TestStatelessFunctionalAPI(TestCase):
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
     ])
-    def test_functional_call(self, functional_call):
-        module = MockModule()
-        self._run_call_with_mock_module(module, functional_call)
-
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
     def test_functional_call_with_jit(self, functional_call):
         module = MockModule()
         jit_module = torch.jit.script(module)
@@ -121,86 +100,14 @@ class TestStatelessFunctionalAPI(TestCase):
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(jit_module, functional_call)
+            _run_call_with_mock_module(self, jit_module, functional_call)
         x = torch.rand((1, 1))
         traced_module = torch.jit.trace(module, x)
         with self.assertRaisesRegex(
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(traced_module, functional_call)
-
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
-    @unittest.skip("This doesn't work right now")
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_call_with_data_parallel(self, functional_call):
-        module = MockModule()
-        module.to(device_type)
-        dp_module = torch.nn.DataParallel(module, [0, 1])
-        self._run_call_with_mock_module(dp_module, functional_call, device=device_type, prefix='module')
-
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_call_with_data_parallel_error(self, functional_call):
-        module = MockModule()
-        module.to(device_type)
-        dp_module = torch.nn.DataParallel(module, [0, 1])
-        with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
-            functional_call(
-                dp_module,
-                {'module.weight': torch.zeros(5, device=device_type)},
-                (torch.ones(2, 5, device=device_type),))
-
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_call_with_gradient(self, functional_call):
-        module = MockModule()
-        x = torch.rand((1, 1))
-        weight = torch.tensor([[1.0]], requires_grad=True)
-        bias = torch.tensor([0.0], requires_grad=True)
-        buffer = torch.tensor([0.0])
-        parameters = {'l1.weight': weight,
-                      'l1.bias': bias,
-                      'buffer': buffer}
-        res = functional_call(module, parameters, x)
-        # Check that a backward step calculates the gradient of the supplied parameters
-        res.backward()
-        self.assertIsNotNone(weight.grad)
-        self.assertIsNotNone(bias.grad)
-        self.assertIsNone(buffer.grad)
-        # Gradient was not calculated for the module stated and buffers
-        self.assertIsNone(module.l1.weight.grad)
-        self.assertIsNone(module.l1.bias.grad)
-        self.assertIsNone(module.buffer.grad)
-
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
-    def test_functional_batch_norm(self, functional_call):
-        module = torch.nn.BatchNorm1d(10)
-        module.train()  # Allow stats update
-        # lets replace the running_mean buffer and check if its correctly updated
-        x = torch.full((20, 10), 128.0)
-        rm = torch.zeros(10)
-        parameters = {'running_mean': rm}
-        prev_rm = module.running_mean.clone()
-        functional_call(module, parameters, x)
-        cur_rm = module.running_mean
-        self.assertEqual(cur_rm, prev_rm)
-        self.assertEqual(rm, torch.full((10,), 12.8))
-        # Now run functional without reparameterization and check that the module has
-        # been updated
-        functional_call(module, {}, x)
-        self.assertEqual(module.running_mean, torch.full((10,), 12.8))
+            _run_call_with_mock_module(self, traced_module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -661,30 +568,6 @@ class TestStatelessFunctionalAPI(TestCase):
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
     ])
-    def test_in_place_operator(self, functional_call):
-        class Foo(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.foo = torch.nn.Buffer(torch.tensor([0.0]))
-
-            def forward(self, x):
-                self.foo.add_(1)
-                return x + self.foo
-
-        foo = torch.tensor([2.0])
-        x = torch.randn(1)
-        a = {'foo': foo}
-        mod = Foo()
-        functional_call(mod, a, x)
-        self.assertEqual(mod.foo, torch.tensor([0.0]))
-        self.assertEqual(a['foo'], torch.tensor([3.0]))
-        self.assertEqual(foo, torch.tensor([3.0]))
-        self.assertTrue(a['foo'] is foo)
-
-    @parametrize("functional_call", [
-        subtest(torch.func.functional_call, "torch_func"),
-        subtest(stateless.functional_call, "stateless")
-    ])
     def test_setattr_strict(self, functional_call):
         class Bar(torch.nn.Module):
             def __init__(self) -> None:
@@ -886,6 +769,99 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertTrue(all(t1 is t2 for t1, t2 in zip(buffers, (module.buffer,))))
 
 
+class TestStatelessFunctionalAPIDevice(TestCase):
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_call(self, device, functional_call):
+        module = MockModule().to(device)
+        _run_call_with_mock_module(self, module, functional_call, device=device)
+
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_call_with_gradient(self, device, functional_call):
+        module = MockModule().to(device)
+        x = torch.rand((1, 1), device=device)
+        weight = torch.tensor([[1.0]], device=device, requires_grad=True)
+        bias = torch.tensor([0.0], device=device, requires_grad=True)
+        buffer = torch.tensor([0.0], device=device)
+        parameters = {'l1.weight': weight,
+                      'l1.bias': bias,
+                      'buffer': buffer}
+        res = functional_call(module, parameters, x)
+        # Check that a backward step calculates the gradient of the supplied parameters
+        res.backward()
+        self.assertIsNotNone(weight.grad)
+        self.assertIsNotNone(bias.grad)
+        self.assertIsNone(buffer.grad)
+        # Gradient was not calculated for the module stated and buffers
+        self.assertIsNone(module.l1.weight.grad)
+        self.assertIsNone(module.l1.bias.grad)
+        self.assertIsNone(module.buffer.grad)
+
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_batch_norm(self, device, functional_call):
+        module = torch.nn.BatchNorm1d(10).to(device)
+        module.train()  # Allow stats update
+        # lets replace the running_mean buffer and check if its correctly updated
+        x = torch.full((20, 10), 128.0, device=device)
+        rm = torch.zeros(10, device=device)
+        parameters = {'running_mean': rm}
+        prev_rm = module.running_mean.clone()
+        functional_call(module, parameters, x)
+        cur_rm = module.running_mean
+        self.assertEqual(cur_rm, prev_rm)
+        self.assertEqual(rm, torch.full((10,), 12.8, device=device))
+        # Now run functional without reparameterization and check that the module has
+        # been updated
+        functional_call(module, {}, x)
+        self.assertEqual(module.running_mean, torch.full((10,), 12.8, device=device))
+
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_in_place_operator(self, device, functional_call):
+        class Foo(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.foo = torch.nn.Buffer(torch.tensor([0.0]))
+
+            def forward(self, x):
+                self.foo.add_(1)
+                return x + self.foo
+
+        foo = torch.tensor([2.0], device=device)
+        x = torch.randn(1, device=device)
+        a = {'foo': foo}
+        mod = Foo().to(device)
+        functional_call(mod, a, x)
+        self.assertEqual(mod.foo, torch.tensor([0.0], device=device))
+        self.assertEqual(a['foo'], torch.tensor([3.0], device=device))
+        self.assertEqual(foo, torch.tensor([3.0], device=device))
+        self.assertTrue(a['foo'] is foo)
+
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @parametrize("functional_call", [
+        subtest(torch.func.functional_call, "torch_func"),
+        subtest(stateless.functional_call, "stateless")
+    ])
+    def test_functional_call_with_data_parallel_error(self, device, functional_call):
+        module = MockModule().to(device)
+        dp_module = torch.nn.DataParallel(module, [0, 1])
+        with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
+            functional_call(
+                dp_module,
+                {'module.weight': torch.zeros(5, device=device)},
+                (torch.ones(2, 5, device=device),))
+
+
 class TestStatelessDeprecation(TestCase):
     def test_private_stateless_warns(self):
         script = """
@@ -933,6 +909,7 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
+instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals())
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -68,7 +69,9 @@ def _run_call_with_mock_module(test, module, functional_call, device='cpu'):
     test.assertEqual(cur_buffer, prev_buffer)
 
 
-class TestStatelessFunctionalAPI(TestCase):
+class TestStatelessFunctionalAPICPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
         orig_parameters, orig_buffers = tuple(module.parameters()), tuple(module.buffers())
@@ -773,6 +776,8 @@ class TestStatelessFunctionalAPI(TestCase):
 
 
 class TestStatelessFunctionalAPIDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
@@ -867,6 +872,8 @@ class TestStatelessFunctionalAPIDevice(TestCase):
 
 
 class TestStatelessDeprecation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_private_stateless_warns(self):
         script = """
 import torch
@@ -897,6 +904,8 @@ exit(len(w))
             stateless.functional_call(m, params, x)
 
 class TestPythonOptimizeMode(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_runs_with_optimize_flag(self):
         script = "import torch; import torch._functorch.deprecated"
         try:
@@ -911,7 +920,7 @@ class TestPythonOptimizeMode(TestCase):
 
 
 instantiate_parametrized_tests(
-    TestStatelessFunctionalAPI,
+    TestStatelessFunctionalAPICPU,
 )
 instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals(), allow_xpu=True)
 

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,7 +9,10 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -847,7 +850,8 @@ class TestStatelessFunctionalAPIDevice(TestCase):
         self.assertEqual(foo, torch.tensor([3.0], device=device))
         self.assertTrue(a['foo'] is foo)
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @onlyAccelerator
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multiple accelerator devices not available')
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
@@ -909,7 +913,7 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
-instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals())
+instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals(), allow_xpu=True)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Part of #142029 (Intel GPU support for PyTorch test cases).

Classify all four test classes in `test/test_stateless.py` so `--hw-classification` can partition the file.

- rename `TestStatelessFunctionalAPI` to `TestStatelessFunctionalAPICPU` and classify it `CPU`: its tests are API-shape and error-message checks that allocate on CPU only, so they belong to the CPU partition rather than being run per-device
- classify `TestStatelessFunctionalAPIDevice` as `ACCELERATOR`
- classify `TestStatelessDeprecation` and `TestPythonOptimizeMode` as `GENERIC`

**Point needing a second opinion (@astachowiczhabana):** per the discussion the rule is to give everything currently `GENERIC` a CPU suffix and `CPU` classification. I applied that to `TestStatelessFunctionalAPI` but deliberately *not* to `TestStatelessDeprecation` and `TestPythonOptimizeMode`. Those two run no tensor operations at all - one checks a deprecation warning on import in a subprocess, the other checks that the module imports under `python -OO` - so
there is no device-dependent behavior to attribute to CPU. This reading matches the `HardwareClassification` docstring, which reserves CPU/CUDA/MPS/XPU for device-specific behavior and describes `GENERIC` as the classification for
classes that do not use `instantiate_device_type_tests`, as well as existing precedent (e.g. `TestTorchAutocast`, `TestMemoryProfiler`). Happy to change it if the rule is meant to be unconditional.

No change in test results - only a class rename.

## Test Plan

Single-XPU machine, no CUDA:

```
python test/test_stateless.py -v                              # Ran 58 tests ... OK (skipped=4)
python test/test_stateless.py --hw-classification CPU         # 35 tests
python test/test_stateless.py --hw-classification ACCELERATOR # 20 tests
python test/test_stateless.py --hw-classification GENERIC     #  3 tests
lintrunner -a test/test_stateless.py                          # no lint issues
```

35 + 20 + 3 = 58, so the classifications partition the file exactly with none unclassified.

---

Stack of following PRs:
- https://github.com/pytorch/pytorch/pull/192218
- https://github.com/pytorch/pytorch/pull/192325
- -> https://github.com/pytorch/pytorch/pull/192326
