### PR TITLE
[Testcase Refactoring] Migrate test_fsdp_unshard_params.py to instantiate_device_type_tests

### DIFF
--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -21,6 +21,11 @@ from torch.distributed.fsdp._flat_param import FlatParameter
 from torch.distributed.fsdp.fully_sharded_data_parallel import FLAT_PARAM
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -31,6 +36,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_WITH_ROCM,
@@ -55,6 +61,8 @@ class TestUnshardParamsBase(FSDPTestContinuous):
     """
     This contains any methods common to both the sharded and non-sharded cases.
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _test_unshard_params_writeback(
         self,
@@ -217,7 +225,11 @@ class TestUnshardParams(TestUnshardParamsBase):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_writeback(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_writeback(self, device):
         """Tests the ``writeback`` argument (using default for all others)."""
         self.run_subtests(
             self._get_test_unshard_params_writeback_config(),
@@ -225,7 +237,11 @@ class TestUnshardParams(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_param_data(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_param_data(self, device):
         """
         Tests that parameters are exposed correctly for ``recurse=True`` and
         all other argument configs for a non-FSDP root module.
@@ -236,7 +252,11 @@ class TestUnshardParams(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_singleton_param_writeback(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_singleton_param_writeback(self, device):
         """
         Tests ``writeback=True`` for a singleton parameter, which includes
         testing that writing to padding does not persist.
@@ -262,7 +282,11 @@ class TestUnshardParams(TestUnshardParamsBase):
 
     @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/159348")
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_respects_reshard(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_respects_reshard(self, device):
         """
         Tests that unsharding parameters respects the expected reshard behavior
         between forward and backward as well as after backward.
@@ -359,7 +383,11 @@ class TestUnshardParams(TestUnshardParamsBase):
         self.assertEqual(0, _get_unsharded_storage_size(inner_flat_param))
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_recurse(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_recurse(self, device):
         """Tests the ``recurse`` argument (using default for all others)."""
         self.run_subtests(
             {
@@ -428,7 +456,11 @@ class TestUnshardParams(TestUnshardParamsBase):
             self.assertEqual(expected_inner_numel, inner_flat_param.numel())
 
     @skip_if_lt_x_gpu(2)
-    def test_named_parameters_and_buffers(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_named_parameters_and_buffers(self, device):
         """
         Tests that ``named_parameters()`` and ``named_buffers()`` for a
         top-level FSDP-wrapped model matches their behavior for the equivalent
@@ -470,7 +502,11 @@ class TestUnshardParams(TestUnshardParamsBase):
                     self.assertEqual(p1, p2)
 
     @skip_if_lt_x_gpu(2)
-    def test_with_grads_core(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_with_grads_core(self, device):
         """
         Tests the core usage of``with_grads=True`` by comparing against DDP as
         the unsharded equivalent.
@@ -604,7 +640,11 @@ class TestUnshardParams(TestUnshardParamsBase):
             _check_grads(ddp_model, fsdp_model, old_fsdp_grads)
 
     @skip_if_lt_x_gpu(2)
-    def test_with_grads_none_grads(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_with_grads_none_grads(self, device):
         """
         Tests that if all ranks' ``FlatParameter`` has ``None`` gradient, then
         each original parameter sees ``None`` gradient as well.
@@ -641,7 +681,11 @@ class TestUnshardParams(TestUnshardParamsBase):
                 self.assertTrue(param.grad is None)
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_submodule(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_submodule(self, device):
         model = nn.Sequential(
             nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
             nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
@@ -660,7 +704,11 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    def test_unshard_params_writeback_no_shard(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_writeback_no_shard(self, device):
         """Tests the ``writeback`` argument (using default for all others)."""
         self.run_subtests(
             self._get_test_unshard_params_writeback_config(),
@@ -668,7 +716,11 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(1)
-    def test_unshard_params_param_data_no_shard(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_param_data_no_shard(self, device):
         """
         Tests that parameters are exposed correctly for ``recurse=True`` and
         all other argument configs for a non-FSDP root module.
@@ -689,7 +741,11 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_from_forward_raises(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_from_forward_raises(self, device):
         class MyModule(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -706,7 +762,11 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
             model(model)
 
     @skip_if_lt_x_gpu(2)
-    def test_unshard_params_from_backward_raises(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_unshard_params_from_backward_raises(self, device):
         model = FSDP(nn.Linear(2, 1, device=device_type.type))
         output = model(torch.ones(2, device=device_type.type))
 
@@ -722,7 +782,11 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
             output.backward()
 
     @skip_if_lt_x_gpu(2)
-    def test_rank0_only_with_writeback_raises(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_rank0_only_with_writeback_raises(self, device):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
@@ -735,7 +799,11 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 pass
 
     @skip_if_lt_x_gpu(2)
-    def test_offload_to_cpu_no_shard_raises(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_offload_to_cpu_no_shard_raises(self, device):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
@@ -749,5 +817,14 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 pass
 
 
+instantiate_device_type_tests(
+    TestUnshardParams, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestUnshardParamsNoShard, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestUnshardParamsErrors, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -691,6 +691,7 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         self.run_subtests(
             self._get_test_unshard_params_writeback_config(),
             self._test_unshard_params_writeback,
+            device=device,
         )
 
     @skip_if_lt_x_gpu(1)
@@ -706,6 +707,7 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         self.run_subtests(
             config,
             self._test_unshard_params_param_data,
+            device=device,
         )
 
 

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
     FSDPInitMode,
     FSDPTestContinuous,
-    get_devtype,
     NestedWrappedModule,
     TransformerWithSharedParams,
 )
@@ -40,8 +39,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
 )
 
-
-device_type = torch.device(get_devtype())
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -66,8 +63,12 @@ class TestUnshardParamsBase(FSDPTestContinuous):
         self,
         writeback: bool,
         check_outer: bool,
+        device: str,
         **fsdp_kwargs: dict[str, Any],
     ):
+        # Type-only device (no index): each rank must stay on the device bound
+        # by the framework, and the injected `device` carries the primary index.
+        device_type = torch.device(torch.device(device).type)
         model = nn.Sequential(
             nn.Linear(5, 5, bias=False, device=device_type.type),
             nn.Linear(5, 3, bias=False, device=device_type.type),
@@ -131,7 +132,9 @@ class TestUnshardParamsBase(FSDPTestContinuous):
         cpu_offload: CPUOffload,
         mixed_precision: MixedPrecision | None,
         use_orig_params: bool,
+        device: str,
     ):
+        device_type = torch.device(torch.device(device).type)
         local_model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
@@ -228,6 +231,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         self.run_subtests(
             self._get_test_unshard_params_writeback_config(),
             self._test_unshard_params_writeback,
+            device=device,
         )
 
     @skip_if_lt_x_gpu(2)
@@ -239,6 +243,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         self.run_subtests(
             self._get_test_unshard_params_param_data_config(),
             self._test_unshard_params_param_data,
+            device=device,
         )
 
     @skip_if_lt_x_gpu(2)
@@ -248,6 +253,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         testing that writing to padding does not persist.
         NOTE: This method depends on FSDP internals.
         """
+        device_type = torch.device(torch.device(device).type)
         model = FSDP(nn.Linear(1, 1, bias=False, device=device_type.type))
         flat_param = model._handle.flat_param
         self.assertEqual(1, flat_param.numel())
@@ -286,6 +292,7 @@ class TestUnshardParams(TestUnshardParamsBase):
                 "use_orig_params": [False, True],
             },
             self._test_unshard_params_respects_reshard,
+            device=device,
         )
 
     def _test_unshard_params_respects_reshard(
@@ -294,8 +301,10 @@ class TestUnshardParams(TestUnshardParamsBase):
         offload_to_cpu: bool,
         mixed_precision: MixedPrecision | None,
         use_orig_params: bool,
+        device: str,
     ):
         """NOTE: This method depends on FSDP internals."""
+        device_type = torch.device(torch.device(device).type)
         fsdp_kwargs = {
             "mixed_precision": mixed_precision,
             "use_orig_params": use_orig_params,
@@ -375,6 +384,7 @@ class TestUnshardParams(TestUnshardParamsBase):
                 "use_orig_params": [False, True],
             },
             self._test_unshard_params_recurse,
+            device=device,
         )
 
     def _test_unshard_params_recurse(
@@ -383,8 +393,10 @@ class TestUnshardParams(TestUnshardParamsBase):
         unshard_outer: bool,
         mixed_precision: MixedPrecision | None,
         use_orig_params: bool,
+        device: str,
     ):
         """NOTE: This method depends on FSDP internals."""
+        device_type = torch.device(torch.device(device).type)
         fsdp_kwargs = {
             "mixed_precision": mixed_precision,
             "use_orig_params": use_orig_params,
@@ -493,6 +505,7 @@ class TestUnshardParams(TestUnshardParamsBase):
                 "use_orig_params": [True],
             },
             self._test_with_grads_core,
+            device=device,
         )
 
     def _test_with_grads_core(
@@ -501,6 +514,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         offload_to_cpu: bool,
         sharding_strategy: ShardingStrategy,
         use_orig_params: bool,
+        device: str,
     ):
         def _check_grads(
             ddp_model: DDP,
@@ -567,6 +581,7 @@ class TestUnshardParams(TestUnshardParamsBase):
                 ]
             return None  # unused
 
+        device_type = torch.device(torch.device(device).type)
         is_supported = use_orig_params and not offload_to_cpu
         model = TransformerWithSharedParams.init(
             self.process_group,
@@ -624,9 +639,13 @@ class TestUnshardParams(TestUnshardParamsBase):
                 ]
             },
             self._test_with_grads_none_grads,
+            device=device,
         )
 
-    def _test_with_grads_none_grads(self, sharding_strategy: ShardingStrategy):
+    def _test_with_grads_none_grads(
+        self, sharding_strategy: ShardingStrategy, device: str
+    ):
+        device_type = torch.device(torch.device(device).type)
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
@@ -648,6 +667,7 @@ class TestUnshardParams(TestUnshardParamsBase):
 
     @skip_if_lt_x_gpu(2)
     def test_unshard_submodule(self, device):
+        device_type = torch.device(torch.device(device).type)
         model = nn.Sequential(
             nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
             nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
@@ -705,6 +725,7 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 with fsdp_module.summon_full_params(fsdp_module):
                     pass
 
+        device_type = torch.device(torch.device(device).type)
         model = FSDP(MyModule()).to(device_type.type)
         with self.assertRaisesRegex(
             AssertionError, "Cannot manually unshard parameters during forward/backward"
@@ -713,6 +734,7 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
 
     @skip_if_lt_x_gpu(2)
     def test_unshard_params_from_backward_raises(self, device):
+        device_type = torch.device(torch.device(device).type)
         model = FSDP(nn.Linear(2, 1, device=device_type.type))
         output = model(torch.ones(2, device=device_type.type))
 

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -817,14 +817,8 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 pass
 
 
-instantiate_device_type_tests(
-    TestUnshardParams, globals(), except_for="cpu", allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestUnshardParamsNoShard, globals(), except_for="cpu", allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestUnshardParamsErrors, globals(), except_for="cpu", allow_xpu=True
-)
+instantiate_device_type_tests(TestUnshardParams, globals(), except_for="cpu")
+instantiate_device_type_tests(TestUnshardParamsNoShard, globals(), except_for="cpu")
+instantiate_device_type_tests(TestUnshardParamsErrors, globals(), except_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -22,9 +22,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import FLAT_PARAM
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
@@ -225,10 +223,6 @@ class TestUnshardParams(TestUnshardParamsBase):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_writeback(self, device):
         """Tests the ``writeback`` argument (using default for all others)."""
         self.run_subtests(
@@ -237,10 +231,6 @@ class TestUnshardParams(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_param_data(self, device):
         """
         Tests that parameters are exposed correctly for ``recurse=True`` and
@@ -252,10 +242,6 @@ class TestUnshardParams(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_singleton_param_writeback(self, device):
         """
         Tests ``writeback=True`` for a singleton parameter, which includes
@@ -282,10 +268,6 @@ class TestUnshardParams(TestUnshardParamsBase):
 
     @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/159348")
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_respects_reshard(self, device):
         """
         Tests that unsharding parameters respects the expected reshard behavior
@@ -383,10 +365,6 @@ class TestUnshardParams(TestUnshardParamsBase):
         self.assertEqual(0, _get_unsharded_storage_size(inner_flat_param))
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_recurse(self, device):
         """Tests the ``recurse`` argument (using default for all others)."""
         self.run_subtests(
@@ -456,10 +434,6 @@ class TestUnshardParams(TestUnshardParamsBase):
             self.assertEqual(expected_inner_numel, inner_flat_param.numel())
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_named_parameters_and_buffers(self, device):
         """
         Tests that ``named_parameters()`` and ``named_buffers()`` for a
@@ -502,10 +476,6 @@ class TestUnshardParams(TestUnshardParamsBase):
                     self.assertEqual(p1, p2)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_with_grads_core(self, device):
         """
         Tests the core usage of``with_grads=True`` by comparing against DDP as
@@ -640,10 +610,6 @@ class TestUnshardParams(TestUnshardParamsBase):
             _check_grads(ddp_model, fsdp_model, old_fsdp_grads)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_with_grads_none_grads(self, device):
         """
         Tests that if all ranks' ``FlatParameter`` has ``None`` gradient, then
@@ -681,10 +647,6 @@ class TestUnshardParams(TestUnshardParamsBase):
                 self.assertTrue(param.grad is None)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_submodule(self, device):
         model = nn.Sequential(
             nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
@@ -704,10 +666,6 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_writeback_no_shard(self, device):
         """Tests the ``writeback`` argument (using default for all others)."""
         self.run_subtests(
@@ -716,10 +674,6 @@ class TestUnshardParamsNoShard(TestUnshardParamsBase):
         )
 
     @skip_if_lt_x_gpu(1)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_param_data_no_shard(self, device):
         """
         Tests that parameters are exposed correctly for ``recurse=True`` and
@@ -741,10 +695,6 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_from_forward_raises(self, device):
         class MyModule(nn.Module):
             def __init__(self) -> None:
@@ -762,10 +712,6 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
             model(model)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_unshard_params_from_backward_raises(self, device):
         model = FSDP(nn.Linear(2, 1, device=device_type.type))
         output = model(torch.ones(2, device=device_type.type))
@@ -782,10 +728,6 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
             output.backward()
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_rank0_only_with_writeback_raises(self, device):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
@@ -799,10 +741,6 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 pass
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_offload_to_cpu_no_shard_raises(self, device):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -21,9 +21,7 @@ from torch.distributed.fsdp._flat_param import FlatParameter
 from torch.distributed.fsdp.fully_sharded_data_parallel import FLAT_PARAM
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -779,8 +777,14 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
                 pass
 
 
-instantiate_device_type_tests(TestUnshardParams, globals(), except_for="cpu")
-instantiate_device_type_tests(TestUnshardParamsNoShard, globals(), except_for="cpu")
-instantiate_device_type_tests(TestUnshardParamsErrors, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestUnshardParams, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestUnshardParamsNoShard, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestUnshardParamsErrors, globals(), except_for="cpu", allow_xpu=True
+)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Runs the three concrete test classes in this file through
`instantiate_device_type_tests`.

## Motivation

None of the three classes had `hw_classification` bookkeeping despite being
accelerator-only. This mirrors the pure-tagging pass #191909 did for other
files in this suite.

The existing `skip_if_lt_x_gpu` world-size gates are deliberately left alone.
Its device-agnostic implementation has already landed in #185184, so no
per-file rewrite is needed here.


## Changes

- Fifteen tests across `TestUnshardParams`, `TestUnshardParamsNoShard` and
  `TestUnshardParamsErrors` keep their `skip_if_lt_x_gpu(1)` / `(2)` gates
  unchanged. No `@requires_capabilities` is added — per team review, a
  capability is only registered where an existing decorator already named
  it, and `skip_if_lt_x_gpu` is a generic world-size gate, not a
  capability-specific one.
- `TestUnshardParamsBase` is abstract — it holds only `_test_*` helpers — so
  `instantiate_device_type_tests` is called on each of the three concrete
  subclasses rather than on the base. It scans only
  `generic_test_class.__dict__` and not inherited members.

`instantiate_device_type_tests` is added with `except_for="cpu"`, and the
test methods gain the `device` parameter it injects.

This change is purely additive — no existing gate is removed or rewritten.


## Test Plan

Verified on an accelerator backend (4 devices): `Ran 15 tests ... OK`.

## Related

Part of #185590.

The world-size gates in this file are unchanged; their device-agnostic
implementation is provided by the landed #185184.
