### PR TITLE
[Testcase Refactoring]Add hw_classification to elastic multiprocessing redirects_test.py

### DIFF
--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -17,10 +17,7 @@ from torch.distributed.elastic.multiprocessing.redirects import (
     redirect_stderr,
     redirect_stdout,
 )
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    TestCase,
-)
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 libc = ctypes.CDLL("libc.so.6")

--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -19,7 +19,6 @@ from torch.distributed.elastic.multiprocessing.redirects import (
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    run_tests,
     TestCase,
 )
 
@@ -148,4 +147,7 @@ class RedirectsTest(TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    raise RuntimeError(
+        "This test is not currently used and should be "
+        "enabled in discover_tests.py if required."
+    )

--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -18,6 +18,7 @@ from torch.distributed.elastic.multiprocessing.redirects import (
     redirect_stderr,
     redirect_stdout,
 )
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 libc = ctypes.CDLL("libc.so.6")
@@ -25,6 +26,8 @@ c_stderr = ctypes.c_void_p.in_dll(libc, "stderr")
 
 
 class RedirectsTest(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")

--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -11,21 +11,24 @@ import os
 import shutil
 import sys
 import tempfile
-import unittest
 
 from torch.distributed.elastic.multiprocessing.redirects import (
     redirect,
     redirect_stderr,
     redirect_stdout,
 )
-from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 libc = ctypes.CDLL("libc.so.6")
 c_stderr = ctypes.c_void_p.in_dll(libc, "stderr")
 
 
-class RedirectsTest(unittest.TestCase):
+class RedirectsTest(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
@@ -145,7 +148,4 @@ class RedirectsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    raise RuntimeError(
-        "This test is not currently used and should be "
-        "enabled in discover_tests.py if required."
-    )
+    run_tests()


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to
`RedirectsTest` in
`test/distributed/elastic/multiprocessing/redirects_test.py`.

## Changes

- **Import `HardwareClassification`** from `common_utils`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `RedirectsTest`.  All six tests exercise pure CPU stdout/stderr
  redirect logic across Python, C, and shell without any device
  dependency.

## Not changed

- No test logic, assertions, or redirect operations are modified.

## Test plan

- `python test/distributed/elastic/multiprocessing/redirects_test.py` —
  TODO: confirm all six tests pass on CPU.