### PR TITLE
Fix operator benchmark CUDA timing double count

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -387,7 +387,7 @@ class BenchmarkRunner:
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)
-        return result.median * iters
+        return result.median
 
     def _launch_backward(self, test_case, iters, print_per_iter=False):
         """This function runs forward path of an op to get an output. Then the backward path is executed
@@ -408,7 +408,7 @@ class BenchmarkRunner:
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)
-        return result.median * iters
+        return result.median
 
     def _measure_metrics(self, launch_test, test_case, iters, print_per_iter):
         """


### PR DESCRIPTION
## Summary

The CUDA/XPU timing path already measures a full call to func(iters, ...), and func itself runs the operator iters times. Multiplying by iters again double-counted the iteration count in both forward and backward timing paths.

Moreover, this also affects the reported "Memory Bandwidth (GB/s)": `get_memory_traffic_bytes()` is per single execution, and it is divided by the (inflated) per-op time, so bandwidth was underestimated by the same ~`iters`x factor on CUDA/XPU.

## Root Cause
`Timer` measures one execution of `stmt = "func(iters, ...)"`, and `func` (`run_forward` / `run_backward`) already loops `iters` times internally. So `result.median` is the total time for `iters` operator executions. The non-GPU path returns exactly that (`timeit.timeit(..., number=1)`), and the downstream code relies on this contract(in `_measure_metrics`):

```python
report_run_time = 1e6 * run_time_sec / iters   # benchmark_core.py:451
```
run_time_sec must be the total time for iters runs. Multiplying `result.median` by `iters` returned iters**2 runs' worth of time.

## Fix
return `result.median` directly in both `_launch_forward` and `_launch_backward`.

@jainapurva @jeffdaily @apakbin
