### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to 4 dynamo test classes

### DIFF
--- a/test/dynamo/test_python_autograd.py
+++ b/test/dynamo/test_python_autograd.py
@@ -5,6 +5,7 @@ import torch
 import torch._dynamo
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter, same
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 if TYPE_CHECKING:
@@ -204,6 +205,8 @@ def simple(a, b):
 
 
 class TestPythonAutograd(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _common(self, fn, expected_ops):
         args1 = [torch.randn(10), torch.randn(10)]
         args2 = [torch.randn(10), torch.randn(10)]

--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -5,9 +5,12 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import config as dc
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class RecompileTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_automatic_dynamic_reduce_recompiles(self):
         # Test the counterfactual, lots of recompiles without this config
         def foo(x, y):

--- a/test/dynamo/test_skip_non_tensor.py
+++ b/test/dynamo/test_skip_non_tensor.py
@@ -5,6 +5,7 @@ import torch
 import torch._dynamo
 import torch._dynamo.test_case
 from torch._dynamo.testing import CompileCounter
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 _variable = 0
@@ -63,6 +64,8 @@ class MyModule(torch.nn.Module):
 
 
 class SkipNonTensorTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_add_tensor1(self):
         def fn(a, b):
             return a + b

--- a/test/dynamo/test_view.py
+++ b/test/dynamo/test_view.py
@@ -2,10 +2,13 @@
 import torch
 import torch._dynamo
 import torch._dynamo.test_case
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 @torch._dynamo.config.patch("capture_scalar_outputs", True)
 class ViewTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_view_to_2d(self):
         @torch.compile(fullgraph=True, backend="eager")
         def f(t, _u0):


### PR DESCRIPTION
## Summary

This PR classifies 4 test classes in `test/dynamo/` as device-unrelated by adding `hw_classification = HardwareClassification.GENERIC`, enabling the PyTorch test infrasturcture to correctly identify these tests as hardware-agnostic.

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` and the corresponding import to:
 - `TestPythonAutograd` in `test/dynamo/test_python_autograd.py`
 - `RecompilTests` in `test/dynamo/test_recompiles.py`
 - `SkipNonTensorTests` in `test/dynamo/test_skip_non_tensor.py`
 - `ViewTests` in `test/dynamo/test_view.py`

## Test plan

`python test/dynamo/test_python_autograd.py --hw-classification GENERIC -v`
`python test/dynamo/test_recompiles.py --hw-classification GENERIC -v`
`python test/dynamo/test_skip_non_tensor.py --hw-classification GENERIC -v`
`python test/dynamo/test_view.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98