### PR TITLE
[Testcase Refactoring] Refactor custom op out lowering tests with hw_classification

### DIFF
--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -11,9 +11,7 @@ from torch._inductor import config
 from torch._inductor.codegen import common
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import HAS_TRITON
 

--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -9,19 +9,15 @@ from torch._inductor import config
 from torch._inductor.codegen import common
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
-    parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
-DEVICES = ("cpu", GPU_TYPE) if HAS_GPU else ("cpu",)
-
-
-@instantiate_parametrized_tests
-class TestCustomOpOutLowering(InductorTestCase):
-    """Tests for lowering functional custom ops to out-variant ExternKernelOut."""
+class TestCustomOpOutLoweringAccelerator(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _register_add_one_ops(self, lib):
         """Register a simple add_one op with functional + .out overloads."""
@@ -47,7 +43,6 @@ class TestCustomOpOutLowering(InductorTestCase):
 
         return torch.ops.mylib.add_one, torch.ops.mylib.add_one.out
 
-    @parametrize("device", DEVICES)
     def test_add_one_lowered_to_out(self, device):
         """Test that a simple functional op gets lowered to its out-variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -66,7 +61,6 @@ class TestCustomOpOutLowering(InductorTestCase):
 
             FileCheck().check(".out(").check_not(".default(").run(code)
 
-    @parametrize("device", DEVICES)
     def test_add_one_lowered_to_out_dynamic_shape(self, device):
         """Out-variant lowering with symbolic output shape (see #185503)."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -111,7 +105,6 @@ class TestCustomOpOutLowering(InductorTestCase):
 
         return torch.ops.mylib.split_add, torch.ops.mylib.split_add.out
 
-    @parametrize("device", DEVICES)
     def test_multi_output_lowered_to_out(self, device):
         """Test a two-output functional op gets lowered to its .out variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -130,7 +123,6 @@ class TestCustomOpOutLowering(InductorTestCase):
             self.assertEqual(compiled_out, eager_out)
             FileCheck().check(".out(").check("out0=").check("out1=").run(code)
 
-    @parametrize("device", DEVICES)
     def test_op_without_out_variant_falls_through(self, device):
         """Test that ops without an out-variant fall through to FallbackKernel."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -155,6 +147,15 @@ class TestCustomOpOutLowering(InductorTestCase):
                 torch.compile(f, backend="inductor", fullgraph=True), x
             )
             self.assertEqual(compiled_out, eager_out)
+
+
+instantiate_device_type_tests(
+    TestCustomOpOutLoweringAccelerator, globals(), allow_mps=True, allow_xpu=True
+)
+
+
+class TestCustomOpOutLoweringGeneric(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_cpp_wrapper_runtime_dispatch_single_output_fallback(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -195,6 +196,9 @@ class TestCustomOpOutLowering(InductorTestCase):
             else:
                 FileCheck().check_regex(output_assert).run(source_code)
             self.assertNotRegex(source_code, r"\bbuf\d+\s*=\s*buf\d+\b")
+
+
+instantiate_parametrized_tests(TestCustomOpOutLoweringGeneric)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -9,49 +9,75 @@ from torch._inductor import config
 from torch._inductor.codegen import common
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_utils import HardwareClassification
 
 
-DEVICES = ("cpu", GPU_TYPE) if HAS_GPU else ("cpu",)
+def _register_add_one_ops(lib):
+    """Register a simple add_one op with functional + .out overloads."""
+    lib.define("add_one(Tensor x) -> Tensor")
+    lib.define(
+        "add_one.out(Tensor x, *, Tensor(a!) out) -> Tensor(a!)",
+        tags=(torch.Tag.out,),
+    )
+
+    def _add_one_impl(x: torch.Tensor) -> torch.Tensor:
+        return x + 1
+
+    def _add_one_out_impl(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+        out.copy_(x + 1)
+        return out
+
+    lib.impl("add_one", _add_one_impl, "CompositeExplicitAutograd")
+    lib.impl("add_one.out", _add_one_out_impl, "CompositeExplicitAutograd")
+
+    @torch.library.register_fake("mylib::add_one", lib=lib)
+    def _add_one_fake(x):
+        return x.new_empty(x.shape)
+
+    return torch.ops.mylib.add_one, torch.ops.mylib.add_one.out
 
 
-@instantiate_parametrized_tests
-class TestCustomOpOutLowering(InductorTestCase):
-    """Tests for lowering functional custom ops to out-variant ExternKernelOut."""
+def _register_split_add_ops(lib):
+    """Register a split_add op returning two tensors with functional + .out overloads."""
+    lib.define("split_add(Tensor x, float a, float b) -> (Tensor, Tensor)")
+    lib.define(
+        "split_add.out(Tensor x, float a, float b, *, Tensor(a!) out0, Tensor(b!) out1) -> (Tensor(a!), Tensor(b!))",
+        tags=(torch.Tag.out,),
+    )
 
-    def _register_add_one_ops(self, lib):
-        """Register a simple add_one op with functional + .out overloads."""
-        lib.define("add_one(Tensor x) -> Tensor")
-        lib.define(
-            "add_one.out(Tensor x, *, Tensor(a!) out) -> Tensor(a!)",
-            tags=(torch.Tag.out,),
-        )
+    def _split_add_impl(x, a, b):
+        return (x + a, x + b)
 
-        def _add_one_impl(x: torch.Tensor) -> torch.Tensor:
-            return x + 1
+    def _split_add_out_impl(x, a, b, *, out0, out1):
+        out0.copy_(x + a)
+        out1.copy_(x + b)
+        return (out0, out1)
 
-        def _add_one_out_impl(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
-            out.copy_(x + 1)
-            return out
+    lib.impl("split_add", _split_add_impl, "CompositeExplicitAutograd")
+    lib.impl("split_add.out", _split_add_out_impl, "CompositeExplicitAutograd")
 
-        lib.impl("add_one", _add_one_impl, "CompositeExplicitAutograd")
-        lib.impl("add_one.out", _add_one_out_impl, "CompositeExplicitAutograd")
+    @torch.library.register_fake("mylib::split_add", lib=lib)
+    def _split_add_fake(x, a, b):
+        return (x.new_empty(x.shape), x.new_empty(x.shape))
 
-        @torch.library.register_fake("mylib::add_one", lib=lib)
-        def _add_one_fake(x):
-            return x.new_empty(x.shape)
+    return torch.ops.mylib.split_add, torch.ops.mylib.split_add.out
 
-        return torch.ops.mylib.add_one, torch.ops.mylib.add_one.out
 
-    @parametrize("device", DEVICES)
+class TestCustomOpOutLoweringAccelerator(InductorTestCase):
+    """Tests for lowering functional custom ops to out-variant ExternKernelOut on accelerators."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
     def test_add_one_lowered_to_out(self, device):
         """Test that a simple functional op gets lowered to its out-variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
-            self._register_add_one_ops(lib)
+            _register_add_one_ops(lib)
 
             def f(x):
                 return torch.ops.mylib.add_one(x)
@@ -66,11 +92,11 @@ class TestCustomOpOutLowering(InductorTestCase):
 
             FileCheck().check(".out(").check_not(".default(").run(code)
 
-    @parametrize("device", DEVICES)
+    @requires_capabilities(Capability.lib.triton)
     def test_add_one_lowered_to_out_dynamic_shape(self, device):
         """Out-variant lowering with symbolic output shape (see #185503)."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
-            self._register_add_one_ops(lib)
+            _register_add_one_ops(lib)
 
             def f(x):
                 return torch.ops.mylib.add_one(x)
@@ -86,36 +112,11 @@ class TestCustomOpOutLowering(InductorTestCase):
             self.assertEqual(compiled_out, eager_out)
             FileCheck().check(".out(").check_not(".default(").run(code)
 
-    def _register_split_add_ops(self, lib):
-        """Register a split_add op returning two tensors with functional + .out overloads."""
-        lib.define("split_add(Tensor x, float a, float b) -> (Tensor, Tensor)")
-        lib.define(
-            "split_add.out(Tensor x, float a, float b, *, Tensor(a!) out0, Tensor(b!) out1) -> (Tensor(a!), Tensor(b!))",
-            tags=(torch.Tag.out,),
-        )
-
-        def _split_add_impl(x, a, b):
-            return (x + a, x + b)
-
-        def _split_add_out_impl(x, a, b, *, out0, out1):
-            out0.copy_(x + a)
-            out1.copy_(x + b)
-            return (out0, out1)
-
-        lib.impl("split_add", _split_add_impl, "CompositeExplicitAutograd")
-        lib.impl("split_add.out", _split_add_out_impl, "CompositeExplicitAutograd")
-
-        @torch.library.register_fake("mylib::split_add", lib=lib)
-        def _split_add_fake(x, a, b):
-            return (x.new_empty(x.shape), x.new_empty(x.shape))
-
-        return torch.ops.mylib.split_add, torch.ops.mylib.split_add.out
-
-    @parametrize("device", DEVICES)
+    @requires_capabilities(Capability.lib.triton)
     def test_multi_output_lowered_to_out(self, device):
         """Test a two-output functional op gets lowered to its .out variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
-            func_op, out_op = self._register_split_add_ops(lib)
+            _register_split_add_ops(lib)
 
             def f(x):
                 a, b = torch.ops.mylib.split_add(x, 1.0, 2.0)
@@ -130,7 +131,7 @@ class TestCustomOpOutLowering(InductorTestCase):
             self.assertEqual(compiled_out, eager_out)
             FileCheck().check(".out(").check("out0=").check("out1=").run(code)
 
-    @parametrize("device", DEVICES)
+    @requires_capabilities(Capability.lib.triton)
     def test_op_without_out_variant_falls_through(self, device):
         """Test that ops without an out-variant fall through to FallbackKernel."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -154,9 +155,76 @@ class TestCustomOpOutLowering(InductorTestCase):
             compiled_out, (code,) = run_and_get_code(
                 torch.compile(f, backend="inductor", fullgraph=True), x
             )
+            self.assertEqual(
+                compiled_out,
+                eager_out,
+                msg="output mismatch for op_without_out_variant_falls_through",
+            )
+            self.assertNotIn(".out(", code)
+
+
+class TestCustomOpOutLoweringCPU(InductorTestCase):
+    """CPU tests for lowering and cpp_wrapper runtime dispatch."""
+
+    hw_classification = HardwareClassification.CPU
+
+    def test_add_one_lowered_to_out(self, device):
+        """Test that a simple functional op gets lowered to its out-variant."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            _register_add_one_ops(lib)
+
+            def f(x):
+                return torch.ops.mylib.add_one(x)
+
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
             self.assertEqual(compiled_out, eager_out)
 
-    def test_cpp_wrapper_runtime_dispatch_single_output_fallback(self):
+            FileCheck().check(".out(").check_not(".default(").run(code)
+
+    def test_add_one_lowered_to_out_dynamic_shape(self, device):
+        """Out-variant lowering with symbolic output shape (see #185503)."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            _register_add_one_ops(lib)
+
+            def f(x):
+                return torch.ops.mylib.add_one(x)
+
+            x = torch.randn(4, 8, device=device)
+            torch._dynamo.mark_dynamic(x, 0)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True, dynamic=True),
+                x,
+            )
+            self.assertEqual(compiled_out, eager_out)
+            FileCheck().check(".out(").check_not(".default(").run(code)
+
+    def test_multi_output_lowered_to_out(self, device):
+        """Test a two-output functional op gets lowered to its .out variant."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            _register_split_add_ops(lib)
+
+            def f(x):
+                a, b = torch.ops.mylib.split_add(x, 1.0, 2.0)
+                return a + b
+
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
+            self.assertEqual(compiled_out, eager_out)
+            FileCheck().check(".out(").check("out0=").check("out1=").run(code)
+
+    def test_op_without_out_variant_falls_through(self, device):
+        """Test that ops without an out-variant fall through to FallbackKernel."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             lib.define("no_out_op(Tensor x) -> Tensor")
 
@@ -172,7 +240,36 @@ class TestCustomOpOutLowering(InductorTestCase):
             def f(x):
                 return torch.ops.mylib.no_out_op(x)
 
-            x = torch.randn(4, 4)
+            x = torch.randn(4, 4, device=device)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True), x
+            )
+            self.assertEqual(
+                compiled_out,
+                eager_out,
+                msg="output mismatch for op_without_out_variant_falls_through",
+            )
+            self.assertNotIn(".out(", code)
+
+    def test_cpp_wrapper_runtime_dispatch_single_output_fallback(self, device):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("no_out_op(Tensor x) -> Tensor")
+
+            def _impl(x):
+                return x + 1
+
+            lib.impl("no_out_op", _impl, "CompositeExplicitAutograd")
+
+            @torch.library.register_fake("mylib::no_out_op", lib=lib)
+            def _fake(x):
+                return x.new_empty(x.shape)
+
+            def f(x):
+                return torch.ops.mylib.no_out_op(x)
+
+            x = torch.randn(4, 4, device=device)
             eager_out = f(x)
 
             with config.patch(
@@ -186,15 +283,19 @@ class TestCustomOpOutLowering(InductorTestCase):
             FileCheck().check("aoti_torch_call_dispatcher").run(source_code)
             output_assert = r'assert_size_stride\([^,]+,\s*\{4L?L?,\s*4L?L?\},\s*\{4L?L?,\s*1L?L?\},\s*"torch.ops.mylib.no_out_op.default"(, .*)?\)'
             wrapper_codegen = common.get_wrapper_codegen_for_device(
-                "cpu", cpp_wrapper=True
+                device, cpp_wrapper=True
             )
             if wrapper_codegen.__name__ == "CppWrapperCpuArrayRef":
-                # ArrayRef wrapper tensors are not AtenTensorHandle, so that wrapper
-                # path intentionally does not emit assert_size_stride.
                 self.assertNotRegex(source_code, output_assert)
             else:
                 FileCheck().check_regex(output_assert).run(source_code)
             self.assertNotRegex(source_code, r"\bbuf\d+\s*=\s*buf\d+\b")
+
+
+instantiate_device_type_tests(
+    TestCustomOpOutLoweringAccelerator, globals(), allow_xpu=True, except_for="cpu"
+)
+instantiate_device_type_tests(TestCustomOpOutLoweringCPU, globals(), only_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -3,6 +3,8 @@
 Tests for inductor lowering of functional custom ops to out-variant via ExternKernelOut.
 """
 
+import unittest
+
 import torch
 from torch._C import FileCheck
 from torch._inductor import config
@@ -10,11 +12,10 @@ from torch._inductor.codegen import common
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 def _register_add_one_ops(lib):
@@ -73,7 +74,7 @@ class TestCustomOpOutLoweringAccelerator(InductorTestCase):
 
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_add_one_lowered_to_out(self, device):
         """Test that a simple functional op gets lowered to its out-variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -92,7 +93,7 @@ class TestCustomOpOutLoweringAccelerator(InductorTestCase):
 
             FileCheck().check(".out(").check_not(".default(").run(code)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_add_one_lowered_to_out_dynamic_shape(self, device):
         """Out-variant lowering with symbolic output shape (see #185503)."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -112,7 +113,7 @@ class TestCustomOpOutLoweringAccelerator(InductorTestCase):
             self.assertEqual(compiled_out, eager_out)
             FileCheck().check(".out(").check_not(".default(").run(code)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_multi_output_lowered_to_out(self, device):
         """Test a two-output functional op gets lowered to its .out variant."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -131,7 +132,7 @@ class TestCustomOpOutLoweringAccelerator(InductorTestCase):
             self.assertEqual(compiled_out, eager_out)
             FileCheck().check(".out(").check("out0=").check("out1=").run(code)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_op_without_out_variant_falls_through(self, device):
         """Test that ops without an out-variant fall through to FallbackKernel."""
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:


### PR DESCRIPTION
### Summary

Refactor `test_custom_op_out_lowering.py` to split tests into accelerator-specific
(ACCELERATOR) and CPU-specific (CPU) classes using `hw_classification`, and migrate
to `instantiate_device_type_tests` for multi-backend support.

### Changes

- Extract `_register_add_one_ops` and `_register_split_add_ops` to module-level helpers
- Split into two classes:
  - `TestCustomOpOutLoweringAccelerator` (ACCELERATOR, 4 lowering tests gated by
    `@unittest.skipIf(not HAS_TRITON)`, `allow_xpu=True, except_for="cpu"`)
  - `TestCustomOpOutLoweringCPU` (CPU, same 4 tests + cpp_wrapper, `only_for="cpu"`)
- Remove `@parametrize("device", DEVICES)`, `GPU_TYPE`/`HAS_GPU` imports, `DEVICES` constant

### Motivation

The original class used `DEVICES = ("cpu", GPU_TYPE)` covering CPU and GPU. The 4 lowering
tests are backend-agnostic (CPU inductor uses cpp backend, no triton). Splitting into
ACCELERATOR (triton-gated) and CPU (unconditional) preserves CPU coverage on CPU-only
machines while GPU variants correctly require triton.

### Test Plan

```
python test/inductor/test_custom_op_out_lowering.py
```
