### PR TITLE
[Testcase Refactoring] Split test_debug_trace.py by hw_classification

### DIFF
--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -353,7 +353,6 @@ instantiate_device_type_tests(
     TestDebugTraceAccelerator,
     globals(),
     except_for="cpu",
-    allow_mps=True,
     allow_xpu=True,
 )
 

--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -11,8 +11,16 @@ from pathlib import Path
 import torch
 from torch._inductor import config, test_operators
 from torch._inductor.utils import fresh_cache
-from torch.testing._internal.common_utils import skipIfWindows
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    skipIfWindows,
+)
 from torch.testing._internal.logging_utils import multiple_logs_to_string
 
 
@@ -33,8 +41,11 @@ def filesize(filename: Path):
     return os.stat(filename).st_size
 
 
+@instantiate_parametrized_tests
 @config.patch("trace.enabled", True)
-class TestDebugTrace(test_torchinductor.TestCase):
+class TestDebugTraceGeneric(test_torchinductor.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_debug_trace(self):
         @torch.compile
         def fn(a, b):
@@ -268,8 +279,13 @@ op2.node.kernel = extern_kernels.mm""",
             example_inputs,
         )
 
-    @unittest.skipIf(not HAS_GPU, "requires GPU")
-    def test_debug_multi_tempalte(self):
+
+@config.patch("trace.enabled", True)
+class TestDebugTraceAccelerator(test_torchinductor.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_debug_multi_tempalte(self, device):
         class ToyModel(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -287,13 +303,16 @@ op2.node.kernel = extern_kernels.mm""",
             ),
             fresh_cache(),
         ):
-            m = ToyModel().to(device=GPU_TYPE)
+            m = ToyModel().to(device=device)
             m = torch.compile(m, mode="max-autotune")
-            input_tensor = torch.randn(100).to(device=GPU_TYPE)
+            input_tensor = torch.randn(100).to(device=device)
             m(input_tensor)
 
 
+@instantiate_parametrized_tests
 class TestLogAutotuningResultsCallSite(test_torchinductor.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_log_results_forwards_required_args_to_debug_formatter(self):
         # Regression: AlgorithmSelectorCache.log_results omitted
         # prescreening_elapse, which raised TypeError under
@@ -328,6 +347,15 @@ class TestLogAutotuningResultsCallSite(test_torchinductor.TestCase):
         # exactly like the production failure under LOG_AUTOTUNE_RESULTS=1.
         sig = inspect.signature(DebugFormatter.log_autotuning_results)
         sig.bind(_Recorder(), *captured["args"], **captured["kwargs"])
+
+
+instantiate_device_type_tests(
+    TestDebugTraceAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -11,15 +11,12 @@ from pathlib import Path
 import torch
 from torch._inductor import config, test_operators
 from torch._inductor.utils import fresh_cache
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     skipIfWindows,
 )
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.logging_utils import multiple_logs_to_string
 
 
@@ -282,7 +279,7 @@ class TestDebugTraceAccelerator(test_torchinductor.TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @config.patch("trace.enabled", True)
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_debug_multi_tempalte(self, device):
         class ToyModel(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -18,7 +18,6 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     skipIfWindows,
 )
 from torch.testing._internal.logging_utils import multiple_logs_to_string
@@ -41,7 +40,6 @@ def filesize(filename: Path):
     return os.stat(filename).st_size
 
 
-@instantiate_parametrized_tests
 @config.patch("trace.enabled", True)
 class TestDebugTraceGeneric(test_torchinductor.TestCase):
     hw_classification = HardwareClassification.GENERIC
@@ -280,10 +278,10 @@ op2.node.kernel = extern_kernels.mm""",
         )
 
 
-@config.patch("trace.enabled", True)
 class TestDebugTraceAccelerator(test_torchinductor.TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @config.patch("trace.enabled", True)
     @requires_capabilities(Capability.lib.triton)
     def test_debug_multi_tempalte(self, device):
         class ToyModel(torch.nn.Module):
@@ -309,7 +307,6 @@ class TestDebugTraceAccelerator(test_torchinductor.TestCase):
             m(input_tensor)
 
 
-@instantiate_parametrized_tests
 class TestLogAutotuningResultsCallSite(test_torchinductor.TestCase):
     hw_classification = HardwareClassification.GENERIC
 

--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -12,10 +12,7 @@ import torch
 from torch._inductor import config, test_operators
 from torch._inductor.utils import fresh_cache
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    skipIfWindows,
-)
+from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
 from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.logging_utils import multiple_logs_to_string
 


### PR DESCRIPTION
### Summary

Split `TestDebugTrace` in `test/inductor/test_debug_trace.py` into
`TestDebugTraceGeneric` (GENERIC) and `TestDebugTraceAccelerator`
(ACCELERATOR), and added `hw_classification` to
`TestLogAutotuningResultsCallSite` (GENERIC). Migrated `GPU_TYPE`/HAS_GPU`
to `instantiate_device_type_tests` with `device` parameter and
`HAS_TRITON`-based triton guard.

### Changes

- Split `TestDebugTrace` into:
  - `TestDebugTraceGeneric` (GENERIC): `test_debug_trace`,
    `test_debug_printer_const`
  - `TestDebugTraceAccelerator` (ACCELERATOR): `test_debug_multi_tempalte`
    with `instantiate_device_type_tests(except_for="cpu", allow_xpu=True)`
- Added `device` parameter to `test_debug_multi_tempalte`, replaced
  `GPU_TYPE` with `device`
- Replaced `@unittest.skipIf(not HAS_GPU)` with
  `@unittest.skipIf(not HAS_TRITON, "requires triton")`
- Moved `@config.patch("trace.enabled", True)` from class-level to method-level
  on `TestDebugTraceAccelerator` to fix incompatibility with
  `instantiate_device_type_tests`
- Added `hw_classification = HardwareClassification.GENERIC` to
  `TestLogAutotuningResultsCallSite`
- Removed unnecessary `@instantiate_parametrized_tests` from GENERIC classes
  (no `@parametrize` decorators used)
- Added imports: `HardwareClassification`, `instantiate_device_type_tests`,
  `HAS_TRITON`
- Removed imports: `GPU_TYPE`, `HAS_GPU`, `instantiate_parametrized_tests`,
  `Capability`, `requires_capabilities`

### Motivation

`TestDebugTrace` mixed device-generic tests (CPU-only IR trace validation)
with a GPU-dependent test (`test_debug_multi_tempalte` using `GPU_TYPE`).
Splitting by classification ensures correct test discovery and enables
the GPU test to run across accelerator backends via
`instantiate_device_type_tests` instead of the legacy `GPU_TYPE`
single-device pattern. `HAS_TRITON` is used instead of the removed
`Capability.lib.triton` API for the triton compilation guard.

### Test Plan

```bash
python test/inductor/test_debug_trace.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo