### PR TITLE
[rpc] Fix dangling this in RRef::handleError static map

### DIFF
--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -67,18 +67,23 @@ RRefForkData RRef::fork() const {
 void RRef::handleError(RPCErrorType errorType, const JitFuture& jitFuture) {
   static std::unordered_map<
       RPCErrorType,
-      std::function<void(const JitFuture& jitFuture)>,
+      std::function<void(RRef*, const JitFuture&)>,
       std::hash<int>>
       errorHandlers = {
           {RPCErrorType::TIMEOUT,
-           [this](const JitFuture& /* unused */) { setTimedOut(); }},
+           [](RRef* rref, const JitFuture& /* unused */) {
+             rref->setTimedOut();
+           }},
           {RPCErrorType::INTENTIONAL_FAILURE,
-           [this](const JitFuture& /* unused */) { setTimedOut(); }},
-          {RPCErrorType::UNKNOWN_ERROR, [](const JitFuture& jitFuture) {
+           [](RRef* rref, const JitFuture& /* unused */) {
+             rref->setTimedOut();
+           }},
+          {RPCErrorType::UNKNOWN_ERROR,
+           [](RRef* /* unused */, const JitFuture& jitFuture) {
              // Default error handler
              RRefContext::handleException(jitFuture);
            }}};
-  errorHandlers.find(errorType)->second(jitFuture);
+  errorHandlers.find(errorType)->second(this, jitFuture);
 }
 
 //////////////////////////  UserRRef  /////////////////////////////////////

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -67,18 +67,18 @@ RRefForkData RRef::fork() const {
 void RRef::handleError(RPCErrorType errorType, const JitFuture& jitFuture) {
   static std::unordered_map<
       RPCErrorType,
-      std::function<void(const JitFuture& jitFuture)>,
+      std::function<void(RRef*, const JitFuture&)>,
       std::hash<int>>
       errorHandlers = {
           {RPCErrorType::TIMEOUT,
-           [this](const JitFuture& /* unused */) { setTimedOut(); }},
+           [](RRef* rref, const JitFuture& /* unused */) { rref->setTimedOut(); }},
           {RPCErrorType::INTENTIONAL_FAILURE,
-           [this](const JitFuture& /* unused */) { setTimedOut(); }},
-          {RPCErrorType::UNKNOWN_ERROR, [](const JitFuture& jitFuture) {
+           [](RRef* rref, const JitFuture& /* unused */) { rref->setTimedOut(); }},
+          {RPCErrorType::UNKNOWN_ERROR, [](RRef* /* unused */, const JitFuture& jitFuture) {
              // Default error handler
              RRefContext::handleException(jitFuture);
            }}};
-  errorHandlers.find(errorType)->second(jitFuture);
+  errorHandlers.find(errorType)->second(this, jitFuture);
 }
 
 //////////////////////////  UserRRef  /////////////////////////////////////

--- a/torch/testing/_internal/distributed/rpc/faulty_agent_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/faulty_agent_rpc_test.py
@@ -179,7 +179,7 @@ class FaultyAgentRpcTest(RpcAgentTestFixture):
         # a timeout. This can be supported by allowing future.wait() to
         # take in an optional timeout (https://github.com/pytorch/pytorch/issues/39280)
         if dst_rank != self.rank:
-            slow_rref = rpc.remote(dst_worker, func, args=args, timeout=2)
+            slow_rref = rpc.remote(dst_worker, func, args=args, timeout=3)
 
             with self.assertRaisesRegex(RuntimeError, expected_error):
                 # to_here() should raise timeout error, since it does not know about the


### PR DESCRIPTION
The static errorHandlers map in RRef::handleError() used lambdas that captured this. Since the map is initialized once, all subsequent calls from any RRef instance would use the first caller's this pointer.

This can cause a use-after-free if the first RRef is destroyed first, and even if not, the wrong RRef's timedOut_ flag is set, leading to incorrect error handling.

Pass this as a parameter to the lambdas instead of capturing it.

Also update _test_remote_message_delay_timeout to use timeout=3 instead of 2. The faulty agent delays PYTHON_REMOTE_CALL by 2 seconds in pipeWrite, which is called synchronously from send(). With timeout=2, rpc.remote() returns around the same time the creation timeout fires, so to_here(0.001) may race with the timedOut_ update. Using timeout=3 provides enough margin for to_here() to consistently take the intended fetch timeout path.