### PR TITLE
[dynamo] Allow backends to eager-init via _dynamo_backend_init

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
@@ -118,6 +118,60 @@ my_backend = aot_autograd(fw_compiler=my_compiler)  # bw_compiler=my_compiler
 model_opt = torch.compile(model, backend=my_backend)
 ```
 
+## Eager Backend Initialization
+
+Backends that need to run one-time eager setup at `torch.compile()` time
+(e.g. loading native libraries or initializing device contexts) can define a
+`_dynamo_backend_init` attribute --- a no-arg callable that fires once the
+backend is resolved, before any invocation.
+
+```python
+def my_backend(gm, example_inputs):
+    return gm.forward
+
+def my_backend_init():
+    load_native_libs()      # runs at compile() time, before any invocation
+
+my_backend._dynamo_backend_init = my_backend_init
+
+@torch.compile(backend=my_backend)
+def fn(x):
+    return x + 1
+```
+
+The hook works whether the backend is passed directly, registered by name
+with `register_backend`, or forced via
+`torch.compiler.set_stance(force_backend=...)`. It is read off the inner
+backend object, so it is found whether it is an instance attribute or a
+class method (resolved via the MRO). When using
+`aot_autograd(fw_compiler=...)`, set the hook on the inner `fw_compiler` ---
+`AotAutograd` reads it at fire time, so it may be set before or after
+`aot_autograd()` is constructed. Only `fw_compiler` is consulted; hooks set
+on `bw_compiler` or `inference_compiler` are ignored.
+
+The hook fires once per scope, per process, on both the normal and
+`fullgraph=True` paths:
+
+- a hook defined as a plain function fires once, however many backends or
+  compile sites use it;
+- a hook defined as an instance method (`def _dynamo_backend_init(self)`)
+  fires once per instance the method is bound to, so two instances can each
+  run their own per-device init;
+- a hook defined as a classmethod fires once per class.
+
+`torch._dynamo.reset()` does not refire it, since native-library
+initialization is process-global; making the hook idempotent is still good
+practice. If the hook raises, the exception propagates out of
+`torch.compile()` and a later compile retries it; under
+`torch.compiler.set_stance(force_backend=...)`, resolution happens on the
+first call, so the hook fires -- and a failure surfaces -- from the call
+instead. Concurrent `torch.compile()` calls that share a hook are
+serialized: a resolution waits for an in-flight init to complete before
+compiling. To be deduplicated, a plain-function hook must be hashable and
+weakly referenceable; for a bound-method hook, its owner (the instance, or
+the class for a classmethod) must be. Otherwise the hook fires on every
+resolution.
+
 ## Examples
 
 ### Debugging Backend

--- a/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_custom_backends.md
@@ -120,9 +120,9 @@ model_opt = torch.compile(model, backend=my_backend)
 
 ## Eager Backend Initialization
 
-Backends that need to run one-time eager setup at `torch.compile()` time
+Backends that need to run eager setup at `torch.compile()` time
 (e.g. loading native libraries or initializing device contexts) can define a
-`_dynamo_backend_init` attribute --- a no-arg callable that fires once the
+`_dynamo_backend_init` attribute --- a no-arg callable that fires when the
 backend is resolved, before any invocation.
 
 ```python
@@ -149,28 +149,28 @@ class method (resolved via the MRO). When using
 `aot_autograd()` is constructed. Only `fw_compiler` is consulted; hooks set
 on `bw_compiler` or `inference_compiler` are ignored.
 
-The hook fires once per scope, per process, on both the normal and
-`fullgraph=True` paths:
+The hook fires every time the backend is resolved, on both the normal
+and `fullgraph=True` paths, before any invocation, so `torch.compile()`
+fails fast on a broken environment. A backend resolved repeatedly (e.g.
+under `torch.compiler.set_stance(force_backend=...)` or the
+`compiled_autograd` rebuild path) fires once per resolution; backends that
+need one-time setup should deduplicate in the hook itself:
 
-- a hook defined as a plain function fires once, however many backends or
-  compile sites use it;
-- a hook defined as an instance method (`def _dynamo_backend_init(self)`)
-  fires once per instance the method is bound to, so two instances can each
-  run their own per-device init;
-- a hook defined as a classmethod fires once per class.
+```python
+import functools
 
-`torch._dynamo.reset()` does not refire it, since native-library
-initialization is process-global; making the hook idempotent is still good
-practice. If the hook raises, the exception propagates out of
-`torch.compile()` and a later compile retries it; under
-`torch.compiler.set_stance(force_backend=...)`, resolution happens on the
-first call, so the hook fires -- and a failure surfaces -- from the call
-instead. Concurrent `torch.compile()` calls that share a hook are
-serialized: a resolution waits for an in-flight init to complete before
-compiling. To be deduplicated, a plain-function hook must be hashable and
-weakly referenceable; for a bound-method hook, its owner (the instance, or
-the class for a classmethod) must be. Otherwise the hook fires on every
-resolution.
+@functools.cache  # once per process
+def my_backend_init():
+    load_native_libs()
+
+my_backend._dynamo_backend_init = my_backend_init
+```
+
+If the hook raises, the exception propagates out of `torch.compile()`;
+under `torch.compiler.set_stance(force_backend=...)`, resolution happens
+on the first call, so the hook fires -- and a failure surfaces -- from
+the call instead.
+
 
 ## Examples
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -387,6 +387,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         name = "init_test_backend_191921"
         torch._dynamo.register_backend(my_backend, name)
         try:
+
             @torch.compile(backend=name)
             def fn(x):
                 return x + 1

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -16,7 +16,11 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyHPU,
 )
-from torch.testing._internal.common_utils import skipIfHpu
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    skipIfHpu,
+)
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
@@ -290,6 +294,7 @@ class TestExplainWithBackend(torch._dynamo.test_case.TestCase):
         self.assertEqual(8, explain_output.op_count)
 
 
+@instantiate_parametrized_tests
 class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
     """Test APIs documented by https://pytorch.org/docs/main/torch.compiler_custom_backends.html"""
 
@@ -319,6 +324,107 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         opt_f = torch.compile(f, backend="my_custom_backend")
         opt_f(torch.randn(3, 3))
         self.assertTrue(backend_run)
+
+    @parametrize("fullgraph", [False, True])
+    def test_dynamo_backend_init(self, fullgraph):
+        # _dynamo_backend_init fires once the backend is resolved, on both the
+        # _optimize (fullgraph=False) and _optimize_assert (fullgraph=True) paths.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        @torch.compile(backend=my_backend, fullgraph=fullgraph)
+        def fn(x):
+            return x + 1
+
+        # In the default config (compiled_autograd off) the hook fires exactly
+        # once, at backend resolution. The compiled_autograd re-fire case is
+        # covered by test_dynamo_backend_init_compiled_autograd_refires.
+        fn(torch.randn(3))
+        self.assertEqual(len(calls), 1)
+
+    @parametrize("compile_api", [torch.compile, torch._dynamo.optimize])
+    def test_dynamo_backend_init_classmethod(self, compile_api):
+        # When _dynamo_backend_init is a method (not an instance attribute),
+        # get_compiler_fn() wraps the backend in WrapBackendDebug and
+        # torch.compile() wraps it in _TorchCompileWrapper. Both forward the
+        # hook via getattr (reading the MRO); functools.wraps alone would drop
+        # a class-level attribute. Regression test for that forwarding on both
+        # entry points.
+        calls = []
+
+        class MyBackend:
+            def __call__(self, gm, example_inputs):
+                return gm.forward
+
+            def _dynamo_backend_init(self):
+                calls.append(1)
+
+        @compile_api(backend=MyBackend())
+        def fn(x):
+            return x + 1
+
+        fn(torch.randn(3))
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_registered(self):
+        # A string backend resolved through the registry must also fire the hook.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+        name = "init_test_backend_191921"
+        torch._dynamo.register_backend(my_backend, name)
+        try:
+            @torch.compile(backend=name)
+            def fn(x):
+                return x + 1
+
+            fn(torch.randn(3))
+            self.assertEqual(len(calls), 1)
+        finally:
+            from torch._dynamo.backends import registry as backend_registry
+
+            backend_registry._COMPILER_FNS.pop(name, None)
+            backend_registry._BACKENDS.pop(name, None)
+            backend_registry._BACKEND_TAGS.pop(name, None)
+
+    def test_dynamo_backend_init_fires_per_compile_site(self):
+        # _dynamo_backend_init fires once per torch.compile() call. Reusing the
+        # same backend across two compiled functions resolves it twice, so the
+        # hook fires twice -- backends must therefore be idempotent.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        @torch.compile(backend=my_backend)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=my_backend)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
+        self.assertEqual(len(calls), 2)
 
     def test_aot_autograd_api(self):
         from functorch.compile import make_boxed_func

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -327,8 +327,8 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
     @parametrize("fullgraph", [False, True])
     def test_dynamo_backend_init(self, fullgraph):
-        # _dynamo_backend_init fires once the backend is resolved, on both the
-        # _optimize (fullgraph=False) and _optimize_assert (fullgraph=True) paths.
+        # Fires eagerly at torch.compile() time, before any invocation, on both
+        # the _optimize (fullgraph=False) and _optimize_assert paths.
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -343,27 +343,27 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x + 1
 
-        # In the default config (compiled_autograd off) the hook fires exactly
-        # once, at backend resolution. The compiled_autograd re-fire case is
-        # covered by test_dynamo_backend_init_compiled_autograd_refires.
+        # Pinned at decoration, not lazily on the first captured graph.
+        self.assertEqual(len(calls), 1)
         fn(torch.randn(3))
         self.assertEqual(len(calls), 1)
 
-    @parametrize("compile_api", [torch.compile, torch._dynamo.optimize])
+    @parametrize(
+        "compile_api",
+        [torch.compile, torch._dynamo.optimize],
+        name_fn=lambda api: api.__name__,
+    )
     def test_dynamo_backend_init_classmethod(self, compile_api):
-        # When _dynamo_backend_init is a method (not an instance attribute),
-        # get_compiler_fn() wraps the backend in WrapBackendDebug and
-        # torch.compile() wraps it in _TorchCompileWrapper. Both forward the
-        # hook via getattr (reading the MRO); functools.wraps alone would drop
-        # a class-level attribute. Regression test for that forwarding on both
-        # entry points.
+        # A class-level hook (here a @classmethod, read via the MRO rather than
+        # the instance __dict__) is read off the inner backend by get_compiler_fn().
         calls = []
 
         class MyBackend:
             def __call__(self, gm, example_inputs):
                 return gm.forward
 
-            def _dynamo_backend_init(self):
+            @classmethod
+            def _dynamo_backend_init(cls):
                 calls.append(1)
 
         @compile_api(backend=MyBackend())
@@ -375,6 +375,8 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
     def test_dynamo_backend_init_registered(self):
         # A string backend resolved through the registry must also fire the hook.
+        from torch._dynamo.backends import registry as backend_registry
+
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -384,26 +386,26 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
             calls.append(1)
 
         my_backend._dynamo_backend_init = my_backend_init
-        name = "init_test_backend_191921"
+        name = "init_test_backend_192345"
         torch._dynamo.register_backend(my_backend, name)
-        try:
-            @torch.compile(backend=name)
-            def fn(x):
-                return x + 1
 
-            fn(torch.randn(3))
-            self.assertEqual(len(calls), 1)
-        finally:
-            from torch._dynamo.backends import registry as backend_registry
-
+        def cleanup_backend():
             backend_registry._COMPILER_FNS.pop(name, None)
             backend_registry._BACKENDS.pop(name, None)
             backend_registry._BACKEND_TAGS.pop(name, None)
 
-    def test_dynamo_backend_init_fires_per_compile_site(self):
-        # _dynamo_backend_init fires once per torch.compile() call. Reusing the
-        # same backend across two compiled functions resolves it twice, so the
-        # hook fires twice -- backends must therefore be idempotent.
+        self.addCleanup(cleanup_backend)
+
+        @torch.compile(backend=name)
+        def fn(x):
+            return x + 1
+
+        fn(torch.randn(3))
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_dedup_per_backend(self):
+        # The hook fires once per backend: the same backend reused across two
+        # compiled functions fires once.
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -424,7 +426,434 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
         fn1(torch.randn(3))
         fn2(torch.randn(3))
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_method_dedup(self):
+        # A classmethod hook must dedup across compile sites: each attribute
+        # access builds a fresh bound-method object (transient), so dedup keys
+        # on (owner, func). Without that, calls==2.
+        calls = []
+
+        class MyBackend:
+            def __call__(self, gm, example_inputs):
+                return gm.forward
+
+            @classmethod
+            def _dynamo_backend_init(cls):
+                calls.append(1)
+
+        backend = MyBackend()
+
+        @torch.compile(backend=backend)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=backend)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_compiled_autograd(self):
+        # compiled_autograd re-enters optimize() on every invocation via the
+        # rebuild path; dedup keeps the hook at one fire.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        # Guard against a vacuous pass: if compiled_autograd stops re-entering,
+        # len(calls)==1 holds for the wrong reason, so count backend resolutions.
+        resolutions = []
+        orig_get_compiler_fn = torch._dynamo.eval_frame.get_compiler_fn
+
+        def counting_get_compiler_fn(compiler_fn):
+            resolutions.append(1)
+            return orig_get_compiler_fn(compiler_fn)
+
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(3)
+        with (
+            torch._dynamo.config.patch(compiled_autograd=True),
+            patch("torch._dynamo.eval_frame.get_compiler_fn", counting_get_compiler_fn),
+        ):
+            opt_fn = torch.compile(fn, backend=my_backend)
+            opt_fn(x)
+            opt_fn(x)
+        self.assertGreater(len(resolutions), 1)
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_aot_autograd(self):
+        # Hook on fw_compiler survives aot_autograd(...). Two wrappers around the
+        # same fw_compiler fire once; and it is read at fire time (__getattr__),
+        # so it can be set after construction.
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        calls = []
+
+        def my_compiler(gm, example_inputs):
+            return make_boxed_func(gm.forward)
+
+        def my_init():
+            calls.append(1)
+
+        my_compiler._dynamo_backend_init = my_init
+        train = aot_autograd(fw_compiler=my_compiler)
+        infer = aot_autograd(fw_compiler=my_compiler)
+
+        def f(x):
+            return torch.relu(x)
+
+        torch.compile(f, backend=train)(torch.randn(3, 3))
+        torch.compile(f, backend=infer)(torch.randn(3, 3))
+        self.assertEqual(len(calls), 1)
+
+        # Setting the hook AFTER constructing aot_autograd still fires.
+        calls.clear()
+
+        def my_compiler2(gm, example_inputs):
+            return make_boxed_func(gm.forward)
+
+        def my_init2():
+            calls.append(1)
+
+        late = aot_autograd(fw_compiler=my_compiler2)
+        my_compiler2._dynamo_backend_init = my_init2
+        torch.compile(f, backend=late)(torch.randn(3, 3))
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_force_backend(self):
+        # force_backend resolves through get_compiler_fn() on every invocation,
+        # so the hook fires once and dedup holds across calls.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(3)
+        with torch.compiler.set_stance(force_backend=my_backend):
+            fn(x)
+            fn(x)
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_force_backend_registered(self):
+        # force_backend with a registered *name* (the typical usage) resolves
+        # through lookup_backend -> get_compiler_fn on every invocation; the hook
+        # fires once.
+        from torch._dynamo.backends import registry as backend_registry
+
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+
+        my_backend._dynamo_backend_init = my_backend_init
+        name = "init_test_force_192345"
+        torch._dynamo.register_backend(my_backend, name)
+
+        def cleanup_backend():
+            backend_registry._COMPILER_FNS.pop(name, None)
+            backend_registry._BACKENDS.pop(name, None)
+            backend_registry._BACKEND_TAGS.pop(name, None)
+
+        self.addCleanup(cleanup_backend)
+
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(3)
+        with torch.compiler.set_stance(force_backend=name):
+            fn(x)
+            fn(x)
+        self.assertEqual(len(calls), 1)
+
+    def test_dynamo_backend_init_per_instance(self):
+        # An instance-method hook dedups per (instance, func): two backend
+        # instances each fire once, so per-device init works.
+        calls = []
+
+        class MyBackend:
+            def __call__(self, gm, example_inputs):
+                return gm.forward
+
+            def _dynamo_backend_init(self):
+                calls.append(1)
+
+        b1 = MyBackend()
+        b2 = MyBackend()
+
+        @torch.compile(backend=b1)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=b2)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
         self.assertEqual(len(calls), 2)
+
+    def test_dynamo_backend_init_unhashable_hook(self):
+        # An unhashable hook callable (e.g. a @dataclass instance) cannot be
+        # weakly keyed; it skips dedup and fires per resolution rather than crashing.
+        from dataclasses import dataclass
+
+        calls = []
+
+        @dataclass
+        class Hook:
+            def __call__(self):
+                calls.append(1)
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        my_backend._dynamo_backend_init = Hook()
+
+        @torch.compile(backend=my_backend)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=my_backend)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
+        self.assertEqual(len(calls), 2)
+
+    def test_dynamo_backend_init_nonweakrefable_hook(self):
+        # A hashable but non-weak-referenceable hook (e.g. a __slots__ instance
+        # without __weakref__) cannot live in the WeakSet; it fires per
+        # resolution rather than crashing after the init succeeded.
+        calls = []
+
+        class Hook:
+            __slots__ = ()
+
+            def __call__(self):
+                calls.append(1)
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        my_backend._dynamo_backend_init = Hook()
+
+        @torch.compile(backend=my_backend)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=my_backend)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
+        self.assertEqual(len(calls), 2)
+
+    def test_dynamo_backend_init_builtin_hook(self):
+        # A C-extension function has __self__ (the module) but no __func__; it
+        # must not be mistaken for a bound method, and must not crash
+        # torch.compile().
+        import gc
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        my_backend._dynamo_backend_init = gc.collect
+
+        @torch.compile(backend=my_backend)
+        def fn(x):
+            return x + 1
+
+        fn(torch.randn(3))
+
+    def test_dynamo_backend_init_raising_retries(self):
+        # A failed init must not poison the dedup state: the next compile
+        # retries the hook instead of silently skipping it.
+        calls = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("init failed")
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        def fn(x):
+            return x + 1
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(fn, backend=my_backend)
+        opt_fn = torch.compile(fn, backend=my_backend)
+        opt_fn(torch.randn(3))
+        self.assertEqual(len(calls), 2)
+
+    def test_dynamo_backend_init_methods_on_shared_owner(self):
+        # Two distinct hooks bound to the same owner must not share a dedup key.
+        calls = []
+
+        class Setup:
+            def init_fw(self):
+                calls.append("fw")
+
+            def init_bw(self):
+                calls.append("bw")
+
+        setup = Setup()
+
+        def fw_backend(gm, example_inputs):
+            return gm.forward
+
+        def bw_backend(gm, example_inputs):
+            return gm.forward
+
+        fw_backend._dynamo_backend_init = setup.init_fw
+        bw_backend._dynamo_backend_init = setup.init_bw
+
+        @torch.compile(backend=fw_backend)
+        def fn1(x):
+            return x + 1
+
+        @torch.compile(backend=bw_backend)
+        def fn2(x):
+            return x + 2
+
+        fn1(torch.randn(3))
+        fn2(torch.randn(3))
+        self.assertEqual(sorted(calls), ["bw", "fw"])
+
+    def test_dynamo_backend_init_concurrent_resolution(self):
+        # Concurrent torch.compile() with the same backend: the second
+        # resolution blocks until the in-flight init completes, so the backend
+        # is never invoked before init has returned.
+        import threading
+
+        calls = []
+        backend_calls = []
+        errors = []
+        init_started = threading.Event()
+        init_complete = threading.Event()
+        release_init = threading.Event()
+
+        def my_backend(gm, example_inputs):
+            # Deterministic contract check: the backend must never be invoked
+            # before init has returned, however t2 is scheduled.
+            if not init_complete.is_set():
+                errors.append("backend invoked before init completed")
+            backend_calls.append(1)
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+            init_started.set()
+            release_init.wait(timeout=60)
+            init_complete.set()
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        def fn(x):
+            return x + 1
+
+        def compile_only():
+            try:
+                torch.compile(fn, backend=my_backend)
+            except Exception as e:
+                errors.append(e)
+
+        def compile_and_run():
+            try:
+                opt_fn = torch.compile(fn, backend=my_backend)
+                opt_fn(torch.randn(3))
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=compile_only)
+        t1.start()
+        self.addCleanup(t1.join, 60)
+        self.assertTrue(init_started.wait(timeout=60))
+        t2 = threading.Thread(target=compile_and_run)
+        t2.start()
+        self.addCleanup(t2.join, 60)
+        self.addCleanup(release_init.set)
+        t2.join(timeout=1)
+        # t2 is blocked in the once-barrier while init is held: the backend
+        # has not been invoked yet.
+        self.assertTrue(t2.is_alive())
+        self.assertEqual(backend_calls, [])
+        release_init.set()
+        t1.join(timeout=60)
+        t2.join(timeout=60)
+        self.assertEqual(errors, [])
+        self.assertEqual(calls, [1])
+        self.assertEqual(backend_calls, [1])
+
+    def test_dynamo_backend_init_reentrant(self):
+        # A backend init that resolves its own backend must re-run the init
+        # (reentrant-lock semantics) instead of waiting on its own in-flight
+        # event. Run in a thread so a deadlock regression fails the test
+        # instead of hanging CI.
+        import threading
+
+        calls = []
+        errors = []
+
+        def my_backend(gm, example_inputs):
+            return gm.forward
+
+        def my_backend_init():
+            calls.append(1)
+            if len(calls) == 1:
+                # Re-entrant resolution of the same backend from inside its init.
+                torch.compile(lambda x: x + 1, backend=my_backend)
+
+        my_backend._dynamo_backend_init = my_backend_init
+
+        def compile_and_run():
+            try:
+
+                @torch.compile(backend=my_backend)
+                def fn(x):
+                    return x + 1
+
+                fn(torch.randn(3))
+            except Exception as e:
+                errors.append(e)
+
+        t = threading.Thread(target=compile_and_run)
+        t.start()
+        self.addCleanup(t.join, 60)
+        t.join(timeout=60)
+        self.assertFalse(t.is_alive(), "reentrant init deadlocked")
+        self.assertEqual(errors, [])
+        self.assertEqual(len(calls), 2)  # outer fire + re-entrant re-run
 
     def test_aot_autograd_api(self):
         from functorch.compile import make_boxed_func

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -403,9 +403,9 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         fn(torch.randn(3))
         self.assertEqual(len(calls), 1)
 
-    def test_dynamo_backend_init_dedup_per_backend(self):
-        # The hook fires once per backend: the same backend reused across two
-        # compiled functions fires once.
+    def test_dynamo_backend_init_per_resolution(self):
+        # The hook fires every time the backend is resolved, not once per
+        # backend: two compiled functions over one backend fire twice.
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -426,39 +426,11 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
         fn1(torch.randn(3))
         fn2(torch.randn(3))
-        self.assertEqual(len(calls), 1)
-
-    def test_dynamo_backend_init_method_dedup(self):
-        # A classmethod hook must dedup across compile sites: each attribute
-        # access builds a fresh bound-method object (transient), so dedup keys
-        # on (owner, func). Without that, calls==2.
-        calls = []
-
-        class MyBackend:
-            def __call__(self, gm, example_inputs):
-                return gm.forward
-
-            @classmethod
-            def _dynamo_backend_init(cls):
-                calls.append(1)
-
-        backend = MyBackend()
-
-        @torch.compile(backend=backend)
-        def fn1(x):
-            return x + 1
-
-        @torch.compile(backend=backend)
-        def fn2(x):
-            return x + 2
-
-        fn1(torch.randn(3))
-        fn2(torch.randn(3))
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls), 2)
 
     def test_dynamo_backend_init_compiled_autograd(self):
         # compiled_autograd re-enters optimize() on every invocation via the
-        # rebuild path; dedup keeps the hook at one fire.
+        # rebuild path; the hook fires once per resolution.
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -470,7 +442,8 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         my_backend._dynamo_backend_init = my_backend_init
 
         # Guard against a vacuous pass: if compiled_autograd stops re-entering,
-        # len(calls)==1 holds for the wrong reason, so count backend resolutions.
+        # len(calls) == len(resolutions) == 1 holds for the wrong reason, so
+        # count backend resolutions.
         resolutions = []
         orig_get_compiler_fn = torch._dynamo.eval_frame.get_compiler_fn
 
@@ -490,12 +463,12 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
             opt_fn(x)
             opt_fn(x)
         self.assertGreater(len(resolutions), 1)
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls), len(resolutions))
 
     def test_dynamo_backend_init_aot_autograd(self):
-        # Hook on fw_compiler survives aot_autograd(...). Two wrappers around the
-        # same fw_compiler fire once; and it is read at fire time (__getattr__),
-        # so it can be set after construction.
+        # Hook on fw_compiler survives aot_autograd(...) and fires per wrapper
+        # (each wrapper is its own resolution); it is read at fire time
+        # (@property), so it can be set after construction.
         from functorch.compile import make_boxed_func
         from torch._dynamo.backends.common import aot_autograd
 
@@ -516,7 +489,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
         torch.compile(f, backend=train)(torch.randn(3, 3))
         torch.compile(f, backend=infer)(torch.randn(3, 3))
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls), 2)
 
         # Setting the hook AFTER constructing aot_autograd still fires.
         calls.clear()
@@ -534,7 +507,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
     def test_dynamo_backend_init_force_backend(self):
         # force_backend resolves through get_compiler_fn() on every invocation,
-        # so the hook fires once and dedup holds across calls.
+        # so the hook fires per invocation.
         calls = []
 
         def my_backend(gm, example_inputs):
@@ -553,12 +526,12 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         with torch.compiler.set_stance(force_backend=my_backend):
             fn(x)
             fn(x)
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls), 2)
 
     def test_dynamo_backend_init_force_backend_registered(self):
         # force_backend with a registered *name* (the typical usage) resolves
-        # through lookup_backend -> get_compiler_fn on every invocation; the hook
-        # fires once.
+        # through lookup_backend -> get_compiler_fn on every invocation; the
+        # hook fires per invocation.
         from torch._dynamo.backends import registry as backend_registry
 
         calls = []
@@ -588,97 +561,11 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         with torch.compiler.set_stance(force_backend=name):
             fn(x)
             fn(x)
-        self.assertEqual(len(calls), 1)
-
-    def test_dynamo_backend_init_per_instance(self):
-        # An instance-method hook dedups per (instance, func): two backend
-        # instances each fire once, so per-device init works.
-        calls = []
-
-        class MyBackend:
-            def __call__(self, gm, example_inputs):
-                return gm.forward
-
-            def _dynamo_backend_init(self):
-                calls.append(1)
-
-        b1 = MyBackend()
-        b2 = MyBackend()
-
-        @torch.compile(backend=b1)
-        def fn1(x):
-            return x + 1
-
-        @torch.compile(backend=b2)
-        def fn2(x):
-            return x + 2
-
-        fn1(torch.randn(3))
-        fn2(torch.randn(3))
-        self.assertEqual(len(calls), 2)
-
-    def test_dynamo_backend_init_unhashable_hook(self):
-        # An unhashable hook callable (e.g. a @dataclass instance) cannot be
-        # weakly keyed; it skips dedup and fires per resolution rather than crashing.
-        from dataclasses import dataclass
-
-        calls = []
-
-        @dataclass
-        class Hook:
-            def __call__(self):
-                calls.append(1)
-
-        def my_backend(gm, example_inputs):
-            return gm.forward
-
-        my_backend._dynamo_backend_init = Hook()
-
-        @torch.compile(backend=my_backend)
-        def fn1(x):
-            return x + 1
-
-        @torch.compile(backend=my_backend)
-        def fn2(x):
-            return x + 2
-
-        fn1(torch.randn(3))
-        fn2(torch.randn(3))
-        self.assertEqual(len(calls), 2)
-
-    def test_dynamo_backend_init_nonweakrefable_hook(self):
-        # A hashable but non-weak-referenceable hook (e.g. a __slots__ instance
-        # without __weakref__) cannot live in the WeakSet; it fires per
-        # resolution rather than crashing after the init succeeded.
-        calls = []
-
-        class Hook:
-            __slots__ = ()
-
-            def __call__(self):
-                calls.append(1)
-
-        def my_backend(gm, example_inputs):
-            return gm.forward
-
-        my_backend._dynamo_backend_init = Hook()
-
-        @torch.compile(backend=my_backend)
-        def fn1(x):
-            return x + 1
-
-        @torch.compile(backend=my_backend)
-        def fn2(x):
-            return x + 2
-
-        fn1(torch.randn(3))
-        fn2(torch.randn(3))
         self.assertEqual(len(calls), 2)
 
     def test_dynamo_backend_init_builtin_hook(self):
-        # A C-extension function has __self__ (the module) but no __func__; it
-        # must not be mistaken for a bound method, and must not crash
-        # torch.compile().
+        # A C-extension function (builtin_function_or_method) as the hook must
+        # not crash torch.compile().
         import gc
 
         def my_backend(gm, example_inputs):
@@ -691,169 +578,6 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
             return x + 1
 
         fn(torch.randn(3))
-
-    def test_dynamo_backend_init_raising_retries(self):
-        # A failed init must not poison the dedup state: the next compile
-        # retries the hook instead of silently skipping it.
-        calls = []
-
-        def my_backend(gm, example_inputs):
-            return gm.forward
-
-        def my_backend_init():
-            calls.append(1)
-            if len(calls) == 1:
-                raise RuntimeError("init failed")
-
-        my_backend._dynamo_backend_init = my_backend_init
-
-        def fn(x):
-            return x + 1
-
-        with self.assertRaises(RuntimeError):
-            torch.compile(fn, backend=my_backend)
-        opt_fn = torch.compile(fn, backend=my_backend)
-        opt_fn(torch.randn(3))
-        self.assertEqual(len(calls), 2)
-
-    def test_dynamo_backend_init_methods_on_shared_owner(self):
-        # Two distinct hooks bound to the same owner must not share a dedup key.
-        calls = []
-
-        class Setup:
-            def init_fw(self):
-                calls.append("fw")
-
-            def init_bw(self):
-                calls.append("bw")
-
-        setup = Setup()
-
-        def fw_backend(gm, example_inputs):
-            return gm.forward
-
-        def bw_backend(gm, example_inputs):
-            return gm.forward
-
-        fw_backend._dynamo_backend_init = setup.init_fw
-        bw_backend._dynamo_backend_init = setup.init_bw
-
-        @torch.compile(backend=fw_backend)
-        def fn1(x):
-            return x + 1
-
-        @torch.compile(backend=bw_backend)
-        def fn2(x):
-            return x + 2
-
-        fn1(torch.randn(3))
-        fn2(torch.randn(3))
-        self.assertEqual(sorted(calls), ["bw", "fw"])
-
-    def test_dynamo_backend_init_concurrent_resolution(self):
-        # Concurrent torch.compile() with the same backend: the second
-        # resolution blocks until the in-flight init completes, so the backend
-        # is never invoked before init has returned.
-        import threading
-
-        calls = []
-        backend_calls = []
-        errors = []
-        init_started = threading.Event()
-        init_complete = threading.Event()
-        release_init = threading.Event()
-
-        def my_backend(gm, example_inputs):
-            # Deterministic contract check: the backend must never be invoked
-            # before init has returned, however t2 is scheduled.
-            if not init_complete.is_set():
-                errors.append("backend invoked before init completed")
-            backend_calls.append(1)
-            return gm.forward
-
-        def my_backend_init():
-            calls.append(1)
-            init_started.set()
-            release_init.wait(timeout=60)
-            init_complete.set()
-
-        my_backend._dynamo_backend_init = my_backend_init
-
-        def fn(x):
-            return x + 1
-
-        def compile_only():
-            try:
-                torch.compile(fn, backend=my_backend)
-            except Exception as e:
-                errors.append(e)
-
-        def compile_and_run():
-            try:
-                opt_fn = torch.compile(fn, backend=my_backend)
-                opt_fn(torch.randn(3))
-            except Exception as e:
-                errors.append(e)
-
-        t1 = threading.Thread(target=compile_only)
-        t1.start()
-        self.addCleanup(t1.join, 60)
-        self.assertTrue(init_started.wait(timeout=60))
-        t2 = threading.Thread(target=compile_and_run)
-        t2.start()
-        self.addCleanup(t2.join, 60)
-        self.addCleanup(release_init.set)
-        t2.join(timeout=1)
-        # t2 is blocked in the once-barrier while init is held: the backend
-        # has not been invoked yet.
-        self.assertTrue(t2.is_alive())
-        self.assertEqual(backend_calls, [])
-        release_init.set()
-        t1.join(timeout=60)
-        t2.join(timeout=60)
-        self.assertEqual(errors, [])
-        self.assertEqual(calls, [1])
-        self.assertEqual(backend_calls, [1])
-
-    def test_dynamo_backend_init_reentrant(self):
-        # A backend init that resolves its own backend must re-run the init
-        # (reentrant-lock semantics) instead of waiting on its own in-flight
-        # event. Run in a thread so a deadlock regression fails the test
-        # instead of hanging CI.
-        import threading
-
-        calls = []
-        errors = []
-
-        def my_backend(gm, example_inputs):
-            return gm.forward
-
-        def my_backend_init():
-            calls.append(1)
-            if len(calls) == 1:
-                # Re-entrant resolution of the same backend from inside its init.
-                torch.compile(lambda x: x + 1, backend=my_backend)
-
-        my_backend._dynamo_backend_init = my_backend_init
-
-        def compile_and_run():
-            try:
-
-                @torch.compile(backend=my_backend)
-                def fn(x):
-                    return x + 1
-
-                fn(torch.randn(3))
-            except Exception as e:
-                errors.append(e)
-
-        t = threading.Thread(target=compile_and_run)
-        t.start()
-        self.addCleanup(t.join, 60)
-        t.join(timeout=60)
-        self.assertFalse(t.is_alive(), "reentrant init deadlocked")
-        self.assertEqual(errors, [])
-        self.assertEqual(len(calls), 2)  # outer fire + re-entrant re-run
 
     def test_aot_autograd_api(self):
         from functorch.compile import make_boxed_func

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2983,11 +2983,6 @@ class _TorchCompileWrapper:
             self.compiler_name = str(backend)
         self.dynamic = dynamic
         self.compiler_fn = lookup_backend(backend)
-        # Forward the eager-init hook so torch.compile() (which wraps backends
-        # here) can trigger it, matching the _dynamo.optimize entry point.
-        self._dynamo_backend_init = getattr(
-            self.compiler_fn, "_dynamo_backend_init", None
-        )
         self.kwargs: dict[str, _Any] = {}
         # only pass the args if they non-empty
         if mode and mode != "default":

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3005,6 +3005,13 @@ class _TorchCompileWrapper:
         if hasattr(self.compiler_fn, "reset"):
             self.compiler_fn.reset()
 
+    # Forwarded so the backend's _dynamo_backend_init can be read off the
+    # wrapper (what get_compiler_fn receives); read at fire time so the hook
+    # can be set on the backend even after torch.compile() wraps it.
+    @property
+    def _dynamo_backend_init(self) -> _Any | None:
+        return getattr(self.compiler_fn, "_dynamo_backend_init", None)
+
 
 _InputT = _ParamSpec("_InputT")
 _RetT = _TypeVar("_RetT")

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2983,6 +2983,11 @@ class _TorchCompileWrapper:
             self.compiler_name = str(backend)
         self.dynamic = dynamic
         self.compiler_fn = lookup_backend(backend)
+        # Forward the eager-init hook so torch.compile() (which wraps backends
+        # here) can trigger it, matching the _dynamo.optimize entry point.
+        self._dynamo_backend_init = getattr(
+            self.compiler_fn, "_dynamo_backend_init", None
+        )
         self.kwargs: dict[str, _Any] = {}
         # only pass the args if they non-empty
         if mode and mode != "default":

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -76,6 +76,14 @@ class AotAutograd:
         self.__name__ = "compiler_fn"
         self.kwargs: AotAutogradKwargs = kwargs
 
+    # Read at fire time so the hook can be set on fw_compiler even after
+    # aot_autograd() is constructed; an explicit assignment on the instance
+    # shadows this. Only fw_compiler is consulted.
+    def __getattr__(self, name: str) -> Any:
+        if name == "_dynamo_backend_init":
+            return getattr(self.kwargs.get("fw_compiler"), "_dynamo_backend_init", None)
+        raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: Sequence[Any], **kwargs: Any
     ) -> Callable[..., Any]:

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -76,13 +76,11 @@ class AotAutograd:
         self.__name__ = "compiler_fn"
         self.kwargs: AotAutogradKwargs = kwargs
 
-    # Read at fire time so the hook can be set on fw_compiler even after
-    # aot_autograd() is constructed; an explicit assignment on the instance
-    # shadows this. Only fw_compiler is consulted.
-    def __getattr__(self, name: str) -> Any:
-        if name == "_dynamo_backend_init":
-            return getattr(self.kwargs.get("fw_compiler"), "_dynamo_backend_init", None)
-        raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+    # Read at fire time (not snapshotted) so the hook can be set on fw_compiler
+    # even after aot_autograd() is constructed. Only fw_compiler is consulted.
+    @property
+    def _dynamo_backend_init(self) -> Any | None:
+        return getattr(self.kwargs.get("fw_compiler"), "_dynamo_backend_init", None)
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: Sequence[Any], **kwargs: Any

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1817,6 +1817,13 @@ def _optimize(
             One can also provide additional context for the backend, like
             torch.jit.fuser("fuser2"), by setting the backend_ctx_ctor attribute.
             See AOTAutogradMemoryEfficientFusionWithContext for the usage.
+            Backends can also run eager one-time initialization by defining a
+            ``_dynamo_backend_init`` attribute (a no-arg callable); it is called
+            once the backend is resolved, before backend_ctx_ctor. It is invoked
+            once per ``torch.compile()`` / ``torch._dynamo.optimize()`` call, so
+            a backend reused across multiple compiled functions is initialized
+            once per site and should be idempotent. Backends forced via
+            ``torch.compiler.set_stance(force_backend=...)`` bypass this hook.
             - Or, a string backend name in `torch._dynamo.list_backends()`
         nopython: If True, graph breaks will be errors and there will
             be a single whole-program graph.
@@ -1873,6 +1880,12 @@ def _optimize(
         )
 
     backend = get_compiler_fn(backend)
+
+    # Allow backends to perform eager initialization (e.g., load native
+    # libraries, initialize device contexts) before the first invocation.
+    backend_init = getattr(backend, "_dynamo_backend_init", None)
+    if backend_init is not None:
+        backend_init()
 
     # Find if backend has any extra context manager
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
@@ -2817,6 +2830,12 @@ def _optimize_assert(
     symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
     backend = get_compiler_fn(backend)
+
+    # Allow backends to perform eager initialization (e.g., load native
+    # libraries, initialize device contexts) before the first invocation.
+    backend_init = getattr(backend, "_dynamo_backend_init", None)
+    if backend_init is not None:
+        backend_init()
 
     # Find if backend has any extra context manager
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1612,6 +1612,121 @@ def _optimize_catch_errors(
     )
 
 
+# Hooks that have completed. Bound-method hooks key weakly on their owner with
+# the completed __func__s in the value, so two methods on one object do not
+# collide; plain-function hooks live in a WeakSet keyed on the function.
+# reset() intentionally does not clear either: native-library init is
+# process-global, not cache state.
+_initialized_hooks: weakref.WeakSet[Callable[..., Any]] = weakref.WeakSet()
+_initialized_methods: weakref.WeakKeyDictionary[Any, set[Callable[..., Any]]] = (
+    weakref.WeakKeyDictionary()
+)
+# (Event, initiator thread id) for in-flight inits, keyed (owner, func).
+# Waiters block until the init completes or fails; the initiator id lets a
+# re-entrant resolution from the init's own thread re-run instead of waiting
+# on itself. Entries are removed when the init finishes.
+_pending_inits: dict[tuple[Any, Callable[..., Any]], tuple[threading.Event, int]] = {}
+_init_lock = threading.Lock()
+
+
+def _maybe_fire_backend_init(backend: Callable[..., Any]) -> None:
+    # Unwrap _TorchCompileWrapper (a fresh instance per torch.compile).
+    inner = (
+        backend.compiler_fn
+        if isinstance(backend, torch._TorchCompileWrapper)
+        else backend
+    )
+    backend_init = getattr(inner, "_dynamo_backend_init", None)
+    if backend_init is None:
+        return
+    # Dedup key: (owner, func) for bound methods -- per-instance for instance
+    # methods, per-class for classmethods, and two distinct methods on one
+    # owner do not collide -- else the callable itself. Keying on the owner
+    # (not the transient bound-method object) keeps the entry alive via its
+    # owner, and distinguishes instances that share one class-level method.
+    # Bound methods are detected with inspect.ismethod, not
+    # hasattr(__self__): a C-extension function has __self__ (the module, for
+    # module-level functions) but no __func__, and keying on the module would
+    # collide across hooks.
+    if inspect.ismethod(backend_init):
+        owner, func = backend_init.__self__, backend_init.__func__  # type: ignore[attr-defined]
+        is_method = True
+    else:
+        owner, func = backend_init, backend_init
+        is_method = False
+
+    while True:
+        unhashable = False
+        try:
+            if is_method:
+                funcs = _initialized_methods.get(owner)
+                done = funcs is not None and func in funcs
+            else:
+                done = func in _initialized_hooks
+        except TypeError:
+            unhashable = True
+        if unhashable:
+            # Unhashable or non-weak-referenceable hook: cannot dedup, so fire
+            # on every resolution rather than crash. Called outside the except
+            # so a raising init does not chain onto the TypeError traceback.
+            backend_init()
+            return
+        if done:
+            return
+        with _init_lock:
+            if is_method:
+                funcs = _initialized_methods.get(owner)
+                if funcs is not None and func in funcs:
+                    return
+            elif func in _initialized_hooks:
+                return
+            entry = _pending_inits.get((owner, func))
+            if entry is None:
+                event = threading.Event()
+                _pending_inits[(owner, func)] = (event, threading.get_ident())
+                fire = True
+                reentrant = False
+            else:
+                event, initiator = entry
+                fire = False
+                # A backend whose init itself resolves this hook must not wait
+                # on its own event: re-run the init (reentrant-lock semantics);
+                # the outer init still records the result.
+                reentrant = initiator == threading.get_ident()
+        if fire:
+            try:
+                backend_init()
+            except BaseException:
+                # A failed init must not poison the dedup state: release
+                # waiters so a later compile retries the hook.
+                with _init_lock:
+                    _pending_inits.pop((owner, func), None)
+                event.set()
+                raise
+            with _init_lock:
+                _pending_inits.pop((owner, func), None)
+                try:
+                    if is_method:
+                        _initialized_methods.setdefault(owner, set()).add(func)
+                    else:
+                        _initialized_hooks.add(func)
+                except TypeError:
+                    # WeakSet.__contains__ silently returns False for
+                    # non-weak-referenceable hooks, so reaching here does not
+                    # prove weakrefability and add may still raise. The hook
+                    # has fired but cannot be recorded; it refires on the next
+                    # resolution.
+                    pass
+            event.set()
+            return
+        if reentrant:
+            backend_init()
+            return
+        # Another thread is running this init: wait for it and re-check. If it
+        # failed, this thread retries the hook itself.
+        event.wait()
+
+
 def get_compiler_fn(
     compiler_fn: str | Callable[..., Any] | None,
 ) -> WrapBackendDebug:
@@ -1631,6 +1746,7 @@ def get_compiler_fn(
     else:
         compiler_str = None
     compiler_fn = lookup_backend(compiler_fn)  # type: ignore[arg-type]
+    _maybe_fire_backend_init(compiler_fn)
     return wrap_backend_debug(compiler_fn, compiler_str)
 
 
@@ -1816,14 +1932,11 @@ def _optimize(
             graph faster.
             One can also provide additional context for the backend, like
             torch.jit.fuser("fuser2"), by setting the backend_ctx_ctor attribute.
-            See AOTAutogradMemoryEfficientFusionWithContext for the usage.
-            Backends can also run eager one-time initialization by defining a
-            ``_dynamo_backend_init`` attribute (a no-arg callable); it is called
-            once the backend is resolved, before backend_ctx_ctor. It is invoked
-            once per ``torch.compile()`` / ``torch._dynamo.optimize()`` call, so
-            a backend reused across multiple compiled functions is initialized
-            once per site and should be idempotent. Backends forced via
-            ``torch.compiler.set_stance(force_backend=...)`` bypass this hook.
+            Backends can also define a ``_dynamo_backend_init`` no-arg callable
+            for one-time eager initialization; it fires once per hook (per
+            backend instance for instance-method hooks) when the backend is
+            resolved. See the "Eager Backend Initialization" section of
+            torch.compiler_custom_backends.md.
             - Or, a string backend name in `torch._dynamo.list_backends()`
         nopython: If True, graph breaks will be errors and there will
             be a single whole-program graph.
@@ -1880,12 +1993,6 @@ def _optimize(
         )
 
     backend = get_compiler_fn(backend)
-
-    # Allow backends to perform eager initialization (e.g., load native
-    # libraries, initialize device contexts) before the first invocation.
-    backend_init = getattr(backend, "_dynamo_backend_init", None)
-    if backend_init is not None:
-        backend_init()
 
     # Find if backend has any extra context manager
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
@@ -2830,12 +2937,6 @@ def _optimize_assert(
     symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
     backend = get_compiler_fn(backend)
-
-    # Allow backends to perform eager initialization (e.g., load native
-    # libraries, initialize device contexts) before the first invocation.
-    backend_init = getattr(backend, "_dynamo_backend_init", None)
-    if backend_init is not None:
-        backend_init()
 
     # Find if backend has any extra context manager
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1612,119 +1612,14 @@ def _optimize_catch_errors(
     )
 
 
-# Hooks that have completed. Bound-method hooks key weakly on their owner with
-# the completed __func__s in the value, so two methods on one object do not
-# collide; plain-function hooks live in a WeakSet keyed on the function.
-# reset() intentionally does not clear either: native-library init is
-# process-global, not cache state.
-_initialized_hooks: weakref.WeakSet[Callable[..., Any]] = weakref.WeakSet()
-_initialized_methods: weakref.WeakKeyDictionary[Any, set[Callable[..., Any]]] = (
-    weakref.WeakKeyDictionary()
-)
-# (Event, initiator thread id) for in-flight inits, keyed (owner, func).
-# Waiters block until the init completes or fails; the initiator id lets a
-# re-entrant resolution from the init's own thread re-run instead of waiting
-# on itself. Entries are removed when the init finishes.
-_pending_inits: dict[tuple[Any, Callable[..., Any]], tuple[threading.Event, int]] = {}
-_init_lock = threading.Lock()
-
-
 def _maybe_fire_backend_init(backend: Callable[..., Any]) -> None:
-    # Unwrap _TorchCompileWrapper (a fresh instance per torch.compile).
-    inner = (
-        backend.compiler_fn
-        if isinstance(backend, torch._TorchCompileWrapper)
-        else backend
-    )
-    backend_init = getattr(inner, "_dynamo_backend_init", None)
-    if backend_init is None:
-        return
-    # Dedup key: (owner, func) for bound methods -- per-instance for instance
-    # methods, per-class for classmethods, and two distinct methods on one
-    # owner do not collide -- else the callable itself. Keying on the owner
-    # (not the transient bound-method object) keeps the entry alive via its
-    # owner, and distinguishes instances that share one class-level method.
-    # Bound methods are detected with inspect.ismethod, not
-    # hasattr(__self__): a C-extension function has __self__ (the module, for
-    # module-level functions) but no __func__, and keying on the module would
-    # collide across hooks.
-    if inspect.ismethod(backend_init):
-        owner, func = backend_init.__self__, backend_init.__func__  # type: ignore[attr-defined]
-        is_method = True
-    else:
-        owner, func = backend_init, backend_init
-        is_method = False
-
-    while True:
-        unhashable = False
-        try:
-            if is_method:
-                funcs = _initialized_methods.get(owner)
-                done = funcs is not None and func in funcs
-            else:
-                done = func in _initialized_hooks
-        except TypeError:
-            unhashable = True
-        if unhashable:
-            # Unhashable or non-weak-referenceable hook: cannot dedup, so fire
-            # on every resolution rather than crash. Called outside the except
-            # so a raising init does not chain onto the TypeError traceback.
-            backend_init()
-            return
-        if done:
-            return
-        with _init_lock:
-            if is_method:
-                funcs = _initialized_methods.get(owner)
-                if funcs is not None and func in funcs:
-                    return
-            elif func in _initialized_hooks:
-                return
-            entry = _pending_inits.get((owner, func))
-            if entry is None:
-                event = threading.Event()
-                _pending_inits[(owner, func)] = (event, threading.get_ident())
-                fire = True
-                reentrant = False
-            else:
-                event, initiator = entry
-                fire = False
-                # A backend whose init itself resolves this hook must not wait
-                # on its own event: re-run the init (reentrant-lock semantics);
-                # the outer init still records the result.
-                reentrant = initiator == threading.get_ident()
-        if fire:
-            try:
-                backend_init()
-            except BaseException:
-                # A failed init must not poison the dedup state: release
-                # waiters so a later compile retries the hook.
-                with _init_lock:
-                    _pending_inits.pop((owner, func), None)
-                event.set()
-                raise
-            with _init_lock:
-                _pending_inits.pop((owner, func), None)
-                try:
-                    if is_method:
-                        _initialized_methods.setdefault(owner, set()).add(func)
-                    else:
-                        _initialized_hooks.add(func)
-                except TypeError:
-                    # WeakSet.__contains__ silently returns False for
-                    # non-weak-referenceable hooks, so reaching here does not
-                    # prove weakrefability and add may still raise. The hook
-                    # has fired but cannot be recorded; it refires on the next
-                    # resolution.
-                    pass
-            event.set()
-            return
-        if reentrant:
-            backend_init()
-            return
-        # Another thread is running this init: wait for it and re-check. If it
-        # failed, this thread retries the hook itself.
-        event.wait()
+    # _TorchCompileWrapper and AotAutograd forward the attribute to the
+    # backend they wrap via a @property.
+    backend_init = getattr(backend, "_dynamo_backend_init", None)
+    if backend_init is not None:
+        # Fires on every resolution, before any invocation; backends that
+        # need one-time setup deduplicate themselves (e.g. functools.cache).
+        backend_init()
 
 
 def get_compiler_fn(
@@ -1933,10 +1828,9 @@ def _optimize(
             One can also provide additional context for the backend, like
             torch.jit.fuser("fuser2"), by setting the backend_ctx_ctor attribute.
             Backends can also define a ``_dynamo_backend_init`` no-arg callable
-            for one-time eager initialization; it fires once per hook (per
-            backend instance for instance-method hooks) when the backend is
-            resolved. See the "Eager Backend Initialization" section of
-            torch.compiler_custom_backends.md.
+            for eager initialization; it fires every time the backend is
+            resolved, before any invocation. See the "Eager Backend
+            Initialization" section of torch.compiler_custom_backends.md.
             - Or, a string backend name in `torch._dynamo.list_backends()`
         nopython: If True, graph breaks will be errors and there will
             be a single whole-program graph.

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -97,15 +97,6 @@ class WrapBackendDebug:
             self.get_compiler_config = cast(
                 CompilerConfigProvider, unconfigured_compiler_fn
             ).get_compiler_config
-        # Forward the eager-init hook via hasattr/getattr (reads the MRO) so it
-        # works whether it is an instance attribute or a class method.
-        # functools.wraps above only copies __dict__, which would drop a
-        # class-level _dynamo_backend_init on the direct
-        # torch._dynamo.optimize(backend=instance) path.
-        if hasattr(unconfigured_compiler_fn, "_dynamo_backend_init"):
-            self._dynamo_backend_init = (
-                unconfigured_compiler_fn._dynamo_backend_init  # type: ignore[attr-defined]
-            )
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -97,6 +97,15 @@ class WrapBackendDebug:
             self.get_compiler_config = cast(
                 CompilerConfigProvider, unconfigured_compiler_fn
             ).get_compiler_config
+        # Forward the eager-init hook via hasattr/getattr (reads the MRO) so it
+        # works whether it is an instance attribute or a class method.
+        # functools.wraps above only copies __dict__, which would drop a
+        # class-level _dynamo_backend_init on the direct
+        # torch._dynamo.optimize(backend=instance) path.
+        if hasattr(unconfigured_compiler_fn, "_dynamo_backend_init"):
+            self._dynamo_backend_init = (
+                unconfigured_compiler_fn._dynamo_backend_init  # type: ignore[attr-defined]
+            )
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any


### PR DESCRIPTION
## Problem

Out-of-tree backends (e.g. NPU) often need to run one-time eager setup at `torch.compile()` time -- loading native libraries, initializing device contexts, spawning worker threads -- before the backend is first invoked. Today the earliest the backend's `__call__` runs is on the first captured graph, deep inside tracing. Backends work around this by monkey-patching `torch._dynamo.optimize` or stashing global state, which is fragile and version-coupled.

## Solution

Backends can define a `_dynamo_backend_init` no-arg callable. It runs once the backend is resolved, before any invocation.

```python
def my_backend(gm, example_inputs):
    return gm.forward

def my_backend_init():
    load_native_libs()      # runs at compile() time, before any invocation
my_backend._dynamo_backend_init = my_backend_init

@torch.compile(backend=my_backend)
def fn(x):
    return x + 1
```

Backends that don't define it are unaffected.

## Why a new hook

- The backend `__call__` runs lazily, only after graph capture -- too late for setup that must precede any compilation. A `functools.cache`'d init called from `__call__` has the same timing.
- Module-level init is too early: vendor packages are imported eagerly for device support, so heavy setup would run at import time for every user, including those who never compile.
- User-side init before `torch.compile` only works for backends the user holds directly, and defeats `register_backend(name)`.

## Contract

- Fires at `torch.compile()` time, once the backend is resolved and before any invocation.
- Fires once per hook per process: reusing a backend across many `torch.compile()` sites (or under `compiled_autograd`, or `force_backend`) initializes it only once. Making the hook idempotent is still good practice.
- May be an instance attribute, a `@classmethod`, or an instance method (an instance-method hook fires once per backend instance, so two instances can each run their own init).
- For `aot_autograd(fw_compiler=...)`, set it on the inner `fw_compiler` (hooks on `bw_compiler` or `inference_compiler` are ignored).
- Concurrent `torch.compile()` calls sharing a hook are serialized: a resolution waits for an in-flight init to complete. If the init raises, the exception propagates and the next compile retries it.

## Tests

- `test/dynamo/test_backends.py`
---

> AI-Assisted: Author reviewed and validated all AI-generated content.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98