### PR TITLE
Fix DTensor _scaled_mm so rowwise MXFP8 linears with TP >= 2 keep the correct Partial(sum) output placement

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -5,6 +5,7 @@ import itertools
 import math
 import unittest
 from typing import cast
+from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
@@ -30,6 +31,7 @@ from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_MX_GEMM,
     SM90OrLater,
 )
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
@@ -50,6 +52,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 funcol = torch.ops.c10d_functional
+mx_skip_msg = "MX gemm is only supported on CUDA capability 10.0+"
 
 
 def scale_for_fp8(
@@ -64,6 +67,91 @@ def scale_for_fp8(
     t_fp8 = (t / scale[:, None, :, None]).to(e4m3_type)
 
     return t_fp8.flatten(end_dim=1).flatten(start_dim=-2), scale.view(scale_shape)
+
+
+def _current_rank_int_for_mesh(
+    mesh,
+    value: int | torch.SymInt,  # pyrefly: ignore[bad-parameter-annotation]
+) -> int:
+    from torch.distributed.tensor._dispatch import _current_rank_int
+
+    return _current_rank_int(value, current_rank=mesh._rank)
+
+
+def _make_blockwise_scale_2d(
+    rows: int, sf_k: int, dtype: torch.dtype, device: str
+) -> torch.Tensor:
+    base = torch.tensor(
+        [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+        device=device,
+        dtype=torch.float32,
+    )
+    idx = torch.arange(rows * sf_k, device=device).remainder(base.numel())
+    return base[idx].reshape(rows, sf_k).to(dtype)
+
+
+def _flat_blockwise_scale_slice(
+    scale_2d: torch.Tensor,
+    *,
+    row_start: int = 0,
+    row_count: int | None = None,
+    sf_k_start: int = 0,
+    sf_k_count: int | None = None,
+) -> torch.Tensor:
+    from torch._vendor.quack.blockscaled_layout_utils import (
+        pack_scale_2d_to_blocked_contig,
+        scale_blocked_for_cublas,
+    )
+
+    row_count = row_count if row_count is not None else scale_2d.shape[0] - row_start
+    sf_k_count = (
+        sf_k_count if sf_k_count is not None else scale_2d.shape[1] - sf_k_start
+    )
+    return scale_blocked_for_cublas(
+        pack_scale_2d_to_blocked_contig(
+            scale_2d[
+                row_start : row_start + row_count,
+                sf_k_start : sf_k_start + sf_k_count,
+            ]
+        ),
+        row_count,
+        sf_k_count,
+    )
+
+
+def _make_rowwise_mxfp8_tp_inputs(
+    device_mesh,
+    device_type: str,
+    *,
+    m: int,
+    n: int,
+    k: int,
+    block_size: int = 32,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    DTensor,
+    DTensor,
+    DTensor,
+    DTensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    from torch.testing._internal.common_quantized import to_blocked, to_mxfp
+
+    t1 = (
+        torch.randn(m, k, device=device_type, dtype=torch.bfloat16) * (k**-0.5)
+    ).contiguous()
+    t2 = (
+        torch.randn(n, k, device=device_type, dtype=torch.bfloat16) * (k**-0.5)
+    ).contiguous()
+    scale1, t1_fp8 = to_mxfp(t1, block_size=block_size, format="mxfp8")
+    scale2, t2_fp8 = to_mxfp(t2, block_size=block_size, format="mxfp8")
+    dist_t1_fp8 = distribute_tensor(t1_fp8, device_mesh, [Shard(1)])
+    dist_t2_fp8 = distribute_tensor(t2_fp8, device_mesh, [Shard(1)])
+    dist_scale1 = DTensor.from_local(to_blocked(scale1), device_mesh, [Replicate()])
+    dist_scale2 = DTensor.from_local(to_blocked(scale2), device_mesh, [Replicate()])
+    return t1, t2, dist_t1_fp8, dist_t2_fp8, dist_scale1, dist_scale2, scale1, scale2
 
 
 class DistMatrixOpsTest(DTensorTestBase):
@@ -542,8 +630,10 @@ class DistMatrixOpsTest(DTensorTestBase):
 
         1D blockwise scales arise in MX (microscaling) formats where a data
         tensor [M, K] has a flattened scale of shape [M * K / block_size].
-        Shard(>=1) is invalid on a 1D tensor, so the strategy must map
-        non-contracting shards to Shard(0) and reject contracting-dim shards.
+        Shard(>=1) is invalid on a 1D tensor, so the strategy maps
+        non-contracting shards to Shard(0) and keeps contracting-dim shards
+        Replicate so dispatch can localize the K slice later. The dispatch-time
+        half of that behavior is covered separately by the localization tests.
         """
         from torch.distributed.tensor._ops._matrix_ops import _scaled_mm_scale_placement
 
@@ -566,41 +656,582 @@ class DistMatrixOpsTest(DTensorTestBase):
         result = _scaled_mm_scale_placement(
             Shard(0), torch.Size([64]), contracting_dim=1
         )
-        self.assertIsNotNone(result)
         self.assertEqual(result, Shard(0))
 
         # B_t (kn): dim 1 = n (non-contracting), dim 0 = k (contracting)
         result = _scaled_mm_scale_placement(
             Shard(1), torch.Size([64]), contracting_dim=0
         )
-        self.assertIsNotNone(result)
         self.assertEqual(result, Shard(0))
 
-        # --- 1D blockwise + contracting shard -> None (unsupported) ---
+        # --- 1D blockwise + contracting shard -> Replicate (localized later) ---
         result = _scaled_mm_scale_placement(
             Shard(1), torch.Size([64]), contracting_dim=1
         )
-        self.assertIsNone(result)
+        self.assertEqual(result, Replicate())
         result = _scaled_mm_scale_placement(
             Shard(0), torch.Size([64]), contracting_dim=0
         )
-        self.assertIsNone(result)
+        self.assertEqual(result, Replicate())
 
         # --- 1D blockwise + Replicate -> Replicate ---
         result = _scaled_mm_scale_placement(
             Replicate(), torch.Size([64]), contracting_dim=1
         )
-        self.assertIsNotNone(result)
         self.assertEqual(result, Replicate())
 
         # --- 1D blockwise + Partial -> Replicate ---
         result = _scaled_mm_scale_placement(
             Partial(), torch.Size([64]), contracting_dim=0
         )
-        self.assertIsNotNone(result)
         self.assertEqual(result, Replicate())
 
+    @skipIfRocm
     @with_comms
+    @skip_unless_torch_gpu
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm_blockwise_1d_scale_localization(self):
+        from torch._vendor.quack.blockscaled_layout_utils import MX_BLOCK_SIZE
+        from torch.distributed.tensor._dispatch import (
+            _localize_blockwise_scaled_mm_scale,
+        )
+        from torch.distributed.tensor._utils import (
+            compute_local_shape_and_global_offset,
+        )
+
+        device_mesh = self.build_device_mesh()
+        block_size = MX_BLOCK_SIZE
+        m, n = 128, 96
+        k = block_size * self.world_size * 2
+        sf_k = k // block_size
+        scale_a_2d = _make_blockwise_scale_2d(
+            m, sf_k, torch.float8_e8m0fnu, self.device_type
+        )
+        scale_b_2d = _make_blockwise_scale_2d(
+            n, sf_k, torch.float8_e8m0fnu, self.device_type
+        )
+        scale_a_flat = _flat_blockwise_scale_slice(scale_a_2d)
+        scale_b_flat = _flat_blockwise_scale_slice(scale_b_2d)
+
+        data_a = distribute_tensor(
+            torch.zeros(m, k, device=self.device_type, dtype=torch.float8_e4m3fn),
+            device_mesh,
+            [Shard(1)],
+        )
+        data_b = distribute_tensor(
+            torch.zeros(k, n, device=self.device_type, dtype=torch.float8_e4m3fn),
+            device_mesh,
+            [Shard(0)],
+        )
+        localized_a = _localize_blockwise_scaled_mm_scale(
+            scale_a_flat,
+            data_a._local_tensor,
+            data_a._spec,
+            contracting_dim=1,
+            non_contracting_dim=0,
+        )
+        localized_b = _localize_blockwise_scaled_mm_scale(
+            scale_b_flat,
+            data_b._local_tensor,
+            data_b._spec,
+            contracting_dim=0,
+            non_contracting_dim=1,
+        )
+
+        local_shape_a, global_offset_a = compute_local_shape_and_global_offset(
+            data_a._spec.tensor_meta.shape, data_a.device_mesh, data_a.placements
+        )
+        local_shape_a = tuple(data_a._local_tensor.shape)
+        global_offset_a = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_a
+        )
+        local_sf_k_a = local_shape_a[1] // block_size
+        start_sf_k_a = global_offset_a[1] // block_size
+        expected_a = _flat_blockwise_scale_slice(
+            scale_a_2d,
+            row_count=local_shape_a[0],
+            sf_k_start=start_sf_k_a,
+            sf_k_count=local_sf_k_a,
+        )
+        self.assertEqual(localized_a, expected_a)
+        local_shape_b, global_offset_b = compute_local_shape_and_global_offset(
+            data_b._spec.tensor_meta.shape, data_b.device_mesh, data_b.placements
+        )
+        local_shape_b = tuple(data_b._local_tensor.shape)
+        global_offset_b = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_b
+        )
+        local_sf_k_b = local_shape_b[0] // block_size
+        start_sf_k_b = global_offset_b[0] // block_size
+        expected_b = _flat_blockwise_scale_slice(
+            scale_b_2d,
+            row_count=local_shape_b[1],
+            sf_k_start=start_sf_k_b,
+            sf_k_count=local_sf_k_b,
+        )
+        self.assertEqual(localized_b, expected_b)
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm_blockwise_1d_scale_localization_nvfp4(self):
+        from torch.distributed.tensor._dispatch import (
+            _localize_blockwise_scaled_mm_scale,
+        )
+        from torch.distributed.tensor._utils import (
+            compute_local_shape_and_global_offset,
+        )
+        from torch.testing._internal.common_quantized import to_blocked
+
+        device_mesh = self.build_device_mesh()
+        block_size = 16
+        m, n = 128, 96
+        logical_k = block_size * self.world_size * 2
+        packed_k = logical_k // 2
+        sf_k = logical_k // block_size
+        scale_a_2d = _make_blockwise_scale_2d(
+            m, sf_k, torch.float8_e4m3fn, self.device_type
+        )
+        scale_b_2d = _make_blockwise_scale_2d(
+            n, sf_k, torch.float8_e4m3fn, self.device_type
+        )
+        scale_a_flat = to_blocked(scale_a_2d)
+        scale_b_flat = to_blocked(scale_b_2d)
+
+        local_packed_k = packed_k // self.world_size
+        data_a = DTensor.from_local(
+            torch.empty(
+                m,
+                local_packed_k,
+                device=self.device_type,
+                dtype=torch.float4_e2m1fn_x2,
+            ),
+            device_mesh,
+            [Shard(1)],
+            shape=torch.Size([m, packed_k]),
+            stride=(packed_k, 1),
+        )
+        data_b = DTensor.from_local(
+            torch.empty(
+                local_packed_k,
+                n,
+                device=self.device_type,
+                dtype=torch.float4_e2m1fn_x2,
+            ),
+            device_mesh,
+            [Shard(0)],
+            shape=torch.Size([packed_k, n]),
+            stride=(n, 1),
+        )
+        localized_a = _localize_blockwise_scaled_mm_scale(
+            scale_a_flat,
+            data_a._local_tensor,
+            data_a._spec,
+            contracting_dim=1,
+            non_contracting_dim=0,
+        )
+        localized_b = _localize_blockwise_scaled_mm_scale(
+            scale_b_flat,
+            data_b._local_tensor,
+            data_b._spec,
+            contracting_dim=0,
+            non_contracting_dim=1,
+        )
+
+        local_shape_a, global_offset_a = compute_local_shape_and_global_offset(
+            data_a._spec.tensor_meta.shape, data_a.device_mesh, data_a.placements
+        )
+        local_shape_a = tuple(data_a._local_tensor.shape)
+        global_offset_a = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_a
+        )
+        local_sf_k_a = (local_shape_a[1] * 2) // block_size
+        start_sf_k_a = (global_offset_a[1] * 2) // block_size
+        self.assertEqual(
+            localized_a,
+            to_blocked(scale_a_2d[:, start_sf_k_a : start_sf_k_a + local_sf_k_a]),
+        )
+
+        local_shape_b, global_offset_b = compute_local_shape_and_global_offset(
+            data_b._spec.tensor_meta.shape, data_b.device_mesh, data_b.placements
+        )
+        local_shape_b = tuple(data_b._local_tensor.shape)
+        global_offset_b = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_b
+        )
+        local_sf_k_b = (local_shape_b[0] * 2) // block_size
+        start_sf_k_b = (global_offset_b[0] * 2) // block_size
+        self.assertEqual(
+            localized_b,
+            to_blocked(scale_b_2d[:, start_sf_k_b : start_sf_k_b + local_sf_k_b]),
+        )
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm_blockwise_1d_scale_localization_mixed_mk(self):
+        from torch._vendor.quack.blockscaled_layout_utils import MX_BLOCK_SIZE
+        from torch.distributed.tensor._dispatch import (
+            _localize_blockwise_scaled_mm_scale,
+        )
+        from torch.distributed.tensor._utils import (
+            compute_local_shape_and_global_offset,
+        )
+
+        mesh_shape = (2, self.world_size // 2)
+        device_mesh = init_device_mesh(self.device_type, mesh_shape)
+        block_size = MX_BLOCK_SIZE
+        m = 128 * mesh_shape[0]
+        n = 128 * mesh_shape[0]
+        k = block_size * mesh_shape[1] * 4
+        sf_k = k // block_size
+        scale_a_2d = _make_blockwise_scale_2d(
+            m, sf_k, torch.float8_e8m0fnu, self.device_type
+        )
+        scale_b_2d = _make_blockwise_scale_2d(
+            n, sf_k, torch.float8_e8m0fnu, self.device_type
+        )
+
+        data_a = distribute_tensor(
+            torch.zeros(m, k, device=self.device_type, dtype=torch.float8_e4m3fn),
+            device_mesh,
+            [Shard(0), Shard(1)],
+        )
+        local_shape_a, global_offset_a = compute_local_shape_and_global_offset(
+            data_a._spec.tensor_meta.shape, data_a.device_mesh, data_a.placements
+        )
+        local_shape_a = tuple(data_a._local_tensor.shape)
+        global_offset_a = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_a
+        )
+        m_start = global_offset_a[0]
+        scale_a_current = _flat_blockwise_scale_slice(
+            scale_a_2d,
+            row_start=m_start,
+            row_count=local_shape_a[0],
+            sf_k_count=sf_k,
+        )
+        localized_a = _localize_blockwise_scaled_mm_scale(
+            scale_a_current,
+            data_a._local_tensor,
+            data_a._spec,
+            contracting_dim=1,
+            non_contracting_dim=0,
+        )
+        local_sf_k_a = local_shape_a[1] // block_size
+        start_sf_k_a = global_offset_a[1] // block_size
+        expected_a = _flat_blockwise_scale_slice(
+            scale_a_2d,
+            row_start=m_start,
+            row_count=local_shape_a[0],
+            sf_k_start=start_sf_k_a,
+            sf_k_count=local_sf_k_a,
+        )
+        self.assertEqual(localized_a, expected_a)
+
+        data_b = distribute_tensor(
+            torch.zeros(k, n, device=self.device_type, dtype=torch.float8_e4m3fn),
+            device_mesh,
+            [Shard(1), Shard(0)],
+        )
+        local_shape_b, global_offset_b = compute_local_shape_and_global_offset(
+            data_b._spec.tensor_meta.shape, data_b.device_mesh, data_b.placements
+        )
+        local_shape_b = tuple(data_b._local_tensor.shape)
+        global_offset_b = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_b
+        )
+        n_start = global_offset_b[1]
+        scale_b_current = _flat_blockwise_scale_slice(
+            scale_b_2d,
+            row_start=n_start,
+            row_count=local_shape_b[1],
+            sf_k_count=sf_k,
+        )
+        localized_b = _localize_blockwise_scaled_mm_scale(
+            scale_b_current,
+            data_b._local_tensor,
+            data_b._spec,
+            contracting_dim=0,
+            non_contracting_dim=1,
+        )
+        local_sf_k_b = local_shape_b[0] // block_size
+        start_sf_k_b = global_offset_b[0] // block_size
+        expected_b = _flat_blockwise_scale_slice(
+            scale_b_2d,
+            row_start=n_start,
+            row_count=local_shape_b[1],
+            sf_k_start=start_sf_k_b,
+            sf_k_count=local_sf_k_b,
+        )
+        self.assertEqual(localized_b, expected_b)
+
+    @skipIfRocm
+    @skip_unless_torch_gpu
+    def test_scaled_mm_blockwise_1d_scale_localization_rejects_unaligned_offsets(self):
+        from torch._vendor.quack.blockscaled_layout_utils import (
+            pack_scale_2d_to_blocked_contig,
+            scale_blocked_for_cublas,
+        )
+        from torch.distributed.tensor._dispatch import (
+            _localize_blockwise_scaled_mm_scale_from_offsets,
+        )
+
+        rows, global_k, local_k, offset, block_size = 128, 96, 48, 48, 32
+        scale_2d = torch.ones(
+            rows,
+            global_k // block_size,
+            device=self.device_type,
+            dtype=torch.float8_e8m0fnu,
+        )
+        scale_flat = scale_blocked_for_cublas(
+            pack_scale_2d_to_blocked_contig(scale_2d),
+            rows,
+            global_k // block_size,
+        )
+        with self.assertRaisesRegex(ValueError, "block-aligned K offsets"):
+            _localize_blockwise_scaled_mm_scale_from_offsets(
+                scale_flat,
+                rows,
+                global_k,
+                local_k,
+                offset,
+                block_size,
+            )
+        with self.assertRaisesRegex(ValueError, "block-aligned local K sizes"):
+            _localize_blockwise_scaled_mm_scale_from_offsets(
+                scale_flat,
+                rows,
+                global_logical_k=128,
+                local_logical_k=48,
+                logical_k_offset=0,
+                block_size=block_size,
+            )
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm_blockwise_1d_rowwise_tp(self):
+        """Exercise the DTensor rowwise MXFP8 path through sharding propagation.
+
+        This asserts the user-visible DTensor behavior this fix owns: the
+        rowwise TP inputs propagate to Partial(sum), and the handler localizes
+        the flat blockwise MX scales to the correct per-rank payloads before
+        the local tensor call. We stop short of a full local _scaled_mm kernel
+        execution here because that path is still cuBLASLt-shape-sensitive on
+        the current H200/CUDA test environment.
+        """
+        from torch.distributed.tensor._dispatch import (
+            _current_op_schema_for_local_args,
+            _maybe_localize_scaled_mm_blockwise_args,
+        )
+        from torch.distributed.tensor._utils import (
+            compute_local_shape_and_global_offset,
+        )
+
+        device_mesh = self.build_device_mesh()
+        block_size = 32
+        ws = self.world_size
+        m, n, k = 128, 128, block_size * ws * 8
+        _, _, dist_t1_fp8, dist_t2_fp8, dist_scale1, dist_scale2, scale1, scale2 = (
+            _make_rowwise_mxfp8_tp_inputs(
+                device_mesh,
+                self.device_type,
+                m=m,
+                n=n,
+                k=k,
+                block_size=block_size,
+            )
+        )
+
+        op_call = torch.ops.aten._scaled_mm.default
+        op_info = DTensor._op_dispatcher.unwrap_to_op_info(
+            op_call,
+            (
+                dist_t1_fp8,
+                dist_t2_fp8.t(),
+                dist_scale1,
+                dist_scale2,
+                None,
+                None,
+                torch.bfloat16,
+                False,
+            ),
+            {},
+        )
+        DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+        output_sharding = op_info.output_sharding
+        if output_sharding is None:
+            raise AssertionError("output sharding should not be None")
+
+        self.assertFalse(output_sharding.needs_redistribute)
+        self.assertEqual(output_sharding.output_spec.placements, (Partial(),))
+
+        current_op_schema = _current_op_schema_for_local_args(
+            op_call, op_info, output_sharding
+        )
+        local_args = cast(tuple[object, ...], tuple(op_info.local_args))
+        localized_args = _maybe_localize_scaled_mm_blockwise_args(
+            local_args, current_op_schema
+        )
+        localized_scale1 = cast(torch.Tensor, localized_args[2])
+        localized_scale2 = cast(torch.Tensor, localized_args[3])
+
+        local_shape_a, global_offset_a = compute_local_shape_and_global_offset(
+            dist_t1_fp8._spec.tensor_meta.shape,
+            dist_t1_fp8.device_mesh,
+            dist_t1_fp8.placements,
+        )
+        local_shape_a = tuple(dist_t1_fp8._local_tensor.shape)
+        global_offset_a = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_a
+        )
+        local_sf_k_a = local_shape_a[1] // block_size
+        start_sf_k_a = global_offset_a[1] // block_size
+        self.assertEqual(
+            localized_scale1,
+            _flat_blockwise_scale_slice(
+                scale1,
+                row_count=scale1.shape[0],
+                sf_k_start=start_sf_k_a,
+                sf_k_count=local_sf_k_a,
+            ),
+        )
+
+        local_shape_b, global_offset_b = compute_local_shape_and_global_offset(
+            dist_t2_fp8.t()._spec.tensor_meta.shape,
+            dist_t2_fp8.t().device_mesh,
+            dist_t2_fp8.t().placements,
+        )
+        local_shape_b = tuple(dist_t2_fp8.t()._local_tensor.shape)
+        global_offset_b = tuple(
+            _current_rank_int_for_mesh(device_mesh, offset)
+            for offset in global_offset_b
+        )
+        local_sf_k_b = local_shape_b[0] // block_size
+        start_sf_k_b = global_offset_b[0] // block_size
+        self.assertEqual(
+            localized_scale2,
+            _flat_blockwise_scale_slice(
+                scale2,
+                row_count=scale2.shape[0],
+                sf_k_start=start_sf_k_b,
+                sf_k_count=local_sf_k_b,
+            ),
+        )
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    def test_scaled_mm_blockwise_1d_rowwise_tp_e2e_mx_gemm(self):
+        device_mesh = self.build_device_mesh()
+        block_size = 32
+        ws = self.world_size
+        m = 128
+        n = 128
+        k = 128 * ws
+        t1, t2, dist_t1_fp8, dist_t2_fp8, dist_scale1, dist_scale2, _, _ = (
+            _make_rowwise_mxfp8_tp_inputs(
+                device_mesh,
+                self.device_type,
+                m=m,
+                n=n,
+                k=k,
+                block_size=block_size,
+            )
+        )
+        full_ref_res = t1 @ t2.t()
+
+        with CommDebugMode() as comm_mode:
+            dist_res = cast(
+                DTensor,
+                torch._scaled_mm(
+                    dist_t1_fp8,
+                    dist_t2_fp8.t(),
+                    scale_a=dist_scale1,
+                    scale_b=dist_scale2,
+                    out_dtype=torch.bfloat16,
+                ),
+            )
+
+        self.assertEqual(dist_res.placements, (Partial(),))
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(dist_res.full_tensor(), full_ref_res, atol=1.5, rtol=7e-2)
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm_blockwise_1d_uses_custom_handler(self):
+        class ScaledMmHandlerCalled(RuntimeError):
+            pass
+
+        device_mesh = self.build_device_mesh()
+        block_size = 32
+        ws = self.world_size
+        m, n, k = 128, 128, block_size * ws * 4
+        _, _, dist_t1_fp8, dist_t2_fp8, dist_scale1, dist_scale2, _, _ = (
+            _make_rowwise_mxfp8_tp_inputs(
+                device_mesh,
+                self.device_type,
+                m=m,
+                n=n,
+                k=k,
+                block_size=block_size,
+            )
+        )
+
+        def sentinel_handler(op_call, args, kwargs):
+            raise ScaledMmHandlerCalled
+
+        with patch.dict(
+            DTensor._op_dispatcher._custom_op_handlers,
+            {torch.ops.aten._scaled_mm.default: sentinel_handler},
+            clear=False,
+        ):
+            with self.assertRaises(ScaledMmHandlerCalled):
+                torch._scaled_mm(
+                    dist_t1_fp8,
+                    dist_t2_fp8.t(),
+                    scale_a=dist_scale1,
+                    scale_b=dist_scale2,
+                    out_dtype=torch.bfloat16,
+                )
+
+    @skipIfRocm
+    @with_comms
+    @skip_unless_torch_gpu
+    @skip_if_lt_x_gpu(2)
     def test_matmul(self):
         device_mesh = self.build_device_mesh()
         dim = 128

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import itertools
+import math
 import random
 from itertools import chain
 from unittest.mock import patch
@@ -315,6 +316,61 @@ class TestCostModel(DTensorOpTestBase):
                 op_schema
             )
             self.assertFalse(output_sharding.needs_redistribute)
+
+    def test_scaled_mm_blockwise_1d_strategies(self):
+        mesh = self.build_device_mesh()
+        m, n, k = 128, 96, 32 * self.world_size * 2
+        sf_k = k // 32
+
+        def flat_blockwise_numel(rows: int) -> int:
+            return 128 * math.ceil(rows / 128) * 4 * math.ceil(sf_k / 4)
+
+        lhs_tensor_meta = TensorMeta(
+            shape=torch.Size([m, k]),
+            stride=(k, 1),
+            dtype=torch.float8_e4m3fn,
+        )
+        rhs_tensor_meta = TensorMeta(
+            shape=torch.Size([k, n]),
+            stride=(1, k),
+            dtype=torch.float8_e4m3fn,
+        )
+        scale_a_meta = TensorMeta(
+            shape=torch.Size([flat_blockwise_numel(m)]),
+            stride=(1,),
+            dtype=torch.float8_e8m0fnu,
+        )
+        scale_b_meta = TensorMeta(
+            shape=torch.Size([flat_blockwise_numel(n)]),
+            stride=(1,),
+            dtype=torch.float8_e8m0fnu,
+        )
+
+        lhs_spec = DTensorSpec(mesh, (Shard(1),), lhs_tensor_meta)
+        rhs_spec = DTensorSpec(mesh, (Shard(0),), rhs_tensor_meta)
+        scale_a_spec = DTensorSpec(mesh, (Replicate(),), scale_a_meta)
+        scale_b_spec = DTensorSpec(mesh, (Replicate(),), scale_b_meta)
+        op_schema = OpSchema(
+            torch.ops.aten._scaled_mm.default,
+            (
+                lhs_spec,
+                rhs_spec,
+                scale_a_spec,
+                scale_b_spec,
+                None,
+                None,
+                torch.bfloat16,
+                False,
+            ),
+            {},
+        )
+        output_sharding = (
+            DTensor._op_dispatcher.sharding_propagator.propagate_op_sharding_non_cached(
+                op_schema
+            )
+        )
+        self.assertFalse(output_sharding.needs_redistribute)
+        self.assertEqual(output_sharding.output_spec.placements, (Partial(),))
 
     def test_t_prunes_unproven_unbacked_strided_shard_candidates(self):
         from torch._subclasses.fake_tensor import FakeTensorMode

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -2032,6 +2032,39 @@ class TestFP8Matmul(TestCase):
         torch.testing.assert_close(lp_data_actual, lp_data_expected, atol=0, rtol=0)
 
     @skipIfRocm
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @parametrize("mn_sf_k", [(128, 4), (197, 3), (1025, 5)], name_fn=lambda mn_sf_k: f"{mn_sf_k[0]}_{mn_sf_k[1]}")
+    @parametrize("scale_dtype", [torch.float8_e8m0fnu, torch.float8_e4m3fn])
+    def test_blocked_scale_roundtrip_helpers(self, mn_sf_k, scale_dtype, device) -> None:
+        from torch._vendor.quack.blockscaled_layout_utils import (
+            pack_scale_2d_to_blocked_contig,
+            scale_2d_from_cublas,
+            scale_blocked_for_cublas,
+            unpack_scale_blocked_contig,
+        )
+
+        mn, sf_k = mn_sf_k
+        base = torch.tensor(
+            [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+            device=device,
+            dtype=torch.float32,
+        )
+        idx = torch.arange(2 * mn * sf_k, device=device).remainder(base.numel())
+        scale_stack = base[idx].reshape(2, mn, sf_k).to(scale_dtype)
+
+        blocked = pack_scale_2d_to_blocked_contig(scale_stack)
+        self.assertEqual(unpack_scale_blocked_contig(blocked, mn, sf_k), scale_stack)
+        self.assertEqual(unpack_scale_blocked_contig(blocked[1], mn, sf_k), scale_stack[1])
+
+        flat0 = scale_blocked_for_cublas(blocked, mn, sf_k, l_idx=0)
+        flat1 = scale_blocked_for_cublas(blocked, mn, sf_k, l_idx=1)
+        self.assertEqual(flat0, to_blocked(scale_stack[0]))
+        self.assertEqual(flat1, to_blocked(scale_stack[1]))
+        self.assertEqual(scale_2d_from_cublas(flat0, mn, sf_k), scale_stack[0])
+        self.assertEqual(scale_2d_from_cublas(flat1, mn, sf_k), scale_stack[1])
+
+    @skipIfRocm
     @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     @parametrize("mkn", [

--- a/torch/_vendor/quack/blockscaled_gemm_utils.py
+++ b/torch/_vendor/quack/blockscaled_gemm_utils.py
@@ -9,6 +9,11 @@ import torch
 import cutlass
 import cutlass.cute as cute
 
+from .blockscaled_layout_utils import (
+    ceil_div,
+    pack_scale_2d_to_blocked_contig,
+    scale_blocked_for_cublas,
+)
 from .compile_utils import make_fake_tensor as fake_tensor
 from .cute_dsl_utils import get_device_capacity, get_max_active_clusters
 from .gemm_default_epi import GemmDefaultSm100
@@ -56,10 +61,6 @@ FP4_E2M1FN_VALUES = (
     -4.0,
     -6.0,
 )
-
-
-def ceil_div(a: int, b: int) -> int:
-    return (a + b - 1) // b
 
 
 def torch_dtype_for_cutlass(dtype: Type[cutlass.Numeric]) -> torch.dtype:
@@ -233,60 +234,6 @@ def create_blockscaled_scale_tensor(
         .permute(1, 2, 0)
     )[:, :k, :]
     return ref, packed
-
-
-def pack_scale_2d_to_blocked_contig(scale_2d: torch.Tensor) -> torch.Tensor:
-    """Rearrange a (l, mn, sf_k) or (mn, sf_k) e8m0 scale tensor into the
-    contiguous (l, rm, rk, 512) blocked layout shared by the quack kernel and
-    cuBLAS's block-scaling. Each 512 B inner block holds one 128 MN × 4 K
-    swizzled tile. Pads `mn` to a multiple of 128 and `sf_k` to a multiple of
-    4 with zeros."""
-    if scale_2d.dim() == 2:
-        scale_2d = scale_2d.unsqueeze(0)
-    assert scale_2d.dim() == 3, f"expected (l, mn, sf_k), got shape {tuple(scale_2d.shape)}"
-    orig_dtype = scale_2d.dtype
-    l, mn, sf_k = scale_2d.shape
-    rm = ceil_div(mn, 128)
-    rk = ceil_div(sf_k, 4)
-    mn_pad = rm * 128
-    sf_k_pad = rk * 4
-    u8 = scale_2d.contiguous().view(torch.uint8)
-    if mn_pad != mn or sf_k_pad != sf_k:
-        padded = torch.zeros(l, mn_pad, sf_k_pad, device=scale_2d.device, dtype=torch.uint8)
-        padded[:, :mn, :sf_k] = u8
-    else:
-        padded = u8
-    # (l, mn_pad, sf_k_pad) -> (l, rm, 128, rk, 4) -> (l, rm, rk, 128, 4)
-    blocks = padded.view(l, rm, 128, rk, 4).permute(0, 1, 3, 2, 4)
-    # split 128 into (4 outer, 32 inner), then swap to (32, 4)
-    blocks = blocks.reshape(l, rm, rk, 4, 32, 4).transpose(3, 4).contiguous()
-    return blocks.view(l, rm, rk, 512).view(orig_dtype)
-
-
-def scale_view_for_kernel(scale_contig: torch.Tensor, mn: int, sf_k: int, l: int) -> torch.Tensor:
-    """Validate a (l, rm, rk, 512) scale tensor and return it unchanged.
-    Only the innermost 512-B tile must be contiguous (stride 1, size 512);
-    outer (L, rm, rk) strides are free — the kernel reads them from the
-    passed tensor. This lets callers pass a slice/view of a larger buffer
-    with no extra copy. Works for both E8M0 (MX) and E4M3 (NVFP4)."""
-    rm = ceil_div(mn, 128)
-    rk = ceil_div(sf_k, 4)
-    assert scale_contig.shape == (l, rm, rk, 512), (
-        f"expected (l, rm, rk, 512) = ({l}, {rm}, {rk}, 512), got {tuple(scale_contig.shape)}"
-    )
-    assert scale_contig.stride(-1) == 1, (
-        f"innermost 512-B dim must be unit-stride, got stride {scale_contig.stride(-1)}"
-    )
-    return scale_contig
-
-
-def scale_blocked_for_cublas(
-    scale_contig: torch.Tensor, mn: int, sf_k: int, l_idx: int = 0
-) -> torch.Tensor:
-    """Flatten a (l, rm, rk, 512) scale tensor to the 1D swizzled layout
-    torch._scaled_mm expects. Uses a single l slice."""
-    assert scale_contig.is_contiguous() and scale_contig.dim() == 4
-    return scale_contig[l_idx].reshape(-1)
 
 
 _FP4_E2M1_CODE_TO_VALUE = torch.tensor(FP4_E2M1FN_VALUES, dtype=torch.float32)

--- a/torch/_vendor/quack/blockscaled_layout_utils.py
+++ b/torch/_vendor/quack/blockscaled_layout_utils.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# PyTorch-local blockscaled layout helpers shared by DTensor and quack wrappers.
+# The packing formulas mirror the blocked MX/NVFP layouts used by quack and
+# cuBLAS block-scaled GEMM paths.
+
+import torch
+
+MX_BLOCK_SIZE = 32
+NVFP4_BLOCK_SIZE = 16
+
+
+def ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def pack_scale_2d_to_blocked_contig(scale_2d: torch.Tensor) -> torch.Tensor:
+    """Rearrange `(l, mn, sf_k)` or `(mn, sf_k)` scales into blocked layout."""
+    if scale_2d.dim() == 2:
+        scale_2d = scale_2d.unsqueeze(0)
+    assert scale_2d.dim() == 3, f"expected (l, mn, sf_k), got shape {tuple(scale_2d.shape)}"
+    orig_dtype = scale_2d.dtype
+    l, mn, sf_k = scale_2d.shape
+    rm = ceil_div(mn, 128)
+    rk = ceil_div(sf_k, 4)
+    mn_pad = rm * 128
+    sf_k_pad = rk * 4
+    u8 = scale_2d.contiguous().view(torch.uint8)
+    if mn_pad != mn or sf_k_pad != sf_k:
+        padded = torch.zeros(l, mn_pad, sf_k_pad, device=scale_2d.device, dtype=torch.uint8)
+        padded[:, :mn, :sf_k] = u8
+    else:
+        padded = u8
+    blocks = padded.view(l, rm, 128, rk, 4).permute(0, 1, 3, 2, 4)
+    blocks = blocks.reshape(l, rm, rk, 4, 32, 4).transpose(3, 4).contiguous()
+    return blocks.view(l, rm, rk, 512).view(orig_dtype)
+
+
+def unpack_scale_blocked_contig(scale_contig: torch.Tensor, mn: int, sf_k: int) -> torch.Tensor:
+    """Inverse of pack_scale_2d_to_blocked_contig."""
+    squeeze_l = False
+    if scale_contig.dim() == 3:
+        scale_contig = scale_contig.unsqueeze(0)
+        squeeze_l = True
+    assert scale_contig.dim() == 4, (
+        f"expected (l, rm, rk, 512) or (rm, rk, 512), got shape {tuple(scale_contig.shape)}"
+    )
+    orig_dtype = scale_contig.dtype
+    l, rm, rk, inner = scale_contig.shape
+    exp_rm = ceil_div(mn, 128)
+    exp_rk = ceil_div(sf_k, 4)
+    assert inner == 512, f"expected innermost tile size 512, got {inner}"
+    assert rm == exp_rm and rk == exp_rk, (
+        f"expected (rm, rk)=({exp_rm}, {exp_rk}), got ({rm}, {rk})"
+    )
+    u8 = scale_contig.contiguous().view(torch.uint8)
+    blocks = u8.view(l, rm, rk, 32, 4, 4).transpose(3, 4).reshape(l, rm, rk, 128, 4)
+    padded = blocks.permute(0, 1, 3, 2, 4).reshape(l, rm * 128, rk * 4)
+    scale_2d = padded[:, :mn, :sf_k].contiguous().view(orig_dtype)
+    return scale_2d.squeeze(0) if squeeze_l else scale_2d
+
+
+def scale_view_for_kernel(scale_contig: torch.Tensor, mn: int, sf_k: int, l: int) -> torch.Tensor:
+    """Validate a `(l, rm, rk, 512)` scale tensor and return it unchanged.
+
+    Only the innermost 512-B tile must be contiguous (stride 1, size 512);
+    outer `(l, rm, rk)` strides are free.
+    """
+    rm = ceil_div(mn, 128)
+    rk = ceil_div(sf_k, 4)
+    assert scale_contig.shape == (l, rm, rk, 512), (
+        f"expected (l, rm, rk, 512) = ({l}, {rm}, {rk}, 512), got {tuple(scale_contig.shape)}"
+    )
+    assert scale_contig.stride(-1) == 1, (
+        f"innermost 512-B dim must be unit-stride, got stride {scale_contig.stride(-1)}"
+    )
+    return scale_contig
+
+
+def scale_blocked_for_cublas(
+    scale_contig: torch.Tensor, mn: int, sf_k: int, l_idx: int = 0
+) -> torch.Tensor:
+    """Flatten a blocked scale tensor to the 1D swizzled cuBLAS layout."""
+    assert scale_contig.is_contiguous() and scale_contig.dim() == 4
+    return scale_contig[l_idx].reshape(-1)
+
+
+def scale_2d_from_cublas(scale_flat: torch.Tensor, mn: int, sf_k: int) -> torch.Tensor:
+    """Unflatten a 1D cuBLAS block-scaled payload to logical `(mn, sf_k)`."""
+    assert scale_flat.dim() == 1, f"expected 1D flat scale, got shape {tuple(scale_flat.shape)}"
+    rm = ceil_div(mn, 128)
+    rk = ceil_div(sf_k, 4)
+    expected_size = rm * rk * 512
+    assert scale_flat.numel() == expected_size, (
+        f"expected {expected_size} elements for (mn={mn}, sf_k={sf_k}), got {scale_flat.numel()}"
+    )
+    return unpack_scale_blocked_contig(scale_flat.contiguous().view(rm, rk, 512), mn, sf_k)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -12,7 +12,16 @@ import torch.distributed.tensor._random as random
 from torch._library.utils import fill_defaults
 from torch._logging import LazyString
 from torch._prims.rng_prims import run_dtensor_rng_op
+from torch._vendor.quack.blockscaled_layout_utils import (
+    ceil_div as blockscaled_ceil_div,
+    MX_BLOCK_SIZE,
+    NVFP4_BLOCK_SIZE,
+    pack_scale_2d_to_blocked_contig,
+    scale_2d_from_cublas,
+    scale_blocked_for_cublas,
+)
 from torch.distributed._functional_collectives import _are_we_tracing
+from torch.distributed._local_tensor import _map_to_rank_local_val
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._nonlinear_redux import argminmax_handler
@@ -31,6 +40,7 @@ from torch.distributed.tensor._tp_conv import (
 )
 from torch.distributed.tensor._utils import (
     _format_implicit_redistribution_msg,
+    compute_local_shape_and_global_offset,
     ExplicitRedistributionContext,
     try_find_mesh_from_args,
 )
@@ -75,6 +85,205 @@ def _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
     # per-rank tensor are implementation details and may not appear in the
     # returned DTensor object.
     return _ignore_fresh_unbacked_symbols_tls_context()
+
+
+def _flat_blockwise_scale_numel(
+    rows: int, logical_k: int, block_size: int
+) -> tuple[int, int]:
+    sf_k = blockscaled_ceil_div(logical_k, block_size)
+    return 128 * blockscaled_ceil_div(rows, 128) * 4 * blockscaled_ceil_div(
+        sf_k, 4
+    ), sf_k
+
+
+def _current_rank_int(
+    value: int | torch.SymInt, *, current_rank: int | None = None
+) -> int:
+    rank = current_rank
+    if rank is None:
+        if not (dist.is_available() and dist.is_initialized()):
+            raise RuntimeError(
+                "_current_rank_int requires current_rank when distributed is not initialized"
+            )
+        rank = dist.distributed_c10d.get_rank()
+    resolved = _map_to_rank_local_val(value, rank)
+    if not isinstance(resolved, int):
+        raise TypeError(
+            f"expected int-like value for current rank, got {type(resolved)}"
+        )
+    return resolved
+
+
+def _localize_blockwise_scaled_mm_scale_from_offsets(
+    scale_local: torch.Tensor,
+    rows: int,
+    global_logical_k: int,
+    local_logical_k: int,
+    logical_k_offset: int,
+    block_size: int,
+) -> torch.Tensor:
+    global_expected_numel, global_sf_k = _flat_blockwise_scale_numel(
+        rows, global_logical_k, block_size
+    )
+    _, local_sf_k = _flat_blockwise_scale_numel(rows, local_logical_k, block_size)
+    if scale_local.numel() != global_expected_numel:
+        # Callers may hand us an already-localized scale or a non-blockwise case
+        # that happens to share the dtype/shape predicate. In those cases there is
+        # nothing left to localize here.
+        return scale_local
+    if logical_k_offset == 0 and local_logical_k == global_logical_k:
+        return scale_local
+    if logical_k_offset % block_size != 0:
+        raise ValueError(
+            f"blockwise scale localization requires block-aligned K offsets, got offset={logical_k_offset} "
+            f"for block_size={block_size}"
+        )
+    if local_logical_k % block_size != 0:
+        raise ValueError(
+            f"blockwise scale localization requires block-aligned local K sizes, got local_k={local_logical_k} "
+            f"for block_size={block_size}"
+        )
+
+    start_sf_k = logical_k_offset // block_size
+    stop_sf_k = start_sf_k + local_sf_k
+    scale_2d = scale_2d_from_cublas(scale_local, rows, global_sf_k)
+    local_scale_2d = scale_2d[:, start_sf_k:stop_sf_k]
+    local_blocked = pack_scale_2d_to_blocked_contig(local_scale_2d)
+    return scale_blocked_for_cublas(local_blocked, rows, local_sf_k)
+
+
+def _localize_blockwise_scaled_mm_scale(
+    scale_local: torch.Tensor,
+    data_local: torch.Tensor,
+    data_spec: DTensorSpec,
+    *,
+    contracting_dim: int,
+    non_contracting_dim: int,
+) -> torch.Tensor:
+    if scale_local.is_meta or data_local.is_meta:
+        return scale_local
+    if (
+        data_spec.tensor_meta is None
+        or scale_local.dim() != 1
+        or scale_local.numel() <= 1
+    ):
+        return scale_local
+    if scale_local.dtype == torch.float8_e4m3fn:
+        block_size = NVFP4_BLOCK_SIZE
+    elif scale_local.dtype == torch.float8_e8m0fnu:
+        block_size = MX_BLOCK_SIZE
+    else:
+        return scale_local
+
+    current_rank = data_spec.mesh._rank
+    global_shape = tuple(
+        _current_rank_int(dim, current_rank=current_rank)
+        for dim in data_spec.tensor_meta.shape
+    )
+    _, global_offset = compute_local_shape_and_global_offset(
+        data_spec.tensor_meta.shape, data_spec.mesh, data_spec.placements
+    )
+    local_shape = tuple(data_local.shape)
+    global_offset = tuple(
+        _current_rank_int(offset, current_rank=current_rank) for offset in global_offset
+    )
+    logical_k_factor = 2 if data_local.dtype == torch.float4_e2m1fn_x2 else 1
+    return _localize_blockwise_scaled_mm_scale_from_offsets(
+        scale_local,
+        rows=local_shape[non_contracting_dim],
+        global_logical_k=global_shape[contracting_dim] * logical_k_factor,
+        local_logical_k=local_shape[contracting_dim] * logical_k_factor,
+        logical_k_offset=global_offset[contracting_dim] * logical_k_factor,
+        block_size=block_size,
+    )
+
+
+def _maybe_localize_scaled_mm_blockwise_args(
+    local_tensor_args: tuple[object, ...], op_schema: OpSchema
+) -> tuple[object, ...]:
+    if len(local_tensor_args) < 4:
+        return local_tensor_args
+    data_a, data_b, scale_a, scale_b = local_tensor_args[:4]
+    data_a_spec = op_schema.args_schema[0]
+    data_b_spec = op_schema.args_schema[1]
+    if not (
+        isinstance(data_a, torch.Tensor)
+        and isinstance(data_b, torch.Tensor)
+        and isinstance(scale_a, torch.Tensor)
+        and isinstance(scale_b, torch.Tensor)
+        and isinstance(data_a_spec, DTensorSpec)
+        and isinstance(data_b_spec, DTensorSpec)
+    ):
+        return local_tensor_args
+
+    updated_args = list(local_tensor_args)
+    # _scaled_mm strategy is planned as mk,kn->mn: operand A contracts on dim 1
+    # and operand B_t contracts on dim 0.
+    updated_args[2] = _localize_blockwise_scaled_mm_scale(
+        scale_a,
+        data_a,
+        data_a_spec,
+        contracting_dim=1,
+        non_contracting_dim=0,
+    )
+    updated_args[3] = _localize_blockwise_scaled_mm_scale(
+        scale_b,
+        data_b,
+        data_b_spec,
+        contracting_dim=0,
+        non_contracting_dim=1,
+    )
+    return tuple(updated_args)
+
+
+def _current_op_schema_for_local_args(
+    op_call: torch._ops.OpOverload,
+    op_info: OpInfo,
+    output_sharding: OutputSharding,
+) -> OpSchema:
+    current_op_schema = output_sharding.redistribute_schema or op_info.schema
+    if current_op_schema is not None:
+        return current_op_schema
+
+    current_args_schema = (
+        pytree.tree_unflatten(
+            cast(list[object], op_info.flat_args_schema),
+            # pyrefly: ignore [bad-argument-type]
+            op_info.args_tree_spec,
+        )
+        if op_info.args_tree_spec
+        else tuple(op_info.flat_args_schema)
+    )
+    return OpSchema(op_call, current_args_schema, {})
+
+
+def _local_results_for_non_participating_rank(
+    op_call: torch._ops.OpOverload, spec: OutputSpecType
+) -> object:
+    ret_list = op_call._schema.returns
+    if spec is None:
+        return None
+
+    def default_tensor(default_spec: DTensorSpec) -> torch.Tensor:
+        if default_spec.tensor_meta is None:
+            raise RuntimeError(f"{default_spec} has no tensor metadata.")
+        shape = default_spec.tensor_meta.shape
+        dtype = default_spec.tensor_meta.dtype
+        if len(shape) == 0:
+            return torch.zeros((), dtype=dtype)
+        return torch.tensor([], dtype=dtype)
+
+    if isinstance(spec, DTensorSpec):
+        return default_tensor(spec)
+    if isinstance(spec, Sequence):
+        local_results = [default_tensor(s) if s is not None else None for s in spec]
+        if None in local_results:
+            ret_type = str(ret_list[0].type)
+            raise NotImplementedError(
+                f"return type {ret_type} in DTensor op is not supported"
+            )
+        return local_results
+    raise AssertionError(f"output spec type {type(spec)} is not supported")
 
 
 def _as_strided_permutation(
@@ -192,6 +401,75 @@ def found_inf_reduce_handler(
     target_tensor.copy_(found_inf)
 
 
+def scaled_mm_handler(
+    op_call: torch._ops.OpOverload,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> object:
+    # _scaled_mm must localize replicated flat blockwise scales before the
+    # local tensor call. The DTensor custom-op path is consulted ahead of the
+    # generic dispatcher fast path, so do the localization here rather than in
+    # the generic local-call slow path.
+    op_info = dtensor.DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+    dtensor.DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    output_sharding = op_info.output_sharding
+    if output_sharding is None:
+        raise AssertionError("output sharding should not be None")
+    debug_mode = get_active_debug_mode()
+    if debug_mode is not None and output_sharding.output_spec is not None:
+        debug_mode.record_output_placements(output_sharding.output_spec)
+    mesh = op_info.compute_mesh
+    if not mesh._is_current_rank_part_of_mesh():
+        local_results = _local_results_for_non_participating_rank(
+            op_call, output_sharding.output_spec
+        )
+        return dtensor.DTensor._op_dispatcher.wrap(
+            local_results, output_sharding.output_spec
+        )
+    if output_sharding.needs_redistribute:
+        if output_sharding.redistribute_schema is None:
+            raise AssertionError
+        with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+            output_sharding.output_spec
+        ):
+            dtensor.DTensor._op_dispatcher.redistribute_local_args(
+                op_info,
+                output_sharding.redistribute_schema,
+                output_sharding.use_val_from_redistribute_schema,
+            )
+
+    local_tensor_args = (
+        pytree.tree_unflatten(
+            cast(list[object], op_info.local_args),
+            op_info.args_tree_spec,  # type: ignore[arg-type]
+        )
+        if op_info.args_tree_spec
+        else op_info.local_args
+    )
+    local_tensor_args = cast(tuple[object, ...], local_tensor_args)
+    current_op_schema = _current_op_schema_for_local_args(
+        op_call, op_info, output_sharding
+    )
+    local_op_call = op_call
+    if (
+        output_sharding.needs_redistribute
+        and output_sharding.redistribute_schema is not None
+        and output_sharding.redistribute_schema.op != op_call
+    ):
+        local_op_call = output_sharding.redistribute_schema.op
+    else:
+        local_tensor_args = _maybe_localize_scaled_mm_blockwise_args(
+            local_tensor_args, current_op_schema
+        )
+    with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+        output_sharding.output_spec
+    ):
+        local_results = local_op_call(*local_tensor_args, **op_info.local_kwargs)
+    return dtensor.DTensor._op_dispatcher.wrap(
+        local_results, output_sharding.output_spec
+    )
+
+
 class OpDispatcher:
     """
     Op dispatching class instance to handle args/kwargs pre-processing (un-wrapping), sharding
@@ -233,6 +511,7 @@ class OpDispatcher:
             aten.as_strided.default: as_strided_handler,
             aten.argmin.default: argminmax_handler,
             aten.argmax.default: argminmax_handler,
+            aten._scaled_mm.default: scaled_mm_handler,
         }
 
     # ********************************************************************************************
@@ -482,42 +761,10 @@ class OpDispatcher:
             #   2. if the return type is Tensor or List[Tensor], return empty
             #   tensor(s) with correct dtype.
             spec = output_sharding.output_spec
-            ret_list = op_call._schema.returns
-
             if spec is None:
-                # For a scalar return type, the non-participating device has None
-                # as its local result
                 local_results = None
             else:
-
-                def default_tensor(spec: DTensorSpec) -> torch.Tensor:
-                    if spec.tensor_meta is not None:
-                        shape = spec.tensor_meta.shape
-                        dtype = spec.tensor_meta.dtype
-                        if len(shape) == 0:
-                            # scalar tensor
-                            return torch.zeros((), dtype=dtype)
-                        else:
-                            # non-scalar tensor
-                            return torch.tensor([], dtype=dtype)
-                    else:
-                        raise RuntimeError(f"{spec} has no tensor metadata.")
-
-                if isinstance(spec, DTensorSpec):
-                    # return a Tensor value
-                    local_results = default_tensor(spec)
-                elif isinstance(spec, Sequence):
-                    # return a List[Tensor] value
-                    local_results = [
-                        default_tensor(s) if s is not None else None for s in spec
-                    ]
-                    if not isinstance(local_results, list):
-                        raise AssertionError
-                    if None in local_results:
-                        ret_type = str(ret_list[0].type)
-                        raise NotImplementedError(
-                            f"return type {ret_type} in DTensor op is not supported"
-                        )
+                local_results = _local_results_for_non_participating_rank(op_call, spec)
         return local_results
 
     def _dispatch_fast_path_python_tail(

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -72,8 +72,9 @@ def _scaled_mm_scale_placement(
     1. Tensor-wise scale (single element): always Replicate.
     2. 2D (or higher) scale, e.g. row-wise [M,1]: copy data placement directly.
     3. 1D blockwise scale, e.g. MX format [M*K/block_size]: map
-       non-contracting shard to Shard(0)/_ShardingPlaceholder(0), and reject
-       contracting-dim shards (returns None).
+       non-contracting shard to Shard(0)/_ShardingPlaceholder(0), and keep
+       contracting-dim shards Replicate so the local executor can materialize
+       the K-local blocked payload.
     """
     if prod(scale_shape) == 1:
         return Replicate()
@@ -81,16 +82,17 @@ def _scaled_mm_scale_placement(
     if len(scale_shape) != 1:
         return data_placement
 
-    # 1D blockwise scale: Shard(>=1) is invalid on a 1D tensor, so we need
-    # to map the data operand's placement to a valid 1D placement.
+    # 1D blockwise scale: Shard(>=1) is invalid on a 1D tensor, so we keep
+    # contracting-dim sharding replicated at planning time and let dispatch
+    # localize the blocked payload per-rank before the local _scaled_mm call.
     if isinstance(data_placement, _ShardingPlaceholder):
         if data_placement.dim == contracting_dim:
-            return None
+            return Replicate()
         return _ShardingPlaceholder(0)
     # NOTE: isinstance(_, Shard) does not match _StridedShard; see _is_shard_like().
     elif isinstance(data_placement, Shard):
         if data_placement.dim == contracting_dim:
-            return None
+            return Replicate()
         return Shard(0)
     elif isinstance(data_placement, (Replicate, Partial)):
         return Replicate()


### PR DESCRIPTION
Fixes #191992 

Fixed DTensor `_scaled_mm` so rowwise MXFP8 linears with TP >= 2 keep the correct `Partial(sum)` output placement instead of incorrectly falling back to `Shard(...)`.
DTensor treated 1D blocked scales as unsupported when the data operand was sharded on the contracting K dimension, so the valid rowwise TP strategy candidate was dropped during sharding propagation.
A 1D blocked MX scale is a kernel-oriented packed/swizzled payload, not a natural DTensor sharding layout. Trying to represent contracting-dim K sharding directly in the flat payload is fragile and breaks down on mixed mesh cases.

Added a specialized DTensor _scaled_mm path, but only to handle per-rank blockscale localization that the generic dispatcher cannot currently do