### PR TITLE
Introduce hw_available_devices

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,10 +104,10 @@ def pytest_addoption(parser: Parser) -> None:
         help="filter tests by hardware classification categories (e.g., GENERIC ACCELERATOR CPU CUDA MPS XPU)",
     )
     parser.addoption(
-        "--hw-available-devices",
+        "--hw-required-devices",
         type=int,
         default=None,
-        dest="hw_available_devices",
+        dest="hw_required_devices",
         help="only run tests needing at most N devices",
     )
     shard_addoptions(parser)
@@ -133,7 +133,7 @@ class HardwareClassificationPytestPlugin:
             return
         import torch.testing._internal.common_utils as _cu
 
-        requirement = self.hw_classification if self.hw_classification is not None else set(_cu.HardwareClassification)
+        requirement = self.hw_classification or set(_cu.HardwareClassification)
         filtered = []
         _cu.filter_by_hw_classification(
             items,
@@ -171,7 +171,7 @@ def pytest_configure(config: Config) -> None:
     if config.getoption("num_shards"):
         config.pluginmanager.register(PytestShardPlugin(config), "pytestshardplugin")
     hw_cls = config.getoption("hw_classification")
-    hw_dev = config.getoption("hw_available_devices")
+    hw_dev = config.getoption("hw_required_devices")
     if hw_cls or hw_dev is not None:
         config.pluginmanager.register(
             HardwareClassificationPytestPlugin(hw_cls, hw_dev),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,14 +103,22 @@ def pytest_addoption(parser: Parser) -> None:
         type=str.upper,
         help="filter tests by hardware classification categories (e.g., GENERIC ACCELERATOR CPU CUDA MPS XPU)",
     )
+    parser.addoption(
+        "--hw-available-devices",
+        type=int,
+        default=None,
+        dest="hw_available_devices",
+        help="only run tests needing at most N devices",
+    )
     shard_addoptions(parser)
 
 
 class HardwareClassificationPytestPlugin:
-    """Pytest plugin to filter collected tests by hw_classification."""
+    """Pytest plugin to filter collected tests by hw_classification and device count."""
 
-    def __init__(self, hw_classification):
+    def __init__(self, hw_classification, device_count=None):
         self.hw_classification = self._resolve_hw_classification(hw_classification)
+        self.device_count = device_count
 
     @staticmethod
     def _resolve_hw_classification(hw_classification):
@@ -121,16 +129,18 @@ class HardwareClassificationPytestPlugin:
         return {HardwareClassification[name] for name in hw_classification}
 
     def pytest_collection_modifyitems(self, items):
-        if self.hw_classification is None:
+        if self.hw_classification is None and self.device_count is None:
             return
         import torch.testing._internal.common_utils as _cu
 
+        requirement = self.hw_classification if self.hw_classification is not None else set(_cu.HardwareClassification)
         filtered = []
         _cu.filter_by_hw_classification(
             items,
-            self.hw_classification,
+            requirement,
             get_class=lambda item: getattr(item, "cls", None),
             on_match=filtered.append,
+            device_count=self.device_count,
         )
         items[:] = filtered
 
@@ -160,9 +170,11 @@ def pytest_configure(config: Config) -> None:
         config.pluginmanager.register(StepcurrentPlugin(config), "stepcurrentplugin")
     if config.getoption("num_shards"):
         config.pluginmanager.register(PytestShardPlugin(config), "pytestshardplugin")
-    if config.getoption("hw_classification"):
+    hw_cls = config.getoption("hw_classification")
+    hw_dev = config.getoption("hw_available_devices")
+    if hw_cls or hw_dev is not None:
         config.pluginmanager.register(
-            HardwareClassificationPytestPlugin(config.getoption("hw_classification")),
+            HardwareClassificationPytestPlugin(hw_cls, hw_dev),
             "hw_classification_plugin",
         )
 

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -29,6 +29,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda,
@@ -50,6 +51,8 @@ from torch.utils._triton import has_triton_package
 
 
 class TestDebugModeLogSerialization(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_hashed_debug_mode(self, x):
         with DebugMode() as debug_mode, DebugMode.log_tensor_hashes(hash_inputs=True):
             x.sin().sum()
@@ -204,6 +207,8 @@ class TestDebugModeLogSerialization(TestCase):
 
 @requires_cuda
 class TestDTensorDebugMode(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -1295,6 +1300,8 @@ class TestDTensorDebugMode(TestCase):
 class TestDebugModeUtils(TestCase):
     """Test DebugMode with NCCL backend without using DTensor."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_hash_empty_tensor(self):
         t = torch.tensor([])
         # hash tensor fn should not error out with empty tensor
@@ -1305,6 +1312,9 @@ class TestDebugModeUtils(TestCase):
 
 
 class TestDTensorDebugModeNCCLBackend(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+    hw_available_devices = 2
+
     @property
     def world_size(self):
         return 2  # Need at least 2 ranks for collectives

--- a/test/distributed/tensor/debug/test_debug_mode.py
+++ b/test/distributed/tensor/debug/test_debug_mode.py
@@ -1313,7 +1313,7 @@ class TestDebugModeUtils(TestCase):
 
 class TestDTensorDebugModeNCCLBackend(MultiProcessTestCase):
     hw_classification = HardwareClassification.CUDA
-    hw_available_devices = 2
+    hw_required_devices = 2
 
     @property
     def world_size(self):

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -35,11 +35,18 @@ from torch.distributed.tensor._ops.strategy_validation import (
 )
 from torch.distributed.tensor.placement_types import Partial, Shard
 from torch.testing._internal.common_methods_invocations import SampleInput
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_SLOW, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_SLOW,
+    TestCase,
+)
 
 
 class TestPlacementUtilities(TestCase):
     """Test placement utility functions."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_parse_placement_replicate(self):
         p = parse_placement("R")
@@ -73,6 +80,8 @@ class TestPlacementUtilities(TestCase):
 
 class TestPlacementNormalization(TestCase):
     """Test placement normalization for trivial shard deduplication."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_is_trivial_shard_size_1(self):
         """Shard on size-1 dimension is trivial."""
@@ -214,6 +223,8 @@ class TestPlacementNormalization(TestCase):
 class TestInputPlacements(TestCase):
     """Test input/output placement generation."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_1d_input_placements(self):
         t = torch.randn(4, 3)
         placements = get_1d_input_placements_for_tensor(t, include_partial=False)
@@ -293,6 +304,8 @@ class TestInputPlacements(TestCase):
 class TestExtractTensors(TestCase):
     """Test tensor extraction from samples."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_extract_single_input(self):
         sample = SampleInput(torch.randn(4, 3))
         tensors = extract_tensors_from_sample(sample)
@@ -319,6 +332,8 @@ class TestExtractTensors(TestCase):
 
 class TestValidateCombination(TestCase):
     """Test the core validate_combination function."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     world_size = 2
 
@@ -606,6 +621,8 @@ class TestValidateCombination(TestCase):
 class TestCreatePartialInput(TestCase):
     """Test the _create_partial_input helper."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_partial_sum_reduces_correctly(self):
         tensor = torch.randn(4, 3)
         local_tensor = _create_partial_input(tensor, Partial("sum"), world_size=2)
@@ -779,6 +796,8 @@ class TestPartialCombinationValidity(TestCase):
     (e.g., using symmetric splits or ignoring tensor_idx).
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -925,6 +944,8 @@ class TestPartialCombinationValidity(TestCase):
 class TestDecompStrategyPath(TestCase):
     """Test that decomposition-based strategy propagation discovers rules."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -1053,6 +1074,8 @@ class TestDecompStrategyPath(TestCase):
 class TestQuerySingleDimStrategyKwargs(TestCase):
     """Test that query_single_dim_strategy forwards kwargs to strategy functions."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_kwargs_forwarded_to_strategy(self):
         """
         A kwargs-aware strategy should receive the actual kwargs, not {}.
@@ -1116,6 +1139,8 @@ class TestQuerySingleDimStrategyKwargs(TestCase):
 
 class TestCompareRules(TestCase):
     """Test _compare_rules populates per-op statistics correctly."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_true_positives_tracked_by_op(self):
         from torch.distributed.tensor._ops.strategy_validation import (
@@ -1217,6 +1242,8 @@ class TestCompareRules(TestCase):
 
 class TestCompareOperatorEndToEnd(TestCase):
     """End-to-end smoke test for compare_operator."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     world_size = 2
 
@@ -1323,6 +1350,8 @@ class TestCompareOperatorEndToEnd(TestCase):
 class TestAtenLevelValidation(TestCase):
     """Tests for aten-level validation (validate_aten_combination + allow_composite mode)."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -1427,6 +1456,8 @@ class TestAtenLevelValidation(TestCase):
 class TestMainModule(TestCase):
     """Test that strategy_validation can be run as a main module."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_module(self, *extra_args):
         import subprocess
         import sys
@@ -1466,6 +1497,8 @@ class TestMainModule(TestCase):
 
 class TestOpInfoLookup(TestCase):
     """Tests for get_opinfo_by_name, _find_opinfo_candidates, and resolve_op_names."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_opinfo_by_name_exact(self):
         results = get_opinfo_by_name("add")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -178,7 +178,7 @@ TEST_SAVE_XML = ""
 UNITTEST_ARGS : list[str] = []
 USE_PYTEST = False
 HW_CLASSIFICATION : set[HardwareClassification] | None = None
-HW_AVAILABLE_DEVICES: int | None = None
+HW_REQUIRED_DEVICES: int | None = None
 
 
 def get_hw_classification(
@@ -197,14 +197,14 @@ def get_hw_classification(
     return requirement
 
 
-def get_hw_available_devices(
+def get_hw_required_devices(
     test_case_cls: type[unittest.TestCase],
 ) -> int:
-    value = getattr(test_case_cls, "hw_available_devices", 1)
+    value = getattr(test_case_cls, "hw_required_devices", 1)
     if not isinstance(value, int):
         raise TypeError(
             f"{test_case_cls.__module__}.{test_case_cls.__name__}."
-            "hw_available_devices must be an int"
+            "hw_required_devices must be an int"
         )
     return value
 
@@ -221,7 +221,7 @@ def filter_by_hw_classification(
 
     For each item, `get_class` extracts the associated test class. Items whose
     hardware classification is in `requirement` (and whose
-    ``hw_available_devices`` does not exceed `device_count`, when set) are
+    ``hw_required_devices`` does not exceed `device_count`, when set) are
     passed to `on_match`. Prints a summary of matched, mismatched,
     unclassified, and classless items.
     """
@@ -239,7 +239,7 @@ def filter_by_hw_classification(
         if classification is None:
             unclassified += 1
         elif classification in requirement:
-            if device_count is not None and get_hw_available_devices(cls) > device_count:
+            if device_count is not None and get_hw_required_devices(cls) > device_count:
                 pass
             else:
                 passed += 1
@@ -1133,7 +1133,7 @@ def parse_cmd_line_args():
     global UNITTEST_ARGS
     global USE_PYTEST
     global HW_CLASSIFICATION
-    global HW_AVAILABLE_DEVICES
+    global HW_REQUIRED_DEVICES
 
     is_running_via_run_test = "run_test.py" in getattr(__main__, "__file__", "")
     parser = argparse.ArgumentParser(add_help=not is_running_via_run_test, allow_abbrev=False)
@@ -1156,7 +1156,7 @@ def parse_cmd_line_args():
     parser.add_argument('--pytest-single-test', type=str, nargs=1)
     parser.add_argument('--showlocals', action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument('--hw-classification', nargs='+', choices=[e.name for e in HardwareClassification], type=str.upper, default=None)
-    parser.add_argument('--hw-available-devices', type=int, default=None, help='only run tests needing at most N devices')
+    parser.add_argument('--hw-required-devices', type=int, default=None, help='only run tests needing at most N devices')
 
 # Only run when -h or --help flag is active to display both unittest and parser help messages.
     def run_unittest_help(argv):
@@ -1197,7 +1197,7 @@ def parse_cmd_line_args():
         if args.hw_classification is not None
         else None
     )
-    HW_AVAILABLE_DEVICES = args.hw_available_devices
+    HW_REQUIRED_DEVICES = args.hw_required_devices
     if not getattr(expecttest, "ACCEPT", False):
         expecttest.ACCEPT = args.accept
     UNITTEST_ARGS = [sys.argv[0]] + remaining
@@ -1436,7 +1436,7 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
 
         filtered_suite = unittest.TestSuite()
         _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
-        requirement = self.hw_classification if self.hw_classification is not None else set(HardwareClassification)
+        requirement = self.hw_classification or set(HardwareClassification)
         filter_by_hw_classification(
             _iter(tests),
             requirement,
@@ -1499,8 +1499,8 @@ def run_tests(argv=None):
         sys.exit(1)
 
     testLoader = unittest.loader.defaultTestLoader
-    if HW_CLASSIFICATION is not None or HW_AVAILABLE_DEVICES is not None:
-        testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION, HW_AVAILABLE_DEVICES)
+    if HW_CLASSIFICATION is not None or HW_REQUIRED_DEVICES is not None:
+        testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION, HW_REQUIRED_DEVICES)
 
     if SHOWLOCALS:
         argv = [
@@ -1524,8 +1524,8 @@ def run_tests(argv=None):
             other_args += ['--save-xml', TEST_SAVE_XML]
         if HW_CLASSIFICATION is not None:
             other_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
-        if HW_AVAILABLE_DEVICES is not None:
-            other_args += ['--hw-available-devices', str(HW_AVAILABLE_DEVICES)]
+        if HW_REQUIRED_DEVICES is not None:
+            other_args += ['--hw-required-devices', str(HW_REQUIRED_DEVICES)]
 
         test_cases = (
             get_pytest_test_cases(argv) if USE_PYTEST else
@@ -1582,8 +1582,8 @@ def run_tests(argv=None):
         pytest_args = argv + ["--use-main-module"]
         if HW_CLASSIFICATION is not None:
             pytest_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
-        if HW_AVAILABLE_DEVICES is not None:
-            pytest_args += ['--hw-available-devices', str(HW_AVAILABLE_DEVICES)]
+        if HW_REQUIRED_DEVICES is not None:
+            pytest_args += ['--hw-required-devices', str(HW_REQUIRED_DEVICES)]
         test_report_path = ""
         if TEST_SAVE_XML:
             test_report_path = get_report_path(pytest=True)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -178,6 +178,7 @@ TEST_SAVE_XML = ""
 UNITTEST_ARGS : list[str] = []
 USE_PYTEST = False
 HW_CLASSIFICATION : set[HardwareClassification] | None = None
+HW_AVAILABLE_DEVICES: int | None = None
 
 
 def get_hw_classification(
@@ -196,19 +197,33 @@ def get_hw_classification(
     return requirement
 
 
+def get_hw_available_devices(
+    test_case_cls: type[unittest.TestCase],
+) -> int:
+    value = getattr(test_case_cls, "hw_available_devices", 1)
+    if not isinstance(value, int):
+        raise TypeError(
+            f"{test_case_cls.__module__}.{test_case_cls.__name__}."
+            "hw_available_devices must be an int"
+        )
+    return value
+
+
 def filter_by_hw_classification(
     items: Iterable[Any],
     requirement: set[HardwareClassification],
     get_class: Callable[[Any], type | None],
     *,
     on_match: Callable[[Any], None],
+    device_count: int | None = None,
 ) -> None:
-    """Filter items by hardware classification and print a summary.
+    """Filter items by hardware classification and device count, print a summary.
 
     For each item, `get_class` extracts the associated test class. Items whose
-    hardware classification is in `requirement` are passed to `on_match`, if
-    provided. Prints a summary of matched, mismatched, unclassified, and
-    classless items.
+    hardware classification is in `requirement` (and whose
+    ``hw_available_devices`` does not exceed `device_count`, when set) are
+    passed to `on_match`. Prints a summary of matched, mismatched,
+    unclassified, and classless items.
     """
     total = 0
     passed = 0
@@ -224,8 +239,11 @@ def filter_by_hw_classification(
         if classification is None:
             unclassified += 1
         elif classification in requirement:
-            passed += 1
-            on_match(item)
+            if device_count is not None and get_hw_available_devices(cls) > device_count:
+                pass
+            else:
+                passed += 1
+                on_match(item)
 
     mismatched = total - passed - unclassified - no_class
     parts = [
@@ -1115,6 +1133,7 @@ def parse_cmd_line_args():
     global UNITTEST_ARGS
     global USE_PYTEST
     global HW_CLASSIFICATION
+    global HW_AVAILABLE_DEVICES
 
     is_running_via_run_test = "run_test.py" in getattr(__main__, "__file__", "")
     parser = argparse.ArgumentParser(add_help=not is_running_via_run_test, allow_abbrev=False)
@@ -1137,6 +1156,7 @@ def parse_cmd_line_args():
     parser.add_argument('--pytest-single-test', type=str, nargs=1)
     parser.add_argument('--showlocals', action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument('--hw-classification', nargs='+', choices=[e.name for e in HardwareClassification], type=str.upper, default=None)
+    parser.add_argument('--hw-available-devices', type=int, default=None, help='only run tests needing at most N devices')
 
 # Only run when -h or --help flag is active to display both unittest and parser help messages.
     def run_unittest_help(argv):
@@ -1177,6 +1197,7 @@ def parse_cmd_line_args():
         if args.hw_classification is not None
         else None
     )
+    HW_AVAILABLE_DEVICES = args.hw_available_devices
     if not getattr(expecttest, "ACCEPT", False):
         expecttest.ACCEPT = args.accept
     UNITTEST_ARGS = [sys.argv[0]] + remaining
@@ -1392,9 +1413,10 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
 
 class HardwareClassificationTestLoader(unittest.TestLoader):
     """Unittest TestLoader that filters loaded tests by hw_classification."""
-    def __init__(self, hw_classification):
+    def __init__(self, hw_classification, device_count=None):
         super().__init__()
         self.hw_classification = hw_classification
+        self.device_count = device_count
 
     @staticmethod
     def iter_test_cases_recursively(
@@ -1409,16 +1431,18 @@ class HardwareClassificationTestLoader(unittest.TestLoader):
             yield from _iter(element)
 
     def get_filtered_suite(self, tests: unittest.TestSuite) -> unittest.TestSuite:
-        if self.hw_classification is None:
+        if self.hw_classification is None and self.device_count is None:
             return tests
 
         filtered_suite = unittest.TestSuite()
         _iter = HardwareClassificationTestLoader.iter_test_cases_recursively
+        requirement = self.hw_classification if self.hw_classification is not None else set(HardwareClassification)
         filter_by_hw_classification(
             _iter(tests),
-            self.hw_classification,
+            requirement,
             get_class=lambda tc: tc.__class__,
             on_match=filtered_suite.addTest,
+            device_count=self.device_count,
         )
         return filtered_suite
 
@@ -1475,8 +1499,8 @@ def run_tests(argv=None):
         sys.exit(1)
 
     testLoader = unittest.loader.defaultTestLoader
-    if HW_CLASSIFICATION is not None:
-        testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION)
+    if HW_CLASSIFICATION is not None or HW_AVAILABLE_DEVICES is not None:
+        testLoader = HardwareClassificationTestLoader(HW_CLASSIFICATION, HW_AVAILABLE_DEVICES)
 
     if SHOWLOCALS:
         argv = [
@@ -1500,6 +1524,8 @@ def run_tests(argv=None):
             other_args += ['--save-xml', TEST_SAVE_XML]
         if HW_CLASSIFICATION is not None:
             other_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
+        if HW_AVAILABLE_DEVICES is not None:
+            other_args += ['--hw-available-devices', str(HW_AVAILABLE_DEVICES)]
 
         test_cases = (
             get_pytest_test_cases(argv) if USE_PYTEST else
@@ -1556,6 +1582,8 @@ def run_tests(argv=None):
         pytest_args = argv + ["--use-main-module"]
         if HW_CLASSIFICATION is not None:
             pytest_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
+        if HW_AVAILABLE_DEVICES is not None:
+            pytest_args += ['--hw-available-devices', str(HW_AVAILABLE_DEVICES)]
         test_report_path = ""
         if TEST_SAVE_XML:
             test_report_path = get_report_path(pytest=True)


### PR DESCRIPTION
This PR introduces the two-axis test classification approach proposed in PR #190082: hw_classification (device type) + hw_available_devices (device count). The hw_available_devices attribute is an integer that declares how many devices a test class requires. Classes that don't set it default to 1 (single device). When --hw-available-devices N is passed, only tests needing at most N devices are executed