### PR TITLE
Make gradcheck precision defaults overridable in test harness

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5746,6 +5746,15 @@ class BytesIOContext(io.BytesIO):
 # For more information see https://github.com/pytorch/pytorch/issues/56202
 GRADCHECK_NONDET_TOL = 1e-12
 
+# Default gradcheck parameters — these match the values already used by
+# torch.autograd.gradcheck (see torch/autograd/gradcheck.py).
+# Extracting them as constants lets privateuse1 backends override them
+# with dtype-appropriate values (e.g. wider tolerances for float32-only
+# hardware) in their test overlay.
+GRADCHECK_DEFAULT_EPS = 1e-6
+GRADCHECK_DEFAULT_ATOL = 1e-5
+GRADCHECK_DEFAULT_RTOL = 1e-3
+
 TEST_WITH_SLOW_GRADCHECK: bool = TestEnvironment.def_flag(
     "TEST_WITH_SLOW_GRADCHECK",
     env_var="PYTORCH_TEST_WITH_SLOW_GRADCHECK",
@@ -5767,6 +5776,9 @@ def gradcheck(fn, inputs, **kwargs):
     default_values = {
         "check_batched_grad": True,
         "fast_mode": True,
+        "eps": GRADCHECK_DEFAULT_EPS,
+        "atol": GRADCHECK_DEFAULT_ATOL,
+        "rtol": GRADCHECK_DEFAULT_RTOL,
     }
 
     if TEST_WITH_SLOW_GRADCHECK:
@@ -5787,6 +5799,9 @@ def gradgradcheck(fn, inputs, grad_outputs=None, **kwargs):
     default_values = {
         "check_batched_grad": True,
         "fast_mode": True,
+        "eps": GRADCHECK_DEFAULT_EPS,
+        "atol": GRADCHECK_DEFAULT_ATOL,
+        "rtol": GRADCHECK_DEFAULT_RTOL,
     }
 
     if TEST_WITH_SLOW_GRADCHECK:


### PR DESCRIPTION
## Summary

`torch.testing._internal.common_utils.gradcheck` / `gradgradcheck` are the wrappers all PyTorch tests are expected to use instead of calling `torch.autograd.gradcheck` directly. Today they only inject `check_batched_grad` and `fast_mode` defaults and let `eps`/`atol`/`rtol` fall through to the `torch.autograd.gradcheck` signature defaults, so there is no single place a backend can adjust them.

This PR extracts those three values into module-level constants and injects them through the existing `default_values` mechanism:

```python
GRADCHECK_DEFAULT_EPS  = 1e-6
GRADCHECK_DEFAULT_ATOL = 1e-5
GRADCHECK_DEFAULT_RTOL = 1e-3
```

The constants are **identical** to the current `torch.autograd.gradcheck` / `gradgradcheck` signature defaults (`torch/autograd/gradcheck.py`), so this is a **no-op for every existing test**. Explicit keyword arguments still win, since `default_values` only fills in keys that are absent or `None`.

## Motivation

The motivation is out-of-tree backends. Finite-difference gradcheck assumes float64: with `eps=1e-6`, the float32 subtraction in the numerical Jacobian loses roughly the same order of magnitude it is trying to measure, so the noise floor lands far above `atol=1e-5`. Backends whose hardware has no native float64 therefore need wider, dtype-appropriate values. Having them as named constants lets a `privateuse1` test overlay retune gradcheck globally by rebinding three names, instead of patching every call site.

## Test plan

- No behavioral change for in-tree tests: the injected values equal the existing `torch.autograd.gradcheck` defaults, so any test that relied on the defaults is unaffected.
- Tests that pass explicit `eps`/`atol`/`rtol` continue to override, because `default_values` only fills keys that are unset or `None`.
