### PR TITLE
[TEST] Refactored test_execution_trace.py to have hw_classification

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_device_type import (
     skipCPUIf,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     run_tests,
     skipIfHpu,
@@ -57,7 +58,73 @@ except ImportError:
 Json = dict[str, Any]
 
 
+class TestExecutionTraceGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def get_execution_trace_root(self, output_file_name) -> Json:
+        import gzip
+
+        nodes = []
+        with (
+            gzip.open(output_file_name)
+            if output_file_name.endswith(".gz")
+            else open(output_file_name)
+        ) as f:
+            et_graph = json.load(f)
+            if "nodes" not in et_graph:
+                raise AssertionError(f"Expected 'nodes' in execution trace: {et_graph}")
+            nodes = et_graph["nodes"]
+        return nodes
+
+    def test_execution_trace_no_capture(self):
+        with TemporaryFileName("w+t", suffix=".et.json") as file_name:
+            et = ExecutionTraceObserver().register_callback(file_name)
+
+            if file_name != et.get_output_file_path():
+                raise AssertionError(
+                    f"Expected output file path {file_name}, got {et.get_output_file_path()}"
+                )
+            et.unregister_callback()
+            nodes = self.get_execution_trace_root(file_name)
+            found_root_node = False
+            for n in nodes:
+                if "name" not in n:
+                    raise AssertionError(f"Expected node to have 'name': {n}")
+                if "[pytorch|profiler|execution_trace|process]" in n["name"]:
+                    found_root_node = True
+            if not found_root_node:
+                raise AssertionError("Expected to find root node")
+
+    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/124500")
+    def test_execution_trace_nested_tensor(self):
+        def fn(nt):
+            return nt.sin().cos()
+
+        with tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False) as fp:
+            observer = ExecutionTraceObserver().register_callback(fp.name)
+            filename = fp.name
+        with torch.profiler.profile(execution_trace_observer=observer):
+            for i in range(3):
+                values = torch.rand((8 + i, 4 + i))
+                offsets = torch.tensor([0, 2, 4, 6, 8 + i])
+                nt = torch.nested.nested_tensor_from_jagged(values, offsets)
+                fn(nt)
+
+        nodes = self.get_execution_trace_root(filename)
+        os.remove(filename)
+        found_cos = False
+        for n in nodes:
+            if "name" not in n:
+                raise AssertionError(f"Expected node to have 'name': {n}")
+            if "cos" in n["name"]:
+                found_cos = True
+        if not found_cos:
+            raise AssertionError("Expected to find cos node")
+
+
 class TestExecutionTrace(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def payload(self, device, use_device=False):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with record_function("## TEST 1 ##", "1, 2, 3"):
@@ -701,51 +768,6 @@ class TestExecutionTrace(TestCase):
             raise AssertionError(
                 f"Expected {expected_loop_events} loop events, got {event_count}"
             )
-
-    def test_execution_trace_no_capture(self):
-        with TemporaryFileName("w+t", suffix=".et.json") as file_name:
-            et = ExecutionTraceObserver().register_callback(file_name)
-
-            if file_name != et.get_output_file_path():
-                raise AssertionError(
-                    f"Expected output file path {file_name}, got {et.get_output_file_path()}"
-                )
-            et.unregister_callback()
-            nodes = self.get_execution_trace_root(file_name)
-            found_root_node = False
-            for n in nodes:
-                if "name" not in n:
-                    raise AssertionError(f"Expected node to have 'name': {n}")
-                if "[pytorch|profiler|execution_trace|process]" in n["name"]:
-                    found_root_node = True
-            if not found_root_node:
-                raise AssertionError("Expected to find root node")
-
-    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/124500")
-    def test_execution_trace_nested_tensor(self):
-        def fn(nt):
-            return nt.sin().cos()
-
-        with tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False) as fp:
-            observer = ExecutionTraceObserver().register_callback(fp.name)
-            filename = fp.name
-        with torch.profiler.profile(execution_trace_observer=observer):
-            for i in range(3):
-                values = torch.rand((8 + i, 4 + i))
-                offsets = torch.tensor([0, 2, 4, 6, 8 + i])
-                nt = torch.nested.nested_tensor_from_jagged(values, offsets)
-                fn(nt)
-
-        nodes = self.get_execution_trace_root(filename)
-        os.remove(filename)
-        found_cos = False
-        for n in nodes:
-            if "name" not in n:
-                raise AssertionError(f"Expected node to have 'name': {n}")
-            if "cos" in n["name"]:
-                found_cos = True
-        if not found_cos:
-            raise AssertionError("Expected to find cos node")
 
     @skipCPUIf(True, "accelerator required for integral tensor range profiling")
     @patch.dict(


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Split TestExecutionTrace into TestExecutionTrace (hw_classification = GENERIC, 2 tests) + TestExecutionTraceDevice (hw_classification = ACCELERATOR, 11 tests)
- Moved `test_execution_trace_no_capture` and `test_execution_trace_nested_tensor` to TestExecutionTrace (pure CPU logic, no device parameter)
- Kept `instantiate_device_type_tests(TestExecutionTraceDevice, globals(), allow_xpu=True)` for the ACCELERATOR class

## Test Plan
```bash
python test/profiler/test_execution_trace.py -v
Ran 24 tests in 4.519s
OK (skipped=7)

python test/profiler/test_execution_trace.py -v --hw-classification GENERIC
Ran 2 tests in 0.067s
OK

python test/profiler/test_execution_trace.py -v --hw-classification ACCELERATOR
Ran 22 tests in 3.454s
OK (skipped=7)
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
