### PR TITLE
Back out "Hot-load Triton bundles from cache artifacts (#184953)"

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -61,7 +61,7 @@ from torch._inductor.graph import GraphLowering
 from torch._inductor.mock_cache import global_stats, PatchCaches, Stats
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.utils import clear_caches, fresh_cache, GPU_KERNEL_BIN_EXTS
+from torch._inductor.utils import clear_caches, fresh_cache
 from torch._library import capture_triton
 from torch._subclasses import FakeTensorMode
 from torch.compiler._cache import (
@@ -530,17 +530,6 @@ class TestFxGraphCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
-
-    def _find_triton_kernel_binaries(self):
-        found = []
-        triton_dir = os.path.join(cache_dir(), "triton")
-        device_type = "hip" if torch.version.hip else "cuda"
-        binary_ext = GPU_KERNEL_BIN_EXTS[device_type]
-        for dirpath, _, filenames in os.walk(triton_dir):
-            for filename in filenames:
-                if filename.endswith(binary_ext):
-                    found.append(os.path.join(dirpath, filename))
-        return found
 
     def _check_cpu_thread_count_cache_key_no_input(self, return_expr):
         script = textwrap.dedent(
@@ -1031,55 +1020,6 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
-
-    @requires_cuda_and_triton
-    @config.patch(
-        {
-            "fx_graph_cache": True,
-            "fx_graph_remote_cache": False,
-            "bundle_triton_into_fx_graph_cache": True,
-            "triton.store_cubin": True,
-            "compile_threads": 1,
-        }
-    )
-    def test_cache_artifact_load_emits_triton_bundle(self):
-        def fn(x, y):
-            return (x.sin() + y.cos()).relu()
-
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            mock.patch.dict(
-                os.environ,
-                {
-                    "TORCHINDUCTOR_CACHE_DIR": tmpdir,
-                    "TRITON_CACHE_DIR": os.path.join(tmpdir, "triton"),
-                },
-            ),
-        ):
-            self.reset()
-            CacheArtifactManager.clear()
-
-            x = torch.randn(256, 256, device="cuda")
-            y = torch.randn(256, 256, device="cuda")
-            compiled_fn = torch.compile(fn, dynamic=False)
-
-            self.assertEqual(fn(x, y), compiled_fn(x, y))
-            torch.cuda.synchronize()
-
-            artifacts = torch.compiler.save_cache_artifacts()
-            self.assertIsNotNone(artifacts)
-            artifact_bytes, _ = artifacts
-
-            self.assertGreater(len(self._find_triton_kernel_binaries()), 0)
-
-            self.reset()
-            CacheArtifactManager.clear()
-            shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
-
-            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
-
-            self.assertIsNotNone(cache_info)
-            self.assertGreater(len(self._find_triton_kernel_binaries()), 0)
 
     @requires_triton()
     @config.patch(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1982,7 +1982,6 @@ class InductorCacheArtifact(CacheArtifact):
     @override
     def populate_cache(self) -> None:
         FxGraphCache._write_to_local_cache(self.key, self.content)
-        FxGraphCache._emit_triton_bundle(self.content)
 
     @override
     @staticmethod
@@ -2263,15 +2262,6 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         # iterating over all entries in the parent subdir.
         path = os.path.join(subdir, sha256_hash(content))
         write_atomic(path, content, make_dirs=True)
-
-    @staticmethod
-    def _emit_triton_bundle(content: bytes) -> None:
-        if not TritonBundler.is_enabled():
-            return
-
-        graph = pickle.loads(content)
-        if bundle := graph._triton_bundle:
-            TritonBundler.read_and_emit(bundle)
 
     @staticmethod
     def _save_graph(


### PR DESCRIPTION
#184953 (01426c69) made a process-global dict and a shared cache directory
reachable from a second thread, causing repeated internal SIGSEGVs, most
recently S686093. Backing out while we build confidence in the forward fix.

The PR added FxGraphCache._emit_triton_bundle() and called it from
InductorCacheArtifact.populate_cache(), which runs under
torch.compiler.load_cache_artifacts() -- invoked by APF from
PytorchController.__init__ on the non-blocking "pt2_mega_cache" daemon thread.
Before the PR, TritonBundler.read_and_emit had exactly one caller,
cache_hit_post_compile, on the compile thread. After it, two threads reach it.

That exposed two races:

1. CompiledTritonKernels._cache -- load_autotuners() writes it from the loader
   thread while the compile thread's cache_clear() rebinds it. Rebinding drops
   the old dict, so dict_dealloc runs the values' finalizers re-entrantly while
   the loader is still mutating it: heap corruption surfacing as a SIGSEGV
   somewhere unrelated. The crash faulted in PyObject_SetItem on one job
   attempt and dict_dealloc on the other. No CUDA is required -- any value with
   a Python-level __del__ suffices, and the race reproduces in about thirty
   lines of pure CPython on both 3.10 and 3.12.

2. The Triton cache directory -- read_and_emit checks the target is empty and
   then os.replace()s a temp dir onto it, unlocked on POSIX, despite a
   docstring stating it assumes exclusive access to that directory. Usually the
   replace fails ENOTEMPTY and is skipped (leaking the temp dir); if the target
   exists and is empty at replace time the swap succeeds and can discard a
   freshly compiled cubin.

The unlocked accesses predate the PR, but single-threaded unlocked access is
not a race. A file-scoped blame misses this because the change is a new caller
in codecache.py rather than a change to the racing code, which is why the
initial RCA concluded the race was "structural/old". The timeline agrees:
#184953 landed May 27 and the first segfault was June 9, on entitlements
already in the cold-megacache allowlist -- predating the June 10 fleetwide
JustKnobs flip that was originally suspected, which amplified rather than
caused it.

D114901960 fixes (1) with a dedicated lock on every CompiledTritonKernels
accessor and is verified against the crash, but does not address (2). Backing
out closes both and restores the pre-May-27 single-threaded access pattern,
which ran clean for over a year. We want soak time on D114901960 before
depending on it, since it touches a path every torch.compile user hits.

What this gives up: Triton bundles are no longer emitted at megacache populate
time, reverting to emission on the first FX graph cache hit -- the lazy
behavior reported in #172542. Production loads and then compiles, so the cubins
still land; only load-only workflows that inspect Triton artifacts without
compiling regress.

Path forward: re-land on top of D114901960 once it has soaked, with a guard
added for (2).

Test Plan:
Revert-only; no new code. The test added by #184953,
test_cache_artifact_load_emits_triton_bundle, is removed with it.

python test/inductor/test_codecache.py -k test_cache_hot_load
python test/inductor/test_codecache.py -k "bundle or triton_bundler"


Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192368



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo