### PR TITLE
Preserving stack trace frames for helper methods

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -14708,6 +14708,27 @@ graph():
         trace_x = [node for node in graph.nodes if node.name == "x"][0].stack_trace
         self.assertTrue(re.search(r"proxy.py.*in create_node\n", trace_x))
 
+    def test_stack_trace_nonstrict_preserves_helper_frames(self):
+        # Non-strict export should keep frames from helper methods a
+        # forward() delegates to, not just literal "forward" frames.
+        class Foo(torch.nn.Module):
+            def forward_impl(self, x, y):
+                return (x + y).relu()
+
+            def forward(self, x, y):
+                return self.forward_impl(x, y)
+
+        ep = torch.export.export(
+            Foo(), (torch.randn(3, 4), torch.randn(3, 4)), strict=False
+        )
+        trace_relu = [node for node in ep.graph.nodes if node.name == "relu"][
+            0
+        ].meta.get("stack_trace", "")
+        self.assertTrue(re.search(r"in forward\n.*forward_impl", trace_relu))
+        self.assertTrue(
+            re.search(r"in forward_impl\n.*\(x \+ y\)\.relu\(\)", trace_relu)
+        )
+
     @testing.expectedFailureSerDerNonStrict  # register_constant needs to handle serialization
     @testing.expectedFailureSerDer  # register_constant needs to handle serialization
     def test_opaque_obj(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -14708,6 +14708,29 @@ graph():
         trace_x = [node for node in graph.nodes if node.name == "x"][0].stack_trace
         self.assertTrue(re.search(r"proxy.py.*in create_node\n", trace_x))
 
+    def test_stack_trace_nonstrict_preserves_helper_frames(self):
+        # Non-strict export should keep frames from helper methods a
+        # forward() delegates to, not just literal "forward" frames.
+        class Foo(torch.nn.Module):
+            def forward_impl(self, x, y):
+                return (x + y).relu()
+
+            def forward(self, x, y):
+                return self.forward_impl(x, y)
+
+        ep = torch.export.export(
+            Foo(), (torch.randn(3, 4), torch.randn(3, 4)), strict=False
+        )
+        trace_relu = [
+            node
+            for node in ep.graph.nodes
+            if node.op == "call_function" and node.target is torch.ops.aten.relu.default
+        ][0].meta.get("stack_trace", "")
+        self.assertTrue(re.search(r"in forward\n.*forward_impl", trace_relu))
+        self.assertTrue(
+            re.search(r"in forward_impl\n.*\(x \+ y\)\.relu\(\)", trace_relu)
+        )
+
     @testing.expectedFailureSerDerNonStrict  # register_constant needs to handle serialization
     @testing.expectedFailureSerDer  # register_constant needs to handle serialization
     def test_opaque_obj(self):

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -5,6 +5,7 @@ import enum
 import inspect
 import logging
 import operator
+import os
 import sys
 import traceback
 import types
@@ -300,15 +301,20 @@ class TracerBase:
         # for the recorded stack trace
         user_frames: list[traceback.FrameSummary] = []
         if self._record_forward_stack_traces_only:
-            user_frames = [
-                frame
-                for frame in user_stack_summary
+            torch_dir = os.path.dirname(torch.__file__) + os.sep
+            for i, frame in enumerate(user_stack_summary):
+                if frame.filename.startswith(torch_dir):
+                    continue
                 if (
                     frame.name == "forward"
-                    or frame.filename.endswith("torch/__init__.py")
                     or (frame.filename, frame.name) in _STACK_TRACE_ANCHORS
-                )
-            ]
+                ):
+                    user_frames = [
+                        f
+                        for f in user_stack_summary[i:]
+                        if not f.filename.startswith(torch_dir)
+                    ]
+                    break
         else:
             first_forward = -1
             for i, frame in enumerate(user_stack_summary):


### PR DESCRIPTION
Fixes #191967 
Switches the filter to exclude frames by torch-package location instead of by name, so arbitrary user helper methods are preserved just like under strict=True.