### PR TITLE
[TEST] Refactored test_cpp_thread.py to have hw_classification

### DIFF
--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -10,7 +10,12 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
     skipXPUIf,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+)
 
 
 if is_fbcode():
@@ -76,6 +81,7 @@ class PythonProfilerEventHandler(cpp.ProfilerEventHandler):
 
 
 class CppThreadTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     ThreadCount = 20  # set to 2 for debugging
     EventHandler = None
     TraceObject = None


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = ACCELERATOR to CppThreadTest (no structural changes)

## Test Plan
```bash
python test/profiler/test_cpp_thread.py -v
Ran 3 tests in 1.335s
OK

python test/profiler/test_cpp_thread.py -v --hw-classification ACCELERATOR
Ran 3 tests in 1.331s
OK
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
