### PR TITLE
caffe2/torch/csrc: include fmt/format.h in utils.cpp

### DIFF
--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -1,4 +1,4 @@
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/variable.h>


### PR DESCRIPTION
Summary: utils.cpp calls fmt::format(), but fmt 12.2.0 no longer exposes it from fmt/core.h. Include the defining header directly in the Caffe2 sources so the downstream code builds with both the repository-default fmt 9.1.0 and fmt 12.2.0.

Test Plan: CI

Reviewed By: r-barnes

Differential Revision: D114662691


