### PR TITLE
[Test] Refactored test_swa_utils.py to have hw_classification

### DIFF
--- a/test/optim/test_swa_utils.py
+++ b/test/optim/test_swa_utils.py
@@ -10,49 +10,159 @@ from torch.optim.swa_utils import (
     get_swa_multi_avg_fn,
     update_bn,
 )
-from torch.testing._internal.common_device_type import onlyAccelerator, onlyCPU
+from torch.testing._internal.common_device_type import onlyAccelerator
 from torch.testing._internal.common_utils import (
     HardwareClassification,
+    instantiate_parametrized_tests,
     parametrize,
     TestCase,
 )
 
 
-class TestSWAUtils(TestCase):
-    # Instantiated via instantiate_device_type_tests in test/test_optim.py.
-    hw_classification = HardwareClassification.ACCELERATOR
+class SWATestDNN(torch.nn.Module):
+    def __init__(self, input_features):
+        super().__init__()
+        self.n_features = 100
+        self.fc1 = torch.nn.Linear(input_features, self.n_features)
+        self.bn = torch.nn.BatchNorm1d(self.n_features)
 
-    class SWATestDNN(torch.nn.Module):
-        def __init__(self, input_features):
-            super().__init__()
-            self.n_features = 100
-            self.fc1 = torch.nn.Linear(input_features, self.n_features)
-            self.bn = torch.nn.BatchNorm1d(self.n_features)
+    def compute_preactivation(self, x):
+        return self.fc1(x)
 
-        def compute_preactivation(self, x):
-            return self.fc1(x)
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.bn(x)
+        return x
 
-        def forward(self, x):
-            x = self.fc1(x)
-            x = self.bn(x)
-            return x
 
-    class SWATestCNN(torch.nn.Module):
-        def __init__(self, input_channels):
-            super().__init__()
-            self.n_features = 10
-            self.conv1 = torch.nn.Conv2d(
-                input_channels, self.n_features, kernel_size=3, padding=1
+class SWATestCNN(torch.nn.Module):
+    def __init__(self, input_channels):
+        super().__init__()
+        self.n_features = 10
+        self.conv1 = torch.nn.Conv2d(
+            input_channels, self.n_features, kernel_size=3, padding=1
+        )
+        self.bn = torch.nn.BatchNorm2d(self.n_features, momentum=0.3)
+
+    def compute_preactivation(self, x):
+        return self.conv1(x)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn(x)
+        return x
+
+
+class TestSWAUtilsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_averaged_model_state_dict(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
+        )
+        averaged_dnn = AveragedModel(dnn)
+        averaged_dnn2 = AveragedModel(dnn)
+        n_updates = 10
+        for _ in range(n_updates):
+            for p in dnn.parameters():
+                p.detach().add_(torch.randn_like(p))
+            averaged_dnn.update_parameters(dnn)
+        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
+        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
+            self.assertEqual(p_swa, p_swa2)
+        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
+
+    def test_averaged_model_default_avg_fn_picklable(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5),
+            torch.nn.Linear(5, 5),
+        )
+        averaged_dnn = AveragedModel(dnn)
+        pickle.dumps(averaged_dnn)
+
+    @parametrize("use_multi_avg_fn", [True, False])
+    @parametrize("use_buffers", [True, False])
+    def test_averaged_model_exponential(self, use_multi_avg_fn, use_buffers):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Linear(5, 10),
+        )
+        decay = 0.9
+
+        if use_multi_avg_fn:
+            averaged_dnn = AveragedModel(
+                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
             )
-            self.bn = torch.nn.BatchNorm2d(self.n_features, momentum=0.3)
+        else:
 
-        def compute_preactivation(self, x):
-            return self.conv1(x)
+            def avg_fn(p_avg, p, n_avg):
+                return decay * p_avg + (1 - decay) * p
 
-        def forward(self, x):
-            x = self.conv1(x)
-            x = self.bn(x)
-            return x
+            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
+
+        if use_buffers:
+            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
+        else:
+            dnn_params = list(dnn.parameters())
+
+        averaged_params = [
+            torch.zeros_like(param)
+            for param in dnn_params
+            if param.size() != torch.Size([])
+        ]
+
+        n_updates = 10
+        for i in range(n_updates):
+            updated_averaged_params = []
+            for p, p_avg in zip(dnn_params, averaged_params):
+                if p.size() == torch.Size([]):
+                    continue
+                p.detach().add_(torch.randn_like(p))
+                if i == 0:
+                    updated_averaged_params.append(p.clone())
+                else:
+                    updated_averaged_params.append(
+                        (p_avg * decay + p * (1 - decay)).clone()
+                    )
+            averaged_dnn.update_parameters(dnn)
+            averaged_params = updated_averaged_params
+
+        if use_buffers:
+            for p_avg, p_swa in zip(
+                averaged_params,
+                itertools.chain(
+                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
+                ),
+            ):
+                self.assertEqual(p_avg, p_swa)
+        else:
+            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+                self.assertEqual(p_avg, p_swa)
+            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
+                self.assertEqual(b_avg, b_swa)
+
+    def test_bn_update_eval_momentum(self):
+        objects = 100
+        input_channels = 3
+        height, width = 5, 5
+        x = torch.rand(objects, input_channels, height, width)
+        ds_x = torch.utils.data.TensorDataset(x)
+        dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
+        cnn = SWATestCNN(input_channels=input_channels)
+        cnn.eval()
+        update_bn(dl_x, cnn)
+        self.assertFalse(cnn.training)
+
+        self.assertEqual(cnn.bn.momentum, 0.3)
+
+
+instantiate_parametrized_tests(TestSWAUtilsGeneric)
+
+
+class TestSWAUtils(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _test_averaged_model(self, net_device, swa_device, ema):
         net_device = torch.device(net_device)
@@ -134,97 +244,6 @@ class TestSWAUtils(TestCase):
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_avg.device == p_swa.device)
 
-    @onlyCPU
-    def test_averaged_model_state_dict(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
-        )
-        averaged_dnn = AveragedModel(dnn)
-        averaged_dnn2 = AveragedModel(dnn)
-        n_updates = 10
-        for _ in range(n_updates):
-            for p in dnn.parameters():
-                p.detach().add_(torch.randn_like(p))
-            averaged_dnn.update_parameters(dnn)
-        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
-        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
-            self.assertEqual(p_swa, p_swa2)
-        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
-
-    @onlyCPU
-    def test_averaged_model_default_avg_fn_picklable(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5),
-            torch.nn.Linear(5, 5),
-        )
-        averaged_dnn = AveragedModel(dnn)
-        pickle.dumps(averaged_dnn)
-
-    @onlyCPU
-    @parametrize("use_multi_avg_fn", [True, False])
-    @parametrize("use_buffers", [True, False])
-    def test_averaged_model_exponential(self, device, use_multi_avg_fn, use_buffers):
-        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5, momentum=0.3),
-            torch.nn.Linear(5, 10),
-        )
-        decay = 0.9
-
-        if use_multi_avg_fn:
-            averaged_dnn = AveragedModel(
-                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
-            )
-        else:
-
-            def avg_fn(p_avg, p, n_avg):
-                return decay * p_avg + (1 - decay) * p
-
-            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
-
-        if use_buffers:
-            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
-        else:
-            dnn_params = list(dnn.parameters())
-
-        averaged_params = [
-            torch.zeros_like(param)
-            for param in dnn_params
-            if param.size() != torch.Size([])
-        ]
-
-        n_updates = 10
-        for i in range(n_updates):
-            updated_averaged_params = []
-            for p, p_avg in zip(dnn_params, averaged_params):
-                if p.size() == torch.Size([]):
-                    continue
-                p.detach().add_(torch.randn_like(p))
-                if i == 0:
-                    updated_averaged_params.append(p.clone())
-                else:
-                    updated_averaged_params.append(
-                        (p_avg * decay + p * (1 - decay)).clone()
-                    )
-            averaged_dnn.update_parameters(dnn)
-            averaged_params = updated_averaged_params
-
-        if use_buffers:
-            for p_avg, p_swa in zip(
-                averaged_params,
-                itertools.chain(
-                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
-                ),
-            ):
-                self.assertEqual(p_avg, p_swa)
-        else:
-            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-                self.assertEqual(p_avg, p_swa)
-            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
-                self.assertEqual(b_avg, b_swa)
-
     def _test_update_bn(self, dnn, dl_x, dl_xy, device):
         preactivation_sum = torch.zeros(dnn.n_features, device=device)
         preactivation_squared_sum = torch.zeros(dnn.n_features, device=device)
@@ -275,7 +294,7 @@ class TestSWAUtils(TestCase):
         ds_xy = torch.utils.data.TensorDataset(x, y)
         dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
         dl_xy = torch.utils.data.DataLoader(ds_xy, batch_size=5, shuffle=True)
-        dnn = self.SWATestDNN(input_features=input_features).to(device)
+        dnn = SWATestDNN(input_features=input_features).to(device)
         dnn.train()
         self._test_update_bn(dnn, dl_x, dl_xy, device)
         self.assertTrue(dnn.training)
@@ -291,27 +310,10 @@ class TestSWAUtils(TestCase):
         ds_xy = torch.utils.data.TensorDataset(x, y)
         dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
         dl_xy = torch.utils.data.DataLoader(ds_xy, batch_size=5, shuffle=True)
-        cnn = self.SWATestCNN(input_channels=input_channels).to(device)
+        cnn = SWATestCNN(input_channels=input_channels).to(device)
         cnn.train()
         self._test_update_bn(cnn, dl_x, dl_xy, device)
         self.assertTrue(cnn.training)
-
-    @onlyCPU
-    def test_bn_update_eval_momentum(self, device):
-        # check that update_bn preserves eval mode
-        objects = 100
-        input_channels = 3
-        height, width = 5, 5
-        x = torch.rand(objects, input_channels, height, width)
-        ds_x = torch.utils.data.TensorDataset(x)
-        dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
-        cnn = self.SWATestCNN(input_channels=input_channels)
-        cnn.eval()
-        update_bn(dl_x, cnn)
-        self.assertFalse(cnn.training)
-
-        # check that momentum is preserved
-        self.assertEqual(cnn.bn.momentum, 0.3)
 
 
 if __name__ == "__main__":

--- a/test/optim/test_swa_utils.py
+++ b/test/optim/test_swa_utils.py
@@ -10,42 +10,162 @@ from torch.optim.swa_utils import (
     get_swa_multi_avg_fn,
     update_bn,
 )
-from torch.testing._internal.common_device_type import onlyAccelerator, onlyCPU
-from torch.testing._internal.common_utils import parametrize, TestCase
+from torch.testing._internal.common_device_type import onlyAccelerator
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    parametrize,
+    TestCase,
+)
+
+
+class SWATestDNN(torch.nn.Module):
+    def __init__(self, input_features):
+        super().__init__()
+        self.n_features = 100
+        self.fc1 = torch.nn.Linear(input_features, self.n_features)
+        self.bn = torch.nn.BatchNorm1d(self.n_features)
+
+    def compute_preactivation(self, x):
+        return self.fc1(x)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.bn(x)
+        return x
+
+
+class SWATestCNN(torch.nn.Module):
+    def __init__(self, input_channels):
+        super().__init__()
+        self.n_features = 10
+        self.conv1 = torch.nn.Conv2d(
+            input_channels, self.n_features, kernel_size=3, padding=1
+        )
+        self.bn = torch.nn.BatchNorm2d(self.n_features, momentum=0.3)
+
+    def compute_preactivation(self, x):
+        return self.conv1(x)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn(x)
+        return x
+
+
+class TestSWAUtilsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_averaged_model_state_dict(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
+        )
+        averaged_dnn = AveragedModel(dnn)
+        averaged_dnn2 = AveragedModel(dnn)
+        n_updates = 10
+        for _ in range(n_updates):
+            for p in dnn.parameters():
+                p.detach().add_(torch.randn_like(p))
+            averaged_dnn.update_parameters(dnn)
+        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
+        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
+            self.assertEqual(p_swa, p_swa2)
+        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
+
+    def test_averaged_model_default_avg_fn_picklable(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5),
+            torch.nn.Linear(5, 5),
+        )
+        averaged_dnn = AveragedModel(dnn)
+        pickle.dumps(averaged_dnn)
+
+    @parametrize("use_multi_avg_fn", [True, False])
+    @parametrize("use_buffers", [True, False])
+    def test_averaged_model_exponential(self, use_multi_avg_fn, use_buffers):
+        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Linear(5, 10),
+        )
+        decay = 0.9
+
+        if use_multi_avg_fn:
+            averaged_dnn = AveragedModel(
+                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
+            )
+        else:
+
+            def avg_fn(p_avg, p, n_avg):
+                return decay * p_avg + (1 - decay) * p
+
+            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
+
+        if use_buffers:
+            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
+        else:
+            dnn_params = list(dnn.parameters())
+
+        averaged_params = [
+            torch.zeros_like(param)
+            for param in dnn_params
+            if param.size() != torch.Size([])
+        ]
+
+        n_updates = 10
+        for i in range(n_updates):
+            updated_averaged_params = []
+            for p, p_avg in zip(dnn_params, averaged_params):
+                if p.size() == torch.Size([]):
+                    continue
+                p.detach().add_(torch.randn_like(p))
+                if i == 0:
+                    updated_averaged_params.append(p.clone())
+                else:
+                    updated_averaged_params.append(
+                        (p_avg * decay + p * (1 - decay)).clone()
+                    )
+            averaged_dnn.update_parameters(dnn)
+            averaged_params = updated_averaged_params
+
+        if use_buffers:
+            for p_avg, p_swa in zip(
+                averaged_params,
+                itertools.chain(
+                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
+                ),
+            ):
+                self.assertEqual(p_avg, p_swa)
+        else:
+            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+                self.assertEqual(p_avg, p_swa)
+            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
+                self.assertEqual(b_avg, b_swa)
+
+    def test_bn_update_eval_momentum(self):
+        # check that update_bn preserves eval mode
+        objects = 100
+        input_channels = 3
+        height, width = 5, 5
+        x = torch.rand(objects, input_channels, height, width)
+        ds_x = torch.utils.data.TensorDataset(x)
+        dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
+        cnn = SWATestCNN(input_channels=input_channels)
+        cnn.eval()
+        update_bn(dl_x, cnn)
+        self.assertFalse(cnn.training)
+
+        # check that momentum is preserved
+        self.assertEqual(cnn.bn.momentum, 0.3)
+
+
+instantiate_parametrized_tests(TestSWAUtilsGeneric)
 
 
 class TestSWAUtils(TestCase):
-    class SWATestDNN(torch.nn.Module):
-        def __init__(self, input_features):
-            super().__init__()
-            self.n_features = 100
-            self.fc1 = torch.nn.Linear(input_features, self.n_features)
-            self.bn = torch.nn.BatchNorm1d(self.n_features)
-
-        def compute_preactivation(self, x):
-            return self.fc1(x)
-
-        def forward(self, x):
-            x = self.fc1(x)
-            x = self.bn(x)
-            return x
-
-    class SWATestCNN(torch.nn.Module):
-        def __init__(self, input_channels):
-            super().__init__()
-            self.n_features = 10
-            self.conv1 = torch.nn.Conv2d(
-                input_channels, self.n_features, kernel_size=3, padding=1
-            )
-            self.bn = torch.nn.BatchNorm2d(self.n_features, momentum=0.3)
-
-        def compute_preactivation(self, x):
-            return self.conv1(x)
-
-        def forward(self, x):
-            x = self.conv1(x)
-            x = self.bn(x)
-            return x
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _test_averaged_model(self, net_device, swa_device, ema):
         net_device = torch.device(net_device)
@@ -127,97 +247,6 @@ class TestSWAUtils(TestCase):
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_avg.device == p_swa.device)
 
-    @onlyCPU
-    def test_averaged_model_state_dict(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
-        )
-        averaged_dnn = AveragedModel(dnn)
-        averaged_dnn2 = AveragedModel(dnn)
-        n_updates = 10
-        for _ in range(n_updates):
-            for p in dnn.parameters():
-                p.detach().add_(torch.randn_like(p))
-            averaged_dnn.update_parameters(dnn)
-        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
-        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
-            self.assertEqual(p_swa, p_swa2)
-        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
-
-    @onlyCPU
-    def test_averaged_model_default_avg_fn_picklable(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5),
-            torch.nn.Linear(5, 5),
-        )
-        averaged_dnn = AveragedModel(dnn)
-        pickle.dumps(averaged_dnn)
-
-    @onlyCPU
-    @parametrize("use_multi_avg_fn", [True, False])
-    @parametrize("use_buffers", [True, False])
-    def test_averaged_model_exponential(self, device, use_multi_avg_fn, use_buffers):
-        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5, momentum=0.3),
-            torch.nn.Linear(5, 10),
-        )
-        decay = 0.9
-
-        if use_multi_avg_fn:
-            averaged_dnn = AveragedModel(
-                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
-            )
-        else:
-
-            def avg_fn(p_avg, p, n_avg):
-                return decay * p_avg + (1 - decay) * p
-
-            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
-
-        if use_buffers:
-            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
-        else:
-            dnn_params = list(dnn.parameters())
-
-        averaged_params = [
-            torch.zeros_like(param)
-            for param in dnn_params
-            if param.size() != torch.Size([])
-        ]
-
-        n_updates = 10
-        for i in range(n_updates):
-            updated_averaged_params = []
-            for p, p_avg in zip(dnn_params, averaged_params):
-                if p.size() == torch.Size([]):
-                    continue
-                p.detach().add_(torch.randn_like(p))
-                if i == 0:
-                    updated_averaged_params.append(p.clone())
-                else:
-                    updated_averaged_params.append(
-                        (p_avg * decay + p * (1 - decay)).clone()
-                    )
-            averaged_dnn.update_parameters(dnn)
-            averaged_params = updated_averaged_params
-
-        if use_buffers:
-            for p_avg, p_swa in zip(
-                averaged_params,
-                itertools.chain(
-                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
-                ),
-            ):
-                self.assertEqual(p_avg, p_swa)
-        else:
-            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-                self.assertEqual(p_avg, p_swa)
-            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
-                self.assertEqual(b_avg, b_swa)
-
     def _test_update_bn(self, dnn, dl_x, dl_xy, device):
         preactivation_sum = torch.zeros(dnn.n_features, device=device)
         preactivation_squared_sum = torch.zeros(dnn.n_features, device=device)
@@ -268,7 +297,7 @@ class TestSWAUtils(TestCase):
         ds_xy = torch.utils.data.TensorDataset(x, y)
         dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
         dl_xy = torch.utils.data.DataLoader(ds_xy, batch_size=5, shuffle=True)
-        dnn = self.SWATestDNN(input_features=input_features).to(device)
+        dnn = SWATestDNN(input_features=input_features).to(device)
         dnn.train()
         self._test_update_bn(dnn, dl_x, dl_xy, device)
         self.assertTrue(dnn.training)
@@ -284,27 +313,10 @@ class TestSWAUtils(TestCase):
         ds_xy = torch.utils.data.TensorDataset(x, y)
         dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
         dl_xy = torch.utils.data.DataLoader(ds_xy, batch_size=5, shuffle=True)
-        cnn = self.SWATestCNN(input_channels=input_channels).to(device)
+        cnn = SWATestCNN(input_channels=input_channels).to(device)
         cnn.train()
         self._test_update_bn(cnn, dl_x, dl_xy, device)
         self.assertTrue(cnn.training)
-
-    @onlyCPU
-    def test_bn_update_eval_momentum(self, device):
-        # check that update_bn preserves eval mode
-        objects = 100
-        input_channels = 3
-        height, width = 5, 5
-        x = torch.rand(objects, input_channels, height, width)
-        ds_x = torch.utils.data.TensorDataset(x)
-        dl_x = torch.utils.data.DataLoader(ds_x, batch_size=5, shuffle=True)
-        cnn = self.SWATestCNN(input_channels=input_channels)
-        cnn.eval()
-        update_bn(dl_x, cnn)
-        self.assertFalse(cnn.training)
-
-        # check that momentum is preserved
-        self.assertEqual(cnn.bn.momentum, 0.3)
 
 
 if __name__ == "__main__":

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
 from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
-from optim.test_swa_utils import TestSWAUtils
+from optim.test_swa_utils import TestSWAUtils, TestSWAUtilsGeneric  # noqa: F401
 
 import torch
 from torch.nn import Parameter


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Split TestSWAUtils into TestSWAUtilsGeneric (GENERIC, 4 tests) + TestSWAUtils (ACCELERATOR, 5 tests) - Split TestSWAUtils because @onlyCPU tests never use the device parameter and test pure CPU-side logic with no accelerator involvement.
- Move SWATestDNN and SWATestCNN to module level (shared by both classes)
- Remove @onlyCPU decorators from GENERIC tests (no longer needed outside device-type class)
- Update test_optim.py to import TestSWAUtilsGeneric
- Not adding instantiate_device_type_tests here because it's already called in test/test_optim.py where this class gets imported.

## Test Plan
```bash
python test/test_optim.py TestSWAUtilsGeneric TestSWAUtilsCPU TestSWAUtilsCUDA -v
Ran 23 tests in 1.426s
OK (skipped=4)

python test/test_optim.py TestSWAUtilsGeneric TestSWAUtilsCPU TestSWAUtilsCUDA -v --hw-classification GENERIC
Ran 7 tests in 0.052s
OK

python test/test_optim.py TestSWAUtilsGeneric TestSWAUtilsCPU TestSWAUtilsCUDA -v --hw-classification ACCELERATOR
Ran 16 tests in 1.390s
OK (skipped=4)
```

CC: @mansiag05 @RiyaP2508 @vishalgoyal316 
