### PR TITLE
[Test] Refactored test_stateless.py to have hw_classification

### DIFF
--- a/test/optim/test_stateless.py
+++ b/test/optim/test_stateless.py
@@ -8,6 +8,7 @@ import torch.nn.utils.stateless as stateless
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.optim._stateless import swap_in_optimizer_params_and_state
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     load_tests,
     run_tests,
     skipIfTorchDynamo,
@@ -31,6 +32,8 @@ class ChainedLinear(torch.nn.Module):
 
 
 class TestSwapInOptimizerParamsAndState(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     class _TestException(Exception):
         pass
 


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = GENERIC to TestSwapInOptimizerParamsAndState (no structural changes)

## Test Plan
```bash
python test/optim/test_stateless.py -v
Ran 7 tests in 1.066s
OK

python test/optim/test_stateless.py -v --hw-classification GENERIC
Ran 7 tests in 1.104s
OK
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508 