### PR TITLE
[torch] Fix deprecated getPointerTo to be compatible with LLVM 24 (#192381)

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -116,6 +116,16 @@ struct TypedPointer {
 };
 #endif
 
+#if LLVM_VERSION_MAJOR > 23
+llvm::PointerType* llvm_pointer_to(llvm::Type* ty, unsigned addrspace = 0) {
+  return llvm::PointerType::get(ty->getContext(), addrspace);
+}
+#else
+llvm::PointerType* llvm_pointer_to(llvm::Type* ty, unsigned addrspace = 0) {
+  return ty->getPointerTo(addrspace);
+}
+#endif
+
 llvm::CmpInst::Predicate llvm_comparison_predicate(
     CompareSelectOperation compare_op,
     const ScalarType& type) {
@@ -615,7 +625,7 @@ llvm::Type* LLVMCodeGenImpl::dtypeToLLVM(Dtype dtype) {
 }
 
 llvm::Type* LLVMCodeGenImpl::dtypeToLLVMPtr(Dtype dtype) {
-  return dtypeToLLVM(dtype)->getPointerTo();
+  return llvm_pointer_to(dtypeToLLVM(dtype));
 }
 
 void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
@@ -1474,8 +1484,7 @@ void LLVMCodeGenImpl::visit(const LoadPtr& v) {
           first_idx);
 #endif
 
-      auto vaddr = irb_.CreateBitOrPointerCast(
-          addr, llvm::PointerType::get(loadType, 0));
+      auto vaddr = irb_.CreateBitOrPointerCast(addr, llvm_pointer_to(loadType));
 #if LLVM_VERSION_MAJOR >= 12
       value_ = irb_.CreateAlignedLoad(loadType, vaddr, llvm::MaybeAlign(4));
 #else
@@ -1857,8 +1866,8 @@ void LLVMCodeGenImpl::visit(const StorePtr& v) {
           first_idx);
 #endif
 
-      auto vaddr = irb_.CreateBitOrPointerCast(
-          addr, llvm::PointerType::get(val->getType(), 0));
+      auto vaddr =
+          irb_.CreateBitOrPointerCast(addr, llvm_pointer_to(val->getType()));
 
 #if LLVM_VERSION_MAJOR >= 13
       irb_.CreateAlignedStore(val, vaddr, llvm::MaybeAlign(4));


### PR DESCRIPTION
Summary:

Upstream removed `Type::getPointerTo(unsigned)` and `PointerType::get(Type*, unsigned)` API  in https://github.com/llvm/llvm-project/commit/bfc237a5154199383ce21d42f5ca55141a909c33
This breaks our staging build tests with pytorch build failues.
```
fbcode/caffe2/torch/csrc/jit/tensorexpr/llvm_codegen.cpp:618:30: error: no member named 'getPointerTo' in 'llvm::Type'
  618 |   return dtypeToLLVM(dtype)->getPointerTo();
      |          ~~~~~~~~~~~~~~~~~~  ^
fbcode/caffe2/torch/csrc/jit/tensorexpr/llvm_codegen.cpp:1478:40: error: non-const lvalue reference to type 'LLVMContext' cannot bind to a value of unrelated type 'llvm::Type *'
 1478 |           addr, llvm::PointerType::get(loadType, 0));
      |                                        ^~~~~~~~
fbcode/third-party-buck/platform010/build/llvm-fb/21/include/llvm/IR/DerivedTypes.h:767:49: note: passing argument to parameter 'C' here
  767 |   LLVM_ABI static PointerType *get(LLVMContext &C, unsigned AddressSpace);
      |                                                 ^
fbcode/caffe2/torch/csrc/jit/tensorexpr/llvm_codegen.cpp:1861:40: error: non-const lvalue reference to type 'LLVMContext' cannot bind to a temporary of type 'Type *'
 1861 |           addr, llvm::PointerType::get(val->getType(), 0));
      |                                        ^~~~~~~~~~~~~~
fbcode/third-party-buck/platform010/build/llvm-fb/21/include/llvm/IR/DerivedTypes.h:767:49: note: passing argument to parameter 'C' here
  767 |   LLVM_ABI static PointerType *get(LLVMContext &C, unsigned AddressSpace);
      |                                                 ^
3 errors generated.
```
https://www.internalfb.com/sandcastle/workflow/3895613677694709302
Fixing with `llvm_pointer_to` wrapper and `LLVM_VERSION_MAJOR > 23` marcro guard

Test Plan:
```
sl graft -r remote/scratch/server-llvm/staging -t internal:other -f
buck2 build --flagfile fbcode//mode/opt-clang-thinlto -c bolt.disable="True" -c fbcode.split-dwarf="True" -c fbcode.dwp="True" -c cxx.extra_cxxflags="-gpubnames -w -Wno-missing-template-arg-list-after-template-kw -Wno-c++11-narrowing -Wno-c++11-narrowing-const-reference -Wno-vla-cxx-extension -Wno-nontrivial-memcall -Wno-deprecated-literal-operator -Wno-incompatible-pointer-types -ferror-limit=0" -c cxx.extra_cflags="-gpubnames -w -Wno-missing-template-arg-list-after-template-kw -Wno-c++11-narrowing -Wno-c++11-narrowing-const-reference -Wno-vla-cxx-extension -Wno-nontrivial-memcall -Wno-deprecated-literal-operator -Wno-incompatible-pointer-types" -c cxx.extra_cudaflags="-allow-unsupported-compiler -Xcompiler -w -Xcompiler -Wno-missing-template-arg-list-after-template-kw -Xcompiler -Wno-c++11-narrowing -Xcompiler -Wno-c++11-narrowing-const-reference -Xcompiler -Wno-vla-cxx-extension -Xcompiler -Wno-nontrivial-memcall -Xcompiler -Wno-deprecated-literal-operator -Xcompiler -Wno-incompatible-pointer-types -Xcompiler -fclang-abi-compat=17" -c cxx.profile="fbcode//fdo/autofdo/sigrid/predictor/v2/sigrid_remote_predictor:autofdo" fbcode//caffe2:_libtorch -c cxx.modules=False -c fbcode.ignore_stale_profile_error=True --config bolt.msdk=release
```

Reviewed By: yuxuanchen1997

Differential Revision: D114966533




cc @EikanWang @jgong5