### PR TITLE
[TEST] Refactored test_functional_optim.py to have hw_classification

### DIFF
--- a/test/test_functional_optim.py
+++ b/test/test_functional_optim.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 from torch.optim import Adam, AdamW, SGD
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 class MyModule(torch.nn.Module):
@@ -79,6 +79,8 @@ if torch.distributed.is_available():
     not torch.distributed.is_available(), "These are testing distributed functions"
 )
 class TestFunctionalOptimParity(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _validate_parameters(self, params_1, params_2):
         for p1, p2 in zip(params_1, params_2):
             self.assertEqual(p1, p2)


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = HardwareClassification.GENERIC to TestFunctionalOptimParity — all 4 tests are pure CPU logic testing functional optimizer parity (SGD, Adam, AdamW) and custom optimizer registration, with no device references

## Test Plan
```bash
python test/test_functional_optim.py -v
Ran 4 tests in 0.647s
OK

python test/test_functional_optim.py -v --hw-classification GENERIC
Ran 4 tests in 0.654s
OK
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508
