### PR TITLE
[Test] Refactored test_fa3.py to include hw_classification

### DIFF
--- a/test/nn/attention/test_fa3.py
+++ b/test/nn/attention/test_fa3.py
@@ -15,7 +15,12 @@ from torch.nn.attention.experimental._scaled_dot_product_attention_quantized imp
 )
 from torch.nn.attention.varlen import varlen_attn
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 def _fa3_dependencies_available() -> bool:
@@ -32,6 +37,8 @@ def _fa3_dependencies_available() -> bool:
 
 
 class TestFlashAttentionFA3(FlashAttentionTestMixin, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # Mixin configuration
     impl_name = "FA3"
     fwd_kernel_patterns = ["flash_attn_3::fwd"]


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = HardwareClassification.CUDA to TestFlashAttentionFA3 — all 13 tests require CUDA Hopper (SM90) for FA3 kernels, FP8, and SDPA flash backend (no structural changes)

## Test Plan
```bash
python test/nn/attention/test_fa3.py -v
Ran 120 tests in 0.006s
OK (skipped=120)

python test/nn/attention/test_fa3.py -v --hw-classification CUDA
Ran 120 tests in 0.007s
OK (skipped=120)
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508