### PR TITLE
[CuTeDSL][sm107] Fall back to `sm103f` target if CuTeDSL does not have `sm107a` 

### DIFF
--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -24,6 +24,33 @@ except ImportError:
     cuda = None  # type: ignore[assignment]
 
 
+def _compile_for_current_device(cute, func, *args, **kwargs):
+    from cutlass.cutlass_dsl import CuTeDSL
+    from torch._inductor.async_compile import (
+        _cutedsl_arch_from_device_capability,
+    )
+
+    dsl = CuTeDSL._get_dsl()
+    runtime_arch = dsl.envar.arch
+    try:
+        cute.GPUArch(runtime_arch)
+        return cute.compile(func, *args, **kwargs)
+    except KeyError:
+        fallback_arch = _cutedsl_arch_from_device_capability(
+            torch.cuda.get_device_capability()
+        )
+
+    if fallback_arch is None:
+        return cute.compile(func, *args, **kwargs)
+
+    cute.GPUArch(fallback_arch)
+    dsl.envar.arch = fallback_arch
+    try:
+        return cute.compile(func, *args, **kwargs)
+    finally:
+        dsl.envar.arch = runtime_arch
+
+
 # ---------------------------------------------------------------------------
 # Elementwise add kernel
 # APIs: @cute.kernel, @cute.jit, cute.compile, from_dlpack, make_tiled_copy_tv,
@@ -693,7 +720,7 @@ class TestCuteDSLSmoketest(TestCase):
         b_cute = from_dlpack(b).mark_layout_dynamic()
         c_cute = from_dlpack(c).mark_layout_dynamic()
 
-        compiled = cute.compile(_host, a_cute, b_cute, c_cute)
+        compiled = _compile_for_current_device(cute, _host, a_cute, b_cute, c_cute)
         compiled(a_cute, b_cute, c_cute)
         torch.cuda.synchronize()
 
@@ -733,7 +760,9 @@ class TestCuteDSLSmoketest(TestCase):
 
         sgemm = SGemm()
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-        compiled = cute.compile(sgemm, a_cute, b_cute, c_cute, stream=stream)
+        compiled = _compile_for_current_device(
+            cute, sgemm, a_cute, b_cute, c_cute, stream=stream
+        )
         compiled(a_cute, b_cute, c_cute)
         torch.cuda.synchronize()
 
@@ -760,7 +789,9 @@ class TestCuteDSLSmoketest(TestCase):
         _y = from_dlpack(y, assumed_align=16, enable_tvm_ffi=True)
 
         norm = CtaNorm(N, "rms")
-        compiled = cute.compile(norm, _y, _x, _w, None, options="--enable-tvm-ffi")
+        compiled = _compile_for_current_device(
+            cute, norm, _y, _x, _w, None, options="--enable-tvm-ffi"
+        )
         compiled(y, x, weight, None, eps)
         torch.cuda.synchronize()
 
@@ -789,7 +820,9 @@ class TestCuteDSLSmoketest(TestCase):
         _y = from_dlpack(y, assumed_align=16, enable_tvm_ffi=True)
 
         norm = CtaNorm(N, "layer")
-        compiled = cute.compile(norm, _y, _x, _w, _b, options="--enable-tvm-ffi")
+        compiled = _compile_for_current_device(
+            cute, norm, _y, _x, _w, _b, options="--enable-tvm-ffi"
+        )
         compiled(y, x, weight, bias, eps)
         torch.cuda.synchronize()
 
@@ -842,7 +875,7 @@ class TestCuteDSLReadOnlyWrapper(TestCase):
         self.assertEqual(a_cow.const_data_ptr(), a_addr)
         self.assertEqual(b_cow.const_data_ptr(), b_addr)
 
-        compiled = cute.compile(_host, a_cute, b_cute, c_cute)
+        compiled = _compile_for_current_device(cute, _host, a_cute, b_cute, c_cute)
         compiled(a_cute, b_cute, c_cute)
         torch.cuda.synchronize()
 


### PR DESCRIPTION
otherwise we see e.g.,

```
KeyError: 'sm_107a\n\nTo execute this test, run the following from the base repo dir:\n    python test/python_native/test_cutedsl_smoketest.py TestCuteDSLSmoketest.test_sgemm\n\nThis message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0'
```

authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia