### PR TITLE
Validate dim in the softmax and sort meta registrations

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2744,6 +2744,67 @@ class TestMetaKernelRegistrations(TestCase):
         self.assertEqual(diff_b2.shape, expected_bias_shape)
 
 
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_softmax_and_sort_meta_reject_out_of_range_dim(self):
+        # The Python meta registrations for _softmax and sort shadow the C++
+        # structured metas, which do range-check dim, so meta silently accepted a
+        # dim that every other device rejects with IndexError.
+        meta = torch.ones(2, 3, device="meta")
+        scalar = torch.ones((), device="meta")
+        msg = "Dimension out of range"
+
+        for dim in (5, -5):
+            for name, fn in (
+                ("softmax", lambda d=dim: torch.softmax(meta, d)),
+                ("softmin", lambda d=dim: torch.nn.functional.softmin(meta, d)),
+                ("sort", lambda d=dim: torch.sort(meta, d)),
+                ("argsort", lambda d=dim: torch.argsort(meta, d)),
+                ("sort stable", lambda d=dim: torch.sort(meta, stable=True, dim=d)),
+            ):
+                with self.assertRaisesRegex(IndexError, msg, msg=name):
+                    fn()
+
+        # 0-d accepts dim in [-1, 0] and rejects the rest, matching maybe_wrap_dim
+        torch.softmax(scalar, 0)
+        torch.softmax(scalar, -1)
+        torch.sort(scalar, 0)
+        with self.assertRaisesRegex(IndexError, msg):
+            torch.softmax(scalar, 1)
+        with self.assertRaisesRegex(IndexError, msg):
+            torch.sort(scalar, -2)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_meta_sort_binds_dim_and_descending_positionally(self):
+        # sort.default and sort.values take dim and descending positionally while
+        # `stable` is keyword-only, so the meta signature has to match that order.
+        # 1-D matters: descending=True lands in `dim` under the old ordering and
+        # dim=1 is out of range for a 1-D tensor, so a signature regression shows
+        # up here as a spurious IndexError rather than as a missed check.
+        for eager in (torch.randn(4), torch.randn(3, 5)):
+            meta = eager.to("meta")
+            for dim in range(-eager.dim(), eager.dim()):
+                for descending in (False, True):
+                    expected = torch.sort(eager, dim, descending)
+                    got = torch.sort(meta, dim, descending)
+                    self.assertEqual(expected[0].shape, got[0].shape)
+                    self.assertEqual(expected[1].shape, got[1].shape)
+                    for stable in (True, False):
+                        expected = torch.sort(
+                            eager, stable=stable, dim=dim, descending=descending
+                        )
+                        got = torch.sort(
+                            meta, stable=stable, dim=dim, descending=descending
+                        )
+                        self.assertEqual(expected[0].shape, got[0].shape)
+                        self.assertEqual(expected[1].shape, got[1].shape)
+
+        # the out= overloads take the same positional dim/descending
+        values = torch.empty(0, device="meta")
+        indices = torch.empty(0, dtype=torch.long, device="meta")
+        torch.sort(meta, 1, True, out=(values, indices))
+        torch.sort(meta, stable=True, dim=1, out=(values, indices))
+
+
 instantiate_device_type_tests(TestMeta, globals())
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7544,7 +7544,14 @@ def upsample_nearest3d(input, output_size, scales_d=None, scales_h=None, scales_
         aten.sort.values_stable,
     ]
 )
-def meta_sort(self, stable=None, dim=-1, descending=False, values=None, indices=None):
+def meta_sort(
+    self, dim=-1, descending=False, *, stable=None, values=None, indices=None
+):
+    # `stable` is keyword-only in all four schemas this is registered for, while
+    # `dim` and `descending` are positional in sort.default and sort.values. The
+    # old signature listed `stable` second, so those two overloads bound `dim` to
+    # `stable` and `descending` to `dim`.
+    utils.canonicalize_dim(max(self.dim(), 1), dim)
     v, i = torch.empty_like(self), torch.empty_like(self, dtype=torch.int64)
     if values is not None and indices is not None:
         if not isinstance(values, TensorLike):
@@ -8795,6 +8802,10 @@ def meta_foreach_norm(tensors, ord=2, dtype=None):
 @register_meta(aten._softmax)
 @out_wrapper()
 def softmax(x: Tensor, dim: int, half_to_float: bool) -> Tensor:
+    # The C++ structured meta for _softmax range-checks dim, but this Python
+    # registration shadows it, so the check has to be repeated here. max(dim(), 1)
+    # mirrors maybe_wrap_dim's treatment of 0-d tensors, which accept dim in [-1, 0].
+    utils.canonicalize_dim(max(x.dim(), 1), dim)
     if half_to_float:
         if x.dtype not in [torch.half, torch.bfloat16]:
             raise AssertionError(


### PR DESCRIPTION
## Why are these changes needed?

The Python meta registrations for `_softmax` and `sort` shadow the C++ structured metas (`_dispatch_dump` reports the C++ ones as "Meta (inactive)"), and the C++ ones are where the `maybe_wrap_dim` range check lives. Neither Python registration repeats it, so an out-of-range `dim` is silently accepted on meta and fake tensors while every real device raises:

```python
>>> m = torch.ones(2, 3, device="meta")
>>> torch.softmax(m, 5).shape        # (2, 3)      -- no error
>>> torch.sort(m, 5)[0].shape        # (2, 3)      -- no error
>>> torch.argsort(m, 5).shape        # (2, 3)      -- no error
>>> torch.softmax(torch.ones(2, 3), 5)
IndexError: Dimension out of range (expected to be in range of [-2, 1], but got 5)
```

`log_softmax`, `cumsum` and `amax` all raise correctly on meta, so this is an oversight rather than a meta convention. It reproduces under `FakeTensorMode` too, which is the path `torch.export` and dynamo take.

## The part that is not a one-liner

`meta_sort` needed its signature reordered before the check could be correct. It is registered for four overloads:

```
aten::sort(Tensor self, int dim=-1, bool descending=False)
aten::sort.stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False)
aten::sort.values(Tensor self, int dim=-1, bool descending=False, *, Tensor(a!) values, Tensor(b!) indices)
aten::sort.values_stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False, Tensor(a!) values, Tensor(b!) indices)
```

`stable` is keyword-only in all four, while `dim` and `descending` are positional in `sort.default` and `sort.values`. The signature listed `stable` second, so for those two overloads `dim` bound to `stable` and `descending` bound to `dim`:

```
[meta_sort] stable=5 dim=-1 descending=False     # from torch.sort(x, 5)
```

That was invisible while the body ignored `dim`. It stops being invisible the moment anything reads `dim`, so adding the check on top of the old ordering is actively worse than doing nothing:

| | `sort(2d, dim=5)` should raise | `sort(1d, 0, descending=True)` should pass |
|---|---|---|
| main | no raise | passes |
| check only, signature unchanged | **no raise** | **IndexError** |
| this PR | IndexError | passes |

In the middle column `descending=True` arrives as `dim=1`, which is out of range for a 1-D tensor. So the signature reorder is required, not cosmetic.

## Changes

- `meta_sort`: `stable` becomes keyword-only and `dim`/`descending` take their schema positions, so all four overloads bind correctly.
- `_softmax` and `meta_sort`: validate `dim` with `utils.canonicalize_dim(max(x.dim(), 1), dim)`.

`canonicalize_dim` is the helper `log_softmax` already reaches via `amax`, so the message matches CPU byte for byte with no new string, and `max(dim(), 1)` mirrors `maybe_wrap_dim`, which lets a 0-d tensor take `dim` in `[-1, 0]`. I checked that pairing against CPU for 0-d, 1-d and 2-d over `dim` in `[-6, 6]`: it accepts and rejects exactly what CPU does.

## Related issue number

None; self-found. Prior art is the same bug class on a different op: issue #177451 (missing conv2d kernel-size validation in a Python meta registration) was fixed by #180448, and #188328 extends that to transposed conv. If you would rather have an issue filed and triaged first, say so and I will do that instead of carrying this PR.

## Tests

`test/test_meta.py::TestMetaKernelRegistrations`:

- `test_softmax_and_sort_meta_reject_out_of_range_dim` covers `softmax`, `softmin`, `sort`, `argsort` and `sort(stable=True)` at `dim=5` and `dim=-5`, plus the 0-d boundary in both directions.
- `test_meta_sort_binds_dim_and_descending_positionally` compares meta against eager over 1-D and 2-D, every valid `dim`, both `descending`, all three `stable` states, and the two `out=` overloads. The 1-D rows are the ones that catch a signature regression.

Results, run against an installed `torch` whose `_meta_registrations.py` was diffed against `main` and confirmed byte-identical before patching (the repo's `test_meta.py` needs a built PyTorch, so the two test bodies were extracted verbatim; the wheel was restored and re-diffed afterwards):

```
1. pristine main                 : Ran 2 tests  FAILED (failures=1)
2. dim check only, no reorder    : Ran 2 tests  FAILED (failures=1, errors=1)
3. this PR                       : Ran 2 tests  OK
```

Also checked with the change applied: all four `sort` overloads, `Tensor.sort`, `msort`, `argsort` and the untouched `topk` still work; meta output shapes match CPU across every shape/dim/descending/stable combination (0 mismatches); and `torch.compile` still traces `sort`, `argsort` and `softmax` to results equal to eager.

Lint, compared against a clean-tree control so the change is net-zero rather than merely "clean": `ruff check` reports the same single pre-existing finding before and after, `flake8` is clean on both, and `ruff format --diff` no longer mentions any added line (the `meta_sort` signature is pre-wrapped the way the formatter wants, since PYFMT covers `torch/_meta_registrations.py`).
