### PR TITLE
[profiler][cupti] Give logical lanes their own reserved id range

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import torch
 from torch._C._profiler import _ExperimentalConfig
+from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.profiler import (
     kineto_available,
     profile,
@@ -43,6 +44,13 @@ from torch.testing._internal.common_utils import (
     TemporaryFileName,
     TestCase,
 )
+
+
+# get_graph_data() -- how the tests below read a graph's node ids -- needs
+# cudaGraphNodeGetToolsId, i.e. cuda.bindings >= 13.1 and a driver >= 13.1 (or cuda-compat on
+# LD_LIBRARY_PATH); it raises otherwise. Probed only under CUDA, since the probe calls into the
+# CUDA runtime.
+TEST_GRAPH_TOOLS_ID = TEST_CUDA and not _is_tools_id_unavailable()
 
 
 def setUpModule():
@@ -583,6 +591,34 @@ class TestCuptiRecords(TestCase):
         _add_graph_event_node_spans(cols2, 1000, 2000)
         self.assertNotIn("graph_event_node", cols2)
 
+    def test_resolve_lane_columns_offsets_into_reserved_range(self):
+        # Lanes are born in the reserved range: _resolve_lane_columns places the resolver's
+        # ordinal there, so the column never holds a bare ordinal that is indistinguishable from
+        # a CUDA stream id. Rows the resolver declines (None) and eager rows keep their stream.
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import _LOGICAL_LANE_BASE
+        from torch.profiler._cupti.observers.profiler import _resolve_lane_columns
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        frame = {
+            "graph_node_id": i64(101, 102, 0),  # two graphed rows, one eager
+            "stream_id": i64(7, 7, 9),
+        }
+        # node 101 -> lane 8; node 102 -> declined; the eager row is never consulted
+        resolver = {101: (8, "DP")}.get
+        logical, names = _resolve_lane_columns(resolver, frame)
+        self.assertEqual(logical.tolist(), [_LOGICAL_LANE_BASE + 8, 7, 9])
+        self.assertEqual(names.tolist(), ["DP", None, None])
+
+        # an ordinal already in the reserved range is left alone, so the offset never stacks
+        logical, _names = _resolve_lane_columns(
+            {101: (_LOGICAL_LANE_BASE + 8, "DP")}.get, frame
+        )
+        self.assertEqual(logical.tolist()[0], _LOGICAL_LANE_BASE + 8)
+
     def test_add_graph_event_node_spans_attaches_lane_columns(self):
         # The span frame is synthesized after the _COLUMN_BUILDERS lane pass has run, so it must
         # attach its own (logical_lane, lane_name); without them the export's reassignment is
@@ -590,6 +626,7 @@ class TestCuptiRecords(TestCase):
         # kernel moves to the process-group lane.
         import numpy as np
 
+        from torch.profiler._cupti.monitor_trace import _LOGICAL_LANE_BASE
         from torch.profiler._cupti.observers.profiler import _add_graph_event_node_spans
 
         node = (7 << 32) | 11
@@ -615,7 +652,8 @@ class TestCuptiRecords(TestCase):
             cols, 1000, 2000, lane_resolver=lambda g: (61, "DP")
         )
         gen = cols["graph_event_node"]
-        self.assertEqual(gen["logical_lane"].tolist(), [61])
+        # the resolver's ordinal 61, placed in the reserved lane range at assignment time
+        self.assertEqual(gen["logical_lane"].tolist(), [_LOGICAL_LANE_BASE + 61])
         self.assertEqual(gen["lane_name"].tolist(), ["DP"])
         self.assertEqual(gen["stream_id"].tolist(), [377])  # capture stream preserved
 
@@ -1003,6 +1041,246 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(names[(0, 8)], "side comms")
         self.assertEqual(names[(0, 7)].strip(), "stream 7")
 
+    def test_normalize_logical_lanes_offsets_into_reserved_range(self):
+        # A resolver lane id IS a stream id to the exports (same per-device tid namespace) and
+        # its name is only a label, so a lane landing on a live stream would silently merge the
+        # two sets of ops onto one lane and rename that stream. Every reassigned lane moves into
+        # the reserved range by a CONSTANT offset -- not "above whatever this window holds" --
+        # so the id depends only on the resolver's assignment and is comparable across traces.
+        # No CUDA.
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import (
+            _LOGICAL_LANE_BASE,
+            _normalize_logical_lanes,
+        )
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        columns = {
+            "kernel": {
+                "device_id": i64(0, 0, 0),
+                # graphed on 7 -> lane 9, which stream 9's eager kernel already owns; graphed on
+                # 40 -> lane 50, which nothing owns; eager on 9.
+                "stream_id": i64(7, 40, 9),
+                "graph_node_id": i64(101, 202, 0),
+                "logical_lane": i64(9, 50, 9),
+            },
+        }
+        _normalize_logical_lanes(columns)
+        # Both reassigned lanes offset by the base, whether or not they collided; the eager row
+        # is not reassigned, so it stays on its stream.
+        self.assertEqual(
+            columns["kernel"]["logical_lane"].tolist(),
+            [_LOGICAL_LANE_BASE + 9, _LOGICAL_LANE_BASE + 50, 9],
+        )
+
+        # idempotent: ids already in the reserved range are left alone, so re-running does not
+        # offset twice (a window can be exported to both .json and .pftrace).
+        _normalize_logical_lanes(columns)
+        self.assertEqual(
+            columns["kernel"]["logical_lane"].tolist(),
+            [_LOGICAL_LANE_BASE + 9, _LOGICAL_LANE_BASE + 50, 9],
+        )
+
+    def test_normalize_logical_lanes_id_is_stable_across_windows(self):
+        # The point of the constant offset: one logical lane keeps one id across traces of the
+        # same job, whatever streams happened to be live in each window -- including a window
+        # where the resolver's own id (8) is a live stream. An "allocate above what this window
+        # holds" scheme would hand out a different id each time. No CUDA.
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import (
+            _LOGICAL_LANE_BASE,
+            _normalize_logical_lanes,
+        )
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        def lane_for(streams):
+            # row 0 is the graphed op the resolver puts on lane 8; the rest are eager.
+            n = len(streams)
+            columns = {
+                "kernel": {
+                    "device_id": i64(*([0] * n)),
+                    "stream_id": i64(*streams),
+                    "graph_node_id": i64(101, *([0] * (n - 1))),
+                    "logical_lane": i64(8, *streams[1:]),
+                }
+            }
+            _normalize_logical_lanes(columns)
+            return columns["kernel"]["logical_lane"].tolist()[0]
+
+        for streams in ([7, 7], [7, 8], [7, 40, 8, 9]):
+            self.assertEqual(
+                lane_for(streams), _LOGICAL_LANE_BASE + 8, msg=f"{streams}"
+            )
+
+    def test_pftrace_lane_names_are_per_device(self):
+        # A lane is (gpu, stream), so the pftrace stream-lane names are interned on that pair,
+        # not on the bare stream id: one device's resolver name must not relabel another device's
+        # identically-numbered lane. Two collisions in one window -- dev 0's REAL stream 8 vs
+        # dev 1's lane 8 named "DP", and lane 9 named differently on each device. None of them is
+        # a same-device clash, so the normalizer leaves every id alone. No CUDA.
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import (
+            _assign_render_event_ids,
+            _build_render_stages,
+            _LOGICAL_LANE_BASE,
+            _normalize_logical_lanes,
+            _STREAM_IID_BASE,
+        )
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        columns = {
+            "kernel": {
+                "start_ns": i64(1000, 3000, 5000, 7000),
+                "end_ns": i64(2000, 4000, 6000, 8000),
+                "device_id": i64(0, 1, 0, 1),
+                "stream_id": i64(8, 7, 7, 7),
+                "graph_node_id": i64(0, 102, 103, 104),
+                "logical_lane": i64(8, 8, 9, 9),
+                "lane_name": np.array([None, "DP", "TP", "PP"], dtype=object),
+                "name": np.array(["eagerOnEight", "k1", "k2", "k3"], dtype=object),
+            },
+        }
+        _normalize_logical_lanes(columns)
+        # dev 0's eager row keeps stream 8; the three reassigned lanes move into the reserved
+        # range, where the cross-device id reuse is still legal -- (dev, lane) is the key.
+        b = _LOGICAL_LANE_BASE
+        self.assertEqual(
+            columns["kernel"]["logical_lane"].tolist(), [8, b + 8, b + 9, b + 9]
+        )
+
+        event_id, _corr, wait_off, wait_ids = _assign_render_event_ids(columns, {})
+        specs, *_ = _build_render_stages(
+            columns, 1, {}, [], event_id, (wait_off, wait_ids)
+        )
+        lane_names = [name for iid, name, _cat in specs if iid >= _STREAM_IID_BASE]
+        # One lane per (device, lane id), ordered by that pair; dev 1's stream 7 is absent
+        # because both of its ops moved off it. Interning on the bare stream id would collapse
+        # this to 2 lanes, labelling dev 0's real stream 8 "DP" and its lane 9 "PP".
+        self.assertEqual(
+            lane_names,
+            [
+                "[000008] stream 8",
+                f"[{b + 9}] TP",
+                f"[{b + 8}] DP",
+                f"[{b + 9}] PP",
+            ],
+        )
+
+    def test_normalize_logical_lanes_offsets_negative_lane(self):
+        # A negative lane id is abs()-folded onto a positive lane by the chrome path
+        # (_sanitize_tid) but kept as-is by pftrace, so the two exports would disagree on the
+        # lane count. The reserved-range offset lands it non-negative, no special case. No CUDA.
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import (
+            _LOGICAL_LANE_BASE,
+            _normalize_logical_lanes,
+        )
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        columns = {
+            "kernel": {
+                "device_id": i64(0),
+                "stream_id": i64(7),
+                "graph_node_id": i64(101),
+                "logical_lane": i64(-5),
+            },
+        }
+        _normalize_logical_lanes(columns)
+        self.assertEqual(
+            columns["kernel"]["logical_lane"].tolist(), [_LOGICAL_LANE_BASE - 5]
+        )
+
+    def test_merge_moves_logical_lane_to_reserved_range(self):
+        # End to end through the single merge entry point: the colliding lane moves into the
+        # reserved range before the chrome export reads the columns, so the graphed kernel gets
+        # its own lane (named by the resolver) and the stream it would have merged with keeps
+        # its work and its name. No CUDA.
+        import tempfile
+
+        import numpy as np
+
+        from torch.profiler._cupti.monitor_trace import (
+            _LOGICAL_LANE_BASE,
+            merge_trace_window_into_chrome_trace,
+        )
+
+        def i64(*vals):
+            return np.array(vals, dtype=np.int64)
+
+        columns = {
+            "kernel": {
+                "start_ns": i64(1000, 3000, 5000),
+                "end_ns": i64(2000, 4000, 6000),
+                "device_id": i64(0, 0, 0),
+                "context_id": i64(1, 1, 1),
+                # graphed replayed on 7 -> lane 9, already owned by eagerOnNine's stream
+                "stream_id": i64(7, 7, 9),
+                "correlation_id": i64(11, 12, 13),
+                "graph_id": i64(0, 1, 0),
+                "graph_node_id": i64(0, 102, 0),
+                "logical_lane": i64(7, 9, 9),
+                "lane_name": np.array([None, "side comms", None], dtype=object),
+                "name": np.array(
+                    ["eagerKernel", "graphKernel", "eagerOnNine"], dtype=object
+                ),
+                "annotation": np.array([None, None, None], dtype=object),
+                "grid_x": i64(1, 1, 1),
+                "grid_y": i64(1, 1, 1),
+                "grid_z": i64(1, 1, 1),
+                "block_x": i64(32, 32, 32),
+                "block_y": i64(1, 1, 1),
+                "block_z": i64(1, 1, 1),
+                "registers_per_thread": i64(0, 0, 0),
+                "static_shared_memory": i64(0, 0, 0),
+                "dynamic_shared_memory": i64(0, 0, 0),
+                "priority": i64(0, 0, 0),
+                "queued": i64(0, 0, 0),
+                "channel": i64(0, 0, 0),
+                "channel_type": i64(0, 0, 0),
+            },
+        }
+        window = {"columns": columns, "user_annotations": {}}
+
+        with tempfile.TemporaryDirectory() as d:
+            cpu_path = os.path.join(d, "cpu.json")
+            with open(cpu_path, "wb") as f:
+                f.write(
+                    json.dumps({"baseTimeNanoseconds": 0, "traceEvents": []}).encode()
+                )
+            out_path = os.path.join(d, "out.json")
+            merge_trace_window_into_chrome_trace(cpu_path, out_path, window)
+            with open(out_path, "rb") as f:
+                out = json.loads(f.read())
+
+        kernels = {e["name"]: e for e in out["traceEvents"] if e.get("cat") == "kernel"}
+        graphed = kernels["graphKernel"]
+        lane = _LOGICAL_LANE_BASE + 9
+        self.assertEqual(graphed["tid"], lane)
+        self.assertEqual(graphed["args"]["stream"], lane)
+        self.assertEqual(graphed["args"]["original_stream"], 7)
+        self.assertEqual(kernels["eagerKernel"]["tid"], 7)
+        self.assertEqual(kernels["eagerOnNine"]["tid"], 9)
+
+        names = {
+            (e["pid"], e["tid"]): e["args"]["name"]
+            for e in out["traceEvents"]
+            if e.get("ph") == "M" and e.get("name") == "thread_name"
+        }
+        self.assertEqual(names[(0, lane)], "side comms")
+        self.assertEqual(names[(0, 9)].strip(), "stream 9")
+
     def test_gpu_user_annotation_stays_on_capture_stream(self):
         # A GPU-side user annotation stays on its kernels' real capture stream, never a lane the
         # resolver reassigned kernels onto. But when a capture stream has no work left to
@@ -1298,7 +1576,7 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(meta_off[1] - meta_off[0], 0)  # kernel row: no spread blob
 
     def test_pftrace_lane_names_order_by_id(self):
-        # Perfetto sorts GPU hardware-queue lanes lexicographically by name, so lane names must
+        # Perfetto sorts GPU stream lanes lexicographically by name, so lane names must
         # be prefixed with the zero-padded lane id -> the lane order matches the chrome path's
         # numeric lane-id order. A resolver-named lane must not sort ahead of a lower-id stream
         # lane (regression: "aaa_comm" (lane 50) sorted before "stream 7"). No CUDA.
@@ -1307,7 +1585,7 @@ class TestCuptiRecords(TestCase):
         from torch.profiler._cupti.monitor_trace import (
             _assign_render_event_ids,
             _build_render_stages,
-            _HW_QUEUE_IID_BASE,
+            _STREAM_IID_BASE,
         )
 
         def i64(*vals):
@@ -1332,7 +1610,7 @@ class TestCuptiRecords(TestCase):
         )
         # hw-queue lanes are appended in ascending lane-id order; Perfetto re-sorts by name, so
         # the names sorted lexicographically must equal that ascending-id order.
-        lane_names = [name for iid, name, _cat in specs if iid >= _HW_QUEUE_IID_BASE]
+        lane_names = [name for iid, name, _cat in specs if iid >= _STREAM_IID_BASE]
         self.assertEqual(len(lane_names), 2)
         self.assertEqual(
             sorted(lane_names), lane_names
@@ -1662,11 +1940,11 @@ class TestCuptiRecords(TestCase):
 
             name_table = captured["name_table"]
             specs, _gfx, stage_cols, *_ = captured["render"]
-            ts, dur, event_id, gpu, hw_queue_iid, stage, _context, name_iid, _wait = (
+            ts, dur, event_id, gpu, stream_iid, stage, _context, name_iid, _wait = (
                 stage_cols
             )
             # specs maps every iid -> name: the stage iids (Kernel/Memcpy/Memset/Annotation)
-            # and the hardware-queue lane iids (labeled "[<padded lane id>] <label>").
+            # and the stream-lane iids (labeled "[<padded lane id>] <label>").
             name_by_iid = {int(iid): name for iid, name, _cat in specs}
             render_slices = []
             render_lane_names = {}  # (device, lane_id) -> lane label, id prefix stripped
@@ -1676,7 +1954,7 @@ class TestCuptiRecords(TestCase):
                 # kernels/annotations carry a name_iid into the global table; memcpy/memset
                 # fall back to the stage spec name ("Memcpy"/"Memset").
                 name = name_table[niid - 1] if niid else name_by_iid[int(stage[i])]
-                label = name_by_iid[int(hw_queue_iid[i])]
+                label = name_by_iid[int(stream_iid[i])]
                 lane_id = int(label[1 : label.index("]")])
                 render_lane_names[(int(gpu[i]), lane_id)] = label[
                     label.index("]") + 1 :
@@ -1754,20 +2032,21 @@ class TestCuptiRecords(TestCase):
 
     def test_pftrace_chrome_lane_order_parity(self):
         # The GPU lane DISPLAY ORDER matches across formats -- both order by numeric lane id.
-        # Chrome orders lanes by tid (numeric); pftrace names its hardware-queue lanes
+        # Chrome orders lanes by tid (numeric); pftrace names its stream lanes
         # "[<zero-padded id>] <label>" so that Perfetto's lexicographic sort of those labels
         # reproduces the numeric id order. Assert the id sequences agree and are strictly
         # ascending. The window mixes a low-id "stream" lane (7), a higher-id resolver-named
-        # lane (17, "side comms"), and a mid "stream" lane (9): the named high-id lane must NOT
-        # sort ahead of the low-id stream lane (the regression the id prefix fixes), and the
-        # single- vs double-digit pair (7 vs 17) locks the zero-padding -- without it "[17]"
-        # would sort before "[7]". No CUDA.
+        # lane (17, "side comms" -- rendered in the reserved range as 100017), and a mid
+        # "stream" lane (9): the named high-id lane must NOT sort ahead of the low-id stream lane
+        # (the regression the id prefix fixes), and the differing digit counts lock the
+        # zero-padding -- without it "[100017]" would sort before "[7]". No CUDA.
         import tempfile
 
         import numpy as np
 
         from torch.profiler._cupti.monitor_trace import (
-            _HW_QUEUE_IID_BASE,
+            _LOGICAL_LANE_BASE,
+            _STREAM_IID_BASE,
             merge_trace_window_into_chrome_trace,
         )
 
@@ -1852,15 +2131,15 @@ class TestCuptiRecords(TestCase):
         # hw-queue lane specs, sorted lexicographically by label as Perfetto would, then the
         # lane id parsed back out of each "[<padded id>] ..." prefix.
         lane_specs = sorted(
-            (name for iid, name, _cat in specs if iid >= _HW_QUEUE_IID_BASE)
+            (name for iid, name, _cat in specs if iid >= _STREAM_IID_BASE)
         )
         pftrace_order = [int(name[1 : name.index("]")]) for name in lane_specs]
 
-        self.assertEqual(chrome_order, [7, 9, 17])
+        self.assertEqual(chrome_order, [7, 9, _LOGICAL_LANE_BASE + 17])
         self.assertEqual(chrome_order, pftrace_order)
         self.assertEqual(pftrace_order, sorted(pftrace_order))  # strictly ascending
-        # zero-padding is load-bearing: labels are "[07]"/"[09]"/"[17]", so lexicographic
-        # order == id order (unpadded "[17]" would sort before "[7]").
+        # zero-padding is load-bearing: labels are "[000007]"/"[000009]"/"[100017]", so
+        # lexicographic order == id order (unpadded "[100017]" would sort before "[7]").
         self.assertTrue(
             all("]" in name and name.startswith("[0") for name in lane_specs[:2])
         )
@@ -2424,6 +2703,7 @@ class TestCuptiMonitorCUDA(TestCase):
         self.assertNotIn(sync, monitor._enabled)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    @unittest.skipIf(not TEST_GRAPH_TOOLS_ID, "requires cudaGraphNodeGetToolsId")
     def test_event_node_recorder_arm_before_capture(self):
         # End-to-end usage, and the ordering contract it depends on: the recorder learns a
         # graph's ordered event-record nodes from a graph-INSTANTIATE hook, so it has to be
@@ -2488,6 +2768,7 @@ class TestCuptiMonitorCUDA(TestCase):
         self.assertNotIn(before_exec_id, r.graph_event_nodes)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    @unittest.skipIf(not TEST_GRAPH_TOOLS_ID, "requires cudaGraphNodeGetToolsId")
     def test_event_nodes_on_concurrent_branches_use_node_id_order(self):
         # The serial-chain case above is the one where every candidate ordering agrees. This
         # is the case that separates them: two event nodes on CONCURRENT branches of differing

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -310,6 +310,105 @@ def _runtime_is_launch(name: str) -> bool:
     return _runtime_is_eager_launch(name) or name == "cudaGraphLaunch"
 
 
+# Logical lanes are offset into a reserved range above ordinary CUDA stream ids. Readable on
+# sight: 100008 is resolver lane 8. A real stream this high is not expected, but is detected and
+# worked around in _normalize_logical_lanes, so correctness never rests on the guess.
+_LOGICAL_LANE_BASE = 100_000
+
+
+def _normalize_logical_lanes(columns: dict[str, dict[str, Any]]) -> None:
+    """Move resolver-assigned logical lanes into the reserved lane range.
+
+    A logical lane IS a stream id to both exports -- it is written into the same per-device tid
+    namespace, and its resolver name is only a label looked up afterwards, never part of the
+    lane's identity. So a lane id equal to a live stream id silently merges the two sets of ops
+    onto one row, renames that stream, and (pftrace) clamps each op's duration against the wrong
+    neighbour. Offsetting by _LOGICAL_LANE_BASE separates the two namespaces, which is also why
+    this must run once, up front, over the columns both exports read.
+
+    The offset is deliberately a constant rather than "allocate above whatever this window
+    happens to contain": a lane's rendered id must be a function of the resolver's assignment
+    alone, so the same logical lane keeps the same id across traces of one job. An
+    occupancy-derived id would be 9 in one trace and 12 in the next.
+
+    A lane is (device, stream) in both exports -- chrome pid / pftrace gpu_id -- so only a
+    same-device clash is a clash; the same id on another device is a different lane.
+
+    Idempotent: ids already at or above the base are taken as already living in the reserved
+    range and left alone.
+    """
+    # Every kind carrying a stream id, whether or not it renders: over-inclusion only makes the
+    # allocator skip an id, while an allowlist would silently stop covering a newly added kind.
+    occupied: dict[int, set[int]] = {}  # device -> stream ids it already renders
+    for ks, c in columns.items():
+        if (
+            not c
+            or "stream_id" not in c
+            or "device_id" not in c
+            or not len(c["stream_id"])
+        ):
+            continue
+        s = c["stream_id"]
+        if ks == "cuda_sync":
+            # The "no stream" sentinel renders as tid 1 (_export_tid(-1)), not as itself.
+            s = np.where(s == _SYNC_INVALID, 1, s)
+        for dev, sid in zip(c["device_id"].tolist(), np.abs(s).tolist()):
+            occupied.setdefault(dev, set()).add(sid)
+
+    reassigned: list[tuple[str, Any]] = []  # (kind, row mask)
+    lanes: set[tuple[int, int]] = set()  # (device, lane) pairs in use
+    for ks, c in columns.items():
+        lane = c.get("logical_lane") if c else None
+        if lane is None or not len(lane) or "device_id" not in c:
+            continue
+        mask = lane != c["stream_id"]
+        gnid = c.get("graph_node_id")
+        if gnid is not None:
+            mask &= gnid != 0
+        if not mask.any():
+            continue
+        reassigned.append((ks, mask))
+        lanes.update(zip(c["device_id"][mask].tolist(), lane[mask].tolist()))
+    if not lanes:
+        return
+
+    # The offset also subsumes negative lanes, which _sanitize_tid abs()-folds in the chrome path
+    # but not in pftrace -- the two exports would otherwise disagree on the lane count.
+    remap = {
+        (dev, lane_id): lane_id
+        + (0 if lane_id >= _LOGICAL_LANE_BASE else _LOGICAL_LANE_BASE)
+        for dev, lane_id in lanes
+    }
+    # Fall back to allocating above everything for the ids a constant offset cannot serve: a real
+    # stream already sitting in the reserved range, or a lane leaving the 31-bit space the chrome
+    # tid and the pftrace clamp key share. Cross-trace stability is lost for those lanes only.
+    in_use = set(remap.values())
+    in_use.update(*occupied.values())
+    next_id = max(in_use) + 1
+    for (dev, lane_id), target in sorted(remap.items()):
+        if 0 <= target <= 0x7FFFFFFF and target not in occupied.get(dev, ()):
+            continue
+        remap[(dev, lane_id)] = next_id
+        next_id += 1
+    # Lane ids ride in a chrome tid and, in pftrace, in the low 32 bits of the overlap-clamp key,
+    # so bail rather than hand out an id that would alias there. Needs a stream id near INT32_MAX.
+    if next_id > 0x7FFFFFFF:
+        return
+    remap = {k: v for k, v in remap.items() if k[1] != v}
+    if not remap:
+        return
+
+    for ks, mask in reassigned:
+        c = columns[ks]
+        lane = np.array(c["logical_lane"])
+        dev = c["device_id"]
+        for (remap_dev, lane_id), new_id in remap.items():
+            sel = mask & (dev == remap_dev) & (lane == lane_id)
+            if sel.any():
+                lane[sel] = new_id
+        c["logical_lane"] = lane
+
+
 def _trace_window_entries(
     trace_window: dict[str, object],
     *,
@@ -1075,7 +1174,7 @@ def _nest_track_slices(groups: list, track_uuids: set) -> None:
 
 # GPU render-stage definitions: (column key, stage iid, stage name, RenderStageCategory).
 # COMPUTE == 2 (matches the reference); the rest are OTHER (0). Stage iids are small and
-# share the gpu_specifications iid space with the hardware-queue lanes below.
+# share the gpu_specifications iid space with the stream lanes below.
 _RENDER_STAGES = (
     ("kernel", 1, "Kernel", 2),
     ("gpu_memcpy", 2, "Memcpy", 0),
@@ -1090,7 +1189,7 @@ _RENDER_STAGES = (
     ("graph_event_node", 5, "EventRecord", 0),
     ("graph_host_node", 6, "HostNode", 0),
 )
-_HW_QUEUE_IID_BASE = 100  # hardware-queue iids start past the stage iids
+_STREAM_IID_BASE = 100  # stream-lane iids start past the stage iids
 
 # Chrome-trace categories NOT rendered as CPU track_event slices: "Trace" metadata, and the
 # GPU-side kinds we emit from the columnar window instead (kernels/transfers as GPU Render
@@ -1337,13 +1436,14 @@ def _build_render_stages(
     event_wait: tuple,
 ):
     """Build the GpuRenderStageEvent payload (gpu_specs, gfx_contexts, stage_cols, extra,
-    launch, tables) for the native GPU Render Stages hardware-queue lanes, or None if there are
-    no GPU ops. Each GPU op becomes one event on a (gpu_id, hardware-queue) lane tagged by stage
+    launch, tables) for the native GPU Render Stages stream lanes, or None if there are
+    no GPU ops. Each GPU op becomes one event on a (gpu_id, stream) lane tagged by stage
     (kind). Compute kernels additionally carry kernel_iid -> InternedComputeKernel (which names
     the slice) and a structured ComputeKernelLaunch (grid/workgroup Dim3 + args named via
     name_iid -> InternedComputeArgName) -> the viewer's GPU Compute "Launch Statistics" panel;
-    memcpy/memset carry their byte count as generic extra_data. The hardware queue is the CUDA
-    stream (one lane per stream), so all streams are preserved; the scalar kernel args
+    memcpy/memset carry their byte count as generic extra_data. Perfetto calls the lane a
+    hardware queue (hw_queue_iid on the wire); for CUDA it is the stream, so all streams are
+    preserved -- as are the synthetic logical lanes, which share that id space. The scalar args
     (device/stream/correlation/channel/...) ride along as extra_data. Each event has its own
     duration -- no stack pairing -- so durations are exact (no nesting)."""
     ts_p, dur_p, gpu_p, stage_p, kname_p = [], [], [], [], []
@@ -1352,14 +1452,14 @@ def _build_render_stages(
     extra_p: dict[str, list] = {k: [] for k, _g, _s in _RENDER_EXTRA}
     meta_p: list = []  # per-row spread blob (graph annotation + collective descriptor)
     stream_p: list = []
-    lane_names_by_id: dict[int, str] = {}  # reassigned logical lane -> resolver name
+    lane_names: dict[tuple[int, int], str] = {}  # (device, lane) -> resolver name
     for _ks, stage_iid, _name, _cat, c in _render_stage_cols(columns):
         n = len(c["start_ns"])
         z = np.zeros(n, dtype=np.int64)
         ts_p.append(np.ascontiguousarray(c["start_ns"], dtype=np.int64))
         dur_p.append(np.maximum(c["end_ns"] - c["start_ns"], 0).astype(np.int64))
         gpu_p.append(np.ascontiguousarray(c["device_id"], dtype=np.int64))
-        # One lane per stream (the hardware queue); preserves all streams (channel is
+        # One lane per stream; preserves all streams (channel is
         # 0/unpopulated in many captures, which would otherwise collapse every stream
         # into a single lane). The CUPTI channel is kept as extra_data instead.
         # Reassign graphed ops onto their logical lane (mirrors the chrome path): CUPTI piles
@@ -1375,11 +1475,14 @@ def _build_render_stages(
                 reassign &= gnid_col != 0
             lname_col = c.get("lane_name")
             if lname_col is not None:
-                for lv, nm, rs in zip(
-                    lane_col.tolist(), lname_col.tolist(), reassign.tolist()
+                for dv, lv, nm, rs in zip(
+                    c["device_id"].tolist(),
+                    lane_col.tolist(),
+                    lname_col.tolist(),
+                    reassign.tolist(),
                 ):
                     if rs and nm is not None:
-                        lane_names_by_id[int(lv)] = str(nm)
+                        lane_names[(int(dv), int(lv))] = str(nm)
             stream_p.append(np.where(reassign, lane_col, stream_col).astype(np.int64))
         else:
             stream_p.append(stream_col)
@@ -1434,8 +1537,10 @@ def _build_render_stages(
     ann_iid = next(i for ks, i, _n, _c in _RENDER_STAGES if ks == "gpu_annotation")
     end = ts + dur
     sub = np.nonzero(stage != ann_iid)[0]
+    # A lane is (gpu, stream), never a bare stream: the same stream id on two devices is two
+    # lanes. Shared by the clamp below and the stream-lane interning further down.
+    lane = (gpu.astype(np.int64) << np.int64(32)) | (stream & 0xFFFFFFFF)
     if len(sub):
-        lane = (gpu.astype(np.int64) << np.int64(32)) | (stream & 0xFFFFFFFF)
         order = sub[np.lexsort((ts[sub], lane[sub]))]
         nxt_ts = np.empty(len(order), dtype=np.int64)
         nxt_ts[:-1] = ts[order][1:]
@@ -1445,23 +1550,30 @@ def _build_render_stages(
         cap = np.where(same, nxt_ts, np.iinfo(np.int64).max)
         end[order] = np.maximum(ts[order], np.minimum(end[order], cap))
         dur = end - ts
-    # One hardware-queue lane per stream; lanes are split per gpu_id by Perfetto from
-    # (gpu_id, hw_queue_iid). The spanning annotation and its kernels share the lane and the
-    # viewer depth-nests them (annotation at depth 0, kernels at depth 1) once the kernels are
-    # clamped to not overlap each other. Perfetto sorts lanes lexicographically by name, so
-    # prefix every lane (resolver-named or "stream N") with a bracketed zero-padded lane id ->
-    # the lane order matches the chrome path's numeric lane-id order (otherwise "stream 7" sorts
-    # after "stream 26674", and resolver-named lanes like "DP" interleave alphabetically). The
-    # "[" is a constant leading char, so the padded digits still decide the order.
-    uniq, inv = np.unique(stream, return_inverse=True)
-    width = len(str(int(uniq.max()))) if len(uniq) else 1
-    labels = [lane_names_by_id.get(int(k), f"stream {int(k)}") for k in uniq.tolist()]
+    # One lane per (gpu, stream); lanes are split per gpu_id by Perfetto from
+    # (gpu_id, stream_iid). Interning on the same (gpu, stream) key keeps each device's names
+    # its own -- the iid table is global, so interning on the bare stream would let one device's
+    # resolver name ("DP") relabel another device's identically-numbered CUDA stream. The
+    # spanning annotation and its kernels share the lane and the viewer depth-nests them
+    # (annotation at depth 0, kernels at depth 1) once the kernels are clamped to not overlap
+    # each other. Perfetto sorts lanes lexicographically by name, so prefix every lane
+    # (resolver-named or "stream N") with a bracketed zero-padded lane id -> the lane order
+    # matches the chrome path's numeric lane-id order (otherwise "stream 7" sorts after
+    # "stream 26674", and resolver-named lanes like "DP" interleave alphabetically). The "["
+    # is a constant leading char, so the padded digits still decide the order.
+    uniq, inv = np.unique(lane, return_inverse=True)
+    uniq_dev, uniq_lane = (uniq >> 32).tolist(), (uniq & 0xFFFFFFFF).tolist()
+    width = len(str(max(uniq_lane))) if len(uniq) else 1
     specs = [(iid, name, cat) for _ks, iid, name, cat in _RENDER_STAGES]
     specs += [
-        (_HW_QUEUE_IID_BASE + j, f"[{int(k):0{width}d}] {labels[j]}", 0)
-        for j, k in enumerate(uniq.tolist())
+        (
+            _STREAM_IID_BASE + j,
+            f"[{k:0{width}d}] {lane_names.get((d, k), f'stream {k}')}",
+            0,
+        )
+        for j, (d, k) in enumerate(zip(uniq_dev, uniq_lane))
     ]
-    hw_queue_iid = (inv + _HW_QUEUE_IID_BASE).astype(np.uint64)
+    stream_iid = (inv + _STREAM_IID_BASE).astype(np.uint64)
     # event_id is a unique per-row id (assigned by _assign_render_event_ids and passed in, in
     # this exact row order). The CPU launch's gpu_correlation lists the event_ids of the
     # render stages it launched (a graph replay -> all its nodes); event_wait_ids (below) draw
@@ -1498,7 +1610,7 @@ def _build_render_stages(
         dur,
         event_id,
         gpu,
-        hw_queue_iid,
+        stream_iid,
         stage,
         context,
         name_iid,
@@ -1819,7 +1931,7 @@ def _build_chrome_counters(counters, base_ns: int) -> list[dict]:
 def _gpu_annotation_render_column(
     trace_window: dict, base_ns: int
 ) -> dict[str, Any] | None:
-    """Synthetic ``gpu_annotation`` render-stage column for the pftrace GPU hardware queues,
+    """Synthetic ``gpu_annotation`` render-stage column for the pftrace GPU stream lanes,
     built from the columnar window via the same synthesizer as the chrome gpu_user_annotation
     events -- so it lands on the kernels' capture stream, never a reassigned logical lane.
     None when there are no GPU annotations. Kineto emits no gpu_user_annotation in
@@ -2307,7 +2419,7 @@ def _window_to_pftrace(
     )
     active_devices = _active_devices(columns)
     # GPU counters (power/temp/clocks) -> GpuCounterEvents: the viewer renders them under
-    # "GPU / Counters / <gpu>", a sibling of the render-stage hardware queues, keyed by gpu_id.
+    # "GPU / Counters / <gpu>", a sibling of the render-stage stream lanes, keyed by gpu_id.
     counters = _merge_counters(
         _build_gpu_counters(columns.get("environment"), active_devices),
         _build_pm_counters(columns.get("pm_sampling"), active_devices),
@@ -2346,6 +2458,9 @@ def merge_trace_window_into_chrome_trace(
     data = _orjson.loads(raw) if _orjson is not None else json.loads(raw)
 
     base_ns = int(data.get("baseTimeNanoseconds", _default_base_ns()))
+    _normalize_logical_lanes(
+        cast("dict[str, dict[str, Any]]", trace_window.get("columns", {}))
+    )
     # Perfetto-native output: encode straight from the columnar window (skip building the
     # chrome event dicts entirely -- that build dominates the JSON path).
     if ".pftrace" in output_path:

--- a/torch/profiler/_cupti/observers/base.py
+++ b/torch/profiler/_cupti/observers/base.py
@@ -37,6 +37,11 @@ GraphAnnotationResolver = Callable[[int], "Any | None"]
 # graph node's annotation, hence its lane, is stable once baked), or None to keep the op on its
 # CUDA stream. Keyed on graph_node_id alone, so it is wrapped in functools.cache like the
 # annotation resolver; it reads the node's name via the graph annotation registry.
+# The returned lane is an ordinal in the resolver's own space -- small ints are the norm -- and
+# is offset into the reserved lane range when the column is built, since a bare ordinal would
+# otherwise be indistinguishable from a CUDA stream id. So the ordinal, not the rendered id, is
+# what stays stable for a given lane across traces, and returning the op's own stream number
+# still means "a logical lane that happens to be numbered like that stream", not "leave it".
 LaneResolver = Callable[[int], "tuple[int, str] | None"]
 
 # graph_node_id -> predecessor graph_node_ids (or None when the node has no recorded

--- a/torch/profiler/_cupti/observers/profiler.py
+++ b/torch/profiler/_cupti/observers/profiler.py
@@ -17,7 +17,10 @@ from cupti.cupti import ActivityKind  # pyrefly: ignore[missing-import]
 
 import torch
 from torch.profiler._cupti.cupti_python import OVERHEAD_KIND_NAMES
-from torch.profiler._cupti.monitor_trace import merge_trace_window_into_chrome_trace
+from torch.profiler._cupti.monitor_trace import (
+    _LOGICAL_LANE_BASE,
+    merge_trace_window_into_chrome_trace,
+)
 from torch.profiler._cupti.observers.base import (
     CuptiMonitorObserver,
     default_graph_annotation_resolver,
@@ -890,7 +893,13 @@ def _resolve_lane_columns(lane_resolver, frame: dict[str, Any]) -> Any:
     get the resolver's (lane, name), or keep their CUDA stream when it returns None; eager rows
     keep their CUDA stream and no name (the monitor names those "stream N"). The resolver is
     keyed and memoized on graph_node_id by the observer (see CuptiMonitorObserver._lane_resolver),
-    so distinct nodes resolve once for its lifetime."""
+    so distinct nodes resolve once for its lifetime.
+
+    A resolver returns an ordinal in its own space, which is placed in the reserved lane range
+    here -- lanes share the CUDA stream namespace, so an un-offset ordinal would be a stream id
+    (see _normalize_logical_lanes, which enforces the same invariant for windows built
+    elsewhere). Returning the op's own stream number is therefore still a distinct logical lane;
+    None is how a resolver says "leave it on its CUDA stream"."""
     gnid = frame["graph_node_id"]
     n = len(gnid)
     logical = np.array(
@@ -902,7 +911,10 @@ def _resolve_lane_columns(lane_resolver, frame: dict[str, Any]) -> Any:
             continue
         res = lane_resolver(g)
         if res is not None:
-            logical[i], names[i] = res
+            lane, names[i] = res
+            logical[i] = lane + (
+                0 if lane >= _LOGICAL_LANE_BASE else _LOGICAL_LANE_BASE
+            )
     return logical, names
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192391

A resolver-assigned logical lane IS a stream id to both exports: it is written
into the same per-device tid namespace, and its resolver name is only a label
looked up afterwards, never part of the lane's identity. So a lane id equal to
a live stream id on the same device silently merges the two sets of ops onto
one row and renames that stream, and in the .pftrace path the merged lane also
gets each op's duration clamped against the wrong neighbour. Nothing enforced
the invariant -- it was delegated, undocumented, to whoever installs the
graph_lane_resolver.

Lanes are separated from that namespace by an offset into a reserved range
(_LOGICAL_LANE_BASE, so 100008 reads as resolver lane 8), applied where lanes
are assigned -- _resolve_lane_columns, the one place both column producers go
through -- so the column never holds a bare ordinal. _normalize_logical_lanes
enforces the same invariant at the merge entry point, before it forks to either
export, for windows built elsewhere. The offset is a constant rather than
"allocate above whatever this window happens to hold" because a lane's id has
to be a function of the resolver's assignment alone: consumers compare lanes
across traces of one job, and an occupancy-derived id would be 9 in one trace
and 12 in the next. It also subsumes negative lane ids, which the chrome path
abs()-folds and pftrace does not. Ids already in the reserved range are left
alone, which keeps the pass idempotent -- one window can be exported to both
.json and .pftrace. A real stream sitting in the reserved range is not expected
but is still detected, and those lanes fall back to allocating above everything
in the window, so correctness never rests on the constant.

Fixing that surfaced a second, independent bug. A lane renders per device
(chrome pid, pftrace gpu_id) and the .pftrace overlap clamp already keyed on
(gpu, stream), but the hardware-queue NAME interning a few lines below it
keyed on the bare stream id -- one interned name shared by every GPU. So one
device's resolver name relabelled another device's identically-numbered CUDA
stream: device 0's real stream 8 rendered as "DP" because device 1 named its
lane 8 that. Interning on the same (gpu, stream) key the clamp uses fixes it
and makes the two exports agree, the chrome path having always been per
(device, lane).

Visible change: a reassigned lane now renders with a six-digit id, so the
pftrace lane labels read "[100008] DP" and the stream lanes zero-pad to match
("[000007] stream 7"). The padding is load-bearing -- Perfetto sorts lanes
lexicographically, so unpadded "[100008]" would sort ahead of "[7]".

Also gates two pre-existing tests. test_event_node_recorder_arm_before_capture
and test_event_nodes_on_concurrent_branches_use_node_id_order read graph node
ids through CUDAGraph.get_graph_data(), which raises without
cudaGraphNodeGetToolsId (cuda.bindings >= 13.1 plus a driver >= 13.1, or
cuda-compat on LD_LIBRARY_PATH), so on an older driver they ERROR rather than
skip and the whole-file run below could not be read as green. They now gate on
the same predicate the runtime error uses, _is_tools_id_unavailable(),
mirroring how test_cuda_graph_utils.py gates TestMarkKernels; the probe calls
into the CUDA runtime, so it is evaluated only when TEST_CUDA is set, and both
tests already live in a CUDA-only class.

Also renames the "hardware queue" wording in monitor_trace.py to "stream". The
Perfetto wire field is hw_queue_iid and the C++ shim feeding it keeps that
name, but the Python-side lane is a CUDA stream (or a logical lane in its id
space), and the extra indirection only obscured that.

Test Plan:

Seven new tests: the reserved-range offset (colliding and non-colliding lanes
alike) plus idempotence, cross-window id stability, a negative lane, an
end-to-end case through the merge entry point, one covering the offset at
assignment time, and one pinning the per-device interning -- a window where a
real stream and a differently-named lane share an id across two devices, which
the old interning collapsed into one mislabelled lane.

```
python test/profiler/test_cupti_monitor.py TestCuptiRecords
# Ran 46 tests ... OK
```

Whole file, against a local build (system CUDA 13.1, CUPTI stub codegen on so
the native .pftrace encoder is compiled in):

```
python test/profiler/test_cupti_monitor.py
# Ran 83 tests ... OK (skipped=2)
```

The 2 skips are the graph event-node tests gated above; they pass rather than
skip when cuda-compat supplies the API:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.3/compat:$LD_LIBRARY_PATH \
  python test/profiler/test_cupti_monitor.py
# Ran 83 tests ... OK
```

test_pftrace_chrome_lane_order_parity needed its expected ids updated for the
reserved range; test_pftrace_lane_names_order_by_id did not, being
single-device and calling the render path directly.

```
lintrunner -a torch/profiler/_cupti/monitor_trace.py \
  torch/profiler/_cupti/observers/profiler.py \
  torch/profiler/_cupti/observers/base.py \
  test/profiler/test_cupti_monitor.py
```

This commit was authored with the assistance of an AI coding agent.