### PR TITLE
[CPU][XEON]Extend the core-list to support range selection

### DIFF
--- a/test/backends/xeon/test_launch.py
+++ b/test/backends/xeon/test_launch.py
@@ -5,10 +5,17 @@ import subprocess
 import tempfile
 import unittest
 
-from torch.testing._internal.common_utils import IS_LINUX, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 @unittest.skipIf(not IS_LINUX, "Only works on linux")
+@instantiate_parametrized_tests
 class TestTorchrun(TestCase):
     def setUp(self):
         super().setUp()
@@ -87,6 +94,55 @@ class TestTorchrun(TestCase):
             raise AssertionError(
                 f"Expected [0, 1], got {cpuinfo.numa_aware_check([2, 3, 4, 5])}"
             )
+
+    @parametrize(
+        "core_list,expected",
+        [
+            ("0", [0]),
+            ("0,1,2,3", [0, 1, 2, 3]),
+            ("0, 1, 2, 3", [0, 1, 2, 3]),
+            ("0-3", [0, 1, 2, 3]),
+            ("5-5", [5]),
+            ("0-31,65,92-94", list(range(32)) + [65, 92, 93, 94]),
+            (" 0-2 , 8 ", [0, 1, 2, 8]),
+            ("8,0-2", [0, 1, 2, 8]),
+            ("0-2,1-3", [0, 1, 2, 3]),
+            ("0,0,1", [0, 1]),
+            ("0-3,", [0, 1, 2, 3]),
+        ],
+    )
+    def test_parse_core_list(self, core_list, expected):
+        from torch.backends.xeon.run_cpu import _parse_core_list
+
+        self.assertEqual(_parse_core_list(core_list), expected)
+
+    @parametrize(
+        "core_list", ["", " ", ",", "3-0", "0-", "-3", "a", "0-a", "0--3", "1.5", "0 1"]
+    )
+    def test_parse_core_list_invalid(self, core_list):
+        from torch.backends.xeon.run_cpu import _parse_core_list
+
+        with self.assertRaises(ValueError):
+            _parse_core_list(core_list)
+
+    def test_core_list_ranges(self):
+        cmds = []
+        with subprocess.Popen(
+            f"python -m torch.backends.xeon.run_cpu --core-list 0-1,3 --ncores-per-instance 2 \
+            --use-default-allocator --disable-iomp --disable-numactl \
+            --log-path {self._test_dir} --no-python pwd",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        ) as p:
+            for line in p.stdout.readlines():
+                line = str(line, "utf-8").strip()
+                if "taskset" in line:
+                    cmds.append(line[line.index("taskset") :])
+        # 3 cores with 2 cores per instance yields a single instance; the
+        # contiguous pair collapses back into a range for taskset.
+        self.assertEqual(len(cmds), 1)
+        self.assertTrue(cmds[0].startswith("taskset -c 0-1 "), cmds[0])
 
     def test_multi_threads(self):
         num = 0

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -110,6 +110,14 @@ Multi-instance inference
    python -m torch.backends.xeon.run_cpu --core-list "0, 1, 2, 3" --ninstances 2 --ncores-per-instance 2
    --rank 0 python_script args
 
+   --core-list also accepts ranges, so cores can be picked without enumerating every id.
+
+   eg: run two instances on cores 0-31 and 64-95 respectively
+
+::
+
+   python -m torch.backends.xeon.run_cpu --core-list "0-31,64-95" --ncores-per-instance 32 python_script args
+
 3. To look up what optional arguments this module offers:
 
 ::
@@ -143,6 +151,38 @@ from torch.distributed.elastic.multiprocessing import (
 format_str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 logging.basicConfig(level=logging.INFO, format=format_str)
 logger = logging.getLogger(__name__)
+
+
+def _parse_core_list(core_list):
+    """Expand a core list such as "0-31,65,92-102" into a sorted list of unique core ids."""
+    cores = []
+    for entry in core_list.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        core_list_entry_pattern = re.compile(r"(\d+)(?:-(\d+))?")
+        matched = core_list_entry_pattern.fullmatch(entry)
+        if not matched:
+            raise ValueError(
+                f'Invalid entry "{entry}" in core list "{core_list}"; expected a core id such as "5" or a range such as "0-31".'
+            )
+        start = int(matched.group(1))
+        end = start if matched.group(2) is None else int(matched.group(2))
+        if end < start:
+            raise ValueError(
+                f'Invalid range "{entry}" in core list "{core_list}"; the end core id must not be smaller than the start core id.'
+            )
+        cores.extend(range(start, end + 1))
+    if not cores:
+        raise ValueError(f'No core id found in core list "{core_list}".')
+    unique_cores = sorted(set(cores))
+    if len(unique_cores) != len(cores):
+        logger.warning(
+            'core list "%s" contains duplicate core ids; using %s unique core(s)',
+            core_list,
+            len(unique_cores),
+        )
+    return unique_cores
 
 
 class _CPUinfo:
@@ -443,7 +483,7 @@ Value applied: %s. Value ignored: %s",
         set_kmp_affinity = True
         enable_taskset = False
         if args.core_list:  # user specify what cores will be used by params
-            cores = [int(x) for x in args.core_list.split(",")]
+            cores = _parse_core_list(args.core_list)
             if args.ncores_per_instance == -1:
                 raise RuntimeError(
                     'please specify the "--ncores-per-instance" if you have pass the --core-list params'
@@ -807,7 +847,8 @@ https://github.com/intel/intel-extension-for-pytorch/blob/master/docs/tutorials/
         metavar="\b",
         default=None,
         type=str,
-        help='Specify the core list as "core_id, core_id, ....", otherwise, all the cores will be used.',
+        help='Specify the core list as "core_id, core_id, ...." or as ranges such as "0-31,65,92-102", \
+otherwise, all the cores will be used.',
     )
     group.add_argument(
         "--log-path",

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -110,6 +110,14 @@ Multi-instance inference
    python -m torch.backends.xeon.run_cpu --core-list "0, 1, 2, 3" --ninstances 2 --ncores-per-instance 2
    --rank 0 python_script args
 
+   --core-list also accepts ranges, so cores can be picked without enumerating every id.
+
+   eg: run two instances on cores 0-31 and 64-95 respectively
+
+::
+
+   python -m torch.backends.xeon.run_cpu --core-list "0-31,64-95" --ncores-per-instance 32 python_script args
+
 3. To look up what optional arguments this module offers:
 
 ::
@@ -143,6 +151,38 @@ from torch.distributed.elastic.multiprocessing import (
 format_str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 logging.basicConfig(level=logging.INFO, format=format_str)
 logger = logging.getLogger(__name__)
+
+
+def _parse_core_list(core_list):
+    """Expand a core list such as "0-31,65,92-102" into a sorted list of unique core ids."""
+    cores = []
+    for entry in core_list.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        core_list_entry_pattern = re.compile(r"(\d+)(?:-(\d+))?")
+        matched = core_list_entry_pattern.fullmatch(entry)
+        if not matched:
+            raise ValueError(
+                f'Invalid entry "{entry}" in core list "{core_list}"; expected a core id such as "5" or a range such as "0-31".'
+            )
+        start = int(matched.group(1))
+        end = start if matched.group(2) is None else int(matched.group(2))
+        if end < start:
+            raise ValueError(
+                f'Invalid range "{entry}" in core list "{core_list}"; the end core id must not be smaller than the start core id.'
+            )
+        cores.extend(range(start, end + 1))
+    if not cores:
+        raise ValueError(f'No core id found in core list "{core_list}".')
+    unique_cores = sorted(set(cores))
+    if len(unique_cores) != len(cores):
+        logger.warning(
+            'core list "%s" contains duplicate core ids; using %s unique core(s)',
+            core_list,
+            len(unique_cores),
+        )
+    return unique_cores
 
 
 class _CPUinfo:
@@ -463,11 +503,24 @@ Value applied: %s. Value ignored: %s",
             elif len(args.ncores_per_instance) > 1:
                 args.ninstances = len(args.ncores_per_instance)
         if args.core_list:  # user specify what cores will be used by params
-            cores = [int(x) for x in args.core_list.split(",")]
+            cores = _parse_core_list(args.core_list)
             if args.ncores_per_instance == [-1]:
                 raise RuntimeError(
                     'please specify the "--ncores-per-instance" if you have pass the --core-list params'
                 )
+            if args.ninstances == -1 and len(args.ncores_per_instance) == 1:
+                ncores = args.ncores_per_instance[0]
+                if ncores <= 0:
+                    raise RuntimeError(
+                        f'"--ncores-per-instance" must be a positive integer, got {ncores}'
+                    )
+                if ncores > len(cores):
+                    raise RuntimeError(
+                        f"--core-list has {len(cores)} core(s), fewer than --ncores-per-instance "
+                        f"{ncores}; no instance can be launched"
+                    )
+                args.ninstances = len(cores) // ncores
+                args.ncores_per_instance = args.ncores_per_instance * args.ninstances
             if args.ninstances > 0 and sum(args.ncores_per_instance) < len(cores):
                 logger.warning(
                     "only first %s cores will be used, \
@@ -878,7 +931,8 @@ https://github.com/intel/intel-extension-for-pytorch/blob/master/docs/tutorials/
         metavar="\b",
         default=None,
         type=str,
-        help='Specify the core list as "core_id, core_id, ....", otherwise, all the cores will be used.',
+        help='Specify the core list as "core_id, core_id, ...." or as ranges such as "0-31,65,92-102", \
+otherwise, all the cores will be used.',
     )
     group.add_argument(
         "--log-path",


### PR DESCRIPTION
# Motivation

Extend --core-list argument to support range selection (i.e. 0-31, 62-79). This will enhance the user experience and eliminate redundant operations.

# Test
Tested and passed with python test/backends/xeon/test_launch.py

# Platform
Intel(R) Xeon(R) 6960P
Ubuntu  6.8.0-60-generic

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01