### PR TITLE
[AOTI] Stop dry-compiling ISA probes in aoti_load_package

### DIFF
--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -166,6 +166,81 @@ class TestAOTIPackageDeviceValidation(TestCase):
             ):
                 torch._C._aoti.AOTIModelPackageLoader(str(tmp), "model", False, 1, -1)
 
+    def test_aoti_load_does_not_invoke_compiler_isa_probe(self):
+        from torch._inductor import config as inductor_config, cpu_vec_isa
+
+        class FakeAOTIModelPackageLoader:
+            @staticmethod
+            def load_metadata_from_package(file, model_name):
+                return {"AOTI_DEVICE_KEY": "cpu", "AOTI_CPU_ISA": "AVX2"}
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+        def clear_isa_caches():
+            cpu_vec_isa.valid_vec_isa_list.cache_clear()
+            cpu_vec_isa.cpuinfo_vec_isa_list.cache_clear()
+            cpu_vec_isa.VecISA._VecISA__bool__impl.cache_clear()
+            cpu_vec_isa.VecAVX512.__bool__.cache_clear()
+            cpu_vec_isa.VecAVX512VNNI.__bool__.cache_clear()
+            cpu_vec_isa.VecAMX.__bool__.cache_clear()
+
+        clear_isa_caches()
+        try:
+            with (
+                inductor_config.patch({"cpp.vec_isa_ok": None, "cpp.simdlen": None}),
+                mock.patch.object(
+                    torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoader
+                ),
+                mock.patch.object(
+                    cpu_vec_isa.VecISA,
+                    "check_build",
+                    side_effect=AssertionError(
+                        "the load path must not dry-compile ISA probe programs"
+                    ),
+                ),
+            ):
+                _load_aoti("model.pt2", "model", False, 1, -1)
+        finally:
+            clear_isa_caches()
+
+    def test_aoti_load_still_warns_on_isa_mismatch(self):
+        class FakeAOTIModelPackageLoader:
+            @staticmethod
+            def load_metadata_from_package(file, model_name):
+                # An ISA string no host can satisfy, so the mismatch warning
+                # must fire regardless of the machine running the test.
+                return {
+                    "AOTI_DEVICE_KEY": "cpu",
+                    "AOTI_CPU_ISA": "AVX512 AVX512_VNNI AMX_TILE NONEXISTENT_ISA",
+                }
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+        with (
+            mock.patch.object(
+                torch._C._aoti, "AOTIModelPackageLoader", FakeAOTIModelPackageLoader
+            ),
+            mock.patch("torch.export.pt2_archive._package.logger.warning") as mock_warn,
+        ):
+            _load_aoti("model.pt2", "model", False, 1, -1)
+
+        mock_warn.assert_called_once()
+        self.assertIn("Device information mismatch", mock_warn.call_args[0][0])
+
+    def test_cpuinfo_vec_isa_list_covers_valid_vec_isa_list(self):
+        from torch._inductor import cpu_vec_isa
+
+        # The cpuinfo-detected list may only ever be a (non-strict) superset
+        # of the toolchain-validated list: the dry-compile probe can remove
+        # ISAs the compiler cannot build for, never add them.
+        valid = {str(isa) for isa in cpu_vec_isa.valid_vec_isa_list()}
+        detected = {str(isa) for isa in cpu_vec_isa.cpuinfo_vec_isa_list()}
+        self.assertTrue(
+            valid.issubset(detected), f"{valid=} not a subset of {detected=}"
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -294,14 +294,23 @@ def _cuda_fatbin_command(
     return cmd
 
 
-def get_device_information(device_type: str) -> dict[str, str]:
+def get_device_information(
+    device_type: str, *, check_build: bool = True
+) -> dict[str, str]:
     """
     Gets all the current device information used to compile the .so.
+
+    With ``check_build=False``, ``AOTI_CPU_ISA`` is detected from cpuinfo
+    without dry-compiling toolchain probes (multi-second on machines with a
+    cold inductor cache). Use it on paths that only describe the host, such
+    as package loading, rather than compile for it.
     """
     metadata: dict[str, str] = {
         "AOTI_PLATFORM": sys.platform,
         "AOTI_MACHINE": platform.machine(),
-        "AOTI_CPU_ISA": str(torch._inductor.cpu_vec_isa.pick_vec_isa()).upper(),
+        "AOTI_CPU_ISA": str(
+            torch._inductor.cpu_vec_isa.pick_vec_isa(check_build=check_build)
+        ).upper(),
         "AOTI_COMPUTE_CAPABILITY": str(
             get_interface_for_device(device_type).get_compute_capability()
         ),

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -601,11 +601,7 @@ def get_isa_from_cpu_capability(
     return vec_isa_list[0]
 
 
-# Cache the cpuinfo to avoid I/O overhead. Meanwhile, the cpuinfo content
-# might have too much redundant content that is useless for ISA check. Hence,
-# we only cache some key isa information.
-@functools.cache
-def valid_vec_isa_list() -> list[VecISA]:
+def _detect_vec_isa_list(check_build: bool) -> list[VecISA]:
     isa_list: list[VecISA] = []
     if sys.platform == "darwin" and platform.processor() == "arm":
         isa_list.append(VecNEON())
@@ -649,17 +645,41 @@ def valid_vec_isa_list() -> list[VecISA]:
         isa_list.extend(
             isa
             for isa in supported_vec_isa_list
-            if all(flag in _cpu_supported_x86_isa for flag in str(isa).split()) and isa
+            if all(flag in _cpu_supported_x86_isa for flag in str(isa).split())
+            and (not check_build or isa)
         )
 
     return isa_list
 
 
-def pick_vec_isa() -> VecISA:
+# Cache the cpuinfo to avoid I/O overhead. Meanwhile, the cpuinfo content
+# might have too much redundant content that is useless for ISA check. Hence,
+# we only cache some key isa information.
+@functools.cache
+def valid_vec_isa_list() -> list[VecISA]:
+    """ISAs the host CPU supports AND the toolchain can produce a working
+    ``.so`` for (each candidate is verified with the dry-compile + dlopen
+    probe from `Note [Checking for Vectorized Support in Inductor]`)."""
+    return _detect_vec_isa_list(check_build=True)
+
+
+@functools.cache
+def cpuinfo_vec_isa_list() -> list[VecISA]:
+    """ISAs the host CPU supports, detected from cpuinfo alone -- no compiler
+    is invoked. The dry-compile probe in valid_vec_isa_list exists to verify
+    the *toolchain* before codegen; paths that only need to describe the host
+    (e.g. the package-load device-info check) can use this instead and avoid
+    multi-second probe costs on machines with a cold inductor cache."""
+    return _detect_vec_isa_list(check_build=False)
+
+
+def pick_vec_isa(*, check_build: bool = True) -> VecISA:
     if config.is_fbcode() and (platform.machine() in ["x86_64", "AMD64"]):
         return VecAVX2()
 
-    _valid_vec_isa_list: list[VecISA] = valid_vec_isa_list()
+    _valid_vec_isa_list: list[VecISA] = (
+        valid_vec_isa_list() if check_build else cpuinfo_vec_isa_list()
+    )
     if not _valid_vec_isa_list:
         return invalid_vec_isa
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1063,7 +1063,11 @@ def _load_aoti(
     device = loaded_metadata["AOTI_DEVICE_KEY"]
     from torch._inductor.codecache import get_device_information
 
-    current_device_info = get_device_information(device)
+    # check_build=False: this check only describes the host for the advisory
+    # mismatch warning below; nothing is compiled on the load path, so the
+    # toolchain dry-compile probes would add seconds of load time for no
+    # signal (https://github.com/pytorch/pytorch/issues/191715).
+    current_device_info = get_device_information(device, check_build=False)
 
     for k, v in current_device_info.items():
         if k in loaded_metadata:


### PR DESCRIPTION
### Summary

`aoti_load_package` currently spends multiple seconds before a `.pt2` is usable on any machine with a cold inductor cache (serverless containers, fresh CI runners). The entire cost is `get_device_information()` on the load path: its `AOTI_CPU_ISA` field is computed by `pick_vec_isa()` → `VecISA.check_build()`, which dry-compiles and `dlopen`s probe programs with the host C++ compiler — up to 8 toolchain probes on an AMX host. The only consumer of that field at load time is the advisory "Device information mismatch" warning; nothing is recompiled on mismatch, the packaged `.so` is used as-is either way.

The toolchain probe exists to protect **codegen** (see `Note [Checking for Vectorized Support in Inductor]` — it guards against Sleef symbol mismatches when *compiling* vectorized code). The load path compiles nothing, so it only needs to *describe the host*.

This PR adds a compiler-free lane through the existing detection logic and uses it on the load path only:

- `cpu_vec_isa.py`: the body of `valid_vec_isa_list()` moves to `_detect_vec_isa_list(check_build)`; the x86 filter's `and isa` (which triggers the `check_build` dry-compile via `VecISA.__bool__`) becomes `and (not check_build or isa)`. Cached `valid_vec_isa_list()` keeps today's behavior; new cached `cpuinfo_vec_isa_list()` detects from cpuinfo alone (`torch.cpu._is_avx2_supported()` etc. — already how candidates are pre-filtered today).
- `pick_vec_isa(*, check_build: bool = True)`: with `check_build=False` it selects from the cpuinfo-detected list. All other semantics are unchanged and shared — the fbcode carve-out, `config.cpp.simdlen`, and `ATEN_CPU_CAPABILITY` handling — so both lanes return identical strings whenever the toolchain is healthy.
- `codecache.py`: `get_device_information()` forwards a new `check_build` keyword (default `True` — the packaging/write side is untouched: at compile time the probes are already warm in-process and the metadata should keep describing what codegen actually validated).
- `_package.py`: `_load_aoti` passes `check_build=False`.

Behavior change is deliberately minimal:
- On hosts with a working toolchain, the host ISA string is **identical** to today's, so the mismatch warning fires in exactly the same cases — this PR is orthogonal to #191904, which makes the comparison itself direction-aware.
- On hosts **without** a C++ toolchain (common for slim inference images), the load path previously reported `AOTI_CPU_ISA = INVALID_VEC_ISA` and warned spuriously on every load; it now reports the CPU's real capability.

### Measured

Host: Intel Xeon Silver 4510, AMX-capable (avx2+avx512+vnni+amx_tile — the worst case, 8 toolchain probes), g++ 11.4, torch `2.14.0.dev20260806+cpu`; tiny 2-layer MLP `.pt2` pinned to AVX2, fresh process + fresh `TORCHINDUCTOR_CACHE_DIR` per measurement (the repro script from #191715):

| | `aoti_load_package` (cold) | direct loader construction |
|---|---|---|
| before | 8.14 s | 0.003 s |
| after | **0.069 s** | 0.002 s |

Outputs identical before/after and vs eager. The "Device information mismatch" warning still fires with the byte-identical message in the same situation (`AVX512 AVX512_VNNI AMX_TILE vs AVX2`), confirming no change to the warning semantics.

Also validated across a serverless fleet (the scenario from #191715): 10 fresh Modal containers, 3 clouds (AWS / GCP / Azure), 8 regions, paired before/after on each host against the same image-baked AVX2-pinned `.pt2`:

| host class | n | before (cold) | after (cold) | direct-loader control |
|---|---|---|---|---|
| AVX-512 VNNI | 6 | 7.45–7.91 s | 0.156–0.189 s | 0.003–0.005 s |
| AVX2-only | 4 | 2.97–3.86 s | 0.205–0.280 s | 0.004–0.006 s |

On every host: outputs identical, and the mismatch warning count is unchanged before vs after (fires on the AVX-512 hosts where artifact ≠ host string, silent on AVX2 hosts where they match).

Reference numbers across clouds/ISAs are in #191715 (2.9–10.6 s before, on 2.13 stable and 2.14 nightly).

### Test Plan

Added to `TestAOTIPackageDeviceValidation` in `test/export/test_package.py`:
- `test_aoti_load_does_not_invoke_compiler_isa_probe` — clears the ISA caches, patches `VecISA.check_build` to raise, and asserts `_load_aoti` completes without ever dry-compiling.
- `test_aoti_load_still_warns_on_isa_mismatch` — the advisory warning still fires on a genuine mismatch (artifact ISA unsatisfiable on any host, so the assertion holds regardless of the machine and composes with the direction-aware check proposed in #191904).
- `test_cpuinfo_vec_isa_list_covers_valid_vec_isa_list` — structural invariant: the cpuinfo-detected ISA list is always a (non-strict) superset of the toolchain-validated list.

Fixes #191715

cc @desertfire @angelayi @jansel
