### PR TITLE
[MTIA][Inductor] Upstream the template signature-constexpr hook and delete the 169-line fork (#192395)

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -1363,6 +1363,96 @@ class TestTemplateRender(TestCase):
                 kernels[0]
             )
 
+    @requires_gpu()
+    @requires_triton()
+    @config.patch(cuda_backend="triton")
+    def test_extra_signature_constexprs_promotes_meta_key(self):
+        """Meta params can be moved from the template body into the signature.
+
+        By default a meta param is rendered as a body define, so every value
+        renders the same kernel signature. A backend whose autotuner varies
+        Config(kwargs) needs the param in the signature instead, so each value
+        is a distinct specialization. extra_signature_constexprs() promotes it;
+        gen_defines() drops it from the body so it is not declared twice.
+        """
+        import re
+
+        class PromotingTemplateKernel(TritonTemplateKernel):
+            def extra_signature_constexprs(self) -> list[str]:
+                return ["BLOCK_SIZE"]
+
+            def gen_defines(self):
+                return "".join(
+                    f"{line}\n"
+                    for line in super().gen_defines().splitlines()
+                    if "BLOCK_SIZE" not in line
+                )
+
+        class PromotingTritonTemplate(TritonTemplate):
+            kernel_type = PromotingTemplateKernel
+
+        BLOCK_SIZE = 32
+
+        add_template = PromotingTritonTemplate(
+            name="promoted_add",
+            grid=lambda *args, **kwargs: (1, 1, 1),
+            source=(
+                r"""
+{{def_kernel("A", "B")}}
+    xoffset = tl.program_id(0)
+    xindex = xoffset + tl.arange(0, BLOCK_SIZE)
+    xmask = tl.full([BLOCK_SIZE], True, tl.int1)
+    tmp0 = tl.load(A + xindex)
+    tmp1 = tl.load(B + xindex)
+    tmp2 = tmp0 + tmp1
+    {{store_output(("xindex",), "tmp2", mask="xmask", val_shape=("BLOCK_SIZE",))}}
+    """
+            ),
+        )
+
+        def add_override(a, b, alpha=None):
+            layout = FixedLayout(a.get_device(), a.get_dtype(), a.get_size())
+            choices = []
+            add_template.maybe_append_choice(
+                choices,
+                input_nodes=(a, b),
+                layout=layout,
+                num_stages=1,
+                num_warps=2,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+            node, _ = autotune_select_algorithm("promoted_add", choices, [a, b], layout)
+            return node
+
+        with patch_lowering(
+            {
+                torch.ops.aten.add.Tensor: (
+                    add_override,
+                    True,
+                    ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+                    False,
+                )
+            }
+        ):
+
+            @torch.compile
+            def add(a, b):
+                return a + b
+
+            a = torch.zeros((BLOCK_SIZE,), device=GPU_TYPE)
+            b = torch.zeros((BLOCK_SIZE,), device=GPU_TYPE)
+
+            _result, kernels = run_and_get_kernels(add, a, b)
+
+        self.assertEqual(len(kernels), 1)
+        kernel = kernels[0]
+        signature = kernel.split("):", 1)[0]
+
+        # Promoted into the signature ...
+        self.assertRegex(signature, r"BLOCK_SIZE\s*:\s*tl\.constexpr")
+        # ... and not also declared as a body define.
+        self.assertIsNone(re.search(r"BLOCK_SIZE\s*:\s*tl\.constexpr\s*=", kernel))
+
     def test_subgraph_nodes_participate_in_template_index_dtype(self):
         """Covers implicit template buffers that are not explicit arguments."""
         import sympy

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -56,6 +56,8 @@ from .autotune_process import (
 )
 from .codecache import code_hash, PersistentCache, PyCodeCache
 from .codegen.common import (
+    ArgName,
+    ConstexprArg,
     CSEVariable,
     IndentedBuffer,
     KernelTemplate,
@@ -894,12 +896,27 @@ class TritonTemplateKernel(TritonKernel):
                     return V.graph.sizevars.optimization_hint(f, fallback=0)
         return 0
 
+    def extra_signature_constexprs(self) -> list[str]:
+        """Meta keys to promote to signature ``tl.constexpr`` params.
+
+        Empty by default, so templates render exactly as before. A backend that
+        autotunes template parameters (e.g. tile sizes) can override this to move
+        those names out of the body defines and into the kernel signature, which
+        makes each value a distinct compiled specialization that a launcher-level
+        autotuner can select between. Overriders are expected to strip the same
+        names from :meth:`gen_defines` so they are not declared twice.
+        """
+        return []
+
     def jit_lines(self):
         """Render decorators and metadata for the generated Triton template."""
         if self.use_jit:
             return "@triton.jit"
 
         argdefs, _, signature, _ = self.args.python_argdefs()
+        for _name in self.extra_signature_constexprs():
+            argdefs.append(ArgName(_name, is_constexpr=True))
+            signature.append(ConstexprArg(_name))
         triton_meta: TritonMeta = {
             "signature": signature_to_meta(
                 signature,
@@ -1054,6 +1071,8 @@ class TritonTemplateKernel(TritonKernel):
         def hook():
             # python_argdefs() cannot be run until after the rest of the template lazily adds more args
             arg_defs, *_ = self.args.python_argdefs()
+            for _name in self.extra_signature_constexprs():
+                arg_defs.append(ArgName(_name, is_constexpr=True))
             code = IndentedBuffer()
             code.splice(self.gen_common_triton_imports())
             code.splice(self.jit_lines())
@@ -1061,7 +1080,10 @@ class TritonTemplateKernel(TritonKernel):
                 f"def {self.kernel_name}({', '.join(x.full_name() for x in arg_defs)}):"
             )
             with code.indent():
-                code.splice(self.defines)
+                # via gen_defines() so a subclass can filter the body defines --
+                # e.g. drop names promoted to signature constexprs by
+                # extra_signature_constexprs(). Base impl returns self.defines.
+                code.splice(self.gen_defines())
                 code.splice(renames.getvalue())
                 self.codegen_prologue(code)
             return code.getvalue()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -56,6 +56,8 @@ from .autotune_process import (
 )
 from .codecache import code_hash, PersistentCache, PyCodeCache
 from .codegen.common import (
+    ArgName,
+    ConstexprArg,
     CSEVariable,
     IndentedBuffer,
     KernelTemplate,
@@ -894,12 +896,23 @@ class TritonTemplateKernel(TritonKernel):
                     return V.graph.sizevars.optimization_hint(f, fallback=0)
         return 0
 
+    def extra_signature_constexprs(self) -> list[str]:
+        """Extra ``tl.constexpr`` params to add to the kernel signature.
+
+        Empty by default. Subclasses that override this should strip the same
+        names from :meth:`gen_defines`, or they will be declared twice.
+        """
+        return []
+
     def jit_lines(self):
         """Render decorators and metadata for the generated Triton template."""
         if self.use_jit:
             return "@triton.jit"
 
         argdefs, _, signature, _ = self.args.python_argdefs()
+        for _name in self.extra_signature_constexprs():
+            argdefs.append(ArgName(_name, is_constexpr=True))
+            signature.append(ConstexprArg(_name))
         triton_meta: TritonMeta = {
             "signature": signature_to_meta(
                 signature,
@@ -1054,6 +1067,8 @@ class TritonTemplateKernel(TritonKernel):
         def hook():
             # python_argdefs() cannot be run until after the rest of the template lazily adds more args
             arg_defs, *_ = self.args.python_argdefs()
+            for _name in self.extra_signature_constexprs():
+                arg_defs.append(ArgName(_name, is_constexpr=True))
             code = IndentedBuffer()
             code.splice(self.gen_common_triton_imports())
             code.splice(self.jit_lines())
@@ -1061,7 +1076,7 @@ class TritonTemplateKernel(TritonKernel):
                 f"def {self.kernel_name}({', '.join(x.full_name() for x in arg_defs)}):"
             )
             with code.indent():
-                code.splice(self.defines)
+                code.splice(self.gen_defines())
                 code.splice(renames.getvalue())
                 self.codegen_prologue(code)
             return code.getvalue()


### PR DESCRIPTION
Summary:

`TritonTemplateKernel` renders template meta params (tile sizes and similar) as
defines in the kernel body. Every value therefore produces the same kernel
signature, and specialization comes from re-rendering the template once per
config.

That does not fit a backend whose autotuner selects between configs at launch
time by varying `Config(kwargs)`: those only become distinct compiled
specializations when the params live in the **signature**. This adds an opt-in
hook so such a backend can promote chosen names out of the body defines and into
the signature, instead of forking `jit_lines` and `def_kernel` to do it.

## Changes

`torch/_inductor/select_algorithm.py`:

- `TritonTemplateKernel.extra_signature_constexprs()` returns `[]`. Opt-in, so no
  existing backend changes behaviour.
- `jit_lines` appends those names to `argdefs` / `signature`.
- `def_kernel` appends them to `arg_defs`, and renders body defines via
  `self.gen_defines()` rather than splicing `self.defines` directly, so a
  subclass can strip the promoted names. `gen_defines()` already existed and
  returns `self.defines`, so this is a no-op upstream and turns it into a
  reachable extension point.

The two must be overridden together: promoting a name without dropping it from
`gen_defines()` declares it twice and the kernel fails to compile.

## Test

`test_extra_signature_constexprs_promotes_meta_key` in
`test/inductor/test_select_algorithm.py` renders a template through a subclass
that overrides both hooks, and asserts the promoted name appears in the kernel
signature as a `tl.constexpr` and not as a body define.

Test Plan:
The `def_kernel` -> `gen_defines()` change is load-bearing and was NOT covered by
the forked methods' "only deltas are the marked MTIA: blocks" comment. Without it
the promoted params are emitted as body defines AND signature constexprs, so
every templated_gemm kernel fails to compile.

MTIA Inductor device suite (`inductor_tests:afg_inductor_unittest-<arch>`, filter
`templated_gemm`; exact target in MM_MEGA_TEST_PLAN.md Part A):

| state | result |
|---|---|
| base (fork intact) | 380 pass |
| hook without the gen_defines() change | 377 fail |
| this diff | **380 pass** (parity with base) |

Unit tests, 51 pass:
```
buck2 test fbcode//mode/opt fbcode//mtia/compiler/graph_compiler/inductor/backend/tests:test_scheduling
```
https://www.internalfb.com/intern/testinfra/testrun/11821949209689503
`TemplateSignatureConstexprTest` gains four cases asserting the upstream side of
the contract, which a pure unit test of the MTIA overrides cannot see (an earlier
version of that class passed while codegen was broken):
- `test_upstream_jit_lines_promotes_extra_signature_constexprs`
- `test_upstream_def_kernel_routes_defines_through_gen_defines`
- `test_mtia_no_longer_forks_upstream_methods`
- `test_upstream_default_is_a_no_op`

Negative-tested: reintroducing `code.splice(self.defines)` upstream makes
`test_upstream_def_kernel_routes_defines_through_gen_defines` fail, and restoring
it passes.

Full stack after rebase onto master: 262 unit tests pass, lint clean.

NOTE: `select_algorithm.py` is OSS PyTorch, so this exports to GitHub. It is
deliberately a leaf off D113575720 rather than inside the autotune stack, so the
export does not block D113575718 / D113575719 / D113575720 / D113575722 or
D114629187 from landing.

Reviewed By: srostrup

Differential Revision: D115076789


