### PR TITLE
[CI] Backfill arch-gated tests into the ciflow/h100 and ciflow/b200 lists

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -443,6 +443,26 @@ test_python_smoke() {
   time python test/run_test.py --include test_matmul_cuda test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_foreach -k TestForeachMM $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_linalg -k polar $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/_composable/fsdp/test_fully_shard_comm -k "TestFullyShardSymmMem" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/tensor/test_matrix_ops -k "test_grouped_mm" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include dynamo/test_logging -k "test_autotuning" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include dynamo/test_reconstruct -k "test_tma_experimental_reconstruct or test_tma_stable_reconstruct" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_aot_inductor -k "test_varlen_attn_paged_kv_cache" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_combo_kernels -k "test_combo_kernel_tma_descriptor_block_name or test_combo_kernel_yz_overflow or test_pdl_codegen_in_combo_kernel or test_pdl_combo_kernel_pointwise or test_pdl_combo_kernel_reduction" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_cuda_repro -k "test_atomic_add_bfloat16 or test_chunked_unrolled_slice_gather_int32_overflow or test_float8_e8m0fnu or test_index_add_fallback or test_index_add_fallback_direct" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_cutlass_fallback -k "test_addmm_fallback_on_cutlass_failure or test_extern_kernel_included_in_prescreening or test_fallback_to_aten_when_cutlass_benchmarks_fail or test_issue_171094_dimensions" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_flex_decoding -k "test_tma_decoding" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_flex_flash -k "test_dynamic_multiple_scalar_closures_with_max_autotune or test_max_autotune_score_mod" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_lookup_table -k "test_mixed_template_configs or test_multiple_configs_same_template or test_tma_lookup_table_entry" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_loop_ordering -k "test_fp8_cast_and_t" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_torchinductor -k "test_pdl_mutation or test_pdl_template_and_delay" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_triton_kernels -k "test_add_kernel_on_device_tma_new_api or test_add_kernel_on_device_tma_old_api or test_descriptor_load_store_read_write_detection" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_user_streams -k "test_pdl_correctness_with_multiple_streams or test_pdl_cross_stream_events_preserved or test_pdl_mutation_across_streams or test_pdl_no_fusion_across_streams or test_pdl_same_stream_consecutive_kernels or test_pdl_single_side_stream or test_pdl_stress_multistream_correctness" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_cuda -k "test_cublas_workspace_explicit_allocation or test_out_of_memory_retry or test_pinned_memory_use_background_threads or test_preferred_blas_library_settings" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_foreach -k "test_foreach_mm_cond_rejects or test_foreach_mm_fallback_correctness or test_foreach_mm_nvmath" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_linalg -k "test__int_mm" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_nn -k "TestFusedRMSNormOverrideNumerics or TestFusedRMSNormOverrideRouting" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_scatter_gather_ops -k "test_smem_stage_alignment_multi_iter" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 
@@ -466,6 +486,11 @@ test_python_smoke_b200() {
       test_varlen_attention \
       $PYTHON_TEST_EXTRA_OPTION \
       --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/test_cupy_as_tensor -k "test_cupy_as_tensor" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_max_autotune -k "test_honor_sm_carveout_with_triton_tma or test_max_autotune_addmm_persistent_tma or test_max_autotune_mm_persistent_tma_large_input_tensor_int64_indexing or test_max_autotune_regular_mm_persistent_tma or test_max_autotune_regular_mm_persistent_tma_strided or test_persistent_tma_epilogue_fusion_store_cache" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_max_autotune_blackwell -k "test_blackwell_addmm_1d_bias_epilogue_tma_load or test_blackwell_addmm_relu_epilogue_fusion_tma_store or test_blackwell_max_autotune_addmm_persistent_tma or test_blackwell_max_autotune_regular_mm_persistent_tma or test_blackwell_max_autotune_scaled_mm_per_row_persistent_tma or test_blackwell_max_autotune_scaled_mm_per_tensor_persistent_tma or test_blackwell_mm_scale_bias_epilogue_tma_load or test_blackwell_mm_sigmoid_epilogue_fusion_tma_store or test_blackwell_mm_sigmoid_epilogue_tma_load" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include inductor/test_torchinductor_strided_blocks -k "test_2d_welford_reduction or test_reduction" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include profiler/test_cupti_monitor -k "test_cupti_monitor_enable_hes_early_guard or test_cupti_monitor_observed_kinds_present" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -153,6 +153,12 @@
 - third_party/fbgemm
 - .ci/pytorch/test.sh
 - .github/labeler.yml
+- test/distributed/test_cupy_as_tensor.py
+- test/distributed/test_symmetric_memory.py
+- test/inductor/test_flex_gemm.py
+- test/inductor/test_max_autotune_blackwell.py
+- test/inductor/test_torchinductor_strided_blocks.py
+- test/profiler/test_cupti_monitor.py
 
 "ciflow/h100":
 - test/test_matmul_cuda.py
@@ -166,6 +172,30 @@
 - third_party/fbgemm
 - .ci/pytorch/test.sh
 - .github/labeler.yml
+- test/distributed/_composable/fsdp/test_fully_shard_comm.py
+- test/distributed/tensor/test_matrix_ops.py
+- test/distributed/test_symmetric_memory.py
+- test/dynamo/test_logging.py
+- test/dynamo/test_reconstruct.py
+- test/inductor/test_aot_inductor.py
+- test/inductor/test_combo_kernels.py
+- test/inductor/test_cuda_repro.py
+- test/inductor/test_cutlass_backend.py
+- test/inductor/test_cutlass_evt.py
+- test/inductor/test_cutlass_fallback.py
+- test/inductor/test_flex_attention.py
+- test/inductor/test_flex_decoding.py
+- test/inductor/test_flex_flash.py
+- test/inductor/test_lookup_table.py
+- test/inductor/test_loop_ordering.py
+- test/inductor/test_torchinductor.py
+- test/inductor/test_triton_kernels.py
+- test/inductor/test_user_streams.py
+- test/test_cuda.py
+- test/test_foreach.py
+- test/test_linalg.py
+- test/test_nn.py
+- test/test_scatter_gather_ops.py
 
 "ciflow/rocm-mi300":
 - test/test_matmul_cuda.py

--- a/tools/linter/adapters/gpu_arch_coverage-baseline.json
+++ b/tools/linter/adapters/gpu_arch_coverage-baseline.json
@@ -1,36 +1,4 @@
 {
   "_comment": "Files with arch-gated tests that predate GPU_ARCH_COVERAGE. Remove entries as they are added to the ciflow lists; do not add new ones.",
-  "known_uncovered": [
-    "ciflow/b200::distributed/test_cupy_as_tensor",
-    "ciflow/b200::distributed/test_symmetric_memory",
-    "ciflow/b200::inductor/test_flex_gemm",
-    "ciflow/b200::inductor/test_max_autotune",
-    "ciflow/b200::inductor/test_max_autotune_blackwell",
-    "ciflow/b200::inductor/test_torchinductor_strided_blocks",
-    "ciflow/b200::profiler/test_cupti_monitor",
-    "ciflow/h100::distributed/_composable/fsdp/test_fully_shard_comm",
-    "ciflow/h100::distributed/tensor/test_matrix_ops",
-    "ciflow/h100::distributed/test_symmetric_memory",
-    "ciflow/h100::dynamo/test_logging",
-    "ciflow/h100::dynamo/test_reconstruct",
-    "ciflow/h100::inductor/test_aot_inductor",
-    "ciflow/h100::inductor/test_combo_kernels",
-    "ciflow/h100::inductor/test_cuda_repro",
-    "ciflow/h100::inductor/test_cutlass_backend",
-    "ciflow/h100::inductor/test_cutlass_evt",
-    "ciflow/h100::inductor/test_cutlass_fallback",
-    "ciflow/h100::inductor/test_flex_attention",
-    "ciflow/h100::inductor/test_flex_decoding",
-    "ciflow/h100::inductor/test_flex_flash",
-    "ciflow/h100::inductor/test_lookup_table",
-    "ciflow/h100::inductor/test_loop_ordering",
-    "ciflow/h100::inductor/test_torchinductor",
-    "ciflow/h100::inductor/test_triton_kernels",
-    "ciflow/h100::inductor/test_user_streams",
-    "ciflow/h100::test_cuda",
-    "ciflow/h100::test_foreach",
-    "ciflow/h100::test_linalg",
-    "ciflow/h100::test_nn",
-    "ciflow/h100::test_scatter_gather_ops"
-  ]
+  "known_uncovered": []
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192397
* #192396

Adds the 31 files the GPU_ARCH_COVERAGE baseline was suppressing, and empties
the baseline. 79 arch-gated test symbols across these files currently never run
on hardware that satisfies their gate -- they skip silently on the a10g/A100
runners that serve most of CI.

Every entry here was produced by `lintrunner -a`, not written by hand, so the
lists now match what the linter derives from the gates.

Two things worth reviewing closely:

inductor/test_max_autotune is added to test_python_smoke_b200(). The file was
already in the h100 smoke list and in labeler.yml under both labels, so it looks
covered -- but six of its tests require SM100OrLater and the b200 smoke list did
not include the file, so those never ran anywhere. This is the case a floor-only
(rather than range-based) model of the gates would miss.

Several files needed only a labeler.yml entry because another test.sh function
already runs them, so nothing auto-triggered the job that does:
test_cutlass_backend and test_cutlass_evt (run by test_h100_cutlass_backend),
test_flex_gemm (test_python_smoke_b200), test_symmetric_memory
(_run_symm_mem_tests), test_flex_attention. Until now those only ran on the
6-hourly cron or a manually applied label.

Expect this to be red initially. These tests have never executed on sm90+/sm100,
so some will fail for real reasons. Failures that are not quick fixes should get
`# gpu-coverage: skip <reason>` plus a tracking issue rather than blocking the
rest -- the value is that the gap becomes recorded instead of invisible.

Test Plan:

The linter reports no remaining gaps, with an empty baseline:

```
python tools/linter/adapters/gpu_arch_coverage_linter.py --show-backfill | wc -l   # 0
spin lint -- --take GPU_ARCH_COVERAGE .github/labeler.yml .ci/pytorch/test.sh
```

Counts: 30 entries added to .github/labeler.yml (24 h100, 6 b200), 25 lines to
.ci/pytorch/test.sh (20 h100, 5 b200).

Not yet validated locally: the generated -k expressions have not been executed
on H100 or B200 (the local build fails in third_party/fbgemm on an unrelated
AVX512-BF16 toolchain issue). The ciflow/h100 and ciflow/b200 jobs on this PR
are what actually exercise them -- in particular whether each -k selects the
intended tests and whether they pass.

Co-authored-by: Claude <noreply@anthropic.com>
Authored with assistance from Claude Code.