### PR TITLE
[CUDA][CuTeDSL] Wire up Quack RMSNorm to `sm12x`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from itertools import product
 from functools import partial
 from collections import OrderedDict
-from unittest import SkipTest
+from unittest import mock, SkipTest
 
 import torch
 from torch import inf, nan
@@ -16215,6 +16215,16 @@ class TestFusedRMSNormOverrideRouting(TestCase):
     covered by test/python_native/.
     """
 
+    def test_sm12x_supported(self):
+        from torch._native.ops.norm.rmsnorm_impl import _is_supported
+
+        x = torch.randn(8, 128, dtype=torch.float16, device="cuda")
+        for capability in ((12, 0), (12, 1)):
+            with mock.patch(
+                "torch.cuda.get_device_capability", return_value=capability
+            ):
+                self.assertTrue(_is_supported(x))
+
     def test_fwd_cond_fires_supported_fp16(self):
         from torch._native.ops.norm.rmsnorm_impl import _fused_rms_norm_cond
 
@@ -16327,23 +16337,26 @@ class TestFusedRMSNormOverrideRouting(TestCase):
         self.assertFalse(_fused_rms_norm_cond(x, [n], None, 1e-5))
 
     def test_fwd_cond_smem_boundary(self):
-        # bf16 fwd: 2^20 fits the smem budget (verified to launch), 2^21
-        # overflows it (verified launch failure without the cond guard).
+        # SM12x has a smaller cluster and smem budget than SM90/SM100.
         from torch._native.ops.norm.rmsnorm_impl import _fused_rms_norm_cond
 
-        x = torch.empty(1, 1 << 20, dtype=torch.bfloat16, device="cuda")
-        self.assertTrue(_fused_rms_norm_cond(x, [1 << 20], None, 1e-5))
-        x = torch.empty(1, 1 << 21, dtype=torch.bfloat16, device="cuda")
-        self.assertFalse(_fused_rms_norm_cond(x, [1 << 21], None, 1e-5))
+        major, _ = torch.cuda.get_device_capability()
+        fit_n, overflow_n = (1 << 18, 1 << 19) if major == 12 else (1 << 20, 1 << 21)
+        x = torch.empty(1, fit_n, dtype=torch.bfloat16, device="cuda")
+        self.assertTrue(_fused_rms_norm_cond(x, [fit_n], None, 1e-5))
+        x = torch.empty(1, overflow_n, dtype=torch.bfloat16, device="cuda")
+        self.assertFalse(_fused_rms_norm_cond(x, [overflow_n], None, 1e-5))
 
     def test_bwd_cond_false_on_huge_normalized_dim(self):
         # The bwd smem footprint is smem_stages * (x + dout) tiles, so its
-        # bound is tighter than the fwd's: bf16 2^18 fits, 2^19 does not.
+        # bound is tighter than the fwd's and tighter again on SM12x.
         from torch._native.ops.norm.rmsnorm_impl import (
             _fused_rms_norm_backward_cond,
         )
 
-        for n, expected in ((1 << 18, True), (1 << 19, False)):
+        major, _ = torch.cuda.get_device_capability()
+        cases = ((1 << 16, True), (1 << 17, False)) if major == 12 else ((1 << 18, True), (1 << 19, False))
+        for n, expected in cases:
             x = torch.empty(1, n, dtype=torch.bfloat16, device="cuda")
             gout = torch.empty(1, n, dtype=torch.bfloat16, device="cuda")
             rstd = torch.empty(1, 1, dtype=torch.float32, device="cuda")

--- a/torch/_native/ops/norm/rmsnorm_impl.py
+++ b/torch/_native/ops/norm/rmsnorm_impl.py
@@ -22,18 +22,17 @@ def _is_supported(input: torch.Tensor) -> bool:
     if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return False
     major, _ = torch.cuda.get_device_capability(input.device)
-    return major in (9, 10)
+    return major in (9, 10, 12)
 
 
-# quack splits each row across a CTA cluster (at most 16 on SM90/SM100, the
-# only archs _is_supported accepts) and stages the per-CTA row tile in shared
-# memory. Rows whose tile exceeds the smem budget even at the max cluster size
-# cannot launch, and far beyond that (e.g. N=2^28) the CuTe DSL compiler hangs
-# or crashes before any smem check could fire (gh-186800). Bound N here so
-# such rows fall back to aten. The reserve covers the reduction buffer,
-# mbarriers, and smem alignment (mirrors quack's _BWD_SMEM_RESERVED_BYTES).
+# quack splits each row across a CTA cluster (at most 16 on SM90/SM100 and 8
+# on SM12x) and stages the per-CTA row tile in shared memory. Rows whose tile
+# exceeds the smem budget even at the max cluster size cannot launch, and far
+# beyond that (e.g. N=2^28) the CuTe DSL compiler hangs or crashes before any
+# smem check could fire (gh-186800). Bound N here so such rows fall back to
+# aten. The reserve covers the reduction buffer, mbarriers, and smem alignment
+# (mirrors quack's _BWD_SMEM_RESERVED_BYTES).
 _SMEM_RESERVED_BYTES = 4 * 1024
-_MAX_CLUSTER_N = 16
 # The kernel rounds the per-CTA tile up to vecsize * threads_per_row elements
 # (reduction_base._get_tiled_copy). Both are powers of 2 with vecsize <= 8 and
 # threads_per_row <= 256, so rounding up to 2048 never under-estimates.
@@ -50,14 +49,22 @@ def _smem_budget_bytes(device: torch.device) -> int:
     return smem - _SMEM_RESERVED_BYTES
 
 
-def _row_tile_elems(n: int) -> int:
-    per_cta = -(-n // _MAX_CLUSTER_N)
+def _max_cluster_n(device: torch.device) -> int:
+    major, _ = torch.cuda.get_device_capability(device)
+    return 8 if major == 12 else 16
+
+
+def _row_tile_elems(device: torch.device, n: int) -> int:
+    per_cta = -(-n // _max_cluster_n(device))
     return -(-per_cta // _TILE_ROUND_ELEMS) * _TILE_ROUND_ELEMS
 
 
 def _fwd_fits_smem(input: torch.Tensor, n: int) -> bool:
     # Fwd smem holds one row tile of x (rmsnorm.py sX).
-    return _row_tile_elems(n) * input.element_size() <= _smem_budget_bytes(input.device)
+    return (
+        _row_tile_elems(input.device, n) * input.element_size()
+        <= _smem_budget_bytes(input.device)
+    )
 
 
 def _bwd_fits_smem(input: torch.Tensor, grad_out: torch.Tensor, n: int) -> bool:
@@ -68,7 +75,7 @@ def _bwd_fits_smem(input: torch.Tensor, grad_out: torch.Tensor, n: int) -> bool:
     # Bwd smem holds smem_stages buffers of both x and dout (rmsnorm.py
     # sX/sdO).
     tile_bytes = (
-        _row_tile_elems(n)
+        _row_tile_elems(input.device, n)
         * _BWD_SMEM_STAGES
         * (input.element_size() + grad_out.element_size())
     )

--- a/torch/_native/ops/norm/rmsnorm_impl.py
+++ b/torch/_native/ops/norm/rmsnorm_impl.py
@@ -61,10 +61,9 @@ def _row_tile_elems(device: torch.device, n: int) -> int:
 
 def _fwd_fits_smem(input: torch.Tensor, n: int) -> bool:
     # Fwd smem holds one row tile of x (rmsnorm.py sX).
-    return (
-        _row_tile_elems(input.device, n) * input.element_size()
-        <= _smem_budget_bytes(input.device)
-    )
+    return _row_tile_elems(
+        input.device, n
+    ) * input.element_size() <= _smem_budget_bytes(input.device)
 
 
 def _bwd_fits_smem(input: torch.Tensor, grad_out: torch.Tensor, n: int) -> bool:


### PR DESCRIPTION
Seems to work and speedup and fixes some test failures in e.g., `TestFusedRMSNormOverrideRouting.test_bwd_cond_misaligned_input_gated_on_size`

some benchmarks on sm121:
```
   dtype / shape         Forward speedup    Backward speedup                                                                                 
  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━                                                                                                                                                                                                                              
   BF16, (2048, 4096)              1.04×               1.55×                                                                                 
  ────────────────────  ─────────────────  ──────────────────                                                                                
   BF16, (4096, 8192)              1.14×               2.11×                                                                                 
  ────────────────────  ─────────────────  ──────────────────                                                                                
   FP16, (2048, 4096)              1.05×               1.55×                                                                                 
  ────────────────────  ─────────────────  ──────────────────                                                                                
   FP16, (4096, 8192)              1.15×               2.10×                                                                                                                                                                                                                               
  ────────────────────  ─────────────────  ──────────────────                                                                                                                                                                                                                              
   FP32, (8192, 4096)              1.12×               2.07×   
   ```

authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia