### PR TITLE
[ROCm][TunableOp] Skip second profile beyond tuning limits

### DIFF
--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -356,14 +356,28 @@ class TunableOp {
           continue;
         }
 
+        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
+        int max_tuning_iter = ctx->GetMaxTuningIterations();
+
         // 2nd phase skip, more aggressive
         approx_num_iter = 10;
-        s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
-        approx_duration = s._mean;
-        // bail if too slow
-        if (approx_duration > 1.15 * min_duration_ms) {
-          TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
-          continue;
+
+        // Skip the fixed 10-iteration second profile when either active tuning
+        // limit cannot accommodate it, based on the initial profile's mean.
+        // A limit of zero means that limit is disabled.
+        const bool skip_second_profile =
+            (max_tuning_iter > 0 && max_tuning_iter < approx_num_iter) ||
+            (max_tuning_duration > 0 &&
+             max_tuning_duration < approx_num_iter * approx_duration);
+
+        if (!skip_second_profile) {
+          s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
+          approx_duration = s._mean;
+          // bail if too slow
+          if (approx_duration > 1.15 * min_duration_ms) {
+            TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
+            continue;
+          }
         }
 
         if (do_numerics_check) {
@@ -404,8 +418,6 @@ class TunableOp {
         }
 
         // for tuning does user set max duration, max iters, or both?
-        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
-        int max_tuning_iter = ctx->GetMaxTuningIterations();
         int tuning_iter = 100; // default
         if (max_tuning_duration > 0) {
           int duration_iters = max_tuning_duration / approx_duration;


### PR DESCRIPTION
Fixes #190433

## Summary

TunableOp currently runs a fixed 10-iteration second profile after its initial estimate, even when the configured maximum tuning duration or iteration count cannot accommodate that pass. For expensive GEMMs, this preliminary profiling can dominate tuning time despite small tuning limits.

Use the initial profile's mean duration to estimate whether all 10 iterations fit. Skip the second profile when either active tuning limit is smaller than the required iteration count or estimated duration. A zero limit retains its existing meaning of disabled. The final tuning profile remains unchanged and uses the initial estimate when the second profile is skipped.

## Test plan

- `spin quicklint` — `ok No lint issues.`
- Reproduced the issue before the change on an MI250 with the reported shape and 50 ms / 5 iteration limits. The current build enumerated 2,109 candidates and was still tuning at candidate 26 after 20 seconds.
- [ ] Runtime validation with a rebuilt PyTorch.

## AI assistance

> Cursor assisted with preparing this patch and drafting this description.

The implementation was iteratively reviewed and simplified by the author to match the intended behavior discussed in #190433.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang