### PR TITLE
[TunableOp] Size screening profiles by the tuning limits

### DIFF
--- a/aten/src/ATen/cuda/tunable/StreamTimer.cpp
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.cpp
@@ -19,7 +19,10 @@ StreamTimer::StreamTimer() {
   AT_CUDA_CHECK(cudaEventCreate(&end_));
 }
 
-StreamTimer::~StreamTimer() = default;
+StreamTimer::~StreamTimer() {
+  C10_CUDA_CHECK_WARN(cudaEventDestroy(start_));
+  C10_CUDA_CHECK_WARN(cudaEventDestroy(end_));
+}
 
 void StreamTimer::Start() {
   AT_CUDA_CHECK(cudaEventSynchronize(start_));
@@ -43,7 +46,10 @@ StreamTimerNoSync::StreamTimerNoSync() {
   AT_CUDA_CHECK(cudaEventCreate(&end_));
 }
 
-StreamTimerNoSync::~StreamTimerNoSync() = default;
+StreamTimerNoSync::~StreamTimerNoSync() {
+  C10_CUDA_CHECK_WARN(cudaEventDestroy(start_));
+  C10_CUDA_CHECK_WARN(cudaEventDestroy(end_));
+}
 
 void StreamTimerNoSync::Start() {
   AT_CUDA_CHECK(cudaEventRecord(start_, at::cuda::getCurrentCUDAStream()));

--- a/aten/src/ATen/cuda/tunable/StreamTimer.h
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.h
@@ -18,6 +18,10 @@ namespace at::cuda::tunable {
 class StreamTimer : public ITimer {
   public:
     StreamTimer();
+    StreamTimer(const StreamTimer&) = delete;
+    StreamTimer& operator=(const StreamTimer&) = delete;
+    StreamTimer(StreamTimer&&) = delete;
+    StreamTimer& operator=(StreamTimer&&) = delete;
     ~StreamTimer() override;
 
     void Start() override;
@@ -34,6 +38,10 @@ class StreamTimer : public ITimer {
 class StreamTimerNoSync : public ITimer {
   public:
     StreamTimerNoSync();
+    StreamTimerNoSync(const StreamTimerNoSync&) = delete;
+    StreamTimerNoSync& operator=(const StreamTimerNoSync&) = delete;
+    StreamTimerNoSync(StreamTimerNoSync&&) = delete;
+    StreamTimerNoSync& operator=(StreamTimerNoSync&&) = delete;
     ~StreamTimerNoSync() override;
 
     void Start() override;

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -194,14 +194,15 @@ class TunableOp {
       return timer.Duration() / num_iter;
     }
 
-    static at::native::tunable::Stats ProfileStats(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset) {
+    // warmup_iter reduces outliers on a candidate's first touch. It is
+    // redundant when profiling a candidate that was just profiled, so
+    // back-to-back passes over the same candidate pass 0.
+    static at::native::tunable::Stats ProfileStats(Callable<ParamsT> *op, const std::vector<ParamsT*> &param, size_t num_iter, size_t &offset, size_t warmup_iter = 2) {
       TuningContext* ctx = getTuningContext();
       bool do_flush = ctx->IsICacheFlushEnabled();
       std::vector<StreamTimerNoSync> timer(num_iter);
 
-      // Small Mandatory Warmup
-      // Reduces outliers
-      for (size_t i = 0; i < 2; i++) {
+      for (size_t i = 0; i < warmup_iter; i++) {
         TORCH_CHECK(op->Call(param[(i+offset++)%param.size()]) == OK);
       }
 
@@ -218,6 +219,23 @@ class TunableOp {
         s.sample_value(timer[i].Duration());
       }
       return s;
+    }
+
+    // A screening pass exists only to avoid the cost of the final tuning
+    // profile, so it must never cost more than that profile is allowed to.
+    // Size it by the same limits, capped at the pass's nominal count.
+    // A limit of zero means that limit is disabled.
+    static int ScreenIters(TuningContext* ctx, double per_iter_ms, int nominal_iter) {
+      int iters = nominal_iter;
+      double max_tuning_duration = ctx->GetMaxTuningDurationMs();
+      int max_tuning_iter = ctx->GetMaxTuningIterations();
+      if (max_tuning_duration > 0 && per_iter_ms > 0) {
+        iters = std::min(iters, static_cast<int>(max_tuning_duration / per_iter_ms));
+      }
+      if (max_tuning_iter > 0) {
+        iters = std::min(iters, max_tuning_iter);
+      }
+      return std::max(1, iters);
     }
 
   protected:
@@ -267,18 +285,28 @@ class TunableOp {
       // for rotating buffer
       size_t offset = 0;
 
+      // reused across candidates; StreamTimer does not free its events
+      StreamTimer probe_timer{};
+
       for (size_t i = 0; i < candidate_names.size(); i++) {
         auto* candidate = GetOp(candidate_names[i]); // borrow pointer
         TORCH_CHECK(candidate != nullptr);
 
+        // this support probe is also the candidate's first touch, so time it
+        // and use it to size the screening passes below. It carries one-time
+        // setup cost and therefore over-estimates, which is the safe direction
+        // when the estimate is only used to bound work.
+        probe_timer.Start();
         auto status = candidate->Call(reusable_params[0]);
+        probe_timer.End();
         if (status != OK) {
           TUNABLE_LOG3("├──unsupported id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
           continue;
         }
+        double probe_duration = probe_timer.Duration();
 
         // collect a small profile
-        int approx_num_iter = 3;
+        int approx_num_iter = ScreenIters(ctx, probe_duration, 3);
         auto s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
         double approx_duration = s._mean;
         // bail if too slow
@@ -287,22 +315,13 @@ class TunableOp {
           continue;
         }
 
-        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
-        int max_tuning_iter = ctx->GetMaxTuningIterations();
-
-        // 2nd phase skip, more aggressive
-        approx_num_iter = 10;
-
-        // Skip the fixed 10-iteration second profile when either active tuning
-        // limit cannot accommodate it, based on the initial profile's mean.
-        // A limit of zero means that limit is disabled.
-        const bool skip_second_profile =
-            (max_tuning_iter > 0 && max_tuning_iter < approx_num_iter) ||
-            (max_tuning_duration > 0 &&
-             max_tuning_duration < approx_num_iter * approx_duration);
-
-        if (!skip_second_profile) {
-          s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
+        // 2nd phase skip, more aggressive. This pass only earns its cost by
+        // producing a better estimate than the one above, so run it only when
+        // the tuning limits leave room for more iterations than phase 1 got.
+        int second_num_iter = ScreenIters(ctx, approx_duration, 10);
+        if (second_num_iter > approx_num_iter) {
+          approx_num_iter = second_num_iter;
+          s = ProfileStats(candidate, reusable_params, approx_num_iter, offset, 0);
           approx_duration = s._mean;
           // bail if too slow
           if (approx_duration > 1.15 * min_duration_ms) {
@@ -349,6 +368,8 @@ class TunableOp {
         }
 
         // for tuning does user set max duration, max iters, or both?
+        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
+        int max_tuning_iter = ctx->GetMaxTuningIterations();
         int tuning_iter = 100; // default
         if (max_tuning_duration > 0) {
           int duration_iters = max_tuning_duration / approx_duration;
@@ -374,7 +395,7 @@ class TunableOp {
             "instance id=", i, ", ", op_sig, "(", params_sig, ") ", candidate_names[i]);
         TUNABLE_LOG3("├──offset at ", offset);
         WarmUp(candidate, reusable_params, warmup_iter, offset);
-        s = ProfileStats(candidate, reusable_params, tuning_iter, offset);
+        s = ProfileStats(candidate, reusable_params, tuning_iter, offset, 0);
         auto s_stddev = s.stddev();
         // Assume normal distribution.
         // Solution with smallest mean + 2*sigma will be a better solution?

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -287,14 +287,28 @@ class TunableOp {
           continue;
         }
 
+        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
+        int max_tuning_iter = ctx->GetMaxTuningIterations();
+
         // 2nd phase skip, more aggressive
         approx_num_iter = 10;
-        s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
-        approx_duration = s._mean;
-        // bail if too slow
-        if (approx_duration > 1.15 * min_duration_ms) {
-          TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
-          continue;
+
+        // Skip the fixed 10-iteration second profile when either active tuning
+        // limit cannot accommodate it, based on the initial profile's mean.
+        // A limit of zero means that limit is disabled.
+        const bool skip_second_profile =
+            (max_tuning_iter > 0 && max_tuning_iter < approx_num_iter) ||
+            (max_tuning_duration > 0 &&
+             max_tuning_duration < approx_num_iter * approx_duration);
+
+        if (!skip_second_profile) {
+          s = ProfileStats(candidate, reusable_params, approx_num_iter, offset);
+          approx_duration = s._mean;
+          // bail if too slow
+          if (approx_duration > 1.15 * min_duration_ms) {
+            TUNABLE_LOG3("├──2nd skip slow instance id=", i, ", ", op_sig, '(', params_sig, ") ", candidate_names[i]);
+            continue;
+          }
         }
 
         if (do_numerics_check) {
@@ -335,8 +349,6 @@ class TunableOp {
         }
 
         // for tuning does user set max duration, max iters, or both?
-        double max_tuning_duration = ctx->GetMaxTuningDurationMs();
-        int max_tuning_iter = ctx->GetMaxTuningIterations();
         int tuning_iter = 100; // default
         if (max_tuning_duration > 0) {
           int duration_iters = max_tuning_duration / approx_duration;


### PR DESCRIPTION
Fixes #190433

## Problem

TunableOp screens every candidate twice before profiling it for real, at a hard-coded 3 and then 10 iterations. Those screens exist only to avoid the cost of the final tuning profile, but their cost is a fixed constant while the profile they protect is derived from the configured limits. The two diverge exactly when calls are expensive: on the GEMM from #190433, with `PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS=50` against a 34 ms call, the final profile is capped at a single iteration while the screens still spend 17 calls to save at most 3.

The defect is therefore not that the limits are ignored, but that the screening passes are blind to them.

## Change

`ScreenIters()` applies the same limits that already size the final tuning profile, treating the 3 and 10 as caps rather than constants, so a screen can never cost more than the profile it protects. The second screen runs only when the limits leave room for more iterations than the first one got, since below that it cannot improve on the estimate already in hand. Sizing the first screen needs an estimate before any profiling has happened, so the support probe that already runs for every candidate is now timed; it carries one-time setup cost and therefore over-estimates, which is the safe direction when the value is used only to bound work.

`ProfileStats` also ran two mandatory warmup calls on every invocation, including on a candidate it had just finished profiling. Warmup now happens only on a candidate's first touch, which removes four redundant calls per candidate independently of any limit.

Separately, `StreamTimer` and `StreamTimerNoSync` each created two CUDA events and never destroyed them, leaking `2 * num_iter` events per `ProfileStats` call and roughly 200 per candidate at default settings. Both destructors now release their events, and copy and move are deleted because a user-provided destructor would otherwise leave the deprecated implicit copy constructor in place on a type held by `std::vector`.

## Relationship to the first commit

The first commit on this branch skipped the second screen outright whenever a limit was small. That is simpler but discontinuous, and at the shipped defaults of 30 ms and 100 iterations it disables the 1.15x filter for every op slower than roughly 3 ms, which is a large class of real GEMMs. The second commit replaces it with the scaled version, which keeps the filter wherever the budget can still fund it and reaches zero only when it genuinely cannot.

## Results

Tuning wall time for a single `torch.mm`, measured on gfx90a with 4320 candidates per shape:

| shape (per-call) | main | 1st commit | this PR |
|---|---|---|---|
| 1024^3 (0.036 ms) | 3.14 s | 3.17 s | 3.13 s |
| 4096^3 (1.087 ms) | 37.97 s | 37.94 s | 35.41 s |
| 8192x8192x4096 (4.145 ms) | 124.56 s | 104.98 s | 94.67 s |
| 65536x32768x384, 50/5 limits (34 ms) | 560.14 s | 431.40 s | 274.14 s |

Verbose logs confirm the mechanism, not just the outcome. For the 4.145 ms shape at default limits the second screen is retained and stays equally selective (307 candidates killed on main, 313 here), while the first commit drops it entirely (0 killed, and the population reaching full tuning goes from 289 to 596). For the 34 ms shape the screen correctly collapses to nothing in both.

Tuned solution quality is unchanged. Recorded winner times move from 0.9460 to 0.9458 ms, 3.6125 to 3.6168 ms, and 21.5442 to 21.5453 ms. Two shapes select a different solution ID among near-equivalent candidates with no measurable throughput difference.

## Test plan

```
python test/test_linalg.py -v -k tunableop
```

41 tests, OK with 12 platform skips (gfx942-only TF32, FP8 MI300+, ROCm-unsupported cuBLASLt cases) in 150.8s on gfx90a.

A positive control was run before any measurement, forcing `max_tuning_iterations=2` on a cheap GEMM and confirming zero second-screen lines and `tuning iters 2` in the verbose log, so the numbers above are not from a stale hipified build.

Validation is ROCm-only; there is no NVIDIA hardware on the machine used, so the cuBLASLt path is left to upstream CI.

## Scope

What remains after this change is the candidate count multiplied by the per-candidate cost, and a single fp16 GEMM enumerates 4320 candidates on this hardware. Bounding that total would mean abandoning the sweep partway through, which the existing knobs deliberately do not do: `PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS` and `PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS` are per-solution by documented design. A total budget would be a new user-facing knob whose result depends on enumeration order and machine load rather than being reproducible, so it is a separate proposal on its own merits, not part of this fix.

What was genuinely defective is the disproportion, screening that costs several times what the profile it protects is permitted to cost. That is what this fixes, and it is what we can reasonably achieve without changing the meaning of the existing knobs: 2x on the reported case, no loss of tuned solution quality, and no behavior change for ops cheap enough that the limits never bind.

## AI assistance

> The second commit and this description were drafted with Claude (Claude Code). The design, the measurements, and the conclusions were reviewed by the author before posting.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang
