### PR TITLE
[inductor] Handle Triton cluster_dims metadata from both binary and metadata layouts

### DIFF
--- a/test/inductor/test_triton_cluster_dims.py
+++ b/test/inductor/test_triton_cluster_dims.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: inductor"]
+
+from types import SimpleNamespace
+
+from torch._inductor.runtime.triton_heuristics import _get_binary_cta_args
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestTritonClusterDims(TestCase):
+    def test_cluster_dims_from_binary(self):
+        binary = SimpleNamespace(num_ctas=4, cluster_dims=(1, 2, 3))
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_metadata(self):
+        binary = SimpleNamespace(
+            num_ctas=4,
+            metadata=SimpleNamespace(cluster_dims=(1, 2, 3)),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_mixed_binary_and_metadata_layouts(self):
+        binary = SimpleNamespace(
+            cluster_dims=(1, 2, 3),
+            metadata=SimpleNamespace(num_ctas=4),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_from_legacy_metadata_name(self):
+        binary = SimpleNamespace(
+            num_ctas=4,
+            metadata=SimpleNamespace(clusterDims=(1, 2, 3)),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
+    def test_cluster_dims_returns_empty_tuple_without_cluster_info(self):
+        self.assertEqual(_get_binary_cta_args(SimpleNamespace()), ())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_triton_cluster_dims.py
+++ b/test/inductor/test_triton_cluster_dims.py
@@ -36,8 +36,22 @@ class TestTritonClusterDims(TestCase):
 
         self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
 
+    def test_binary_cluster_dims_take_precedence_over_metadata(self):
+        binary = SimpleNamespace(
+            num_ctas=4,
+            cluster_dims=(1, 2, 3),
+            metadata=SimpleNamespace(cluster_dims=(4, 5, 6)),
+        )
+
+        self.assertEqual(_get_binary_cta_args(binary), (4, 1, 2, 3))
+
     def test_cluster_dims_returns_empty_tuple_without_cluster_info(self):
         self.assertEqual(_get_binary_cta_args(SimpleNamespace()), ())
+
+    def test_num_ctas_without_cluster_dims_returns_empty_tuple(self):
+        binary = SimpleNamespace(num_ctas=4)
+
+        self.assertEqual(_get_binary_cta_args(binary), ())
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3080,6 +3080,27 @@ class StaticTritonCompileResult(CompileResult[_T]):
         return launcher
 
 
+def _get_binary_cta_args(binary: Any) -> tuple[int, ...]:
+    """Read cluster launch metadata from either the binary or metadata object."""
+
+    metadata = getattr(binary, "metadata", None)
+    num_ctas = getattr(binary, "num_ctas", None)
+    if num_ctas is None and metadata is not None:
+        num_ctas = getattr(metadata, "num_ctas", None)
+
+    if num_ctas is None:
+        return ()
+
+    for owner in (binary, metadata):
+        if owner is None:
+            continue
+        for attr in ("cluster_dims", "clusterDims"):
+            if hasattr(owner, attr):
+                return (num_ctas, *getattr(owner, attr))
+
+    return ()
+
+
 class TritonCompileResult(CompileResult[CompiledKernel]):
     """
     Upstream Triton CompileKernel can not be pickled.  This is a wrapper
@@ -3206,20 +3227,7 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 if hasattr(binary, "num_warps")
                 else binary.metadata.num_warps
             ),
-            "cta_args": (
-                (
-                    binary.num_ctas,
-                    *get_first_attr(binary, "cluster_dims", "clusterDims"),
-                )
-                if hasattr(binary, "num_ctas")
-                else (
-                    (binary.metadata.num_ctas, *binary.metadata.cluster_dims)
-                    if hasattr(binary, "metadata")
-                    and hasattr(binary.metadata, "num_ctas")
-                    and hasattr(binary.metadata, "cluster_dims")
-                    else ()
-                )
-            ),
+            "cta_args": _get_binary_cta_args(binary),
             "function": get_first_attr(binary, "function", "cu_function"),
             "runner": get_first_attr(binary, "run", "c_wrapper"),
             "math": math_lib,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3081,8 +3081,6 @@ class StaticTritonCompileResult(CompileResult[_T]):
 
 
 def _get_binary_cta_args(binary: Any) -> tuple[int, ...]:
-    """Read cluster launch metadata from either the binary or metadata object."""
-
     metadata = getattr(binary, "metadata", None)
     num_ctas = getattr(binary, "num_ctas", None)
     if num_ctas is None and metadata is not None:


### PR DESCRIPTION
Supersedes #177540, which was auto-closed as stale.

Some Triton versions expose cluster dims on the compiled binary, others on
`metadata`. Inductor assumes a single layout, so a binary carrying `num_ctas`
with cluster dims on `metadata` trips the `get_first_attr` assertion.

Review feedback from #177540:
- test for `num_ctas` present with no cluster dims on either object
- test pinning `binary` precedence over `metadata`
- dropped the helper docstring

On returning `()`: the previous code raised `AssertionError` in that case, and
could only ever produce a 4-tuple or `()`. `cta_args` is spliced positionally
into the legacy launcher args, so a 1-tuple would misalign everything after it.

Rebased onto main. The 43 CI failures on #177540 were infrastructure (unbuilt
docker image, missing `pkg_resources`, missing GTest).

@jansel


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo