### PR TITLE
[triton][inductor] Eliminate full-tile loads when the value repeats across the reduction (#192410)

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -19,6 +19,8 @@ from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
     get_triton_reduction_function,
+    IndexingOptions,
+    TritonCSEVariable,
     TritonKernel,
     TritonKernelOverrides,
     TritonSymbols,
@@ -192,6 +194,224 @@ def helper(x):
 
         self.assertFalse(kernel.persistent_reduction)
         self.assertEqual(seen_scores, [tiling_scores])
+
+    def test_reduction_invariant_load_indexing(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            x_index = x_tree.full_range().symbol()
+            r_index = r_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+
+            def indexing(index):
+                options = kernel.indexing(
+                    index,
+                    reduction_invariant_indexing=True,
+                )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                invariant_options = indexing(invariant_index)
+                x_options = indexing(x_index)
+                reduction_options = indexing(r_index)
+
+            self.assertEqual(
+                tuple(map(str, invariant_options.expand_shape or ())), ("1", "1")
+            )
+            self.assertEqual(
+                tuple(map(str, x_options.expand_shape or ())), ("XBLOCK", "1")
+            )
+            self.assertTrue(invariant_options.reduction_invariant_indexing)
+            self.assertTrue(x_options.reduction_invariant_indexing)
+            self.assertFalse(reduction_options.reduction_invariant_indexing)
+
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                predicate_options = indexing(invariant_index)
+            self.assertEqual(
+                tuple(map(str, predicate_options.expand_shape or ())),
+                ("XBLOCK", "1"),
+            )
+            self.assertTrue(predicate_options.reduction_invariant_indexing)
+
+    def test_reduction_invariant_load_indexing_extents(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+
+            def indexing(mask):
+                with patch.object(kernel, "_load_mask", mask):
+                    options = kernel.indexing(
+                        invariant_index,
+                        reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            for reduction_numel in (
+                sympy.Symbol("u1", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(reduction_numel=reduction_numel),
+                    patch.object(r_tree, "numel", reduction_numel),
+                ):
+                    self.assertFalse(indexing(scalar_mask).reduction_invariant_indexing)
+
+            with patch.object(kernel, "is_combo_kernel", True):
+                self.assertTrue(indexing(scalar_mask).reduction_invariant_indexing)
+                scalar_1d_mask = TritonCSEVariable(
+                    "tmp1", ValueRanges.unknown(), torch.bool, shape=("1",)
+                )
+                with (
+                    patch.object(x_tree, "tensor_dim", None),
+                    patch.object(r_tree, "tensor_dim", 0),
+                ):
+                    self.assertEqual(
+                        tuple(map(str, indexing(scalar_1d_mask).expand_shape or ())),
+                        ("1",),
+                    )
+                    for pointwise_numel in (
+                        sympy.Symbol("u0", integer=True, nonnegative=True),
+                        sympy.S.Zero,
+                    ):
+                        with (
+                            self.subTest(pointwise_numel=pointwise_numel),
+                            patch.object(x_tree, "numel", pointwise_numel),
+                        ):
+                            self.assertFalse(
+                                indexing(scalar_1d_mask).reduction_invariant_indexing
+                            )
+
+    def test_reduction_invariant_load_indexing_unknown_mask(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            indirect = kernel.cse.namedvar("tmp1", dtype=torch.int64, shape=("1", "1"))
+            self.assertIsInstance(indirect, TritonCSEVariable)
+            indirect_index = sympy.Symbol(indirect.name, integer=True)
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                resolved_options = kernel.indexing(
+                    indirect_index,
+                    reduction_invariant_indexing=True,
+                )
+                indirect.mask_vars.add("unknown_mask")
+                options = kernel.indexing(
+                    indirect_index,
+                    reduction_invariant_indexing=True,
+                )
+
+            self.assertIsInstance(resolved_options, IndexingOptions)
+            self.assertTrue(resolved_options.reduction_invariant_indexing)
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertFalse(options.reduction_invariant_indexing)
+            self.assertEqual(
+                tuple(map(str, options.expand_shape or ())),
+                ("XBLOCK", "R0_BLOCK"),
+            )
+
+    def test_reduction_invariant_load_indexing_schedule_guards(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree = kernel.range_trees[0]
+            x_index = x_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for guarded_mode in (
+                "cooperative_reduction",
+                "mix_order_reduction",
+            ):
+                with (
+                    self.subTest(guarded_mode=guarded_mode),
+                    patch.object(kernel, guarded_mode, True),
+                ):
+                    with patch.object(kernel, "_load_mask", scalar_mask):
+                        options = kernel.indexing(
+                            invariant_index,
+                            reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_invariant_indexing)
+                    with patch.object(kernel, "_load_mask", x_mask):
+                        options = kernel.indexing(
+                            x_index,
+                            reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_invariant_indexing)
+
+    def test_template_indexing_disables_reduction_invariant_narrowing(self):
+        from torch._inductor.select_algorithm import TritonTemplateKernel
+
+        kernel = object.__new__(TritonTemplateKernel)
+        kernel.template_out_shape = ("XBLOCK", "R0_BLOCK")
+        kernel.template_mask = "template_mask"
+        index = sympy.Symbol("xindex", integer=True)
+        expected = object()
+
+        with patch.object(
+            TritonKernel,
+            "indexing",
+            autospec=True,
+            return_value=expected,
+        ) as indexing:
+            actual = kernel.indexing(
+                index,
+                reduction_invariant_indexing=True,
+            )
+
+        self.assertIs(expected, actual)
+        self.assertFalse(indexing.call_args.kwargs["reduction_invariant_indexing"])
 
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -20,7 +20,10 @@ from torch._inductor.codegen.simd import IterationRangesRoot
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
+    FixedTritonConfig,
     get_triton_reduction_function,
+    IndexingOptions,
+    TritonCSEVariable,
     TritonKernel,
     TritonKernelOverrides,
     TritonSymbols,
@@ -194,6 +197,350 @@ def helper(x):
 
         self.assertFalse(kernel.persistent_reduction)
         self.assertEqual(seen_scores, [tiling_scores])
+
+    def test_reduction_invariant_load_indexing(self):
+        self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            x_index = x_tree.full_range().symbol()
+            r_index = r_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+
+            def indexing(index):
+                options = kernel.indexing(
+                    index,
+                    allow_reduction_invariant_indexing=True,
+                )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                invariant_options = indexing(invariant_index)
+                x_options = indexing(x_index)
+                reduction_options = indexing(r_index)
+
+            self.assertEqual(
+                tuple(map(str, invariant_options.expand_shape or ())), ("1", "1")
+            )
+            self.assertEqual(
+                tuple(map(str, x_options.expand_shape or ())), ("XBLOCK", "1")
+            )
+            self.assertTrue(invariant_options.reduction_axes_omitted)
+            self.assertTrue(x_options.reduction_axes_omitted)
+            self.assertFalse(reduction_options.reduction_axes_omitted)
+
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                predicate_options = indexing(invariant_index)
+            self.assertEqual(
+                tuple(map(str, predicate_options.expand_shape or ())),
+                ("XBLOCK", "1"),
+            )
+            self.assertTrue(predicate_options.reduction_axes_omitted)
+
+    def test_reduction_invariant_load_indexing_extents(self):
+        self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            self.assertTrue(r_tree.is_loop)
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+
+            def indexing(mask):
+                with patch.object(kernel, "_load_mask", mask):
+                    options = kernel.indexing(
+                        invariant_index,
+                        allow_reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            for reduction_numel in (
+                sympy.Symbol("u1", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(reduction_numel=reduction_numel),
+                    patch.object(r_tree, "numel", reduction_numel),
+                ):
+                    self.assertTrue(indexing(scalar_mask).reduction_axes_omitted)
+
+        persistent_kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            optimize_mask=False,
+            override_persistent_reduction=True,
+            override_cooperative_reduction=False,
+        )
+        with V.set_kernel_handler(persistent_kernel):
+            r_tree = persistent_kernel.range_trees[1]
+            self.assertFalse(r_tree.is_loop)
+            scalar_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+
+            def persistent_indexing():
+                with patch.object(persistent_kernel, "_load_mask", scalar_mask):
+                    options = persistent_kernel.indexing(
+                        sympy.Symbol("s1", integer=True, positive=True),
+                        allow_reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            self.assertTrue(persistent_indexing().reduction_axes_omitted)
+            for reduction_numel in (
+                sympy.Symbol("u2", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(persistent_reduction_numel=reduction_numel),
+                    patch.object(r_tree, "numel", reduction_numel),
+                ):
+                    self.assertFalse(persistent_indexing().reduction_axes_omitted)
+
+        no_x_kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            fixed_config=FixedTritonConfig({"XBLOCK": 1, "R0_BLOCK": 128}),
+            is_combo_kernel=True,
+            optimize_mask=False,
+            per_subkernel_blocks=True,
+            override_persistent_reduction=True,
+            override_cooperative_reduction=False,
+        )
+        with V.set_kernel_handler(no_x_kernel):
+            x_tree, r_tree = no_x_kernel.range_trees
+            self.assertTrue(no_x_kernel.no_x_dim)
+            self.assertIsNone(x_tree.tensor_dim)
+            self.assertEqual(r_tree.tensor_dim, 0)
+            scalar_mask = TritonCSEVariable(
+                "tmp2", ValueRanges.unknown(), torch.bool, shape=("1",)
+            )
+
+            def no_x_indexing():
+                with patch.object(no_x_kernel, "_load_mask", scalar_mask):
+                    options = no_x_kernel.indexing(
+                        sympy.Symbol("s1", integer=True, positive=True),
+                        allow_reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            self.assertEqual(
+                tuple(map(str, no_x_indexing().expand_shape or ())),
+                ("1",),
+            )
+            for pointwise_numel in (
+                sympy.Symbol("u0", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(pointwise_numel=pointwise_numel),
+                    patch.object(x_tree, "numel", pointwise_numel),
+                ):
+                    self.assertTrue(no_x_indexing().reduction_axes_omitted)
+
+    def test_reduction_invariant_load_indexing_device_gate(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_index = kernel.range_trees[0].full_range().symbol()
+            x_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            self.assertIsNone(self._graph.current_device)
+            for device, expected_narrowing in (
+                (None, False),
+                (torch.device("cpu"), False),
+                (torch.device("cuda"), True),
+            ):
+                device_context = (
+                    contextlib.nullcontext()
+                    if device is None
+                    else self._graph.set_current_device(device)
+                )
+                with (
+                    self.subTest(device=device),
+                    device_context,
+                    patch.object(kernel, "_load_mask", x_mask),
+                ):
+                    options = kernel.indexing(
+                        x_index,
+                        allow_reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                self.assertEqual(expected_narrowing, options.reduction_axes_omitted)
+
+    def test_reduction_invariant_load_indexing_unknown_mask(self):
+        self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            indirect = kernel.cse.namedvar("tmp1", dtype=torch.int64, shape=("1", "1"))
+            self.assertIsInstance(indirect, TritonCSEVariable)
+            indirect_index = sympy.Symbol(indirect.name, integer=True)
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                resolved_options = kernel.indexing(
+                    indirect_index,
+                    allow_reduction_invariant_indexing=True,
+                )
+                indirect.mask_vars.add("unknown_mask")
+                options = kernel.indexing(
+                    indirect_index,
+                    allow_reduction_invariant_indexing=True,
+                )
+
+            self.assertIsInstance(resolved_options, IndexingOptions)
+            self.assertTrue(resolved_options.reduction_axes_omitted)
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertFalse(options.reduction_axes_omitted)
+            self.assertEqual(
+                tuple(map(str, options.expand_shape or ())),
+                ("XBLOCK", "R0_BLOCK"),
+            )
+
+    def test_reduction_invariant_load_indexing_schedule_guards(self):
+        self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree = kernel.range_trees[0]
+            x_index = x_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for guarded_mode in (
+                "cooperative_reduction",
+                "mix_order_reduction",
+            ):
+                with (
+                    self.subTest(guarded_mode=guarded_mode),
+                    patch.object(kernel, guarded_mode, True),
+                ):
+                    with patch.object(kernel, "_load_mask", scalar_mask):
+                        options = kernel.indexing(
+                            invariant_index,
+                            allow_reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_axes_omitted)
+                    with patch.object(kernel, "_load_mask", x_mask):
+                        options = kernel.indexing(
+                            x_index,
+                            allow_reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_axes_omitted)
+
+    def test_reduction_invariant_load_indexing_copy_shape(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_index = kernel.range_trees[0].full_range().symbol()
+            x_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                options = kernel.indexing(
+                    x_index,
+                    copy_shape=("XBLOCK", "R0_BLOCK"),
+                    allow_reduction_invariant_indexing=True,
+                )
+
+        self.assertIsInstance(options, IndexingOptions)
+        self.assertFalse(options.reduction_axes_omitted)
+        self.assertEqual(options.expand_shape, ("XBLOCK", "R0_BLOCK"))
+
+    def test_reduction_invariant_load_indexing_override_mask(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            x_index = x_tree.full_range().symbol()
+            override_mask = r_tree.mask_name()
+            x_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                options = kernel.indexing(
+                    x_index,
+                    override_mask=override_mask,
+                    allow_reduction_invariant_indexing=True,
+                )
+
+        self.assertIsInstance(options, IndexingOptions)
+        self.assertFalse(options.reduction_axes_omitted)
+        self.assertEqual(options.expand_shape, ("XBLOCK", "R0_BLOCK"))
+        self.assertIn(override_mask, options.mask_vars)
 
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -6,6 +6,7 @@ import functools
 import gc
 import math
 import os
+import re
 import sys
 import unittest
 
@@ -76,6 +77,47 @@ def _strip_triton_static_asserts(code):
     return "\n".join(
         line for line in code.splitlines() if "tl.static_assert" not in line
     )
+
+
+_TRITON_KERNEL_BODY = re.compile(
+    r"async_compile\.triton\('[^']+', '''(?P<body>.*?)\n\s*''', device_str='cuda'\)",
+    re.DOTALL,
+)
+
+
+def _triton_load_lines(code, pointer_type):
+    kernel_bodies = [
+        match.group("body") for match in _TRITON_KERNEL_BODY.finditer(code)
+    ]
+    if not kernel_bodies:
+        raise AssertionError("expected at least one generated Triton kernel")
+
+    load_lines = []
+    for kernel_body in kernel_bodies:
+        pointers = set(
+            re.findall(rf"'([A-Za-z_]\w*)': '\*{re.escape(pointer_type)}'", kernel_body)
+        )
+        load_lines.extend(
+            line
+            for line in kernel_body.splitlines()
+            if any(
+                re.search(rf"\btl\.load\({re.escape(pointer)}(?!\w)", line)
+                for pointer in pointers
+            )
+        )
+    return load_lines
+
+
+def _triton_loads(code, pointer_type):
+    return [line.strip() for line in _triton_load_lines(code, pointer_type)]
+
+
+def _triton_int64_load_lines(code):
+    return _triton_load_lines(code, "i64")
+
+
+def _triton_int64_loads(code):
+    return [line.strip() for line in _triton_int64_load_lines(code)]
 
 
 try:
@@ -2946,6 +2988,473 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             1,
             "Repeated masked loads should compile to a single stable graph",
         )
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_masked_index_load(self, persistent_reductions):
+        def fn(index, source0, source1, value0, value1):
+            gathered0 = torch.index_select(source0, 0, index)
+            gathered1 = torch.index_select(source1, 0, index)
+            values = torch.cat((value0 + gathered0, value1 + gathered1), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        inputs = (
+            index,
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(2, len(index_loads))
+        for index_load in index_loads:
+            self.assertIn("[XBLOCK, 1]", index_load)
+            self.assertNotRegex(index_load, r"R\d+_BLOCK")
+        if persistent_reductions:
+            self.assertIn("@triton_heuristics.persistent_reduction", code)
+            self.assertNotIn("for r0_offset in tl.range", code)
+        else:
+            self.assertNotIn("@triton_heuristics.persistent_reduction", code)
+            self.assertIn("for r0_offset in tl.range", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize(
+        "row_dtype",
+        [
+            torch.float32,
+            torch.bfloat16,
+            torch.bool,
+        ],
+    )
+    def test_reduction_invariant_masked_load_dtypes(self, row_dtype):
+        def fn(row, value0, value1):
+            broadcast_row = row[:, None, None]
+            values = torch.cat((value0 + broadcast_row, value1 + broadcast_row), dim=1)
+            return values.square().sum(dim=-1)
+
+        if row_dtype == torch.bool:
+            row = torch.randint(0, 2, (16,), device=device_type, dtype=row_dtype)
+        else:
+            row = torch.randn(16, device=device_type, dtype=row_dtype)
+        value_dtype = torch.float16 if row_dtype == torch.float32 else torch.float32
+        inputs = (
+            row,
+            torch.randn(16, 2, 64, device=device_type, dtype=value_dtype),
+            torch.randn(16, 3, 64, device=device_type, dtype=value_dtype),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": True,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        pointer_type = {
+            torch.float32: "fp32",
+            torch.bfloat16: "bf16",
+            torch.bool: "i1",
+        }[row_dtype]
+        row_loads = _triton_loads(code, pointer_type)
+        self.assertEqual(2, len(row_loads))
+        for row_load in row_loads:
+            self.assertIn("[XBLOCK, 1]", row_load)
+            self.assertNotRegex(row_load, r"R\d+_BLOCK")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_invariant_load_direct_reduction(self):
+        def fn(row0, row1):
+            value0 = row0[:, :, None].expand(-1, -1, 65)
+            value1 = row1[:, :, None].expand(-1, -1, 65)
+            return torch.cat((value0, value1), dim=1).sum(dim=-1)
+
+        inputs = (
+            torch.randn(16, 2, device=device_type),
+            torch.randn(16, 3, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "fp32")
+        self.assertEqual(2, len(row_loads))
+        for row_load in row_loads:
+            self.assertIn("[XBLOCK, 1]", row_load)
+        self.assertIn("tl.broadcast_to", code)
+        self.assertIn("[XBLOCK, R0_BLOCK]", code)
+        self.assertIn("r0_mask", code)
+        self.assertIn("tl.sum", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_indirect_load(self, persistent_reductions):
+        def fn(index, source, value0, value1):
+            row = torch.index_select(source, 0, index)
+            values = torch.cat(
+                (value0 + row[:, None, None], value1 + row[:, None, None]), dim=1
+            )
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=device_type),
+            torch.randn(16, device=device_type, dtype=torch.bfloat16),
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        for pointer_type in ("i64", "bf16"):
+            loads = _triton_loads(code, pointer_type)
+            self.assertEqual(2, len(loads))
+            for load in loads:
+                self.assertIn("[XBLOCK, 1]", load)
+                self.assertNotRegex(load, r"R\d+_BLOCK")
+        if persistent_reductions:
+            self.assertIn("@triton_heuristics.persistent_reduction", code)
+        else:
+            self.assertIn("for r0_offset in tl.range", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+        }
+    )
+    def test_partially_reduction_invariant_masked_load(self):
+        def fn(value0, value1, row):
+            values = torch.cat((value0 * row[:, None], value1), dim=0)
+            return values.square().sum()
+
+        inputs = (
+            torch.randn(64, 128, device=device_type),
+            torch.randn(32, 128, device=device_type),
+            torch.randn(64, device=device_type, dtype=torch.float16),
+        )
+
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "fp16")
+        self.assertEqual(1, len(row_loads))
+        self.assertIn("R0_BLOCK", row_loads[0])
+        self.assertNotIn("R1_BLOCK", row_loads[0])
+        self.assertIn("R0_BLOCK", code)
+        self.assertIn("R1_BLOCK", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_reduction_invariant_pointwise_load(self, persistent_reductions):
+        def fn(row, value):
+            padded = torch.cat(
+                (
+                    row,
+                    torch.zeros(
+                        value.shape[0] - row.shape[0],
+                        device=row.device,
+                        dtype=row.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=device_type, dtype=torch.int64),
+            torch.randn(26, 65, 65, device=device_type, dtype=torch.bfloat16),
+        )
+        expected = fn(*inputs)
+        with config.patch({"triton.persistent_reductions": persistent_reductions}):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "i64")
+        self.assertEqual(1, len(row_loads))
+        self.assertIn("[YBLOCK, 1, 1]", row_loads[0])
+        self.assertNotIn("XBLOCK", row_loads[0])
+        self.assertNotRegex(row_loads[0], r"R\d+_BLOCK")
+        self.assertIn("YBLOCK", code)
+        self.assertIn("XBLOCK", code)
+        self.assertIn("R0_BLOCK", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "benchmark_combo_kernel": False,
+            "combo_kernel_allow_mixed_sizes": 2,
+            "combo_kernel_max_distance": -1,
+            "combo_kernel_peak_memory_increase_gb": None,
+            "combo_kernel_peak_memory_pct_threshold": None,
+            "combo_kernel_per_subkernel_blocks": False,
+            "combo_kernels": True,
+            "combo_kernels_autotune": 0,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "max_autotune": False,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.mix_order_reduction": False,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_combo_reduction_invariant_pointwise_load(self):
+        def reduction(target, value):
+            padded = torch.cat(
+                (
+                    target,
+                    torch.zeros(
+                        value.shape[0] - target.shape[0],
+                        device=value.device,
+                        dtype=target.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        def fn(target0, value0, target1, value1):
+            return reduction(target0, value0), reduction(target1, value1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=device_type, dtype=torch.int64),
+            torch.randn(17, 97, 64, device=device_type, dtype=torch.bfloat16),
+            torch.randint(-4, 5, (11,), device=device_type, dtype=torch.int64),
+            torch.randn(19, 129, 64, device=device_type, dtype=torch.bfloat16),
+        )
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+
+        self.assertEqual(expected, actual)
+        self.assertIn("RoundRobinComboKernelGrid", code)
+        target_loads = _triton_loads(code, "i64")
+        self.assertEqual(2, len(target_loads))
+        for target_load in target_loads:
+            self.assertIn("[YBLOCK, 1, 1]", target_load)
+            self.assertNotIn("XBLOCK", target_load)
+            self.assertNotRegex(target_load, r"R\d+_BLOCK")
+            self.assertNotIn("xmask", target_load)
+            self.assertNotRegex(target_load, r"r\d+_mask")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("pointwise_dependency", ["address", "predicate"])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_pointwise_dependent_load_stays_dense(self, pointwise_dependency):
+        if pointwise_dependency == "address":
+
+            def fn(row, value):
+                return (value.float() + row.float()[:, :, None]).square().sum(dim=-1)
+
+            row = torch.randint(-4, 5, (26, 65), device=device_type, dtype=torch.int64)
+        else:
+
+            def fn(row, value):
+                padded = torch.cat(
+                    (
+                        row[:, None],
+                        torch.zeros(
+                            (row.shape[0], value.shape[1] - 1),
+                            device=row.device,
+                            dtype=row.dtype,
+                        ),
+                    ),
+                    dim=1,
+                )
+                return (value.float() + padded.float()[:, :, None]).square().sum(dim=-1)
+
+            row = torch.randint(-4, 5, (26,), device=device_type, dtype=torch.int64)
+
+        value = torch.randn(26, 65, 65, device=device_type, dtype=torch.bfloat16)
+        expected = fn(row, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), row, value
+        )
+
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "i64")
+        self.assertEqual(1, len(row_loads))
+        if pointwise_dependency == "address":
+            self.assertRegex(row_loads[0], r"\bx\d+\b")
+            self.assertIn("xmask", row_loads[0])
+        else:
+            self.assertIn("XBLOCK", row_loads[0])
+        self.assertNotRegex(row_loads[0], r"R\d+_BLOCK")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_pointer_keeps_masked_index_load_dense(self):
+        def fn(index, source, left):
+            gathered = torch.index_select(source, 2, index).float()
+            values = torch.cat((left, gathered), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(64, device=device_type)[:32]
+        source = torch.randn(16, 2, 64, device=device_type, dtype=torch.bfloat16)
+        left = torch.randn(16, 1, 32, device=device_type)
+
+        expected = fn(index, source, left)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, left
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertNotIn("[XBLOCK, 1]", index_loads[0])
+        self.assertIn("r0_", index_loads[0])
+        indirect_loads = _triton_loads(code, "bf16")
+        self.assertEqual(1, len(indirect_loads))
+        self.assertIn("R0_BLOCK", indirect_loads[0])
+        self.assertRegex(indirect_loads[0], r"\btmp\d+\b")
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_mask_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=-1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        source = torch.randn(16, 2, 32, device=device_type)
+        value = torch.randn(16, 2, 16, device=device_type)
+
+        expected = fn(index, source, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, value
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertIn("R0_BLOCK", index_loads[0])
+        self.assertIn("r0_", index_loads[0])
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.dense_indexing": True,
+        }
+    )
+    def test_explicit_dense_indexing_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        source = torch.randn(16, 2, 64, device=device_type)
+        value = torch.randn(16, 3, 64, device=device_type)
+
+        expected = fn(index, source, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, value
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertIn("R0_BLOCK", index_loads[0])
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.persistent_reductions": False,
+        }
+    )
+    def test_loop_epilogue_masked_index_load_scope(self):
+        def fn(index, mask, value):
+            positions = torch.arange(index.numel(), device=index.device)
+            masked_index = torch.ops.aten._unsafe_masked_index(
+                index, mask, [positions], 0
+            )
+            reduced = (value + masked_index[:, None]).sum(dim=-1)
+            return reduced + masked_index
+
+        index = torch.arange(16, device=device_type, dtype=torch.int64)
+        mask = torch.tensor([True, False] * 8, device=device_type)
+        value = torch.randn(16, 64, device=device_type)
+
+        expected = fn(index, mask, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, mask, value
+        )
+        self.assertEqual(expected, actual)
+        self.assertIn("for r0_offset in tl.range", code)
+        index_load_lines = _triton_int64_load_lines(code)
+        self.assertEqual(2, len(index_load_lines))
+        indentation = [len(line) - len(line.lstrip()) for line in index_load_lines]
+        self.assertEqual(2, len(set(indentation)))
+        epilogue_load, loop_load = sorted(
+            index_load_lines, key=lambda line: len(line) - len(line.lstrip())
+        )
+        self.assertLess(
+            len(epilogue_load) - len(epilogue_load.lstrip()),
+            len(loop_load) - len(loop_load.lstrip()),
+        )
+        self.assertNotRegex(epilogue_load, r"r\d+_|R\d+_BLOCK")
+        self.assertIn("[XBLOCK, 1]", loop_load)
 
     def test_max_autotune_nograd(self):
         """

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -9,6 +9,7 @@ import sympy
 
 import torch
 from torch._dynamo.source import ConstantSource
+from torch._inductor import config
 from torch._inductor.codegen.cpp import cexpr
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import texpr
@@ -21,14 +22,24 @@ from torch._inductor.sizevars import (
     stride_at_vec_range,
 )
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import run_and_get_triton_code
+from torch._inductor.utils import (
+    run_and_get_code,
+    run_and_get_kernels,
+    run_and_get_triton_code,
+)
+from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_MACOS,
     IS_WINDOWS,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_CPU,
+    HAS_CUDA_AND_TRITON,
+    HAS_GPU,
+)
 from torch.utils._sympy.functions import (
     FloorDiv,
     Identity,
@@ -46,6 +57,10 @@ from torch.utils._sympy.numbers import int_oo
 # int64_t is long long on MacOS, but long on 64-bit Linux
 LONG_SUFFIX = "LL" if IS_MACOS or IS_WINDOWS else "L"
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
+REDUCTION_INVARIANT_X_LOAD = r"tl\.load\([^\n]*\[XBLOCK, 1\]"
+REDUCTION_INVARIANT_YX_LOAD = r"tl\.load\([^\n]*\[YBLOCK, 1, 1\]"
+DENSE_X_INDEX_LOAD = r"tl\.load\([^\n]*tl\.broadcast_to\(x\d+, \[XBLOCK, R0_BLOCK\]\)"
+REDUCTION_DEPENDENT_LOAD = r"tl\.load\([^\n]*r0_"
 
 
 class TestIndexingSimplification(InductorTestCase):
@@ -1230,6 +1245,502 @@ class TestOptimizationHintWideUnbackedSubstitution(InductorTestCase):
 
         self.assertLessEqual(sizevars.optimization_hint(u0, fallback=1024), 16)
         self.assertGreaterEqual(sizevars.optimization_hint(s0 - u0, fallback=1024), 0)
+
+
+@instantiate_parametrized_tests
+class ReductionInvariantIndexingTests(InductorTestCase):
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_masked_index_load(self, persistent_reductions):
+        def fn(index, source0, source1, value0, value1):
+            gathered0 = torch.index_select(source0, 0, index)
+            gathered1 = torch.index_select(source1, 0, index)
+            values = torch.cat((value0 + gathered0, value1 + gathered1), dim=1)
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=GPU_TYPE),
+            torch.randn(16, 2, 64, device=GPU_TYPE),
+            torch.randn(16, 3, 64, device=GPU_TYPE),
+            torch.randn(16, 2, 64, device=GPU_TYPE),
+            torch.randn(16, 3, 64, device=GPU_TYPE),
+        )
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+            )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        kernel = kernels[0]
+        FileCheck().check_regex(REDUCTION_INVARIANT_X_LOAD).check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).run(kernel)
+        FileCheck().check_regex(REDUCTION_DEPENDENT_LOAD).check_regex(
+            REDUCTION_DEPENDENT_LOAD
+        ).check_regex(REDUCTION_DEPENDENT_LOAD).check_regex(
+            REDUCTION_DEPENDENT_LOAD
+        ).run(kernel)
+        if persistent_reductions:
+            FileCheck().check("@triton_heuristics.persistent_reduction").check_not(
+                "for r0_offset in tl.range"
+            ).run(kernel)
+        else:
+            FileCheck().check_not("@triton_heuristics.persistent_reduction").check(
+                "for r0_offset in tl.range"
+            ).run(kernel)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("row_dtype", [torch.float32, torch.bfloat16, torch.bool])
+    def test_reduction_invariant_masked_load_dtypes(self, row_dtype):
+        def fn(row, value0, value1):
+            broadcast_row = row[:, None, None]
+            values = torch.cat((value0 + broadcast_row, value1 + broadcast_row), dim=1)
+            return values.square().sum(dim=-1)
+
+        if row_dtype == torch.bool:
+            row = torch.randint(0, 2, (16,), device=GPU_TYPE, dtype=row_dtype)
+        else:
+            row = torch.randn(16, device=GPU_TYPE, dtype=row_dtype)
+        value_dtype = torch.float16 if row_dtype == torch.float32 else torch.float32
+        inputs = (
+            row,
+            torch.randn(16, 2, 64, device=GPU_TYPE, dtype=value_dtype),
+            torch.randn(16, 3, 64, device=GPU_TYPE, dtype=value_dtype),
+        )
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": True,
+            }
+        ):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+            )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        kernel = kernels[0]
+        FileCheck().check_regex(REDUCTION_INVARIANT_X_LOAD).check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).run(kernel)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_invariant_load_direct_reduction(self):
+        def fn(row0, row1):
+            value0 = row0[:, :, None].expand(-1, -1, 65)
+            value1 = row1[:, :, None].expand(-1, -1, 65)
+            return torch.cat((value0, value1), dim=1).sum(dim=-1)
+
+        inputs = (
+            torch.randn(16, 2, device=GPU_TYPE),
+            torch.randn(16, 3, device=GPU_TYPE),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check_regex(REDUCTION_INVARIANT_X_LOAD).check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).check("tl.broadcast_to").check("[XBLOCK, R0_BLOCK]").check("tl.sum").run(
+            kernels[0]
+        )
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_indirect_load(self, persistent_reductions):
+        def fn(index, source, value0, value1):
+            row = torch.index_select(source, 0, index)
+            values = torch.cat(
+                (value0 + row[:, None, None], value1 + row[:, None, None]), dim=1
+            )
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=GPU_TYPE),
+            torch.randn(16, device=GPU_TYPE, dtype=torch.bfloat16),
+            torch.randn(16, 2, 64, device=GPU_TYPE),
+            torch.randn(16, 3, 64, device=GPU_TYPE),
+        )
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+            )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        kernel = kernels[0]
+        FileCheck().check_regex(REDUCTION_INVARIANT_X_LOAD).check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).check_regex(REDUCTION_INVARIANT_X_LOAD).check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).run(kernel)
+        if persistent_reductions:
+            FileCheck().check("@triton_heuristics.persistent_reduction").run(kernel)
+        else:
+            FileCheck().check("for r0_offset in tl.range").run(kernel)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+        }
+    )
+    def test_partially_reduction_invariant_masked_load(self):
+        def fn(value0, value1, row):
+            values = torch.cat((value0 * row[:, None], value1), dim=0)
+            return values.square().sum()
+
+        inputs = (
+            torch.randn(64, 128, device=GPU_TYPE),
+            torch.randn(32, 128, device=GPU_TYPE),
+            torch.randn(64, device=GPU_TYPE, dtype=torch.float16),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        FileCheck().check_regex(r"tl\.load\([^\n]*R0_BLOCK[^\n]*, 1\]").run(
+            "\n".join(kernels)
+        )
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("persistent_reductions", [False, True])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_reduction_invariant_pointwise_load(self, persistent_reductions):
+        def fn(row, value):
+            padded = torch.cat(
+                (
+                    row,
+                    torch.zeros(
+                        value.shape[0] - row.shape[0],
+                        device=row.device,
+                        dtype=row.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=GPU_TYPE, dtype=torch.int64),
+            torch.randn(26, 65, 65, device=GPU_TYPE, dtype=torch.bfloat16),
+        )
+        with config.patch({"triton.persistent_reductions": persistent_reductions}):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+            )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check_regex(REDUCTION_INVARIANT_YX_LOAD).run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "benchmark_combo_kernel": False,
+            "combo_kernel_allow_mixed_sizes": 2,
+            "combo_kernel_max_distance": -1,
+            "combo_kernel_peak_memory_increase_gb": None,
+            "combo_kernel_peak_memory_pct_threshold": None,
+            "combo_kernel_per_subkernel_blocks": False,
+            "combo_kernels": True,
+            "combo_kernels_autotune": 0,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "max_autotune": False,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.mix_order_reduction": False,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_combo_reduction_invariant_pointwise_load(self):
+        def reduction(target, value):
+            padded = torch.cat(
+                (
+                    target,
+                    torch.zeros(
+                        value.shape[0] - target.shape[0],
+                        device=value.device,
+                        dtype=target.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        def fn(target0, value0, target1, value1):
+            return reduction(target0, value0), reduction(target1, value1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=GPU_TYPE, dtype=torch.int64),
+            torch.randn(17, 97, 64, device=GPU_TYPE, dtype=torch.bfloat16),
+            torch.randint(-4, 5, (11,), device=GPU_TYPE, dtype=torch.int64),
+            torch.randn(19, 129, 64, device=GPU_TYPE, dtype=torch.bfloat16),
+        )
+        actual, code = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(code))
+        FileCheck().check_regex(REDUCTION_INVARIANT_YX_LOAD).check_regex(
+            REDUCTION_INVARIANT_YX_LOAD
+        ).run(code[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    @config.patch(
+        {
+            "benchmark_combo_kernel": False,
+            "combo_kernel_allow_mixed_sizes": 2,
+            "combo_kernel_max_distance": -1,
+            "combo_kernel_peak_memory_increase_gb": None,
+            "combo_kernel_peak_memory_pct_threshold": None,
+            "combo_kernel_per_subkernel_blocks": False,
+            "combo_kernels": True,
+            "combo_kernels_autotune": 0,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "max_autotune": False,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.mix_order_reduction": False,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_combo_reduction_invariant_zero_pointwise_extent(self):
+        def reduction(mask, target, value):
+            pointwise_extent = torch.nonzero(mask).numel()
+            value = value[:, :pointwise_extent, :]
+            padded = torch.cat(
+                (
+                    target,
+                    torch.zeros(
+                        value.shape[0] - target.shape[0],
+                        device=value.device,
+                        dtype=target.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        def fn(mask0, target0, value0, mask1, target1, value1):
+            return reduction(mask0, target0, value0), reduction(mask1, target1, value1)
+
+        inputs = (
+            torch.zeros(16, device=GPU_TYPE, dtype=torch.bool),
+            torch.randint(-4, 5, (13,), device=GPU_TYPE, dtype=torch.int64),
+            torch.randn(17, 16, 64, device=GPU_TYPE, dtype=torch.bfloat16),
+            torch.ones(16, device=GPU_TYPE, dtype=torch.bool),
+            torch.randint(-4, 5, (11,), device=GPU_TYPE, dtype=torch.int64),
+            torch.randn(19, 16, 64, device=GPU_TYPE, dtype=torch.bfloat16),
+        )
+        actual, code = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(0, actual[0].numel())
+        self.assertEqual((19, 16), actual[1].shape)
+        self.assertEqual(1, len(code))
+        FileCheck().check("SequentialComboKernelGrid").check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).check_regex(REDUCTION_INVARIANT_X_LOAD).run(code[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("pointwise_dependency", ["address", "predicate"])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_pointwise_dependent_load_keeps_pointwise_axis(self, pointwise_dependency):
+        if pointwise_dependency == "address":
+
+            def fn(row, value0, value1):
+                values = torch.cat(
+                    (value0.float() + row.float()[:, :, None], value1.float()),
+                    dim=1,
+                )
+                return values.square().sum(dim=-1)
+
+            inputs = (
+                torch.randint(-4, 5, (26, 2), device=GPU_TYPE, dtype=torch.int64),
+                torch.randn(26, 2, 65, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randn(26, 3, 65, device=GPU_TYPE, dtype=torch.bfloat16),
+            )
+        else:
+
+            def fn(row, value):
+                padded = torch.cat(
+                    (
+                        row[:, None],
+                        torch.zeros(
+                            (row.shape[0], value.shape[1] - 1),
+                            device=row.device,
+                            dtype=row.dtype,
+                        ),
+                    ),
+                    dim=1,
+                )
+                return (value.float() + padded.float()[:, :, None]).square().sum(dim=-1)
+
+            inputs = (
+                torch.randint(-4, 5, (26,), device=GPU_TYPE, dtype=torch.int64),
+                torch.randn(26, 65, 65, device=GPU_TYPE, dtype=torch.bfloat16),
+            )
+
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        reduction_kernels = [kernel for kernel in kernels if "tl.sum(" in kernel]
+        self.assertEqual(1, len(reduction_kernels))
+        FileCheck().check_regex(r"tl\.load\([^\n]*\[YBLOCK, XBLOCK, 1\]").run(
+            reduction_kernels[0]
+        )
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_pointer_keeps_masked_index_load_dense(self):
+        def fn(index, source, left):
+            gathered = torch.index_select(source, 2, index).float()
+            values = torch.cat((left, gathered), dim=1)
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(64, device=GPU_TYPE)[:32],
+            torch.randn(16, 2, 64, device=GPU_TYPE, dtype=torch.bfloat16),
+            torch.randn(16, 1, 32, device=GPU_TYPE),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check_regex(r"tl\.load\([^\n]*r0_[^\n]*R0_BLOCK").run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_mask_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=-1)
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=GPU_TYPE),
+            torch.randn(16, 2, 32, device=GPU_TYPE),
+            torch.randn(16, 2, 16, device=GPU_TYPE),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check_regex(DENSE_X_INDEX_LOAD).run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.dense_indexing": True,
+        }
+    )
+    def test_explicit_dense_indexing_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=1)
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=GPU_TYPE),
+            torch.randn(16, 2, 64, device=GPU_TYPE),
+            torch.randn(16, 3, 64, device=GPU_TYPE),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check_regex(DENSE_X_INDEX_LOAD).run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.persistent_reductions": False,
+        }
+    )
+    def test_loop_epilogue_masked_index_load_scope(self):
+        def fn(index, mask, value):
+            positions = torch.arange(index.numel(), device=index.device)
+            masked_index = torch.ops.aten._unsafe_masked_index(
+                index, mask, [positions], 0
+            )
+            reduced = (value + masked_index[:, None]).sum(dim=-1)
+            return reduced + masked_index
+
+        inputs = (
+            torch.arange(16, device=GPU_TYPE, dtype=torch.int64),
+            torch.tensor([True, False] * 8, device=GPU_TYPE),
+            torch.randn(16, 64, device=GPU_TYPE),
+        )
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+        )
+
+        self.assertEqual(fn(*inputs), actual)
+        self.assertEqual(1, len(kernels))
+        kernel = kernels[0]
+        FileCheck().check("for r0_offset in tl.range").check_regex(
+            REDUCTION_INVARIANT_X_LOAD
+        ).check("tl.sum").check_regex(r"tl\.load\(").run(kernel)
 
 
 class TestOptimizationHintIdentityExpansion(InductorTestCase):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -378,6 +378,7 @@ class IndexingOptions:
     _has_rindex: bool
     index: sympy.Expr
     expand_shape: Sequence[int | str] | None
+    reduction_axes_omitted: bool = False
 
     def has_mask(self) -> bool:
         return bool(self.mask_vars)
@@ -3798,9 +3799,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        allow_reduction_invariant_indexing=False,
     ):
         """
-        Compute the index and mask to pass to tl.load() or tl.store()
+        Compute the index and mask to pass to tl.load() or tl.store().
+
+        ``allow_reduction_invariant_indexing`` lets a caller request narrower
+        indexing when it can consume a shape with omitted reduction axes. The
+        returned ``IndexingOptions.reduction_axes_omitted`` records whether the
+        narrowing was actually applied.
         """
         index = self.prepare_indexing(index)
         index_vars = index.free_symbols
@@ -4188,6 +4195,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_shape=expand_shape,
             )
 
+        reduction_axes_omitted = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
                 # This avoids full broadcasting (need_dense) when performing native matmul.
@@ -4246,6 +4254,24 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_str = "[" + ",".join(map(str, expand_list)) + "]"
                 expand_shape = tuple(expand_list)
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+            elif (
+                allow_reduction_invariant_indexing
+                and copy_shape is None
+                and override_mask is None
+                and not config.triton.dense_indexing
+                and not dense_indexing
+                and (
+                    minimal_shape := self._reduction_invariant_indexing_shape(
+                        index,
+                        mask_vars,
+                    )
+                )
+                is not None
+            ):
+                expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                expand_shape = minimal_shape
+                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                reduction_axes_omitted = True
             else:
                 expand_str, expand_shape = _get_expand_str()
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
@@ -4276,6 +4302,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             has_rindex,
             index,
             expand_shape=expand_shape,
+            reduction_axes_omitted=reduction_axes_omitted,
         )
 
     def codegen_block_ptr(
@@ -4547,6 +4574,85 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _reduction_invariant_indexing_shape(
+        self,
+        index: sympy.Expr,
+        mask_vars: Iterable[str | TritonCSEVariable],
+    ) -> BlockShapeType:
+        """Return a minimal shape for reduction-invariant masked indexing.
+
+        For a row index used by a rowwise reduction, dense indexing emits an
+        address such as ``tl.broadcast_to(x, [XBLOCK, R0_BLOCK])`` and loads the
+        same ``index[x]`` value in every reduction lane. If the address and all
+        non-range predicates are independent of the reduction coordinate, this
+        returns ``[XBLOCK, 1]`` instead. The reduction consumer broadcasts that
+        one loaded value across its reduction lanes.
+
+        An axis remains singleton only when both the address and every non-range
+        predicate are broadcast on it. Omitting a fixed-tile reduction axis also
+        requires a positive logical extent, which permits removing its synthetic
+        range mask. Looped reductions need no extent proof because an empty range
+        executes no loop body. Temporary values participate through their
+        propagated block shapes, so this also covers provably invariant indirect
+        addresses.
+        """
+        load_mask = self._load_mask
+        if not self.inside_reduction or load_mask is None:
+            return None
+
+        # Lane-shape changes are currently qualified only on CUDA and ROCm.
+        # Other Triton backends retain dense indexing until they are covered.
+        device = V.graph.current_device
+        if device is None or device.type != "cuda":
+            return None
+
+        # These schedules introduce coordinate scopes outside the block shape
+        # tracked by this proof.
+        if self.cooperative_reduction or self.mix_order_reduction:
+            return None
+
+        active_range_trees = self.active_range_trees()
+        load_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
+        load_masks.add(load_mask)
+        shape = self._broadcast_shape_with_masks(
+            TritonSymbols.get_block_shape(index), load_masks
+        )
+        if shape is None:
+            return None
+        if not shape:
+            shape = ("1",) * self.triton_tensor_ndim()
+
+        dense_shape = tuple(self.dense_size_list())
+        if len(shape) != len(dense_shape):
+            return None
+        omitted_reduction = False
+        for tree in active_range_trees:
+            dim = tree.tensor_dim
+            if dim is None or str(shape[dim]) == str(dense_shape[dim]):
+                continue
+            if not tree.is_reduction:
+                if str(shape[dim]) != "1":
+                    return None
+                continue
+            if (
+                str(shape[dim]) != "1"
+                # Fixed-tile reductions execute even at zero logical extent, while
+                # looped reductions execute no body and therefore no narrowed load.
+                or (
+                    not tree.is_loop
+                    and not V.graph.sizevars.statically_known_gt(
+                        tree.numel, sympy.S.Zero
+                    )
+                )
+            ):
+                return None
+            omitted_reduction = True
+
+        if not omitted_reduction:
+            return None
+
+        return tuple(shape)
+
     GDC_WAIT = "tl.extra.cuda.gdc_wait()"
     GDC_LAUNCH = "tl.extra.cuda.gdc_launch_dependents()"
 
@@ -4807,12 +4913,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index,
             block_ptr=True,
             tma_compatibility_checker=tma_checker,
+            allow_reduction_invariant_indexing=True,
         )
 
-        if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
-            indexing.index
-        ):
-            self.has_load_with_contiguous_rdim = True
+        if isinstance(indexing, IndexingOptions):
+            if self._has_stride1_on_rdim(indexing.index):
+                self.has_load_with_contiguous_rdim = True
+            reduction_axes_omitted = indexing.reduction_axes_omitted
+        else:
+            reduction_axes_omitted = False
 
         has_rindex = indexing.has_rindex()
         has_tmpmask = indexing.has_tmpmask()
@@ -4999,7 +5108,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        if not self.inside_reduction or (
+            not indexing.has_rmask()
+            and not has_rindex
+            # The address and predicate producers for a narrowed load live in
+            # the loop-local compute buffer, so re-emit it for each loop chunk.
+            and not reduction_axes_omitted
+        ):
             self.outside_loop_vars.add(result_var)
 
         return result_var

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -374,6 +374,7 @@ class IndexingOptions:
     _has_rindex: bool
     index: sympy.Expr
     expand_shape: Sequence[int | str] | None
+    reduction_invariant_indexing: bool = False
 
     def has_mask(self) -> bool:
         return bool(self.mask_vars)
@@ -3767,6 +3768,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        reduction_invariant_indexing=False,
     ):
         """
         Compute the index and mask to pass to tl.load() or tl.store()
@@ -4157,6 +4159,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_shape=expand_shape,
             )
 
+        reduction_invariant_indexing_applied = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
                 # This avoids full broadcasting (need_dense) when performing native matmul.
@@ -4215,6 +4218,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_str = "[" + ",".join(map(str, expand_list)) + "]"
                 expand_shape = tuple(expand_list)
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+            elif (
+                reduction_invariant_indexing
+                and not config.triton.dense_indexing
+                and not dense_indexing
+                and (
+                    minimal_shape := self._reduction_invariant_indexing_shape(
+                        index,
+                        mask_vars,
+                    )
+                )
+                is not None
+            ):
+                expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                expand_shape = minimal_shape
+                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                reduction_invariant_indexing_applied = True
             else:
                 expand_str, expand_shape = _get_expand_str()
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
@@ -4245,6 +4264,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             has_rindex,
             index,
             expand_shape=expand_shape,
+            reduction_invariant_indexing=reduction_invariant_indexing_applied,
         )
 
     def codegen_block_ptr(
@@ -4516,6 +4536,71 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _reduction_invariant_indexing_shape(
+        self,
+        index: sympy.Expr,
+        mask_vars: Iterable[str | TritonCSEVariable],
+    ) -> BlockShapeType:
+        """Return a minimal shape for reduction-invariant masked indexing.
+
+        An axis remains singleton only when both the address and every non-range
+        predicate are broadcast on it. Omitting a reduction axis additionally
+        requires a positive logical extent, which permits removing its synthetic
+        range mask. Temporary values participate through their propagated block
+        shapes, so this also covers provably invariant indirect addresses.
+        """
+        if not self.inside_reduction or self._load_mask is None:
+            return None
+
+        # These schedules introduce coordinate scopes outside the block shape
+        # tracked by this proof.
+        if self.cooperative_reduction or self.mix_order_reduction:
+            return None
+
+        active_range_trees = self.active_range_trees()
+        # A combo grid can launch a subkernel because a sibling has a larger grid.
+        # A singleton load still needs one valid pointwise coordinate in that
+        # subkernel, including for axes without a tensor dimension.
+        if self.is_combo_kernel and any(
+            not tree.is_reduction
+            and not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            for tree in active_range_trees
+        ):
+            return None
+
+        load_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
+        if self._load_mask:
+            load_masks.add(self._load_mask)
+        shape = self._broadcast_shape_with_masks(
+            TritonSymbols.get_block_shape(index), load_masks
+        )
+        if shape is None:
+            return None
+        if not shape:
+            shape = tuple("1" for _ in range(self.triton_tensor_ndim()))
+
+        dense_shape = tuple(self.dense_size_list())
+        if len(shape) != len(dense_shape):
+            return None
+        omitted_reduction = False
+        for tree in active_range_trees:
+            dim = tree.tensor_dim
+            if dim is None or shape[dim] == dense_shape[dim]:
+                continue
+            if not tree.is_reduction:
+                if str(shape[dim]) != "1":
+                    return None
+                continue
+            if (
+                str(shape[dim]) != "1"
+                # A zero-length reduction makes the existing dense load fully masked.
+                or not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            ):
+                return None
+            omitted_reduction = True
+
+        return tuple(shape) if omitted_reduction else None
+
     GDC_WAIT = "tl.extra.cuda.gdc_wait()"
     GDC_LAUNCH = "tl.extra.cuda.gdc_launch_dependents()"
 
@@ -4776,6 +4861,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index,
             block_ptr=True,
             tma_compatibility_checker=tma_checker,
+            reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
         )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
@@ -4785,6 +4873,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         has_rindex = indexing.has_rindex()
         has_tmpmask = indexing.has_tmpmask()
+        has_indirect = indexing.has_indirect()
+        has_reduction_invariant_indexing = (
+            isinstance(indexing, IndexingOptions)
+            and indexing.reduction_invariant_indexing
+        )
 
         # Keep the variable in cache if were going to reuse it. Equiv., if any of the following hold
         #  1) We are doing broadcasting
@@ -4968,7 +5061,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        if not self.inside_reduction or (
+            not indexing.has_rmask()
+            and not has_rindex
+            # Temporary addresses and masks are emitted in the reduction body.
+            # Keep this dependency predicate explicit so direct unmasked loads
+            # remain liftable. Do not reuse a body-local load across iterations.
+            and not ((has_indirect or has_tmpmask) and has_reduction_invariant_indexing)
+        ):
             self.outside_loop_vars.add(result_var)
 
         return result_var

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1809,10 +1809,10 @@ class TritonTemplateKernel(TritonKernel):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        allow_reduction_invariant_indexing=False,
     ):
         """
-        Override the default indexing to use our custom mask and force
-        dense indexing.
+        Override the default indexing to use our custom mask and output shape.
         """
         return super().indexing(
             index,
@@ -1824,6 +1824,7 @@ class TritonTemplateKernel(TritonKernel):
             block_ptr=block_ptr,
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mask_constant_index,
+            allow_reduction_invariant_indexing=allow_reduction_invariant_indexing,
         )
 
     def codegen_range_tree(self):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1809,6 +1809,7 @@ class TritonTemplateKernel(TritonKernel):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        reduction_invariant_indexing=False,
     ):
         """
         Override the default indexing to use our custom mask and force
@@ -1824,6 +1825,8 @@ class TritonTemplateKernel(TritonKernel):
             block_ptr=block_ptr,
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mask_constant_index,
+            # Templates own their output broadcast shape and mask.
+            reduction_invariant_indexing=False,
         )
 
     def codegen_range_tree(self):


### PR DESCRIPTION
Summary:

**Why:**
- An `ops.masked` reduction can make Inductor emit a full `[XBLOCK, R0_BLOCK]` load for a value that depends only on the output row. Every reduction lane then repeats address, predicate, and load work for the same per-row value.

- A representative graph is:

```python
def fn(index, source0, source1, value0, value1):
    gathered0 = torch.index_select(source0, 0, index)
    gathered1 = torch.index_select(source1, 0, index)
    values = torch.cat((value0 + gathered0, value1 + gathered1), dim=1)
    return values.square().sum(dim=-1)
```

- Elementwise, the first gather computes `gathered0[x, c, r] = source0[index[x], c, r]`. In the measured CMF instance, Inductor flattens `(row, concatenation position)` into `xindex` and recovers the row as `x1 = xindex // 192`:

```python
# Before: the same index[x] value is loaded in every reduction lane.
tmp7 = tl.load(in_ptr1 + tl.broadcast_to(x1, [XBLOCK, R0_BLOCK]), ...)

# After: load once per row and broadcast at the reduction consumer.
tmp7 = tl.load(in_ptr1 + tl.broadcast_to(x1, [XBLOCK, 1]), ...)
```

- The gathered-data loads and reduction remain `[XBLOCK, R0_BLOCK]`; only the invariant index load stays narrow. With `XBLOCK=4` and `R0_BLOCK=128`, the old Triton IR represents four logical index values as a `4x128` load in each masked branch. This is not a claim of 128x HBM traffic; it removes redundant lane-wise address, predicate, load, register, and dependent-wait work.

- In the artifact-derived CMF representative, an isolated A/B changing only these load shapes reduced latency from approximately 277 us to 191 us, registers from 68 to 50, and wait instructions from 49 to 17. This is mechanism evidence; model-level effects are reported below.

**What:**
- Use existing block-shape propagation to prove that a load address and every non-range predicate are invariant over one or more reduction axes, then emit the load at the smallest proven shape.
- Qualify the lane-shape change on CUDA/HIP with a non-throwing current-device check. Other Triton backends and missing-device codegen retain dense indexing.
- Keep unproven cases dense: unknown mask shapes, reduction-dependent addresses or predicates, fixed-tile reductions whose positive extent cannot be proven, cooperative and mix-order reductions, explicit dense indexing, block pointers/TMA, `copy_shape`, and `override_mask`.
- Looped reductions do not require a positive-extent proof because an empty `tl.range` executes no body. Dynamic combo subkernels can omit a pointwise axis because a zero-width PID interval executes no branch; an end-to-end zero-extent combo regression covers that dispatch path.
- This diff targets `load()`. D114995186 extends the same proof to `index_expr()` and `check_bounds()`; native-matmul indexing remains separate.
- Generated-code tests live in `test_indexing.py` and use the existing `run_and_get_kernels` / `FileCheck` utilities. Coverage includes looped and persistent reductions, direct and indirect loads, partial axes, dynamic combo zero-width dispatch, negative legality cases, and the distinct FP32, BF16-upcast, and boolean load-emission paths.

**Fixed-class benchmark, latency reduction:**

| **Class** | **MI300** | **MI350** | **H100** |
| -- | -- | -- | -- |
| Pointwise-axis omission | 2.00-2.18% | 2.28-2.33% | 2.65% |
| Combo kernel, one grid topology | 1.67% | Not timed; gates pass | 2.01%, 16/20 blocks, drift observed |

**mts_gpu_benchmark QPS:**

| **Model** | **MI300** | **MI350** | **H100** | **Verdict** |
| -- | -- | -- | -- | -- |
| CMF | +0.487% | +0.255% | +0.865% | Win |
| HIM Facebook | +0.087%, 90% CI [-0.023%, +0.198%] | +0.065%, one card | +0.164% | Neutral, inside the +/-0.25% band |
| OBA | No eligible site | No eligible site | Not timed | N/A |
| HIM Instagram | No eligible site | No eligible site | Not timed | N/A |

`No eligible site` means the control artifact had no masked reduction load matching the proof. Per-card provenance is in a comment on this diff.

Test Plan:
- Seven focused `TritonKernel.indexing()` legality tests pass, covering backend gating, looped and fixed-tile extents, unknown masks, schedule guards, `copy_shape`, and `override_mask`. TestX: https://www.internalfb.com/intern/testinfra/testrun/14636698978229753

```
buck test -c fbcode.disable_re_tests=True 'fbcode//caffe2/test/inductor:codegen_triton' -- test_reduction_invariant_load_indexing --env PYTORCH_TEST_REMOTE_GPU=0 --env HIP_VISIBLE_DEVICES=2 --timeout=600 --print-passing-details
```

- The dynamic sequential-combo zero-pointwise-extent regression passes on MI300. TestX: https://www.internalfb.com/intern/testinfra/testrun/31525197416972585

- The final D1 source passes all 19 `ReductionInvariantIndexingTests` on an idle MI300 GPU (20 Buck results including listing/aggregate; 0 failures/skips). TestX: https://www.internalfb.com/intern/testinfra/testrun/28710447649876688

```
buck test fbcode//mode/opt 'fbcode//caffe2/test/inductor:indexing' -- ReductionInvariantIndexingTests --env HIP_VISIBLE_DEVICES=2 --timeout=1200 --print-passing-details
```

- Standard and extra `arc lint` pass. Scoped production Pyrefly reports zero `bad-argument-type` errors, Citrine reports no applicable findings, and fbcode/xplat mirrors are byte-identical.

- The production mechanism and fixed-class timing matrices were exercised on MI300, MI350, and H100. `mts_gpu_benchmark` crossover runs produced the model table in the summary; accepted arms passed source, package, configuration, idle, and no-lowering/no-autotuning gates.

Differential Revision: D114905866




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo