### PR TITLE
[triton][inductor] Use propagated shapes for native matmul indexing (#192411)

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -19,6 +19,8 @@ from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
     get_triton_reduction_function,
+    IndexingOptions,
+    TritonCSEVariable,
     TritonKernel,
     TritonKernelOverrides,
     TritonSymbols,
@@ -192,6 +194,224 @@ def helper(x):
 
         self.assertFalse(kernel.persistent_reduction)
         self.assertEqual(seen_scores, [tiling_scores])
+
+    def test_reduction_invariant_load_indexing(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            x_index = x_tree.full_range().symbol()
+            r_index = r_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+
+            def indexing(index):
+                options = kernel.indexing(
+                    index,
+                    reduction_invariant_indexing=True,
+                )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                invariant_options = indexing(invariant_index)
+                x_options = indexing(x_index)
+                reduction_options = indexing(r_index)
+
+            self.assertEqual(
+                tuple(map(str, invariant_options.expand_shape or ())), ("1", "1")
+            )
+            self.assertEqual(
+                tuple(map(str, x_options.expand_shape or ())), ("XBLOCK", "1")
+            )
+            self.assertTrue(invariant_options.reduction_invariant_indexing)
+            self.assertTrue(x_options.reduction_invariant_indexing)
+            self.assertFalse(reduction_options.reduction_invariant_indexing)
+
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                predicate_options = indexing(invariant_index)
+            self.assertEqual(
+                tuple(map(str, predicate_options.expand_shape or ())),
+                ("XBLOCK", "1"),
+            )
+            self.assertTrue(predicate_options.reduction_invariant_indexing)
+
+    def test_reduction_invariant_load_indexing_extents(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+
+            def indexing(mask):
+                with patch.object(kernel, "_load_mask", mask):
+                    options = kernel.indexing(
+                        invariant_index,
+                        reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            for reduction_numel in (
+                sympy.Symbol("u1", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(reduction_numel=reduction_numel),
+                    patch.object(r_tree, "numel", reduction_numel),
+                ):
+                    self.assertFalse(indexing(scalar_mask).reduction_invariant_indexing)
+
+            with patch.object(kernel, "is_combo_kernel", True):
+                self.assertTrue(indexing(scalar_mask).reduction_invariant_indexing)
+                scalar_1d_mask = TritonCSEVariable(
+                    "tmp1", ValueRanges.unknown(), torch.bool, shape=("1",)
+                )
+                with (
+                    patch.object(x_tree, "tensor_dim", None),
+                    patch.object(r_tree, "tensor_dim", 0),
+                ):
+                    self.assertEqual(
+                        tuple(map(str, indexing(scalar_1d_mask).expand_shape or ())),
+                        ("1",),
+                    )
+                    for pointwise_numel in (
+                        sympy.Symbol("u0", integer=True, nonnegative=True),
+                        sympy.S.Zero,
+                    ):
+                        with (
+                            self.subTest(pointwise_numel=pointwise_numel),
+                            patch.object(x_tree, "numel", pointwise_numel),
+                        ):
+                            self.assertFalse(
+                                indexing(scalar_1d_mask).reduction_invariant_indexing
+                            )
+
+    def test_reduction_invariant_load_indexing_unknown_mask(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            indirect = kernel.cse.namedvar("tmp1", dtype=torch.int64, shape=("1", "1"))
+            self.assertIsInstance(indirect, TritonCSEVariable)
+            indirect_index = sympy.Symbol(indirect.name, integer=True)
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                resolved_options = kernel.indexing(
+                    indirect_index,
+                    reduction_invariant_indexing=True,
+                )
+                indirect.mask_vars.add("unknown_mask")
+                options = kernel.indexing(
+                    indirect_index,
+                    reduction_invariant_indexing=True,
+                )
+
+            self.assertIsInstance(resolved_options, IndexingOptions)
+            self.assertTrue(resolved_options.reduction_invariant_indexing)
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertFalse(options.reduction_invariant_indexing)
+            self.assertEqual(
+                tuple(map(str, options.expand_shape or ())),
+                ("XBLOCK", "R0_BLOCK"),
+            )
+
+    def test_reduction_invariant_load_indexing_schedule_guards(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree = kernel.range_trees[0]
+            x_index = x_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for guarded_mode in (
+                "cooperative_reduction",
+                "mix_order_reduction",
+            ):
+                with (
+                    self.subTest(guarded_mode=guarded_mode),
+                    patch.object(kernel, guarded_mode, True),
+                ):
+                    with patch.object(kernel, "_load_mask", scalar_mask):
+                        options = kernel.indexing(
+                            invariant_index,
+                            reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_invariant_indexing)
+                    with patch.object(kernel, "_load_mask", x_mask):
+                        options = kernel.indexing(
+                            x_index,
+                            reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_invariant_indexing)
+
+    def test_template_indexing_disables_reduction_invariant_narrowing(self):
+        from torch._inductor.select_algorithm import TritonTemplateKernel
+
+        kernel = object.__new__(TritonTemplateKernel)
+        kernel.template_out_shape = ("XBLOCK", "R0_BLOCK")
+        kernel.template_mask = "template_mask"
+        index = sympy.Symbol("xindex", integer=True)
+        expected = object()
+
+        with patch.object(
+            TritonKernel,
+            "indexing",
+            autospec=True,
+            return_value=expected,
+        ) as indexing:
+            actual = kernel.indexing(
+                index,
+                reduction_invariant_indexing=True,
+            )
+
+        self.assertIs(expected, actual)
+        self.assertFalse(indexing.call_args.kwargs["reduction_invariant_indexing"])
 
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -413,6 +413,50 @@ def helper(x):
         self.assertIs(expected, actual)
         self.assertFalse(indexing.call_args.kwargs["reduction_invariant_indexing"])
 
+    def test_reduction_invariant_indexing_consumers(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+
+        for device_type, expected_shape in (
+            ("cuda", ("XBLOCK", "1")),
+            ("cpu", ("XBLOCK", "R0_BLOCK")),
+        ):
+            with self.subTest(device_type=device_type):
+                kernel = TritonKernel(
+                    {"x": xnumel, "r0_": rnumel},
+                    features=SIMDKernelFeatures([], xnumel, rnumel),
+                    override_persistent_reduction=False,
+                    override_cooperative_reduction=False,
+                )
+                scalar_mask = TritonCSEVariable(
+                    "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+                )
+
+                with (
+                    V.set_kernel_handler(kernel),
+                    patch.object(kernel, "_load_mask", scalar_mask),
+                    patch.object(
+                        self._graph,
+                        "get_current_device_or_throw",
+                        return_value=torch.device(device_type),
+                    ),
+                ):
+                    x_index = kernel.range_trees[0].full_range().symbol()
+                    value = TritonKernelOverrides.index_expr(x_index, torch.int64)
+                    with patch.object(
+                        kernel,
+                        "indirect_assert",
+                        wraps=kernel.indirect_assert,
+                    ) as indirect_assert:
+                        kernel.check_bounds(x_index, xnumel, lower=True, upper=True)
+
+                self.assertEqual(expected_shape, tuple(map(str, value.shape or ())))
+                checked_index = indirect_assert.call_args.args[0]
+                self.assertIn(
+                    "[" + ", ".join(expected_shape) + "]",
+                    checked_index,
+                )
+
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -457,6 +457,63 @@ def helper(x):
                     checked_index,
                 )
 
+    def test_native_matmul_indexing_uses_propagated_shapes(self):
+        ynumel = sympy.Integer(65)
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"y": ynumel, "x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], ynumel * xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with (
+            V.set_kernel_handler(kernel),
+            patch.object(kernel, "is_native_matmul", True),
+        ):
+            r_index = kernel.range_trees[2].full_range().symbol()
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for index, mask_shape, expected_shape in (
+                (
+                    invariant_index,
+                    ("YBLOCK", "XBLOCK", "1"),
+                    ("YBLOCK", "XBLOCK", "1"),
+                ),
+                (r_index, ("1", "1", "1"), ("1", "1", "R0_BLOCK")),
+            ):
+                with self.subTest(index=index, mask_shape=mask_shape):
+                    load_mask = TritonCSEVariable(
+                        "tmp0", ValueRanges.unknown(), torch.bool, shape=mask_shape
+                    )
+                    with patch.object(kernel, "_load_mask", load_mask):
+                        options = kernel.indexing(index)
+
+                    self.assertIsInstance(options, IndexingOptions)
+                    self.assertEqual(
+                        expected_shape,
+                        tuple(map(str, options.expand_shape or ())),
+                    )
+
+            unresolved_index = kernel.cse.namedvar(
+                "tmp1", dtype=torch.int64, shape=("1", "1", "1")
+            )
+            self.assertIsInstance(unresolved_index, TritonCSEVariable)
+            unresolved_index.mask_vars.add("unknown_mask")
+            load_mask = TritonCSEVariable(
+                "tmp2", ValueRanges.unknown(), torch.bool, shape=("1", "1", "1")
+            )
+            with patch.object(kernel, "_load_mask", load_mask):
+                options = kernel.indexing(
+                    sympy.Symbol(unresolved_index.name, integer=True)
+                )
+
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertEqual(
+                ("YBLOCK", "XBLOCK", "R0_BLOCK"),
+                tuple(map(str, options.expand_shape or ())),
+            )
+
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -417,6 +417,50 @@ def helper(x):
             indexing.call_args.kwargs["allow_reduction_invariant_indexing"]
         )
 
+    def test_reduction_invariant_indexing_consumers(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+
+        for device_type, expected_shape in (
+            ("cuda", ("XBLOCK", "1")),
+            ("cpu", ("XBLOCK", "R0_BLOCK")),
+        ):
+            with self.subTest(device_type=device_type):
+                kernel = TritonKernel(
+                    {"x": xnumel, "r0_": rnumel},
+                    features=SIMDKernelFeatures([], xnumel, rnumel),
+                    override_persistent_reduction=False,
+                    override_cooperative_reduction=False,
+                )
+                scalar_mask = TritonCSEVariable(
+                    "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+                )
+
+                with (
+                    V.set_kernel_handler(kernel),
+                    patch.object(kernel, "_load_mask", scalar_mask),
+                    patch.object(
+                        self._graph,
+                        "get_current_device_or_throw",
+                        return_value=torch.device(device_type),
+                    ),
+                ):
+                    x_index = kernel.range_trees[0].full_range().symbol()
+                    value = TritonKernelOverrides.index_expr(x_index, torch.int64)
+                    with patch.object(
+                        kernel,
+                        "indirect_assert",
+                        wraps=kernel.indirect_assert,
+                    ) as indirect_assert:
+                        kernel.check_bounds(x_index, xnumel, lower=True, upper=True)
+
+                self.assertEqual(expected_shape, tuple(map(str, value.shape or ())))
+                checked_index = indirect_assert.call_args.args[0]
+                self.assertIn(
+                    "[" + ", ".join(expected_shape) + "]",
+                    checked_index,
+                )
+
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -21,6 +21,8 @@ from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import (
     _materialize_trunc_to_float_expr,
     get_triton_reduction_function,
+    IndexingOptions,
+    TritonCSEVariable,
     TritonKernel,
     TritonKernelOverrides,
     TritonSymbols,
@@ -194,6 +196,226 @@ def helper(x):
 
         self.assertFalse(kernel.persistent_reduction)
         self.assertEqual(seen_scores, [tiling_scores])
+
+    def test_reduction_invariant_load_indexing(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            x_index = x_tree.full_range().symbol()
+            r_index = r_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+
+            def indexing(index):
+                options = kernel.indexing(
+                    index,
+                    allow_reduction_invariant_indexing=True,
+                )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                invariant_options = indexing(invariant_index)
+                x_options = indexing(x_index)
+                reduction_options = indexing(r_index)
+
+            self.assertEqual(
+                tuple(map(str, invariant_options.expand_shape or ())), ("1", "1")
+            )
+            self.assertEqual(
+                tuple(map(str, x_options.expand_shape or ())), ("XBLOCK", "1")
+            )
+            self.assertTrue(invariant_options.reduction_axes_omitted)
+            self.assertTrue(x_options.reduction_axes_omitted)
+            self.assertFalse(reduction_options.reduction_axes_omitted)
+
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            with patch.object(kernel, "_load_mask", x_mask):
+                predicate_options = indexing(invariant_index)
+            self.assertEqual(
+                tuple(map(str, predicate_options.expand_shape or ())),
+                ("XBLOCK", "1"),
+            )
+            self.assertTrue(predicate_options.reduction_axes_omitted)
+
+    def test_reduction_invariant_load_indexing_extents(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree, r_tree = kernel.range_trees
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+
+            def indexing(mask):
+                with patch.object(kernel, "_load_mask", mask):
+                    options = kernel.indexing(
+                        invariant_index,
+                        allow_reduction_invariant_indexing=True,
+                    )
+                self.assertIsInstance(options, IndexingOptions)
+                return options
+
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            for reduction_numel in (
+                sympy.Symbol("u1", integer=True, nonnegative=True),
+                sympy.S.Zero,
+            ):
+                with (
+                    self.subTest(reduction_numel=reduction_numel),
+                    patch.object(r_tree, "numel", reduction_numel),
+                ):
+                    self.assertFalse(indexing(scalar_mask).reduction_axes_omitted)
+
+            with patch.object(kernel, "is_combo_kernel", True):
+                self.assertTrue(indexing(scalar_mask).reduction_axes_omitted)
+                scalar_1d_mask = TritonCSEVariable(
+                    "tmp1", ValueRanges.unknown(), torch.bool, shape=("1",)
+                )
+                with (
+                    patch.object(x_tree, "tensor_dim", None),
+                    patch.object(r_tree, "tensor_dim", 0),
+                ):
+                    self.assertEqual(
+                        tuple(map(str, indexing(scalar_1d_mask).expand_shape or ())),
+                        ("1",),
+                    )
+                    for pointwise_numel in (
+                        sympy.Symbol("u0", integer=True, nonnegative=True),
+                        sympy.S.Zero,
+                    ):
+                        with (
+                            self.subTest(pointwise_numel=pointwise_numel),
+                            patch.object(x_tree, "numel", pointwise_numel),
+                        ):
+                            self.assertFalse(
+                                indexing(scalar_1d_mask).reduction_axes_omitted
+                            )
+
+    def test_reduction_invariant_load_indexing_unknown_mask(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            indirect = kernel.cse.namedvar("tmp1", dtype=torch.int64, shape=("1", "1"))
+            self.assertIsInstance(indirect, TritonCSEVariable)
+            indirect_index = sympy.Symbol(indirect.name, integer=True)
+
+            with patch.object(kernel, "_load_mask", scalar_mask):
+                resolved_options = kernel.indexing(
+                    indirect_index,
+                    allow_reduction_invariant_indexing=True,
+                )
+                indirect.mask_vars.add("unknown_mask")
+                options = kernel.indexing(
+                    indirect_index,
+                    allow_reduction_invariant_indexing=True,
+                )
+
+            self.assertIsInstance(resolved_options, IndexingOptions)
+            self.assertTrue(resolved_options.reduction_axes_omitted)
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertFalse(options.reduction_axes_omitted)
+            self.assertEqual(
+                tuple(map(str, options.expand_shape or ())),
+                ("XBLOCK", "R0_BLOCK"),
+            )
+
+    def test_reduction_invariant_load_indexing_schedule_guards(self):
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with V.set_kernel_handler(kernel):
+            x_tree = kernel.range_trees[0]
+            x_index = x_tree.full_range().symbol()
+            scalar_mask = TritonCSEVariable(
+                "tmp0", ValueRanges.unknown(), torch.bool, shape=("1", "1")
+            )
+            x_mask = TritonCSEVariable(
+                "tmp1", ValueRanges.unknown(), torch.bool, shape=("XBLOCK", "1")
+            )
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for guarded_mode in (
+                "cooperative_reduction",
+                "mix_order_reduction",
+            ):
+                with (
+                    self.subTest(guarded_mode=guarded_mode),
+                    patch.object(kernel, guarded_mode, True),
+                ):
+                    with patch.object(kernel, "_load_mask", scalar_mask):
+                        options = kernel.indexing(
+                            invariant_index,
+                            allow_reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_axes_omitted)
+                    with patch.object(kernel, "_load_mask", x_mask):
+                        options = kernel.indexing(
+                            x_index,
+                            allow_reduction_invariant_indexing=True,
+                        )
+                        self.assertIsInstance(options, IndexingOptions)
+                        self.assertFalse(options.reduction_axes_omitted)
+
+    def test_template_indexing_disables_reduction_invariant_narrowing(self):
+        from torch._inductor.select_algorithm import TritonTemplateKernel
+
+        kernel = object.__new__(TritonTemplateKernel)
+        kernel.template_out_shape = ("XBLOCK", "R0_BLOCK")
+        kernel.template_mask = "template_mask"
+        index = sympy.Symbol("xindex", integer=True)
+        expected = object()
+
+        with patch.object(
+            TritonKernel,
+            "indexing",
+            autospec=True,
+            return_value=expected,
+        ) as indexing:
+            actual = kernel.indexing(
+                index,
+                allow_reduction_invariant_indexing=True,
+            )
+
+        self.assertIs(expected, actual)
+        self.assertFalse(
+            indexing.call_args.kwargs["allow_reduction_invariant_indexing"]
+        )
 
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -461,6 +461,63 @@ def helper(x):
                     checked_index,
                 )
 
+    def test_native_matmul_indexing_uses_propagated_shapes(self):
+        ynumel = sympy.Integer(65)
+        xnumel = sympy.Integer(65)
+        rnumel = sympy.Integer(65)
+        kernel = TritonKernel(
+            {"y": ynumel, "x": xnumel, "r0_": rnumel},
+            features=SIMDKernelFeatures([], ynumel * xnumel, rnumel),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+
+        with (
+            V.set_kernel_handler(kernel),
+            patch.object(kernel, "is_native_matmul", True),
+        ):
+            r_index = kernel.range_trees[2].full_range().symbol()
+            invariant_index = sympy.Symbol("s0", integer=True, positive=True)
+            for index, mask_shape, expected_shape in (
+                (
+                    invariant_index,
+                    ("YBLOCK", "XBLOCK", "1"),
+                    ("YBLOCK", "XBLOCK", "1"),
+                ),
+                (r_index, ("1", "1", "1"), ("1", "1", "R0_BLOCK")),
+            ):
+                with self.subTest(index=index, mask_shape=mask_shape):
+                    load_mask = TritonCSEVariable(
+                        "tmp0", ValueRanges.unknown(), torch.bool, shape=mask_shape
+                    )
+                    with patch.object(kernel, "_load_mask", load_mask):
+                        options = kernel.indexing(index)
+
+                    self.assertIsInstance(options, IndexingOptions)
+                    self.assertEqual(
+                        expected_shape,
+                        tuple(map(str, options.expand_shape or ())),
+                    )
+
+            unresolved_index = kernel.cse.namedvar(
+                "tmp1", dtype=torch.int64, shape=("1", "1", "1")
+            )
+            self.assertIsInstance(unresolved_index, TritonCSEVariable)
+            unresolved_index.mask_vars.add("unknown_mask")
+            load_mask = TritonCSEVariable(
+                "tmp2", ValueRanges.unknown(), torch.bool, shape=("1", "1", "1")
+            )
+            with patch.object(kernel, "_load_mask", load_mask):
+                options = kernel.indexing(
+                    sympy.Symbol(unresolved_index.name, integer=True)
+                )
+
+            self.assertIsInstance(options, IndexingOptions)
+            self.assertEqual(
+                ("YBLOCK", "XBLOCK", "R0_BLOCK"),
+                tuple(map(str, options.expand_shape or ())),
+            )
+
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_sizearg(self):
         from torch._inductor.utils import (

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -120,6 +120,20 @@ def _triton_int64_loads(code):
     return [line.strip() for line in _triton_int64_load_lines(code)]
 
 
+def _triton_kernel_lines(code, marker):
+    kernel_bodies = [
+        match.group("body") for match in _TRITON_KERNEL_BODY.finditer(code)
+    ]
+    if not kernel_bodies:
+        raise AssertionError("expected at least one generated Triton kernel")
+    return [
+        line.strip()
+        for kernel_body in kernel_bodies
+        for line in kernel_body.splitlines()
+        if marker in line
+    ]
+
+
 try:
     try:
         import triton  # @manual
@@ -3023,12 +3037,67 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         for index_load in index_loads:
             self.assertIn("[XBLOCK, 1]", index_load)
             self.assertNotRegex(index_load, r"R\d+_BLOCK")
+        bounds_checks = _triton_kernel_lines(code, "tl.device_assert")
+        self.assertEqual(2, len(bounds_checks))
+        for bounds_check in bounds_checks:
+            self.assertIn("[XBLOCK, 1]", bounds_check)
+            self.assertNotRegex(bounds_check, r"R\d+_BLOCK")
         if persistent_reductions:
             self.assertIn("@triton_heuristics.persistent_reduction", code)
             self.assertNotIn("for r0_offset in tl.range", code)
         else:
             self.assertNotIn("@triton_heuristics.persistent_reduction", code)
             self.assertIn("for r0_offset in tl.range", code)
+
+    @unittest.skipIf(not (TEST_CUDA or TEST_WITH_ROCM), "requires CUDA or ROCm")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_masked_index_expr(self, persistent_reductions):
+        def fn(value):
+            positions = torch.arange(
+                value.shape[0], device=value.device, dtype=torch.int64
+            )
+            positions = positions[:, None, None].expand(-1, 2, value.shape[-1])
+            values = torch.cat((positions, value), dim=1)
+            return values.sum(dim=-1)
+
+        value = torch.randint(0, 10, (16, 3, 64), device=device_type, dtype=torch.int64)
+        expected = fn(value)
+
+        def compile_with(dense_indexing):
+            with config.patch(
+                {
+                    "force_disable_caches": True,
+                    "triton.dense_indexing": dense_indexing,
+                    "triton.persistent_reductions": persistent_reductions,
+                }
+            ):
+                return run_and_get_code(torch.compile(fn, fullgraph=True), value)
+
+        actual, (code,) = compile_with(dense_indexing=False)
+        dense_actual, (dense_code,) = compile_with(dense_indexing=True)
+        self.assertEqual(expected, actual)
+        self.assertEqual(expected, dense_actual)
+
+        def row_index_broadcasts(generated_code):
+            return [
+                line
+                for line in _triton_kernel_lines(generated_code, "tl.broadcast_to(x")
+                if re.search(r"tl\.broadcast_to\(x\d+, \[XBLOCK,", line)
+            ]
+
+        narrow_broadcasts = [
+            line for line in row_index_broadcasts(code) if "[XBLOCK, 1]" in line
+        ]
+        self.assertEqual(1, len(narrow_broadcasts), narrow_broadcasts)
+        row_symbols = re.findall(r"tl\.broadcast_to\((x\d+),", narrow_broadcasts[0])
+        self.assertEqual(1, len(row_symbols), row_symbols)
+        dense_broadcasts = [
+            line
+            for line in row_index_broadcasts(dense_code)
+            if f"tl.broadcast_to({row_symbols[0]}," in line
+        ]
+        self.assertEqual(1, len(dense_broadcasts), dense_broadcasts)
+        self.assertIn("[XBLOCK, R0_BLOCK]", dense_broadcasts[0])
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     @parametrize(

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -6,6 +6,7 @@ import functools
 import gc
 import math
 import os
+import re
 import sys
 import unittest
 
@@ -76,6 +77,47 @@ def _strip_triton_static_asserts(code):
     return "\n".join(
         line for line in code.splitlines() if "tl.static_assert" not in line
     )
+
+
+_TRITON_KERNEL_BODY = re.compile(
+    r"async_compile\.triton\('[^']+', '''(?P<body>.*?)\n\s*''', device_str='cuda'\)",
+    re.DOTALL,
+)
+
+
+def _triton_load_lines(code, pointer_type):
+    kernel_bodies = [
+        match.group("body") for match in _TRITON_KERNEL_BODY.finditer(code)
+    ]
+    if not kernel_bodies:
+        raise AssertionError("expected at least one generated Triton kernel")
+
+    load_lines = []
+    for kernel_body in kernel_bodies:
+        pointers = set(
+            re.findall(rf"'([A-Za-z_]\w*)': '\*{re.escape(pointer_type)}'", kernel_body)
+        )
+        load_lines.extend(
+            line
+            for line in kernel_body.splitlines()
+            if any(
+                re.search(rf"\btl\.load\({re.escape(pointer)}(?!\w)", line)
+                for pointer in pointers
+            )
+        )
+    return load_lines
+
+
+def _triton_loads(code, pointer_type):
+    return [line.strip() for line in _triton_load_lines(code, pointer_type)]
+
+
+def _triton_int64_load_lines(code):
+    return _triton_load_lines(code, "i64")
+
+
+def _triton_int64_loads(code):
+    return [line.strip() for line in _triton_int64_load_lines(code)]
 
 
 try:
@@ -2946,6 +2988,473 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             1,
             "Repeated masked loads should compile to a single stable graph",
         )
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_masked_index_load(self, persistent_reductions):
+        def fn(index, source0, source1, value0, value1):
+            gathered0 = torch.index_select(source0, 0, index)
+            gathered1 = torch.index_select(source1, 0, index)
+            values = torch.cat((value0 + gathered0, value1 + gathered1), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        inputs = (
+            index,
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(2, len(index_loads))
+        for index_load in index_loads:
+            self.assertIn("[XBLOCK, 1]", index_load)
+            self.assertNotRegex(index_load, r"R\d+_BLOCK")
+        if persistent_reductions:
+            self.assertIn("@triton_heuristics.persistent_reduction", code)
+            self.assertNotIn("for r0_offset in tl.range", code)
+        else:
+            self.assertNotIn("@triton_heuristics.persistent_reduction", code)
+            self.assertIn("for r0_offset in tl.range", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize(
+        "row_dtype",
+        [
+            torch.float32,
+            torch.bfloat16,
+            torch.bool,
+        ],
+    )
+    def test_reduction_invariant_masked_load_dtypes(self, row_dtype):
+        def fn(row, value0, value1):
+            broadcast_row = row[:, None, None]
+            values = torch.cat((value0 + broadcast_row, value1 + broadcast_row), dim=1)
+            return values.square().sum(dim=-1)
+
+        if row_dtype == torch.bool:
+            row = torch.randint(0, 2, (16,), device=device_type, dtype=row_dtype)
+        else:
+            row = torch.randn(16, device=device_type, dtype=row_dtype)
+        value_dtype = torch.float16 if row_dtype == torch.float32 else torch.float32
+        inputs = (
+            row,
+            torch.randn(16, 2, 64, device=device_type, dtype=value_dtype),
+            torch.randn(16, 3, 64, device=device_type, dtype=value_dtype),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": True,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        pointer_type = {
+            torch.float32: "fp32",
+            torch.bfloat16: "bf16",
+            torch.bool: "i1",
+        }[row_dtype]
+        row_loads = _triton_loads(code, pointer_type)
+        self.assertEqual(2, len(row_loads))
+        for row_load in row_loads:
+            self.assertIn("[XBLOCK, 1]", row_load)
+            self.assertNotRegex(row_load, r"R\d+_BLOCK")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_invariant_load_direct_reduction(self):
+        def fn(row0, row1):
+            value0 = row0[:, :, None].expand(-1, -1, 65)
+            value1 = row1[:, :, None].expand(-1, -1, 65)
+            return torch.cat((value0, value1), dim=1).sum(dim=-1)
+
+        inputs = (
+            torch.randn(16, 2, device=device_type),
+            torch.randn(16, 3, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "fp32")
+        self.assertEqual(2, len(row_loads))
+        for row_load in row_loads:
+            self.assertIn("[XBLOCK, 1]", row_load)
+        self.assertIn("tl.broadcast_to", code)
+        self.assertIn("[XBLOCK, R0_BLOCK]", code)
+        self.assertIn("r0_mask", code)
+        self.assertIn("tl.sum", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    def test_reduction_invariant_indirect_load(self, persistent_reductions):
+        def fn(index, source, value0, value1):
+            row = torch.index_select(source, 0, index)
+            values = torch.cat(
+                (value0 + row[:, None, None], value1 + row[:, None, None]), dim=1
+            )
+            return values.square().sum(dim=-1)
+
+        inputs = (
+            torch.randperm(16, device=device_type),
+            torch.randn(16, device=device_type, dtype=torch.bfloat16),
+            torch.randn(16, 2, 64, device=device_type),
+            torch.randn(16, 3, 64, device=device_type),
+        )
+
+        expected = fn(*inputs)
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.persistent_reductions": persistent_reductions,
+            }
+        ):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+        self.assertEqual(expected, actual)
+        for pointer_type in ("i64", "bf16"):
+            loads = _triton_loads(code, pointer_type)
+            self.assertEqual(2, len(loads))
+            for load in loads:
+                self.assertIn("[XBLOCK, 1]", load)
+                self.assertNotRegex(load, r"R\d+_BLOCK")
+        if persistent_reductions:
+            self.assertIn("@triton_heuristics.persistent_reduction", code)
+        else:
+            self.assertIn("for r0_offset in tl.range", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+        }
+    )
+    def test_partially_reduction_invariant_masked_load(self):
+        def fn(value0, value1, row):
+            values = torch.cat((value0 * row[:, None], value1), dim=0)
+            return values.square().sum()
+
+        inputs = (
+            torch.randn(64, 128, device=device_type),
+            torch.randn(32, 128, device=device_type),
+            torch.randn(64, device=device_type, dtype=torch.float16),
+        )
+
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "fp16")
+        self.assertEqual(1, len(row_loads))
+        self.assertIn("R0_BLOCK", row_loads[0])
+        self.assertNotIn("R1_BLOCK", row_loads[0])
+        self.assertIn("R0_BLOCK", code)
+        self.assertIn("R1_BLOCK", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("persistent_reductions", [False, True])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_reduction_invariant_pointwise_load(self, persistent_reductions):
+        def fn(row, value):
+            padded = torch.cat(
+                (
+                    row,
+                    torch.zeros(
+                        value.shape[0] - row.shape[0],
+                        device=row.device,
+                        dtype=row.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=device_type, dtype=torch.int64),
+            torch.randn(26, 65, 65, device=device_type, dtype=torch.bfloat16),
+        )
+        expected = fn(*inputs)
+        with config.patch({"triton.persistent_reductions": persistent_reductions}):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True), *inputs
+            )
+
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "i64")
+        self.assertEqual(1, len(row_loads))
+        self.assertIn("[YBLOCK, 1, 1]", row_loads[0])
+        self.assertNotIn("XBLOCK", row_loads[0])
+        self.assertNotRegex(row_loads[0], r"R\d+_BLOCK")
+        self.assertIn("YBLOCK", code)
+        self.assertIn("XBLOCK", code)
+        self.assertIn("R0_BLOCK", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "benchmark_combo_kernel": False,
+            "combo_kernel_allow_mixed_sizes": 2,
+            "combo_kernel_max_distance": -1,
+            "combo_kernel_peak_memory_increase_gb": None,
+            "combo_kernel_peak_memory_pct_threshold": None,
+            "combo_kernel_per_subkernel_blocks": False,
+            "combo_kernels": True,
+            "combo_kernels_autotune": 0,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "max_autotune": False,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.mix_order_reduction": False,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_combo_reduction_invariant_pointwise_load(self):
+        def reduction(target, value):
+            padded = torch.cat(
+                (
+                    target,
+                    torch.zeros(
+                        value.shape[0] - target.shape[0],
+                        device=value.device,
+                        dtype=target.dtype,
+                    ),
+                )
+            )
+            return (value.float() + padded.float()[:, None, None]).square().sum(dim=-1)
+
+        def fn(target0, value0, target1, value1):
+            return reduction(target0, value0), reduction(target1, value1)
+
+        inputs = (
+            torch.randint(-4, 5, (13,), device=device_type, dtype=torch.int64),
+            torch.randn(17, 97, 64, device=device_type, dtype=torch.bfloat16),
+            torch.randint(-4, 5, (11,), device=device_type, dtype=torch.int64),
+            torch.randn(19, 129, 64, device=device_type, dtype=torch.bfloat16),
+        )
+        expected = fn(*inputs)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *inputs)
+
+        self.assertEqual(expected, actual)
+        self.assertIn("RoundRobinComboKernelGrid", code)
+        target_loads = _triton_loads(code, "i64")
+        self.assertEqual(2, len(target_loads))
+        for target_load in target_loads:
+            self.assertIn("[YBLOCK, 1, 1]", target_load)
+            self.assertNotIn("XBLOCK", target_load)
+            self.assertNotRegex(target_load, r"R\d+_BLOCK")
+            self.assertNotIn("xmask", target_load)
+            self.assertNotRegex(target_load, r"r\d+_mask")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @parametrize("pointwise_dependency", ["address", "predicate"])
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "split_reductions": False,
+            "triton.cooperative_reductions": False,
+            "triton.force_cooperative_reductions": False,
+            "triton.max_tiles": 3,
+            "triton.multi_kernel": 0,
+            "triton.persistent_reductions": True,
+            "triton.prefer_nd_tiling": True,
+            "triton.tile_reductions": True,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_pointwise_dependent_load_stays_dense(self, pointwise_dependency):
+        if pointwise_dependency == "address":
+
+            def fn(row, value):
+                return (value.float() + row.float()[:, :, None]).square().sum(dim=-1)
+
+            row = torch.randint(-4, 5, (26, 65), device=device_type, dtype=torch.int64)
+        else:
+
+            def fn(row, value):
+                padded = torch.cat(
+                    (
+                        row[:, None],
+                        torch.zeros(
+                            (row.shape[0], value.shape[1] - 1),
+                            device=row.device,
+                            dtype=row.dtype,
+                        ),
+                    ),
+                    dim=1,
+                )
+                return (value.float() + padded.float()[:, :, None]).square().sum(dim=-1)
+
+            row = torch.randint(-4, 5, (26,), device=device_type, dtype=torch.int64)
+
+        value = torch.randn(26, 65, 65, device=device_type, dtype=torch.bfloat16)
+        expected = fn(row, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), row, value
+        )
+
+        self.assertEqual(expected, actual)
+        row_loads = _triton_loads(code, "i64")
+        self.assertEqual(1, len(row_loads))
+        if pointwise_dependency == "address":
+            self.assertRegex(row_loads[0], r"\bx\d+\b")
+            self.assertIn("xmask", row_loads[0])
+        else:
+            self.assertIn("XBLOCK", row_loads[0])
+        self.assertNotRegex(row_loads[0], r"R\d+_BLOCK")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_pointer_keeps_masked_index_load_dense(self):
+        def fn(index, source, left):
+            gathered = torch.index_select(source, 2, index).float()
+            values = torch.cat((left, gathered), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(64, device=device_type)[:32]
+        source = torch.randn(16, 2, 64, device=device_type, dtype=torch.bfloat16)
+        left = torch.randn(16, 1, 32, device=device_type)
+
+        expected = fn(index, source, left)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, left
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertNotIn("[XBLOCK, 1]", index_loads[0])
+        self.assertIn("r0_", index_loads[0])
+        indirect_loads = _triton_loads(code, "bf16")
+        self.assertEqual(1, len(indirect_loads))
+        self.assertIn("R0_BLOCK", indirect_loads[0])
+        self.assertRegex(indirect_loads[0], r"\btmp\d+\b")
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(force_disable_caches=True)
+    def test_reduction_dependent_mask_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=-1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        source = torch.randn(16, 2, 32, device=device_type)
+        value = torch.randn(16, 2, 16, device=device_type)
+
+        expected = fn(index, source, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, value
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertIn("R0_BLOCK", index_loads[0])
+        self.assertIn("r0_", index_loads[0])
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.dense_indexing": True,
+        }
+    )
+    def test_explicit_dense_indexing_keeps_masked_index_load_dense(self):
+        def fn(index, source, value):
+            gathered = torch.index_select(source, 0, index)
+            values = torch.cat((gathered, value), dim=1)
+            return values.square().sum(dim=-1)
+
+        index = torch.randperm(16, device=device_type)
+        source = torch.randn(16, 2, 64, device=device_type)
+        value = torch.randn(16, 3, 64, device=device_type)
+
+        expected = fn(index, source, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, source, value
+        )
+        self.assertEqual(expected, actual)
+        index_loads = _triton_int64_loads(code)
+        self.assertEqual(1, len(index_loads))
+        self.assertIn("R0_BLOCK", index_loads[0])
+        self.assertIn("@triton_heuristics.persistent_reduction", code)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.persistent_reductions": False,
+        }
+    )
+    def test_loop_epilogue_masked_index_load_scope(self):
+        def fn(index, mask, value):
+            positions = torch.arange(index.numel(), device=index.device)
+            masked_index = torch.ops.aten._unsafe_masked_index(
+                index, mask, [positions], 0
+            )
+            reduced = (value + masked_index[:, None]).sum(dim=-1)
+            return reduced + masked_index
+
+        index = torch.arange(16, device=device_type, dtype=torch.int64)
+        mask = torch.tensor([True, False] * 8, device=device_type)
+        value = torch.randn(16, 64, device=device_type)
+
+        expected = fn(index, mask, value)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, fullgraph=True), index, mask, value
+        )
+        self.assertEqual(expected, actual)
+        self.assertIn("for r0_offset in tl.range", code)
+        index_load_lines = _triton_int64_load_lines(code)
+        self.assertEqual(2, len(index_load_lines))
+        indentation = [len(line) - len(line.lstrip()) for line in index_load_lines]
+        self.assertEqual(2, len(set(indentation)))
+        epilogue_load, loop_load = sorted(
+            index_load_lines, key=lambda line: len(line) - len(line.lstrip())
+        )
+        self.assertLess(
+            len(epilogue_load) - len(epilogue_load.lstrip()),
+            len(loop_load) - len(loop_load.lstrip()),
+        )
+        self.assertNotRegex(epilogue_load, r"r\d+_|R\d+_BLOCK")
+        self.assertIn("[XBLOCK, 1]", loop_load)
 
     def test_max_autotune_nograd(self):
         """

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4167,62 +4167,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         reduction_invariant_indexing_applied = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
-                # This avoids full broadcasting (need_dense) when performing native matmul.
-                # For example, self._load_mask previously required tl.broadcast_to() in index_str.
-                # Due to the restrictions of tl.dot semantics, we only want to expand the block
-                # shape for the necessary axes.
-                #
-                # Previously:
-                #   tmp1 = tl.load(ptr + tl.broadcast_to(r0, [YBLOCK, XBLOCK, R0_BLOCK]),
-                #                  r0_mask & tmp0 & xmask)
-                #
-                # Now:
-                #   tmp1 = tl.load(ptr + tl.broadcast_to(r0, [1, 1, R0_BLOCK]),
-                #                  r0_mask & tmp0 & xmask)
-                #
-                # We achieve this by determining the required block shape through mask inspection.
-                # When a temporary variable appears in the mask (e.g., self._load_mask), we retrieve
-                # its true shape by inspecting tmp.mask_vars tracked by TritonCSEVariable.
-                #
-                # Caution: it may miss the correct block shape if the specific mask was constant
-                # and thus not tracked in TritonCSEVariable.mask_vars.
-                #
-                # TODO: Once the shape propagation PR lands, reimplement this logic:
-                #       https://github.com/pytorch/pytorch/pull/152198
-                mask_shape = mask_vars.copy()
+                required_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
                 if self._load_mask:
-                    mask_shape.add(self._load_mask)
-
-                axis_masks = OrderedSet(
-                    tree.mask_name() for tree in self.active_range_trees()
+                    required_masks.add(self._load_mask)
+                minimal_shape = self._broadcast_shape_with_masks(
+                    TritonSymbols.get_block_shape(index), required_masks
                 )
-                while not mask_shape.issubset(axis_masks):
-                    tmp_masks = mask_shape.difference(axis_masks)
-                    tmp = tmp_masks.pop()
-                    if not isinstance(tmp, TritonCSEVariable):
-                        raise AssertionError(
-                            f"expected TritonCSEVariable, got {type(tmp)}"
-                        )
-                    mask_shape.discard(tmp)
-                    mask_shape.update(tmp.mask_vars)
-
-                # e.g., expand_list becomes ['ZBLOCK', 1, 1, 'R0_BLOCK']
-                expand_list = ["1"] * len(self.dense_size_list())
-                for mask in mask_shape:
-                    if not isinstance(mask, str):
-                        raise AssertionError(f"expected str mask, got {type(mask)}")
-                    for tree in self.active_range_trees():
-                        if tree.owns_mask(mask):
-                            dim = tree.tensor_dim
-                            if not isinstance(dim, int):
-                                raise AssertionError(
-                                    f"expected int dim, got {type(dim)}"
-                                )
-                            expand_list[dim] = self.dense_size_list()[dim]
-
-                expand_str = "[" + ",".join(map(str, expand_list)) + "]"
-                expand_shape = tuple(expand_list)
-                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                dense_shape = tuple(self.dense_size_list())
+                # Native matmul operands retain the kernel rank for scalar indices.
+                minimal_shape = self._preserve_scalar_shape_rank(minimal_shape)
+                # Native-matmul indexing producers currently yield owned masks and
+                # scalar/full-rank index shapes; keep dense indexing as a defensive
+                # fallback. Dense is valid for auxiliary loads, and real tl.dot
+                # operands are checked in reshape_transpose_broadcast_for_dot.
+                if minimal_shape is None or len(minimal_shape) != len(dense_shape):
+                    expand_str, expand_shape = _get_expand_str()
+                    index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                    mask_vars = dense_mask_vars
+                else:
+                    expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                    expand_shape = minimal_shape
+                    index_str = f"tl.broadcast_to({index_str}, {expand_str})"
             elif (
                 reduction_invariant_indexing
                 and not config.triton.dense_indexing
@@ -4548,6 +4513,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _preserve_scalar_shape_rank(self, shape: BlockShapeType) -> BlockShapeType:
+        if shape is not None and not shape:
+            return tuple("1" for _ in range(self.triton_tensor_ndim()))
+        return shape
+
     def _reduction_invariant_indexing_shape(
         self,
         index: sympy.Expr,
@@ -4586,10 +4556,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         shape = self._broadcast_shape_with_masks(
             TritonSymbols.get_block_shape(index), load_masks
         )
+        shape = self._preserve_scalar_shape_rank(shape)
         if shape is None:
             return None
-        if not shape:
-            shape = tuple("1" for _ in range(self.triton_tensor_ndim()))
 
         dense_shape = tuple(self.dense_size_list())
         if len(shape) != len(dense_shape):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -374,6 +374,7 @@ class IndexingOptions:
     _has_rindex: bool
     index: sympy.Expr
     expand_shape: Sequence[int | str] | None
+    reduction_invariant_indexing: bool = False
 
     def has_mask(self) -> bool:
         return bool(self.mask_vars)
@@ -3767,6 +3768,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        reduction_invariant_indexing=False,
     ):
         """
         Compute the index and mask to pass to tl.load() or tl.store()
@@ -4157,6 +4159,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_shape=expand_shape,
             )
 
+        reduction_invariant_indexing_applied = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
                 # This avoids full broadcasting (need_dense) when performing native matmul.
@@ -4215,6 +4218,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_str = "[" + ",".join(map(str, expand_list)) + "]"
                 expand_shape = tuple(expand_list)
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+            elif (
+                reduction_invariant_indexing
+                and not config.triton.dense_indexing
+                and not dense_indexing
+                and (
+                    minimal_shape := self._reduction_invariant_indexing_shape(
+                        index,
+                        mask_vars,
+                    )
+                )
+                is not None
+            ):
+                expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                expand_shape = minimal_shape
+                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                reduction_invariant_indexing_applied = True
             else:
                 expand_str, expand_shape = _get_expand_str()
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
@@ -4245,6 +4264,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             has_rindex,
             index,
             expand_shape=expand_shape,
+            reduction_invariant_indexing=reduction_invariant_indexing_applied,
         )
 
     def codegen_block_ptr(
@@ -4516,6 +4536,71 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _reduction_invariant_indexing_shape(
+        self,
+        index: sympy.Expr,
+        mask_vars: Iterable[str | TritonCSEVariable],
+    ) -> BlockShapeType:
+        """Return a minimal shape for reduction-invariant masked indexing.
+
+        An axis remains singleton only when both the address and every non-range
+        predicate are broadcast on it. Omitting a reduction axis additionally
+        requires a positive logical extent, which permits removing its synthetic
+        range mask. Temporary values participate through their propagated block
+        shapes, so this also covers provably invariant indirect addresses.
+        """
+        if not self.inside_reduction or self._load_mask is None:
+            return None
+
+        # These schedules introduce coordinate scopes outside the block shape
+        # tracked by this proof.
+        if self.cooperative_reduction or self.mix_order_reduction:
+            return None
+
+        active_range_trees = self.active_range_trees()
+        # A combo grid can launch a subkernel because a sibling has a larger grid.
+        # A singleton load still needs one valid pointwise coordinate in that
+        # subkernel, including for axes without a tensor dimension.
+        if self.is_combo_kernel and any(
+            not tree.is_reduction
+            and not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            for tree in active_range_trees
+        ):
+            return None
+
+        load_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
+        if self._load_mask:
+            load_masks.add(self._load_mask)
+        shape = self._broadcast_shape_with_masks(
+            TritonSymbols.get_block_shape(index), load_masks
+        )
+        if shape is None:
+            return None
+        if not shape:
+            shape = tuple("1" for _ in range(self.triton_tensor_ndim()))
+
+        dense_shape = tuple(self.dense_size_list())
+        if len(shape) != len(dense_shape):
+            return None
+        omitted_reduction = False
+        for tree in active_range_trees:
+            dim = tree.tensor_dim
+            if dim is None or shape[dim] == dense_shape[dim]:
+                continue
+            if not tree.is_reduction:
+                if str(shape[dim]) != "1":
+                    return None
+                continue
+            if (
+                str(shape[dim]) != "1"
+                # A zero-length reduction makes the existing dense load fully masked.
+                or not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            ):
+                return None
+            omitted_reduction = True
+
+        return tuple(shape) if omitted_reduction else None
+
     GDC_WAIT = "tl.extra.cuda.gdc_wait()"
     GDC_LAUNCH = "tl.extra.cuda.gdc_launch_dependents()"
 
@@ -4776,6 +4861,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index,
             block_ptr=True,
             tma_compatibility_checker=tma_checker,
+            reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
         )
 
         if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
@@ -4785,6 +4873,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         has_rindex = indexing.has_rindex()
         has_tmpmask = indexing.has_tmpmask()
+        has_indirect = indexing.has_indirect()
+        has_reduction_invariant_indexing = (
+            isinstance(indexing, IndexingOptions)
+            and indexing.reduction_invariant_indexing
+        )
 
         # Keep the variable in cache if were going to reuse it. Equiv., if any of the following hold
         #  1) We are doing broadcasting
@@ -4968,7 +5061,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        if not self.inside_reduction or (
+            not indexing.has_rmask()
+            and not has_rindex
+            # Temporary addresses and masks are emitted in the reduction body.
+            # Keep this dependency predicate explicit so direct unmasked loads
+            # remain liftable. Do not reuse a body-local load across iterations.
+            and not ((has_indirect or has_tmpmask) and has_reduction_invariant_indexing)
+        ):
             self.outside_loop_vars.add(result_var)
 
         return result_var

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2467,7 +2467,12 @@ class TritonKernelOverrides(TritonOverrides):
     def index_expr(cls, expr, dtype):
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
-            expr, block_ptr=False, tma_compatibility_checker=None
+            expr,
+            block_ptr=False,
+            tma_compatibility_checker=None,
+            reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
         )
         if not isinstance(indexing, IndexingOptions):
             raise AssertionError(f"expected IndexingOptions, got {type(indexing)}")
@@ -4477,7 +4482,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         if not isinstance(expr, sympy.Expr):
             raise AssertionError(f"expected sympy.Expr, got {type(expr)}")
-        indexing = self.indexing(expr, block_ptr=False, tma_compatibility_checker=None)
+        indexing = self.indexing(
+            expr,
+            block_ptr=False,
+            tma_compatibility_checker=None,
+            reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
+        )
         if not isinstance(indexing, IndexingOptions):
             raise AssertionError(f"expected IndexingOptions, got {type(indexing)}")
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -374,6 +374,7 @@ class IndexingOptions:
     _has_rindex: bool
     index: sympy.Expr
     expand_shape: Sequence[int | str] | None
+    reduction_axes_omitted: bool = False
 
     def has_mask(self) -> bool:
         return bool(self.mask_vars)
@@ -3795,6 +3796,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        allow_reduction_invariant_indexing=False,
     ):
         """
         Compute the index and mask to pass to tl.load() or tl.store()
@@ -4185,6 +4187,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_shape=expand_shape,
             )
 
+        reduction_axes_omitted = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
                 # This avoids full broadcasting (need_dense) when performing native matmul.
@@ -4243,6 +4246,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_str = "[" + ",".join(map(str, expand_list)) + "]"
                 expand_shape = tuple(expand_list)
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+            elif (
+                allow_reduction_invariant_indexing
+                and not config.triton.dense_indexing
+                and not dense_indexing
+                and (
+                    minimal_shape := self._reduction_invariant_indexing_shape(
+                        index,
+                        mask_vars,
+                    )
+                )
+                is not None
+            ):
+                expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                expand_shape = minimal_shape
+                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                reduction_axes_omitted = True
             else:
                 expand_str, expand_shape = _get_expand_str()
                 index_str = f"tl.broadcast_to({index_str}, {expand_str})"
@@ -4273,6 +4292,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             has_rindex,
             index,
             expand_shape=expand_shape,
+            reduction_axes_omitted=reduction_axes_omitted,
         )
 
     def codegen_block_ptr(
@@ -4544,6 +4564,71 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _reduction_invariant_indexing_shape(
+        self,
+        index: sympy.Expr,
+        mask_vars: Iterable[str | TritonCSEVariable],
+    ) -> BlockShapeType:
+        """Return a minimal shape for reduction-invariant masked indexing.
+
+        An axis remains singleton only when both the address and every non-range
+        predicate are broadcast on it. Omitting a reduction axis additionally
+        requires a positive logical extent, which permits removing its synthetic
+        range mask. Temporary values participate through their propagated block
+        shapes, so this also covers provably invariant indirect addresses.
+        """
+        if not self.inside_reduction or self._load_mask is None:
+            return None
+
+        # These schedules introduce coordinate scopes outside the block shape
+        # tracked by this proof.
+        if self.cooperative_reduction or self.mix_order_reduction:
+            return None
+
+        active_range_trees = self.active_range_trees()
+        # A combo grid can launch a subkernel because a sibling has a larger grid.
+        # A singleton load still needs one valid pointwise coordinate in that
+        # subkernel, including for axes without a tensor dimension.
+        if self.is_combo_kernel and any(
+            not tree.is_reduction
+            and not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            for tree in active_range_trees
+        ):
+            return None
+
+        load_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
+        if self._load_mask:
+            load_masks.add(self._load_mask)
+        shape = self._broadcast_shape_with_masks(
+            TritonSymbols.get_block_shape(index), load_masks
+        )
+        if shape is None:
+            return None
+        if not shape:
+            shape = ("1",) * self.triton_tensor_ndim()
+
+        dense_shape = tuple(self.dense_size_list())
+        if len(shape) != len(dense_shape):
+            return None
+        omitted_reduction = False
+        for tree in active_range_trees:
+            dim = tree.tensor_dim
+            if dim is None or str(shape[dim]) == str(dense_shape[dim]):
+                continue
+            if not tree.is_reduction:
+                if str(shape[dim]) != "1":
+                    return None
+                continue
+            if (
+                str(shape[dim]) != "1"
+                # A zero-length reduction makes the existing dense load fully masked.
+                or not V.graph.sizevars.statically_known_gt(tree.numel, sympy.S.Zero)
+            ):
+                return None
+            omitted_reduction = True
+
+        return tuple(shape) if omitted_reduction else None
+
     GDC_WAIT = "tl.extra.cuda.gdc_wait()"
     GDC_LAUNCH = "tl.extra.cuda.gdc_launch_dependents()"
 
@@ -4804,12 +4889,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index,
             block_ptr=True,
             tma_compatibility_checker=tma_checker,
+            # Lane-shape changes are currently qualified only on CUDA and ROCm.
+            # Other Triton backends retain dense indexing until they are covered.
+            allow_reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
         )
 
-        if isinstance(indexing, IndexingOptions) and self._has_stride1_on_rdim(
-            indexing.index
-        ):
-            self.has_load_with_contiguous_rdim = True
+        if isinstance(indexing, IndexingOptions):
+            if self._has_stride1_on_rdim(indexing.index):
+                self.has_load_with_contiguous_rdim = True
+            reduction_axes_omitted = indexing.reduction_axes_omitted
+        else:
+            reduction_axes_omitted = False
 
         has_rindex = indexing.has_rindex()
         has_tmpmask = indexing.has_tmpmask()
@@ -4996,7 +5088,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        if not self.inside_reduction or (
+            not indexing.has_rmask()
+            and not has_rindex
+            # Narrowed masked loads are emitted in the reduction body and must
+            # not be reused across loop iterations.
+            and not reduction_axes_omitted
+        ):
             self.outside_loop_vars.add(result_var)
 
         return result_var

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4195,62 +4195,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         reduction_axes_omitted = False
         if need_dense and not have_dense:
             if self.inside_reduction and self.is_native_matmul:
-                # This avoids full broadcasting (need_dense) when performing native matmul.
-                # For example, self._load_mask previously required tl.broadcast_to() in index_str.
-                # Due to the restrictions of tl.dot semantics, we only want to expand the block
-                # shape for the necessary axes.
-                #
-                # Previously:
-                #   tmp1 = tl.load(ptr + tl.broadcast_to(r0, [YBLOCK, XBLOCK, R0_BLOCK]),
-                #                  r0_mask & tmp0 & xmask)
-                #
-                # Now:
-                #   tmp1 = tl.load(ptr + tl.broadcast_to(r0, [1, 1, R0_BLOCK]),
-                #                  r0_mask & tmp0 & xmask)
-                #
-                # We achieve this by determining the required block shape through mask inspection.
-                # When a temporary variable appears in the mask (e.g., self._load_mask), we retrieve
-                # its true shape by inspecting tmp.mask_vars tracked by TritonCSEVariable.
-                #
-                # Caution: it may miss the correct block shape if the specific mask was constant
-                # and thus not tracked in TritonCSEVariable.mask_vars.
-                #
-                # TODO: Once the shape propagation PR lands, reimplement this logic:
-                #       https://github.com/pytorch/pytorch/pull/152198
-                mask_shape = mask_vars.copy()
+                required_masks = OrderedSet[str | TritonCSEVariable](mask_vars)
                 if self._load_mask:
-                    mask_shape.add(self._load_mask)
-
-                axis_masks = OrderedSet(
-                    tree.mask_name() for tree in self.active_range_trees()
+                    required_masks.add(self._load_mask)
+                minimal_shape = self._broadcast_shape_with_masks(
+                    TritonSymbols.get_block_shape(index), required_masks
                 )
-                while not mask_shape.issubset(axis_masks):
-                    tmp_masks = mask_shape.difference(axis_masks)
-                    tmp = tmp_masks.pop()
-                    if not isinstance(tmp, TritonCSEVariable):
-                        raise AssertionError(
-                            f"expected TritonCSEVariable, got {type(tmp)}"
-                        )
-                    mask_shape.discard(tmp)
-                    mask_shape.update(tmp.mask_vars)
-
-                # e.g., expand_list becomes ['ZBLOCK', 1, 1, 'R0_BLOCK']
-                expand_list = ["1"] * len(self.dense_size_list())
-                for mask in mask_shape:
-                    if not isinstance(mask, str):
-                        raise AssertionError(f"expected str mask, got {type(mask)}")
-                    for tree in self.active_range_trees():
-                        if tree.owns_mask(mask):
-                            dim = tree.tensor_dim
-                            if not isinstance(dim, int):
-                                raise AssertionError(
-                                    f"expected int dim, got {type(dim)}"
-                                )
-                            expand_list[dim] = self.dense_size_list()[dim]
-
-                expand_str = "[" + ",".join(map(str, expand_list)) + "]"
-                expand_shape = tuple(expand_list)
-                index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                dense_shape = tuple(self.dense_size_list())
+                # Native matmul operands retain the kernel rank for scalar indices.
+                minimal_shape = self._preserve_scalar_shape_rank(minimal_shape)
+                # Native-matmul indexing producers currently yield owned masks and
+                # scalar/full-rank index shapes; keep dense indexing as a defensive
+                # fallback. Dense is valid for auxiliary loads, and real tl.dot
+                # operands are checked in reshape_transpose_broadcast_for_dot.
+                if minimal_shape is None or len(minimal_shape) != len(dense_shape):
+                    expand_str, expand_shape = _get_expand_str()
+                    index_str = f"tl.broadcast_to({index_str}, {expand_str})"
+                    mask_vars = dense_mask_vars
+                else:
+                    expand_str = "[" + ", ".join(map(str, minimal_shape)) + "]"
+                    expand_shape = minimal_shape
+                    index_str = f"tl.broadcast_to({index_str}, {expand_str})"
             elif (
                 allow_reduction_invariant_indexing
                 and not config.triton.dense_indexing
@@ -4576,6 +4541,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         return result_shape
 
+    def _preserve_scalar_shape_rank(self, shape: BlockShapeType) -> BlockShapeType:
+        if shape is not None and not shape:
+            return tuple("1" for _ in range(self.triton_tensor_ndim()))
+        return shape
+
     def _reduction_invariant_indexing_shape(
         self,
         index: sympy.Expr,
@@ -4614,10 +4584,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         shape = self._broadcast_shape_with_masks(
             TritonSymbols.get_block_shape(index), load_masks
         )
+        shape = self._preserve_scalar_shape_rank(shape)
         if shape is None:
             return None
-        if not shape:
-            shape = ("1",) * self.triton_tensor_ndim()
 
         dense_shape = tuple(self.dense_size_list())
         if len(shape) != len(dense_shape):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2467,7 +2467,12 @@ class TritonKernelOverrides(TritonOverrides):
     def index_expr(cls, expr, dtype):
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
-            expr, block_ptr=False, tma_compatibility_checker=None
+            expr,
+            block_ptr=False,
+            tma_compatibility_checker=None,
+            allow_reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
         )
         if not isinstance(indexing, IndexingOptions):
             raise AssertionError(f"expected IndexingOptions, got {type(indexing)}")
@@ -4505,7 +4510,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         if not isinstance(expr, sympy.Expr):
             raise AssertionError(f"expected sympy.Expr, got {type(expr)}")
-        indexing = self.indexing(expr, block_ptr=False, tma_compatibility_checker=None)
+        indexing = self.indexing(
+            expr,
+            block_ptr=False,
+            tma_compatibility_checker=None,
+            allow_reduction_invariant_indexing=(
+                V.graph.get_current_device_or_throw().type == "cuda"
+            ),
+        )
         if not isinstance(indexing, IndexingOptions):
             raise AssertionError(f"expected IndexingOptions, got {type(indexing)}")
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1809,6 +1809,7 @@ class TritonTemplateKernel(TritonKernel):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        reduction_invariant_indexing=False,
     ):
         """
         Override the default indexing to use our custom mask and force
@@ -1824,6 +1825,8 @@ class TritonTemplateKernel(TritonKernel):
             block_ptr=block_ptr,
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mask_constant_index,
+            # Templates own their output broadcast shape and mask.
+            reduction_invariant_indexing=False,
         )
 
     def codegen_range_tree(self):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1809,6 +1809,7 @@ class TritonTemplateKernel(TritonKernel):
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
+        allow_reduction_invariant_indexing=False,
     ):
         """
         Override the default indexing to use our custom mask and force
@@ -1824,6 +1825,8 @@ class TritonTemplateKernel(TritonKernel):
             block_ptr=block_ptr,
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mask_constant_index,
+            # Templates own their output broadcast shape and mask.
+            allow_reduction_invariant_indexing=False,
         )
 
     def codegen_range_tree(self):


### PR DESCRIPTION
Summary:

**Why:**
- The legacy walk derives shape indirectly from transitive mask ownership. Constant folding can drop a mask from `mask_vars` while `TritonCSEVariable.shape` still records the required dimension, so the walk can under-expand.
- Reading propagated shapes directly fixes that information-loss case and discharges the existing TODO to reimplement this logic once shape propagation landed.

**What:**
- Replace native matmul's recursive `mask_vars` walk with shared block-shape propagation.
- Preserve full-rank scalar indexing. Fall back to dense indexing when a required mask shape is unknown or has the wrong rank. The legacy walk raised for unresolved mask ownership; it had no explicit rank-mismatch check.
- Cover production-valid 3-D indexing, reduction-dependent indexing, scalar rank preservation, and the unknown-mask dense fallback.

**Scope:** Codegen cleanup and correctness hardening, not a model-QPS claim. The retained OBA, CMF, HIM, and HIM-IG model wrappers contained no native-matmul site. Native-matmul indexing producers currently yield owned masks and scalar/full-rank index shapes, so the dense path is a defensive fallback; real `tl.dot` operands retain separate axis-dependence validation.

Test Plan:
- Propagated-shape and dense-fallback unit coverage passed. TestX: https://www.internalfb.com/intern/testinfra/testrun/22517998173524648

```
buck test -c fbcode.disable_re_tests=True 'fbcode//caffe2/test/inductor:codegen_triton' -- test_native_matmul_indexing_uses_propagated_shapes --env PYTORCH_TEST_REMOTE_GPU=0 --timeout=600 --print-passing-details
```

- H100 CUDA 12.4: `test_matmul`, indexed 3-D `test_bmm_fusion_complex1`, and indexed 4-D `test_bmm_fusion_complex2` passed 3/3. Buck build: https://www.internalfb.com/buck2/27eb5b14-d42d-4f32-9da5-43f80ce8f0a7
- Sealed MI350/gfx950 run from the exact three-diff source, after a five-sample idle gate. Real indexed 3-D and 4-D native-matmul graphs each generated one `tl.dot` kernel and matched eager output. Artifact hashes are in a comment on this diff.

Differential Revision: D114995237


