### PR TITLE
[MPS] Support non-divisible adaptive_avg_pool2d

### DIFF
--- a/aten/src/ATen/native/mps/kernels/AdaptivePooling.h
+++ b/aten/src/ATen/native/mps/kernels/AdaptivePooling.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct AdaptiveAvgPool2DParams {
+  long B;
+  long C;
+  long input_height;
+  long input_width;
+  long output_height;
+  long output_width;
+  long input_strides[4];
+  long output_strides[4];
+};

--- a/aten/src/ATen/native/mps/kernels/AdaptivePooling.metal
+++ b/aten/src/ATen/native/mps/kernels/AdaptivePooling.metal
@@ -1,0 +1,126 @@
+#include <ATen/native/mps/kernels/AdaptivePooling.h>
+#include <metal_stdlib>
+
+using namespace metal;
+
+template <typename T>
+kernel void adaptive_avg_pool2d_forward(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant AdaptiveAvgPool2DParams& params [[buffer(2)]],
+    uint output_index [[thread_position_in_grid]]) {
+  const ulong output_width = ulong(params.output_width);
+  const ulong output_height = ulong(params.output_height);
+  const ulong output_plane = output_height * output_width;
+  const ulong channel_plane = ulong(output_index) / output_plane;
+  const ulong output_offset = ulong(output_index) % output_plane;
+  const ulong batch = channel_plane / ulong(params.C);
+  const ulong channel = channel_plane % ulong(params.C);
+  const ulong output_y = output_offset / output_width;
+  const ulong output_x = output_offset % output_width;
+
+  const ulong input_y_start =
+      output_y * ulong(params.input_height) / output_height;
+  const ulong input_y_end =
+      ((output_y + 1) * ulong(params.input_height) + output_height - 1) /
+      output_height;
+  const ulong input_x_start =
+      output_x * ulong(params.input_width) / output_width;
+  const ulong input_x_end =
+      ((output_x + 1) * ulong(params.input_width) + output_width - 1) /
+      output_width;
+
+  const ulong input_base = batch * ulong(params.input_strides[0]) +
+      channel * ulong(params.input_strides[1]);
+  float sum = 0.0f;
+  for (ulong input_y = input_y_start; input_y < input_y_end; ++input_y) {
+    for (ulong input_x = input_x_start; input_x < input_x_end; ++input_x) {
+      sum += float(input
+                       [input_base + input_y * ulong(params.input_strides[2]) +
+                        input_x * ulong(params.input_strides[3])]);
+    }
+  }
+  const float count =
+      float((input_y_end - input_y_start) * (input_x_end - input_x_start));
+  const ulong output_storage_index = batch * ulong(params.output_strides[0]) +
+      channel * ulong(params.output_strides[1]) +
+      output_y * ulong(params.output_strides[2]) +
+      output_x * ulong(params.output_strides[3]);
+  output[output_storage_index] = T(sum / count);
+}
+
+template <typename T>
+kernel void adaptive_avg_pool2d_backward(
+    constant T* grad_output [[buffer(0)]],
+    device T* grad_input [[buffer(1)]],
+    constant AdaptiveAvgPool2DParams& params [[buffer(2)]],
+    uint input_index [[thread_position_in_grid]]) {
+  const ulong input_width = ulong(params.input_width);
+  const ulong input_height = ulong(params.input_height);
+  const ulong input_plane = input_height * input_width;
+  const ulong channel_plane = ulong(input_index) / input_plane;
+  const ulong input_offset = ulong(input_index) % input_plane;
+  const ulong batch = channel_plane / ulong(params.C);
+  const ulong channel = channel_plane % ulong(params.C);
+  const ulong input_y = input_offset / input_width;
+  const ulong input_x = input_offset % input_width;
+
+  const ulong output_y_start =
+      input_y * ulong(params.output_height) / input_height;
+  const ulong output_y_end =
+      ((input_y + 1) * ulong(params.output_height) + input_height - 1) /
+      input_height;
+  const ulong output_x_start =
+      input_x * ulong(params.output_width) / input_width;
+  const ulong output_x_end =
+      ((input_x + 1) * ulong(params.output_width) + input_width - 1) /
+      input_width;
+
+  const ulong output_base = batch * ulong(params.output_strides[0]) +
+      channel * ulong(params.output_strides[1]);
+  float sum = 0.0f;
+  for (ulong output_y = output_y_start; output_y < output_y_end; ++output_y) {
+    const ulong input_y_start =
+        output_y * input_height / ulong(params.output_height);
+    const ulong input_y_end =
+        ((output_y + 1) * input_height + ulong(params.output_height) - 1) /
+        ulong(params.output_height);
+    for (ulong output_x = output_x_start; output_x < output_x_end; ++output_x) {
+      const ulong input_x_start =
+          output_x * input_width / ulong(params.output_width);
+      const ulong input_x_end =
+          ((output_x + 1) * input_width + ulong(params.output_width) - 1) /
+          ulong(params.output_width);
+      const float count =
+          float((input_y_end - input_y_start) * (input_x_end - input_x_start));
+      sum +=
+          float(grad_output
+                    [output_base + output_y * ulong(params.output_strides[2]) +
+                     output_x * ulong(params.output_strides[3])]) /
+          count;
+    }
+  }
+  const ulong input_storage_index = batch * ulong(params.input_strides[0]) +
+      channel * ulong(params.input_strides[1]) +
+      input_y * ulong(params.input_strides[2]) +
+      input_x * ulong(params.input_strides[3]);
+  grad_input[input_storage_index] = T(sum);
+}
+
+#define REGISTER_ADAPTIVE_AVG_POOL2D(T)                        \
+  template [[host_name("adaptive_avg_pool2d_forward_" #T)]]    \
+  kernel void adaptive_avg_pool2d_forward<T>(                  \
+      constant T * input [[buffer(0)]],                        \
+      device T * output [[buffer(1)]],                         \
+      constant AdaptiveAvgPool2DParams & params [[buffer(2)]], \
+      uint output_index [[thread_position_in_grid]]);          \
+  template [[host_name("adaptive_avg_pool2d_backward_" #T)]]   \
+  kernel void adaptive_avg_pool2d_backward<T>(                 \
+      constant T * grad_output [[buffer(0)]],                  \
+      device T * grad_input [[buffer(1)]],                     \
+      constant AdaptiveAvgPool2DParams & params [[buffer(2)]], \
+      uint input_index [[thread_position_in_grid]]);
+
+REGISTER_ADAPTIVE_AVG_POOL2D(float)
+REGISTER_ADAPTIVE_AVG_POOL2D(half)
+REGISTER_ADAPTIVE_AVG_POOL2D(bfloat)

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -57,6 +57,7 @@ static void adaptive_avg_pool2d_metal(const Tensor& input, Tensor& output, bool 
 
   auto stream = getCurrentMPSStream();
   const auto direction = backward ? "backward"sv : "forward"sv;
+  // TODO: Use 32-bit indexing when input is small enough.
   const auto kernel = fmt::format("adaptive_avg_pool2d_{}_{}", direction, scalarToMetalTypeString(input));
   const auto params = backward ? adaptive_avg_pool2d_params(output, input) : adaptive_avg_pool2d_params(input, output);
   @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <fmt/format.h>
+#include <string_view>
 
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Pool.h>
@@ -52,9 +53,11 @@ static AdaptiveAvgPool2DParams adaptive_avg_pool2d_params(const Tensor& input, c
 }
 
 static void adaptive_avg_pool2d_metal(const Tensor& input, Tensor& output, bool backward) {
+  using namespace std::string_view_literals;
+
   auto stream = getCurrentMPSStream();
-  const auto kernel =
-      fmt::format("adaptive_avg_pool2d_{}_{}", backward ? "backward" : "forward", scalarToMetalTypeString(input));
+  const auto direction = backward ? "backward"sv : "forward"sv;
+  const auto kernel = fmt::format("adaptive_avg_pool2d_{}_{}", direction, scalarToMetalTypeString(input));
   const auto params = backward ? adaptive_avg_pool2d_params(output, input) : adaptive_avg_pool2d_params(input, output);
   @autoreleasepool {
     auto pso = lib.getPipelineStateForFunc(kernel);
@@ -128,9 +131,10 @@ Tensor& adaptive_avg_pool2d_out_mps(const Tensor& input, IntArrayRef output_size
   int64_t strideH = 0, strideW = 0;
   int64_t kernel_sizeH = 0, kernel_sizeW = 0;
 
-  const bool regular_downsample = isizeH >= osizeH && isizeW >= osizeW && isizeH % osizeH == 0 && isizeW % osizeW == 0;
-  const bool regular_upsample = isizeH <= osizeH && isizeW <= osizeW && osizeH % isizeH == 0 && osizeW % isizeW == 0;
-  if (!regular_downsample && !regular_upsample) {
+  const bool divisible_downsample =
+      isizeH >= osizeH && isizeW >= osizeW && isizeH % osizeH == 0 && isizeW % osizeW == 0;
+  const bool divisible_upsample = isizeH <= osizeH && isizeW <= osizeW && osizeH % isizeH == 0 && osizeW % isizeW == 0;
+  if (!divisible_downsample && !divisible_upsample) {
     mps::adaptive_avg_pool2d_metal(input, output, false);
     return output;
   }

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -1,7 +1,11 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <fmt/format.h>
+
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/AdaptivePooling.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -18,6 +22,55 @@
 #endif
 namespace at::native {
 namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/AdaptivePooling_metallib.h>
+#endif
+
+static AdaptiveAvgPool2DParams adaptive_avg_pool2d_params(const Tensor& input, const Tensor& output) {
+  const bool batched = input.dim() == 4;
+  const auto input_strides = input.strides();
+  const auto output_strides = output.strides();
+  return {
+      .B = batched ? input.size(0) : 1,
+      .C = input.size(-3),
+      .input_height = input.size(-2),
+      .input_width = input.size(-1),
+      .output_height = output.size(-2),
+      .output_width = output.size(-1),
+      .input_strides = {batched ? input_strides[0] : 0,
+                        input_strides[batched ? 1 : 0],
+                        input_strides[batched ? 2 : 1],
+                        input_strides[batched ? 3 : 2]},
+      .output_strides = {batched ? output_strides[0] : 0,
+                         output_strides[batched ? 1 : 0],
+                         output_strides[batched ? 2 : 1],
+                         output_strides[batched ? 3 : 2]},
+  };
+}
+
+static void adaptive_avg_pool2d_metal(const Tensor& input, Tensor& output, bool backward) {
+  auto stream = getCurrentMPSStream();
+  const auto kernel =
+      fmt::format("adaptive_avg_pool2d_{}_{}", backward ? "backward" : "forward", scalarToMetalTypeString(input));
+  const auto params = backward ? adaptive_avg_pool2d_params(output, input) : adaptive_avg_pool2d_params(input, output);
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(kernel);
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto encoder = stream->commandEncoder();
+        getMPSProfiler().beginProfileKernel(pso, kernel, {input});
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder, input, output, params);
+        mtl_dispatch1DJob(encoder, pso, output.numel());
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    });
+  }
+}
+
 static void set_kernel_params(int64_t isizeH,
                               int64_t isizeW,
                               int64_t osizeH,
@@ -75,7 +128,14 @@ Tensor& adaptive_avg_pool2d_out_mps(const Tensor& input, IntArrayRef output_size
   int64_t strideH = 0, strideW = 0;
   int64_t kernel_sizeH = 0, kernel_sizeW = 0;
 
-  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW, true);
+  const bool regular_downsample = isizeH >= osizeH && isizeW >= osizeW && isizeH % osizeH == 0 && isizeW % osizeW == 0;
+  const bool regular_upsample = isizeH <= osizeH && isizeW <= osizeW && osizeH % isizeH == 0 && osizeW % isizeW == 0;
+  if (!regular_downsample && !regular_upsample) {
+    mps::adaptive_avg_pool2d_metal(input, output, false);
+    return output;
+  }
+
+  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW);
 
   if (isizeH >= osizeH) {
     output = at::avg_pool2d(input,
@@ -146,7 +206,17 @@ Tensor adaptive_avg_pool2d_backward_mps(const Tensor& gradOutput, const Tensor& 
   int64_t strideH = 0, strideW = 0;
   int64_t kernel_sizeH = 0, kernel_sizeW = 0;
 
-  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW, true);
+  const bool regular_downsample = isizeH >= osizeH && isizeW >= osizeW && isizeH % osizeH == 0 && isizeW % osizeW == 0;
+  const bool regular_upsample = isizeH <= osizeH && isizeW <= osizeW && osizeH % isizeH == 0 && osizeW % isizeW == 0;
+  if (!regular_downsample && !regular_upsample) {
+    auto gradInput = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    if (gradInput.numel() != 0) {
+      mps::adaptive_avg_pool2d_metal(gradOutput, gradInput, true);
+    }
+    return gradInput;
+  }
+
+  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW);
 
   auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   if (gradInput.numel() != 0) {

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6623,7 +6623,6 @@ for dtype in (torch.int32, torch.int64):
             )
 
     @skip_if_gpu_halide  # slow
-    @xfail_if_mps  # Non-divisible input sizes are not implemented on MPS device
     @parametrize("combo_kernels", (False, True))
     def test_adaptive_avg_pool2d1(self, combo_kernels):
         with config.patch(combo_kernels=combo_kernels):
@@ -6651,7 +6650,6 @@ for dtype in (torch.int32, torch.int64):
                 (torch.randn(2, 4, 6, 6),),
             )
 
-    @xfail_if_mps  # Non-divisible input sizes are not implemented on MPS device
     def test_adaptive_avg_pool2d2(self):
         # Big kernel size, use fallback
         def fn(x):
@@ -6667,7 +6665,7 @@ for dtype in (torch.int32, torch.int64):
 
     @requires_gpu()
     @skip_if_gpu_halide  # slow
-    @xfail_if_mps  # Non-divisible input sizes are not implemented on MPS device
+    @xfail_if_mps  # MPS does not support float64
     @parametrize("comprehensive_padding", (False, True))
     def test_adaptive_avg_pool2d_flatten_sum(self, comprehensive_padding):
         def fn(x):
@@ -16853,8 +16851,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         o = torch.optim.AdamW(params)
         pt2_optimizer_step(o)
 
-    # Skipped on MPS because avgpool size is not divisible
-    @xfail_if_mps
+    @xfail_if_mps  # MPS does not support float64
     @skip_if_gpu_halide
     def test_adaptive_avg_pool1d_argmax(self):
         # https://github.com/pytorch/pytorch/issues/113013

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -409,7 +409,6 @@ class TestPoolingNN(NNTestCase):
 
 
 class TestPoolingNNDeviceType(NNTestCase):
-    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     def test_adaptive_pooling_avg_nhwc(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
@@ -430,7 +429,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, ref_out)
         self.assertEqual(input.grad, ref_input.grad)
 
-    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     def test_adaptive_pooling_avg_nhwc_non_contiguous(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last)
@@ -454,7 +452,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(input.grad, ref_input.grad)
 
     @onlyAccelerator
-    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_backward(self, device):
         input = torch.randint(
@@ -480,7 +477,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(input.grad, ref_input.grad)
 
     @onlyAccelerator
-    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_forward(self, device):
         input = torch.randint(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16415,10 +16415,8 @@ op_db: list[OpInfo] = [
                # INTERNAL ASSERT FAILED at "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":185,
                # please report a bug to PyTorch.
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
-               # RuntimeError: Adaptive pool MPS: input sizes must be divisible by output sizes
+               # 5D inputs use adaptive_avg_pool3d, which is not implemented on MPS.
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
            ),
            supports_out=False),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15504,15 +15504,6 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            error_inputs_func=error_inputs_adaptive_avg_pool1d,
-           skips=(
-               # RuntimeError: Adaptive pool MPS: input sizes must be divisible
-               # by output sizes. Non-divisible input sizes are not implemented
-               # on MPS device yet
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
-           ),
            sample_inputs_func=sample_inputs_adaptive_avg_pool1d),
     OpInfo('nn.functional.adaptive_avg_pool2d',
            dtypes=floating_types_and(torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15528,15 +15528,6 @@ op_db: list[OpInfo] = [
                #            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
            ),
-           skips=(
-               # RuntimeError: Adaptive pool MPS: input sizes must be divisible
-               # by output sizes. Non-divisible input sizes are not implemented
-               # on MPS device yet
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
-           ),
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -612,7 +612,6 @@ if torch.backends.mps.is_available():
             "float_power": None,
             # MPS: input sizes must be divisible by output sizes
             "nn.functional.adaptive_avg_pool1d": None,
-            "nn.functional.adaptive_avg_pool2d": None,
             # Convolution for integral types is not supported on MPS
             "nn.functional.conv1d": [torch.int64],
             "nn.functional.conv2d": [torch.int64],

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -610,8 +610,6 @@ if torch.backends.mps.is_available():
                 torch.float32,
             ],
             "float_power": None,
-            # MPS: input sizes must be divisible by output sizes
-            "nn.functional.adaptive_avg_pool1d": None,
             # Convolution for integral types is not supported on MPS
             "nn.functional.conv1d": [torch.int64],
             "nn.functional.conv2d": [torch.int64],


### PR DESCRIPTION
## Summary

Add Metal forward and backward kernels for `adaptive_avg_pool2d` shapes whose input and output sizes are not evenly divisible.

The existing regular pooling path remains unchanged. The new path computes the exact adaptive pooling windows and supports float32, float16, bfloat16, and strided layouts.

This also removes the corresponding MPS expected failures from the common tests.

Fixes #96056

## Testing

```text
python test/test_mps.py -k adaptive_avg_pool2d
python test/test_ops.py -k adaptive_avg_pool2d
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo