### PR TITLE
[Testcase Refactoring] Make with_comms backend dynamically resolved for out-of-tree accelerators

### DIFF
--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -84,7 +84,7 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
 
 # wrapper to initialize comms (processgroup + rpc)
-def with_comms(func=None, init_rpc=True, backend="nccl"):
+def with_comms(func=None, init_rpc=True, backend=None):
     if func is None:
         return partial(
             with_comms,
@@ -94,16 +94,24 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        # Skip test if backend requires accelerator but not enough devices available
         acc = torch.accelerator.current_accelerator()
-        if backend in ["nccl", "xccl", "hccl"]:
+        if backend is None:
+            resolved_backend = (
+                dist.get_default_backend_for_device(acc)
+                if acc is not None
+                else "gloo"
+            )
+        else:
+            resolved_backend = backend
+
+        if resolved_backend in ["nccl", "xccl", "hccl"]:
             if (
                 acc is None
-                or backend != dist.get_default_backend_for_device(acc)
+                or resolved_backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
                 sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-        self.init_comms(init_rpc=init_rpc, backend=backend)
+        self.init_comms(init_rpc=init_rpc, backend=resolved_backend)
         func(self, *args, **kwargs)
         self.destroy_comms(destroy_rpc=init_rpc)
 

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -84,7 +84,7 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
 
 # wrapper to initialize comms (processgroup + rpc)
-def with_comms(func=None, init_rpc=True, backend="nccl"):
+def with_comms(func=None, init_rpc=True, backend=None):
     if func is None:
         return partial(
             with_comms,
@@ -94,16 +94,37 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        # Skip test if backend requires accelerator but not enough devices available
-        acc = torch.accelerator.current_accelerator()
-        if backend in ["nccl", "xccl", "hccl"]:
+        # Use self.device_type to determine the correct backend for this test variant.
+        # instantiate_device_type_tests sets device_type per variant (e.g., "cpu",
+        # "privateuse1"), so CPU variants use "gloo" even when an accelerator is
+        # present on the host.
+        device_type = getattr(self, "device_type", "cpu")
+        if backend is None:
+            if device_type == "cpu":
+                resolved_backend = "gloo"
+            else:
+                acc = torch.accelerator.current_accelerator()
+                resolved_backend = (
+                    dist.get_default_backend_for_device(acc)
+                    if acc is not None
+                    else "gloo"
+                )
+        else:
+            resolved_backend = backend
+
+        # Skip test if backend requires accelerator but not enough devices available.
+        # Use dist.is_backend_available() instead of hard-coded backend list.
+        if resolved_backend != "gloo":
+            if not dist.is_backend_available(resolved_backend):
+                sys.exit(TEST_SKIPS["backend_unavailable"].exit_code)
+            acc = torch.accelerator.current_accelerator()
             if (
                 acc is None
-                or backend != dist.get_default_backend_for_device(acc)
+                or resolved_backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
                 sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-        self.init_comms(init_rpc=init_rpc, backend=backend)
+        self.init_comms(init_rpc=init_rpc, backend=resolved_backend)
         func(self, *args, **kwargs)
         self.destroy_comms(destroy_rpc=init_rpc)
 

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -100,15 +100,7 @@ def with_comms(func=None, init_rpc=True, backend=None):
         # present on the host.
         device_type = getattr(self, "device_type", "cpu")
         if backend is None:
-            if device_type == "cpu":
-                resolved_backend = "gloo"
-            else:
-                acc = torch.accelerator.current_accelerator()
-                resolved_backend = (
-                    dist.get_default_backend_for_device(acc)
-                    if acc is not None
-                    else "gloo"
-                )
+            resolved_backend = dist.get_default_backend_for_device(device_type)
         else:
             resolved_backend = backend
 


### PR DESCRIPTION
## Summary

The `with_comms` decorator in `ShardedTensorTestBase` hardcodes
`backend="nccl"` as the default. This causes test variants for non-NCCL
accelerator backends (e.g. PrivateUse1 backends using HCCL) to be
skipped at the wrapper level, because
`backend != dist.get_default_backend_for_device(acc)`.

This PR changes the default from `"nccl"` to `None`, and resolves the
backend dynamically in the wrapper via a single lookup:
`dist.get_default_backend_for_device(self.device_type)` (where
`self.device_type` is set by `instantiate_device_type_tests`, with a
`getattr` fallback to `"cpu"` for classes not using it).

`get_default_backend_for_device` queries `Backend.default_device_backend_map`
(`"cpu": GLOO`, `"cuda": NCCL`, `"xpu": XCCL`, `"mps": GLOO`, plus
out-of-tree entries registered via `register_backend(..., devices=[...])`),
so each device variant gets its own backend:
- CPU variant → `gloo`
- CUDA → `nccl`
- XPU → `xccl`
- PrivateUse1 (e.g. NPU, renamed via `rename_privateuse1_backend`) → `hccl`

Resolving from `self.device_type` (the variant's own device) rather than
`torch.accelerator.current_accelerator()` (the host's accelerator) ensures
per-device test variants get the correct backend even on cross-device hosts.
For example, a CPU variant on an NPU host resolves to `gloo` instead of the
host's `hccl` (which would cause `ProcessGroupHCCL::scatter` to receive a
CPU tensor when an NPU tensor is expected); likewise a `cuda` variant on an
NPU-only host resolves to `nccl` and is correctly skipped, rather than being
mis-resolved to `hccl`.

The accelerator-backend skip check uses `resolved_backend != "gloo"` +
`dist.is_backend_available()` instead of a hard-coded backend list, so
new accelerator backends are automatically supported without modifying
the check.

## Changes

- Changed `with_comms(func=None, init_rpc=True, backend="nccl")` to
  `with_comms(func=None, init_rpc=True, backend=None)`.
- Added dynamic resolution logic in the wrapper: when `backend is None`,
  resolve via a single lookup
  `dist.get_default_backend_for_device(device_type)`, where `device_type`
  is obtained from `getattr(self, "device_type", "cpu")` (the `"cpu"`
  default ensures backward compatibility with classes not using
  `instantiate_device_type_tests`).
- Replaced `if resolved_backend in ["nccl", "xccl", "hccl"]:` with
  `if resolved_backend != "gloo":`, and added
  `dist.is_backend_available(resolved_backend)` check to skip tests when
  the backend is not compiled/available. New accelerator backends are
  automatically supported without modifying the check.
- Moved `torch.accelerator.current_accelerator()` call into the
  accelerator-backend branch (only needed when `resolved_backend` is not
  `"gloo"`), avoiding unnecessary accelerator initialization for CPU
  variants.
- Updated all references from `backend` to `resolved_backend` in the
  skip-check and `init_comms` call.

## Before vs After

| Scenario | Before (hardcoded) | After (this PR) |
|---|---|---|
| CPU variant, no accelerator | `nccl` → skip ✗ | `gloo` ✓ |
| CPU variant, NPU present on host | `nccl` → skip ✗ | `gloo` ✓ |
| PrivateUse1 variant, NPU present | `nccl` → skip ✗ | `hccl` ✓ |
| CUDA variant, CUDA present | `nccl` ✓ | `nccl` ✓ |
| Explicit `backend="gloo"` | `gloo` ✓ | `gloo` ✓ |
| Backend not compiled (e.g. `xccl`) | N/A (not in list) | `is_backend_available` → skip ✓ |

## Not changed

- Callers that explicitly pass `backend=` are unaffected (backward
  compatible).
- The skip logic for accelerator backends is preserved — tests are still
  skipped if the backend is not available, does not match the current
  accelerator, or if device count is insufficient.
- `init_pg` is not modified (already handles dynamic device binding via
  `torch.accelerator.set_device_index`).

## Test plan

- Backend resolution verified on an out-of-tree accelerator backend
  (PrivateUse1, torch_npu 2.13.0+git45fbeae on PyTorch 2.13.0a0+gitfad7424,
  Ascend 910B3, NPU host):
  - `device_type="npu"` → backend resolved to `hccl` ✅
  - `device_type="cpu"` (with NPU present on host) → backend resolved to
    `gloo` ✅ (previously mis-resolved to the host's `hccl`)
  - `get_default_backend_for_device("cpu")` returns `"gloo"` as expected,
    confirming the single-lookup approach is equivalent to the removed
    `device_type == "cpu"` special-case.
- Note: `test_sharded_tensor_reshard.py` does not call
  `instantiate_device_type_tests`, so `TestReshard` has no per-device
  variants (e.g. `TestReshardCPU`/`TestReshardNPU`); `device_type` falls
  back to the `"cpu"` default. The per-device variant paths were verified
  via mock test classes (`FakeNPUTest` / `FakeCPUTest`) that set
  `device_type` and assert the backend passed to `init_comms`.
- Note: The test methods in `test_sharded_tensor_reshard.py` are decorated
  with `@requires_nccl()`, which skips them on hosts where NCCL is not
  compiled (independent of this PR). Replacing `@requires_nccl()` with a
  capability-based decorator is tracked as a separate follow-up.
- TODO: Run other ShardedTensor test files that use `with_comms` to
  confirm no regressions.