### PR TITLE
[Testcase Refactoring] Label test_c10d_spawn_nccl with HardwareClassification

### DIFF
--- a/test/distributed/test_c10d_spawn_nccl.py
+++ b/test/distributed/test_c10d_spawn_nccl.py
@@ -5,8 +5,10 @@ from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 
 import torch
 import torch.distributed as c10d
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -22,13 +24,15 @@ NO_NCCL = not hasattr(c10d, "ProcessGroupNCCL")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsNccl(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_nccl()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_broadcast(self):
+        def test_broadcast(self, device):
             self._test_broadcast("nccl")
 
         @requires_nccl()
@@ -36,7 +40,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_reduce(self):
+        def test_reduce(self, device):
             self._test_reduce("nccl")
 
         @requires_nccl()
@@ -44,7 +48,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_allreduce(self):
+        def test_allreduce(self, device):
             self._test_allreduce("nccl")
 
         @requires_nccl()
@@ -52,7 +56,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_gather(self):
+        def test_all_gather(self, device):
             self._test_all_gather("nccl")
 
         @requires_nccl()
@@ -60,7 +64,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_to_all(self):
+        def test_all_to_all(self, device):
             self._test_all_to_all("nccl")
 
         @requires_nccl()
@@ -68,7 +72,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_to_all_single(self):
+        def test_all_to_all_single(self, device):
             self._test_all_to_all_single("nccl")
 
         # Test Ops only supported in NCCL.
@@ -77,14 +81,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_reduce_scatter(self):
+        def test_reduce_scatter(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             # This is required because these functions calls directly to the .dist and needs
             # the world to be initialized
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="nccl"
             )
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(torch.device(device).type, self.rank)
             x0 = torch.ones(5, 5, device=device) + self.rank
             x1 = torch.ones(5, 5, device=device) + self.rank + 1
             x0.requires_grad = True
@@ -109,14 +113,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_reduce_scatter_non_contiguous(self):
+        def test_reduce_scatter_non_contiguous(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             # This is required because these functions calls directly to the .dist and needs
             # the world to be initialized
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="nccl"
             )
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(torch.device(device).type, self.rank)
 
             class NonContiguousGrad(torch.autograd.Function):
                 @staticmethod
@@ -140,14 +144,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_reduce_non_contiguous(self):
+        def test_all_reduce_non_contiguous(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             # This is required because these functions calls directly to the .dist and needs
             # the world to be initialized
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="nccl"
             )
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(torch.device(device).type, self.rank)
 
             class NonContiguousGrad(torch.autograd.Function):
                 @staticmethod
@@ -168,13 +172,13 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"
         )
-        def test_all_gather_base(self):
+        def test_all_gather_base(self, device):
             store = c10d.FileStore(self.file_name, self.world_size)
             c10d.init_process_group(
                 store=store, rank=self.rank, world_size=self.world_size, backend="nccl"
             )
 
-            device = torch.device(f"cuda:{self.rank}")
+            device = torch.device(torch.device(device).type, self.rank)
             x = torch.ones(5, 5, device=device) + self.rank
             x.requires_grad = True
 
@@ -194,6 +198,10 @@ if not TEST_WITH_DEV_DBG_ASAN:
 
             x_s = 2 * (3 * torch.ones(5, 5, device=device)).cos()
             self.assertEqual(x.grad, x_s)
+
+    instantiate_device_type_tests(
+        TestDistributedNNFunctionsNccl, globals(), only_for=("cuda",)
+    )
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_spawn_nccl.py
+++ b/test/distributed/test_c10d_spawn_nccl.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as c10d
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -22,6 +23,8 @@ NO_NCCL = not hasattr(c10d, "ProcessGroupNCCL")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsNccl(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_nccl()
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
## Summary

This PR labels `TestDistributedNNFunctionsNccl` as `HardwareClassification.CUDA` and migrates it to `instantiate_device_type_tests(only_for=("cuda",))` with a `device` parameter on every `test_*` method, following the TEST_LINTER (#190173) CUDA-specific requirements and reviewer wjlFlyer's feedback.

## Changes

- **`test/distributed/test_c10d_spawn_nccl.py`**:
  - Added `hw_classification = HardwareClassification.CUDA` to `TestDistributedNNFunctionsNccl`, plus the `HardwareClassification` and `instantiate_device_type_tests` imports. The class tests NCCL collective ops (`@requires_nccl` + `backend="nccl"` + `torch.device(...cuda...)`), which are CUDA-specific.
  - Added `instantiate_device_type_tests(TestDistributedNNFunctionsNccl, globals(), only_for=("cuda",))` (inside the `if not TEST_WITH_DEV_DBG_ASAN:` block, alongside the class definition). This aligns with the TEST_LINTER direction (#190173): CUDA-specific classes must be instantiated with `only_for="cuda"` + per-method `device` param.
  - Added a `device` parameter to all 10 `test_*` methods.
  - Replaced the 4 occurrences of `device = torch.device(f"cuda:{self.rank}")` with `device = torch.device(torch.device(device).type, self.rank)` — this derives the per-rank device from the injected `device` parameter (strips the index to get the type-only string, then re-applies `self.rank`), avoiding the hardcoded `"cuda"` string and matching the approach in #192037 / #192190.

## Motivation

`TestDistributedNNFunctionsNccl` had no `hw_classification`, so it was silently dropped under `--hw-classification CUDA` filtering. Per reviewer feedback (wjlFlyer, referencing #190173), a CUDA-specific class must be instantiated with `instantiate_device_type_tests` and every `test_*` method must accept a `device` parameter — adding the label alone is not sufficient. This PR implements that full migration so the file survives removal from the #190173 allowlist.

## Test Plan

- `lintrunner` clean; AST verification confirms `CUDA` label + 10/10 methods with `device` param + `instantiate_device_type_tests(only_for=("cuda",))`.
- On a non-CUDA backend (NPU), all 10 tests are skipped by `@requires_nccl()` (`c10d was not compiled with the NCCL backend`) — behavior unchanged before/after migration. CUDA execution is verified via upstream CI.

```
python test/distributed/test_c10d_spawn_nccl.py --hw-classification CUDA
# Ran 10 tests, OK (skipped=10) on non-CUDA backend
```

## Notes

- This PR follows the migration approach of #192037 (`test_nvshmem.py`) and #192190 (`test_shmem_triton.py`), which migrate `MultiProcContinuousTest`/`MultiProcessTestCase` subclasses to `instantiate_device_type_tests(only_for=("cuda",))` + per-method `device` param.
- `TestDistributedNNFunctionsNccl` retains `@requires_nccl()` / `@skip_if_lt_x_gpu(2)` unchanged. Making `skip_if_lt_x_gpu` recognize out-of-tree accelerators is a separate framework-level change, tracked in pytorch/pytorch#187650; this PR does not modify that helper.
- This is part of the test case refactoring initiative tracked in #185590.
