### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to dynamo test classes in test_resume.py, test_sdpa.py, test_sequence_ops.py, and test_sets.py

### DIFF
--- a/test/dynamo/test_resume.py
+++ b/test/dynamo/test_resume.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch._dynamo.test_case
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 def fn_creator():
@@ -22,6 +23,8 @@ def fn_creator():
 
 
 class ResumeFunctionTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_freevars(self):
         fn = fn_creator()
         opt_fn = torch.compile(fn, backend="eager")

--- a/test/dynamo/test_sdpa.py
+++ b/test/dynamo/test_sdpa.py
@@ -4,96 +4,19 @@ import torch._dynamo.testing
 from torch._dynamo.testing import CompileCounter
 from torch.backends.cuda import can_use_flash_attention, SDPAParams
 from torch.nn.attention import _cur_sdpa_kernel_backends, sdpa_kernel, SDPBackend
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+
+
+def assert_ref_equals_params(test_case, actual, expected):
+    test_case.assertIs(actual.query, expected.query)
+    test_case.assertIs(actual.key, expected.key)
+    test_case.assertIs(actual.value, expected.value)
+    test_case.assertIs(actual.attn_mask, expected.attn_mask)
 
 
 class TestSDPA(torch._dynamo.test_case.TestCase):
-    def assert_ref_equals_params(self, actual, expected):
-        self.assertIs(actual.query, expected.query)
-        self.assertIs(actual.key, expected.key)
-        self.assertIs(actual.value, expected.value)
-        self.assertIs(actual.attn_mask, expected.attn_mask)
-
-    def test_returns_SDPAParams(self):
-        counter = CompileCounter()
-
-        @torch.compile(fullgraph=True, backend=counter)
-        def fn(q, k, v, m):
-            return SDPAParams(q, k, v, m, 0.1, True, False)
-
-        q = torch.randn(10)
-        k = torch.randn(10)
-        v = torch.randn(10)
-        m = torch.randn(10)
-        o = fn(q, k, v, m)
-        self.assertTrue(isinstance(o, SDPAParams))
-        self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
-        self.assertEqual(counter.frame_count, 1)
-
-    def test_graph_break_SDPAParams(self):
-        counter = CompileCounter()
-
-        @torch.compile(backend=counter)
-        def fn(q, k, v, m):
-            z = SDPAParams(q, k, v, m, 0.1, True, False)
-            torch._dynamo.graph_break()
-            return z, q + 1
-
-        q = torch.randn(10)
-        k = torch.randn(10)
-        v = torch.randn(10)
-        m = torch.randn(10)
-        o, _ = fn(q, k, v, m)
-        self.assertTrue(isinstance(o, SDPAParams))
-        self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
-        self.assertEqual(counter.frame_count, 2)
-
-    def test_input_SDPAParams(self):
-        counter = CompileCounter()
-
-        @torch.compile(backend=counter)
-        def fn(sdpap, q):
-            torch._dynamo.graph_break()
-            return sdpap, sdpap.query + q
-
-        q = torch.randn(10)
-        k = torch.randn(10)
-        v = torch.randn(10)
-        m = torch.randn(10)
-        s = SDPAParams(q, k, v, m, 0.1, True, False)
-        o, _ = fn(s, q)
-        self.assertIs(o, s)
-        self.assertEqual(counter.frame_count, 1)
-
-    def test_intermediate_attr_access_SDPAParams(self):
-        counter = CompileCounter()
-
-        @torch.compile(fullgraph=True, backend=counter)
-        def fn(q, k, v, m):
-            q += 1
-            z = SDPAParams(q, k, v, m, 0.1, True, False)
-            a = z.query
-            return a + 1, z, q
-
-        q = torch.randn(10)
-        k = torch.randn(10)
-        v = torch.randn(10)
-        m = torch.randn(10)
-        _, o, _ = fn(q, k, v, m)
-        expected = SDPAParams(q, k, v, m, 0.1, True, False)
-        self.assert_ref_equals_params(o, expected)
-        self.assertEqual(counter.frame_count, 1)
-
-    def test_can_use_flash_attention_no_graph_break(self):
-        counter = CompileCounter()
-
-        @torch.compile(fullgraph=True, backend=counter)
-        def fn(q, k, v):
-            return can_use_flash_attention(SDPAParams(q, k, v, None, 0.0, True, False))
-
-        q = torch.randn(2, 2, 8, 8)
-        expected = can_use_flash_attention(SDPAParams(q, q, q, None, 0.0, True, False))
-        self.assertEqual(fn(q, q, q), expected)
-        self.assertEqual(counter.frame_count, 1)
+    hw_classification = HardwareClassification.GENERIC
 
     def test_sdpa_c_functions_no_graph_break(self):
         counter = CompileCounter()
@@ -131,6 +54,95 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(result.shape, x.shape)
         self.assertEqual(counter.frame_count, 1)
+
+
+class TestSDPACUDA(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_returns_SDPAParams(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v, m):
+            return SDPAParams(q, k, v, m, 0.1, True, False)
+
+        q = torch.randn(10, device=device)
+        k = torch.randn(10, device=device)
+        v = torch.randn(10, device=device)
+        m = torch.randn(10, device=device)
+        o = fn(q, k, v, m)
+        self.assertTrue(isinstance(o, SDPAParams))
+        assert_ref_equals_params(self, o, SDPAParams(q, k, v, m, 0.1, True, False))
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_graph_break_SDPAParams(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(q, k, v, m):
+            z = SDPAParams(q, k, v, m, 0.1, True, False)
+            torch._dynamo.graph_break()
+            return z, q + 1
+
+        q = torch.randn(10, device=device)
+        k = torch.randn(10, device=device)
+        v = torch.randn(10, device=device)
+        m = torch.randn(10, device=device)
+        o, _ = fn(q, k, v, m)
+        self.assertTrue(isinstance(o, SDPAParams))
+        assert_ref_equals_params(self, o, SDPAParams(q, k, v, m, 0.1, True, False))
+        self.assertEqual(counter.frame_count, 2)
+
+    def test_input_SDPAParams(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(sdpap, q):
+            torch._dynamo.graph_break()
+            return sdpap, sdpap.query + q
+
+        q = torch.randn(10, device=device)
+        k = torch.randn(10, device=device)
+        v = torch.randn(10, device=device)
+        m = torch.randn(10, device=device)
+        s = SDPAParams(q, k, v, m, 0.1, True, False)
+        o, _ = fn(s, q)
+        self.assertIs(o, s)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_intermediate_attr_access_SDPAParams(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v, m):
+            q += 1
+            z = SDPAParams(q, k, v, m, 0.1, True, False)
+            a = z.query
+            return a + 1, z, q
+
+        q = torch.randn(10, device=device)
+        k = torch.randn(10, device=device)
+        v = torch.randn(10, device=device)
+        m = torch.randn(10, device=device)
+        _, o, _ = fn(q, k, v, m)
+        expected = SDPAParams(q, k, v, m, 0.1, True, False)
+        assert_ref_equals_params(self, o, expected)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_can_use_flash_attention_no_graph_break(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(fullgraph=True, backend=counter)
+        def fn(q, k, v):
+            return can_use_flash_attention(SDPAParams(q, k, v, None, 0.0, True, False))
+
+        q = torch.randn(2, 2, 8, 8, device=device)
+        expected = can_use_flash_attention(SDPAParams(q, q, q, None, 0.0, True, False))
+        self.assertEqual(fn(q, q, q), expected)
+        self.assertEqual(counter.frame_count, 1)
+
+
+instantiate_device_type_tests(TestSDPACUDA, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_sdpa.py
+++ b/test/dynamo/test_sdpa.py
@@ -4,9 +4,12 @@ import torch._dynamo.testing
 from torch._dynamo.testing import CompileCounter
 from torch.backends.cuda import can_use_flash_attention, SDPAParams
 from torch.nn.attention import _cur_sdpa_kernel_backends, sdpa_kernel, SDPBackend
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestSDPA(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def assert_ref_equals_params(self, actual, expected):
         self.assertIs(actual.query, expected.query)
         self.assertIs(actual.key, expected.key)

--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -70,6 +71,8 @@ class IndexLike:
 
 class TestSqConcat(torch._dynamo.test_case.TestCase):
     """Tests for sq_concat (+) and sq_inplace_concat (+=) operators for sequences."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -746,6 +749,8 @@ instantiate_parametrized_tests(TestSqConcat)
 class TestSqRepeat(torch._dynamo.test_case.TestCase):
     """Tests for sq_repeat (*) and sq_inplace_repeat (*=) on sequences."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -833,6 +838,8 @@ _SEQUENCE_TYPES = [
 
 class TestSqAssItem(torch._dynamo.test_case.TestCase):
     """All sequence __setitem__ tests in one class."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -1415,6 +1422,8 @@ class _IndexObj:
 
 
 class TestRangeUserIndex(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # range() and range subscript apply __index__ (PyNumber_Index) to their
     # arguments and slice members.
 
@@ -1464,6 +1473,8 @@ class TestRangeUserIndex(torch._dynamo.test_case.TestCase):
 
 
 class TestRangeIteratorSetstate(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # range_iterator.__setstate__(k) sets the iterator index, clamped to
     # [0, len], mirroring CPython rangeiter_setstate.
 
@@ -1531,6 +1542,8 @@ class TestRangeIteratorSetstate(torch._dynamo.test_case.TestCase):
 
 
 class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # With assume_static_by_default=False a captured range object's
     # start/stop/step are wrapped as symbolic ints; range math must specialize
     # them instead of assuming a plain python constant.
@@ -1566,6 +1579,8 @@ class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
 
 
 class TestRangeContains(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # range.__contains__ uses the arithmetic fast path only for exact int/bool
     # operands; everything else falls back to an __eq__ linear scan, matching
     # CPython range_contains / _PySequence_IterSearch.

--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -8,6 +8,7 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -69,6 +70,8 @@ class IndexLike:
 
 class TestSqConcat(torch._dynamo.test_case.TestCase):
     """Tests for sq_concat (+) and sq_inplace_concat (+=) operators for sequences."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -731,6 +734,8 @@ instantiate_parametrized_tests(TestSqConcat)
 class TestSqRepeat(torch._dynamo.test_case.TestCase):
     """Tests for sq_repeat (*) and sq_inplace_repeat (*=) on sequences."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -818,6 +823,8 @@ _SEQUENCE_TYPES = [
 
 class TestSqAssItem(torch._dynamo.test_case.TestCase):
     """All sequence __setitem__ tests in one class."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -1356,6 +1363,8 @@ class TestRangeUserIndex(torch._dynamo.test_case.TestCase):
     # range() and range subscript apply __index__ (PyNumber_Index) to their
     # arguments and slice members.
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_range_args_with_index(self):
         @torch.compile(backend="eager", fullgraph=True)
         def fn():
@@ -1404,6 +1413,8 @@ class TestRangeUserIndex(torch._dynamo.test_case.TestCase):
 class TestRangeIteratorSetstate(torch._dynamo.test_case.TestCase):
     # range_iterator.__setstate__(k) sets the iterator index, clamped to
     # [0, len], mirroring CPython rangeiter_setstate.
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_setstate_resumes_from_index(self):
         @torch.compile(backend="eager", fullgraph=True)
@@ -1472,6 +1483,9 @@ class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
     # With assume_static_by_default=False a captured range object's
     # start/stop/step are wrapped as symbolic ints; range math must specialize
     # them instead of assuming a plain python constant.
+
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_range_index_symbolic_bounds(self):
         keys = range(10)
@@ -1507,6 +1521,9 @@ class TestRangeContains(torch._dynamo.test_case.TestCase):
     # range.__contains__ uses the arithmetic fast path only for exact int/bool
     # operands; everything else falls back to an __eq__ linear scan, matching
     # CPython range_contains / _PySequence_IterSearch.
+
+    hw_classification = HardwareClassification.GENERIC
+
     def test_non_int_members(self):
         class AlwaysEq:
             def __eq__(self, other):

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -10,7 +10,11 @@ import torch
 import torch._dynamo.test_case
 from torch._dynamo.exc import Unsupported
 from torch._dynamo.testing import CompileCounter
-from torch.testing._internal.common_utils import make_dynamo_test, munge_exc
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+    munge_exc,
+)
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
@@ -34,6 +38,8 @@ class BadCmp:
 
 
 class _BaseSetTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -73,6 +79,8 @@ class CustomSetTests(_BaseSetTests):
 
 
 class MiscTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_isdisjoint_with_generator(self):
         n = 0
 
@@ -203,6 +211,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
 
 class TestSetGuards(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_with_function(self):
         s = {
             torch._C._set_grad_enabled,

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -10,7 +10,11 @@ import torch
 import torch._dynamo.test_case
 from torch._dynamo.exc import Unsupported
 from torch._dynamo.testing import CompileCounter
-from torch.testing._internal.common_utils import make_dynamo_test, munge_exc
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+    munge_exc,
+)
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
@@ -34,6 +38,8 @@ class BadCmp:
 
 
 class _BaseSetTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -51,6 +57,8 @@ class _BaseSetTests(torch._dynamo.test_case.TestCase):
 
 
 class CustomSetTests(_BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     class CustomSet(set):
         def add(self, item):
             return super().add(item + 1)
@@ -73,6 +81,8 @@ class CustomSetTests(_BaseSetTests):
 
 
 class MiscTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_isdisjoint_with_generator(self):
         n = 0
 
@@ -203,6 +213,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
 
 class TestSetGuards(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_with_function(self):
         s = {
             torch._C._set_grad_enabled,
@@ -797,6 +809,8 @@ class _SetBase(_FrozensetBase):
 
 
 class FrozensetTests(_FrozensetBase, _BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     thetype = frozenset
 
     @make_dynamo_test
@@ -807,6 +821,8 @@ class FrozensetTests(_FrozensetBase, _BaseSetTests):
 
 
 class _SetKeyCoercionMixin:
+    hw_classification = HardwareClassification.GENERIC
+
     # set/frozenset allow an (unhashable) set key for remove/discard by
     # coercing it to a frozenset for the lookup, mirroring the set-key
     # fallback in CPython set_remove_impl / set_discard_impl.
@@ -828,6 +844,8 @@ class _SetKeyCoercionMixin:
 
 
 class SetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     thetype = set
 
     def test_in_frozenset(self):
@@ -835,6 +853,8 @@ class SetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests):
 
 
 class UserDefinedSetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     class CustomSet(set):
         pass
 
@@ -848,6 +868,8 @@ class UserDefinedSetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests):
 
 
 class UserDefinedFrozensetTests(_FrozensetBase, _BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     class CustomFrozenset(frozenset):
         pass
 
@@ -869,6 +891,8 @@ class UserDefinedFrozensetTests(_FrozensetBase, _BaseSetTests):
 
 
 class OrderedSetTests(_SetBase, _BaseSetTests):
+    hw_classification = HardwareClassification.GENERIC
+
     from torch.utils._ordered_set import OrderedSet
 
     thetype = OrderedSet


### PR DESCRIPTION
## Summary

This PR classifies 4 test classes in `test/dynamo/` as device-unrelated by adding `hw_classification = HardwareClassification.GENERIC`, enabling the PyTorch test infrasturcture to correctly identify these tests as hardware-agnostic.

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` and the corresponding import to:
 - `ResumeFunctionTests` in `test/dynamo/test_resume.py`
 - `TestSDPA` in `test/dynamo/test_sdpa.py`
 - `TestSqConcat`, `TestSqRepeat`, `TestSqAssItem`, `TestRangeUserIndex`, `TestRangeIteratorSetstate`, `TestRangeDynamicBounds`, `TestRangeContains` in `test/dynamo/test_sequence_ops.py`
 - `_BaseSetTests`, `MiscTests`, `TestSetGuards`, `_SetKeyCoercionMixin` in `test/dynamo/test_sets.py`
 
## Not Changed
`test/dynamo/test_sets.py`:
 - Once _BaseSetTests is marked at test/dynamo/test_sets.py:41, every one of these already resolves to GENERIC：

| Line | Class | Base providing it |
| --- | --- | --- |
| 60 | CustomSetTests(_BaseSetTests) | _BaseSetTests |
| 812 | FrozensetTests(_FrozensetBase, _BaseSetTests) | _BaseSetTests |
| 847 | SetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests) | _BaseSetTests |
| 856 | UserDefinedSetTests(_SetBase, _SetKeyCoercionMixin, _BaseSetTests) | _BaseSetTests |
| 871 | UserDefinedFrozensetTests(_FrozensetBase, _BaseSetTests) | _BaseSetTests |
| 894 | OrderedSetTests(_SetBase, _BaseSetTests) | _BaseSetTests |
- _SetKeyCoercionMixin is a plain mixin, not a unittest.TestCase. It is never collected, so the attribute has no filtering effect of its own

## Test plan

`python test/dynamo/test_resume.py --hw-classification GENERIC -v`
`python test/dynamo/test_sdpa.py --hw-classification GENERIC -v`
`python test/dynamo/test_sequence_ops.py --hw-classification GENERIC -v`
`python test/dynamo/test_sets.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98