### PR TITLE
[Testcase Refactoring]Make test_sharding_plan.py device-generic and add hw_classification label

### DIFF
--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -9,13 +9,11 @@ from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
-    onlyAccelerator,
+    requires_capabilities,
 )
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
-)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -62,11 +60,11 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     def test_sharding_plan_errors(self, device):
+        device_type = torch.device(device).type
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
             plan={
@@ -76,7 +74,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         )
 
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device)
+            device_type
         )
 
         with self.assertRaisesRegex(
@@ -116,16 +114,16 @@ class TestShardingPlan(ShardedTensorTestBase):
             # shard the module with the provided sharding plan
             shard_module(megatron_lm, sharding_plan_wrong_param_path)
 
-    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     def test_custom_sharding_planner(self, device):
+        device_type = torch.device(device).type
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device)
+            device_type
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM, device_type=torch.device(device).type
+            device_count=TEST_GPU_NUM, device_type=device_type
         )
         sharding_plan = planner.build_plan(megatron_lm)
 
@@ -137,24 +135,24 @@ class TestShardingPlan(ShardedTensorTestBase):
         self.assertTrue(isinstance(megatron_lm.fc1.bias, ShardedTensor))
         self.assertTrue(isinstance(megatron_lm.fc2.bias, ShardedTensor))
 
-    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    @requires_capabilities(Capability.distributed.backend)
     def test_shard_module_sub_process_group(self, device):
+        device_type = torch.device(device).type
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:2/{torch.device(device).type}:2",
-                f"rank:3/{torch.device(device).type}:3",
+                f"rank:2/{device_type}:2",
+                f"rank:3/{device_type}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                f"rank:2/{torch.device(device).type}:2",
-                f"rank:3/{torch.device(device).type}:3",
+                f"rank:2/{device_type}:2",
+                f"rank:3/{device_type}:3",
             ],
         )
         sharding_plan = ShardingPlan(
@@ -170,7 +168,9 @@ class TestShardingPlan(ShardedTensorTestBase):
             shard_module(megatron_lm, sharding_plan, process_group=pg)
 
 
-instantiate_device_type_tests(TestShardingPlan, globals())
+instantiate_device_type_tests(
+    TestShardingPlan, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -54,7 +54,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_sharding_plan_errors(self):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
@@ -106,7 +106,7 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_planner(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
@@ -126,7 +126,7 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend()
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_shard_module_sub_process_group(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -61,7 +62,7 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_sharding_plan_errors(self):
+    def test_sharding_plan_errors(self, device):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
             plan={
@@ -70,8 +71,9 @@ class TestShardingPlan(ShardedTensorTestBase):
             output_plan={"": rowwise_sharding_spec},
         )
 
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(torch.device(self.device_type, self.rank)
-)
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
+            torch.device(device, self.rank)
+        )
 
         with self.assertRaisesRegex(
             TypeError, "Only `ShardingSpec` and `Sharder` are supported to shard"
@@ -113,12 +115,12 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_custom_sharding_planner(self):
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
-            self.rank
+    def test_custom_sharding_planner(self, device):
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
+            torch.device(device, self.rank)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=self.device_type
+            device_count=TEST_GPU_NUM,device_type=device
         )
         sharding_plan = planner.build_plan(megatron_lm)
 
@@ -133,20 +135,20 @@ class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
-    def test_shard_module_sub_process_group(self):
+    def test_shard_module_sub_process_group(self, device):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/{self.device_type}:2",
-                "rank:3/{self.device_type}:3",
+                f"rank:2/{device}:2",
+                f"rank:3/{device}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                "rank:2/{self.device_type}:2",
-                "rank:3/{self.device_type}:3",
+                f"rank:2/{device}:2",
+                f"rank:3/{device}:3",
             ],
         )
         sharding_plan = ShardingPlan(
@@ -160,6 +162,9 @@ class TestShardingPlan(ShardedTensorTestBase):
 
         if self.rank >= 2:
             shard_module(megatron_lm, sharding_plan, process_group=pg)
+
+
+instantiate_device_type_tests(TestShardingPlan, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,7 +12,11 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -52,6 +56,8 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 
 
 class TestShardingPlan(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+    
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,13 +8,13 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
-)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
+)
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -61,7 +61,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 
 class TestShardingPlan(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
-    
+
     @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
@@ -125,7 +125,7 @@ class TestShardingPlan(ShardedTensorTestBase):
             torch.device(device)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=torch.device(device).type
+            device_count=TEST_GPU_NUM, device_type=torch.device(device).type
         )
         sharding_plan = planner.build_plan(megatron_lm)
 

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -12,7 +12,10 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -59,6 +62,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
     
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
@@ -72,7 +76,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         )
 
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device, self.rank)
+            torch.device(device)
         )
 
         with self.assertRaisesRegex(
@@ -112,15 +116,16 @@ class TestShardingPlan(ShardedTensorTestBase):
             # shard the module with the provided sharding plan
             shard_module(megatron_lm, sharding_plan_wrong_param_path)
 
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_custom_sharding_planner(self, device):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(
-            torch.device(device, self.rank)
+            torch.device(device)
         )
         planner = ChunkAllShardingPlanner(
-            device_count=TEST_GPU_NUM,device_type=device
+            device_count=TEST_GPU_NUM,device_type=torch.device(device).type
         )
         sharding_plan = planner.build_plan(megatron_lm)
 
@@ -132,6 +137,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         self.assertTrue(isinstance(megatron_lm.fc1.bias, ShardedTensor))
         self.assertTrue(isinstance(megatron_lm.fc2.bias, ShardedTensor))
 
+    @onlyAccelerator
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
@@ -140,15 +146,15 @@ class TestShardingPlan(ShardedTensorTestBase):
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:2/{device}:2",
-                f"rank:3/{device}:3",
+                f"rank:2/{torch.device(device).type}:2",
+                f"rank:3/{torch.device(device).type}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                f"rank:2/{device}:2",
-                f"rank:3/{device}:3",
+                f"rank:2/{torch.device(device).type}:2",
+                f"rank:3/{torch.device(device).type}:3",
             ],
         )
         sharding_plan = ShardingPlan(

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,7 +8,10 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu,requires_accelerator_dist_backend
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -35,9 +38,9 @@ class ChunkAllShardingPlanner(ShardingPlanner):
     dim = 0
     devices = []
 
-    def __init__(self, chunk_dim=0, device_count=0,device_type="cuda"):
+    def __init__(self, chunk_dim=0, device_count=0, device_type="cuda"):
         self.dim = chunk_dim
-        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)] 
+        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)]
 
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         named_params = module.named_parameters()
@@ -108,7 +111,9 @@ class TestShardingPlan(ShardedTensorTestBase):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
         )
-        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM,device_type=self.device_type)
+        planner = ChunkAllShardingPlanner(
+            device_count=TEST_GPU_NUM,device_type=self.device_type
+        )
         sharding_plan = planner.build_plan(megatron_lm)
 
         shard_module(megatron_lm, sharding_plan)

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -8,7 +8,7 @@ from torch.distributed._shard import shard_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharding_plan import ShardingPlan, ShardingPlanner
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu,requires_accelerator_dist_backend
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
@@ -35,9 +35,9 @@ class ChunkAllShardingPlanner(ShardingPlanner):
     dim = 0
     devices = []
 
-    def __init__(self, chunk_dim=0, device_count=0):
+    def __init__(self, chunk_dim=0, device_count=0,device_type="cuda"):
         self.dim = chunk_dim
-        self.devices = [f"rank:{i}/cuda:{i}" for i in range(device_count)]
+        self.devices = [f"rank:{i}/{device_type}:{i}" for i in range(device_count)] 
 
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         named_params = module.named_parameters()
@@ -51,7 +51,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 class TestShardingPlan(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_sharding_plan_errors(self):
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)[0]
         sharding_plan_wrong_plan = ShardingPlan(
@@ -61,7 +61,8 @@ class TestShardingPlan(ShardedTensorTestBase):
             output_plan={"": rowwise_sharding_spec},
         )
 
-        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]]).cuda(self.rank)
+        megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).to(torch.device(self.device_type, self.rank)
+)
 
         with self.assertRaisesRegex(
             TypeError, "Only `ShardingSpec` and `Sharder` are supported to shard"
@@ -102,12 +103,12 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_custom_sharding_planner(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank).cuda(
             self.rank
         )
-        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM)
+        planner = ChunkAllShardingPlanner(device_count=TEST_GPU_NUM,device_type=self.device_type)
         sharding_plan = planner.build_plan(megatron_lm)
 
         shard_module(megatron_lm, sharding_plan)
@@ -120,21 +121,21 @@ class TestShardingPlan(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     def test_shard_module_sub_process_group(self):
         megatron_lm = SimpleMegatronLM([[17, 12], [12, 29]], rank=self.rank)
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                "rank:2/{self.device_type}:2",
+                "rank:3/{self.device_type}:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                "rank:2/{self.device_type}:2",
+                "rank:3/{self.device_type}:3",
             ],
         )
         sharding_plan = ShardingPlan(


### PR DESCRIPTION
## Summary

The three tests in `test/distributed/_shard/sharding_plan/test_sharding_plan.py`
verify `ShardingPlan` / `ShardingPlanner` sharding rules and error handling —
generic distributed logic that is not CUDA-specific. However, the test file
hardcodes CUDA device strings, uses `@requires_nccl()` for admission, and
relies on a hardcoded backend list, preventing out-of-tree accelerator
backends (e.g. PrivateUse1 backends such as NPU) from reusing the tests.

This PR replaces all CUDA-specific and hardcoded-backend patterns with
device-generic equivalents based on the capability registration mechanism
(PR #191919), and adds the `hw_classification = HardwareClassification.ACCELERATOR`
label per the distributed test class labeling rules.

## Changes

- Replaced `@requires_nccl()` with
  `@requires_capabilities(Capability.distributed.backend)` on all three
  test methods. This gates on device-declared capability rather than a
  hardcoded backend name list — new backends only need to override
  `_capabilities()` instead of extending the common backend mapping.
- Changed `@with_comms(init_rpc=False)` to use the default `backend=None`,
  which resolves to `self.backend` at runtime via the
  `ShardedTensorTestBase.backend` property (PR #194992). No module-level
  `backend` or `device_type` globals are needed.
- Added `device_type = torch.device(device).type` at the start of each
  test method, deriving the bare device type (e.g. `"npu"`) from the
  `instantiate_device_type_tests`-injected `device` parameter (e.g.
  `"npu:0"`). This avoids the pitfall where
  `torch.device(device, self.rank)` fails due to duplicate index when
  `device` already carries an index string.
- Replaced `.to(torch.device(device, self.rank))` with `.to(device_type)`
  in `test_sharding_plan_errors` and `test_custom_sharding_planner`.
- Replaced hardcoded `"cuda"` in placement strings with
  `f"rank:2/{device_type}:2"` in `test_shard_module_sub_process_group`
  (4 placement strings).
- Replaced `ChunkAllShardingPlanner(device_type=device)` with
  `ChunkAllShardingPlanner(device_type=device_type)` — passes the bare
  device type string instead of the indexed device string.
- Added `device` parameter to all three test method signatures
  (`test_xxx(self)` → `test_xxx(self, device)`, framework injection).
  The `device` parameter triggers `setUpClass` which resolves
  `privateuse1` to the actual backend name; it is also used to derive
  `device_type` via `torch.device(device).type` at the start of each
  method.
- Replaced `instantiate_device_type_tests(TestShardingPlan, globals())`
  with `instantiate_device_type_tests(TestShardingPlan, globals(),
  except_for="cpu", allow_xpu=True)` — excludes CPU variants at
  instantiation layer (these tests require a distributed accelerator
  backend) and enables XPU variants.

  Note: before this PR these distributed tests never actually executed
  on XPU (`with_comms` skipped them on backend mismatch, `"nccl" !=
  "xccl"`), so `allow_xpu=True` is coverage enablement rather than
  conservation — the tests are device-agnostic after the refactor and
  the dynamic backend resolution path is the same one verified on
  PrivateUse1 (HCCL) and CUDA (NCCL). XPU execution itself will be
  confirmed by XPU CI / follow-up testing.
- Added `hw_classification = HardwareClassification.ACCELERATOR` to
  `TestShardingPlan`.

## Not changed

- `TEST_GPU_NUM` naming retained for backward compatibility (the constant
  itself is hardware-agnostic; renaming is a follow-up).
- `ChunkAllShardingPlanner.__init__` signature unchanged (retains
  `device_type` parameter with default `"cuda"`).
- The numerical assertions and test logic are unchanged.
- `test_common.py` not modified — upstream main already uses
  `self.fc1.to(torch.device(rank))` which correctly resolves to the
  current accelerator device.

## Dependencies

This PR depends on the following infrastructure PRs (all submitted, not
yet merged into upstream main):

| Infrastructure | Source PR | Status |
|---|---|---|
| Capability registration mechanism (`Capability` + `requires_capabilities`) | #191919 | Submitted |
| `PrivateUse1TestBase._capabilities()` override | #193080 | Submitted |
| `ShardedTensorTestBase.backend` property + `with_comms(backend=None)` default | #194992 | Submitted |
| `skip_if_lt_x_gpu` hardware-agnostic implementation | #187650 | Submitted |
| `ShardedTensorTestBase.init_pg` dynamic device binding | #190528 | Submitted |
| `HardwareClassification` enum | #190991 | Merged |

Without #193080, `@requires_capabilities` silently skips PrivateUse1
variants (tests pass as skipped, not failed). This PR can merge before
#193080.

## Test plan

- `python test/distributed/_shard/sharding_plan/test_sharding_plan.py` on CPU
  (no accelerator): no variants generated (`except_for="cpu"`,
  `Ran 0 tests`).
- `python test/distributed/_shard/sharding_plan/test_sharding_plan.py` on an
  out-of-tree accelerator backend (PrivateUse1, torch_npu 2.13.0+git45fbeae
  on PyTorch 2.13.0a0+gitfad7424, Ascend 910B3, 4 NPUs):
  3 NPU variants pass (`ok`), CPU variants not generated (`OK`).
- `python test/distributed/_shard/sharding_plan/test_sharding_plan.py` on CUDA
  (NVIDIA A100-SXM4-80GB x8, PyTorch 2.13.0a0): 3 CUDA variants pass (`ok`),
  CPU variants not generated (`OK`).