### PR TITLE
[Testcase Refactoring] Label test_c10d_nccl classes with HardwareClassification

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -67,6 +67,7 @@ from torch.testing._internal.common_distributed import (
     with_nccl_blocking_wait,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_SANDCASTLE,
@@ -141,6 +142,8 @@ _log_configure(level=logging.INFO, force=True)
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @retry_on_connect_failures
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -241,6 +244,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @retry_on_connect_failures
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -249,6 +254,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupNCCLNoGPUTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
@@ -272,6 +278,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
 
 
 class ProcessGroupNCCLInitTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
     device_type = "cuda"
 
     def setUp(self):
@@ -323,6 +330,8 @@ class ProcessGroupNCCLInitTest(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(
@@ -2177,6 +2186,8 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase
 ):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -3849,6 +3860,8 @@ class DistributedDataParallelTest(
 
 
 class WorkHookTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 2
@@ -4068,6 +4081,8 @@ class WorkHookTest(MultiProcessTestCase):
 
 
 class NcclErrorHandlingTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -4368,6 +4383,8 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
 
 
 class NcclUserBufferRegistrationTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as nccl_debug_file:
@@ -4500,6 +4517,8 @@ class NcclUserBufferRegistrationTest(MultiProcessTestCase):
 
 
 class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self):
         return f"cuda:{self.rank}"
@@ -5063,6 +5082,8 @@ class SetDeviceMethod(Enum):
 class NcclProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(1)
     def test_collectives(self):
@@ -5121,6 +5142,8 @@ instantiate_parametrized_tests(NcclProcessGroupWithDispatchedCollectivesTests)
 
 
 class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -5574,6 +5597,8 @@ instantiate_parametrized_tests(LargeCommTest)
 
 
 class SparseCollective(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5648,6 +5673,8 @@ class SparseCollective(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLOneRankTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5812,6 +5839,8 @@ class NCCLTraceTestBase(MultiProcessTestCase):
 
 
 class NCCLTraceTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     def _verify_trace(self, t, include_collectives, timing_enabled, is_json):
         ver = t["version"]
         self.assertEqual(ver, "2.10")
@@ -7212,6 +7241,8 @@ class NCCLTraceTestDumpOnTimeoutBase(NCCLTraceTestBase):
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     @parametrize("timing_enabled", [True, False])
@@ -7264,6 +7295,8 @@ instantiate_parametrized_tests(NCCLTraceTest)
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.CUDA
+
     @check_if_test_is_skipped
     def _check_return_codes(self, fn, elapsed_time):
         # the base test infra assumes processes exit with matching return codes,
@@ -7318,6 +7351,8 @@ class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
 
 @skip_but_pass_in_sandcastle
 class NcclErrorDumpTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     def _wait_process(self, rank, timeout):
         try:
             self.processes[rank].join(timeout)
@@ -7374,6 +7409,8 @@ class NcclErrorDumpTest(NCCLTraceTestBase):
 
 # tests that needs to be run with a larger world size
 class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -69,6 +69,7 @@ from torch.testing._internal.common_distributed import (
     with_nccl_blocking_wait,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_SANDCASTLE,
@@ -143,6 +144,8 @@ _log_configure(level=logging.INFO, force=True)
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @retry_on_connect_failures
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -243,6 +246,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @retry_on_connect_failures
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -251,6 +256,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupNCCLNoGPUTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
@@ -274,6 +280,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
 
 
 class ProcessGroupNCCLInitTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
     device_type = "cuda"
 
     def setUp(self):
@@ -325,6 +332,8 @@ class ProcessGroupNCCLInitTest(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(
@@ -2223,6 +2232,8 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase
 ):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -3895,6 +3906,8 @@ class DistributedDataParallelTest(
 
 
 class WorkHookTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 2
@@ -4114,6 +4127,8 @@ class WorkHookTest(MultiProcessTestCase):
 
 
 class NcclErrorHandlingTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -4414,6 +4429,8 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
 
 
 class NcclUserBufferRegistrationTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as nccl_debug_file:
@@ -4546,6 +4563,8 @@ class NcclUserBufferRegistrationTest(MultiProcessTestCase):
 
 
 class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self):
         return f"cuda:{self.rank}"
@@ -5160,6 +5179,8 @@ class SetDeviceMethod(Enum):
 class NcclProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(1)
     def test_collectives(self):
@@ -5218,6 +5239,8 @@ instantiate_parametrized_tests(NcclProcessGroupWithDispatchedCollectivesTests)
 
 
 class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -5671,6 +5694,8 @@ instantiate_parametrized_tests(LargeCommTest)
 
 
 class SparseCollective(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5745,6 +5770,8 @@ class SparseCollective(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLOneRankTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5909,6 +5936,8 @@ class NCCLTraceTestBase(MultiProcessTestCase):
 
 
 class NCCLTraceTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     def _verify_trace(self, t, include_collectives, timing_enabled, is_json):
         ver = t["version"]
         self.assertEqual(ver, "2.10")
@@ -7309,6 +7338,8 @@ class NCCLTraceTestDumpOnTimeoutBase(NCCLTraceTestBase):
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     @parametrize("timing_enabled", [True, False])
@@ -7361,6 +7392,8 @@ instantiate_parametrized_tests(NCCLTraceTest)
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.CUDA
+
     @check_if_test_is_skipped
     def _check_return_codes(self, fn, elapsed_time):
         # the base test infra assumes processes exit with matching return codes,
@@ -7415,6 +7448,8 @@ class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
 
 @skip_but_pass_in_sandcastle
 class NcclErrorDumpTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     def _wait_process(self, rank, timeout):
         try:
             self.processes[rank].join(timeout)
@@ -7471,6 +7506,8 @@ class NcclErrorDumpTest(NCCLTraceTestBase):
 
 # tests that needs to be run with a larger world size
 class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(
@@ -7647,6 +7684,8 @@ class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
 
 @unittest.skipIf(TEST_WITH_ROCM, "NCCL symmetric memory is not supported on ROCm")
 class SymmMemCftHandleTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """Host-side NCCL CFT logical-endpoint handles exposed on _SymmetricMemory.
 
     These are the `(le_id, le_offset)` coordinates a custom kernel feeds to the


### PR DESCRIPTION
## Summary
This PR adds `hw_classification = HardwareClassification.CUDA` labels to all 19 `TestCase` subclasses in `test/distributed/test_c10d_nccl.py`, plus the `HardwareClassification` import. It is a labeling-only change (20 lines added, no behavioral or mechanism changes).

## Changes
- **`test/distributed/test_c10d_nccl.py`**: Added the `HardwareClassification` import and `hw_classification = HardwareClassification.CUDA` to all 19 `TestCase` subclasses.

## Motivation
All 19 classes are CUDA-only. The file gates on NCCL at module load (`if not c10d.is_nccl_available(): sys.exit(0)`) and every class is guarded by `@requires_nccl()`. NCCL is the CUDA-specific comm backend (other accelerator backends use their own: HCCL, XCCL, etc.), so the gate is a genuine backend-capability check rather than historical CUDA-only gating. This covers both the classes that create a real NCCL process group on `cuda:{rank}` and perform collectives, and the framework-logic classes that exercise their property through an NCCL backend (`RendezvousEnvTest` exercises env:// rendezvous URL parsing, `TimeoutTest` exercises store-layer timeout, `ProcessGroupNCCLNoGPUTest` asserts the no-GPU error path of `ProcessGroupNCCL`).

Labeling them all `CUDA` keeps the classification consistent with the file-level NCCL gate. An unclassified class is silently dropped under `--hw-classification` filtering; labeling them `CUDA` ensures the whole file is correctly categorized and excluded from accelerator-backend verification (where NCCL is unavailable), rather than being silently dropped as unclassified.

No split, instantiation, or mechanism change is needed: no class is mixed, the CUDA classes are single-device-type only (no `instantiate_device_type_tests`, matching the `NCCLSymmetricMemoryTest` precedent in `test_nccl.py`), and the hard-coded `cuda:{rank}` / `backend="nccl"` are consistent with the `CUDA` label. `SetDeviceMethod` (an `Enum`) and the two trace base classes (`NCCLTraceTestBase`, `NCCLTraceTestDumpOnTimeoutBase`, which have no `test_*` methods and are not collected by unittest) need no label.

## Test Plan
- Verified `--hw-classification` filtering on an 8-device accelerator backend (NCCL not available, `c10d.is_nccl_available()` returns `False`):
  - `python test/distributed/test_c10d_nccl.py` (no filter) → `c10d NCCL not available, skipping tests`, exit 0. The file-level `sys.exit(0)` gate fires at module load, so no tests run — consistent with the `CUDA` label (the file should not run where NCCL is unavailable).
  - `python test/distributed/test_c10d_nccl.py --hw-classification CUDA` → same module-load exit; the `CUDA` label correctly categorizes the file.
  - `python test/distributed/test_c10d_nccl.py --hw-classification GENERIC ACCELERATOR` → same module-load exit, 0 tests. The CUDA-only file is correctly excluded from accelerator-backend verification as expected.
- Confirmed 19 classes labeled `CUDA`, 0 `GENERIC`, and `SYNTAX_OK` via AST parse.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
