### PR TITLE
Fix flaky QNNPACK sparse GEMM tests from near-zero cancellation (#192425)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
@@ -478,12 +478,19 @@ class GemmBlockSparseMicrokernelTester {
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
+          const float refValue = acc[mIndex * n() + nIndex];
+          // Bias is added after the dot product, so a result near zero is the
+          // difference of two much larger values and retains their rounding
+          // error. Scale the tolerance by the larger pre-addition magnitude
+          // rather than the cancelled result, which carries no precision.
+          const float magnitude =
+              std::max(std::abs(refValue), std::abs(refValue - bias[nIndex]));
           ASSERT_NEAR(
               c[mIndex * cStride() + nIndex],
-              acc[mIndex * n() + nIndex],
-              std::abs(acc[mIndex * n() + nIndex]) * 1.0e-3f)
+              refValue,
+              magnitude * 1.0e-3f)
               << "at " << mIndex << ", " << nIndex
-              << ": reference = " << acc[mIndex * n() + nIndex]
+              << ": reference = " << refValue
               << ", optimized = " << c[mIndex * cStride() + nIndex]
               << ", Mr x Nr = " << mr() << " x " << nr()
               << ", M x N x K = " << m() << " x " << n() << " x " << k();


### PR DESCRIPTION
Summary:

`GemmBlockSparseMicrokernelTester::test_packed()` compared the dequantized
float output against the reference with a relative-only tolerance:

  ASSERT_NEAR(c[...], acc[...], std::abs(acc[...]) * 1.0e-3f)

The reference is computed as `acc * dequantization_scale + bias`, where the
scaled dot product and the bias are each on the order of thousands while the
sum can land arbitrarily close to zero. When that cancellation happens, the
result keeps the rounding error of the much larger pre-addition operands, but
the tolerance is derived from the cancelled result and collapses toward zero,
so the assertion fails for a numerically correct kernel.

A captured failure shows the shape clearly: reference `-0.20254421`, kernel
`-0.20214844`, absolute error `4.0e-4`, tolerance `2.0e-4`. The error is one
ulp of the pre-cancellation magnitude, not of the final value, so no choice
of relative factor fixes this.

The tolerance is now scaled by the larger of the final value and the
pre-bias-addition magnitude (`refValue - bias[nIndex]`), which is the
quantity the rounding error is actually proportional to. This keeps the
tolerance tight for ordinary outputs and only relaxes it for the cancelling
case.

Note the assertion in `test()` (the non-packed path) still uses `ASSERT_EQ`
and is left alone: it randomizes `kernel_zero_points` and is a separate code
path that is not implicated here.

The `xplat/` copy of this header is kept byte-identical to the `fbcode/` one,
matching how D47195288 updated both.

Test Plan:
Built and stress-ran the affected test on x86_64. Note the `packedA_k_gt_8_subtile`
tests named in the flaky-test report are ARM-only (`#if CPUINFO_ARCH_ARM`) and are
not present in the x86_64 binary, but they share the exact assertion changed here;
the SSE2 `packedA_*` tests exercise the same line and reproduce the same failure.

Before the fix, the full suite failed roughly once every 60 runs:

```
buck2 build fbcode//caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:q8gemm-sparse-test
./q8gemm-sparse-test --gtest_repeat=60 --gtest_brief=1
# [  FAILED  ] Q8GEMM_8x4c1x4__SSE2.packedA_k_gt_8_nozp
```

After the fix, over 1000 consecutive full-suite runs pass:

```
./q8gemm-sparse-test --gtest_repeat=700 --gtest_brief=1   # 700x PASSED, 34 tests
./q8gemm-sparse-test --gtest_repeat=300 --gtest_brief=1   # 300x PASSED, 34 tests
```

Negative control, to confirm the looser tolerance still catches real errors:
injecting a `+0.05f` offset into the reference makes the `packedA_*` tests fail
as expected, so the assertion retains its diagnostic power.

```
arc lint   # ok No lint issues.
```

This diff was authored with the assistance of an AI coding agent.

Differential Revision: D115137221




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01