### PR TITLE
[Testcase Refactoring] Make test_symm_mem_registry device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_symm_mem_registry.py
+++ b/test/inductor/test_symm_mem_registry.py
@@ -7,14 +7,19 @@ This test suite validates the symm_mem argument registration system, which allow
 operators to declare which arguments require symmetric memory allocation.
 """
 
-import unittest
+from unittest import skipIf
 from unittest.mock import patch
 
 import torch
 from torch._library.simple_registry import singleton, SymmMemArgsHolder
 from torch.library import Library  # noqa: SCOPED_LIBRARY
-from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 def register_symm_mem_args(op, arg_names):
@@ -37,6 +42,8 @@ def register_symm_mem_args(op, arg_names):
 
 class TestSymmMemRegistry(TestCase):
     """Test suite for SymmMemArgsHolder core functionality."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         """Clear test entries from registry before each test."""
@@ -145,6 +152,8 @@ class TestSymmMemRegistry(TestCase):
 class TestLibraryIntegration(TestCase):
     """Test suite for Library.register_symm_mem_args integration."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         """Clear test entries from registry before each test."""
         super().setUp()
@@ -223,7 +232,9 @@ class TestLibraryIntegration(TestCase):
 
 
 class TestFunctionalOpCompile(TestCase):
-    """Test that functional ops with registered symm_mem_args work with torch.compile."""
+    """Test _maybe_realize_symm_mem_args behavior for registered ops."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -237,84 +248,6 @@ class TestFunctionalOpCompile(TestCase):
             del singleton._data[key]
         torch._dynamo.reset()
         super().tearDown()
-
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_compiles_with_symm_mem_args(self):
-        """Test that a functional op with registered symm_mem_args compiles and runs."""
-        lib = Library("test_func_symm", "DEF")  # noqa: SCOPED_LIBRARY
-        lib.define("my_functional_op(Tensor input, str group_name) -> Tensor")
-        lib.register_symm_mem_args("my_functional_op", ["input"])
-
-        @torch.library.impl(lib, "my_functional_op", "Meta")
-        def meta_impl(input, group_name):
-            return torch.empty_like(input)
-
-        @torch.library.impl(lib, "my_functional_op", "CUDA")
-        def cuda_impl(input, group_name):
-            return input + 1.0
-
-        def f_eager(x):
-            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
-
-        @torch.compile(backend="inductor", fullgraph=True)
-        def f_compiled(x):
-            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
-
-        x = torch.randn(4, 4, device="cuda")
-
-        eager_result = f_eager(x.clone())
-        compiled_result = f_compiled(x.clone())
-        torch.testing.assert_close(compiled_result, eager_result)
-
-        expected = x + 1.0
-        torch.testing.assert_close(compiled_result, expected)
-
-        # Verify the registration is visible in the registry
-        entry = singleton.find("test_func_symm::my_functional_op")
-        self.assertTrue(entry.symm_mem_args.is_registered())
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
-        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
-
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_with_multiple_symm_mem_args(self):
-        """Test that multiple symm_mem args are registered and visible during compilation."""
-        lib = Library("test_func_multi", "DEF")  # noqa: SCOPED_LIBRARY
-        lib.define(
-            "my_multi_arg_op(Tensor input, Tensor out, str group_name) -> Tensor"
-        )
-        lib.register_symm_mem_args("my_multi_arg_op", ["input", "out"])
-
-        @torch.library.impl(lib, "my_multi_arg_op", "Meta")
-        def meta_impl(input, out, group_name):
-            return torch.empty_like(input)
-
-        @torch.library.impl(lib, "my_multi_arg_op", "CUDA")
-        def cuda_impl(input, out, group_name):
-            # use both symm_mem args to verify functionality
-            return input + out
-
-        def f_eager(x, y):
-            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
-
-        @torch.compile(backend="inductor", fullgraph=True)
-        def f_compiled(x, y):
-            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
-
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
-
-        eager_result = f_eager(x.clone(), y.clone())
-        compiled_result = f_compiled(x.clone(), y.clone())
-        torch.testing.assert_close(compiled_result, eager_result)
-
-        expected = x + y
-        torch.testing.assert_close(compiled_result, expected)
-
-        # Verify both args are registered
-        entry = singleton.find("test_func_multi::my_multi_arg_op")
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("out"))
-        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
 
     def test_unregistered_op_skips_realization(self):
         """Test that _maybe_realize_symm_mem_args returns early for unregistered ops."""
@@ -399,6 +332,114 @@ class TestFunctionalOpCompile(TestCase):
         self.assertEqual(len(realize_log), 1)
         self.assertIn("SYMM_MEM", realize_log[0][0])
         self.assertEqual(realize_log[0][1], "test_group")
+
+
+class TestFunctionalOpCompileDevice(TestCase):
+    """Test that functional ops with registered symm_mem_args compile and run on device."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        test_keys = [k for k in singleton._data if k.startswith("test_")]
+        for key in test_keys:
+            del singleton._data[key]
+
+    def tearDown(self):
+        test_keys = [k for k in singleton._data if k.startswith("test_")]
+        for key in test_keys:
+            del singleton._data[key]
+        torch._dynamo.reset()
+        super().tearDown()
+
+    @skipIf(not HAS_TRITON, "Requires Triton")
+    def test_functional_op_compiles_with_symm_mem_args(self, device):
+        """Test that a functional op with registered symm_mem_args compiles and runs."""
+        ns = f"test_func_symm_{device.replace(':', '_')}"
+        lib = Library(ns, "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define("my_functional_op(Tensor input, str group_name) -> Tensor")
+        lib.register_symm_mem_args("my_functional_op", ["input"])
+
+        @torch.library.impl(lib, "my_functional_op", "Meta")
+        def meta_impl(input, group_name):
+            return torch.empty_like(input)
+
+        @torch.library.register_kernel(
+            f"{ns}::my_functional_op", torch.device(device).type, lib=lib
+        )
+        def device_impl(input, group_name):
+            return input + 1.0
+
+        def f_eager(x):
+            return getattr(torch.ops, ns).my_functional_op(x, "test_group")
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f_compiled(x):
+            return getattr(torch.ops, ns).my_functional_op(x, "test_group")
+
+        x = torch.randn(4, 4, device=device)
+
+        eager_result = f_eager(x.clone())
+        compiled_result = f_compiled(x.clone())
+        torch.testing.assert_close(compiled_result, eager_result)
+
+        expected = x + 1.0
+        torch.testing.assert_close(compiled_result, expected)
+
+        # Verify the registration is visible in the registry
+        entry = singleton.find(f"{ns}::my_functional_op")
+        self.assertTrue(entry.symm_mem_args.is_registered())
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
+        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
+
+    @skipIf(not HAS_TRITON, "Requires Triton")
+    def test_functional_op_with_multiple_symm_mem_args(self, device):
+        """Test that multiple symm_mem args are registered and visible during compilation."""
+        ns = f"test_func_multi_{device.replace(':', '_')}"
+        lib = Library(ns, "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define(
+            "my_multi_arg_op(Tensor input, Tensor out, str group_name) -> Tensor"
+        )
+        lib.register_symm_mem_args("my_multi_arg_op", ["input", "out"])
+
+        @torch.library.impl(lib, "my_multi_arg_op", "Meta")
+        def meta_impl(input, out, group_name):
+            return torch.empty_like(input)
+
+        @torch.library.register_kernel(
+            f"{ns}::my_multi_arg_op", torch.device(device).type, lib=lib
+        )
+        def device_impl(input, out, group_name):
+            # use both symm_mem args to verify functionality
+            return input + out
+
+        def f_eager(x, y):
+            return getattr(torch.ops, ns).my_multi_arg_op(x, y, "test_group")
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f_compiled(x, y):
+            return getattr(torch.ops, ns).my_multi_arg_op(x, y, "test_group")
+
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
+
+        eager_result = f_eager(x.clone(), y.clone())
+        compiled_result = f_compiled(x.clone(), y.clone())
+        torch.testing.assert_close(compiled_result, eager_result)
+
+        expected = x + y
+        torch.testing.assert_close(compiled_result, expected)
+
+        # Verify both args are registered
+        entry = singleton.find(f"{ns}::my_multi_arg_op")
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("out"))
+        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
+
+
+instantiate_device_type_tests(
+    TestFunctionalOpCompileDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_symm_mem_registry.py
+++ b/test/inductor/test_symm_mem_registry.py
@@ -7,14 +7,17 @@ This test suite validates the symm_mem argument registration system, which allow
 operators to declare which arguments require symmetric memory allocation.
 """
 
-import unittest
 from unittest.mock import patch
 
 import torch
 from torch._library.simple_registry import singleton, SymmMemArgsHolder
 from torch.library import Library  # noqa: SCOPED_LIBRARY
-from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def register_symm_mem_args(op, arg_names):
@@ -37,6 +40,8 @@ def register_symm_mem_args(op, arg_names):
 
 class TestSymmMemRegistry(TestCase):
     """Test suite for SymmMemArgsHolder core functionality."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         """Clear test entries from registry before each test."""
@@ -145,6 +150,8 @@ class TestSymmMemRegistry(TestCase):
 class TestLibraryIntegration(TestCase):
     """Test suite for Library.register_symm_mem_args integration."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         """Clear test entries from registry before each test."""
         super().setUp()
@@ -225,6 +232,8 @@ class TestLibraryIntegration(TestCase):
 class TestFunctionalOpCompile(TestCase):
     """Test that functional ops with registered symm_mem_args work with torch.compile."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         test_keys = [k for k in singleton._data if k.startswith("test_")]
@@ -237,84 +246,6 @@ class TestFunctionalOpCompile(TestCase):
             del singleton._data[key]
         torch._dynamo.reset()
         super().tearDown()
-
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_compiles_with_symm_mem_args(self):
-        """Test that a functional op with registered symm_mem_args compiles and runs."""
-        lib = Library("test_func_symm", "DEF")  # noqa: SCOPED_LIBRARY
-        lib.define("my_functional_op(Tensor input, str group_name) -> Tensor")
-        lib.register_symm_mem_args("my_functional_op", ["input"])
-
-        @torch.library.impl(lib, "my_functional_op", "Meta")
-        def meta_impl(input, group_name):
-            return torch.empty_like(input)
-
-        @torch.library.impl(lib, "my_functional_op", "CUDA")
-        def cuda_impl(input, group_name):
-            return input + 1.0
-
-        def f_eager(x):
-            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
-
-        @torch.compile(backend="inductor", fullgraph=True)
-        def f_compiled(x):
-            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
-
-        x = torch.randn(4, 4, device="cuda")
-
-        eager_result = f_eager(x.clone())
-        compiled_result = f_compiled(x.clone())
-        torch.testing.assert_close(compiled_result, eager_result)
-
-        expected = x + 1.0
-        torch.testing.assert_close(compiled_result, expected)
-
-        # Verify the registration is visible in the registry
-        entry = singleton.find("test_func_symm::my_functional_op")
-        self.assertTrue(entry.symm_mem_args.is_registered())
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
-        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
-
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
-    def test_functional_op_with_multiple_symm_mem_args(self):
-        """Test that multiple symm_mem args are registered and visible during compilation."""
-        lib = Library("test_func_multi", "DEF")  # noqa: SCOPED_LIBRARY
-        lib.define(
-            "my_multi_arg_op(Tensor input, Tensor out, str group_name) -> Tensor"
-        )
-        lib.register_symm_mem_args("my_multi_arg_op", ["input", "out"])
-
-        @torch.library.impl(lib, "my_multi_arg_op", "Meta")
-        def meta_impl(input, out, group_name):
-            return torch.empty_like(input)
-
-        @torch.library.impl(lib, "my_multi_arg_op", "CUDA")
-        def cuda_impl(input, out, group_name):
-            # use both symm_mem args to verify functionality
-            return input + out
-
-        def f_eager(x, y):
-            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
-
-        @torch.compile(backend="inductor", fullgraph=True)
-        def f_compiled(x, y):
-            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
-
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
-
-        eager_result = f_eager(x.clone(), y.clone())
-        compiled_result = f_compiled(x.clone(), y.clone())
-        torch.testing.assert_close(compiled_result, eager_result)
-
-        expected = x + y
-        torch.testing.assert_close(compiled_result, expected)
-
-        # Verify both args are registered
-        entry = singleton.find("test_func_multi::my_multi_arg_op")
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
-        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("out"))
-        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
 
     def test_unregistered_op_skips_realization(self):
         """Test that _maybe_realize_symm_mem_args returns early for unregistered ops."""
@@ -399,6 +330,106 @@ class TestFunctionalOpCompile(TestCase):
         self.assertEqual(len(realize_log), 1)
         self.assertIn("SYMM_MEM", realize_log[0][0])
         self.assertEqual(realize_log[0][1], "test_group")
+
+
+class TestFunctionalOpCompileDevice(TestCase):
+    """Test that functional ops with registered symm_mem_args compile and run on device."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        test_keys = [k for k in singleton._data if k.startswith("test_")]
+        for key in test_keys:
+            del singleton._data[key]
+
+    def tearDown(self):
+        test_keys = [k for k in singleton._data if k.startswith("test_")]
+        for key in test_keys:
+            del singleton._data[key]
+        torch._dynamo.reset()
+        super().tearDown()
+
+    def test_functional_op_compiles_with_symm_mem_args(self, device):
+        """Test that a functional op with registered symm_mem_args compiles and runs."""
+        lib = Library("test_func_symm", "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define("my_functional_op(Tensor input, str group_name) -> Tensor")
+        lib.register_symm_mem_args("my_functional_op", ["input"])
+
+        @torch.library.impl(lib, "my_functional_op", "Meta")
+        def meta_impl(input, group_name):
+            return torch.empty_like(input)
+
+        @torch.library.impl(lib, "my_functional_op", "CUDA")
+        def cuda_impl(input, group_name):
+            return input + 1.0
+
+        def f_eager(x):
+            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f_compiled(x):
+            return torch.ops.test_func_symm.my_functional_op(x, "test_group")
+
+        x = torch.randn(4, 4, device=device)
+
+        eager_result = f_eager(x.clone())
+        compiled_result = f_compiled(x.clone())
+        torch.testing.assert_close(compiled_result, eager_result)
+
+        expected = x + 1.0
+        torch.testing.assert_close(compiled_result, expected)
+
+        # Verify the registration is visible in the registry
+        entry = singleton.find("test_func_symm::my_functional_op")
+        self.assertTrue(entry.symm_mem_args.is_registered())
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
+        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
+
+    def test_functional_op_with_multiple_symm_mem_args(self, device):
+        """Test that multiple symm_mem args are registered and visible during compilation."""
+        lib = Library("test_func_multi", "DEF")  # noqa: SCOPED_LIBRARY
+        lib.define(
+            "my_multi_arg_op(Tensor input, Tensor out, str group_name) -> Tensor"
+        )
+        lib.register_symm_mem_args("my_multi_arg_op", ["input", "out"])
+
+        @torch.library.impl(lib, "my_multi_arg_op", "Meta")
+        def meta_impl(input, out, group_name):
+            return torch.empty_like(input)
+
+        @torch.library.impl(lib, "my_multi_arg_op", "CUDA")
+        def cuda_impl(input, out, group_name):
+            # use both symm_mem args to verify functionality
+            return input + out
+
+        def f_eager(x, y):
+            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f_compiled(x, y):
+            return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
+
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
+
+        eager_result = f_eager(x.clone(), y.clone())
+        compiled_result = f_compiled(x.clone(), y.clone())
+        torch.testing.assert_close(compiled_result, eager_result)
+
+        expected = x + y
+        torch.testing.assert_close(compiled_result, expected)
+
+        # Verify both args are registered
+        entry = singleton.find("test_func_multi::my_multi_arg_op")
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
+        self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("out"))
+        self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
+
+
+instantiate_device_type_tests(
+    TestFunctionalOpCompileDevice, globals(), only_for=("cuda",)
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Decouple `test/inductor/test_symm_mem_registry.py` to use the device-agnostic test pattern with `instantiate_device_type_tests` and `hw_classification`, replacing the restrictive `@requires_gpu_and_triton` decorator (via `HAS_CUDA_AND_TRITON`) and hardcoded `"CUDA"` dispatch key.

## Changes

- Split `TestFunctionalOpCompile` into `TestFunctionalOpCompile` (GENERIC, no device param) and `TestFunctionalOpCompileDevice` (ACCELERATOR, with device param + `instantiate_device_type_tests`)
- Replace hardcoded `"CUDA"` dispatch key with `torch.device(device).type` in 2 device-dependent test methods
- Replace `@unittest.skipIf(not HAS_CUDA_AND_TRITON, ...)` with `@skipIf(not HAS_TRITON, "Requires Triton")` (method-level)
- Add `hw_classification = HardwareClassification.GENERIC` to 3 existing classes (`TestSymmMemRegistry`, `TestLibraryIntegration`, `TestFunctionalOpCompile`)
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestFunctionalOpCompileDevice`
- Add `instantiate_device_type_tests(TestFunctionalOpCompileDevice, globals(), except_for="cpu", allow_xpu=True)` call
- Use `torch.testing.assert_close` (not `self.assertEqual`) for tensor comparisons in device tests, consistent with the original code
- Use device-suffixed op namespaces (`f"test_func_symm_{device.replace(':', '_')}}"`) to prevent "operator already defined" errors in multi-device CI
- Rename `cuda_impl` to `device_impl` and use `torch.library.register_kernel` for device kernel registration
- Remove `HAS_CUDA_AND_TRITON` import; add `instantiate_device_type_tests`, `HardwareClassification`, `HAS_TRITON` imports

## Motivation

The original code used `@unittest.skipIf(not HAS_CUDA_AND_TRITON, ...)` where `HAS_CUDA_AND_TRITON = torch.cuda.is_available() and HAS_TRITON`. This gates device-dependent tests on CUDA availability alone, and the hardcoded `"CUDA"` dispatch key prevents out-of-tree accelerators (e.g., Ascend NPU via `PrivateUse1`) from running these tests even though the test op bodies (`input + 1.0`, `input + out`) are device-agnostic.

By using `instantiate_device_type_tests` with `except_for="cpu"` and `allow_xpu=True`, the tests run on all non-CPU device types registered in the test framework, including out-of-tree backends.

Triton gating is handled by `@skipIf(not HAS_TRITON, "Requires Triton")` (method-level), which preserves the original Triton availability check without coupling to CUDA availability.

## Test Plan

Verified on CPU (no GPU):

```bash
python -m pytest test/inductor/test_symm_mem_registry.py -v --tb=short
# Result: 17 passed, 0 failed (17 GENERIC tests)
```

Verified on NPU (Ascend 910B4):

```bash
python -m pytest test/inductor/test_symm_mem_registry.py -v --tb=short
# Result: 19 passed, 0 failed (17 GENERIC + 2 ACCELERATOR via PrivateUse1)
```

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 17 | 17 | 0 | 0 | All GENERIC tests passed |
| NPU (Ascend 910B4) | 19 | 19 | 0 | 0 | All passed (17 GENERIC + 2 ACCELERATOR via PrivateUse1) |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.15.0.dev20260820+cpu |
| torch_npu | 2.15.0+gitf2e1583 |
| triton-ascend | 3.6.0+git0cfb1708 |
| CANN | 9.1.0 GA |
| NPU | Ascend 910B4 |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo