### PR TITLE
[Testcase Refactoring] Classify dynamo test cases as GENERIC in test_unittest.py and test_user_defined_object.py

### DIFF
--- a/test/dynamo/test_unittest.py
+++ b/test/dynamo/test_unittest.py
@@ -3,10 +3,15 @@ import unittest
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class TestUnittest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.enable_trace_unittest

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -7,7 +7,10 @@ import unittest
 import torch
 import torch._dynamo.testing as dynamo_testing
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class SlotsOnly:
@@ -101,6 +104,8 @@ class SlotsAndProperty:
 
 
 class TestSlotsAttrAssignment(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for attribute assignment on objects with __slots__."""
 
     def test_valid_slot_assignment(self):
@@ -491,6 +496,8 @@ class WithGetattribute:
 
 
 class TestSlotsFromCPython(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Slot tests extracted from CPython's test_descr.py::test_slots."""
 
     def setUp(self):
@@ -741,6 +748,8 @@ class TestSlotsFromCPython(TestCase):
 
 
 class TestUserDefinedClassDict(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_class_dict_read(self):
         class MyClass:
             x = 3
@@ -835,6 +844,8 @@ class TestUserDefinedClassDict(TestCase):
 
 
 class TestClassSetattr(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_setattr_class_attribute(self):
         class MyModule:
             x = 10
@@ -910,6 +921,8 @@ class _DelClassMeta(metaclass=_SetitemDelitemMeta):
 
 
 class TestUserDefinedSetitem(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """__setitem__ on user-defined classes (UDOV) and metaclasses (UDCV).
 
     enable_trace_load_build_class lets us define helper classes inside the
@@ -1214,6 +1227,8 @@ class TestUserDefinedSetitem(TestCase):
 
 
 class TestObjectConstruction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @make_dynamo_test
     def test_object_call_identity(self):
         a = object()


### PR DESCRIPTION
## Summary

This PR classifies 2 test classes in `test/dynamo/` as device-unrelated by adding `hw_classification = HardwareClassification.GENERIC`, enabling the PyTorch test infrasturcture to correctly identify these tests as hardware-agnostic.

## Changes

Added `hw_classification = HardwareClassification.GENERIC` and the corresponding import to:
- test/dynamo/test_unittest.py --TestUnittest class
- test/dynamo/test_user_defined_object.py, 6 test classes:
  - TestSlotsAttrAssignment
  - TestSlotsFromCPython
  - TestSimpleNamespace
  - TestUserDefinedClassDict
  - TestClassSetattr
  - TestUserDefinedSetitem
  - TestObjectConstruction

## Test plan

`python test/dynamo/test_unittest.py --hw-classification GENERIC -v`
`python test/dynamo/test_user_defined_object.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98