### PR TITLE
Decouple test_split_cat_fx_aten_passes.py for device-agnostic testing

### DIFF
--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -4,8 +4,8 @@ import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.inductor_utils import GPU_TYPE
-from torch.testing._internal.triton_utils import requires_gpu_and_triton
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 try:
@@ -221,6 +221,8 @@ class _TestSelectCat(torch.nn.Module):
 
 
 class TestSplitCatAten(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
             return False
@@ -246,10 +248,9 @@ class TestSplitCatAten(TestCase):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
         self.assertTrue(
-            self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
+            self.compare_dict_tensors(ref_grad, res_grad, rtol, atol)
         )
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -257,12 +258,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad(self):
+    def test_split_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCat()
         traced = torch.compile(module)
@@ -276,10 +277,10 @@ class TestSplitCatAten(TestCase):
         counters.clear()
 
         inputs = [
-            torch.randn(1024, 96 * 21, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96 * 4, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 96 * 21, device=device),
+            torch.randn(1024, 96 * 4, device=device),
+            torch.randn(1024, 96, device=device),
+            torch.randn(1024, 96, device=device),
         ]
         module = _TestSplitCatPartial()
         traced = torch.compile(module)
@@ -292,7 +293,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -300,12 +300,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad_singular(self):
+    def test_split_cat_post_grad_singular(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCatSingular()
         traced = torch.compile(module)
@@ -318,7 +318,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -326,11 +325,11 @@ class TestSplitCatAten(TestCase):
             "select_cat_aten_pass": {},
         },
     )
-    def test_select_cat_post_grad(self):
+    def test_select_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 6, 128, device=device),
+            torch.randn(1024, 6, 128, device=device),
         ]
         module = _TestSelectCat()
         traced = torch.compile(module)
@@ -343,7 +342,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -351,10 +349,10 @@ class TestSplitCatAten(TestCase):
             "move_view_after_cat_aten_pass": {},
         },
     )
-    def test_move_view_after_cat_aten(self):
+    def test_move_view_after_cat_aten(self, device):
         counters.clear()
         inputs = [
-            torch.randn(7, 8, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(7, 8, 96, device=device),
         ]
         module = _TestMoveViewAferCat()
         traced = torch.compile(module)
@@ -369,13 +367,15 @@ class TestSplitCatAten(TestCase):
 
 
 class TestSplitCatAtenNormalizationPasses(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
             "normalization_aten_pass": {},
         },
     )
-    def test_split_aten_normalization(self):
+    def test_split_aten_normalization(self, device):
         def arg_only_size_same(x):
             return torch.ops.aten.split.Tensor(x, 300, 1)
 
@@ -383,7 +383,7 @@ class TestSplitCatAtenNormalizationPasses(TestCase):
             return torch.ops.aten.split.Tensor(x, 320, 1)
 
         args = [
-            torch.randn(4096, 300),
+            torch.randn(4096, 300, device=device),
         ]
         for fn, expected_split_norm_count in [
             (arg_only_size_same, 1),
@@ -399,6 +399,12 @@ class TestSplitCatAtenNormalizationPasses(TestCase):
                 msg=lambda msg: f"{msg}\nfor {fn}",
             )
             counters.clear()
+
+
+instantiate_device_type_tests(TestSplitCatAten, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestSplitCatAtenNormalizationPasses, globals(), except_for="cpu"
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

GPU_TYPE to device parameter, 2 classes ACCELERATOR

## Changes

- GPU_TYPE -> device parameter (injected by instantiate_device_type_tests)
- @skipIf/@requires_gpu_and_triton -> except_for="cpu"
- hw_classification = HardwareClassification.GENERIC|ACCELERATOR
- Mixed classes split into GENERIC + ACCELERATOR

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | Pass | Pass | 0 | 0 | ACCELERATOR tests excluded by except_for="cpu" |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260801+cpu |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo