### PR TITLE
Decouple test_split_cat_fx_passes.py for device-agnostic testing

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -5,9 +5,8 @@ import torch
 from torch._dynamo.utils import counters
 from torch._inductor.fx_passes.misc_patterns import numpy_compat_normalization
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
-from torch.testing._internal.triton_utils import requires_gpu
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
 
 
 def patch(f):
@@ -27,6 +26,8 @@ def patch(f):
 
 
 class TestSplitCatFxPasses(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
             "normalization_pass": {},
@@ -1550,19 +1551,25 @@ class TestSplitCatFxPasses(TestCase):
             for k in n.kwargs:
                 self.assertTrue(k not in {"x", "x1", "x2", "a", "axis", "keepdims"})
 
+
+class TestSplitCatFxPassesDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @patch
-    @requires_gpu
-    def test_stack_normalization_axis_kwarg(self):
+    def test_stack_normalization_axis_kwarg(self, device):
         def fn(x, y):
             return torch.stack([x, y], axis=1)
 
-        x, y = (torch.rand((4, 4), device=GPU_TYPE) for _ in range(2))
+        x, y = (torch.rand((4, 4), device=device) for _ in range(2))
         expected = fn(x, y)
         actual = torch.compile(fn)(x, y)
 
         self.assertEqual(actual, expected)
 
 
+instantiate_device_type_tests(TestSplitCatFxPassesDevice, globals(), except_for="cpu")
+
+
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU:
+    if IS_LINUX:
         run_tests()


### PR DESCRIPTION
## Summary

Split TestSplitCatFxPasses into GENERIC + ACCELERATOR

## Changes

- GPU_TYPE -> device parameter (injected by instantiate_device_type_tests)
- @skipIf/@requires_gpu_and_triton -> except_for="cpu"
- hw_classification = HardwareClassification.GENERIC|ACCELERATOR
- Mixed classes split into GENERIC + ACCELERATOR

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | Pass | Pass | 0 | 0 | ACCELERATOR tests excluded by except_for="cpu" |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260801+cpu |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo