### PR TITLE
Decouple test_snode_runtime.py for device-agnostic testing

### DIFF
--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -10,7 +10,8 @@ from torch._inductor.comm_analysis import estimate_nccl_collective_runtime
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_collective
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 aten = torch.ops.aten
@@ -43,22 +44,19 @@ def calculate_runtime(f, *args) -> float:
     return ret
 
 
-DEVICE = GPU_TYPE
-
-
-def T(*size, dtype=torch.float32, device=DEVICE, grad=False) -> torch.Tensor:
+def T(*size, dtype=torch.float32, device="cuda", grad=False) -> torch.Tensor:
     return torch.randn(size, dtype=dtype, device=device, requires_grad=grad)
 
 
 class TestCase(InductorTestCase):
-    device = DEVICE
-
     """
     Helper methods to compare runtime estimate against 0. Since this estimate is hardware dependent,
     stronger comparisons may fail depending on the host's specs.
 
     atol/rtol must be provided explicitly with each call, since precision/rel_tol overrides are not always utilized
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def setUp(self):
         super().setUp()
@@ -85,16 +83,16 @@ class TestCase(InductorTestCase):
 
 
 class UnsupportedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_no_op(self):
+    def test_no_op(self, device):
         def f(a):
             return a
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertZero(calculate_runtime(f, *inp))
 
-    def test_no_cuda(self):
+    def test_no_cuda(self, device):
         def f(a):
             return a
 
@@ -103,105 +101,105 @@ class UnsupportedTests(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_conv1d(self):
+    def test_conv1d(self, device):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
 
-        inp = (T(33, 16, 30), T(20, 16, 5))
+        inp = (T(33, 16, 30, device=device), T(20, 16, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d(self):
+    def test_conv2d(self, device):
         def f(x, y):
             return torch.nn.functional.conv2d(x, y, padding=1)
 
-        inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
+        inp = (T(8, 4, 3, 3, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d_transpose(self):
+    def test_conv2d_transpose(self, device):
         def f(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, padding=1)
 
-        inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
+        inp = (T(8, 1, 1, 1, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv3d(self):
+    def test_conv3d(self, device):
         def f(x, y):
             return torch.nn.functional.conv3d(x, y)
 
-        inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
+        inp = (T(20, 16, 50, 10, 20, device=device), T(33, 16, 3, 3, 3, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_mm(self):
+    def test_mm(self, device):
         def f(a, b):
             return torch.mm(a, b)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_addmm(self):
+    def test_addmm(self, device):
         def f(a, b, c):
             return torch.addmm(a, b, c)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_bmm(self):
+    def test_bmm(self, device):
         def f(a, b):
             return torch.bmm(a, b)
 
         inp = (
-            T(10, 10, 10),
-            T(10, 10, 10),
+            T(10, 10, 10, device=device),
+            T(10, 10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class MemoryBoundedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_relu(self):
+    def test_relu(self, device):
         def f(a):
             return torch.nn.functional.relu(a)
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_horizontal_reduction_pointwise(self):
+    def test_horizontal_reduction_pointwise(self, device):
         def f(a):
             b = a.sum(dim=1)
             c = a.cos()
             return b, c
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_pointwise(self):
+    def test_pointwise(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
-    def test_dynamic(self):
+    def test_dynamic(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class InputDistanceTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _get_snodes(self, f, *args):
         metrics.reset()
@@ -210,7 +208,7 @@ class InputDistanceTests(TestCase):
         torch._logging.set_logs()
         return [snode for snode, _ in metrics.nodes_num_elem]
 
-    def test_chain_with_reduction(self):
+    def test_chain_with_reduction(self, device):
         """
         input -> sum (depth 0) -> sum (depth 1)
         Reductions prevent full fusion, giving us distinct depth levels.
@@ -220,13 +218,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10, 10))
+        snodes = self._get_snodes(f, T(10, 10, 10, device=device))
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_fused_node_depth_range(self):
+    def test_fused_node_depth_range(self, device):
         """
         A reduction fused with its pointwise epilogue should have
         min_input_distance=0 and max_input_distance=1.
@@ -236,13 +234,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.cos()
 
-        snodes = self._get_snodes(f, T(10, 10))
+        snodes = self._get_snodes(f, T(10, 10, device=device))
         # The reduction and pointwise get fused
         self.assertEqual(len(snodes), 1)
         self.assertEqual(snodes[0].min_input_distance, 0)
         self.assertEqual(snodes[0].max_input_distance, 1)
 
-    def test_extern_kernel_chain(self):
+    def test_extern_kernel_chain(self, device):
         """
         mm (depth 0, extern) -> cos+sum fused (depth 1)
         """
@@ -252,13 +250,15 @@ class InputDistanceTests(TestCase):
             d = c.cos()
             return d.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10))
+        snodes = self._get_snodes(
+            f, T(10, 10, device=device), T(10, 10, device=device)
+        )
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_foreach_basic(self):
+    def test_foreach_basic(self, device):
         """
         foreach_add on graph inputs should have depth 0.
         """
@@ -266,14 +266,14 @@ class InputDistanceTests(TestCase):
         def f(xs, ys):
             return torch._foreach_add(xs, ys)
 
-        xs = [T(10), T(20)]
-        ys = [T(10), T(20)]
+        xs = [T(10, device=device), T(20, device=device)]
+        ys = [T(10, device=device), T(20, device=device)]
         snodes = self._get_snodes(f, xs, ys)
         for s in snodes:
             self.assertEqual(s.min_input_distance, 0)
             self.assertEqual(s.max_input_distance, 0)
 
-    def test_foreach_after_extern(self):
+    def test_foreach_after_extern(self, device):
         """
         mm (extern, depth 0) -> foreach_add (depth 1)
         The extern kernel creates a fusion barrier so the foreach
@@ -284,7 +284,12 @@ class InputDistanceTests(TestCase):
             c = torch.mm(a, b)
             return torch._foreach_add([c, c], ys)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10), [T(10, 10), T(10, 10)])
+        snodes = self._get_snodes(
+            f,
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            [T(10, 10, device=device), T(10, 10, device=device)],
+        )
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
@@ -293,7 +298,7 @@ class InputDistanceTests(TestCase):
 
 @skipIf(not dist.is_available(), "requires distributed")
 class TestCommAnalysis(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
     WORLD_SIZE: int = 8
     RANKS = list(range(8))
@@ -328,23 +333,23 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
-    def test_legacy_all_reduce(self):
+    def test_legacy_all_reduce(self, device):
         def fn(x):
             r = c10d.all_reduce(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_reduce_coalesced(self):
+    def test_legacy_all_reduce_coalesced(self, device):
         def fn(x):
             rs = c10d.all_reduce_coalesced(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_gather_into_tensor_coalesced(self):
+    def test_legacy_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -354,26 +359,26 @@ class TestCommAnalysis(TestCase):
             )
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce(self):
+    def test_all_reduce(self, device):
         def fn(x):
             r = _c10d.all_reduce(x, "sum", "0")
             return _c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce_coalesced(self):
+    def test_all_reduce_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_reduce_coalesced(x, "sum", "0")
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor(self):
+    def test_all_gather_into_tensor(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor(
                 x,
@@ -382,10 +387,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor_coalesced(self):
+    def test_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -394,10 +399,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor(self):
+    def test_reduce_scatter_tensor(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor(
                 x,
@@ -407,10 +412,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(self.WORLD_SIZE, 10)
+        inp = T(self.WORLD_SIZE, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor_coalesced(self):
+    def test_reduce_scatter_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor_coalesced(
                 x,
@@ -420,12 +425,21 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(self.WORLD_SIZE, 10), T(self.WORLD_SIZE, 15)]
+        inp = [
+            T(self.WORLD_SIZE, 10, device=device),
+            T(self.WORLD_SIZE, 15, device=device),
+        ]
         self._verify_runtime_estimation(fn, (inp,))
+
+
+instantiate_device_type_tests(UnsupportedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(ComputeBoundedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(MemoryBoundedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(InputDistanceTests, globals(), except_for="cpu")
+instantiate_device_type_tests(TestCommAnalysis, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
-        run_tests(needs="filelock")
+    run_tests(needs="filelock")


### PR DESCRIPTION
## Summary

DEVICE=GPU_TYPE to device parameter, 6 classes ACCELERATOR

## Changes

- GPU_TYPE -> device parameter (injected by instantiate_device_type_tests)
- @skipIf/@requires_gpu_and_triton -> except_for="cpu"
- hw_classification = HardwareClassification.GENERIC|ACCELERATOR
- Mixed classes split into GENERIC + ACCELERATOR

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | Pass | Pass | 0 | 0 | ACCELERATOR tests excluded by except_for="cpu" |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260801+cpu |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo