### PR TITLE
[Testcase Refactoring] Make test_smoke device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -6,7 +6,8 @@ import torch
 import torch._logging
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 from torch.utils._triton import has_triton
 
 
@@ -73,4 +74,6 @@ instantiate_device_type_tests(
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    run_tests()
+    if IS_LINUX:
+        if (not HAS_CUDA_AND_TRITON) or torch.cuda.get_device_properties(0).major <= 5:
+            run_tests()

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -1,16 +1,11 @@
 # Owner(s): ["module: inductor"]
 import logging
-import unittest
 
 import torch
 import torch._logging
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
-    HAS_GPU,
-)
+from torch.testing._internal.common_utils import IS_LINUX, HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON, HAS_GPU
 
 
 class MLP(torch.nn.Module):
@@ -30,21 +25,29 @@ def _test_f(x):
 
 
 class SmokeTest(TestCase):
-    @unittest.skipIf(not HAS_GPU, "Triton is not available")
-    def test_mlp(self):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_compile_invalid_options(self):
+        with self.assertRaises(RuntimeError):
+            torch.compile(_test_f, mode="ha")
+
+
+class SmokeTestDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_mlp(self, device):
         torch._logging.set_logs(
             dynamo=logging.DEBUG, inductor=logging.DEBUG, aot=logging.DEBUG
         )
 
-        mlp = torch.compile(MLP().to(GPU_TYPE))
+        mlp = torch.compile(MLP().to(device))
         for _ in range(3):
-            mlp(torch.randn(1, device=GPU_TYPE))
+            mlp(torch.randn(1, device=device))
 
         # set back to defaults
         torch._logging.set_logs()
 
-    @unittest.skipIf(not HAS_GPU, "Triton is not available")
-    def test_compile_decorator(self):
+    def test_compile_decorator(self, device):
         @torch.compile
         def foo(x):
             return torch.sin(x) + x.min()
@@ -54,12 +57,13 @@ class SmokeTest(TestCase):
             return x * x
 
         for _ in range(3):
-            foo(torch.full((3, 4), 0.7, device=GPU_TYPE))
-            bar(torch.rand((2, 2), device=GPU_TYPE))
+            foo(torch.full((3, 4), 0.7, device=device))
+            bar(torch.rand((2, 2), device=device))
 
-    def test_compile_invalid_options(self):
-        with self.assertRaises(RuntimeError):
-            torch.compile(_test_f, mode="ha")
+
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+
+instantiate_device_type_tests(SmokeTestDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -5,12 +5,9 @@ import unittest
 import torch
 import torch._logging
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
-    HAS_GPU,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 
 class MLP(torch.nn.Module):
@@ -30,21 +27,31 @@ def _test_f(x):
 
 
 class SmokeTest(TestCase):
-    @unittest.skipIf(not HAS_GPU, "Triton is not available")
-    def test_mlp(self):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_compile_invalid_options(self):
+        with self.assertRaises(RuntimeError):
+            torch.compile(_test_f, mode="ha")
+
+
+class SmokeTestDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @unittest.skipIf(not has_triton(), "requires triton")
+    def test_mlp(self, device):
         torch._logging.set_logs(
             dynamo=logging.DEBUG, inductor=logging.DEBUG, aot=logging.DEBUG
         )
 
-        mlp = torch.compile(MLP().to(GPU_TYPE))
+        mlp = torch.compile(MLP().to(device))
         for _ in range(3):
-            mlp(torch.randn(1, device=GPU_TYPE))
+            mlp(torch.randn(1, device=device))
 
         # set back to defaults
         torch._logging.set_logs()
 
-    @unittest.skipIf(not HAS_GPU, "Triton is not available")
-    def test_compile_decorator(self):
+    @unittest.skipIf(not has_triton(), "requires triton")
+    def test_compile_decorator(self, device):
         @torch.compile
         def foo(x):
             return torch.sin(x) + x.min()
@@ -54,17 +61,16 @@ class SmokeTest(TestCase):
             return x * x
 
         for _ in range(3):
-            foo(torch.full((3, 4), 0.7, device=GPU_TYPE))
-            bar(torch.rand((2, 2), device=GPU_TYPE))
+            foo(torch.full((3, 4), 0.7, device=device))
+            bar(torch.rand((2, 2), device=device))
 
-    def test_compile_invalid_options(self):
-        with self.assertRaises(RuntimeError):
-            torch.compile(_test_f, mode="ha")
+
+instantiate_device_type_tests(
+    SmokeTestDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if IS_LINUX and HAS_GPU:
-        if (not HAS_CUDA_AND_TRITON) or torch.cuda.get_device_properties(0).major <= 5:
-            run_tests()
+    run_tests()


### PR DESCRIPTION
## Summary

Decouple `test/inductor/test_smoke.py` to use the device-agnostic test pattern with `instantiate_device_type_tests` and `hw_classification`, replacing the restrictive `@unittest.skipIf(not HAS_GPU)` guard and `GPU_TYPE` references.

## Changes

- Split `SmokeTest` into `SmokeTest` (GENERIC, no device param) and `SmokeTestDevice` (ACCELERATOR, with device param)
- Move `test_compile_invalid_options` to `SmokeTest` (GENERIC, no device dependency)
- Replace `GPU_TYPE` with `device` parameter in `test_mlp` and `test_compile_decorator`
- Remove `@unittest.skipIf(not HAS_GPU)` decorators, replaced by `except_for="cpu"` class-level guard
- Add `@unittest.skipIf(not has_triton(), "requires triton")` to `test_mlp` and `test_compile_decorator` for Triton gating
- Add `hw_classification = HardwareClassification.GENERIC` to `SmokeTest`
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `SmokeTestDevice`
- Add `instantiate_device_type_tests(SmokeTestDevice, globals(), except_for="cpu", allow_xpu=True)` call
- Remove `GPU_TYPE` and `HAS_GPU` imports; add `has_triton` import from `torch.utils._triton`
- Remove the `HAS_GPU` restriction from the `__main__` guard (keep the existing `IS_LINUX` and CUDA arch checks unchanged)

## Motivation

The `@unittest.skipIf(not HAS_GPU)` guard uses `HAS_GPU` from `inductor_utils`, which checks `GPU_TYPES` (currently `["cuda", "mps", "xpu", "mtia"]`). Out-of-tree accelerators registered via `PrivateUse1` (e.g., Ascend NPU) are not included in this list, causing all device-dependent tests to be skipped.

By using `instantiate_device_type_tests` with `except_for="cpu"` and `allow_xpu=True`, the tests run on all non-CPU device types registered in the test framework, including out-of-tree backends.

Triton gating is preserved via `@unittest.skipIf(not has_triton(), "requires triton")`. This ensures tests skip gracefully on devices where Triton is not available (e.g., CUDA-without-Triton), rather than crashing on `torch.compile()`.

## Test Plan

Verified on CPU (no GPU):

```bash
python -m pytest test/inductor/test_smoke.py -v --tb=short
# Result: 1 passed, 0 failed (1 GENERIC test)
```

Verified on NPU (Ascend 910B4):

```bash
python -m pytest test/inductor/test_smoke.py -v --tb=short
# Result: 3 passed, 0 failed (1 GENERIC + 2 ACCELERATOR via PrivateUse1)
```

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 1 | 1 | 0 | 0 | GENERIC test passed |
| NPU (Ascend 910B4) | 3 | 3 | 0 | 0 | All passed (1 GENERIC + 2 ACCELERATOR via PrivateUse1) |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260810+cpu |
| torch_npu | 2.14.0+gitc775ad3 |
| triton-ascend | 3.6.0+git0cfb1708 |
| CANN | 9.1.0 GA |
| NPU | Ascend 910B4 |
| Python | 3.12.13 |