### PR TITLE
[Testcase Refactoring] Make test_subgraph_choice device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_subgraph_choice.py
+++ b/test/inductor/test_subgraph_choice.py
@@ -1,40 +1,26 @@
 # Owner(s): ["module: inductor"]
+import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
 import torch
-from torch._inductor.ir import Buffer, FixedLayout, FlexibleLayout
+from torch._inductor.ir import FixedLayout, FlexibleLayout
 from torch._inductor.lowering import register_lowering
 from torch._inductor.select_algorithm import autotune_select_algorithm
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
-
-
-def decomposeK(a, b, kPartitions):
-    m = a.shape[0]
-    n = b.shape[1]
-    k = a.shape[1]
-
-    B = k // kPartitions
-    a_reshaped = torch.permute(a.reshape(m, B, kPartitions), (1, 0, 2))
-    b_reshaped = b.reshape(B, kPartitions, n)
-    result = torch.bmm(a_reshaped, b_reshaped, out_dtype=torch.float32)
-    result_fp32 = result.to(torch.float32)
-    reduced_buf = torch.sum(result_fp32, 0)
-    return reduced_buf.to(a.dtype)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 
 class TestSubgraphChoice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
 
-    def _create_buffer(self, name, shape, dtype):
-        return Buffer(
-            name=name,
-            layout=FixedLayout(torch.device(f"{GPU_TYPE}:0"), dtype=dtype, size=shape),
-        )
-
-    def test_subgraph_decompose_k(self):
+    @unittest.skipIf(not has_triton(), "requires triton")
+    def test_subgraph_decompose_k(self, device):
         from torch._inductor.kernel.mm import aten_mm
         from torch._inductor.kernel.mm_common import mm_args
 
@@ -77,12 +63,8 @@ class TestSubgraphChoice(TestCase):
             )
             return node
 
-        a_in = torch.randn(
-            mat1_shape, dtype=torch.float16, device=torch.device(f"{GPU_TYPE}:0")
-        )
-        b_in = torch.randn(
-            mat2_shape, dtype=torch.float16, device=torch.device(f"{GPU_TYPE}:0")
-        )
+        a_in = torch.randn(mat1_shape, dtype=torch.float16, device=device)
+        b_in = torch.randn(mat2_shape, dtype=torch.float16, device=device)
 
         def func(mat1, mat2):
             return torch.ops.mylib.matmul_decompose(mat1, mat2)
@@ -94,16 +76,13 @@ class TestSubgraphChoice(TestCase):
         # Check same results of compiled result and regular torch.mm
         torch.testing.assert_close(res, a_in @ b_in, atol=1e-1, rtol=1e-1)
 
-    def test_subgraph_freeze_layout(self):
+    @unittest.skipIf(not has_triton(), "requires triton")
+    def test_subgraph_freeze_layout(self, device):
         from torch._inductor.kernel.mm_common import mm_args
 
         M, N, K = (4, 128, 14240)
-        a_in = torch.randn(
-            (M, K), dtype=torch.bfloat16, device=torch.device(f"{GPU_TYPE}:0")
-        )
-        b_in = torch.randn(
-            (K, N), dtype=torch.bfloat16, device=torch.device(f"{GPU_TYPE}:0")
-        )
+        a_in = torch.randn((M, K), dtype=torch.bfloat16, device=device)
+        b_in = torch.randn((K, N), dtype=torch.bfloat16, device=device)
 
         @torch.library.custom_op("mylib::matmul_decompose_padding", mutates_args={})
         def matmul_decompose(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -170,7 +149,10 @@ class TestSubgraphChoice(TestCase):
             compiled_func(a_in, b_in)
 
 
+instantiate_device_type_tests(
+    TestSubgraphChoice, globals(), except_for="cpu", allow_xpu=True
+)
+
+
 if __name__ == "__main__":
-    # Set env to make it work in CI.
-    if HAS_GPU and HAS_CPU:
-        run_tests()
+    run_tests()

--- a/test/inductor/test_subgraph_choice.py
+++ b/test/inductor/test_subgraph_choice.py
@@ -7,7 +7,8 @@ from torch._inductor.ir import Buffer, FixedLayout, FlexibleLayout
 from torch._inductor.lowering import register_lowering
 from torch._inductor.select_algorithm import autotune_select_algorithm
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 def decomposeK(a, b, kPartitions):
@@ -25,16 +26,18 @@ def decomposeK(a, b, kPartitions):
 
 
 class TestSubgraphChoice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
 
-    def _create_buffer(self, name, shape, dtype):
+    def _create_buffer(self, name, shape, dtype, device):
         return Buffer(
             name=name,
-            layout=FixedLayout(torch.device(f"{GPU_TYPE}:0"), dtype=dtype, size=shape),
+            layout=FixedLayout(torch.device(device), dtype=dtype, size=shape),
         )
 
-    def test_subgraph_decompose_k(self):
+    def test_subgraph_decompose_k(self, device):
         from torch._inductor.kernel.mm import aten_mm
         from torch._inductor.kernel.mm_common import mm_args
 
@@ -77,12 +80,8 @@ class TestSubgraphChoice(TestCase):
             )
             return node
 
-        a_in = torch.randn(
-            mat1_shape, dtype=torch.float16, device=torch.device(f"{GPU_TYPE}:0")
-        )
-        b_in = torch.randn(
-            mat2_shape, dtype=torch.float16, device=torch.device(f"{GPU_TYPE}:0")
-        )
+        a_in = torch.randn(mat1_shape, dtype=torch.float16, device=torch.device(device))
+        b_in = torch.randn(mat2_shape, dtype=torch.float16, device=torch.device(device))
 
         def func(mat1, mat2):
             return torch.ops.mylib.matmul_decompose(mat1, mat2)
@@ -94,16 +93,12 @@ class TestSubgraphChoice(TestCase):
         # Check same results of compiled result and regular torch.mm
         torch.testing.assert_close(res, a_in @ b_in, atol=1e-1, rtol=1e-1)
 
-    def test_subgraph_freeze_layout(self):
+    def test_subgraph_freeze_layout(self, device):
         from torch._inductor.kernel.mm_common import mm_args
 
         M, N, K = (4, 128, 14240)
-        a_in = torch.randn(
-            (M, K), dtype=torch.bfloat16, device=torch.device(f"{GPU_TYPE}:0")
-        )
-        b_in = torch.randn(
-            (K, N), dtype=torch.bfloat16, device=torch.device(f"{GPU_TYPE}:0")
-        )
+        a_in = torch.randn((M, K), dtype=torch.bfloat16, device=torch.device(device))
+        b_in = torch.randn((K, N), dtype=torch.bfloat16, device=torch.device(device))
 
         @torch.library.custom_op("mylib::matmul_decompose_padding", mutates_args={})
         def matmul_decompose(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -170,7 +165,8 @@ class TestSubgraphChoice(TestCase):
             compiled_func(a_in, b_in)
 
 
+instantiate_device_type_tests(TestSubgraphChoice, globals(), except_for="cpu")
+
+
 if __name__ == "__main__":
-    # Set env to make it work in CI.
-    if HAS_GPU and HAS_CPU:
-        run_tests()
+    run_tests()


### PR DESCRIPTION
## Summary

Refactor `test/inductor/test_subgraph_choice.py` to use the device-agnostic test pattern with `instantiate_device_type_tests` and `hw_classification`, replacing the restrictive `GPU_TYPE` device references and `@skipIf(not HAS_GPU)` guard.

## Changes

- Replace `GPU_TYPE` with `device` parameter (injected by `instantiate_device_type_tests`)
- Replace `@skipIf(not HAS_GPU)` with `except_for="cpu"` + `allow_xpu=True`
- Add `hw_classification = HardwareClassification.ACCELERATOR`
- Remove `GPU_TYPE`, `HAS_CPU`, `HAS_GPU` imports; add `instantiate_device_type_tests`, `HardwareClassification`, and `has_triton` (from `torch.utils._triton`)
- Add `@unittest.skipIf(not has_triton(), "requires triton")` on both test methods to preserve the Triton requirement
- Remove dead code: `decomposeK` function and `_create_buffer` method
- Simplify `torch.device(device)` to `device` (already a valid device string)
- Replace `__main__` guard with plain `run_tests()`

## Motivation

The `@skipIf(not HAS_GPU)` guard uses `GPU_TYPES` (currently `["cuda", "mps", "xpu", "mtia"]`), which excludes out-of-tree accelerators registered via `PrivateUse1` (e.g., Ascend NPU). By using `instantiate_device_type_tests` with `except_for="cpu"` + `allow_xpu=True`, the tests run on all non-CPU device types. The `allow_xpu=True` preserves XPU coverage that was previously included via `HAS_XPU_AND_TRITON`.

## Test Plan

Verified on CPU (no GPU) and NPU (Ascend 910B4):

```
# CPU collect-only (ACCELERATOR tests excluded by except_for="cpu")
python -m pytest test/inductor/test_subgraph_choice.py --collect-only -v
# 0 tests collected (all ACCELERATOR, excluded on CPU)

# NPU (Ascend 910B4)
python -m pytest test/inductor/test_subgraph_choice.py -v
# 2 passed, 0 failed
```

## Verification Report

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 0 | 0 | 0 | 0 | Pass (ACCELERATOR excluded by except_for="cpu") |
| NPU (Ascend 910B4) | 2 | 2 | 0 | 0 | **All passed** |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260801+cpu |
| torch_npu | 2.14.0+gitc775ad3 |
| CANN | 9.1.0 GA |
| triton-ascend | 3.6.0+git0cfb1708 |
| NPU | Ascend 910B4 x8 |
| Platform | aarch64 Linux |