### PR TITLE
[Testcase Refactoring] Make test_split_cat_fx_aten_passes device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -4,8 +4,8 @@ import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.inductor_utils import GPU_TYPE
-from torch.testing._internal.triton_utils import requires_gpu_and_triton
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 try:
@@ -221,6 +221,8 @@ class _TestSelectCat(torch.nn.Module):
 
 
 class TestSplitCatAten(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
             return False
@@ -245,11 +247,8 @@ class TestSplitCatAten(TestCase):
     def compare_gradients(self, module, traced, rtol=1e-3, atol=1e-3):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
-        self.assertTrue(
-            self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
-        )
+        self.assertTrue(self.compare_dict_tensors(ref_grad, res_grad, rtol, atol))
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -257,12 +256,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad(self):
+    def test_split_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCat()
         traced = torch.compile(module)
@@ -276,10 +275,10 @@ class TestSplitCatAten(TestCase):
         counters.clear()
 
         inputs = [
-            torch.randn(1024, 96 * 21, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96 * 4, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 96 * 21, device=device),
+            torch.randn(1024, 96 * 4, device=device),
+            torch.randn(1024, 96, device=device),
+            torch.randn(1024, 96, device=device),
         ]
         module = _TestSplitCatPartial()
         traced = torch.compile(module)
@@ -292,7 +291,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -300,12 +298,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad_singular(self):
+    def test_split_cat_post_grad_singular(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCatSingular()
         traced = torch.compile(module)
@@ -318,7 +316,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -326,11 +323,11 @@ class TestSplitCatAten(TestCase):
             "select_cat_aten_pass": {},
         },
     )
-    def test_select_cat_post_grad(self):
+    def test_select_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 6, 128, device=device),
+            torch.randn(1024, 6, 128, device=device),
         ]
         module = _TestSelectCat()
         traced = torch.compile(module)
@@ -343,7 +340,6 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -351,10 +347,10 @@ class TestSplitCatAten(TestCase):
             "move_view_after_cat_aten_pass": {},
         },
     )
-    def test_move_view_after_cat_aten(self):
+    def test_move_view_after_cat_aten(self, device):
         counters.clear()
         inputs = [
-            torch.randn(7, 8, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(7, 8, 96, device=device),
         ]
         module = _TestMoveViewAferCat()
         traced = torch.compile(module)
@@ -369,6 +365,8 @@ class TestSplitCatAten(TestCase):
 
 
 class TestSplitCatAtenNormalizationPasses(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -399,6 +397,9 @@ class TestSplitCatAtenNormalizationPasses(TestCase):
                 msg=lambda msg: f"{msg}\nfor {fn}",
             )
             counters.clear()
+
+
+instantiate_device_type_tests(TestSplitCatAten, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -1,12 +1,14 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
 import torch._inductor
 from torch._dynamo.utils import counters
-from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.inductor_utils import GPU_TYPE
-from torch.testing._internal.triton_utils import requires_gpu_and_triton
-
+from torch._inductor.test_case import TestCase, run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 try:
     # importing this will register fbgemm lowerings for inductor
@@ -221,6 +223,8 @@ class _TestSelectCat(torch.nn.Module):
 
 
 class TestSplitCatAten(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
             return False
@@ -245,11 +249,9 @@ class TestSplitCatAten(TestCase):
     def compare_gradients(self, module, traced, rtol=1e-3, atol=1e-3):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
-        self.assertTrue(
-            self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
-        )
+        self.assertTrue(self.compare_dict_tensors(ref_grad, res_grad, rtol, atol))
 
-    @requires_gpu_and_triton
+    @unittest.skipIf(not has_triton(), "requires triton")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -257,12 +259,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad(self):
+    def test_split_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCat()
         traced = torch.compile(module)
@@ -276,10 +278,10 @@ class TestSplitCatAten(TestCase):
         counters.clear()
 
         inputs = [
-            torch.randn(1024, 96 * 21, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96 * 4, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 96 * 21, device=device),
+            torch.randn(1024, 96 * 4, device=device),
+            torch.randn(1024, 96, device=device),
+            torch.randn(1024, 96, device=device),
         ]
         module = _TestSplitCatPartial()
         traced = torch.compile(module)
@@ -292,7 +294,7 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
+    @unittest.skipIf(not has_triton(), "requires triton")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -300,12 +302,12 @@ class TestSplitCatAten(TestCase):
             "split_cat_aten_pass": {"threshold_to_cat": 5},
         },
     )
-    def test_split_cat_post_grad_singular(self):
+    def test_split_cat_post_grad_singular(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 32, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 128, device=device),
+            torch.randn(1024, 32, device=device),
         ]
         module = _TestSplitCatSingular()
         traced = torch.compile(module)
@@ -318,7 +320,7 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
+    @unittest.skipIf(not has_triton(), "requires triton")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -326,11 +328,11 @@ class TestSplitCatAten(TestCase):
             "select_cat_aten_pass": {},
         },
     )
-    def test_select_cat_post_grad(self):
+    def test_select_cat_post_grad(self, device):
         counters.clear()
         inputs = [
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
-            torch.randn(1024, 6, 128, device=torch.device(device=GPU_TYPE)),
+            torch.randn(1024, 6, 128, device=device),
+            torch.randn(1024, 6, 128, device=device),
         ]
         module = _TestSelectCat()
         traced = torch.compile(module)
@@ -343,7 +345,7 @@ class TestSplitCatAten(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
-    @requires_gpu_and_triton
+    @unittest.skipIf(not has_triton(), "requires triton")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -351,10 +353,10 @@ class TestSplitCatAten(TestCase):
             "move_view_after_cat_aten_pass": {},
         },
     )
-    def test_move_view_after_cat_aten(self):
+    def test_move_view_after_cat_aten(self, device):
         counters.clear()
         inputs = [
-            torch.randn(7, 8, 96, device=torch.device(device=GPU_TYPE)),
+            torch.randn(7, 8, 96, device=device),
         ]
         module = _TestMoveViewAferCat()
         traced = torch.compile(module)
@@ -369,6 +371,8 @@ class TestSplitCatAten(TestCase):
 
 
 class TestSplitCatAtenNormalizationPasses(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},
         post_grad_fusion_options={
@@ -399,6 +403,9 @@ class TestSplitCatAtenNormalizationPasses(TestCase):
                 msg=lambda msg: f"{msg}\nfor {fn}",
             )
             counters.clear()
+
+
+instantiate_device_type_tests(TestSplitCatAten, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_split_cat_fx_aten_passes.py
+++ b/test/inductor/test_split_cat_fx_aten_passes.py
@@ -5,10 +5,11 @@ import unittest
 import torch
 import torch._inductor
 from torch._dynamo.utils import counters
-from torch._inductor.test_case import TestCase, run_tests
+from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
 from torch.utils._triton import has_triton
+
 
 try:
     # importing this will register fbgemm lowerings for inductor


### PR DESCRIPTION
## Summary

Decouple `test/inductor/test_split_cat_fx_aten_passes.py` to use the device-agnostic test pattern with `instantiate_device_type_tests` and `hw_classification`, replacing the restrictive `@requires_gpu_and_triton` decorator and `GPU_TYPE` references.

## Changes

- Replace `GPU_TYPE` with `device` parameter (injected by `instantiate_device_type_tests`) across 4 test methods in `TestSplitCatAten`
- Remove 4 `@requires_gpu_and_triton` decorators, replaced by `@unittest.skipIf(not has_triton(), "requires triton")` on each test method
- Replace `torch.device(device=GPU_TYPE)` with `device` parameter directly
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestSplitCatAten` (4 device-dependent tests)
- Add `hw_classification = HardwareClassification.GENERIC` to `TestSplitCatAtenNormalizationPasses` (1 device-agnostic test, not instantiated with `instantiate_device_type_tests`)
- Add `instantiate_device_type_tests(TestSplitCatAten, globals(), except_for="cpu")` call
- Remove `GPU_TYPE` and `requires_gpu_and_triton` imports; add `unittest`, `instantiate_device_type_tests`, `HardwareClassification`, and `has_triton` (from `torch.utils._triton`) imports

## Motivation

The `@requires_gpu_and_triton` decorator uses `GPU_TYPE` from `inductor_utils`, which checks `GPU_TYPES` (currently `["cuda", "mps", "xpu", "mtia"]`). Out-of-tree accelerators registered via `PrivateUse1` (e.g., Ascend NPU) are not included in this list, causing all tests to be skipped even though they only need a generic accelerator with Triton support.

By using `instantiate_device_type_tests` with `except_for="cpu"`, the tests run on all non-CPU device types registered in the test framework, including out-of-tree backends. The `hw_classification` attribute provides metadata for `--hw-classification` filtering (introduced in #186918).

Triton gating is preserved via `@unittest.skipIf(not has_triton(), "requires triton")` on each test method, using `has_triton()` from `torch.utils._triton`.

## Test Plan

Verified on CPU (no GPU):

```bash
python -m pytest test/inductor/test_split_cat_fx_aten_passes.py -v --tb=short
# Result: 1 passed, 0 failed (1 GENERIC test)
```

Verified on NPU (Ascend 910B4):

```bash
python -m pytest test/inductor/test_split_cat_fx_aten_passes.py -v --tb=short
# Result: 5 passed, 0 failed in 134.76s (1 GENERIC + 4 ACCELERATOR via PrivateUse1)
```

## Verification Report

### Verification Results

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 1 | 1 | 0 | 0 | GENERIC test passed (ACCELERATOR excluded by `except_for="cpu"`) |
| NPU (Ascend 910B4) | 5 | 5 | 0 | 0 | All passed (1 GENERIC + 4 ACCELERATOR via PrivateUse1) |

### NPU Test Details

| Test | Classification | Result | Time |
|------|---------------|--------|------|
| `test_split_aten_normalization` | GENERIC | PASSED | 17.7s |
| `test_move_view_after_cat_aten_npu` | ACCELERATOR | PASSED | 72.6s |
| `test_select_cat_post_grad_npu` | ACCELERATOR | PASSED | 0.3s |
| `test_split_cat_post_grad_npu` | ACCELERATOR | PASSED | 21.7s |
| `test_split_cat_post_grad_singular_npu` | ACCELERATOR | PASSED | 21.7s |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.14.0.dev20260810+cpu |
| torch_npu | 2.14.0+gitc775ad3 |
| triton-ascend | 3.6.0+git0cfb1708 |
| CANN | 9.1.0 GA |
| NPU | Ascend 910B4 |
| Python | 3.12.13 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo