### PR TITLE
[Testcase Refactoring] Make test_snode_runtime device-agnostic via instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -10,7 +10,8 @@ from torch._inductor.comm_analysis import estimate_nccl_collective_runtime
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_collective
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 aten = torch.ops.aten
@@ -43,16 +44,12 @@ def calculate_runtime(f, *args) -> float:
     return ret
 
 
-DEVICE = GPU_TYPE
-
-
-def T(*size, dtype=torch.float32, device=DEVICE, grad=False) -> torch.Tensor:
+def T(*size, device, dtype=torch.float32, grad=False) -> torch.Tensor:
     return torch.randn(size, dtype=dtype, device=device, requires_grad=grad)
 
 
 class TestCase(InductorTestCase):
-    device = DEVICE
-
+    hw_classification = HardwareClassification.ACCELERATOR
     """
     Helper methods to compare runtime estimate against 0. Since this estimate is hardware dependent,
     stronger comparisons may fail depending on the host's specs.
@@ -85,14 +82,16 @@ class TestCase(InductorTestCase):
 
 
 class UnsupportedTests(TestCase):
-    device = DEVICE
-
-    def test_no_op(self):
+    def test_no_op(self, device):
         def f(a):
             return a
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertZero(calculate_runtime(f, *inp))
+
+
+class UnsupportedTestsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_no_cuda(self):
         def f(a):
@@ -103,106 +102,100 @@ class UnsupportedTests(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
-    device = DEVICE
-
-    def test_conv1d(self):
+    def test_conv1d(self, device):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
 
-        inp = (T(33, 16, 30), T(20, 16, 5))
+        inp = (T(33, 16, 30, device=device), T(20, 16, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d(self):
+    def test_conv2d(self, device):
         def f(x, y):
             return torch.nn.functional.conv2d(x, y, padding=1)
 
-        inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
+        inp = (T(8, 4, 3, 3, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d_transpose(self):
+    def test_conv2d_transpose(self, device):
         def f(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, padding=1)
 
-        inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
+        inp = (T(8, 1, 1, 1, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv3d(self):
+    def test_conv3d(self, device):
         def f(x, y):
             return torch.nn.functional.conv3d(x, y)
 
-        inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
+        inp = (T(20, 16, 50, 10, 20, device=device), T(33, 16, 3, 3, 3, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_mm(self):
+    def test_mm(self, device):
         def f(a, b):
             return torch.mm(a, b)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_addmm(self):
+    def test_addmm(self, device):
         def f(a, b, c):
             return torch.addmm(a, b, c)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_bmm(self):
+    def test_bmm(self, device):
         def f(a, b):
             return torch.bmm(a, b)
 
         inp = (
-            T(10, 10, 10),
-            T(10, 10, 10),
+            T(10, 10, 10, device=device),
+            T(10, 10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class MemoryBoundedTests(TestCase):
-    device = DEVICE
-
-    def test_relu(self):
+    def test_relu(self, device):
         def f(a):
             return torch.nn.functional.relu(a)
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_horizontal_reduction_pointwise(self):
+    def test_horizontal_reduction_pointwise(self, device):
         def f(a):
             b = a.sum(dim=1)
             c = a.cos()
             return b, c
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_pointwise(self):
+    def test_pointwise(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
-    def test_dynamic(self):
+    def test_dynamic(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class InputDistanceTests(TestCase):
-    device = DEVICE
-
     def _get_snodes(self, f, *args):
         metrics.reset()
         torch._logging.set_logs(inductor_metrics=True)
@@ -210,7 +203,7 @@ class InputDistanceTests(TestCase):
         torch._logging.set_logs()
         return [snode for snode, _ in metrics.nodes_num_elem]
 
-    def test_chain_with_reduction(self):
+    def test_chain_with_reduction(self, device):
         """
         input -> sum (depth 0) -> sum (depth 1)
         Reductions prevent full fusion, giving us distinct depth levels.
@@ -220,13 +213,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10, 10))
+        snodes = self._get_snodes(f, T(10, 10, 10, device=device))
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_fused_node_depth_range(self):
+    def test_fused_node_depth_range(self, device):
         """
         A reduction fused with its pointwise epilogue should have
         min_input_distance=0 and max_input_distance=1.
@@ -236,13 +229,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.cos()
 
-        snodes = self._get_snodes(f, T(10, 10))
+        snodes = self._get_snodes(f, T(10, 10, device=device))
         # The reduction and pointwise get fused
         self.assertEqual(len(snodes), 1)
         self.assertEqual(snodes[0].min_input_distance, 0)
         self.assertEqual(snodes[0].max_input_distance, 1)
 
-    def test_extern_kernel_chain(self):
+    def test_extern_kernel_chain(self, device):
         """
         mm (depth 0, extern) -> cos+sum fused (depth 1)
         """
@@ -252,13 +245,13 @@ class InputDistanceTests(TestCase):
             d = c.cos()
             return d.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10))
+        snodes = self._get_snodes(f, T(10, 10, device=device), T(10, 10, device=device))
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_foreach_basic(self):
+    def test_foreach_basic(self, device):
         """
         foreach_add on graph inputs should have depth 0.
         """
@@ -266,14 +259,14 @@ class InputDistanceTests(TestCase):
         def f(xs, ys):
             return torch._foreach_add(xs, ys)
 
-        xs = [T(10), T(20)]
-        ys = [T(10), T(20)]
+        xs = [T(10, device=device), T(20, device=device)]
+        ys = [T(10, device=device), T(20, device=device)]
         snodes = self._get_snodes(f, xs, ys)
         for s in snodes:
             self.assertEqual(s.min_input_distance, 0)
             self.assertEqual(s.max_input_distance, 0)
 
-    def test_foreach_after_extern(self):
+    def test_foreach_after_extern(self, device):
         """
         mm (extern, depth 0) -> foreach_add (depth 1)
         The extern kernel creates a fusion barrier so the foreach
@@ -284,7 +277,12 @@ class InputDistanceTests(TestCase):
             c = torch.mm(a, b)
             return torch._foreach_add([c, c], ys)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10), [T(10, 10), T(10, 10)])
+        snodes = self._get_snodes(
+            f,
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            [T(10, 10, device=device), T(10, 10, device=device)],
+        )
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
@@ -293,8 +291,6 @@ class InputDistanceTests(TestCase):
 
 @skipIf(not dist.is_available(), "requires distributed")
 class TestCommAnalysis(TestCase):
-    device = DEVICE
-
     WORLD_SIZE: int = 8
     RANKS = list(range(8))
 
@@ -328,23 +324,23 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
-    def test_legacy_all_reduce(self):
+    def test_legacy_all_reduce(self, device):
         def fn(x):
             r = c10d.all_reduce(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_reduce_coalesced(self):
+    def test_legacy_all_reduce_coalesced(self, device):
         def fn(x):
             rs = c10d.all_reduce_coalesced(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_gather_into_tensor_coalesced(self):
+    def test_legacy_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -354,26 +350,26 @@ class TestCommAnalysis(TestCase):
             )
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce(self):
+    def test_all_reduce(self, device):
         def fn(x):
             r = _c10d.all_reduce(x, "sum", "0")
             return _c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce_coalesced(self):
+    def test_all_reduce_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_reduce_coalesced(x, "sum", "0")
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor(self):
+    def test_all_gather_into_tensor(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor(
                 x,
@@ -382,10 +378,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor_coalesced(self):
+    def test_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -394,10 +390,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor(self):
+    def test_reduce_scatter_tensor(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor(
                 x,
@@ -407,10 +403,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(self.WORLD_SIZE, 10)
+        inp = T(self.WORLD_SIZE, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor_coalesced(self):
+    def test_reduce_scatter_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor_coalesced(
                 x,
@@ -420,12 +416,31 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(self.WORLD_SIZE, 10), T(self.WORLD_SIZE, 15)]
+        inp = [
+            T(self.WORLD_SIZE, 10, device=device),
+            T(self.WORLD_SIZE, 15, device=device),
+        ]
         self._verify_runtime_estimation(fn, (inp,))
+
+
+instantiate_device_type_tests(
+    UnsupportedTests, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    ComputeBoundedTests, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    MemoryBoundedTests, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    InputDistanceTests, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestCommAnalysis, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
-        run_tests(needs="filelock")
+    run_tests(needs="filelock")

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -10,7 +10,8 @@ from torch._inductor.comm_analysis import estimate_nccl_collective_runtime
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_collective
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 aten = torch.ops.aten
@@ -43,22 +44,19 @@ def calculate_runtime(f, *args) -> float:
     return ret
 
 
-DEVICE = GPU_TYPE
-
-
-def T(*size, dtype=torch.float32, device=DEVICE, grad=False) -> torch.Tensor:
+def T(*size, dtype=torch.float32, device="cpu", grad=False) -> torch.Tensor:
     return torch.randn(size, dtype=dtype, device=device, requires_grad=grad)
 
 
 class TestCase(InductorTestCase):
-    device = DEVICE
-
     """
     Helper methods to compare runtime estimate against 0. Since this estimate is hardware dependent,
     stronger comparisons may fail depending on the host's specs.
 
     atol/rtol must be provided explicitly with each call, since precision/rel_tol overrides are not always utilized
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def setUp(self):
         super().setUp()
@@ -85,13 +83,13 @@ class TestCase(InductorTestCase):
 
 
 class UnsupportedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_no_op(self):
+    def test_no_op(self, device):
         def f(a):
             return a
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertZero(calculate_runtime(f, *inp))
 
     def test_no_cuda(self):
@@ -103,105 +101,105 @@ class UnsupportedTests(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_conv1d(self):
+    def test_conv1d(self, device):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
 
-        inp = (T(33, 16, 30), T(20, 16, 5))
+        inp = (T(33, 16, 30, device=device), T(20, 16, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d(self):
+    def test_conv2d(self, device):
         def f(x, y):
             return torch.nn.functional.conv2d(x, y, padding=1)
 
-        inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
+        inp = (T(8, 4, 3, 3, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv2d_transpose(self):
+    def test_conv2d_transpose(self, device):
         def f(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, padding=1)
 
-        inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
+        inp = (T(8, 1, 1, 1, device=device), T(1, 4, 5, 5, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_conv3d(self):
+    def test_conv3d(self, device):
         def f(x, y):
             return torch.nn.functional.conv3d(x, y)
 
-        inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
+        inp = (T(20, 16, 50, 10, 20, device=device), T(33, 16, 3, 3, 3, device=device))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_mm(self):
+    def test_mm(self, device):
         def f(a, b):
             return torch.mm(a, b)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_addmm(self):
+    def test_addmm(self, device):
         def f(a, b, c):
             return torch.addmm(a, b, c)
 
         inp = (
-            T(10, 10),
-            T(10, 10),
-            T(10, 10),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            T(10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_bmm(self):
+    def test_bmm(self, device):
         def f(a, b):
             return torch.bmm(a, b)
 
         inp = (
-            T(10, 10, 10),
-            T(10, 10, 10),
+            T(10, 10, 10, device=device),
+            T(10, 10, 10, device=device),
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class MemoryBoundedTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_relu(self):
+    def test_relu(self, device):
         def f(a):
             return torch.nn.functional.relu(a)
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_horizontal_reduction_pointwise(self):
+    def test_horizontal_reduction_pointwise(self, device):
         def f(a):
             b = a.sum(dim=1)
             c = a.cos()
             return b, c
 
-        inp = (T(10, 10),)
+        inp = (T(10, 10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    def test_pointwise(self):
+    def test_pointwise(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
-    def test_dynamic(self):
+    def test_dynamic(self, device):
         def f(x):
             return x.cos()
 
-        inp = (T(10),)
+        inp = (T(10, device=device),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
 
 class InputDistanceTests(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _get_snodes(self, f, *args):
         metrics.reset()
@@ -210,7 +208,7 @@ class InputDistanceTests(TestCase):
         torch._logging.set_logs()
         return [snode for snode, _ in metrics.nodes_num_elem]
 
-    def test_chain_with_reduction(self):
+    def test_chain_with_reduction(self, device):
         """
         input -> sum (depth 0) -> sum (depth 1)
         Reductions prevent full fusion, giving us distinct depth levels.
@@ -220,13 +218,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10, 10))
+        snodes = self._get_snodes(f, T(10, 10, 10, device=device))
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_fused_node_depth_range(self):
+    def test_fused_node_depth_range(self, device):
         """
         A reduction fused with its pointwise epilogue should have
         min_input_distance=0 and max_input_distance=1.
@@ -236,13 +234,13 @@ class InputDistanceTests(TestCase):
             a = x.sum(dim=-1)
             return a.cos()
 
-        snodes = self._get_snodes(f, T(10, 10))
+        snodes = self._get_snodes(f, T(10, 10, device=device))
         # The reduction and pointwise get fused
         self.assertEqual(len(snodes), 1)
         self.assertEqual(snodes[0].min_input_distance, 0)
         self.assertEqual(snodes[0].max_input_distance, 1)
 
-    def test_extern_kernel_chain(self):
+    def test_extern_kernel_chain(self, device):
         """
         mm (depth 0, extern) -> cos+sum fused (depth 1)
         """
@@ -252,13 +250,13 @@ class InputDistanceTests(TestCase):
             d = c.cos()
             return d.sum(dim=-1)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10))
+        snodes = self._get_snodes(f, T(10, 10, device=device), T(10, 10, device=device))
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
         self.assertEqual(max(all_max), 1)
 
-    def test_foreach_basic(self):
+    def test_foreach_basic(self, device):
         """
         foreach_add on graph inputs should have depth 0.
         """
@@ -266,14 +264,14 @@ class InputDistanceTests(TestCase):
         def f(xs, ys):
             return torch._foreach_add(xs, ys)
 
-        xs = [T(10), T(20)]
-        ys = [T(10), T(20)]
+        xs = [T(10, device=device), T(20, device=device)]
+        ys = [T(10, device=device), T(20, device=device)]
         snodes = self._get_snodes(f, xs, ys)
         for s in snodes:
             self.assertEqual(s.min_input_distance, 0)
             self.assertEqual(s.max_input_distance, 0)
 
-    def test_foreach_after_extern(self):
+    def test_foreach_after_extern(self, device):
         """
         mm (extern, depth 0) -> foreach_add (depth 1)
         The extern kernel creates a fusion barrier so the foreach
@@ -284,7 +282,12 @@ class InputDistanceTests(TestCase):
             c = torch.mm(a, b)
             return torch._foreach_add([c, c], ys)
 
-        snodes = self._get_snodes(f, T(10, 10), T(10, 10), [T(10, 10), T(10, 10)])
+        snodes = self._get_snodes(
+            f,
+            T(10, 10, device=device),
+            T(10, 10, device=device),
+            [T(10, 10, device=device), T(10, 10, device=device)],
+        )
         all_min = [s.min_input_distance for s in snodes]
         all_max = [s.max_input_distance for s in snodes]
         self.assertEqual(min(all_min), 0)
@@ -293,7 +296,7 @@ class InputDistanceTests(TestCase):
 
 @skipIf(not dist.is_available(), "requires distributed")
 class TestCommAnalysis(TestCase):
-    device = DEVICE
+    hw_classification = HardwareClassification.ACCELERATOR
 
     WORLD_SIZE: int = 8
     RANKS = list(range(8))
@@ -328,23 +331,23 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
-    def test_legacy_all_reduce(self):
+    def test_legacy_all_reduce(self, device):
         def fn(x):
             r = c10d.all_reduce(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_reduce_coalesced(self):
+    def test_legacy_all_reduce_coalesced(self, device):
         def fn(x):
             rs = c10d.all_reduce_coalesced(x, "sum", "", self.RANKS, self.WORLD_SIZE)
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_legacy_all_gather_into_tensor_coalesced(self):
+    def test_legacy_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -354,26 +357,26 @@ class TestCommAnalysis(TestCase):
             )
             return [c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce(self):
+    def test_all_reduce(self, device):
         def fn(x):
             r = _c10d.all_reduce(x, "sum", "0")
             return _c10d.wait_tensor(r)
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_reduce_coalesced(self):
+    def test_all_reduce_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_reduce_coalesced(x, "sum", "0")
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor(self):
+    def test_all_gather_into_tensor(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor(
                 x,
@@ -382,10 +385,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(10, 10)
+        inp = T(10, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_all_gather_into_tensor_coalesced(self):
+    def test_all_gather_into_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.all_gather_into_tensor_coalesced(
                 x,
@@ -394,10 +397,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(10, 10), T(15, 15)]
+        inp = [T(10, 10, device=device), T(15, 15, device=device)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor(self):
+    def test_reduce_scatter_tensor(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor(
                 x,
@@ -407,10 +410,10 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = T(self.WORLD_SIZE, 10)
+        inp = T(self.WORLD_SIZE, 10, device=device)
         self._verify_runtime_estimation(fn, (inp,))
 
-    def test_reduce_scatter_tensor_coalesced(self):
+    def test_reduce_scatter_tensor_coalesced(self, device):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor_coalesced(
                 x,
@@ -420,12 +423,21 @@ class TestCommAnalysis(TestCase):
             )
             return [_c10d.wait_tensor(r) for r in rs]
 
-        inp = [T(self.WORLD_SIZE, 10), T(self.WORLD_SIZE, 15)]
+        inp = [
+            T(self.WORLD_SIZE, 10, device=device),
+            T(self.WORLD_SIZE, 15, device=device),
+        ]
         self._verify_runtime_estimation(fn, (inp,))
+
+
+instantiate_device_type_tests(UnsupportedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(ComputeBoundedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(MemoryBoundedTests, globals(), except_for="cpu")
+instantiate_device_type_tests(InputDistanceTests, globals(), except_for="cpu")
+instantiate_device_type_tests(TestCommAnalysis, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
-        run_tests(needs="filelock")
+    run_tests(needs="filelock")

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -49,7 +49,6 @@ def T(*size, device, dtype=torch.float32, grad=False) -> torch.Tensor:
 
 
 class TestCase(InductorTestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
     """
     Helper methods to compare runtime estimate against 0. Since this estimate is hardware dependent,
     stronger comparisons may fail depending on the host's specs.
@@ -82,6 +81,8 @@ class TestCase(InductorTestCase):
 
 
 class UnsupportedTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_no_op(self, device):
         def f(a):
             return a
@@ -102,6 +103,8 @@ class UnsupportedTestsGeneric(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_conv1d(self, device):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
@@ -163,6 +166,8 @@ class ComputeBoundedTests(TestCase):
 
 
 class MemoryBoundedTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_relu(self, device):
         def f(a):
             return torch.nn.functional.relu(a)
@@ -196,6 +201,8 @@ class MemoryBoundedTests(TestCase):
 
 
 class InputDistanceTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _get_snodes(self, f, *args):
         metrics.reset()
         torch._logging.set_logs(inductor_metrics=True)
@@ -291,6 +298,8 @@ class InputDistanceTests(TestCase):
 
 @skipIf(not dist.is_available(), "requires distributed")
 class TestCommAnalysis(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     WORLD_SIZE: int = 8
     RANKS = list(range(8))
 


### PR DESCRIPTION
## Summary

Refactor `test/inductor/test_snode_runtime.py` to use the device-agnostic test pattern with `instantiate_device_type_tests` and `hw_classification`, replacing the restrictive `@skipIf(not HAS_GPU)` guard (implicit via `DEVICE = GPU_TYPE`) and hardcoded `GPU_TYPE` device references.

## Changes

- Replace module-level `DEVICE = GPU_TYPE` with `device` parameter injected by `instantiate_device_type_tests`
- Split `UnsupportedTests` into:
  - `UnsupportedTests` (ACCELERATOR): `test_no_op` (uses `device`)
  - `UnsupportedTestsGeneric` (GENERIC): `test_no_cuda` (device-independent, not passed to `instantiate_device_type_tests`)
- Set `hw_classification` on each subclass individually (`ACCELERATOR` for device-dependent classes, `GENERIC` for `UnsupportedTestsGeneric`)
- Instantiate 5 ACCELERATOR classes with `except_for="cpu", allow_xpu=True`
- Make `T(*size, device, ...)` require `device` parameter (no silent CPU fallback)
- Simplify `__main__` guard to unconditional `run_tests(needs="filelock")`
- Remove `GPU_TYPE`, `HAS_GPU` imports; add `instantiate_device_type_tests` and `HardwareClassification`

## Motivation

The `DEVICE = GPU_TYPE` pattern uses `GPU_TYPES = ["cuda", "mps", "xpu", "mtia"]`, which excludes out-of-tree accelerators registered via `PrivateUse1`. By using `instantiate_device_type_tests` with `except_for="cpu"` + `allow_xpu=True`, the tests run on all non-CPU device types (CUDA, XPU, PrivateUse1, HPU). The `allow_xpu=True` preserves XPU coverage that was previously included via `HAS_XPU_AND_TRITON`.

## Test Plan

Verified on CPU (no GPU) and NPU (Ascend 910B4):

```
# CPU collect-only (ACCELERATOR tests excluded by except_for="cpu")
python -m pytest test/inductor/test_snode_runtime.py --collect-only -v
# 1 GENERIC test collected (test_no_cuda), 0 errors

# NPU (Ascend 910B4)
python -m pytest test/inductor/test_snode_runtime.py -v
# 27 tests collected, 27 passed, 0 failed, 0 skipped
```

## Verification Report

| Hardware | Cases | Passed | Failed | Skipped | Result |
|----------|-------|--------|--------|---------|--------|
| CPU (no GPU) | 1 | 1 | 0 | 0 | Pass (GENERIC test_no_cuda; ACCELERATOR excluded by except_for="cpu") |
| NPU (Ascend 910B4) | 27 | 27 | 0 | 0 | All pass (1 GENERIC + 26 ACCELERATOR) |

### Environment

| Item | Version |
|------|---------|
| PyTorch | 2.15.0.dev20260819+cpu |
| torch_npu | 2.15.0.dev20260819+gitf2e1583 |
| CANN | 9.1.0 GA |
| triton-ascend | 3.6.0+git0cfb1708 |
| NPU | Ascend 910B4 x8 |
| Platform | aarch64 Linux |
