### PR TITLE
[typing] Export torch.distributed.algorithms symbols

### DIFF
--- a/torch/distributed/algorithms/__init__.py
+++ b/torch/distributed/algorithms/__init__.py
@@ -1,1 +1,4 @@
 from .join import Join, Joinable, JoinHook
+
+
+__all__ = ["Join", "Joinable", "JoinHook"]


### PR DESCRIPTION
## Summary

Add an explicit `__all__` to `torch.distributed.algorithms` for its three existing public re-exports:

- `Join`
- `Joinable`
- `JoinHook`

Without `__all__`, static type checkers can treat these imported names as private. The module already exposes these symbols at runtime, so this change only makes the intended public interface explicit and does not change runtime behavior.

Partially addresses #131765.

## Test plan

- `python -m py_compile torch/distributed/algorithms/__init__.py`
- `python -m ruff check torch/distributed/algorithms/__init__.py`
- AST check that the imported and exported symbol sets match with no duplicates
- `git diff --check`

`spin quicklint` was attempted, but PyTorch's lintrunner initializer reports that its clang-format setup does not support Windows.

## AI assistance disclosure

> Codex assisted with issue triage, duplicate-PR checks, and drafting this three-line change.

The contribution is intentionally limited to declaring the module's existing public imports in `__all__`; no implementation or runtime semantics are modified.

cc @lolpack @maggiemoss @ndmitchell @kinto0 @samwgoldman