### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to test_trace_rules.py and test_tree_map.py

### DIFF
--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -28,7 +28,14 @@ from torch._dynamo.variables import (
     TorchInGraphFunctionVariable,
     UserFunctionVariable,
 )
-from torch.testing._internal.common_utils import skipIfWindows, TEST_CUDA, TEST_XPU
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    skipIfWindows,
+)
 from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
@@ -308,6 +315,8 @@ def gen_allowed_objs_and_ids(record=False, c_binding_only=True) -> AllowedObject
 
 
 class TraceRuleTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _check_set_equality(self, generated, used, rule_map, ignored_set):
         x = generated - used
         y = used - generated
@@ -339,19 +348,6 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
                     lambda msg: f"{msg}\n{m} from trace_rules.MOD_INLINELIST/LEGACY_MOD_INLINELIST "
                     "is not a python module, please check and correct it.",
                 )
-
-    @unittest.skipUnless(TEST_XPU or TEST_CUDA, "GPU is not available")
-    def test_gpu_manual_seed_functions_graph_break(self):
-        for name in (
-            f"torch.{GPU_TYPE}.manual_seed",
-            f"torch.{GPU_TYPE}.manual_seed_all",
-            f"torch.{GPU_TYPE}.random.manual_seed",
-            f"torch.{GPU_TYPE}.random.manual_seed_all",
-        ):
-            self.assertIs(
-                torch._dynamo.trace_rules.lookup(load_object(name)),
-                SkipFunctionVariable,
-            )
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/114831")
     @unittest.skip(
@@ -523,6 +519,8 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
 
 
 class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @unittest.skipIf(
         not torch.distributed.is_available(),
         "need to import MLP module from distributed",
@@ -544,7 +542,26 @@ class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):
         )
 
 
+class TraceRuleTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_gpu_manual_seed_functions_graph_break(self, device):
+        for name in (
+            f"torch.{GPU_TYPE}.manual_seed",
+            f"torch.{GPU_TYPE}.manual_seed_all",
+            f"torch.{GPU_TYPE}.random.manual_seed",
+            f"torch.{GPU_TYPE}.random.manual_seed_all",
+        ):
+            self.assertIs(
+                torch._dynamo.trace_rules.lookup(load_object(name)),
+                SkipFunctionVariable,
+            )
+
+
 class SingleOpCompileTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_top_level_torch_exp_compiles_through_dynamo(self):
         x = torch.randn(4)
 
@@ -568,6 +585,9 @@ class SingleOpCompileTests(torch._dynamo.test_case.TestCase):
         )
         # Numerical results should match
         self.assertTrue(torch.allclose(y_lambda, y_exp))
+
+
+instantiate_device_type_tests(TraceRuleTestsDevice, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -28,12 +28,11 @@ from torch._dynamo.variables import (
     TorchInGraphFunctionVariable,
     UserFunctionVariable,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
+    HardwareClassification,
     skipIfWindows,
-    TEST_CUDA,
-    TEST_XPU,
+    skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE
 
@@ -314,6 +313,8 @@ def gen_allowed_objs_and_ids(record=False, c_binding_only=True) -> AllowedObject
 
 
 class TraceRuleTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _check_set_equality(self, generated, used, rule_map, ignored_set):
         x = generated - used
         y = used - generated
@@ -345,19 +346,6 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
                     lambda msg: f"{msg}\n{m} from trace_rules.MOD_INLINELIST/LEGACY_MOD_INLINELIST "
                     "is not a python module, please check and correct it.",
                 )
-
-    @unittest.skipUnless(TEST_XPU or TEST_CUDA, "GPU is not available")
-    def test_gpu_manual_seed_functions_graph_break(self):
-        for name in (
-            f"torch.{GPU_TYPE}.manual_seed",
-            f"torch.{GPU_TYPE}.manual_seed_all",
-            f"torch.{GPU_TYPE}.random.manual_seed",
-            f"torch.{GPU_TYPE}.random.manual_seed_all",
-        ):
-            self.assertIs(
-                torch._dynamo.trace_rules.lookup(load_object(name)),
-                SkipFunctionVariable,
-            )
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/114831")
     @unittest.skip(
@@ -434,21 +422,6 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
             ref = fn(x)
             res = opt_fn(x)
             self.assertEqual(ref, res)
-
-    @parametrize("device", ("cuda", torch.device("cuda")))
-    def test_is_compile_supported_constant(self, device):
-        def fn(x, device):
-            if is_compile_supported(device):
-                return x + 1
-            else:
-                return x - 1
-
-        x = torch.rand(3)
-        expected = x + 1 if is_compile_supported(device) else x - 1
-        cnt = CompileCounter()
-        opt_fn = torch.compile(backend=cnt, fullgraph=True)(fn)
-        self.assertEqual(expected, opt_fn(x, device))
-        self.assertEqual(cnt.frame_count, 1)
 
     def test_force_inline_custom_function(self):
         mod, func = create_dummy_module_and_function()
@@ -545,6 +518,8 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
 
 
 class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @unittest.skipIf(
         not torch.distributed.is_available(),
         "need to import MLP module from distributed",
@@ -566,7 +541,40 @@ class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):
         )
 
 
+class TraceRuleTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_gpu_manual_seed_functions_graph_break(self, device):
+        for name in (
+            f"torch.{GPU_TYPE}.manual_seed",
+            f"torch.{GPU_TYPE}.manual_seed_all",
+            f"torch.{GPU_TYPE}.random.manual_seed",
+            f"torch.{GPU_TYPE}.random.manual_seed_all",
+        ):
+            self.assertIs(
+                torch._dynamo.trace_rules.lookup(load_object(name)),
+                SkipFunctionVariable,
+            )
+
+    @skipIfXpu
+    def test_is_compile_supported_constant(self, device):
+        def fn(x, device):
+            if is_compile_supported(device):
+                return x + 1
+            else:
+                return x - 1
+
+        x = torch.rand(3)
+        expected = x + 1 if is_compile_supported(device) else x - 1
+        cnt = CompileCounter()
+        opt_fn = torch.compile(backend=cnt, fullgraph=True)(fn)
+        self.assertEqual(expected, opt_fn(x, device))
+        self.assertEqual(cnt.frame_count, 1)
+
+
 class SingleOpCompileTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_top_level_torch_exp_compiles_through_dynamo(self):
         x = torch.randn(4)
 
@@ -592,7 +600,9 @@ class SingleOpCompileTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(torch.allclose(y_lambda, y_exp))
 
 
-instantiate_parametrized_tests(TraceRuleTests)
+instantiate_device_type_tests(
+    TraceRuleTestsDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_tree_map.py
+++ b/test/dynamo/test_tree_map.py
@@ -9,6 +9,7 @@ import torch._dynamo
 import torch.utils._pytree as python_pytree
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     subtest,
@@ -129,6 +130,8 @@ def _assert_trees_allclose(test_case: TestCase, ref, res) -> None:
 
 @instantiate_parametrized_tests
 class TreeMapCompileTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()
@@ -1119,6 +1122,8 @@ class TreeMapCompileTests(TestCase):
 
 @instantiate_parametrized_tests
 class TreeMapWithPathCompileTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()


### PR DESCRIPTION
## Summary

This PR makes `test/dynamo/test_trace_rules.py` and `test/dynamo/test_tree_map.py` device-generic by replacing hardcoded CUDA/XPU assumptions with `HardwareClassification` labels and extracting GPU-specific tests into a device-parameterized class.

## Changes

- **test/dynamo/test_trace_rules.py**:
  - Deleted `TEST_CUDA`/`TEST_XPU`/`GPU_TYPE`, imports `instantiate_device_type_tests` and `HardwareClassification`.
  - Added `hw_classification = HardwareClassification.GENERIC` to `TraceRuleTests`, `TestModuleSurviveSkipFiles`, and `SingleOpCompileTests`.
  - Added `TraceRuleTestsDevice` (HardwareClassification.ACCELERATOR) with `test_manual_seed_functions_graph_break(self, device)`, which derives the device name from `torch.device(device).type`, and instantiated it with `instantiate_device_type_tests(..., only_for=("cuda", "xpu"), allow_xpu=True)`.

- **test/dynamo/test_tree_map.py**:
  - Added `HardwareClassification` import.
  - Added `hw_classification = HardwareClassification.GENERIC` to `TreeMapCompileTests` and `TreeMapWithPathCompileTests`.

## Test plan

`python test/dynamo/test_trace_rules.py --hw-classification GENERIC -v`
`python test/dynamo/test_trace_rules.py --hw-classification ACCELERATOR -v`
`python test/dynamo/test_tree_map.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590