### PR TITLE
[fsdp2] CPUOffloadPolicy per-phase stashing (offload_after_forward/backward)

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_api.py
@@ -194,6 +194,18 @@ class CPUOffloadPolicy(OffloadPolicy):
             and for the copies to overlap with compute. However, the pinned
             memory cannot be used by other processes. Set this to ``False`` if
             you have insufficient CPU memory. (Default: ``True``)
+        offload_after_forward (bool): Whether to stash the sharded parameter
+            back to CPU after forward (freeing device memory during the
+            forward-to-backward window). If ``False``, the sharded parameter
+            is kept on the compute device after forward. (Default: ``True``)
+        offload_after_backward (bool): Whether to offload the sharded
+            parameter and gradient to CPU after backward, so the optimizer
+            step runs on CPU. If ``False``, the sharded parameter and gradient
+            are kept on the compute device after backward, so the optimizer
+            step runs on the compute device (e.g. to use a device-only fused
+            optimizer). (Default: ``True``)
     """
 
     pin_memory: bool = True
+    offload_after_forward: bool = True
+    offload_after_backward: bool = True

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -708,7 +708,7 @@ def foreach_reduce(
                 storage_offset=flat_grad_offset,
             )
             to_accumulate_grad = fsdp_param.sharded_param.grad is not None
-            if fsdp_param.offload_to_cpu:
+            if fsdp_param.offload_to_cpu and fsdp_param.offload_after_backward:
                 # Only overlap the D2H copy (copying to pinned memory) when no
                 # in-backward CPU consumer of the grad exists. Two such
                 # consumers suppress the overlap:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -229,6 +229,18 @@ class FSDPParam:
         self.pin_memory = (
             self.offload_to_cpu and cast(CPUOffloadPolicy, offload_policy).pin_memory
         )
+        # Per-phase stashing: whether to move the sharded param home back to
+        # CPU after forward / backward. Both default True == legacy behavior
+        # (home always on CPU). Setting offload_after_backward=False keeps the
+        # sharded param + grad on the compute device for a device-side optimizer.
+        self.offload_after_forward: bool = (
+            self.offload_to_cpu
+            and cast(CPUOffloadPolicy, offload_policy).offload_after_forward
+        )
+        self.offload_after_backward: bool = (
+            self.offload_to_cpu
+            and cast(CPUOffloadPolicy, offload_policy).offload_after_backward
+        )
         self.grad_offload_event: torch.Event | None = None
         self._init_sharded_param(param, device, shard_placement_fn, mesh_info)
         if self.post_forward_mesh_info:
@@ -342,7 +354,15 @@ class FSDPParam:
             padded_sharded_param.narrow(
                 dim=shard_dim, start=0, length=sharded_param.size(shard_dim)
             ).copy_(sharded_param)
-        if self.offload_to_cpu and not padded_sharded_param.is_meta:
+        # The sharded param's resting device is CPU only when it is offloaded
+        # after backward. With offload_after_backward=False it rests on the
+        # compute device (so an eager-initialized / device-side optimizer sees a
+        # device param) and is only transiently stashed to CPU after forward.
+        if (
+            self.offload_to_cpu
+            and self.offload_after_backward
+            and not padded_sharded_param.is_meta
+        ):
             padded_sharded_param = padded_sharded_param.cpu()
             if self.pin_memory:
                 padded_sharded_param = padded_sharded_param.pin_memory()
@@ -1275,7 +1295,11 @@ class FSDPParam:
             )
             local_tensor = padded_local_tensor
             updated_local_tensor = True
-        if self.pin_memory and not local_tensor.is_pinned():
+        if (
+            self.offload_after_backward
+            and self.pin_memory
+            and not local_tensor.is_pinned()
+        ):
             local_tensor = local_tensor.cpu().pin_memory()
             updated_local_tensor = True
         if not same_local_tensor:
@@ -1292,6 +1316,53 @@ class FSDPParam:
                     "Expected sharded_param._local_tensor to be contiguous"
                 )
         self._sharding_spec = self.sharded_param._spec
+
+    @torch.no_grad()
+    def _ensure_sharded_param_device(self, device: torch.device) -> None:
+        """Move the sharded parameter's home storage to ``device`` for per-phase
+        stashing (CPU offload). No-op unless CPU offload is enabled and a real
+        device change is needed. Rebuilds the DTensor local-tensor view and
+        sharding spec, mirroring ``reset_sharded_param``.
+
+        Only the default plain-tensor path is supported. Tensor subclasses /
+        all-gather extensions (with ``fsdp_pre_all_gather``) are not supported:
+        if a real device migration is required for one, we fail fast rather than
+        silently leaving the sharded param on the wrong device (which would later
+        crash the optimizer step with a device mismatch).
+        """
+        if not self.offload_to_cpu:
+            return
+        local_tensor = self._sharded_param_data
+        if local_tensor.is_meta or local_tensor.device.type == device.type:
+            return
+        if type(local_tensor) is not torch.Tensor:
+            raise NotImplementedError(
+                "Per-phase CPU offload stashing (offload_after_forward / "
+                "offload_after_backward) does not support tensor subclasses / "
+                "all-gather extensions. Use the defaults "
+                "(offload_after_forward=True, offload_after_backward=True) or "
+                "plain-tensor parameters."
+            )
+        shard_dim = self.fsdp_placement.dim
+        padded = local_tensor.view(self.padded_sharded_param_size).to(
+            device, non_blocking=True
+        )
+        if device.type == "cpu" and self.pin_memory:
+            padded = padded.pin_memory()
+        self._sharded_param_data = padded.view(-1)
+        cur_local = cast(DTensor, self.sharded_param)._local_tensor
+        length = cur_local.size(shard_dim) if cur_local.numel() > 0 else 0
+        new_local = padded.narrow(dim=shard_dim, start=0, length=length)
+        # Change BOTH the outer DTensor wrapper device (via ``.data``, so grad
+        # assignment / device checks see the new device and the Parameter object
+        # identity is preserved for the optimizer) AND the inner ``_local_tensor``
+        # (so the foreach optimizer math on the local shard runs on the new
+        # device). Setting only one leaves a half-migrated param: ``.data`` alone
+        # keeps a stale CPU local tensor; ``._local_tensor`` alone keeps a stale
+        # CPU wrapper device.
+        self.sharded_param.data = self.to_sharded_dtensor(new_local)
+        cast(DTensor, self.sharded_param)._local_tensor = new_local
+        self._sharding_spec = cast(DTensor, self.sharded_param)._spec
 
     def __repr__(self):
         return f"FSDPParam(fqn={self._param_fqn}, orig_size={self._orig_size})"

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -578,6 +578,14 @@ class FSDPParamGroup:
             if not is_bw():
                 self.reshard()
                 self._record_post_forward()
+                # Per-phase CPU-offload stashing: move the sharded param home
+                # to CPU (free device memory in the fwd->bwd window) or keep it
+                # on the compute device, per ``offload_after_forward``.
+                cpu_device = torch.device("cpu")
+                for fsdp_param in self.fsdp_params:
+                    fsdp_param._ensure_sharded_param_device(
+                        cpu_device if fsdp_param.offload_after_forward else self.device
+                    )
             self._training_state = TrainingState.IDLE
             return output
 
@@ -620,6 +628,14 @@ class FSDPParamGroup:
                 and self._training_state == TrainingState.FORWARD  # partial path taken
             )
             self._training_state = TrainingState.POST_BACKWARD
+            # Per-phase CPU-offload: when keeping the sharded param on device after
+            # backward (offload_after_backward=False), promote it to device BEFORE
+            # the gradient is assigned in foreach_reduce, so the (device) sharded
+            # grad lands on a (device) sharded param. It stays on device through the
+            # optimizer step and is stashed back to CPU after the next forward.
+            for fsdp_param in self.fsdp_params:
+                if not fsdp_param.offload_after_backward:
+                    fsdp_param._ensure_sharded_param_device(self.device)
             with record_function(self._with_fqn("FSDP::post_backward_accumulate")):
                 for fsdp_param in self.fsdp_params:
                     fsdp_param.accumulate_unsharded_grad_if_needed()
@@ -1075,7 +1091,8 @@ class FSDPParamGroup:
         fsdp_params_not_on_cpu = [
             fsdp_param
             for fsdp_param in self.fsdp_params
-            if fsdp_param.sharded_param.device.type != "cpu"
+            if fsdp_param.offload_after_backward
+            and fsdp_param.sharded_param.device.type != "cpu"
         ]
         if fsdp_params_not_on_cpu:
             raise RuntimeError(


### PR DESCRIPTION
Summary:
Adds two flags to FSDP2 `CPUOffloadPolicy` so the sharded parameter can be stashed to CPU per phase instead of always: `offload_after_forward` (stash after forward, freeing device memory during the forward->backward activation-peak window) and `offload_after_backward` (offload param+grad to CPU after backward so the optimizer step runs on CPU). Both default `True` == legacy behavior, so this is a pure additive change.

The motivating case is FSDP2 cpu_offload + a device-side fused optimizer (e.g. `FusedAdamDTensorV2`, Shampoo), which crashed at train-module creation: `Attempted to set the storage of a tensor on device "cpu" to a storage on different device "cuda:0"` from `torch.zeros_like(p.data)` in the optimizer's eager state init, because the sharded param DTensor was on CPU while its mesh expected cuda. Setting `offload_after_backward=False` keeps the sharded param + grad on the compute device after backward (and at rest, so eager optimizer-state init sees a device param), while `offload_after_forward=True` still frees it during the fwd->bwd window.

Implementation notes:
- `_ensure_sharded_param_device` migrates the sharded param in place changing BOTH the outer DTensor wrapper device (via `.data`, preserving Parameter identity for the optimizer) AND the inner `_local_tensor`; changing only one leaves a half-migrated param that fails grad-assign (stale wrapper device) or the foreach optimizer math (stale local device).
- The device promotion for `offload_after_backward=False` runs in `post_backward` BEFORE `foreach_reduce` assigns the grad, not in `finalize_backward` (too late).
- The forced-CPU spots (`_init_sharded_param`, `reset_sharded_param`, `_validate_cpu_offload_params`) are gated on `offload_after_backward` so the resting device is the compute device when it is `False`.
- fbcode and xplat caffe2 mirrors are updated identically (byte-for-byte).

Test Plan:
- micro_run smoke (FSDP2 + mlp + 2 GPU): legacy `--cpu-offload` and new `--cpu-offload --no-offload-after-backward` both complete 3 iters clean; `--eager-optim-state` (mimics APF eager optim init) also clean.
- The stacked APF wiring diff D114822475 exercises these flags end-to-end: real flow f1093954539 shrunk + `local_mp_random` + production `FusedAdamDTensorV2` ran to completion (100 batches, SUCCEEDED); the original device-mismatch crash no longer occurs.

Differential Revision: D114822119


