### PR TITLE
[Testcase Refactoring] Tag TestFullyShardSpmdTypes with hw_classification

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -15,7 +15,11 @@ from torch.distributed.fsdp._fully_shard._fsdp_init import _get_mesh_info
 from torch.distributed.tensor import init_device_mesh, Replicate, Shard
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
@@ -81,6 +85,14 @@ class DenseSparseParams(nn.Module):
 
 @unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
 class TestFullyShardSpmdTypes(TestCase):
+    # These tests check how FSDP propagates spmd_types annotations, which is
+    # bookkeeping the device never participates in: the process group is the
+    # fake backend and every mesh below is built on "cpu". Nothing here reads
+    # or writes accelerator memory, so the class is GENERIC rather than
+    # ACCELERATOR, and it is deliberately not passed to
+    # `instantiate_device_type_tests` -- there is no device to parametrize on.
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -15,6 +15,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_init import _get_mesh_info
 from torch.distributed.tensor import init_device_mesh, Replicate, Shard
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -90,8 +91,7 @@ class TestFullyShardSpmdTypes(TestCase):
     # "cpu" rather than derived from whatever accelerator is present, so this
     # is CPU-specific by construction, not device-agnostic framework logic --
     # GENERIC is for things like the Dynamo dispatcher that do not reference
-    # any device at all. It is deliberately not passed to
-    # `instantiate_device_type_tests` -- there is no device to parametrize on.
+    # any device at all.
     hw_classification = HardwareClassification.CPU
 
     @classmethod
@@ -128,7 +128,7 @@ class TestFullyShardSpmdTypes(TestCase):
             dist.destroy_process_group()
         super().tearDownClass()
 
-    def test_restores_param_spmd_type_for_compute(self):
+    def test_restores_param_spmd_type_for_compute(self, device):
         """FSDP restores user SPMD metadata on params for compute.
 
         FSDP should preserve the compute-mesh annotations when applied with
@@ -245,7 +245,7 @@ class TestFullyShardSpmdTypes(TestCase):
                     2,
                 )
 
-    def test_full_param_annotations_do_not_require_init_compute_mesh(self):
+    def test_full_param_annotations_do_not_require_init_compute_mesh(self, device):
         """Full per-axis annotations are enough without an init compute mesh."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)
 
@@ -286,7 +286,7 @@ class TestFullyShardSpmdTypes(TestCase):
                 {self.dp_axis: spmd.P, self.cp_axis: spmd.P, self.tp_axis: spmd.I},
             )
 
-    def test_local_v_param_requires_partition_spec(self):
+    def test_local_v_param_requires_partition_spec(self, device):
         """Local-only V@TP params are ambiguous for FSDP.
 
         Without PartitionSpec shard info, FSDP cannot choose the matching
@@ -320,7 +320,7 @@ class TestFullyShardSpmdTypes(TestCase):
             """Cannot convert plain Varying to a DTensor placement. Use S(dim) to specify which tensor dimension is sharded.""",
         )
 
-    def test_partial_param_annotations_infer_fsdp_axes_at_init(self):
+    def test_partial_param_annotations_infer_fsdp_axes_at_init(self, device):
         """Use init-time current_mesh to infer omitted FSDP axes as R.
 
         Params annotate only TP; FSDP fills DP/CP axes during fully_shard().
@@ -361,7 +361,7 @@ class TestFullyShardSpmdTypes(TestCase):
                 {self.dp_axis: spmd.P, self.cp_axis: spmd.P, self.tp_axis: spmd.I},
             )
 
-    def test_mixed_dense_sparse_params_use_per_param_restore_meshes(self):
+    def test_mixed_dense_sparse_params_use_per_param_restore_meshes(self, device):
         """
         Test restoring per-param dense and sparse type meshes.
 
@@ -434,7 +434,7 @@ class TestFullyShardSpmdTypes(TestCase):
             ),
         )
 
-    def test_spmd_params_require_dp_mesh_dims(self):
+    def test_spmd_params_require_dp_mesh_dims(self, device):
         """Require explicit DP mesh axes before FSDP handles spmd_types params."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)
 
@@ -458,7 +458,7 @@ class TestFullyShardSpmdTypes(TestCase):
             "replicates across.",
         )
 
-    def test_fully_annotated_sparse_param_requires_sparse_storage_mesh(self):
+    def test_fully_annotated_sparse_param_requires_sparse_storage_mesh(self, device):
         """Fully-annotated sparse param + dense FSDP mesh errors out."""
         model = nn.Linear(16, 16, bias=False)
         spmd.assert_type(
@@ -486,7 +486,7 @@ class TestFullyShardSpmdTypes(TestCase):
             "the FSDP DP mesh.",
         )
 
-    def test_spmd_restore_mesh_must_contain_annotated_axes(self):
+    def test_spmd_restore_mesh_must_contain_annotated_axes(self, device):
         """Partial TP annotations w/ sparse current_mesh context fail."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)
         spmd.assert_type(model.unsharded_weight, {self.tp_axis: spmd.I})
@@ -509,7 +509,7 @@ class TestFullyShardSpmdTypes(TestCase):
         )
         self.assertIn("Annotate only axes in the compute mesh", str(cm.exception))
 
-    def test_partial_non_storage_annotations_require_current_mesh(self):
+    def test_partial_non_storage_annotations_require_current_mesh(self, device):
         """Partial non-storage annotations need a shared current mesh."""
         model = nn.Linear(16, 16, bias=False)
         spmd.assert_type(model.weight, {self.ep_axis: spmd.S(0)})
@@ -535,7 +535,7 @@ class TestFullyShardSpmdTypes(TestCase):
             "mesh_dp_shard, mesh_cp, mesh_tp).",
         )
 
-    def test_partial_param_annotations_missing_non_fsdp_axis_errors(self):
+    def test_partial_param_annotations_missing_non_fsdp_axis_errors(self, device):
         """Require annotations for storage axes that FSDP does not manage."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)
 
@@ -569,7 +569,7 @@ class TestFullyShardSpmdTypes(TestCase):
             "(mesh_tp,).",
         )
 
-    def test_fsdp_dp_axes_must_be_r(self):
+    def test_fsdp_dp_axes_must_be_r(self, device):
         """FSDP-managed DP axes must be Replicate in spmd_types annotations."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)
 
@@ -599,5 +599,6 @@ class TestFullyShardSpmdTypes(TestCase):
         )
 
 
+instantiate_device_type_tests(TestFullyShardSpmdTypes, globals(), only_for="cpu")
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -85,13 +85,14 @@ class DenseSparseParams(nn.Module):
 
 @unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
 class TestFullyShardSpmdTypes(TestCase):
-    # These tests check how FSDP propagates spmd_types annotations, which is
-    # bookkeeping the device never participates in: the process group is the
-    # fake backend and every mesh below is built on "cpu". Nothing here reads
-    # or writes accelerator memory, so the class is GENERIC rather than
-    # ACCELERATOR, and it is deliberately not passed to
+    # These tests check how FSDP propagates spmd_types annotations. The
+    # process group is the fake backend and every mesh below is hard-coded to
+    # "cpu" rather than derived from whatever accelerator is present, so this
+    # is CPU-specific by construction, not device-agnostic framework logic --
+    # GENERIC is for things like the Dynamo dispatcher that do not reference
+    # any device at all. It is deliberately not passed to
     # `instantiate_device_type_tests` -- there is no device to parametrize on.
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.CPU
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

Classify `TestFullyShardSpmdTypes` in `test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py` as CPU-specific and instantiate its tests for CPU.

## Motivation

The class tests how `fully_shard` propagates `spmd_types` annotations. It uses a fake process group and explicitly constructs CPU device meshes. Its hardware classification is therefore `CPU`, rather than `GENERIC` or `ACCELERATOR`.

## Changes

- Add `hw_classification = HardwareClassification.CPU`.
- Instantiate the class with `instantiate_device_type_tests(..., only_for="cpu")`.
- Add the framework-injected `device` parameter to each test method.
- Preserve the existing CPU meshes, fake backend, assertions, and `spmd_types` availability gate.

No accelerator capability declarations or distributed test-base changes are introduced.

## Validation

With `spmd_types` available, targeted validation ran all 11 CPU tests successfully with no skips.

Without `spmd_types`, the existing availability gate skips the tests. Such skips do not establish functional test coverage.

See the Checks tab for CI results.

## Dependencies

No dependency on an unmerged PR. Executing the test bodies requires the existing `spmd_types` environment dependency.

Part of #185590.