### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_subgraph_rewriter.py

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -13,6 +13,7 @@ from torch.fx.experimental.rewriter import RewritingTracer
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.jit_utils import JitTestCase
 
 
@@ -39,6 +40,8 @@ def wrapped_gemm_bias_mul_with_c(a, b, bias, c):
 
 
 class TestSubgraphRewriter(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_subgraph_rewriter_preserves_logic(self):
         class M(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestSubgraphRewriter as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/fx/test_subgraph_rewriter.py : import HardwareClassification, and add hw_classification to TestSubgraphRewriter classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_subgraph_rewriter.py

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.