### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_source_matcher_utils.py

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -16,6 +16,7 @@ from torch.fx.passes.utils.source_matcher_utils import (
     get_source_partitions,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     raise_on_run_directly,
@@ -29,6 +30,8 @@ def _get_node_names(nodes: list[torch.fx.Node]) -> list[str]:
 
 
 class TestSourceMatcher(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_module_partitioner_linear_relu_linear(self):
         class M(torch.nn.Module):


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestSourceMatcher as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/fx/test_source_matcher_utils.py : import HardwareClassification, and add hw_classification to TestSourceMatcher classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_source_matcher_utils.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.