### PR TITLE
[Testcase Refactoring] Add hw_classification in test/higher_order_ops/test_local_map.py

### DIFF
--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -30,6 +30,7 @@ if torch.distributed.is_available():
     from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_CROSSREF,
     TEST_WITH_TORCHDYNAMO,
@@ -216,6 +217,8 @@ def get_local_mapped_functions(mesh):
 
 
 class TestLocalMap(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestLocalMap as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/higher_order_ops/test_local_map.py : import HardwareClassification, and add hw_classification to TestLocalMap classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/higher_order_ops/test_local_map.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.