### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_hop_infra.py

### DIFF
--- a/test/test_hop_infra.py
+++ b/test/test_hop_infra.py
@@ -4,7 +4,12 @@ import importlib
 import pkgutil
 
 import torch
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 from torch.testing._internal.hop_db import (
     FIXME_hop_that_doesnt_have_opinfo_test_allowlist,
     hop_db,
@@ -24,6 +29,8 @@ do_imports()
 
 @skipIfTorchDynamo("not applicable")
 class TestHOPInfra(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_all_hops_have_opinfo(self):
         """All HOPs should have an OpInfo in torch/testing/_internal/hop_db.py"""
         from torch._ops import _higher_order_ops


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestHOPInfra as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/test_hop_infra.py : import HardwareClassification, and add hw_classification to TestHOPInfra classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_hop_infra.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.