### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_fx_passes.py

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -14,7 +14,12 @@ from torch.fx.passes.operator_support import OperatorSupport
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions, topo_sort
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 
-from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 from torch.testing._internal.jit_utils import JitTestCase
 
 logging.basicConfig(level=logging.WARNING)
@@ -297,6 +302,7 @@ class MockOperatorSupport(OperatorSupport):
 
 @instantiate_parametrized_tests
 class TestFXGraphPasses(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize("fn, expected_partition, bookend_non_compute_pass", [
         (TestPartitionFunctions.forward1, [["add_7", "add_6"], ["add_5", "add_4", "add_3"], ["add_2", "add_1", "add"]], False),
@@ -1143,6 +1149,7 @@ class NoAnchorFound:
 
 @instantiate_parametrized_tests
 class TestFXMatcherUtils(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize("test_model", [
         SingleNodePattern,


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestFXGraphPasses, TestFXMatcherUtils as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/test_fx_passes.py : import HardwareClassification, and add hw_classification to TestFXGraphPasses, TestFXMatcherUtils classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_fx_passes.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.