### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_fx_gragh_print.py

### DIFF
--- a/test/test_fx_graph_print.py
+++ b/test/test_fx_graph_print.py
@@ -3,11 +3,13 @@
 import torch
 from torch.fx import symbolic_trace
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, HardwareClassification
 
 
 class TestFxGraphPrint(TestCase):
     """Tests for GraphModule.print_readable() with additional_meta."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_print_readable_with_list_of_meta_keys(self):
         """Test print_readable with a list of meta keys to include."""

--- a/test/test_fx_graph_print.py
+++ b/test/test_fx_graph_print.py
@@ -3,7 +3,11 @@
 import torch
 from torch.fx import symbolic_trace
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import run_tests, TestCase, HardwareClassification
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestFxGraphPrint(TestCase):


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestFxGraphPrint as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/test_fx_graph_print.py : import HardwareClassification, and add hw_classification to TestFxGraphPrint classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_fx_graph_print.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.