### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_const_fold.py

### DIFF
--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -6,10 +6,16 @@ import torch
 import torch.fx
 from torch.fx.experimental import const_fold
 from torch.fx.passes.shape_prop import _extract_tensor_metadata, ShapeProp
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class TestConstFold(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_attr(self, node):
         mod = node.graph.owning_module
         target = str(node.target)


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestConstFoldclass, enabling hardware-based test classification and filtering.

## Changes
test/fx/test_fx_const_fold.py : import HardwareClassification and add hw_classification to TestConstFoldclass。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python test/fx/test_fx_const_fold.py

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian