### PR TITLE
Route MPS tensors through linalg.vector_norm in torch.norm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1359,6 +1359,15 @@ class TestLinalg(TestCase):
                             norm_dtype)
 
 
+    def test_norm_fast_path_requires_vector_norm_kernel(self):
+        # torch.norm only reroutes to linalg.vector_norm on the backends listed
+        # in torch/functional.py. That list cannot be replaced by a plain layout
+        # check: 'fro' reaches every backend today through composite
+        # frobenius_norm, while linalg.vector_norm needs a real kernel.
+        has_kernel = torch._C._dispatch_has_kernel_for_dispatch_key
+        self.assertTrue(has_kernel("aten::frobenius_norm.dim", "CompositeImplicitAutograd"))
+        self.assertFalse(has_kernel("aten::linalg_vector_norm", "CompositeImplicitAutograd"))
+
     def test_vector_norm_decom_unbacked_checks(self):
         from torch._refs.linalg import _check_vector_norm_args
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2656,6 +2656,40 @@ class TestMPS(TestCaseMPS):
         res_cpu = torch.norm(d_cpu[0, :, :]), torch.norm(d_cpu[1, :, :])
         self.assertEqual(res, res_cpu)
 
+    @parametrize("dtype", [torch.float32, torch.complex64])
+    @parametrize("p", [None, 1, 2, 0.5, float('inf'), float('-inf'), 'fro', 'nuc'])
+    def test_norm_matches_cpu(self, dtype, p):
+        # torch.norm reroutes strided inputs to linalg.vector_norm/matrix_norm.
+        # MPS used to be excluded, which left it on the legacy path with its own
+        # dtype handling and a different default dim for 'nuc'. Errors are part
+        # of the contract here, so mirror whatever CPU does.
+        for shape in [(4, 4), (2, 4, 4)]:
+            c = torch.randn(shape, dtype=dtype)
+            m = c.to("mps")
+            for dim, keepdim in itertools.product([None, 0, [0, 1]], [False, True]):
+                kwargs = {"p": p, "dim": dim, "keepdim": keepdim, "dtype": dtype}
+                try:
+                    expected = torch.norm(c, **kwargs)
+                except Exception as exc:
+                    with self.assertRaises(type(exc)):
+                        torch.norm(m, **kwargs)
+                else:
+                    self.assertEqual(torch.norm(m, **kwargs).cpu(), expected)
+
+    def test_norm_dtype_conversion_matches_cpu(self):
+        c = torch.randn(4, 4, dtype=torch.float16)
+        m = c.to("mps")
+        for p in [2, 'fro']:
+            self.assertEqual(
+                torch.norm(m, p=p, dtype=torch.float32).cpu(),
+                torch.norm(c, p=p, dtype=torch.float32),
+            )
+        out_mps = torch.empty((), dtype=torch.float32, device="mps")
+        out_cpu = torch.empty((), dtype=torch.float32)
+        torch.norm(m, p=2, dtype=torch.float32, out=out_mps)
+        torch.norm(c, p=2, dtype=torch.float32, out=out_cpu)
+        self.assertEqual(out_mps.cpu(), out_cpu)
+
     def test_linalg_vector_norm(self):
         x_mps = torch.tensor([0, 0, 0, 2, 3], dtype=torch.float, device="mps")
         x_cpu = x_mps.detach().clone().cpu()

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1840,11 +1840,12 @@ def norm(
     # NB. All the repeated code and weird python is to please TorchScript.
     #     For a more compact implementation see the relevant function in `_refs/__init__.py`
 
-    # We don't do this for MPS or sparse tensors
+    # Only for strided tensors on backends that have a linalg.vector_norm kernel
     if input.layout == torch.strided and input.device.type in (
         "cpu",
         "cuda",
         "xpu",
+        "mps",
         "meta",
         torch.utils.backend_registration._privateuse1_backend_name,
     ):


### PR DESCRIPTION
Description drafted with an AI assistant, quoted below; I've reviewed the change.

> `torch.norm` reroutes strided inputs to `linalg.vector_norm`/`linalg.matrix_norm`, but MPS was excluded when that landed (#84624) because MPS had no `linalg.vector_norm` kernel. It has one now, so the carve-out only keeps MPS on the legacy path with divergent behavior:
>
> ```python
> c = torch.randn(3, 3, dtype=torch.complex64, device="mps")
> c.norm(2, [0, 1], False, dtype=torch.complex64)
> # RuntimeError: Expected out tensor to have dtype float, but got c10::complex<float>
> # CPU/CUDA: returns float32
> ```
>
> `'fro'` likewise rejected `dtype` outright on MPS while accepting it on CPU.
>
> **BC-breaking:** `torch.norm(x, 'nuc')` with `x.ndim > 2` now raises on MPS instead of returning a batched nuclear norm, matching CPU. The legacy path defaulted to `dim={-2, -1}`, while the linalg path forwards every dim and `matrix_norm` requires exactly two. This only became reachable when MPS gained SVD in #185954.

## Test plan

The added test mirrors CPU results *and* errors across `p` x `dim` x `keepdim` x `dtype` for `float32`/`complex64` at both 2-D and 3-D, so the `'nuc'` change above is asserted rather than implicit. A second test covers a real dtype conversion (`float16` -> `float32`) and the `out=` overload.

```
python test/test_mps.py -k test_norm
```
