### PR TITLE
[Testcase Refactoring] Split DeterministicTest and migrate to HAS_TRITON guards

### DIFF
--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -12,24 +12,26 @@ import torch._inductor.config as inductor_config
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
     skipIfRocm,
 )
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU_AND_TRITON,
-    IS_BIG_GPU,
-)
+from torch.testing._internal.inductor_utils import HAS_TRITON, IS_BIG_GPU
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 
 
 @instantiate_parametrized_tests
-class DeterministicTest(TestCase):
+class DeterministicTestGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self._exit_stack = contextlib.ExitStack()
@@ -47,117 +49,6 @@ class DeterministicTest(TestCase):
                 self.assertEqual(inductor_config.deterministic, new_val)
         finally:
             torch.use_deterministic_algorithms(old_val, warn_only=True)
-
-    @parametrize("deterministic", [False, True])
-    def test_mm_padding(self, deterministic):
-        with inductor_config.patch(deterministic=deterministic):
-
-            @torch.compile()
-            def foo(x, y):
-                return x @ y
-
-            inps = [torch.rand([2049, 2049], device=GPU_TYPE) for _ in range(2)]
-            out = foo(*inps)
-            self.assertEqual(out, inps[0] @ inps[1])
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["pad_mm_bench"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["pad_mm_bench"] > 0)
-
-    @parametrize("deterministic", [False, True])
-    @inductor_config.patch(max_autotune=True)
-    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
-    def test_max_autotune(self, deterministic):
-        with inductor_config.patch(deterministic=deterministic):
-
-            @torch.compile()
-            def foo(x, y):
-                return x @ y
-
-            inps = [torch.rand([2048, 2048], device=GPU_TYPE) for _ in range(2)]
-            out = foo(*inps)
-            self.assertEqual(out, inps[0] @ inps[1])
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] > 0)
-
-    def test_pointwise_coordesc_tuning(self):
-        @torch.compile(mode="max-autotune")
-        def f(x):
-            return x + 1
-
-        x = torch.randn(2048, device=GPU_TYPE)
-        self.assertEqual(f(x), x + 1)
-
-        self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
-
-    @parametrize("deterministic", [False, True])
-    def test_reduction_coordesc_tuning(self, deterministic):
-        with inductor_config.patch(
-            deterministic=deterministic, coordinate_descent_tuning=True
-        ):
-
-            @torch.compile()
-            def foo(x):
-                return x.sum(dim=-1)
-
-            inp = torch.rand([2048, 2048], device=GPU_TYPE)
-
-            out = foo(inp)
-            self.assertEqual(out, inp.sum(dim=-1))
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
-
-    @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU + Triton")
-    @inductor_config.patch(batch_invariant=True)
-    def test_persistent_reduction_batch_invariance(self):
-        H = 768
-        FULL = 1024
-
-        def fn(x, w, b):
-            return torch.nn.functional.layer_norm(x, (H,), weight=w, bias=b)
-
-        torch.manual_seed(0)
-        w = torch.randn(H, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(H, device=GPU_TYPE, dtype=torch.bfloat16)
-        x_full = torch.randn(FULL, H, device=GPU_TYPE, dtype=torch.bfloat16)
-
-        compiled = torch.compile(fn)
-        torch._dynamo.reset()
-        out_full = compiled(x_full, w, b)
-        self.assertEqual(out_full, fn(x_full, w, b))
-
-        # Halving sweep, matching what the benchmark harness does.
-        size = FULL // 2
-        while size >= 1:
-            torch._dynamo.reset()
-            out = compiled(x_full[:size].contiguous(), w, b)
-            ref = out_full[:size].contiguous()
-            self.assertTrue(
-                torch.equal(ref, out),
-                lambda msg: f"{msg}\npersistent reduction diverged at size={size} (FULL={FULL})",
-            )
-            size //= 2
-
-    @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU + Triton")
-    def test_cumsum_deterministic(self):
-        from torch._inductor.utils import run_and_get_code
-
-        x = torch.randn(1_000_003, device=GPU_TYPE, dtype=torch.float32)
-        compiled = torch.compile(lambda v: torch.cumsum(v, dim=0))
-
-        torch.use_deterministic_algorithms(True, warn_only=False)
-        eager = torch.cumsum(x, dim=0)
-        result, (_,) = run_and_get_code(compiled, x)
-        for _ in range(5):
-            self.assertEqual(result.view(torch.int32), compiled(x).view(torch.int32))
-        self.assertEqual(result.view(torch.int32), eager.view(torch.int32))
 
     def test_reorder_for_locality_preserves_randint_order(self):
         with inductor_config.patch(fallback_random=True):
@@ -232,10 +123,151 @@ class DeterministicTest(TestCase):
             self.assertTrue(
                 "The result is bitwise equivalent to the previously saved result"
                 in out.stdout.decode(),
-                lambda msg: f"{msg}\nstdout: {out.stdout.decode()}, stderr: {out.stderr.decode()}",
+                lambda msg: (
+                    f"{msg}\nstdout: {out.stdout.decode()}, stderr: {out.stderr.decode()}"
+                ),
             )
 
 
+class DeterministicTestAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._exit_stack = contextlib.ExitStack()
+        self._exit_stack.enter_context(fresh_cache())
+
+    def tearDown(self) -> None:
+        self._exit_stack.close()
+        super().tearDown()
+
+    @parametrize("deterministic", [False, True])
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_mm_padding(self, device, deterministic):
+        with inductor_config.patch(deterministic=deterministic):
+
+            @torch.compile()
+            def foo(x, y):
+                return x @ y
+
+            inps = [torch.rand([2049, 2049], device=device) for _ in range(2)]
+            out = foo(*inps)
+            self.assertEqual(out, inps[0] @ inps[1])
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["pad_mm_bench"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["pad_mm_bench"] > 0)
+
+    @parametrize("deterministic", [False, True])
+    @inductor_config.patch(max_autotune=True)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
+    def test_max_autotune(self, device, deterministic):
+        with inductor_config.patch(deterministic=deterministic):
+
+            @torch.compile()
+            def foo(x, y):
+                return x @ y
+
+            inps = [torch.rand([2048, 2048], device=device) for _ in range(2)]
+            out = foo(*inps)
+            self.assertEqual(out, inps[0] @ inps[1])
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] > 0)
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_pointwise_coordesc_tuning(self, device):
+        @torch.compile(mode="max-autotune")
+        def f(x):
+            return x + 1
+
+        x = torch.randn(2048, device=device)
+        self.assertEqual(f(x), x + 1)
+
+        self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
+
+    @parametrize("deterministic", [False, True])
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_reduction_coordesc_tuning(self, device, deterministic):
+        with inductor_config.patch(
+            deterministic=deterministic, coordinate_descent_tuning=True
+        ):
+
+            @torch.compile()
+            def foo(x):
+                return x.sum(dim=-1)
+
+            inp = torch.rand([2048, 2048], device=device)
+
+            out = foo(inp)
+            self.assertEqual(out, inp.sum(dim=-1))
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @inductor_config.patch(batch_invariant=True)
+    def test_persistent_reduction_batch_invariance(self, device):
+        H = 768
+        FULL = 1024
+
+        def fn(x, w, b):
+            return torch.nn.functional.layer_norm(x, (H,), weight=w, bias=b)
+
+        torch.manual_seed(0)
+        w = torch.randn(H, device=device, dtype=torch.bfloat16)
+        b = torch.randn(H, device=device, dtype=torch.bfloat16)
+        x_full = torch.randn(FULL, H, device=device, dtype=torch.bfloat16)
+
+        compiled = torch.compile(fn)
+        torch._dynamo.reset()
+        out_full = compiled(x_full, w, b)
+        self.assertEqual(out_full, fn(x_full, w, b))
+
+        # Halving sweep, matching what the benchmark harness does.
+        size = FULL // 2
+        while size >= 1:
+            torch._dynamo.reset()
+            out = compiled(x_full[:size].contiguous(), w, b)
+            ref = out_full[:size].contiguous()
+            self.assertTrue(
+                torch.equal(ref, out),
+                lambda msg: (
+                    f"{msg}\npersistent reduction diverged at size={size} (FULL={FULL})"
+                ),
+            )
+            size //= 2
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cumsum_deterministic(self, device):
+        from torch._inductor.utils import run_and_get_code
+
+        x = torch.randn(1_000_003, device=device, dtype=torch.float32)
+        compiled = torch.compile(lambda v: torch.cumsum(v, dim=0))
+
+        torch.use_deterministic_algorithms(True, warn_only=False)
+        eager = torch.cumsum(x, dim=0)
+        result, (_,) = run_and_get_code(compiled, x)
+        for _ in range(5):
+            self.assertEqual(result.view(torch.int32), compiled(x).view(torch.int32))
+        self.assertEqual(result.view(torch.int32), eager.view(torch.int32))
+
+
+instantiate_device_type_tests(
+    DeterministicTestAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+
 if __name__ == "__main__":
-    if HAS_GPU_AND_TRITON:
+    from torch.utils._triton import has_triton
+
+    if has_triton():
         run_tests()

--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -12,24 +12,28 @@ import torch._inductor.config as inductor_config
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
     skipIfRocm,
 )
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU_AND_TRITON,
-    IS_BIG_GPU,
-)
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 
 
 @instantiate_parametrized_tests
-class DeterministicTest(TestCase):
+class DeterministicTestGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self._exit_stack = contextlib.ExitStack()
@@ -47,117 +51,6 @@ class DeterministicTest(TestCase):
                 self.assertEqual(inductor_config.deterministic, new_val)
         finally:
             torch.use_deterministic_algorithms(old_val, warn_only=True)
-
-    @parametrize("deterministic", [False, True])
-    def test_mm_padding(self, deterministic):
-        with inductor_config.patch(deterministic=deterministic):
-
-            @torch.compile()
-            def foo(x, y):
-                return x @ y
-
-            inps = [torch.rand([2049, 2049], device=GPU_TYPE) for _ in range(2)]
-            out = foo(*inps)
-            self.assertEqual(out, inps[0] @ inps[1])
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["pad_mm_bench"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["pad_mm_bench"] > 0)
-
-    @parametrize("deterministic", [False, True])
-    @inductor_config.patch(max_autotune=True)
-    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
-    def test_max_autotune(self, deterministic):
-        with inductor_config.patch(deterministic=deterministic):
-
-            @torch.compile()
-            def foo(x, y):
-                return x @ y
-
-            inps = [torch.rand([2048, 2048], device=GPU_TYPE) for _ in range(2)]
-            out = foo(*inps)
-            self.assertEqual(out, inps[0] @ inps[1])
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] > 0)
-
-    def test_pointwise_coordesc_tuning(self):
-        @torch.compile(mode="max-autotune")
-        def f(x):
-            return x + 1
-
-        x = torch.randn(2048, device=GPU_TYPE)
-        self.assertEqual(f(x), x + 1)
-
-        self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
-
-    @parametrize("deterministic", [False, True])
-    def test_reduction_coordesc_tuning(self, deterministic):
-        with inductor_config.patch(
-            deterministic=deterministic, coordinate_descent_tuning=True
-        ):
-
-            @torch.compile()
-            def foo(x):
-                return x.sum(dim=-1)
-
-            inp = torch.rand([2048, 2048], device=GPU_TYPE)
-
-            out = foo(inp)
-            self.assertEqual(out, inp.sum(dim=-1))
-
-            if deterministic:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] == 0)
-            else:
-                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
-
-    @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU + Triton")
-    @inductor_config.patch(batch_invariant=True)
-    def test_persistent_reduction_batch_invariance(self):
-        H = 768
-        FULL = 1024
-
-        def fn(x, w, b):
-            return torch.nn.functional.layer_norm(x, (H,), weight=w, bias=b)
-
-        torch.manual_seed(0)
-        w = torch.randn(H, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(H, device=GPU_TYPE, dtype=torch.bfloat16)
-        x_full = torch.randn(FULL, H, device=GPU_TYPE, dtype=torch.bfloat16)
-
-        compiled = torch.compile(fn)
-        torch._dynamo.reset()
-        out_full = compiled(x_full, w, b)
-        self.assertEqual(out_full, fn(x_full, w, b))
-
-        # Halving sweep, matching what the benchmark harness does.
-        size = FULL // 2
-        while size >= 1:
-            torch._dynamo.reset()
-            out = compiled(x_full[:size].contiguous(), w, b)
-            ref = out_full[:size].contiguous()
-            self.assertTrue(
-                torch.equal(ref, out),
-                lambda msg: f"{msg}\npersistent reduction diverged at size={size} (FULL={FULL})",
-            )
-            size //= 2
-
-    @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU + Triton")
-    def test_cumsum_deterministic(self):
-        from torch._inductor.utils import run_and_get_code
-
-        x = torch.randn(1_000_003, device=GPU_TYPE, dtype=torch.float32)
-        compiled = torch.compile(lambda v: torch.cumsum(v, dim=0))
-
-        torch.use_deterministic_algorithms(True, warn_only=False)
-        eager = torch.cumsum(x, dim=0)
-        result, (_,) = run_and_get_code(compiled, x)
-        for _ in range(5):
-            self.assertEqual(result.view(torch.int32), compiled(x).view(torch.int32))
-        self.assertEqual(result.view(torch.int32), eager.view(torch.int32))
 
     def test_reorder_for_locality_preserves_randint_order(self):
         with inductor_config.patch(fallback_random=True):
@@ -236,6 +129,138 @@ class DeterministicTest(TestCase):
             )
 
 
+class DeterministicTestAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._exit_stack = contextlib.ExitStack()
+        self._exit_stack.enter_context(fresh_cache())
+
+    def tearDown(self) -> None:
+        self._exit_stack.close()
+        super().tearDown()
+
+    @parametrize("deterministic", [False, True])
+    def test_mm_padding(self, device, deterministic):
+        with inductor_config.patch(deterministic=deterministic):
+
+            @torch.compile()
+            def foo(x, y):
+                return x @ y
+
+            inps = [torch.rand([2049, 2049], device=device) for _ in range(2)]
+            out = foo(*inps)
+            self.assertEqual(out, inps[0] @ inps[1])
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["pad_mm_bench"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["pad_mm_bench"] > 0)
+
+    @parametrize("deterministic", [False, True])
+    @inductor_config.patch(max_autotune=True)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
+    def test_max_autotune(self, device, deterministic):
+        with inductor_config.patch(deterministic=deterministic):
+
+            @torch.compile()
+            def foo(x, y):
+                return x @ y
+
+            inps = [torch.rand([2048, 2048], device=device) for _ in range(2)]
+            out = foo(*inps)
+            self.assertEqual(out, inps[0] @ inps[1])
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["select_algorithm_autotune"] > 0)
+
+    def test_pointwise_coordesc_tuning(self, device):
+        @torch.compile(mode="max-autotune")
+        def f(x):
+            return x + 1
+
+        x = torch.randn(2048, device=device)
+        self.assertEqual(f(x), x + 1)
+
+        self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
+
+    @parametrize("deterministic", [False, True])
+    def test_reduction_coordesc_tuning(self, device, deterministic):
+        with inductor_config.patch(
+            deterministic=deterministic, coordinate_descent_tuning=True
+        ):
+
+            @torch.compile()
+            def foo(x):
+                return x.sum(dim=-1)
+
+            inp = torch.rand([2048, 2048], device=device)
+
+            out = foo(inp)
+            self.assertEqual(out, inp.sum(dim=-1))
+
+            if deterministic:
+                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] == 0)
+            else:
+                self.assertTrue(counters["inductor"]["coordesc_tuning_bench"] > 0)
+
+    @requires_capabilities(Capability.lib.triton)
+    @inductor_config.patch(batch_invariant=True)
+    def test_persistent_reduction_batch_invariance(self, device):
+        H = 768
+        FULL = 1024
+
+        def fn(x, w, b):
+            return torch.nn.functional.layer_norm(x, (H,), weight=w, bias=b)
+
+        torch.manual_seed(0)
+        w = torch.randn(H, device=device, dtype=torch.bfloat16)
+        b = torch.randn(H, device=device, dtype=torch.bfloat16)
+        x_full = torch.randn(FULL, H, device=device, dtype=torch.bfloat16)
+
+        compiled = torch.compile(fn)
+        torch._dynamo.reset()
+        out_full = compiled(x_full, w, b)
+        self.assertEqual(out_full, fn(x_full, w, b))
+
+        # Halving sweep, matching what the benchmark harness does.
+        size = FULL // 2
+        while size >= 1:
+            torch._dynamo.reset()
+            out = compiled(x_full[:size].contiguous(), w, b)
+            ref = out_full[:size].contiguous()
+            self.assertTrue(
+                torch.equal(ref, out),
+                lambda msg: f"{msg}\npersistent reduction diverged at size={size} (FULL={FULL})",
+            )
+            size //= 2
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_cumsum_deterministic(self, device):
+        from torch._inductor.utils import run_and_get_code
+
+        x = torch.randn(1_000_003, device=device, dtype=torch.float32)
+        compiled = torch.compile(lambda v: torch.cumsum(v, dim=0))
+
+        torch.use_deterministic_algorithms(True, warn_only=False)
+        eager = torch.cumsum(x, dim=0)
+        result, (_,) = run_and_get_code(compiled, x)
+        for _ in range(5):
+            self.assertEqual(result.view(torch.int32), compiled(x).view(torch.int32))
+        self.assertEqual(result.view(torch.int32), eager.view(torch.int32))
+
+
+instantiate_device_type_tests(
+    DeterministicTestAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
+
 if __name__ == "__main__":
-    if HAS_GPU_AND_TRITON:
+    if HAS_TRITON:
         run_tests()


### PR DESCRIPTION
[Testcase Refactoring] Split DeterministicTest and migrate to HAS_TRITON guards

### Summary

Split DeterministicTest into DeterministicTestGeneric (GENERIC) and
DeterministicTestAccelerator (ACCELERATOR), migrate GPU_TYPE to device
parameter, and replace HAS_GPU_AND_TRITON with HAS_TRITON guards.

### Changes

- Split DeterministicTest into Generic and Accelerator classes with
  hw_classification
- Add device parameter to 6 Accelerator methods, replace GPU_TYPE
- Replace 2x @unittest.skipIf(not HAS_GPU_AND_TRITON) with
  @unittest.skipIf(not HAS_TRITON)
- Add 4x @unittest.skipIf(not HAS_TRITON) on methods using torch.compile
  that had no triton guard
- Add @unittest.skipIf(not IS_BIG_GPU) on test_max_autotune
- Reorder @parametrize to outermost position
- Add instantiate_device_type_tests(except_for="cpu", allow_xpu=True)
- Replace __main__ HAS_GPU_AND_TRITON with has_triton()
- Update imports: remove GPU_TYPE, HAS_GPU_AND_TRITON; add HAS_TRITON,
  IS_BIG_GPU, HardwareClassification, instantiate_device_type_tests

### Motivation

The original class mixed GENERIC and ACCELERATOR tests under a single
HAS_GPU_AND_TRITON gate, preventing GENERIC tests from running without
an accelerator. Splitting by HardwareClassification and using per-method
HAS_TRITON guards allows each test to run on its appropriate targets.

### Test Plan

```
python test/inductor/test_deterministic.py
```