### PR TITLE
[cudaMallocAsync] Support torch.cuda.MemPool lifecycle

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -159,10 +159,23 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
     // If pool was created by another graph's capture_begin, first should be nonzero.
     // If pool was created by graph_pool_handle, second should be nonzero.
     TORCH_INTERNAL_ASSERT(!(pool.first && pool.second));
+  }
+#if !defined(USE_ROCM)
+  if (pool.second != 0 &&
+      c10::cuda::CUDACachingAllocator::name() == "cudaMallocAsync") {
+    TORCH_WARN_ONCE(
+        "CUDA graph capture ignores a user-created memory pool with "
+        "backend:cudaMallocAsync; CUDA manages captured graph memory through "
+        "the default async pool.");
+    pool = {0, 0};
+  }
+#endif
+  if (pool.first != 0 || pool.second != 0) {
     mempool_id_ = pool;
   } else {
-    // User did not ask us to share a mempool. Create graph pool handle using is_user_created=false.
-    // Sets just the first value, to distinguish it from MempoolId_ts created by graph_pool_handle().
+    // No supported pool was supplied. Create graph pool handle using
+    // is_user_created=false. Sets just the first value, to distinguish it from
+    // MempoolId_ts created by graph_pool_handle().
     mempool_id_ = at::cuda::MemPool::graph_pool_handle(false);
     TORCH_INTERNAL_ASSERT(mempool_id_.first > 0);
   }

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -140,6 +140,11 @@ std::vector<size_t> pytorch_memory_limits;
 std::unordered_set<UsageStream, UsageStreamHash> capture_free_streams;
 bool capture_underway = false;
 
+// User MemPools are lifecycle-only because cudaMallocAsync keeps allocation
+// ownership in CUDA's default pool. Presence in this map also distinguishes a
+// pool context from a graph capture.
+ska::flat_hash_map<MempoolId_t, int, MempoolIdHash> pool_use_count;
+
 // Implementation functions
 
 // Assumes the caller holds general_mutex
@@ -877,12 +882,18 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
         "does not track individual blocks.)");
   }
 
-  // CUDAGraph interactions
   void beginAllocateToPool(
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
       std::function<bool(cudaStream_t)> /*filter*/) override {
     std::lock_guard<std::mutex> lk(general_mutex);
+
+    // A user-pool context does not start graph capture.
+    auto it = pool_use_count.find(mempool_id);
+    if (it != pool_use_count.end()) {
+      ++it->second;
+      return;
+    }
 
     TORCH_INTERNAL_ASSERT(capture_free_streams.empty());
     TORCH_CHECK(
@@ -896,6 +907,11 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     assertValidDevice(device);
 
     std::lock_guard<std::mutex> lk(general_mutex);
+
+    // A user-pool context did not enter capture state.
+    if (pool_use_count.count(mempool_id)) {
+      return;
+    }
 
     TORCH_CHECK(
         capture_underway,
@@ -926,19 +942,51 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     capture_underway = false;
   }
 
-  void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) override {
-    // Q: Do we need to do anything special here, like clear long-lived
-    //    pointers created during the original capture (for example,
-    //    tensors intended as the graph's I/O surface) that might still
-    //    be resident in ptr_info?
-    // A: I don't think so.
-    //    Those allocations survived capture because the user held
-    //    explicit tensor references to them,
-    //    Those tensors' destructors will call freeAsync() on each pointer
-    //    when the user is done with them.
-    //    The freeAsync()s will probably incur
-    //    TORCH_WARN("Attempting uncaptured free of a captured allocation..."
-    //    but stale ptrs will not permanently leak into ptr_info.
+  void releasePool(c10::DeviceIndex /*device*/, MempoolId_t mempool_id)
+      override {
+    // User pools own no blocks on this backend.
+    std::lock_guard<std::mutex> lk(general_mutex);
+    auto it = pool_use_count.find(mempool_id);
+    if (it != pool_use_count.end()) {
+      TORCH_INTERNAL_ASSERT(it->second > 0); // matches native: never negative
+      if (--it->second == 0) {
+        pool_use_count.erase(it);
+      }
+    }
+  }
+
+  void createOrIncrefPool(
+      c10::DeviceIndex /*device*/,
+      MempoolId_t mempool_id,
+      std::shared_ptr<CUDAAllocator> /*allocator*/) override {
+    // cudaMallocAsync does not route allocations to custom pools.
+    TORCH_WARN_ONCE(
+        "For backend:cudaMallocAsync, torch.cuda.MemPool is lifecycle-only "
+        "and does not own or isolate CUDA device memory. Allocations inside "
+        "use_mem_pool use the default async pool, CUDA graph capture ignores "
+        "the user pool, and the MemPool's custom allocator is not invoked by "
+        "this backend.");
+    std::lock_guard<std::mutex> lk(general_mutex);
+    ++pool_use_count[mempool_id];
+  }
+
+  int getPoolUseCount(c10::DeviceIndex /*device*/, MempoolId_t mempool_id)
+      override {
+    std::lock_guard<std::mutex> lk(general_mutex);
+    auto it = pool_use_count.find(mempool_id);
+    return it == pool_use_count.end() ? 0 : it->second;
+  }
+
+  void setUseOnOOM(
+      c10::DeviceIndex /*device*/,
+      MempoolId_t /*mempool_id*/,
+      bool /*use_on_oom*/) override {
+    // No per-pool OOM fallback.
+  }
+
+  void setNoSplit(c10::DeviceIndex /*device*/, MempoolId_t /*mempool_id*/)
+      override {
+    // No per-pool block splitting.
   }
 
   void* raw_alloc(size_t nbytes) override {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -195,6 +195,10 @@ def _check_allocator_settings_on_tear_down(test_case):
     # Regression check: no test in `test_case` should leave the runtime
     # expandable_segments knob mismatched against the suite's env-derived
     # baseline. This should be called in the class's `tearDown` method.
+    if TEST_CUDAMALLOCASYNC:
+        # _snapshot() intentionally raises on the cudaMallocAsync backend, and
+        # expandable_segments does not apply to it.
+        return
     md = torch.cuda.memory._snapshot()["allocator_settings"]
     test_case.assertEqual(md["expandable_segments"], EXPANDABLE_SEGMENTS)
 
@@ -8182,6 +8186,54 @@ class TestMemPool(TestCase):
         # each call to torch.cuda.graph_pool_handle() or torch.cuda.MemPool()
         # increments the id
         self.assertTrue(abs(pool2[1] - pool1[1]) > 0)
+
+    @unittest.skipUnless(TEST_CUDAMALLOCASYNC, "requires cudaMallocAsync")
+    def test_mempool_cudamallocasync(self):
+        pool = torch.cuda.MemPool(use_on_oom=False, no_split=True)
+        self.assertEqual(pool.use_count(), 1)
+        for _ in range(2):
+            with torch.cuda.use_mem_pool(pool):
+                self.assertEqual(pool.use_count(), 2)
+                x = torch.ones(4, device="cuda")
+            self.assertEqual(pool.use_count(), 1)
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, pool=pool):
+            y = x + 1
+        self.assertEqual(pool.use_count(), 1)
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y, torch.full((4,), 2.0, device="cuda")))
+        g.reset()
+        self.assertEqual(pool.use_count(), 1)
+
+    @unittest.skipIf(TEST_CUDAMALLOCASYNC, "already running under cudaMallocAsync")
+    @unittest.skipIf(TEST_WITH_ROCM, "hipMallocAsync path not validated")
+    def test_mempool_cudamallocasync_subprocess(self):
+        env = os.environ.copy()
+        env["PYTORCH_ALLOC_CONF"] = "backend:cudaMallocAsync"
+        env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+        torch_parent = os.path.dirname(os.path.dirname(torch.__file__))
+        env["PYTHONPATH"] = os.pathsep.join(
+            dict.fromkeys(filter(None, [torch_parent, *sys.path]))
+        )
+        module = os.path.splitext(os.path.basename(__file__))[0]
+        test = f"{module}.TestMemPool.test_mempool_cudamallocasync"
+        child_code = (
+            "import sys, unittest; "
+            "sys.modules['torchvision'] = None; "
+            "import torch; "
+            "assert torch.cuda.get_allocator_backend() == 'cudaMallocAsync'; "
+            f"suite = unittest.defaultTestLoader.loadTestsFromName({test!r}); "
+            "result = unittest.TextTestRunner(verbosity=2).run(suite); "
+            "raise SystemExit(0 if result.wasSuccessful() else 1)"
+        )
+        subprocess.check_call(
+            [sys.executable, "-S", "-c", child_code],
+            env=env,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            timeout=600,
+        )
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8207,6 +8207,39 @@ class TestMemPool(TestCase):
         g.reset()
         self.assertEqual(pool.use_count(), 1)
 
+    @serialTest()
+    @unittest.skipUnless(TEST_CUDAMALLOCASYNC, "requires cudaMallocAsync")
+    def test_mempool_cudamallocasync_custom_allocator(self):
+        allocator, dummy_allocator = self.get_dummy_allocator(check_vars=True)
+        alloc_lib = ctypes.CDLL(dummy_allocator)
+        called_dummy_alloc = ctypes.c_int.in_dll(alloc_lib, "called_dummy_alloc")
+        called_dummy_free = ctypes.c_int.in_dll(alloc_lib, "called_dummy_free")
+        called_dummy_alloc.value = 0
+        called_dummy_free.value = 0
+        pool = None
+        x = None
+        try:
+            pool = torch.cuda.MemPool(
+                allocator.allocator(), use_on_oom=False, no_split=True
+            )
+            self.assertEqual(pool.use_count(), 1)
+            with torch.cuda.use_mem_pool(pool):
+                self.assertEqual(pool.use_count(), 2)
+                x = torch.ones(4, device="cuda")
+            self.assertEqual(pool.use_count(), 1)
+            self.assertEqual(x.numel(), 4)
+            self.assertEqual(called_dummy_alloc.value, 0)
+        finally:
+            x = None
+            pool = None
+            torch.cuda.synchronize()
+            final_dummy_alloc = called_dummy_alloc.value
+            final_dummy_free = called_dummy_free.value
+            called_dummy_alloc.value = 0
+            called_dummy_free.value = 0
+        self.assertEqual(final_dummy_alloc, 0)
+        self.assertEqual(final_dummy_free, 0)
+
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "already running under cudaMallocAsync")
     @unittest.skipIf(TEST_WITH_ROCM, "hipMallocAsync path not validated")
     def test_mempool_cudamallocasync_subprocess(self):
@@ -8218,13 +8251,16 @@ class TestMemPool(TestCase):
             dict.fromkeys(filter(None, [torch_parent, *sys.path]))
         )
         module = os.path.splitext(os.path.basename(__file__))[0]
-        test = f"{module}.TestMemPool.test_mempool_cudamallocasync"
+        tests = [
+            f"{module}.TestMemPool.test_mempool_cudamallocasync",
+            f"{module}.TestMemPool.test_mempool_cudamallocasync_custom_allocator",
+        ]
         child_code = (
             "import sys, unittest; "
             "sys.modules['torchvision'] = None; "
             "import torch; "
             "assert torch.cuda.get_allocator_backend() == 'cudaMallocAsync'; "
-            f"suite = unittest.defaultTestLoader.loadTestsFromName({test!r}); "
+            f"suite = unittest.defaultTestLoader.loadTestsFromNames({tests!r}); "
             "result = unittest.TextTestRunner(verbosity=2).run(suite); "
             "raise SystemExit(0 if result.wasSuccessful() else 1)"
         )


### PR DESCRIPTION
`torch.cuda.MemPool` does not work with `backend:cudaMallocAsync` because this backend does not implement the pool lifecycle hooks.

The two pool models have a fundamental ownership conflict: `MemPool` expects the selected pool to own its allocations, while cudaMallocAsync keeps ownership in CUDA's default async pool. This PR is the minimum fix: it implements only the `MemPool` lifecycle so a pool can be created, reused, and destroyed without errors. Allocations routed through PyTorch still use the default async pool. Custom allocation and pool isolation are not supported, and a warning explains this limitation.

If a user pool is passed to CUDA graph capture, it is ignored and the graph uses its normal internal pool. This keeps existing cudaMallocAsync graph handling unchanged.

This is sufficient for symmetric memory. It allocates its buffers directly with its own allocator and only enters the `MemPool` temporarily around that operation. It needs the pool lifecycle to work, but it does not need cudaMallocAsync to invoke its custom allocator. This allows training workloads that use symmetric memory to run with cudaMallocAsync.

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia