### PR TITLE
[Testcase Refactoring] Add PrivateUse1 backend support and hw_classification to test_embedding_bag

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -28,11 +28,6 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_ops_common 
 )
 
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
-backend = torch.distributed.get_default_backend_for_device(device_type)
-
 if TEST_WITH_DEV_DBG_ASAN:
     print(
         "Skip dev-asan as torch + multiprocessing spawn have known issues",
@@ -172,14 +167,14 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
 
         self.assertEqual(local_output, sharded_output)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_capabilities(Capability.distributed.backend)
     def test_sharded_embedding_bag_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._test_sharded_embedding_bag_with_test_cases(spec, 1)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_capabilities(Capability.distributed.backend)
     def test_sharded_embedding_bag_rowwise(self, device):
@@ -290,7 +285,9 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
         )
 
 
-instantiate_device_type_tests(TestShardedEmbeddingBag, globals(), except_for=["cpu"])
+instantiate_device_type_tests(
+    TestShardedEmbeddingBag, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -5,11 +5,16 @@ import sys
 import torch
 import torch.distributed as dist
 from torch.distributed._shard import shard_parameter
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -36,6 +41,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestShardedEmbeddingBag(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _run_sharded_embedding_bag(
         self,
         spec,
@@ -166,15 +173,15 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_sharded_embedding_bag_colwise(self):
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    def test_sharded_embedding_bag_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._test_sharded_embedding_bag_with_test_cases(spec, 1)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_sharded_embedding_bag_rowwise(self):
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
+    def test_sharded_embedding_bag_rowwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(0):
             self._test_sharded_embedding_bag_with_test_cases(spec, 0)
 
@@ -280,6 +287,9 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
             max_norm=1.15,
             padding_idx=10,
         )
+
+
+instantiate_device_type_tests(TestShardedEmbeddingBag, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -5,11 +5,17 @@ import sys
 import torch
 import torch.distributed as dist
 from torch.distributed._shard import shard_parameter
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -36,6 +42,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestShardedEmbeddingBag(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _run_sharded_embedding_bag(
         self,
         spec,
@@ -166,15 +174,15 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_sharded_embedding_bag_colwise(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_embedding_bag_colwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._test_sharded_embedding_bag_with_test_cases(spec, 1)
 
     @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_sharded_embedding_bag_rowwise(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_embedding_bag_rowwise(self, device):
         for spec in generate_chunk_sharding_specs_for_test(0):
             self._test_sharded_embedding_bag_with_test_cases(spec, 0)
 
@@ -280,6 +288,9 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
             max_norm=1.15,
             padding_idx=10,
         )
+
+
+instantiate_device_type_tests(TestShardedEmbeddingBag, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -290,7 +290,7 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
         )
 
 
-instantiate_device_type_tests(TestShardedEmbeddingBag, globals())
+instantiate_device_type_tests(TestShardedEmbeddingBag, globals(), except_for=["cpu"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR refactors `TestShardedEmbeddingBag` to use
`instantiate_device_type_tests` + spawn combination with
`except_for="cpu"` and `allow_xpu=True`, replaces
`@requires_accelerator_dist_backend(["nccl", "xccl"])` with
`@requires_capabilities(Capability.distributed.backend)`, removes
module-level global `device_type`/`backend` variables in favor of
`self.backend` property dynamic resolution via `@with_comms(init_rpc=False)`,
and adds `hw_classification = HardwareClassification.ACCELERATOR` label in
`test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py`.

This enables ShardedTensor embedding bag tests to run on out-of-tree backends
and be properly filtered in CI pipelines.

## Changes

- Replaced `@requires_accelerator_dist_backend(["nccl", "xccl"])` with
  `@requires_capabilities(Capability.distributed.backend)` in
  `test_sharded_embedding_bag_colwise` and `test_sharded_embedding_bag_rowwise`.
- Removed module-level global `device_type`/`backend` variables and changed
  `@with_comms(init_rpc=False, backend=backend)` to `@with_comms(init_rpc=False)`.
  The `with_comms` decorator now resolves the backend dynamically via
  `self.backend` property at test runtime (per-device variant), instead of
  using a fixed value captured at module import time.
- Added `instantiate_device_type_tests` import and file-end call with
  `except_for="cpu"` and `allow_xpu=True` to instantiate
  `TestShardedEmbeddingBag` into device-specific subclasses
  (`TestShardedEmbeddingBagPRIVATEUSE1` on NPU, `TestShardedEmbeddingBagCUDA`
  on CUDA, `TestShardedEmbeddingBagXPU` on XPU). CPU is excluded via
  `except_for` since the test class is labeled `ACCELERATOR` and CPU is not
  an accelerator.
- Added `device` parameter to both test methods (framework injection).
- Added `hw_classification = HardwareClassification.ACCELERATOR` class attribute.

## Motivation

1. The `requires_accelerator_dist_backend` decorator only allowed `"nccl"` and
   `"xccl"` backends — replaced with `requires_capabilities(Capability.distributed.backend)`
   (PR #191919) to support out-of-tree accelerators via the Capability mechanism.
2. Module-level global `device_type`/`backend` variables were evaluated at
   import time and passed to `@with_comms` as explicit arguments, bypassing the
   `self.backend` property dynamic resolution mechanism. Removed these globals
   so each device variant resolves its own backend at runtime (PR #194992).
3. The test class was not using `instantiate_device_type_tests` — required for
   ACCELERATOR label compliance (instantiate + spawn combination).
4. The test class lacked `hw_classification` label — unlabeled tests are not
   filtered in CI pipelines.
5. `allow_xpu=True` preserves XPU coverage that was present in the original
   `@requires_accelerator_dist_backend(["nccl", "xccl"])` decorator.

## Not changed

- The test logic remains unchanged; only decorators, method signatures, and
  class attributes are modified.
- `TEST_GPU_NUM` and `skip_if_lt_x_gpu` naming are preserved for backward
  compatibility (hardware-agnostic per `common_distributed` conventions).
- `.to(self.rank)` device placement pattern is preserved (works correctly
  with `init_pg`'s `set_device_index`).

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#191919**: `Capability` mechanism + `requires_capabilities` decorator
- **#193080**: `PrivateUse1TestBase._capabilities()` override (distributed capability registration for PrivateUse1 backends)
- **#194992**: `ShardedTensorTestBase` refactored `with_comms` (`backend=None` default) + `init_pg` (`backend = backend or self.backend`) + `backend` property
- **#187650**: `skip_if_lt_x_gpu` made hardware-agnostic via `torch.accelerator`

Without these, the test will be skipped on PrivateUse1 backends.

## Test plan

- `python test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py`
  on an out-of-tree accelerator backend (PrivateUse1, torch_npu 2.13.0+git45fbeae
  on PyTorch 2.13.0a0+gitfad7424, Ascend 910B3, CANN 9.1.0-beta.1):
  `Ran 2 tests in 45.595s, OK` — `TestShardedEmbeddingBagPRIVATEUSE1` (NPU variant).
  CPU variant is not instantiated (`except_for="cpu"`).
- `python test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py`
  on CPU (no accelerator): `Ran 0 tests, NO TESTS RAN` — CPU is excluded via
  `except_for="cpu"` (ACCELERATOR label, CPU is not an accelerator).
- `python test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py`
  on CUDA (NVIDIA A100-SXM4-80GB, CUDA 12.8): `Ran 2 tests in 73.992s, OK` —
  `TestShardedEmbeddingBagCUDA`. Confirmed no regression on CUDA.