### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_fx_reinplace_pass.py

### DIFF
--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -1,6 +1,11 @@
 # Owner(s): ["module: functionalization"]
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+)
 from torch.fx.passes.reinplace import reinplace
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
@@ -15,7 +20,9 @@ except Exception:
 
 class TestReinplacePass(TestCase):
 
-    def test_reinplace_basic(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_reinplace_basic(self, device):
         # Basic test: the out-of-place add() call should be converted
         # into add_()
         def f(x):
@@ -23,7 +30,7 @@ class TestReinplacePass(TestCase):
             b = a.add(1)
             return b
 
-        inpt = torch.ones(2)
+        inpt = torch.ones(2, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -39,7 +46,7 @@ def forward(self, x_1):
     """)
 
 
-    def test_reinplace_with_view(self):
+    def test_reinplace_with_view(self, device):
         def f(x):
             a = x.clone()
             a_view = a.view(-1)
@@ -50,7 +57,7 @@ def forward(self, x_1):
             c = a_view.add(1)
             return c
 
-        inpt = torch.ones(2)
+        inpt = torch.ones(2, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -67,7 +74,7 @@ def forward(self, x_1):
     return view
     """)
 
-    def test_reinplace_different_metadata(self):
+    def test_reinplace_different_metadata(self, device):
         def f(a_):
             a = a_.clone()
             b = a + 1
@@ -75,7 +82,7 @@ def forward(self, x_1):
             # because that would require resizing "b" (from a float to a bool tensor).
             c = torch.ge(b, a)
             return c
-        inpt = torch.ones(4)
+        inpt = torch.ones(4, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -92,14 +99,14 @@ def forward(self, a__1):
     return ge
     """)
 
-    def test_reinplace_overlapping_memory(self):
+    def test_reinplace_overlapping_memory(self, device):
         def f(a_):
             a = a_.clone()
             b = a.expand(4, 4)
             # Can't reinplace because b has overlapping memory.
             c = b.add(1)
             return c
-        inpt = torch.ones(1)
+        inpt = torch.ones(1, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -118,7 +125,7 @@ def forward(self, a__1):
     # This test won't actually run in CI, because it requires functionalize() from functorch.
     # I'm planning on testing more comprehensively with torchbench models,
     # but we can make this testing better once functorch moves into pytorch/pytorch.
-    def test_reinplace_scatter_op(self):
+    def test_reinplace_scatter_op(self, device):
         def f(a_):
             # for now, don't test mutations to inputs
             a = a_.clone()
@@ -131,7 +138,7 @@ def forward(self, a__1):
 
         if not HAS_FUNCTIONALIZATION:
             return
-        inpt = torch.ones(4)
+        inpt = torch.ones(4, device=device)
         f2 = reinplace(make_fx(functionalize(f))(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -165,7 +172,7 @@ def forward(self, a__1):
     return view_5
     """)
 
-    def test_reinplace_scatter_twice(self):
+    def test_reinplace_scatter_twice(self, device):
         def f(a_):
             # for now, don't test mutations to inputs
             a = a_.clone()
@@ -177,7 +184,7 @@ def forward(self, a__1):
         if not HAS_FUNCTIONALIZATION:
             return
 
-        inpt = torch.ones(4, 4)
+        inpt = torch.ones(4, 4, device=device)
         f2 = reinplace(make_fx(functionalize(f))(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -197,7 +204,7 @@ def forward(self, a__1):
     return clone
     """)
 
-    def test_reinplace_scatter_twice_with_different_view_op_valid(self):
+    def test_reinplace_scatter_twice_with_different_view_op_valid(self, device):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -214,7 +221,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(good_mirror_of_b, c_updated, 0, 1)
             return b_updated
 
-        inpt = torch.ones(4, 4)
+        inpt = torch.ones(4, 4, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -235,7 +242,7 @@ def forward(self, a__1):
     # Test example where we have a scatter op, where the base tensor
     # has the same size/stride/storage offset (even though it is a different view),
     # making it valid to re-inplace
-    def test_reinplace_scatter_twice_with_different_view_op_invalid(self):
+    def test_reinplace_scatter_twice_with_different_view_op_invalid(self, device):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -249,7 +256,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(good_mirror_of_b, c_updated, 0, 0)
             return b_updated
 
-        inpt = torch.ones(4, 4)
+        inpt = torch.ones(4, 4, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -269,7 +276,7 @@ def forward(self, a__1):
     return as_strided
     """)
 
-    def test_reinplace_scatter_twice_with_different_view_op_invalid2(self):
+    def test_reinplace_scatter_twice_with_different_view_op_invalid2(self, device):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -281,7 +288,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(bad_mirror_of_b, c_updated, 0, 1)
             return b_updated
 
-        inpt = torch.ones(4, 4)
+        inpt = torch.ones(4, 4, device=device)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)  # noqa: F841
         actual_out = f2(inpt)  # noqa: F841
@@ -302,9 +309,9 @@ def forward(self, a__1):
     """)
 
 
-    def test_out_node_updated(self):
+    def test_out_node_updated(self, device):
         def f():
-            x = torch.zeros(2, 2)
+            x = torch.zeros(2, 2, device=device)
             y = x.diagonal()
             y_updated = y.add(1)
             z = torch.diagonal_scatter(x, y_updated)
@@ -317,21 +324,22 @@ def forward(self, a__1):
         expected_out = f()
         actual_out = f2()
         self.assertEqual(actual_out, expected_out)
-        self.assertExpectedInline(f2.code, """\
+        _dev_repr = repr(torch.device(device))
+        self.assertExpectedInline(f2.code, f"""\
 
 
 
 def forward(self):
-    zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
+    zeros = torch.ops.aten.zeros.default([2, 2], device = {_dev_repr}, pin_memory = False)
     diagonal = torch.ops.aten.diagonal.default(zeros)
     add = torch.ops.aten.add_.Tensor(diagonal, 1);  diagonal = add = None
     return [zeros]
-    """)
+    """)  # noqa: B950
 
-    def test_reinplace_index_mutation(self):
+    def test_reinplace_index_mutation(self, device):
         def f():
-            a = torch.zeros(4, 4, 4)
-            a[:, 2:] = torch.ones(4, 2, 4)
+            a = torch.zeros(4, 4, 4, device=device)
+            a[:, 2:] = torch.ones(4, 2, 4, device=device)
             return a
 
         if not HAS_FUNCTIONALIZATION:
@@ -340,20 +348,21 @@ def forward(self):
         expected_out = f()
         actual_out = f2()
         self.assertEqual(actual_out, expected_out)
-        self.assertExpectedInline(f2.code, """\
+        _dev_repr = repr(torch.device(device))
+        self.assertExpectedInline(f2.code, f"""\
 
 
 
 def forward(self):
-    zeros = torch.ops.aten.zeros.default([4, 4, 4], device = device(type='cpu'), pin_memory = False)
-    ones = torch.ops.aten.ones.default([4, 2, 4], device = device(type='cpu'), pin_memory = False)
+    zeros = torch.ops.aten.zeros.default([4, 4, 4], device = {_dev_repr}, pin_memory = False)
+    ones = torch.ops.aten.ones.default([4, 2, 4], device = {_dev_repr}, pin_memory = False)
     slice_1 = torch.ops.aten.slice.Tensor(zeros, 1, 2, 9223372036854775807)
     copy = torch.ops.aten.copy_.default(slice_1, ones);  slice_1 = ones = copy = None
     slice_2 = torch.ops.aten.slice.Tensor(zeros, 1, 2, 9223372036854775807);  slice_2 = None
     return zeros
-    """)
+    """)  # noqa: B950
 
-    def test_reinplace_sym_input(self):
+    def test_reinplace_sym_input(self, device):
         # Symbolic input test: the out-of-place add() call should be converted
         # into add_(), and symbolic input won't cause any error.
         def f(x, index):
@@ -362,7 +371,7 @@ def forward(self):
             b = clone.add(1)
             return b
 
-        x = torch.randn((4, 8, 16, 16), requires_grad=False)
+        x = torch.randn((4, 8, 16, 16), requires_grad=False, device=device)
         index = 2
         shape_env = ShapeEnv()
         symbol = shape_env.create_symbol(index, source=ConstantSource(
@@ -387,6 +396,9 @@ def forward(self, x_1, index_1):
     add = torch.ops.aten.add_.Tensor(clone, 1);  add = None
     return clone
     """)
+
+
+instantiate_device_type_tests(TestReinplacePass, globals())
 
 
 if __name__ == '__main__':

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: functionalization"]
 import torch
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     TestCase,
@@ -19,10 +18,9 @@ except Exception:
     HAS_FUNCTIONALIZATION = False
 
 class TestReinplacePass(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    def test_reinplace_basic(self, device):
+    def test_reinplace_basic(self):
         # Basic test: the out-of-place add() call should be converted
         # into add_()
         def f(x):
@@ -30,7 +28,7 @@ class TestReinplacePass(TestCase):
             b = a.add(1)
             return b
 
-        inpt = torch.ones(2, device=device)
+        inpt = torch.ones(2)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -46,7 +44,7 @@ def forward(self, x_1):
     """)
 
 
-    def test_reinplace_with_view(self, device):
+    def test_reinplace_with_view(self):
         def f(x):
             a = x.clone()
             a_view = a.view(-1)
@@ -57,7 +55,7 @@ def forward(self, x_1):
             c = a_view.add(1)
             return c
 
-        inpt = torch.ones(2, device=device)
+        inpt = torch.ones(2)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -74,7 +72,7 @@ def forward(self, x_1):
     return view
     """)
 
-    def test_reinplace_different_metadata(self, device):
+    def test_reinplace_different_metadata(self):
         def f(a_):
             a = a_.clone()
             b = a + 1
@@ -82,7 +80,7 @@ def forward(self, x_1):
             # because that would require resizing "b" (from a float to a bool tensor).
             c = torch.ge(b, a)
             return c
-        inpt = torch.ones(4, device=device)
+        inpt = torch.ones(4)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -99,14 +97,14 @@ def forward(self, a__1):
     return ge
     """)
 
-    def test_reinplace_overlapping_memory(self, device):
+    def test_reinplace_overlapping_memory(self):
         def f(a_):
             a = a_.clone()
             b = a.expand(4, 4)
             # Can't reinplace because b has overlapping memory.
             c = b.add(1)
             return c
-        inpt = torch.ones(1, device=device)
+        inpt = torch.ones(1)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -125,7 +123,7 @@ def forward(self, a__1):
     # This test won't actually run in CI, because it requires functionalize() from functorch.
     # I'm planning on testing more comprehensively with torchbench models,
     # but we can make this testing better once functorch moves into pytorch/pytorch.
-    def test_reinplace_scatter_op(self, device):
+    def test_reinplace_scatter_op(self):
         def f(a_):
             # for now, don't test mutations to inputs
             a = a_.clone()
@@ -138,7 +136,7 @@ def forward(self, a__1):
 
         if not HAS_FUNCTIONALIZATION:
             return
-        inpt = torch.ones(4, device=device)
+        inpt = torch.ones(4)
         f2 = reinplace(make_fx(functionalize(f))(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -172,7 +170,7 @@ def forward(self, a__1):
     return view_5
     """)
 
-    def test_reinplace_scatter_twice(self, device):
+    def test_reinplace_scatter_twice(self):
         def f(a_):
             # for now, don't test mutations to inputs
             a = a_.clone()
@@ -184,7 +182,7 @@ def forward(self, a__1):
         if not HAS_FUNCTIONALIZATION:
             return
 
-        inpt = torch.ones(4, 4, device=device)
+        inpt = torch.ones(4, 4)
         f2 = reinplace(make_fx(functionalize(f))(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -204,7 +202,7 @@ def forward(self, a__1):
     return clone
     """)
 
-    def test_reinplace_scatter_twice_with_different_view_op_valid(self, device):
+    def test_reinplace_scatter_twice_with_different_view_op_valid(self):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -221,7 +219,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(good_mirror_of_b, c_updated, 0, 1)
             return b_updated
 
-        inpt = torch.ones(4, 4, device=device)
+        inpt = torch.ones(4, 4)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -242,7 +240,7 @@ def forward(self, a__1):
     # Test example where we have a scatter op, where the base tensor
     # has the same size/stride/storage offset (even though it is a different view),
     # making it valid to re-inplace
-    def test_reinplace_scatter_twice_with_different_view_op_invalid(self, device):
+    def test_reinplace_scatter_twice_with_different_view_op_invalid(self):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -256,7 +254,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(good_mirror_of_b, c_updated, 0, 0)
             return b_updated
 
-        inpt = torch.ones(4, 4, device=device)
+        inpt = torch.ones(4, 4)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)
         actual_out = f2(inpt)
@@ -276,7 +274,7 @@ def forward(self, a__1):
     return as_strided
     """)
 
-    def test_reinplace_scatter_twice_with_different_view_op_invalid2(self, device):
+    def test_reinplace_scatter_twice_with_different_view_op_invalid2(self):
         def f(a_):
             a = a_.clone()
             b = a[:, 1]
@@ -288,7 +286,7 @@ def forward(self, a__1):
             b_updated = torch.select_scatter(bad_mirror_of_b, c_updated, 0, 1)
             return b_updated
 
-        inpt = torch.ones(4, 4, device=device)
+        inpt = torch.ones(4, 4)
         f2 = reinplace(make_fx(f)(inpt), inpt)
         expected_out = f(inpt)  # noqa: F841
         actual_out = f2(inpt)  # noqa: F841
@@ -309,9 +307,9 @@ def forward(self, a__1):
     """)
 
 
-    def test_out_node_updated(self, device):
+    def test_out_node_updated(self):
         def f():
-            x = torch.zeros(2, 2, device=device)
+            x = torch.zeros(2, 2)
             y = x.diagonal()
             y_updated = y.add(1)
             z = torch.diagonal_scatter(x, y_updated)
@@ -324,22 +322,21 @@ def forward(self, a__1):
         expected_out = f()
         actual_out = f2()
         self.assertEqual(actual_out, expected_out)
-        _dev_repr = repr(torch.device(device))
-        self.assertExpectedInline(f2.code, f"""\
+        self.assertExpectedInline(f2.code, """\
 
 
 
 def forward(self):
-    zeros = torch.ops.aten.zeros.default([2, 2], device = {_dev_repr}, pin_memory = False)
+    zeros = torch.ops.aten.zeros.default([2, 2], device = device(type='cpu'), pin_memory = False)
     diagonal = torch.ops.aten.diagonal.default(zeros)
     add = torch.ops.aten.add_.Tensor(diagonal, 1);  diagonal = add = None
     return [zeros]
-    """)  # noqa: B950
+    """)
 
-    def test_reinplace_index_mutation(self, device):
+    def test_reinplace_index_mutation(self):
         def f():
-            a = torch.zeros(4, 4, 4, device=device)
-            a[:, 2:] = torch.ones(4, 2, 4, device=device)
+            a = torch.zeros(4, 4, 4)
+            a[:, 2:] = torch.ones(4, 2, 4)
             return a
 
         if not HAS_FUNCTIONALIZATION:
@@ -348,21 +345,20 @@ def forward(self):
         expected_out = f()
         actual_out = f2()
         self.assertEqual(actual_out, expected_out)
-        _dev_repr = repr(torch.device(device))
-        self.assertExpectedInline(f2.code, f"""\
+        self.assertExpectedInline(f2.code, """\
 
 
 
 def forward(self):
-    zeros = torch.ops.aten.zeros.default([4, 4, 4], device = {_dev_repr}, pin_memory = False)
-    ones = torch.ops.aten.ones.default([4, 2, 4], device = {_dev_repr}, pin_memory = False)
+    zeros = torch.ops.aten.zeros.default([4, 4, 4], device = device(type='cpu'), pin_memory = False)
+    ones = torch.ops.aten.ones.default([4, 2, 4], device = device(type='cpu'), pin_memory = False)
     slice_1 = torch.ops.aten.slice.Tensor(zeros, 1, 2, 9223372036854775807)
     copy = torch.ops.aten.copy_.default(slice_1, ones);  slice_1 = ones = copy = None
     slice_2 = torch.ops.aten.slice.Tensor(zeros, 1, 2, 9223372036854775807);  slice_2 = None
     return zeros
-    """)  # noqa: B950
+    """)
 
-    def test_reinplace_sym_input(self, device):
+    def test_reinplace_sym_input(self):
         # Symbolic input test: the out-of-place add() call should be converted
         # into add_(), and symbolic input won't cause any error.
         def f(x, index):
@@ -371,7 +367,7 @@ def forward(self):
             b = clone.add(1)
             return b
 
-        x = torch.randn((4, 8, 16, 16), requires_grad=False, device=device)
+        x = torch.randn((4, 8, 16, 16), requires_grad=False)
         index = 2
         shape_env = ShapeEnv()
         symbol = shape_env.create_symbol(index, source=ConstantSource(
@@ -396,9 +392,6 @@ def forward(self, x_1, index_1):
     add = torch.ops.aten.add_.Tensor(clone, 1);  add = None
     return clone
     """)
-
-
-instantiate_device_type_tests(TestReinplacePass, globals())
 
 
 if __name__ == '__main__':

--- a/test/test_fx_reinplace_pass.py
+++ b/test/test_fx_reinplace_pass.py
@@ -2,8 +2,8 @@
 import torch
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    TestCase,
     run_tests,
+    TestCase,
 )
 from torch.fx.passes.reinplace import reinplace
 from torch.fx.experimental.proxy_tensor import make_fx


### PR DESCRIPTION
## Summary
Parameterize TestReinplacePass tests with a device argument and add hw_classification attribute (TestReinplacePass as ACCELERATOR classes), enabling hardware-based test classification and filtering.

## Changes
test/test_fx_reinplace_pass.py : add a device parameter to 11 reinplace test methods, register the class via instantiate_device_type_tests, import HardwareClassification, and add hw_classification to TestReinplacePass classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_fx_reinplace_pass.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.