### PR TITLE
[Testcase Refactoring] Add hw_classification in test/higher_order_ops/test_debug_log.py

### DIFF
--- a/test/higher_order_ops/test_debug_log.py
+++ b/test/higher_order_ops/test_debug_log.py
@@ -4,7 +4,6 @@
 import logging
 
 import torch
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -14,7 +13,7 @@ from torch.utils.debug_log import debug_grad_log
 
 
 class TestDebugGradLog(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -38,8 +37,8 @@ class TestDebugGradLog(TestCase):
     def bwd_logs(self) -> list[str]:
         return [r for r in self._log_records if "[bwd]" in r]
 
-    def test_single_tensor(self, device):
-        x = torch.randn(4, requires_grad=True, device=device)
+    def test_single_tensor(self):
+        x = torch.randn(4, requires_grad=True)
         y = x * 2
         debug_grad_log(y)
         y.sum().backward()
@@ -47,9 +46,9 @@ class TestDebugGradLog(TestCase):
         self.assertEqual(len(self.bwd_logs), 1)
         self.assertIn("t0_grad_norm=", self.bwd_logs[0])
 
-    def test_multi_tensor(self, device):
-        x = torch.randn(4, requires_grad=True, device=device)
-        y = torch.randn(4, requires_grad=True, device=device)
+    def test_multi_tensor(self):
+        x = torch.randn(4, requires_grad=True)
+        y = torch.randn(4, requires_grad=True)
         debug_grad_log(x, y)
         (x * 2 + y * 3).sum().backward()
 
@@ -57,9 +56,9 @@ class TestDebugGradLog(TestCase):
         self.assertIn("t0_grad_norm=", self.bwd_logs[0])
         self.assertIn("t1_grad_norm=", self.bwd_logs[0])
 
-    def test_gradient_values(self, device):
-        x = torch.tensor([1.0], requires_grad=True, device=device)
-        y = torch.tensor([1.0], requires_grad=True, device=device)
+    def test_gradient_values(self):
+        x = torch.tensor([1.0], requires_grad=True)
+        y = torch.tensor([1.0], requires_grad=True)
         debug_grad_log(x, y)
         (x * 2 + y * 3).sum().backward()
 
@@ -67,18 +66,15 @@ class TestDebugGradLog(TestCase):
         self.assertIn("t0_grad_norm=2.0000", self.bwd_logs[0])
         self.assertIn("t1_grad_norm=3.0000", self.bwd_logs[0])
 
-    def test_no_requires_grad_no_log(self, device):
-        x = torch.randn(3, requires_grad=False, device=device)
+    def test_no_requires_grad_no_log(self):
+        x = torch.randn(3, requires_grad=False)
         debug_grad_log(x)
         self.assertEqual(len(self.bwd_logs), 0)
 
-    def test_forward_is_noop(self, device):
-        x = torch.randn(3, requires_grad=True, device=device)
+    def test_forward_is_noop(self):
+        x = torch.randn(3, requires_grad=True)
         debug_grad_log(x)
         self.assertEqual(len(self._log_records), 0)
-
-
-instantiate_device_type_tests(TestDebugGradLog, globals())
 
 
 if __name__ == "__main__":

--- a/test/higher_order_ops/test_debug_log.py
+++ b/test/higher_order_ops/test_debug_log.py
@@ -4,11 +4,18 @@
 import logging
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+)
 from torch.utils.debug_log import debug_grad_log
 
 
 class TestDebugGradLog(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         self._log_records: list[str] = []
@@ -31,8 +38,8 @@ class TestDebugGradLog(TestCase):
     def bwd_logs(self) -> list[str]:
         return [r for r in self._log_records if "[bwd]" in r]
 
-    def test_single_tensor(self):
-        x = torch.randn(4, requires_grad=True)
+    def test_single_tensor(self, device):
+        x = torch.randn(4, requires_grad=True, device=device)
         y = x * 2
         debug_grad_log(y)
         y.sum().backward()
@@ -40,9 +47,9 @@ class TestDebugGradLog(TestCase):
         self.assertEqual(len(self.bwd_logs), 1)
         self.assertIn("t0_grad_norm=", self.bwd_logs[0])
 
-    def test_multi_tensor(self):
-        x = torch.randn(4, requires_grad=True)
-        y = torch.randn(4, requires_grad=True)
+    def test_multi_tensor(self, device):
+        x = torch.randn(4, requires_grad=True, device=device)
+        y = torch.randn(4, requires_grad=True, device=device)
         debug_grad_log(x, y)
         (x * 2 + y * 3).sum().backward()
 
@@ -50,9 +57,9 @@ class TestDebugGradLog(TestCase):
         self.assertIn("t0_grad_norm=", self.bwd_logs[0])
         self.assertIn("t1_grad_norm=", self.bwd_logs[0])
 
-    def test_gradient_values(self):
-        x = torch.tensor([1.0], requires_grad=True)
-        y = torch.tensor([1.0], requires_grad=True)
+    def test_gradient_values(self, device):
+        x = torch.tensor([1.0], requires_grad=True, device=device)
+        y = torch.tensor([1.0], requires_grad=True, device=device)
         debug_grad_log(x, y)
         (x * 2 + y * 3).sum().backward()
 
@@ -60,15 +67,18 @@ class TestDebugGradLog(TestCase):
         self.assertIn("t0_grad_norm=2.0000", self.bwd_logs[0])
         self.assertIn("t1_grad_norm=3.0000", self.bwd_logs[0])
 
-    def test_no_requires_grad_no_log(self):
-        x = torch.randn(3, requires_grad=False)
+    def test_no_requires_grad_no_log(self, device):
+        x = torch.randn(3, requires_grad=False, device=device)
         debug_grad_log(x)
         self.assertEqual(len(self.bwd_logs), 0)
 
-    def test_forward_is_noop(self):
-        x = torch.randn(3, requires_grad=True)
+    def test_forward_is_noop(self, device):
+        x = torch.randn(3, requires_grad=True, device=device)
         debug_grad_log(x)
         self.assertEqual(len(self._log_records), 0)
+
+
+instantiate_device_type_tests(TestDebugGradLog, globals())
 
 
 if __name__ == "__main__":

--- a/test/higher_order_ops/test_debug_log.py
+++ b/test/higher_order_ops/test_debug_log.py
@@ -7,8 +7,8 @@ import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    TestCase,
     run_tests,
+    TestCase,
 )
 from torch.utils.debug_log import debug_grad_log
 


### PR DESCRIPTION
## Summary
Parameterize TestDebugGradLog tests with a device argument and add hw_classification attribute (TestDebugGradLog as ACCELERATOR classes), enabling hardware-based test classification and filtering.

## Changes
test/higher_order_ops/test_debug_log.py : add a device parameter to 5 test methods, register the class via instantiate_device_type_tests, import HardwareClassification, and add hw_classification to TestDebugGradLog classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/higher_order_ops/test_debug_log.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.