### PR TITLE
[Testcase Refactoring]Decouple benchmark device handling from CUDA and XPU

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -41,7 +41,6 @@ import torch._dynamo.utils
 import torch._export
 import torch.distributed
 import torch.multiprocessing as mp
-from torch._C import _has_cuda as HAS_CUDA, _has_xpu as HAS_XPU
 from torch._C._nativert import PyModelRunner
 from torch._dynamo.profiler import fx_insert_profiling, Profiler
 from torch._dynamo.testing import (
@@ -550,37 +549,35 @@ def patch_torch_manual_seed():
     """Make torch manual seed deterministic. Helps with accuracy testing."""
 
     def deterministic_torch_manual_seed(*args, **kwargs):
-        from torch._C import default_generator
-
-        seed = 1337
-        if HAS_CUDA:
-            import torch.cuda
-
-            if not torch.cuda._is_in_bad_fork():
-                torch.cuda.manual_seed_all(seed)
-        if HAS_XPU:
-            import torch.xpu
-
-            if not torch.xpu._is_in_bad_fork():
-                torch.xpu.manual_seed_all(seed)
-        return default_generator.manual_seed(seed)
+        return torch.random.manual_seed(1337)
 
     torch.manual_seed = deterministic_torch_manual_seed
+
+
+def _get_accelerator():
+    return torch.accelerator.current_accelerator(check_available=True)
+
+
+def _is_accelerator_device(device):
+    accelerator = _get_accelerator()
+    return accelerator is not None and torch.device(device).type == accelerator.type
 
 
 def empty_gpu_cache(device):
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
     """
+    device_module = torch.get_device_module(device)
+    empty_cache = getattr(device_module, "empty_cache", None)
 
-    if device not in ["cuda", "xpu", "mps"]:
+    if empty_cache is None:
         log.warning(
-            "Trying to call the empty_gpu_cache for device: %s, which is not in list [cuda, xpu]",
+            "Device %s does not provide an empty_cache API",
             device,
         )
         return
 
-    getattr(torch, device).empty_cache()
+    empty_cache()
 
 
 def synchronize():
@@ -1869,7 +1866,21 @@ class BenchmarkRunner:
                 self.autocast_arg["dtype"] = amp_dtype
 
     def init_optimizer(self, name, device, params):
-        if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:
+        device_type = torch.device(device).type
+
+        capturable_devices = {
+            "cuda",
+            "xpu",
+            "hpu",
+            "xla",
+            torch._C._get_privateuse1_backend_name(),
+        }
+
+        if (
+            device_type in capturable_devices
+            and self.args.training
+            and name not in CI_SKIP_OPTIMIZER
+        ):
             use_sgd = (
                 (name in CI_USE_SGD and self.args.ci)
                 or name in BENCHMARK_USE_SGD
@@ -4409,15 +4420,19 @@ def run(runner, args, original_dir=None):
         return sys.exit(-1)
 
     if not args.devices:
-        if torch.cuda.is_available():
-            args.devices = ["cuda"]
+        accelerator = _get_accelerator()
+        if accelerator is not None:
+            args.devices = [accelerator.type]
         else:
-            log.warning("torch.cuda.is_available() == False, using CPU")
+            log.warning("No accelerator is available, using CPU")
             args.devices = ["cpu"]
 
-    if args.devices != ["cpu"] and (HAS_CUDA or HAS_XPU):
+    if args.devices != ["cpu"]:
         global synchronize
-        synchronize = torch.cuda.synchronize if HAS_CUDA else torch.xpu.synchronize
+        device_module = torch.get_device_module(args.devices[0])
+        device_synchronize = getattr(device_module, "synchronize", None)
+        if device_synchronize is not None:
+            synchronize = device_synchronize
 
     if args.nnc:
         torch._C._jit_override_can_fuse_on_cpu(True)

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -548,39 +548,34 @@ def nothing(f):
 @functools.cache
 def patch_torch_manual_seed():
     """Make torch manual seed deterministic. Helps with accuracy testing."""
+    seed = 1337
+    torch.manual_seed(seed)
 
-    def deterministic_torch_manual_seed(*args, **kwargs):
-        from torch._C import default_generator
 
-        seed = 1337
-        if HAS_CUDA:
-            import torch.cuda
+def _get_accelerator():
+    return torch.accelerator.current_accelerator(check_available = True)
 
-            if not torch.cuda._is_in_bad_fork():
-                torch.cuda.manual_seed_all(seed)
-        if HAS_XPU:
-            import torch.xpu
 
-            if not torch.xpu._is_in_bad_fork():
-                torch.xpu.manual_seed_all(seed)
-        return default_generator.manual_seed(seed)
-
-    torch.manual_seed = deterministic_torch_manual_seed
+def _is_accelerator_device(device):
+    accelerator = _get_accelerator()
+    return (accelerator is not None and torch.device(device).type == accelerator.type)
 
 
 def empty_gpu_cache(device):
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
     """
+    device_module = torch.get_device_module(device)
+    empty_cache = getattr(device_module, "empty_cache", None)
 
-    if device not in ["cuda", "xpu", "mps"]:
+    if empty_cache is None:
         log.warning(
-            "Trying to call the empty_gpu_cache for device: %s, which is not in list [cuda, xpu]",
+            "Device %s does not provide an empty_cache API",
             device,
         )
         return
 
-    getattr(torch, device).empty_cache()
+    empty_cache()
 
 
 def synchronize():
@@ -1869,12 +1864,14 @@ class BenchmarkRunner:
                 self.autocast_arg["dtype"] = amp_dtype
 
     def init_optimizer(self, name, device, params):
-        if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:
+        device_type = torch.device(device).type
+        if _is_accelerator_device(device) and self.args.training and name not in CI_SKIP_OPTIMIZER:
             use_sgd = (
                 (name in CI_USE_SGD and self.args.ci)
                 or name in BENCHMARK_USE_SGD
                 or (
-                    torch.version.hip is None
+                    device_type == "cuda"
+                    and torch.version.hip is None
                     and self.args.backend == "inductor"
                     and self.args.accuracy
                     and name in CUDA_INDUCTOR_ACCURACY_USE_SGD
@@ -4409,15 +4406,21 @@ def run(runner, args, original_dir=None):
         return sys.exit(-1)
 
     if not args.devices:
+        accelerator = _get_accelerator()
         if torch.cuda.is_available():
             args.devices = ["cuda"]
+        elif accelerator is not None:
+            args.devices = [accelerator.type]
         else:
             log.warning("torch.cuda.is_available() == False, using CPU")
             args.devices = ["cpu"]
 
-    if args.devices != ["cpu"] and (HAS_CUDA or HAS_XPU):
+    if args.devices != ["cpu"]:
         global synchronize
-        synchronize = torch.cuda.synchronize if HAS_CUDA else torch.xpu.synchronize
+        device_module = torch.get_device_module(args.devices[0])
+        device_synchronize = getattr(device_module, "synchronize", None)
+        if device_synchronize is not None:
+            synchronize = device_synchronize
 
     if args.nnc:
         torch._C._jit_override_can_fuse_on_cpu(True)

--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -204,7 +204,7 @@ class DeterministicTest(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             saved_pkl = os.path.join(tmpdir, "saved.pkl")
             cmd = (
-                f"{sys.executable} {REPO_ROOT}/benchmarks/dynamo/huggingface.py --backend inductor"
+                f"{sys.executable} {REPO_ROOT}/benchmarks/dynamo/huggingface.py --inductor"
                 + f" --{precision} --accuracy --only {model_name} --{training_or_inference}"
                 + f" --disable-cudagraphs --save-model-outputs-to={saved_pkl}"
             )
@@ -220,7 +220,7 @@ class DeterministicTest(TestCase):
             # self.assertTrue("pass" in out.stdout.decode())
 
             cmd = (
-                f"{sys.executable} {REPO_ROOT}/benchmarks/dynamo/huggingface.py --backend inductor"
+                f"{sys.executable} {REPO_ROOT}/benchmarks/dynamo/huggingface.py --inductor"
                 + f" --{precision} --accuracy --only {model_name} --{training_or_inference}"
                 + f" --disable-cudagraphs --compare-model-outputs-with={saved_pkl}"
             )


### PR DESCRIPTION
## Summary

This PR makes the Dynamo benchmark infrastructure device-generic by replacing hardcoded CUDA/XPU device handling with the accelerator and device-module APIs.

## Changes

 **benchmarks/dynamo/common.py**:

- Replaced CUDA/XPU-specific manual seed handling with the device-generic `torch.manual_seed` API.
- Added helpers to query the currently available accelerator and identify accelerator devices.
- Updated device cache cleanup to dispatch through `torch.get_device_module`.
- Generalized optimizer initialization from CUDA-only handling to the current accelerator type.
- Kept CUDA-specific Inductor accuracy workarounds restricted to CUDA devices.
- Updated default device selection to use the current available accelerator when CUDA is unavailable.
- Updated synchronization to use the synchronization API exposed by the selected device module.
- Addressed Claude review feedback on deterministic seeding by preserving the existing behavior that forces all `torch.manual_seed` calls to use seed 1337, while delegating device-specific seed handling to the device-generic `torch.random.manual_seed` implementation.
- Addressed Claude review feedback on optimizer compatibility by limiting `capturable=True` optimizer initialization to supported device types (`cuda`, `xpu`, `hpu`, `xla`, and PrivateUse1), preventing unsupported initialization on MPS.

**test/inductor/test_deterministic.py**:

- Replaced `--backend inductor` with `--inductor` in the run-to-run determinism test so that the complete Inductor benchmark configuration is enabled.
- The generic `--backend inductor` path invokes `torch._dynamo.optimize` directly, bypassing the wrapper patched by `torch_npu`. Using the dedicated `--inductor` option follows the standard Inductor benchmark path and ensures that the `torch_npu` wrapper is applied correctly.

## Test plan

```bash
python test/inductor/test_deterministic.py
```
Verified locally that the relevant benchmark cases run correctly on CUDA and NPU.

## Notes

This is part of the device-generic benchmark refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track [#185590](https://github.com/pytorch/pytorch/issues/185590).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98