### PR TITLE
[c10d][elastic] Fix FileStore rendezvous leaking the mkstemp file descriptor

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,26 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    def test_create_backend_closes_mkstemp_file_descriptor(self) -> None:
+        # FileStore opens the path on its own, so the file descriptor returned
+        # by mkstemp() must be closed by the backend to avoid leaking it on
+        # every rendezvous creation. Use a real fd + path so FileStore can open
+        # the path, but assert the exact descriptor is closed once.
+        real_fd, real_path = tempfile.mkstemp()
+        self._params_filestore.endpoint = ""
+        try:
+            with (
+                mock.patch("tempfile.mkstemp", return_value=(real_fd, real_path)),
+                mock.patch("os.close") as os_close_mock,
+            ):
+                _, store = create_backend(self._params_filestore)
+
+            os_close_mock.assert_called_once_with(real_fd)
+            self.assertIsInstance(store, FileStore)
+            self.assertEqual(store.path, real_path)  # type: ignore[attr-defined]
+        finally:
+            # os.close was mocked, so the real descriptor is still open here.
+            os.close(real_fd)
+            if os.path.exists(real_path):
+                os.remove(real_path)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,11 +192,14 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."
             ) from exc
+        # FileStore opens the path on its own, so the descriptor returned by
+        # mkstemp() is not needed here and must be closed to avoid leaking it.
+        os.close(fd)
 
     try:
         store = FileStore(path)


### PR DESCRIPTION
Fixes #191394

### Problem
`_create_file_store()` calls `tempfile.mkstemp()`, which returns `(fd, path)`, but discards the file descriptor (`_, path = tempfile.mkstemp()`). `FileStore` opens the path itself, so that descriptor is never used and never closed — one leaked fd per rendezvous.

### Fix
Capture the descriptor and `os.close(fd)` after `mkstemp()` succeeds (`os` already imported). Single-file logic change; `FileStore` behaviour unchanged.

### Test verification (RED → GREEN)
New test `test_create_backend_closes_mkstemp_file_descriptor` asserts the descriptor is closed.
```
# RED (unmodified main):
AssertionError: Expected 'close' to be called once. Called 0 times.
FAILED test_create_backend_closes_mkstemp_file_descriptor
# GREEN (with fix):
1 passed, 30 deselected
```

> **Disclosure (per [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md)):** this change was prepared with AI assistance and was reviewed, tested, and is submitted by me. Happy to iterate on any feedback.


cc @dzhulgakov