### PR TITLE
[c10d][elastic] Fix find_free_port masking socket creation failures

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,17 +6,51 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest.mock import patch
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
     print("T85992919 temporarily disabling in circle ci", file=sys.stderr)
     sys.exit(0)
+
+
+class FindFreePortTest(unittest.TestCase):
+    # A single loopback address so the number of attempts is deterministic.
+    _ONE_ADDR = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+    # Two identical loopback addresses so the loop has a second address to try.
+    _TWO_ADDRS = _ONE_ADDR * 2
+
+    def test_retries_next_address_when_socket_creation_fails(self) -> None:
+        # If creating the socket for the first address fails, find_free_port
+        # must move on to the next address instead of raising UnboundLocalError
+        # while trying to clean up a socket that was never created.
+        good = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with (
+                patch("socket.getaddrinfo", return_value=self._TWO_ADDRS),
+                patch("socket.socket", side_effect=[OSError("first fails"), good]),
+            ):
+                result = find_free_port()
+            self.assertIs(result, good)
+        finally:
+            good.close()
+
+    def test_all_attempts_failing_raise_runtime_error(self) -> None:
+        # When every address fails to build a socket, the documented
+        # RuntimeError must surface -- not an UnboundLocalError from cleanup.
+        with (
+            patch("socket.getaddrinfo", return_value=self._ONE_ADDR),
+            patch("socket.socket", side_effect=OSError("socket failed")),
+        ):
+            with self.assertRaises(RuntimeError):
+                find_free_port()
 
 
 class EtcdServerTest(unittest.TestCase):

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,17 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            # Only close a socket that was actually created; socket.socket()
+            # itself may raise, in which case s is still None.
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes #191395

### Problem
In `find_free_port()`, the `except OSError` branch calls `s.close()`, but `s` is only bound *after* `socket.socket(...)` succeeds. If `socket.socket()` itself raises, `s` is unbound and `s.close()` raises `UnboundLocalError`, masking the original socket-creation error.

### Fix
Initialise `s = None` per attempt and only `s.close()` when a socket was actually created. Preserves the retry-next-address behaviour and the final `RuntimeError` when all addresses fail.

### Test verification (RED → GREEN)
```
# RED (unmodified main): the find_free_port tests fail
# GREEN (with fix): 2 passed
# (2 further tests in the file require an 'etcd' binary not present in this env — unrelated to this fix)
```

> **Disclosure (per [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md)):** this change was prepared with AI assistance and was reviewed, tested, and is submitted by me. Happy to iterate on any feedback.
