### PR TITLE
[distributed][tools] Fix MemoryTracker.load not restoring the operation count

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,4 +1,6 @@
 # Owner(s): ["oncall: distributed"]
+import contextlib
+import io
 import os
 import unittest
 
@@ -62,6 +64,39 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    def test_save_load_preserves_op_index(self):
+        """
+        A save/load round trip must restore the operation count so that
+        ``summary()`` keeps reporting the per-operator memory deltas. This runs
+        on CPU without an accelerator by populating the traces directly, mirror-
+        ing what ``_record_memory_stats()`` does during a monitored run.
+        """
+        tracker = MemoryTracker()
+        for i, name in enumerate(("op_a", "op_b")):
+            tracker.memories_allocated[i] = (name, float(i + 1))
+            tracker.memories_active[i] = (name, float(i + 1))
+            tracker.memories_reserved[i] = (name, float(i + 1))
+        tracker._op_index = 2
+
+        path = "memory_op_index.trace"
+        try:
+            tracker.save_stats(path)
+
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+            self.assertEqual(loaded._op_index, tracker._op_index)
+
+            # With _op_index lost, summary() iterates range(1, 0) and emits no
+            # operator deltas; once restored, the operator name must appear.
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                loaded.summary()
+            self.assertIn("op_b", buf.getvalue())
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,10 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # Restore the operation count so summary()/show_traces() can bound their
+        # iteration. Stats files written before op_index was persisted do not
+        # carry it, so reconstruct it from the number of recorded operations.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397

### Problem
`MemoryTracker.save_stats()` did not persist `_op_index`, and `load()` did not restore it. After `load()`, `_op_index` stayed `0`, so `summary()`/`show_traces()` (which iterate `range(1, self._op_index)`) produced no output on a loaded tracker.

### Fix
Persist `op_index` in `save_stats()` and restore it in `load()`, with a backward-compatible fallback (`stats.get("op_index", len(self.memories_allocated))`) for stats files written before this key existed.

### Test verification (RED → GREEN)
New test `test_save_load_preserves_op_index`:
```
# RED (unmodified main): FAILED test_save_load_preserves_op_index
# GREEN (with fix): 1 passed
```

> **Disclosure (per [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md)):** this change was prepared with AI assistance and was reviewed, tested, and is submitted by me. Happy to iterate on any feedback.
