### PR TITLE
[Testcase Refactoring] Split test_device_assert.py by hardware classification and migrate triton guard to capability mechanism

### DIFF
--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -5,18 +5,22 @@ import torch._inductor.config
 from torch._inductor import metrics
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.triton_utils import requires_gpu_and_triton
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 @instantiate_parametrized_tests
-class TestTorchDeviceAssertTrigger(TestCase):
+class TestTorchDeviceAssertTriggerGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize("backend", ["eager", "aot_eager", "inductor"])
     def test_assert_should_throw(self, backend):
         def func():
@@ -57,13 +61,17 @@ class TestTorchDeviceAssertTrigger(TestCase):
         f_c = torch.compile(func_inline, backend=backend)
         f_c()
 
-    @requires_gpu_and_triton
+
+class TestTorchDeviceAssertTriggerAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
     @torch._inductor.config.patch(force_disable_caches=True)
-    def test_assert_fusion(self):
+    def test_assert_fusion(self, device):
         torch._logging.set_logs(inductor_metrics=True)
 
         def func():
-            a = torch.tensor([1.0, 2.0], device=device_type)
+            a = torch.tensor([1.0, 2.0], device=device)
             result = torch.all(a > 0)
             assert result, "should throw"  # noqa: S101
 
@@ -75,12 +83,12 @@ class TestTorchDeviceAssertTrigger(TestCase):
         self.assertEqual(metrics.generated_kernel_count, 1)
         torch._logging.set_logs()
 
-    @requires_gpu_and_triton
+    @requires_capabilities(Capability.lib.triton)
     @torch._inductor.config.patch(force_disable_caches=True)
-    def test_run_assert_triton(self):
+    def test_run_assert_triton(self, device):
         @torch.compile(backend="inductor")
         def fn():
-            a = torch.tensor([1.0, 2.0], device=device_type)
+            a = torch.tensor([1.0, 2.0], device=device)
             result = torch.all(a > 0)
             assert result, "should throw"  # noqa: S101
 
@@ -95,6 +103,15 @@ class TestTorchDeviceAssertTrigger(TestCase):
 
         _, code = run_and_get_code(fn)
         self.assertEqual(code[0].count("tl.device_assert"), 1)
+
+
+instantiate_device_type_tests(
+    TestTorchDeviceAssertTriggerAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -109,7 +109,6 @@ instantiate_device_type_tests(
     TestTorchDeviceAssertTriggerAccelerator,
     globals(),
     except_for="cpu",
-    allow_mps=True,
     allow_xpu=True,
 )
 

--- a/test/inductor/test_device_assert.py
+++ b/test/inductor/test_device_assert.py
@@ -3,18 +3,19 @@
 import torch
 import torch._inductor.config
 from torch._inductor import metrics
+from unittest import skipIf
+
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 @instantiate_parametrized_tests
@@ -65,7 +66,7 @@ class TestTorchDeviceAssertTriggerGeneric(TestCase):
 class TestTorchDeviceAssertTriggerAccelerator(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
+    @skipIf(not HAS_TRITON, "requires triton")
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_assert_fusion(self, device):
         torch._logging.set_logs(inductor_metrics=True)
@@ -83,7 +84,7 @@ class TestTorchDeviceAssertTriggerAccelerator(TestCase):
         self.assertEqual(metrics.generated_kernel_count, 1)
         torch._logging.set_logs()
 
-    @requires_capabilities(Capability.lib.triton)
+    @skipIf(not HAS_TRITON, "requires triton")
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_run_assert_triton(self, device):
         @torch.compile(backend="inductor")


### PR DESCRIPTION
### Summary

Split `TestTorchDeviceAssertTrigger` into Generic (CPU assert-throw tests) and Accelerator (triton fusion/codegen tests) classes using the `HardwareClassification` mechanism, and gate triton-only tests with `HAS_TRITON`.

### Changes

- Split into `TestTorchDeviceAssertTriggerGeneric` (GENERIC, `@instantiate_parametrized_tests`) and `TestTorchDeviceAssertTriggerAccelerator` (ACCELERATOR, `instantiate_device_type_tests` with `except_for="cpu"`)
- Replaced `@requires_gpu_and_triton` with `@skipIf(not HAS_TRITON, "requires triton")` on accelerator methods (the `Capability.lib.triton` registration was removed upstream)
- Removed module-level `device_type` variable; added `device` parameter to accelerator methods
- Updated imports accordingly

### Motivation

The original class mixed device-agnostic and accelerator-dependent tests. Splitting by `hw_classification` enables proper device-type instantiation. `@requires_gpu_and_triton` is redundant for GPU gating once `except_for="cpu"` is used, and the triton requirement is kept as an explicit `HAS_TRITON` guard.

### Dependencies

None: `HardwareClassification`, `instantiate_device_type_tests` and `HAS_TRITON` are all available in main.

### Test Plan
python test/inductor/test_device_assert.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
