### PR TITLE
[Testcase Refactoring] Decouple test_aot_inductor_package.py from CUDA-specific

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -33,7 +33,11 @@ from torch.testing._internal.common_cuda import (
     requires_triton_ptxas_compat,
     TRITON_PTXAS_VERSION,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    TEST_CUDA,
+)
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -99,6 +103,8 @@ def compile(
     params: f"{cls.__name__}{'Cpp' if params['package_cpp_only'] else ''}_{params['device']}",
 )
 class TestAOTInductorPackage(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def check_model(
         self: TestCase,
         model,
@@ -222,7 +228,7 @@ class TestAOTInductorPackage(TestCase):
         self.check_model(Model(), example_inputs)
 
     def test_int64_floor_divide_tensor_constant_divisor(self):
-        if self.device != "cuda":
+        if self.device != "cuda" and self.device != "privateuseone":
             raise unittest.SkipTest("requires CUDA")
 
         class Model(torch.nn.Module):

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: inductor"]
 import copy
 import dataclasses
-import functools
 import gc
 import io
 import os
@@ -11,10 +10,7 @@ import sys
 import tempfile
 import unittest
 import zipfile
-from collections.abc import Callable
 from pathlib import Path
-
-from parameterized import parameterized_class
 
 import torch
 import torch._inductor.config
@@ -34,22 +30,19 @@ from torch.testing._internal.common_cuda import (
     requires_triton_ptxas_compat,
     TRITON_PTXAS_VERSION,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    parametrize,
+    skipIfXpu,
+    TEST_CUDA,
+)
+from torch.testing._internal.inductor_utils import HAS_TRITON, requires_triton
 from torch.utils import _pytree as pytree
-
-
-def skipif(predicate: Callable[[str, bool], bool], reason: str):
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            if predicate(self.device, self.package_cpp_only):
-                self.skipTest(reason)
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def compile(
@@ -75,36 +68,21 @@ def compile(
     return loaded
 
 
-@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
-@parameterized_class(
-    [
-        {"device": "cpu", "package_cpp_only": False},
-    ]
-    + (
-        [
-            # FIXME: AssertionError: AOTInductor compiled library does not exist at
-            {"device": "cpu", "package_cpp_only": True}
-        ]
-        if not IS_FBCODE
-        else []
-    )
-    + (
-        [
-            {"device": GPU_TYPE, "package_cpp_only": False},
-            {"device": GPU_TYPE, "package_cpp_only": True},
-        ]
-        if sys.platform != "darwin"
-        else []
-    ),
-    class_name_func=lambda cls,
-    _,
-    params: f"{cls.__name__}{'Cpp' if params['package_cpp_only'] else ''}_{params['device']}",
-)
 class TestAOTInductorPackage(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if sys.platform == "darwin":
+            raise unittest.SkipTest("No CUDA on MacOS")
+
     def check_model(
         self: TestCase,
         model,
+        device,
         example_inputs,
+        package_cpp_only,
         inductor_configs=None,
         dynamic_shapes=None,
         atol=None,
@@ -112,13 +90,13 @@ class TestAOTInductorPackage(TestCase):
     ) -> AOTICompiledModel:
         with torch.no_grad():
             torch.manual_seed(0)
-            model = model.to(self.device)
+            model = model.to(device)
             ref_model = copy.deepcopy(model)
             ref_inputs = copy.deepcopy(example_inputs)
             expected = ref_model(*ref_inputs)
 
             inductor_configs = inductor_configs or {}
-            inductor_configs["aot_inductor.package_cpp_only"] = self.package_cpp_only
+            inductor_configs["aot_inductor.package_cpp_only"] = package_cpp_only
 
             torch.manual_seed(0)
             with WritableTempFile(suffix=".pt2") as f:
@@ -135,12 +113,12 @@ class TestAOTInductorPackage(TestCase):
         self.assertEqual(actual, expected, atol=atol, rtol=rtol)
         return compiled_model
 
-    def check_package_cpp_only(self: TestCase) -> None:
+    def check_package_cpp_only(self: TestCase, package_cpp_only) -> None:
         """
         Check if cmake and make are available.
-        Skip self.package_cpp_only=False tests
+        Skip package_cpp_only=False tests
         """
-        if not self.package_cpp_only:
+        if not package_cpp_only:
             raise unittest.SkipTest("Only meant to test cpp package")
         if shutil.which("cmake") is None:
             raise unittest.SkipTest("cmake is not available")
@@ -212,21 +190,25 @@ class TestAOTInductorPackage(TestCase):
             subprocess.run(["make"], cwd=build_path, check=True)
         return build_path, tmp_path
 
-    def test_add(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_add(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 return x + y
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
-        self.check_model(Model(), example_inputs)
+        self.check_model(Model(), example_inputs, device, package_cpp_only)
 
-    def test_int64_floor_divide_tensor_constant_divisor(self):
-        if self.device != "cuda":
-            raise unittest.SkipTest("requires CUDA")
-
+    @onlyAccelerator
+    @skipIfXpu(msg="requires CUDA")
+    @parametrize("package_cpp_only", [True, False])
+    def test_int64_floor_divide_tensor_constant_divisor(self, device, package_cpp_only):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -236,15 +218,15 @@ class TestAOTInductorPackage(TestCase):
                 return torch.floor_divide(x, self.divisor)
 
         example_inputs = (
-            torch.tensor([-5, -1, 0, 7, 8], dtype=torch.int64, device=self.device),
+            torch.tensor([-5, -1, 0, 7, 8], dtype=torch.int64, device=device),
         )
-        self.check_model(Model(), example_inputs)
+        self.check_model(Model(), example_inputs, device, package_cpp_only)
 
     @unittest.skipIf(
         IS_FBCODE, "Subprocess spawning doesn't work in fbcode Buck environment"
     )
-    def test_custom_output_type_missing_pytree_registration_error(self):
-        if self.device != "cpu" or self.package_cpp_only:
+    def test_custom_output_type_missing_pytree_registration_error(self, device):
+        if device != "cpu":
             raise unittest.SkipTest("Only needs one CPU Python package variant")
 
         @dataclasses.dataclass
@@ -304,7 +286,7 @@ model(torch.ones(2))
             msg=proc.stderr,
         )
 
-    def test_remove_intermediate_files(self):
+    def test_remove_intermediate_files(self, device):
         # For CUDA, generated cpp files contain absolute path to the generated cubin files.
         # With the package artifact, that cubin path should be overridden at the run time,
         # so removing those intermediate files in this test to verify that.
@@ -313,13 +295,13 @@ model(torch.ones(2))
                 return x + y
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
         model = Model()
         with torch.no_grad():
             torch.manual_seed(0)
-            model = model.to(self.device)
+            model = model.to(device)
             ref_model = copy.deepcopy(model)
             ref_inputs = copy.deepcopy(example_inputs)
             expected = ref_model(*ref_inputs)
@@ -338,22 +320,21 @@ model(torch.ones(2))
 
             self.assertEqual(actual, expected)
 
-    def test_load_package_with_stream_affinity(self):
-        if self.device == "cpu":
-            self.skipTest("stream affinity requires an accelerator")
-
+    @onlyAccelerator
+    @parametrize("package_cpp_only", [True, False])
+    def test_load_package_with_stream_affinity(self, device, package_cpp_only):
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x + 1
 
-        model = Model().to(self.device)
-        example_inputs = (torch.randn(10, 10, device=self.device),)
+        model = Model().to(device)
+        example_inputs = (torch.randn(10, 10, device=device),)
         expected = model(*example_inputs)
         ep = torch.export.export(model, example_inputs, strict=True)
         package_path = torch._inductor.aoti_compile_and_package(
             ep,
             inductor_configs={
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
             },
         )
         loaded = torch._inductor.aoti_load_package(
@@ -364,7 +345,11 @@ model(torch.ones(2))
 
         self.assertEqual(loaded(*example_inputs), expected)
 
-    def test_load_package_from_directory(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_load_package_from_directory(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -374,12 +359,12 @@ model(torch.ones(2))
                 return x + self.linear(y)
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
         model = Model()
         with torch.no_grad():
-            model = model.to(self.device)
+            model = model.to(device)
             ref_model = copy.deepcopy(model)
             ref_inputs = copy.deepcopy(example_inputs)
             expected = ref_model(*ref_inputs)
@@ -390,7 +375,7 @@ model(torch.ones(2))
                     ep,
                     package_path=f.name,
                     inductor_configs={
-                        "aot_inductor.package_cpp_only": self.package_cpp_only,
+                        "aot_inductor.package_cpp_only": package_cpp_only,
                     },
                 )
 
@@ -459,7 +444,11 @@ model(torch.ones(2))
                 finally:
                     shutil.rmtree(temp_dir)
 
-    def test_linear(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_linear(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -469,18 +458,19 @@ model(torch.ones(2))
                 return x + self.linear(y)
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
-        self.check_model(Model(), example_inputs)
+        self.check_model(Model(), example_inputs, device, package_cpp_only)
 
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     @unittest.skipIf(
         TEST_CUDA and _get_torch_cuda_version() < TRITON_PTXAS_VERSION,
         "Test is only supported on CUDA {}.{}+".format(*TRITON_PTXAS_VERSION),
     )
-    def test_compile_after_package(self):
-        self.check_package_cpp_only()
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_after_package(self, device, package_cpp_only):
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -492,14 +482,14 @@ model(torch.ones(2))
 
         with torch.no_grad():
             example_inputs = (
-                torch.randn(10, 10, device=self.device),
-                torch.randn(10, 10, device=self.device),
+                torch.randn(10, 10, device=device),
+                torch.randn(10, 10, device=device),
             )
-            model = Model().to(device=self.device)
+            model = Model().to(device=device)
             expected = model(*example_inputs)
 
             options = {
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
                 # Require kernels to be compiled into .o files
                 "aot_inductor.embed_kernel_binary": True,
             }
@@ -510,8 +500,9 @@ model(torch.ones(2))
                     model, example_inputs, options, tmp_dir
                 )
 
-                if self.device == GPU_TYPE:
-                    kernel_bin = get_kernel_bin_format(self.device)
+                device = torch.device(device).type
+                if device != "cpu":
+                    kernel_bin = get_kernel_bin_format(device)
                     self.assertTrue(not list(tmp_path.glob(f"*.{kernel_bin}")))
                     # Check that cubin binaries are embedded as object files.
                     # Either individual per-kernel .o files or a single combined .o.
@@ -522,16 +513,16 @@ model(torch.ones(2))
                 # Check if the .so file was build successfully
                 so_path = build_path / "libaoti_model.so"
                 self.assertTrue(so_path.exists())
-                optimized = torch._export.aot_load(str(so_path), self.device)
+                optimized = torch._export.aot_load(str(so_path), device)
                 actual = optimized(*example_inputs)
                 self.assertTrue(torch.allclose(actual, expected))
 
+    @onlyAccelerator
     @requires_triton_ptxas_compat
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
-    def test_compile_after_package_multi_arch(self):
-        if self.device != GPU_TYPE:
-            raise unittest.SkipTest(f"Only meant to test {GPU_TYPE}")
-        self.check_package_cpp_only()
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_after_package_multi_arch(self, device, package_cpp_only):
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -543,14 +534,14 @@ model(torch.ones(2))
 
         with torch.no_grad():
             example_inputs = (
-                torch.randn(10, 10, device=self.device),
-                torch.randn(10, 10, device=self.device),
+                torch.randn(10, 10, device=device),
+                torch.randn(10, 10, device=device),
             )
-            model = Model().to(device=self.device)
+            model = Model().to(device=device)
             expected = model(*example_inputs)
 
             options = {
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
                 # Expect kernel to be embedded in the final binary.
                 # We will make it the default behavior for the standalone mode.
                 "aot_inductor.emit_multi_arch_kernel": True,
@@ -565,16 +556,17 @@ model(torch.ones(2))
                 # Check if the .so file was build successfully
                 so_path = build_path / "libaoti_model.so"
                 self.assertTrue(so_path.exists())
-                optimized = torch._export.aot_load(str(so_path), self.device)
+                optimized = torch._export.aot_load(str(so_path), device)
                 actual = optimized(*example_inputs)
                 self.assertTrue(torch.allclose(actual, expected))
 
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     @requires_triton_ptxas_compat
     @torch._inductor.config.patch("test_configs.use_libtorch", True)
-    def test_compile_after_package_static(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_after_package_static(self, device, package_cpp_only):
         # compile_standalone will set package_cpp_only=True
-        self.check_package_cpp_only()
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -586,10 +578,10 @@ model(torch.ones(2))
 
         with torch.no_grad():
             example_inputs = (
-                torch.randn(10, 10, device=self.device),
-                torch.randn(10, 10, device=self.device),
+                torch.randn(10, 10, device=device),
+                torch.randn(10, 10, device=device),
             )
-            model = Model().to(device=self.device)
+            model = Model().to(device=device)
 
             # Test compilation when no name is passed in
             options = {
@@ -631,9 +623,10 @@ model(torch.ones(2))
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     @requires_triton_ptxas_compat
     @torch._inductor.config.patch("test_configs.use_libtorch", True)
-    def test_compile_standalone_cos(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_standalone_cos(self, device, package_cpp_only):
         # compile_standalone will set package_cpp_only=True
-        self.check_package_cpp_only()
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -643,8 +636,8 @@ model(torch.ones(2))
                 return torch.cos(x)
 
         with torch.no_grad():
-            example_inputs = (torch.randn(8, 32, device=self.device),)
-            model = Model().to(device=self.device)
+            example_inputs = (torch.randn(8, 32, device=device),)
+            model = Model().to(device=device)
 
             # Test compilation when model name is passed in
             options = {
@@ -664,8 +657,9 @@ model(torch.ones(2))
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     @requires_triton_ptxas_compat
     @torch._inductor.config.patch("test_configs.use_libtorch", True)
-    def test_compile_with_exporter(self):
-        self.check_package_cpp_only()
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_with_exporter(self, device, package_cpp_only):
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model1(torch.nn.Module):
             def forward(self, x, y):
@@ -679,8 +673,8 @@ model(torch.ones(2))
             return None
 
         example_inputs = (
-            torch.ones(3, 3).to(self.device),
-            torch.ones(3, 3).to(self.device),
+            torch.ones(3, 3).to(device),
+            torch.ones(3, 3).to(device),
         )
 
         package = _ExportPackage()
@@ -703,7 +697,7 @@ model(torch.ones(2))
                 result = self.cmake_compile_and_run(tmp_dir)
                 if package_example_inputs:
                     out_str = result.stdout
-                    device_str = self.device.upper()
+                    device_str = torch.device(device).type.upper()
 
                     expected_result = (
                         f"output_tensor1\n 2  2  2\n 2  2  2\n 2  2  2\n[ {device_str}FloatType{{3,3}} ]\n"
@@ -714,8 +708,9 @@ model(torch.ones(2))
     @requires_triton_ptxas_compat
     @unittest.skipIf(IS_FBCODE, "cmake won't work in fbcode")
     @torch._inductor.config.patch("test_configs.use_libtorch", True)
-    def test_compile_with_exporter_weights(self):
-        self.check_package_cpp_only()
+    @parametrize("package_cpp_only", [True, False])
+    def test_compile_with_exporter_weights(self, device, package_cpp_only):
+        self.check_package_cpp_only(package_cpp_only)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -729,10 +724,10 @@ model(torch.ones(2))
         def default(*args, **kwargs):
             return None
 
-        example_inputs = (torch.ones(3, 3).to(self.device),)
+        example_inputs = (torch.ones(3, 3).to(device),)
 
         package = _ExportPackage()
-        m1 = Model().to(self.device)
+        m1 = Model().to(device)
         exporter1 = package._exporter("Model", m1)._define_overload("default", default)
         exporter1(*example_inputs)
         expected_res = m1(*example_inputs)
@@ -753,7 +748,11 @@ model(torch.ones(2))
             true_res = next(iter(tensor_model.parameters()))
             self.assertEqual(expected_res, true_res)
 
-    def test_metadata(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_metadata(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -763,20 +762,20 @@ model(torch.ones(2))
                 return x + self.linear(y)
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
         metadata = {"dummy": "moo"}
 
         with torch.no_grad():
             torch.manual_seed(0)
-            model = Model().to(device=self.device)
+            model = Model().to(device=device)
             ref_model = copy.deepcopy(model)
             ref_inputs = copy.deepcopy(example_inputs)
             expected = ref_model(*ref_inputs)
 
             inductor_configs = {
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
                 "aot_inductor.metadata": metadata,
             }
 
@@ -833,7 +832,11 @@ model(torch.ones(2))
         loaded_metadata = compiled_model.get_metadata()  # type: ignore[attr-defined]
         self.assertEqual(loaded_metadata.get("dummy"), "moo")
 
-    def test_bool_input(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_bool_input(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         # Specialize on whichever branch the example input for b is
         class Model(torch.nn.Module):
             def forward(self, x, b):
@@ -842,13 +845,17 @@ model(torch.ones(2))
                 else:
                     return x + x
 
-        example_inputs = (torch.randn(3, 3, device=self.device), True)
-        self.check_model(Model(), example_inputs)
+        example_inputs = (torch.randn(3, 3, device=device), True)
+        self.check_model(Model(), example_inputs, device, package_cpp_only)
 
-    def test_multiple_methods(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_multiple_methods(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         options = {
             "aot_inductor.package": True,
-            "aot_inductor.package_cpp_only": self.package_cpp_only,
+            "aot_inductor.package_cpp_only": package_cpp_only,
         }
 
         class Model1(torch.nn.Module):
@@ -862,8 +869,8 @@ model(torch.ones(2))
         dim0_b = Dim("dim0_b", min=1, max=20)
         dynamic_shapes = {"a": {0: dim0_a}, "b": {0: dim0_b}}
         example_inputs1 = (
-            torch.randn(2, 4, device=self.device),
-            torch.randn(3, 4, device=self.device),
+            torch.randn(2, 4, device=device),
+            torch.randn(3, 4, device=device),
         )
         ep1 = torch.export.export(
             Model1(), example_inputs1, dynamic_shapes=dynamic_shapes, strict=True
@@ -878,12 +885,12 @@ model(torch.ones(2))
                 self.device = device
 
             def forward(self, x):
-                t = torch.tensor(x.size(-1), device=self.device, dtype=torch.float)
+                t = torch.tensor(x.size(-1), device=device, dtype=torch.float)
                 t = torch.sqrt(t * 3)
                 return x * t
 
-        example_inputs2 = (torch.randn(5, 5, device=self.device),)
-        ep2 = torch.export.export(Model2(self.device), example_inputs2, strict=True)
+        example_inputs2 = (torch.randn(5, 5, device=device),)
+        ep2 = torch.export.export(Model2(device), example_inputs2, strict=True)
         aoti_files2 = torch._inductor.aot_compile(
             ep2.module(), example_inputs2, options=options
         )
@@ -898,13 +905,13 @@ model(torch.ones(2))
         self.assertEqual(loaded1(*example_inputs1), ep1.module()(*example_inputs1))
         self.assertEqual(loaded2(*example_inputs2), ep2.module()(*example_inputs2))
 
-    @unittest.skipIf(not HAS_GPU, "requires gpu")
-    def test_duplicate_calls(self):
+    @onlyAccelerator
+    @requires_triton()
+    @parametrize("package_cpp_only", [True, False])
+    def test_duplicate_calls(self, device, package_cpp_only):
         options = {
             "aot_inductor.package": True,
         }
-
-        device = GPU_TYPE
 
         class Model1(torch.nn.Module):
             def __init__(self) -> None:
@@ -920,7 +927,7 @@ model(torch.ones(2))
             torch.randn(2, 4, device=device),
             torch.randn(3, 4, device=device),
         )
-        self.check_model(Model1(), example_inputs1)
+        self.check_model(Model1(), example_inputs1, device, package_cpp_only)
         ep1 = torch.export.export(
             Model1(), example_inputs1, dynamic_shapes=dynamic_shapes, strict=True
         )
@@ -928,10 +935,9 @@ model(torch.ones(2))
             ep1.module(), example_inputs1, options=options
         )
 
-        device = "cpu"
         example_inputs2 = (
-            torch.randn(2, 4, device=device),
-            torch.randn(3, 4, device=device),
+            torch.randn(2, 4, device="cpu"),
+            torch.randn(3, 4, device="cpu"),
         )
         ep2 = torch.export.export(
             Model1(), example_inputs2, dynamic_shapes=dynamic_shapes, strict=True
@@ -954,7 +960,11 @@ model(torch.ones(2))
             torch.allclose(loaded2(*example_inputs2), ep2.module()(*example_inputs2))
         )
 
-    def test_specified_output_dir(self):
+    @parametrize("package_cpp_only", [True, False])
+    def test_specified_output_dir(self, device, package_cpp_only):
+        if device == "cpu" and IS_FBCODE and package_cpp_only:
+            raise unittest.SkipTest("Skip only cpp package when cpu device in fbcode")
+
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -963,8 +973,8 @@ model(torch.ones(2))
                 return torch.cat([a, b], dim=0)
 
         example_inputs = (
-            torch.randn(2, 4, device=self.device),
-            torch.randn(3, 4, device=self.device),
+            torch.randn(2, 4, device=device),
+            torch.randn(3, 4, device=device),
         )
         ep = torch.export.export(Model(), example_inputs, strict=True)
         aoti_files = torch._inductor.aot_compile(
@@ -973,7 +983,7 @@ model(torch.ones(2))
             options={
                 "aot_inductor.output_path": "tmp_output_",
                 "aot_inductor.package": True,
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
             },
         )
         with WritableTempFile(suffix=".pt2") as f:
@@ -983,7 +993,7 @@ model(torch.ones(2))
             torch.allclose(loaded(*example_inputs), ep.module()(*example_inputs))
         )
 
-    def test_save_buffer(self):
+    def test_save_buffer(self, device):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -992,8 +1002,8 @@ model(torch.ones(2))
                 return torch.cat([a, b], dim=0)
 
         example_inputs = (
-            torch.randn(2, 4, device=self.device),
-            torch.randn(3, 4, device=self.device),
+            torch.randn(2, 4, device=device),
+            torch.randn(3, 4, device=device),
         )
         ep = torch.export.export(Model(), example_inputs, strict=True)
 
@@ -1005,11 +1015,13 @@ model(torch.ones(2))
                 torch.allclose(loaded(*example_inputs), ep.module()(*example_inputs))
             )
 
-    @skipif(
-        lambda device, package_cpp_only: device != "cpu" or package_cpp_only,
-        "CPU non-cpp package regression test",
-    )
-    def test_buffer_mutations_persist_across_package_calls(self):
+    @parametrize("package_cpp_only", [False])
+    def test_buffer_mutations_persist_across_package_calls(
+        self, device, package_cpp_only
+    ):
+        if device != "cpu":
+            raise unittest.SkipTest("CPU non-cpp package regression test")
+
         class Model(torch.nn.Module):
             def __init__(self, device):
                 super().__init__()
@@ -1034,11 +1046,11 @@ model(torch.ones(2))
                 )
 
         for always_keep_tensor_constants in (True, False):
-            model = Model(self.device)
+            model = Model(device)
             ep = torch.export.export(model, tuple())
             inductor_configs = {
                 "always_keep_tensor_constants": always_keep_tensor_constants,
-                "aot_inductor.package_cpp_only": self.package_cpp_only,
+                "aot_inductor.package_cpp_only": package_cpp_only,
             }
             with WritableTempFile(suffix=".pt2") as f:
                 package_path = torch._inductor.aoti_compile_and_package(
@@ -1051,9 +1063,9 @@ model(torch.ones(2))
             actual = [tuple(out.clone() for out in loaded()) for _ in range(3)]
             expected = []
             for call_idx in range(3):
-                expected_one = torch.full((1,), call_idx + 2.0, device=self.device)
-                expected_two = torch.full((2,), call_idx + 2.0, device=self.device)
-                expected_index = torch.tensor([call_idx + 2.0, 1.0], device=self.device)
+                expected_one = torch.full((1,), call_idx + 2.0, device=device)
+                expected_two = torch.full((2,), call_idx + 2.0, device=device)
+                expected_index = torch.tensor([call_idx + 2.0, 1.0], device=device)
                 expected.append(
                     (
                         expected_one,
@@ -1065,11 +1077,7 @@ model(torch.ones(2))
                 )
             self.assertEqual(actual, expected)
 
-    @skipif(
-        lambda device, package_cpp_only: package_cpp_only,
-        "No support for cpp only",
-    )
-    def test_package_without_weight(self):
+    def test_package_without_weight(self, device):
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):
                 super().__init__()
@@ -1079,8 +1087,8 @@ model(torch.ones(2))
                 return self.linear(a)
 
         M, N, K = 128, 2048, 4096
-        model = Model(N, K, self.device)
-        example_inputs = (torch.randn(M, K, device=self.device),)
+        model = Model(N, K, device)
+        example_inputs = (torch.randn(M, K, device=device),)
 
         inductor_configs = {
             "always_keep_tensor_constants": True,
@@ -1094,16 +1102,12 @@ model(torch.ones(2))
 
         compiled.load_constants(model.state_dict(), check_full_update=True)
 
-        test_inputs = torch.randn(M, K, device=self.device)
+        test_inputs = torch.randn(M, K, device=device)
         expected = model(test_inputs)
         output = compiled(test_inputs)
         self.assertEqual(expected, output)
 
-    @skipif(
-        lambda device, package_cpp_only: package_cpp_only,
-        "No support for cpp only",
-    )
-    def test_package_user_managed_weight(self):
+    def test_package_user_managed_weight(self, device):
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):
                 super().__init__()
@@ -1113,8 +1117,8 @@ model(torch.ones(2))
                 return self.linear(a)
 
         M, N, K = 128, 4096, 4096
-        model = Model(N, K, self.device)
-        example_inputs = (torch.randn(M, K, device=self.device),)
+        model = Model(N, K, device)
+        example_inputs = (torch.randn(M, K, device=device),)
 
         inductor_configs = {
             "always_keep_tensor_constants": True,
@@ -1130,7 +1134,7 @@ model(torch.ones(2))
             model.state_dict(), check_full_update=True, user_managed=False
         )
 
-        test_inputs = torch.randn(M, K, device=self.device)
+        test_inputs = torch.randn(M, K, device=device)
         expected = model(test_inputs)
         output = compiled(test_inputs)
         self.assertEqual(expected, output)
@@ -1156,14 +1160,14 @@ model(torch.ones(2))
         new_output = new_compiled(test_inputs)
         self.assertEqual(new_output, expected)
 
-    def test_deepcopy_compiled_model(self):
+    def test_deepcopy_compiled_model(self, device):
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 return x + y
 
         example_inputs = (
-            torch.randn(10, 10, device=self.device),
-            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=device),
+            torch.randn(10, 10, device=device),
         )
 
         model = Model()
@@ -1178,11 +1182,8 @@ model(torch.ones(2))
         self.assertEqual(expected, output)
         self.assertEqual(expected, output_copy)
 
-    @skipif(
-        lambda device, package_cpp_only: package_cpp_only,
-        "No support for cpp only",
-    )
-    def test_update_weights(self):
+    @parametrize("package_cpp_only", [False])
+    def test_update_weights(self, device, package_cpp_only):
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):
                 super().__init__()
@@ -1192,32 +1193,29 @@ model(torch.ones(2))
                 return self.linear(a)
 
         M, N, K = 128, 2048, 4096
-        model = Model(N, K, self.device)
-        example_inputs = (torch.randn(M, K, device=self.device),)
+        model = Model(N, K, device)
+        example_inputs = (torch.randn(M, K, device=device),)
 
-        compiled = self.check_model(model, example_inputs)
+        compiled = self.check_model(model, example_inputs, device, package_cpp_only)
 
         new_state_dict = {
-            "linear.weight": torch.randn(N, K, device=self.device),
-            "linear.bias": torch.randn(N, device=self.device),
+            "linear.weight": torch.randn(N, K, device=device),
+            "linear.bias": torch.randn(N, device=device),
         }
         model.load_state_dict(new_state_dict)
 
         compiled.load_constants(model.state_dict(), check_full_update=True)
 
-        test_inputs = torch.randn(M, K, device=self.device)
+        test_inputs = torch.randn(M, K, device=device)
         expected = model(test_inputs)
         output = compiled(test_inputs)
         self.assertEqual(expected, output)
 
-    @skipif(
-        lambda device, package_cpp_only: package_cpp_only,
-        "No support for cpp only",
-    )
-    def test_package_shared_weights(self):
+    @parametrize("package_cpp_only", [False])
+    def test_package_shared_weights(self, device, package_cpp_only):
         options = {
             "aot_inductor.package": True,
-            "aot_inductor.package_cpp_only": self.package_cpp_only,
+            "aot_inductor.package_cpp_only": package_cpp_only,
             "always_keep_tensor_constants": True,
             "aot_inductor.package_constants_in_so": False,
             "aot_inductor.package_constants_on_disk_format": "pickle_weights",
@@ -1294,14 +1292,11 @@ model(torch.ones(2))
         self.assertEqual(gm1.p1, x + 1)
         self.assertEqual(gm1.p2, y + 1)
 
-    @skipif(
-        lambda device, package_cpp_only: package_cpp_only,
-        "No support for cpp only",
-    )
-    def test_package_weights_on_disk_nested_module(self):
+    @parametrize("package_cpp_only", [False])
+    def test_package_weights_on_disk_nested_module(self, device, package_cpp_only):
         options = {
             "aot_inductor.package": True,
-            "aot_inductor.package_cpp_only": self.package_cpp_only,
+            "aot_inductor.package_cpp_only": package_cpp_only,
             "always_keep_tensor_constants": True,
             "aot_inductor.package_constants_in_so": False,
             "aot_inductor.package_constants_on_disk_format": "pickle_weights",
@@ -1318,8 +1313,8 @@ model(torch.ones(2))
             def forward(self, x):
                 return self.linear(x)
 
-        x = torch.randn(3, 3).to(self.device)
-        bar1 = Bar().to(self.device)
+        x = torch.randn(3, 3).to(device)
+        bar1 = Bar().to(device)
         ep = torch.export.export(bar1, (x,))
         package_path = torch._inductor.aoti_compile_and_package(
             ep, inductor_configs=options
@@ -1328,12 +1323,12 @@ model(torch.ones(2))
         loaded1 = pt2_contents.aoti_runners["model"]
         self.assertEqual(loaded1(x), bar1(x))
 
-    def test_loading_wrong_model(self):
+    def test_loading_wrong_model(self, device):
         class Model(torch.nn.Module):
             def forward(self, x):
                 return x + 1
 
-        example_inputs = (torch.randn(10, 10, device=self.device),)
+        example_inputs = (torch.randn(10, 10, device=device),)
         model = Model()
         ep = torch.export.export(model, example_inputs)
         package_path = torch._inductor.aoti_compile_and_package(ep)
@@ -1345,8 +1340,10 @@ model(torch.ones(2))
             load_package(package_path, model_name="forward")
 
 
+instantiate_device_type_tests(TestAOTInductorPackage, globals(), allow_xpu=True)
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU or sys.platform == "darwin":
+    if HAS_TRITON or sys.platform == "darwin":
         run_tests(needs="filelock")

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -8,6 +8,7 @@ import torch
 import torch.cuda
 from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU, TEST_MTIA
 from torch.utils._import_utils import _check_module_exists
+from torch._utils import _is_privateuse1_backend_available
 import inspect
 import contextlib
 import os
@@ -688,6 +689,7 @@ def xfailCUDAIfSM89OrLaterOnWindows(test_fn):
 TRITON_PTXAS_VERSION = (12, 8)
 requires_triton_ptxas_compat = unittest.skipIf(not torch.version.xpu
                                                and torch.version.hip is None
+                                               and not _is_privateuse1_backend_available()
                                                and _get_torch_cuda_version() < TRITON_PTXAS_VERSION,
                                                "Requires CUDA {}.{} to match Tritons ptxas version".format(*TRITON_PTXAS_VERSION))
 


### PR DESCRIPTION
## Summary
This PR add `privateuseone` to accelerator test cases just with `cuda` so out-of-tree accelerator backends can run these tests, hardware classify and instantiate device-specific test classes.

## Changes
- Add `privateuseone` to accelerator test cases just with `cuda`.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `HardwareClassification.GENERIC|ACCELERATOR|CPU|CUDA|XXX` to tests class.

## Motivation
`torch.cuda` and `torch.xpu` only recognizes CUDA and XPU. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_aot_inductor_package.py --hw-classification GENERIC ACCELERATOR XXX`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo