### PR TITLE
[Testcase Refactoring] Label test_symmetric_memory classes with HardwareClassification

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -55,6 +55,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda,
@@ -94,6 +95,8 @@ device_module = torch.get_device_module(device_type)
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -828,6 +831,8 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class AsyncTPTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1228,6 +1233,8 @@ class AsyncTPTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1351,6 +1358,8 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
 # MultiProcessTestCase instead of MultiProcContinuousTest.
 @requires_cuda_p2p_access()
 class SymmMemNegativeTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1524,6 +1533,8 @@ class SymmMemNegativeTest(MultiProcessTestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemCollectiveTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1813,6 +1824,8 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1882,6 +1895,8 @@ class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class LoweringTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_process(self) -> None:
         torch.cuda.set_device(self.device)
         torch.manual_seed(42 + self.rank)
@@ -2399,6 +2414,8 @@ class LoweringTest(MultiProcContinuousTest):
 
 
 class SymmMemSingleProcTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_cuda
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
@@ -2478,6 +2495,8 @@ class SymmMemSingleProcTest(TestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemPoolTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -2654,6 +2673,8 @@ class SymmMemPoolTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     """CUDA symm_mem rendezvous against a torchcomms-backed PG.
 
     Builds a torchcomms comm, wraps it in _BackendWrapper, registers it as
@@ -2708,6 +2729,8 @@ class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
 @skipIf(TEST_WITH_ROCM, "NCCL symmetric memory is not supported on ROCm")
 @skipIf(not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch")
 class ExternalNcclCommRegistrationTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """Tests for the external NCCL comm registration API
     (``register_external_nccl_comm`` and the ``NcclCommRegistration`` handle
     from ``torch.distributed._symmetric_memory._nccl``), exercised against a

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -52,6 +52,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda,
@@ -94,6 +95,8 @@ device_module = torch.get_device_module(device_type)
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -728,6 +731,8 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class AsyncTPTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1091,6 +1096,8 @@ class AsyncTPTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1212,6 +1219,8 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
 # MultiProcessTestCase instead of MultiProcContinuousTest.
 @requires_cuda_p2p_access()
 class SymmMemNegativeTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -1341,6 +1350,8 @@ class SymmMemNegativeTest(MultiProcessTestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemCollectiveTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1629,6 +1640,8 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -1698,6 +1711,8 @@ class SymmetricMemoryTestCudaGraph(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class LoweringTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_process(self) -> None:
         torch.cuda.set_device(self.device)
         torch.manual_seed(42 + self.rank)
@@ -2185,6 +2200,8 @@ class LoweringTest(MultiProcContinuousTest):
 
 
 class SymmMemSingleProcTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_cuda
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
@@ -2264,6 +2281,8 @@ class SymmMemSingleProcTest(TestCase):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class SymmMemPoolTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
@@ -2439,6 +2458,8 @@ class SymmMemPoolTest(MultiProcContinuousTest):
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()
 class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     """CUDA symm_mem rendezvous against a torchcomms-backed PG.
 
     Builds a torchcomms comm, wraps it in _BackendWrapper, registers it as
@@ -2493,6 +2514,8 @@ class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
 @skipIf(TEST_WITH_ROCM, "NCCL symmetric memory is not supported on ROCm")
 @skipIf(not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch")
 class ExternalNcclCommRegistrationTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """Tests for the external NCCL comm registration API
     (``register_external_nccl_comm`` and the ``NcclCommRegistration`` handle
     from ``torch.distributed._symmetric_memory._nccl``), exercised against a


### PR DESCRIPTION
## Summary
This PR adds `hw_classification = HardwareClassification.CUDA` labels to all 11 `TestCase` subclasses in `test/distributed/test_symmetric_memory.py`, plus the `HardwareClassification` import.

## Changes
- **`test/distributed/test_symmetric_memory.py`**:
  - Added `HardwareClassification` to the `common_utils` import block.
  - Labeled all 11 classes `hw_classification = HardwareClassification.CUDA`:
    - `SymmetricMemoryTest` (20 tests, `@requires_cuda_p2p_access`, NVSHMEM/rocSHMEM primitives via `symm_mem`).
    - `AsyncTPTest` (7 tests, fused all_gather/matmul fallbacks on cuda tensors).
    - `SymmMemEmptySetDeviceTest` (2 tests, cuda device + symm_mem P2P).
    - `SymmMemNegativeTest` (4 tests, symm_mem error paths on cuda backend).
    - `SymmMemCollectiveTest` (8 tests, multimem all_reduce, `@skip_if_lt_x_gpu`).
    - `SymmetricMemoryTestCudaGraph` (1 test, cuda graph + symm_mem).
    - `LoweringTest` (9 tests, inductor lowering, `@skip_if_rocm_multiprocess`).
    - `SymmMemSingleProcTest` (2 tests, `@requires_cuda` + `device="cuda"`).
    - `SymmMemPoolTest` (6 tests, symm_mem mempool on cuda).
    - `TorchCommsCudaSymmMemTest` (1 test, cuda+nccl symm_mem rendezvous).
    - `ExternalNcclCommRegistrationTest` (4 tests, `libnccl.so.2` + `cuda:0` + NCCL comm via ctypes).

## Motivation
An unclassified `TestCase` is silently dropped when `--hw-classification CUDA` is passed. The 11 classes in this file had no label, so they were invisible under hardware-classification filtering despite all being CUDA-only. Labeling them `CUDA` makes them correctly collectible under `--hw-classification CUDA`.

These classes exercise NVSHMEM (NVIDIA) / rocSHMEM (AMD) primitives, symmetric-memory collectives, inductor lowering, and NCCL comm registration, all on the `"cuda"` device type. The file supports both NVIDIA and AMD hardware (gated by `TEST_WITH_ROCM`, `skip_if_rocm_multiprocess`, `PLATFORM_SUPPORTS_SYMM_MEM`), but `HardwareClassification` keys on `device_type` string, not hardware brand — and ROCm reuses the `"cuda"` namespace via HIP. So this is a single-device-type test set classified as `CUDA`, not `ACCELERATOR` (there is no `ROCM` enum value, no `ROCmTestBase`, and `only_for="cuda"` produces one `Test_cuda` variant covering both NVIDIA and AMD). `TEST_WITH_ROCM` is a sub-variant flag within `"cuda"`, like `SM90OrLater`/`IS_H100`.

No split, instantiation, or mechanism change is needed: the classes are single-device-type only (no `instantiate_device_type_tests`, matching the `NCCLSymmetricMemoryTest` / `SHMEMTritonTest` precedent — there is no second device type to generate a variant for), and the hard-coded `cuda` / `backend="nccl"` / NVSHMEM APIs are consistent with the `CUDA` label. The label is static metadata and does not change runtime behavior.

## Test Plan
- Verified `lintrunner` reports no lint issues (import ordering and class-header blank lines conform).
- Classification verified by static analysis: all 11 classes use `device_type = "cuda"` + `@requires_cuda`/`@requires_cuda_p2p_access`/`@skip_if_lt_x_gpu` + `torch.device("cuda:...")` + NCCL/NVSHMEM APIs — single device type, consistent with the `CUDA` label and the ROCm-does-not-promote-to-ACCELERATOR rule.


## Notes
- This is part of the test case refactoring initiative tracked in #185590.
