### PR TITLE
Pass group_desc and group_name to NCCL via ncclConfig.commName

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4851,6 +4851,40 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         self.assertEqual(pg_opts.config.comm_name, comm_name.decode())
 
     @requires_nccl()
+    @requires_nccl_version(
+        (2, 27, 3), "Need NCCL 2.27.3+ for testing comm_name in ncclConfig_t"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_comm_name_defaults_to_group_desc_and_name(self):
+        # When the user does not set config.comm_name, ProcessGroupNCCL populates
+        # it with "<group_desc>:<group_name>" so the NCCL profiler / Inspector can
+        # recover the group semantics.
+        nccl_cfg = c10d.ProcessGroupNCCL.NCCLConfig()
+        if not hasattr(nccl_cfg, "comm_name"):
+            raise SkipTest(
+                "comm_name binding absent (PyTorch might be built against NCCL < 2.27.3)"
+            )
+        store = c10d.FileStore(self.file_name, self.world_size)
+        os.environ["NCCL_DEBUG"] = "INFO"
+        with tempfile.NamedTemporaryFile() as nccl_debug_file:
+            os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
+            dist.init_process_group(
+                "nccl", world_size=self.world_size, rank=self.rank, store=store
+            )
+            pg = c10d.new_group([0, 1], group_desc="test_desc")
+            t = torch.tensor([self.rank + 1] * 10).cuda(self.rank)
+            pg.allreduce(t).wait()
+            dist.barrier()
+            nccl_debug_file_content = nccl_debug_file.read()
+        comm_names = [
+            n.strip().decode()
+            for n in re.findall(
+                rb"Comm config Comm name set to (.*)", nccl_debug_file_content
+            )
+        ]
+        self.assertIn(f"{pg.group_desc}:{pg.group_name}", comm_names)
+
+    @requires_nccl()
     @skip_if_lt_x_gpu(4)
     def test_nccl_barrier(self):
         store = c10d.FileStore(self.file_name, self.world_size)

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3077,11 +3077,15 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::initNCCLComm(
   // reset log prefix to include group_desc
   logPrefix_ = createLogPrefix();
 
-#ifdef NCCL_COMM_DESCRIPTION
-  // Pass process group name and description to NCCL communicator
-  std::string commDesc = pg_desc_ + ':' + pg_uid_;
-  options_->config.commDesc = strdup(commDesc.c_str());
-#endif // NCCL_COMM_DESCRIPTION
+#ifdef NCCL_HAS_COMM_NAME
+  // Pass process group description and name to the NCCL communicator so the
+  // NCCL profiler (and NCCL Inspector) can recover the group semantics without
+  // scanning Python frames. NCCL config has no commDesc field, so use commName.
+  if (options_->config.commName == nullptr) {
+    std::string commName = pg_desc_ + ':' + pg_uid_;
+    options_->config.commName = strdup(commName.c_str());
+  }
+#endif // NCCL_HAS_COMM_NAME
 
   // For batch_isend_irecv, ncclGroupStart() would be called upfront
   bool batchP2P = ncclActiveGroupCounter_ > 0;


### PR DESCRIPTION
  ## Summary

  The classic `ProcessGroupNCCL` had a dead code block that wrote `pg_desc_ + ':' + pg_uid_` into `ncclConfig_t::commDesc`, guarded by `NCCL_COMM_DESCRIPTION`. That macro is never defined in the tree, and NCCL's config has no `commDesc` field at all -- as pointed out during the review of the PR that introduced this block (#124149): "It doesn't seem NCCL config has a commDesc field" (https://github.com/pytorch/pytorch/pull/124149). So the process group's description and name never actually reached NCCL.

  This change replaces that block to write the same string into `ncclConfig_t::commName` instead, guarded by the actually-defined `NCCL_HAS_COMM_NAME`. NCCL forwards `comm->config.commName` straight into the profiler plugin's `init(..., commName, ...)` callback, so tools like the NCCL profiler / NCCL Inspector can recover per-communicator group semantics (tp / pp / ep / ...) directly.

  ## Details

  - Macro: `NCCL_COMM_DESCRIPTION` (never defined) -> `NCCL_HAS_COMM_NAME` (defined).
  - Field: `commDesc` (does not exist) -> `commName`.
  - Payload unchanged: `"<group_desc>:<group_name>"`.
  - Only set `commName` when it is still `nullptr`, so a value the user set via the `NCCLConfig.comm_name` pybind property is preserved (it was previously written unconditionally, but `commName` -- unlike the old `commDesc` -- is user-settable).

  ## Test

  Verified end-to-end on a single node with 8x NVIDIA H20 (CUDA 12.9, NCCL 2.28.9). Built official pytorch `main` + this patch in a venv (bundled NCCL, `TORCH_CUDA_ARCH_LIST=9.0`); confirmed `NCCL_HAS_COMM_NAME` was active (the `NCCLConfig.comm_name` pybind is present in the build).

  Test script (2 ranks): create subgroups carrying a `group_desc`, then run a collective on each so the communicator is initialized:

  ```python
  dist.init_process_group("nccl")
  g_tp = dist.new_group(ranks=[0, 1], group_desc="tp")
  g_pp = dist.new_group(ranks=[0, 1], group_desc="pp")
  dist.all_reduce(t)               # world/default comm
  dist.all_reduce(t, group=g_tp)   # tp comm
  dist.all_reduce(t, group=g_pp)   # pp comm
  ```

  ```bash
  torchrun --nproc_per_node=2 commname_test.py
  # with an NCCL profiler plugin loaded (NCCL_PROFILER_PLUGIN=..., NCCL_DEBUG=INFO)
  # so the profiler init callback logs the commName it receives.
  ```


  The profiler `init(..., commName, ...)` receives `"<group_desc>:<group_name>"`.
  Contrast, same script + same profiler plugin, only torch differs:

  | torch build             | commName seen by the NCCL profiler init      |
  | ----------------------- | -------------------------------------------- |
  | stock 2.11 (no patch)   | `""` (empty) for every communicator          |
  | main + this patch       | `default_pg:0`, `tp:1`, `pp:2`               |

  So the PG description and name now propagate into `ncclConfig_t::commName` and reach the NCCL profiler / Inspector, whereas before nothing was set.

  Regression: if the caller does not pass `group_desc`, torch defaults it to `"undefined"` (the default PG uses `"default_pg"`), so `commName` becomes `"undefined:<group_name>"`, init is unaffected; and a user-set `NCCLConfig.comm_name` is not overwritten.
