### PR TITLE
[Testcase Refactoring] Add hw_classification to test/distributed/elastic/metrics/api_test.py 

### DIFF
--- a/test/distributed/elastic/metrics/api_test.py
+++ b/test/distributed/elastic/metrics/api_test.py
@@ -16,7 +16,11 @@ from torch.distributed.elastic.metrics.api import (
     MetricStream,
     prof,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def foo_1():
@@ -48,6 +52,8 @@ class Child(Parent):
 
 
 class MetricsApiTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def foo_2(self):
         pass
 


### PR DESCRIPTION
Summary

Enable --hw-classification filtering for test/distributed/elastic/metrics/api_test.py by tagging its single test class MetricsApiTest with a HardwareClassification label. The class is pure metadata/metrics logic exercised via mock.patch + an in-memory MetricHandler (no device parameter, no accelerator APIs, no @onlyCUDA/@onlyCPU/@skipXPU decorators), so it is classified GENERIC.

Changes

test/distributed/elastic/metrics/api_test.py:

Merged HardwareClassification into the existing from torch.testing._internal.common_utils import (...) import (alphabetically, split across multiple lines for the column limit). No other imports touched.

Added hw_classification = HardwareClassification.GENERIC as the first class attribute of MetricsApiTest, immediately after the class definition and before any method. This is the only attribute added; no test methods, helper classes, or decorators were modified.

Helper classes TestMetricsHandler (extends MetricHandler), Parent (abc.ABC), and Child (Parent) are not TestCase subclasses and intentionally do not carry hw_classification — only test classes are tagged.

No tests were moved, renamed, or had decorators added/removed. The file was already accelerator-unrelated (Strategy 1: plain TestCase, CPU-only logic); the only missing piece for HardwareClassificationTestLoader to filter it was the hw_classification attribute itself.

Motivation

Part of the test-case refactoring initiative (#185590) to tag test classes with HardwareClassification so the suite can be filtered by hardware category via --hw-classification. Without the tag, MetricsApiTest is "unclassified" and is excluded when --hw-classification GENERIC is passed, even though it is logically generic CPU-only logic that should run under that filter. This PR adds the tag so the class is correctly selectable.

The classification is metadata only: it filters tests when --hw-classification is passed; normal discovery and execution are unchanged.

Test Plan

python test/distributed/elastic/metrics/api_test.py -v --hw-classification GENERIC

python test/distributed/elastic/metrics/api_test.py

Both run OK (3/3 tests pass).

Notes

Part of the test case refactoring initiative tracked in #185590. No framework dependency — this PR only adds the classification tag to a single already-generic test class.

[@wjlFlyer](https://github.com/wjlFlyer)
[@pjyFight](https://github.com/pjyFight)
[@FuDdd](https://github.com/FuDdd)
[@fffrog](https://github.com/fffrog)
[@lyriexs666](https://github.com/lyriexs666)
[@jishuangfeng](https://github.com/jishuangfeng)
[@JiasenTian](https://github.com/JiasenTian)