### PR TITLE
[xpu][test][inductor] Enable multiGPU tests in `test_flex_attention.py` for Intel GPU

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -55,9 +55,6 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     TEST_MULTIGPU,
 )
-from torch.testing._internal.common_xpu import (
-    TEST_MULTIXPU,
-)
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -86,6 +83,7 @@ from torch.testing._internal.common_utils import (  # noqa: F401
     TEST_WITH_ROCM,
     TEST_WITH_SLOW,
 )
+from torch.testing._internal.common_xpu import TEST_MULTIXPU
 from torch.testing._internal.inductor_utils import HAS_GPU, HAS_MPS
 from torch.utils._triton import has_triton, has_triton_tma_device
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -53,7 +53,6 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_BF16,
     PLATFORM_SUPPORTS_FP8,
-    TEST_MULTIGPU,
 )
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -80,10 +79,10 @@ from torch.testing._internal.common_utils import (  # noqa: F401
     serialTest,
     skipIfRocm,
     skipIfRocmArch,
+    TEST_MULTIACCELERATOR,
     TEST_WITH_ROCM,
     TEST_WITH_SLOW,
 )
-from torch.testing._internal.common_xpu import TEST_MULTIXPU
 from torch.testing._internal.inductor_utils import HAS_GPU, HAS_MPS
 from torch.utils._triton import has_triton, has_triton_tma_device
 
@@ -5708,7 +5707,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @unittest.skipUnless(TEST_MULTIGPU or TEST_MULTIXPU, "detected only one GPU")
+    @unittest.skipUnless(TEST_MULTIACCELERATOR, "detected only one GPU")
     def test_qkv_and_block_mask_on_the_same_device(self, device):
         second_device = device.split(":")[0] + ":1"
         make_tensor = functools.partial(
@@ -6546,9 +6545,8 @@ class GraphModule(torch.nn.Module):
         with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
             compiled_flex(q, k, v)
 
-    @unittest.skipUnless(TEST_MULTIGPU or TEST_MULTIXPU, "detected only one GPU")
+    @unittest.skipUnless(TEST_MULTIACCELERATOR, "detected only one GPU")
     def test_device_cuda_1(self, device):
-
         class TestModule(torch.nn.Module):
             def forward(self, q, k, v, block_mask):
                 return flex_attention(q, k, v, block_mask=block_mask)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -55,6 +55,9 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     TEST_MULTIGPU,
 )
+from torch.testing._internal.common_xpu import (
+    TEST_MULTIXPU,
+)
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -5707,12 +5710,13 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
 
     @supported_platform
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @unittest.skipUnless(TEST_MULTIGPU or TEST_MULTIXPU, "detected only one GPU")
     def test_qkv_and_block_mask_on_the_same_device(self, device):
+        second_device = device.split(":")[0] + ":1"
         make_tensor = functools.partial(
             torch.ones,
             (2, 2, 256, 32),
-            device="cuda:0",
+            device=device,
             dtype=torch.float32,
             requires_grad=True,
         )
@@ -5721,7 +5725,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         def mask_mod(b, h, q, kv):
             return q >= kv
 
-        block_mask = create_block_mask(mask_mod, 1, 1, 256, 256, device="cuda:1")
+        block_mask = create_block_mask(mask_mod, 1, 1, 256, 256, device=second_device)
         with self.assertRaisesRegex(
             RuntimeError, "Expect q/k/v and block_mask to be on the same device"
         ):
@@ -6544,26 +6548,28 @@ class GraphModule(torch.nn.Module):
         with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg):
             compiled_flex(q, k, v)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @unittest.skipUnless(TEST_MULTIGPU or TEST_MULTIXPU, "detected only one GPU")
     def test_device_cuda_1(self, device):
+        second_device = device.split(":")[0] + ":1"
+
         class TestModule(torch.nn.Module):
             def forward(self, q, k, v, block_mask):
                 return flex_attention(q, k, v, block_mask=block_mask)
 
-        q = torch.randn(1, 1, 256, 32, device="cuda:1", dtype=torch.bfloat16)
-        k = torch.randn(1, 1, 256, 32, device="cuda:1", dtype=torch.bfloat16)
-        v = torch.randn(1, 1, 256, 32, device="cuda:1", dtype=torch.bfloat16)
+        q = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
+        k = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
+        v = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
         mask = create_block_mask(
             lambda b, h, q_idx, kv_idx: q_idx >= kv_idx,
             B=None,
             H=None,
             Q_LEN=256,
             KV_LEN=256,
-            device="cuda:1",
+            device=second_device,
         )
         mod = torch.compile(TestModule())
         attn_output = mod(q, k, v, mask)
-        self.assertEqual(attn_output.device, torch.device("cuda:1"))
+        self.assertEqual(attn_output.device, torch.device(second_device))
 
     @supported_platform
     @skip_on_cpu

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -5709,11 +5709,10 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @supported_platform
     @unittest.skipUnless(TEST_MULTIACCELERATOR, "detected only one GPU")
     def test_qkv_and_block_mask_on_the_same_device(self, device):
-        second_device = device.split(":")[0] + ":1"
         make_tensor = functools.partial(
             torch.ones,
             (2, 2, 256, 32),
-            device=device,
+            device=0,
             dtype=torch.float32,
             requires_grad=True,
         )
@@ -5722,7 +5721,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         def mask_mod(b, h, q, kv):
             return q >= kv
 
-        block_mask = create_block_mask(mask_mod, 1, 1, 256, 256, device=second_device)
+        block_mask = create_block_mask(mask_mod, 1, 1, 256, 256, device=1)
         with self.assertRaisesRegex(
             RuntimeError, "Expect q/k/v and block_mask to be on the same device"
         ):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6548,26 +6548,25 @@ class GraphModule(torch.nn.Module):
 
     @unittest.skipUnless(TEST_MULTIGPU or TEST_MULTIXPU, "detected only one GPU")
     def test_device_cuda_1(self, device):
-        second_device = device.split(":")[0] + ":1"
 
         class TestModule(torch.nn.Module):
             def forward(self, q, k, v, block_mask):
                 return flex_attention(q, k, v, block_mask=block_mask)
 
-        q = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
-        k = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
-        v = torch.randn(1, 1, 256, 32, device=second_device, dtype=torch.bfloat16)
+        q = torch.randn(1, 1, 256, 32, device=1, dtype=torch.bfloat16)
+        k = torch.randn(1, 1, 256, 32, device=1, dtype=torch.bfloat16)
+        v = torch.randn(1, 1, 256, 32, device=1, dtype=torch.bfloat16)
         mask = create_block_mask(
             lambda b, h, q_idx, kv_idx: q_idx >= kv_idx,
             B=None,
             H=None,
             Q_LEN=256,
             KV_LEN=256,
-            device=second_device,
+            device=1,
         )
         mod = torch.compile(TestModule())
         attn_output = mod(q, k, v, mask)
-        self.assertEqual(attn_output.device, torch.device(second_device))
+        self.assertEqual(attn_output.device, torch.device(1))
 
     @supported_platform
     @skip_on_cpu

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -7,6 +7,8 @@ from torch.testing._internal.common_utils import IS_WINDOWS, LazyVal, TEST_XPU
 
 
 XPU_ALREADY_INITIALIZED_ON_IMPORT = torch.xpu.is_initialized()
+TEST_MULTIXPU = TEST_XPU and torch.xpu.device_count() >= 2
+
 
 
 class XPUCodename(enum.Enum):

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -7,7 +7,6 @@ from torch.testing._internal.common_utils import IS_WINDOWS, LazyVal, TEST_XPU
 
 
 XPU_ALREADY_INITIALIZED_ON_IMPORT = torch.xpu.is_initialized()
-TEST_MULTIXPU = TEST_XPU and torch.xpu.device_count() >= 2
 
 
 class XPUCodename(enum.Enum):

--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -10,7 +10,6 @@ XPU_ALREADY_INITIALIZED_ON_IMPORT = torch.xpu.is_initialized()
 TEST_MULTIXPU = TEST_XPU and torch.xpu.device_count() >= 2
 
 
-
 class XPUCodename(enum.Enum):
     PVC = "PVC"  # Intel® Data Center GPU Max Series
     BMG = "BMG"  # Intel® Arc™ Pro Battlemage Graphics


### PR DESCRIPTION
* Enable multiGPU tests in `test_flex_attention.py` for Intel GPU
  * Enable `test/inductor/test_flex_attention.py::TestFlexAttentionXPU::test_device_cuda_1_xpu`
  * Enable `test/inductor/test_flex_attention.py::TestFlexAttentionXPU::test_qkv_and_block_mask_on_the_same_device_xpu`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo