### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_dispatch.py

### DIFF
--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -8,7 +8,11 @@ from collections import namedtuple
 import torch._C as C
 import torch.utils.cpp_extension
 from torch._python_dispatcher import PythonDispatcher
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+)
 
 
 # TODO: Expand the dispatcher API to be a generic API for interfacing with
@@ -55,6 +59,7 @@ def extract_dispatch_table_with_keys(table, dispatch_keys):
 
 
 class TestDispatch(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     namespace_index = 0
 
     def test_all_invariants(self):
@@ -988,6 +993,8 @@ CPU: registered at {extension_path}:5 :: () -> () [ boxed unboxed ]
 
 
 class TestPythonDispatcher(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         dispatcher = PythonDispatcher()
         dispatcher.register(["CPU", "XLA", "Lazy", "CompositeImplicitAutograd"])

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -10,8 +10,8 @@ import torch.utils.cpp_extension
 from torch._python_dispatcher import PythonDispatcher
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    TestCase,
     run_tests,
+    TestCase,
 )
 
 


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestDispatch, TestPythonDispatcher as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/test_dispatch.py : import HardwareClassification, and add hw_classification to TestDispatch, TestPythonDispatcher classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_dispatch.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.