### PR TITLE
[dcp] Support integer dtypes in safetensors consolidation

### DIFF
--- a/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
+++ b/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
@@ -134,8 +134,7 @@ def _parse_input_metadata(
             if fqn in output_data.fqn_data:
                 output_data.fqn_data[fqn] = _FqnData(
                     shape_in_file=tensor_size,
-                    dtype_size=torch.finfo(_getdtype(dtype_str)).bits
-                    // 8,  # Convert bits to bytes
+                    dtype_size=torch.empty((), dtype=_getdtype(dtype_str)).element_size(),
                     dtype_str=dtype_str,
                 )
 


### PR DESCRIPTION
Fixes #192485.

`_parse_input_metadata` uses `torch.finfo` to calculate dtype size, which fails for integer and bool tensors.

This replaces it with `Tensor.element_size()`, which works for all supported dtypes and directly returns the size in bytes.

Testing:

* Reproduced the issue locally.
* Verified integer/bool dtype handling with the fix.
* Targeted regression test passed.
* `git diff --check` passed.
