### PR TITLE
[TEST] Add `hw_classification` to `test_nnapi.py`

### DIFF
--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -8,7 +8,11 @@ import unittest
 import torch
 from torch.backends._nnapi.prepare import convert_model_to_nnapi
 from torch.testing._internal.common_quantized import supported_qengines
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def qpt(t, scale, zero_point, dtype=torch.quint8):
@@ -27,6 +31,8 @@ def nhwc(t):
     "This Pytorch Build has not been built with or does not support QNNPACK",
 )
 class TestNNAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Avoid saturation in fbgemm


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.GENERIC` to `TestNNAPI`
- All 28 test methods use qnnpack quantized engine on CPU — tests NNAPI
- model conversion (JIT trace → NNAPI lowering). No accelerator dependency,
- no split needed.

Depends on: #186918

Follows the [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142) ([#185590](https://github.com/pytorch/pytorch/issues/185590)).

## Test Plan

```
python test/test_nnapi.py -v Ran 28 tests in 9.679s — OK
```

Co-authored-by: Opus 4.6

cc: @vishalgoyal316 @mansiag05 @RiyaP2508