### PR TITLE
[TEST] Add `hw_classification` to `test_pruning.py`

### DIFF
--- a/test/nn/test_pruning.py
+++ b/test/nn/test_pruning.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 import torch.nn.utils.prune as prune
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     run_tests,
     TemporaryFileName,
@@ -16,6 +17,8 @@ from torch.testing._internal.common_utils import (
 
 
 class TestPruningNN(NNTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.GENERIC` to `TestPruningNN`.
- All 34 test methods test `torch.nn.utils.prune` on CPU — structured/unstructured pruning, custom pruning, serialization.
- No accelerator dependency, no split needed.

Depends on: #186918

Follows the [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142) ([#185590](https://github.com/pytorch/pytorch/issues/185590)).

## Test Plan

```
python test/nn/test_pruning.py -v Ran 34 tests in 0.755s — OK
```


Co-authored-by: Opus 4.6

cc: @vishalgoyal316 @mansiag05 @RiyaP2508