### PR TITLE
[TEST] Add `hw_classification` to `test_module_hooks.py`

### DIFF
--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 from torch.testing._internal.common_nn import _create_basic_net, NNTestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     parametrize as parametrize_test,
@@ -186,6 +187,8 @@ class DummyContextManager:
 
 
 class TestModuleHooks(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize_test("named_tuple", (True, False))
     def test_forward_hooks(self, named_tuple):
         fired_hooks: list[int] = []
@@ -549,6 +552,8 @@ def _hook_to_pickle(*args, **kwargs):
 
 
 class TestStateDictHooks(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @swap([True, False])
     def test_load_state_dict_pre_hook(self):
         m = nn.Linear(10, 10)
@@ -943,6 +948,8 @@ class TestStateDictHooks(TestCase):
 
 
 class TestModuleGlobalHooks(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         nn.modules.module._global_backward_hooks = OrderedDict()
         nn.modules.module._global_forward_hooks = OrderedDict()
@@ -1254,6 +1261,8 @@ class TestModuleGlobalHooks(TestCase):
 
 
 class TestModuleHookNN(NNTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to all 4 test classes:
- `TestModuleHooks` (forward/backward hooks, parametrized)
- `TestStateDictHooks` (load/save state_dict hooks)
- `TestModuleGlobalHooks` (global hook registration)
- `TestModuleHookNN` (hook interaction with NNTestCase utilities)

All 54 tests exercise `nn.Module` hook APIs on CPU — no accelerator dependency, no split needed.

Depends on: #186918

Follows the [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142) ([#185590](https://github.com/pytorch/pytorch/issues/185590)).

## Test Plan

```
python test/nn/test_module_hooks.py -v Ran 54 tests in 0.926s — OK
```

Co-authored-by: Opus 4.6

cc: @vishalgoyal316 @mansiag05 @RiyaP2508