### PR TITLE
[Test][XPU] Enable inductor cases on XPU

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
 
 
 USE_LARGE_INPUT = os.environ.get("USE_LARGE_INPUT", "1") == "1"
@@ -72,7 +72,7 @@ class AutoChunkerTest(TestCase):
         weight.grad = None
         bias.grad = None
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         opt_f = torch.compile(f, dynamic=dynamic_shape)
         actual = (
             opt_f(_input, weight, bias),
@@ -80,7 +80,7 @@ class AutoChunkerTest(TestCase):
             weight.grad,
             bias.grad if use_bias else None,
         )
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
 
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
@@ -133,7 +133,7 @@ class AutoChunkerTest(TestCase):
 
         dtype = torch.bfloat16
 
-        mod = LinearAndCEL(C, V).cuda().to(dtype)
+        mod = LinearAndCEL(C, V).to(GPU_TYPE).to(dtype)
 
         def f(x, y):
             x.grad = None
@@ -147,13 +147,13 @@ class AutoChunkerTest(TestCase):
 
         opt_f = torch.compile(f)
 
-        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
-        y = torch.randint(0, V, (B, T)).cuda()
+        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
+        y = torch.randint(0, V, (B, T)).to(GPU_TYPE)
 
         expect = (f(x, y), x.grad, mod.linear.weight.grad, mod.linear.bias.grad)
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         actual = (opt_f(x, y), x.grad, mod.linear.weight.grad, mod.linear.bias.grad)
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
         self.assertTrue(
@@ -195,7 +195,7 @@ class AutoChunkerTest(TestCase):
 
         dtype = torch.bfloat16
 
-        mod = LinearAndCEL(C, V).cuda().to(dtype)
+        mod = LinearAndCEL(C, V).to(GPU_TYPE).to(dtype)
 
         def f(x, y):
             x.grad = None
@@ -218,11 +218,11 @@ class AutoChunkerTest(TestCase):
         opt_f = torch.compile(f)
 
         xs = [
-            torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
+            torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
             for _ in range(gradient_accumulation_steps)
         ]
         ys = [
-            torch.randint(0, V, (B, T)).cuda()
+            torch.randint(0, V, (B, T)).to(GPU_TYPE)
             for _ in range(gradient_accumulation_steps)
         ]
 
@@ -232,14 +232,14 @@ class AutoChunkerTest(TestCase):
             mod.linear.weight.grad,
             mod.linear.bias.grad,
         )
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         actual = (
             step(opt_f, xs, ys),
             *[x.grad for x in xs],
             mod.linear.weight.grad,
             mod.linear.bias.grad,
         )
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
         self.assertTrue(
@@ -394,9 +394,9 @@ class AutoChunkerTest(TestCase):
             "auto_chunker.num_chunk": 16,
             "auto_chunker.amplify_ratio_threshold": 10,
         }
-        mod = torch.compile(LinearAndCEL(C, V).cuda().to(dtype), options=options)
-        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
-        y = torch.randint(0, V, (B, T)).cuda()
+        mod = torch.compile(LinearAndCEL(C, V).to(GPU_TYPE).to(dtype), options=options)
+        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
+        y = torch.randint(0, V, (B, T)).to(GPU_TYPE)
         mod(x, y).backward()
         self.assertEqual(metrics.num_auto_chunking, 1)
 
@@ -404,5 +404,5 @@ class AutoChunkerTest(TestCase):
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_CUDA_AND_TRITON:
+    if HAS_GPU_AND_TRITON:
         run_tests()

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1032,7 +1032,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @config.patch(
         {
             "fx_graph_cache": True,
@@ -1059,12 +1059,12 @@ class TestFxGraphCache(TestCase):
             self.reset()
             CacheArtifactManager.clear()
 
-            x = torch.randn(256, 256, device="cuda")
-            y = torch.randn(256, 256, device="cuda")
+            x = torch.randn(256, 256, device=self.device_type)
+            y = torch.randn(256, 256, device=self.device_type)
             compiled_fn = torch.compile(fn, dynamic=False)
 
             self.assertEqual(fn(x, y), compiled_fn(x, y))
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
 
             artifacts = torch.compiler.save_cache_artifacts()
             self.assertIsNotNone(artifacts)
@@ -1189,7 +1189,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 2)
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 1)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @config.patch(
         {
             "fx_graph_cache": True,
@@ -1205,11 +1205,11 @@ class TestFxGraphCache(TestCase):
         def fn(x):
             return x + 1 * x
 
-        x = torch.randn(3, 2, device="cuda")
+        x = torch.randn(3, 2, device=self.device_type)
 
         with fresh_cache():
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=self.device_type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1227,7 +1227,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(len(cache_info.precompile_artifacts), 1)
 
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=self.device_type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1618,7 +1618,7 @@ class TestFxGraphCache(TestCase):
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_no_arguments_tensor_device_guards(self):
         """
         Usually, when there are example inputs, the device index of the inputs
@@ -1630,25 +1630,36 @@ class TestFxGraphCache(TestCase):
 
         @torch.compile
         def f():
-            y = torch.randn(3, device="cuda")
+            y = torch.randn(3, device=self.device_type)
             return (y,)
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        device_guard0 = (
+            torch.xpu._DeviceGuard(0)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(0)
+        )
+        with device_guard0:
+            torch.accelerator.set_device_idx(0)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:0"))
+            self.assertEqual(result[0].device, torch.device(f"{self.device_type}:0"))
         self.reset()
+
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        device_guard1 = (
+            torch.xpu._DeviceGuard(1)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(1)
+        )
+        with device_guard1:
+            torch.accelerator.set_device_idx(1)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:1"))
+            self.assertEqual(result[0].device, torch.device(f"{self.device_type}:1"))
 
     @config.patch("fx_graph_cache", True)
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_tensor_device_guards_cpu_tensor(self):
         """
         CPU tensor arguments should still cache hit
@@ -1658,15 +1669,25 @@ class TestFxGraphCache(TestCase):
         def f(x):
             return x.sin()
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        device_guard0 = (
+            torch.xpu._DeviceGuard(0)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(0)
+        )
+        with device_guard0:
+            torch.accelerator.set_device_idx(0)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
         self.reset()
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        device_guard1 = (
+            torch.xpu._DeviceGuard(1)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(1)
+        )
+        with device_guard1:
+            torch.accelerator.set_device_idx(1)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
@@ -2359,7 +2380,7 @@ class TestFxGraphCache(TestCase):
         self.assertNotEqual(a, b)
 
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @unittest.expectedFailure  # TODO: pass in optimize_mem at runtime
     def test_async_compile_cache(self):
         class SimpleFunction(torch.autograd.Function):
@@ -2371,7 +2392,7 @@ class TestFxGraphCache(TestCase):
             def backward(ctx, grad_output):
                 return grad_output * 2
 
-        x = torch.rand([10], requires_grad=True, device="cuda")
+        x = torch.rand([10], requires_grad=True, device=self.device_type)
         counters.clear()
 
         sf = SimpleFunction
@@ -4912,8 +4933,8 @@ class TestAutotuneCache(TestCase):
         self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
         self.assertIsNone(graph._compile_context)
 
-    @requires_cuda_and_triton
-    @unittest.skipIf(not SM80OrLater, "Requires SM80+")
+    @requires_gpu_and_triton
+    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
     @config.patch({"use_static_triton_launcher": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -4932,10 +4953,11 @@ class TestAutotuneCache(TestCase):
         def f(x, y, a, b):
             return Model()(x, y, a, b)
 
-        x = torch.randn(100, 100).cuda()
-        y = torch.randn(100, 100).cuda()
-        a = torch.randn(1000, 100).cuda()
-        b = torch.randn(1000, 100).cuda()
+        device = torch.device(GPU_TYPE)
+        x = torch.randn(100, 100, device=device)
+        y = torch.randn(100, 100, device=device)
+        a = torch.randn(1000, 100, device=device)
+        b = torch.randn(1000, 100, device=device)
         f_compiled = torch.compile(f, fullgraph=True)
 
         with PatchCaches():

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1213,7 +1213,6 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
-
     @requires_triton()
     @config.patch(
         {

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1213,6 +1213,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
+
     @requires_triton()
     @config.patch(
         {
@@ -1321,7 +1322,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 2)
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 1)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @config.patch(
         {
             "fx_graph_cache": True,
@@ -1337,11 +1338,11 @@ class TestFxGraphCache(TestCase):
         def fn(x):
             return x + 1 * x
 
-        x = torch.randn(3, 2, device="cuda")
+        x = torch.randn(3, 2, device=self.device_type)
 
         with fresh_cache():
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=self.device_type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1359,7 +1360,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(len(cache_info.precompile_artifacts), 1)
 
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=self.device_type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1750,7 +1751,7 @@ class TestFxGraphCache(TestCase):
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_no_arguments_tensor_device_guards(self):
         """
         Usually, when there are example inputs, the device index of the inputs
@@ -1762,25 +1763,36 @@ class TestFxGraphCache(TestCase):
 
         @torch.compile
         def f():
-            y = torch.randn(3, device="cuda")
+            y = torch.randn(3, device=self.device_type)
             return (y,)
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        device_guard0 = (
+            torch.xpu._DeviceGuard(0)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(0)
+        )
+        with device_guard0:
+            torch.accelerator.set_device_idx(0)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:0"))
+            self.assertEqual(result[0].device, torch.device(f"{self.device_type}:0"))
         self.reset()
+
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        device_guard1 = (
+            torch.xpu._DeviceGuard(1)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(1)
+        )
+        with device_guard1:
+            torch.accelerator.set_device_idx(1)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:1"))
+            self.assertEqual(result[0].device, torch.device(f"{self.device_type}:1"))
 
     @config.patch("fx_graph_cache", True)
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_tensor_device_guards_cpu_tensor(self):
         """
         CPU tensor arguments should still cache hit
@@ -1790,15 +1802,25 @@ class TestFxGraphCache(TestCase):
         def f(x):
             return x.sin()
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        device_guard0 = (
+            torch.xpu._DeviceGuard(0)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(0)
+        )
+        with device_guard0:
+            torch.accelerator.set_device_idx(0)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
         self.reset()
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        device_guard1 = (
+            torch.xpu._DeviceGuard(1)
+            if self.device_type == "xpu"
+            else torch.cuda._DeviceGuard(1)
+        )
+        with device_guard1:
+            torch.accelerator.set_device_idx(1)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
@@ -2491,7 +2513,7 @@ class TestFxGraphCache(TestCase):
         self.assertNotEqual(a, b)
 
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @unittest.expectedFailure  # TODO: pass in optimize_mem at runtime
     def test_async_compile_cache(self):
         class SimpleFunction(torch.autograd.Function):
@@ -2503,7 +2525,7 @@ class TestFxGraphCache(TestCase):
             def backward(ctx, grad_output):
                 return grad_output * 2
 
-        x = torch.rand([10], requires_grad=True, device="cuda")
+        x = torch.rand([10], requires_grad=True, device=self.device_type)
         counters.clear()
 
         sf = SimpleFunction
@@ -5044,8 +5066,8 @@ class TestAutotuneCache(TestCase):
         self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
         self.assertIsNone(graph._compile_context)
 
-    @requires_cuda_and_triton
-    @unittest.skipIf(not SM80OrLater, "Requires SM80+")
+    @requires_gpu_and_triton
+    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
     @config.patch({"use_static_triton_launcher": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -5064,10 +5086,11 @@ class TestAutotuneCache(TestCase):
         def f(x, y, a, b):
             return Model()(x, y, a, b)
 
-        x = torch.randn(100, 100).cuda()
-        y = torch.randn(100, 100).cuda()
-        a = torch.randn(1000, 100).cuda()
-        b = torch.randn(1000, 100).cuda()
+        device = torch.device(GPU_TYPE)
+        x = torch.randn(100, 100, device=device)
+        y = torch.randn(100, 100, device=device)
+        a = torch.randn(1000, 100, device=device)
+        b = torch.randn(1000, 100, device=device)
         f_compiled = torch.compile(f, fullgraph=True)
 
         with PatchCaches():

--- a/test/inductor/test_compile_to_python.py
+++ b/test/inductor/test_compile_to_python.py
@@ -13,8 +13,8 @@ from torch._inductor.utils import fresh_cache
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.utils import stateless
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import IS_BIG_GPU
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.inductor_utils import GPU_TYPE, IS_BIG_GPU
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
 
 
 def _capture(m, x, tracing_mode="fake"):
@@ -197,9 +197,9 @@ def call(args):
             compile_to_python(gm, _flat_inputs(m, x))
 
 
-@requires_cuda_and_triton
-class TestInductorCompileToPythonCudaCodegen(TestCase):
-    # On CUDA, compile_to_python emits actual @triton.jit kernels rather than the CPU
+@requires_gpu_and_triton
+class TestInductorCompileToPythonGPUCodegen(TestCase):
+    # On GPU, compile_to_python emits actual @triton.jit kernels rather than the CPU
     # extern_kernels / cpp_fused path the sibling class goldens. The expect goldens lock
     # the ``call()`` body only: it carries NO autotuning artifacts -- XBLOCK / num_warps
     # are chosen inside ``.run`` at launch time and the arch-specific DeviceProperties
@@ -216,20 +216,20 @@ class TestInductorCompileToPythonCudaCodegen(TestCase):
         return src, _extract_call(src)
 
     def test_pointwise_triton_kernel_codegen(self):
-        m = _Pointwise().eval().cuda()
-        x = torch.randn(128, 64, device="cuda")
+        m = _Pointwise().eval().to(GPU_TYPE)
+        x = torch.randn(128, 64, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
-            """\
+            f"""\
 def call(args):
     flat_1, = args
     args.clear()
     assert_size_stride(flat_1, (128, 64), (64, 1), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    with torch.{GPU_TYPE}._DeviceGuard(0):
+        torch.{GPU_TYPE}.set_device(0)
         flat_1 = copy_if_misaligned(flat_1)
-        buf0 = empty_strided_cuda((128, 64), (64, 1), torch.float32)
+        buf0 = empty_strided_{GPU_TYPE}((128, 64), (64, 1), torch.float32)
         # Topologically Sorted Source Nodes: [], Original ATen: []
         raw_stream0 = get_raw_stream(0)
         triton_poi_fused_0.run(flat_1, buf0, 8192, stream=raw_stream0)
@@ -252,20 +252,20 @@ def call(args):
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
 
     def test_reduction_triton_kernel_codegen(self):
-        m = _SumDim1().eval().cuda()
-        x = torch.randn(64, 256, device="cuda")
+        m = _SumDim1().eval().to(GPU_TYPE)
+        x = torch.randn(64, 256, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
-            """\
+            f"""\
 def call(args):
     flat_1, = args
     args.clear()
     assert_size_stride(flat_1, (64, 256), (256, 1), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    with torch.{GPU_TYPE}._DeviceGuard(0):
+        torch.{GPU_TYPE}.set_device(0)
         flat_1 = copy_if_misaligned(flat_1)
-        buf0 = empty_strided_cuda((64, ), (1, ), torch.float32)
+        buf0 = empty_strided_{GPU_TYPE}((64, ), (1, ), torch.float32)
         # Topologically Sorted Source Nodes: [], Original ATen: []
         raw_stream0 = get_raw_stream(0)
         triton_per_fused_0.run(flat_1, buf0, 64, 256, stream=raw_stream0)
@@ -284,26 +284,30 @@ def call(args):
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
 
     def test_addmm_relu_fused_triton_epilogue_codegen(self):
-        # CUDA counterpart of test_addmm_relu_fused_pointwise_codegen: the matmul is an
+        # GPU counterpart of test_addmm_relu_fused_pointwise_codegen: the matmul is an
         # extern BLAS call but the relu epilogue fuses into a @triton.jit kernel
         # (triton_poi_fused_add_0 here; a real AOTAutograd graph, with source-node
         # provenance, would name it triton_poi_fused_addmm_relu_0) rather than the CPU
         # cpp_fused_relu_0.
-        m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval().cuda()
-        x = torch.randn(5, 4, device="cuda")
+        m = (
+            torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU())
+            .eval()
+            .to(GPU_TYPE)
+        )
+        x = torch.randn(5, 4, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
-            """\
+            f"""\
 def call(args):
     flat_1, flat_2, flat_3 = args
     args.clear()
     assert_size_stride_grouped((flat_3, flat_1), ((5, 4), (3, 4)), ((4, 1), (4, 1)), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    with torch.{GPU_TYPE}._DeviceGuard(0):
+        torch.{GPU_TYPE}.set_device(0)
         flat_3 = copy_if_misaligned(flat_3)
         flat_1 = copy_if_misaligned(flat_1)
-        buf0 = empty_strided_cuda((5, 3), (3, 1), torch.float32)
+        buf0 = empty_strided_{GPU_TYPE}((5, 3), (3, 1), torch.float32)
         # Topologically Sorted Source Nodes: [], Original ATen: [aten.mm]
         extern_kernels.mm(flat_3, reinterpret_tensor(flat_1, (4, 3), (1, 4), 0), out=buf0)
         del flat_1
@@ -329,8 +333,8 @@ def call(args):
         # all collapse into ONE persistent-reduction Triton kernel. Its exact name
         # (the decomposition route) varies, so this checks structure + numerics rather
         # than goldening the call body.
-        m = _Softmax().eval().cuda()
-        x = torch.randn(32, 128, device="cuda")
+        m = _Softmax().eval().to(GPU_TYPE)
+        x = torch.randn(32, 128, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertIn("@triton.jit", src)
         self.assertIn("@triton_heuristics.persistent_reduction", src)
@@ -359,9 +363,9 @@ def call(args):
         m = (
             torch.nn.Sequential(torch.nn.Linear(8192, 64, bias=False), torch.nn.ReLU())
             .eval()
-            .cuda()
+            .to(GPU_TYPE)
         )
-        x = torch.randn(64, 8192, device="cuda")
+        x = torch.randn(64, 8192, device=GPU_TYPE)
         gm = _capture(m, x)
         orig = SubgraphChoiceCaller._compile_for_benchmarking
         bench_calls = []
@@ -399,8 +403,8 @@ def call(args):
             self.skipTest("requires inductor FxGraphCache enabled")
         if not config.use_static_cuda_launcher:
             self.skipTest("requires the static CUDA launcher")
-        m = _Pointwise().eval().cuda()
-        x = torch.randn(1024, 1024, device="cuda")
+        m = _Pointwise().eval().to(GPU_TYPE)
+        x = torch.randn(1024, 1024, device=GPU_TYPE)
         src, cache = compile_to_python(_capture(m, x), _flat_inputs(m, x))
         self.assertIsInstance(cache, bytes)
         with fresh_cache():

--- a/test/inductor/test_compile_to_python.py
+++ b/test/inductor/test_compile_to_python.py
@@ -13,8 +13,8 @@ from torch._inductor.utils import fresh_cache
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.utils import stateless
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import IS_BIG_GPU
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.inductor_utils import IS_BIG_GPU, GPU_TYPE
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
 
 
 def _capture(m, x, tracing_mode="fake"):
@@ -197,9 +197,9 @@ def call(args):
             compile_to_python(gm, _flat_inputs(m, x))
 
 
-@requires_cuda_and_triton
-class TestInductorCompileToPythonCudaCodegen(TestCase):
-    # On CUDA, compile_to_python emits actual @triton.jit kernels rather than the CPU
+@requires_gpu_and_triton
+class TestInductorCompileToPythonGPUCodegen(TestCase):
+    # On GPU, compile_to_python emits actual @triton.jit kernels rather than the CPU
     # extern_kernels / cpp_fused path the sibling class goldens. The expect goldens lock
     # the ``call()`` body only: it carries NO autotuning artifacts -- XBLOCK / num_warps
     # are chosen inside ``.run`` at launch time and the arch-specific DeviceProperties
@@ -216,8 +216,8 @@ class TestInductorCompileToPythonCudaCodegen(TestCase):
         return src, _extract_call(src)
 
     def test_pointwise_triton_kernel_codegen(self):
-        m = _Pointwise().eval().cuda()
-        x = torch.randn(128, 64, device="cuda")
+        m = _Pointwise().eval().to(GPU_TYPE)
+        x = torch.randn(128, 64, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
@@ -226,8 +226,9 @@ def call(args):
     flat_1, = args
     args.clear()
     assert_size_stride(flat_1, (128, 64), (64, 1), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    device_guard0 = torch.xpu._DeviceGuard(0) if GPU_TYPE == 'xpu' else torch.cuda._DeviceGuard(0)
+    with device_guard0:
+        torch.accelerator.set_device_idx(0)
         flat_1 = copy_if_misaligned(flat_1)
         buf0 = empty_strided_cuda((128, 64), (64, 1), torch.float32)
         # Topologically Sorted Source Nodes: [], Original ATen: []
@@ -252,8 +253,8 @@ def call(args):
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
 
     def test_reduction_triton_kernel_codegen(self):
-        m = _SumDim1().eval().cuda()
-        x = torch.randn(64, 256, device="cuda")
+        m = _SumDim1().eval().to(GPU_TYPE)
+        x = torch.randn(64, 256, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
@@ -262,8 +263,9 @@ def call(args):
     flat_1, = args
     args.clear()
     assert_size_stride(flat_1, (64, 256), (256, 1), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    device_guard0 = torch.xpu._DeviceGuard(0) if GPU_TYPE == 'xpu' else torch.cuda._DeviceGuard(0)
+    with device_guard0:
+        torch.accelerator.set_device_idx(0)
         flat_1 = copy_if_misaligned(flat_1)
         buf0 = empty_strided_cuda((64, ), (1, ), torch.float32)
         # Topologically Sorted Source Nodes: [], Original ATen: []
@@ -284,13 +286,13 @@ def call(args):
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
 
     def test_addmm_relu_fused_triton_epilogue_codegen(self):
-        # CUDA counterpart of test_addmm_relu_fused_pointwise_codegen: the matmul is an
+        # GPU counterpart of test_addmm_relu_fused_pointwise_codegen: the matmul is an
         # extern BLAS call but the relu epilogue fuses into a @triton.jit kernel
         # (triton_poi_fused_add_0 here; a real AOTAutograd graph, with source-node
         # provenance, would name it triton_poi_fused_addmm_relu_0) rather than the CPU
         # cpp_fused_relu_0.
-        m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval().cuda()
-        x = torch.randn(5, 4, device="cuda")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval().to(GPU_TYPE)
+        x = torch.randn(5, 4, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertExpectedInline(
             call_src,
@@ -299,8 +301,9 @@ def call(args):
     flat_1, flat_2, flat_3 = args
     args.clear()
     assert_size_stride_grouped((flat_3, flat_1), ((5, 4), (3, 4)), ((4, 1), (4, 1)), 'input')
-    with torch.cuda._DeviceGuard(0):
-        torch.cuda.set_device(0)
+    device_guard0 = torch.xpu._DeviceGuard(0) if GPU_TYPE == 'xpu' else torch.cuda._DeviceGuard(0)
+    with device_guard0:
+        torch.accelerator.set_device_idx(0)
         flat_3 = copy_if_misaligned(flat_3)
         flat_1 = copy_if_misaligned(flat_1)
         buf0 = empty_strided_cuda((5, 3), (3, 1), torch.float32)
@@ -329,8 +332,8 @@ def call(args):
         # all collapse into ONE persistent-reduction Triton kernel. Its exact name
         # (the decomposition route) varies, so this checks structure + numerics rather
         # than goldening the call body.
-        m = _Softmax().eval().cuda()
-        x = torch.randn(32, 128, device="cuda")
+        m = _Softmax().eval().to(GPU_TYPE)
+        x = torch.randn(32, 128, device=GPU_TYPE)
         src, call_src = self._inner_call(m, x)
         self.assertIn("@triton.jit", src)
         self.assertIn("@triton_heuristics.persistent_reduction", src)
@@ -359,9 +362,9 @@ def call(args):
         m = (
             torch.nn.Sequential(torch.nn.Linear(8192, 64, bias=False), torch.nn.ReLU())
             .eval()
-            .cuda()
+            .to(GPU_TYPE)
         )
-        x = torch.randn(64, 8192, device="cuda")
+        x = torch.randn(64, 8192, device=GPU_TYPE)
         gm = _capture(m, x)
         orig = SubgraphChoiceCaller._compile_for_benchmarking
         bench_calls = []
@@ -404,8 +407,8 @@ def call(args):
             self.skipTest("requires inductor FxGraphCache enabled")
         if not config.use_static_cuda_launcher:
             self.skipTest("requires the static CUDA launcher")
-        m = _Pointwise().eval().cuda()
-        x = torch.randn(1024, 1024, device="cuda")
+        m = _Pointwise().eval().to(GPU_TYPE)
+        x = torch.randn(1024, 1024, device=GPU_TYPE)
         src, cache = compile_to_python(_capture(m, x), _flat_inputs(m, x))
         self.assertIsInstance(cache, bytes)
         with fresh_cache():

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -53,7 +53,6 @@ from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
-    HAS_CUDA_AND_TRITON,
     HAS_GPU,
     HAS_GPU_AND_TRITON,
 )
@@ -4111,14 +4110,14 @@ class CompiledAutograd0(torch.nn.Module):
                 compiler_fn=make_compiler_fn(backend="ca_eager", gm_hook=check),
             )
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_cpu_offloading(self):
         def fn():
             def pack(x):
                 return x.cpu()
 
             def unpack(x):
-                return x.cuda()
+                return x.to(GPU_TYPE)
 
             class MyMatMul(torch.autograd.Function):
                 @staticmethod
@@ -4133,7 +4132,7 @@ class CompiledAutograd0(torch.nn.Module):
 
             with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
                 for i in [10, 100, 10, 20, 30]:
-                    x = torch.randn(i, requires_grad=True).cuda()
+                    x = torch.randn(i, requires_grad=True).to(GPU_TYPE)
                     MyMatMul.apply(x).sum().backward()
                     yield x.grad
 
@@ -4157,12 +4156,12 @@ class CompiledAutograd1(torch.nn.Module):
         getitem_3 = sizes[1]
         getitem_4 = sizes[2];  sizes = None
 
-        validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type='cuda', index=0), 6, 0, None), [], False)]);  getitem = None
+        validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [], False)]);  getitem = None
         getitem_5 = validate_outputs[0];  validate_outputs = None
 
         sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_5], [True], []);  getitem_5 = None
         getitem_6 = sum_backward0[0];  sum_backward0 = None
-        validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_6], [((None, None, device(type='cuda', index=0), 6, 0, None), [], False)]);  getitem_6 = None
+        validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_6], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [], False)]);  getitem_6 = None
         getitem_7 = validate_outputs_1[0];  validate_outputs_1 = None
 
         getitem_8 = hooks[0]
@@ -4171,7 +4170,7 @@ class CompiledAutograd1(torch.nn.Module):
         call_hook = torch__dynamo_external_utils_call_hook(getitem_8, getitem_9, hook_type = 'unpack_hook');  getitem_8 = getitem_9 = None
         call_backward = torch__dynamo_external_utils_call_backward(getitem_10, (call_hook,), getitem_7);  getitem_10 = call_hook = getitem_7 = None
         getitem_12 = call_backward[0];  call_backward = None
-        validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_12], [((None, None, device(type='cuda', index=0), 6, 0, None), [getitem_3], False)]);  getitem_12 = getitem_3 = None
+        validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_12], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [getitem_3], False)]);  getitem_12 = getitem_3 = None
         getitem_13 = validate_outputs_2[0];  validate_outputs_2 = None
 
         to_copy_backward0 = torch__dynamo_compiled_autograd_ops_ToCopyBackward0([getitem_13], [True], (None, None, device(type='cpu'), 6, 0, None));  getitem_13 = None
@@ -5335,7 +5334,7 @@ def wrap_test_class(orig_cls):
             dct[name] = unittest.expectedFailure
         elif name.startswith("test_"):
             backend = lookup_backend(name)
-            if not HAS_CUDA_AND_TRITON and backend == "inductor":
+            if not HAS_GPU_AND_TRITON and backend == "inductor":
                 continue
             compiler_fn = make_compiler_fn(
                 backend=backend,
@@ -5653,7 +5652,7 @@ xfail_divergence_from_eager = {
 skipped_tests = set()
 skipped_tests.add("test_graph_queue_callback")
 
-if not HAS_CUDA_AND_TRITON:
+if not HAS_GPU_AND_TRITON:
     # Found Tesla M60 which is too old to be supported by the triton GPU compiler
     skipped_tests.add("test_type_conversions")
 

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -53,7 +53,7 @@ from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
-    HAS_CUDA_AND_TRITON,
+    HAS_GPU_AND_TRITON,
     HAS_GPU,
     HAS_GPU_AND_TRITON,
 )
@@ -4111,14 +4111,14 @@ class CompiledAutograd0(torch.nn.Module):
                 compiler_fn=make_compiler_fn(backend="ca_eager", gm_hook=check),
             )
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_cpu_offloading(self):
         def fn():
             def pack(x):
                 return x.cpu()
 
             def unpack(x):
-                return x.cuda()
+                return x.to(GPU_TYPE)
 
             class MyMatMul(torch.autograd.Function):
                 @staticmethod
@@ -4133,7 +4133,7 @@ class CompiledAutograd0(torch.nn.Module):
 
             with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
                 for i in [10, 100, 10, 20, 30]:
-                    x = torch.randn(i, requires_grad=True).cuda()
+                    x = torch.randn(i, requires_grad=True).to(GPU_TYPE)
                     MyMatMul.apply(x).sum().backward()
                     yield x.grad
 
@@ -4157,12 +4157,12 @@ class CompiledAutograd1(torch.nn.Module):
         getitem_3 = sizes[1]
         getitem_4 = sizes[2];  sizes = None
 
-        validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type='cuda', index=0), 6, 0, None), [], False)]);  getitem = None
+        validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [], False)]);  getitem = None
         getitem_5 = validate_outputs[0];  validate_outputs = None
 
         sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_5], [True], []);  getitem_5 = None
         getitem_6 = sum_backward0[0];  sum_backward0 = None
-        validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_6], [((None, None, device(type='cuda', index=0), 6, 0, None), [], False)]);  getitem_6 = None
+        validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_6], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [], False)]);  getitem_6 = None
         getitem_7 = validate_outputs_1[0];  validate_outputs_1 = None
 
         getitem_8 = hooks[0]
@@ -4171,7 +4171,7 @@ class CompiledAutograd1(torch.nn.Module):
         call_hook = torch__dynamo_external_utils_call_hook(getitem_8, getitem_9, hook_type = 'unpack_hook');  getitem_8 = getitem_9 = None
         call_backward = torch__dynamo_external_utils_call_backward(getitem_10, (call_hook,), getitem_7);  getitem_10 = call_hook = getitem_7 = None
         getitem_12 = call_backward[0];  call_backward = None
-        validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_12], [((None, None, device(type='cuda', index=0), 6, 0, None), [getitem_3], False)]);  getitem_12 = getitem_3 = None
+        validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_12], [((None, None, device(type=GPU_TYPE, index=0), 6, 0, None), [getitem_3], False)]);  getitem_12 = getitem_3 = None
         getitem_13 = validate_outputs_2[0];  validate_outputs_2 = None
 
         to_copy_backward0 = torch__dynamo_compiled_autograd_ops_ToCopyBackward0([getitem_13], [True], (None, None, device(type='cpu'), 6, 0, None));  getitem_13 = None
@@ -5335,7 +5335,7 @@ def wrap_test_class(orig_cls):
             dct[name] = unittest.expectedFailure
         elif name.startswith("test_"):
             backend = lookup_backend(name)
-            if not HAS_CUDA_AND_TRITON and backend == "inductor":
+            if not HAS_GPU_AND_TRITON and backend == "inductor":
                 continue
             compiler_fn = make_compiler_fn(
                 backend=backend,
@@ -5652,7 +5652,7 @@ xfail_divergence_from_eager = {
 
 skipped_tests = set()
 
-if not HAS_CUDA_AND_TRITON:
+if not HAS_GPU_AND_TRITON:
     # Found Tesla M60 which is too old to be supported by the triton GPU compiler
     skipped_tests.add("test_type_conversions")
 

--- a/test/inductor/test_dropout_align_random_eager.py
+++ b/test/inductor/test_dropout_align_random_eager.py
@@ -9,10 +9,10 @@ from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
+    HAS_GPU_AND_TRITON,
     requires_gpu,
 )
 
@@ -81,8 +81,7 @@ def _set_seed(base: int = BASE_SEED):
 
 
 def _sync(x: torch.Tensor):
-    if x.is_cuda:
-        torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
 
 def _timed_run(model, x, backward: bool = False):
@@ -97,7 +96,11 @@ def _timed_run(model, x, backward: bool = False):
 
 def _cuda_rng_u64_seed_off():
     """Return (seed, offset) extracted from torch.cuda.get_rng_state()."""
-    st = torch.cuda.get_rng_state()
+    st = (
+        torch.xpu.get_rng_state()
+        if torch.xpu.is_available()
+        else torch.cuda.get_rng_state()
+    )
     seed = struct.unpack("<Q", st[0:8].cpu().numpy().tobytes())[0]
     off = struct.unpack("<Q", st[8:24].cpu().numpy().tobytes())[0]
     return seed, off
@@ -105,12 +108,13 @@ def _cuda_rng_u64_seed_off():
 
 def set_seed(seed):
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
 
 
 def dropout_parity(shape, p=0.3, dtype=torch.float32, seed=1234):
     """Returns (masks_equal, eager_out, compiled_out)."""
-    DEVICE = torch.device("cuda")
+    DEVICE = torch.device(GPU_TYPE)
     torch._dynamo.reset()
     x = torch.ones(shape, device=DEVICE, dtype=dtype)
     drop_e = torch.nn.Dropout(p).to(DEVICE).train()
@@ -129,7 +133,7 @@ def dropout_parity(shape, p=0.3, dtype=torch.float32, seed=1234):
 # Test class (Inductor idioms)
 # ───────────────────────────────────────────────────────────────
 @unittest.skipIf(
-    not (IS_LINUX and HAS_CUDA_AND_TRITON),
+    not (IS_LINUX and HAS_GPU_AND_TRITON),
     "Inductor CUDA dropout alignment tests require Linux and CUDA",
 )
 @config.patch(align_random_eager=True)
@@ -154,6 +158,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
         )
 
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_linear_block_compile_parity_forward(self):
         device = torch.device(GPU_TYPE)
 
@@ -183,6 +188,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
             self.assertSmallMismatchFraction(y_eager, y_comp)
 
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_linear_block_compile_parity_backward(self):
         device = torch.device(GPU_TYPE)
 
@@ -215,13 +221,16 @@ class TestDropoutAlignRandomEager(InductorTestCase):
             self.assertSmallMismatchFraction(p_ref.grad, p_new.grad)
 
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_dropout_mask_parity_and_rng_offset_cuda(self):
         device = torch.device(GPU_TYPE)
         H, W = BATCH * SEQ_LEN, FFN_DIM
 
         dtypes = [torch.float32, torch.float16, torch.bfloat16]
         for dtype in dtypes:
-            if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+            if dtype is torch.bfloat16 and (
+                torch.cuda.is_available() and not torch.cuda.is_bf16_supported()
+            ):
                 continue
 
             x = torch.ones((H, W), device=device, dtype=dtype)
@@ -262,6 +271,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # multiple dropouts + multiple iterations
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_multi_dropout_multi_iterations_parity(self):
         device = torch.device(GPU_TYPE)
 
@@ -291,6 +301,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # dynamic shapes test (a)
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_dropout_parity_dynamic_shapes(self):
         device = torch.device(GPU_TYPE)
 
@@ -322,6 +333,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # cudagraphs test via mode='reduce-overhead' (b)
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_dropout_parity_cudagraphs_reduce_overhead(self):
         device = torch.device(GPU_TYPE)
 
@@ -452,6 +464,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # nn.Dropout as primitive RNG consumer (should PASS)
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_primitive_nn_dropout_parity(self):
         device = torch.device(GPU_TYPE)
         shape = (BATCH, SEQ_LEN, HIDDEN_DIM)
@@ -477,6 +490,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # Seeds > 2^32 overflow.
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="intel/torch-xpu-ops/issue/4851")
     def test_large_seed(self):
         for seed in [2**33 + 1, 2**40 + 12345]:
             with self.subTest(seed=seed):
@@ -487,5 +501,5 @@ class TestDropoutAlignRandomEager(InductorTestCase):
 
 
 if __name__ == "__main__":
-    if IS_LINUX and HAS_CUDA_AND_TRITON:
+    if IS_LINUX and HAS_GPU_AND_TRITON:
         run_tests(needs="filelock")

--- a/test/inductor/test_dropout_align_random_eager.py
+++ b/test/inductor/test_dropout_align_random_eager.py
@@ -9,10 +9,10 @@ from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
+    HAS_GPU_AND_TRITON,
     requires_gpu,
 )
 
@@ -81,9 +81,7 @@ def _set_seed(base: int = BASE_SEED):
 
 
 def _sync(x: torch.Tensor):
-    if x.is_cuda:
-        torch.cuda.synchronize()
-
+    torch.accelerator.synchronize()
 
 def _timed_run(model, x, backward: bool = False):
     _sync(x)
@@ -97,7 +95,7 @@ def _timed_run(model, x, backward: bool = False):
 
 def _cuda_rng_u64_seed_off():
     """Return (seed, offset) extracted from torch.cuda.get_rng_state()."""
-    st = torch.cuda.get_rng_state()
+    st = torch.xpu.get_rng_state() if torch.xpu.is_available() else torch.cuda.get_rng_state()
     seed = struct.unpack("<Q", st[0:8].cpu().numpy().tobytes())[0]
     off = struct.unpack("<Q", st[8:24].cpu().numpy().tobytes())[0]
     return seed, off
@@ -105,12 +103,13 @@ def _cuda_rng_u64_seed_off():
 
 def set_seed(seed):
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
 
 
 def dropout_parity(shape, p=0.3, dtype=torch.float32, seed=1234):
     """Returns (masks_equal, eager_out, compiled_out)."""
-    DEVICE = torch.device("cuda")
+    DEVICE = torch.device(GPU_TYPE)
     torch._dynamo.reset()
     x = torch.ones(shape, device=DEVICE, dtype=dtype)
     drop_e = torch.nn.Dropout(p).to(DEVICE).train()
@@ -129,7 +128,7 @@ def dropout_parity(shape, p=0.3, dtype=torch.float32, seed=1234):
 # Test class (Inductor idioms)
 # ───────────────────────────────────────────────────────────────
 @unittest.skipIf(
-    not (IS_LINUX and HAS_CUDA_AND_TRITON),
+    not (IS_LINUX and HAS_GPU_AND_TRITON),
     "Inductor CUDA dropout alignment tests require Linux and CUDA",
 )
 @config.patch(align_random_eager=True)
@@ -223,13 +222,16 @@ class TestDropoutAlignRandomEager(InductorTestCase):
             self.assertSmallMismatchFraction(p_ref.grad, p_new.grad)
 
     @requires_gpu()
+    @skipIfXpu(msg="torch-xpu-ops/issues/4851")
     def test_dropout_mask_parity_and_rng_offset_cuda(self):
         device = torch.device(GPU_TYPE)
         H, W = BATCH * SEQ_LEN, FFN_DIM
 
         dtypes = [torch.float32, torch.float16, torch.bfloat16]
         for dtype in dtypes:
-            if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+            if dtype is torch.bfloat16 and (
+                torch.cuda.is_available() and not torch.cuda.is_bf16_supported()
+            ):
                 continue
 
             x = torch.ones((H, W), device=device, dtype=dtype)
@@ -270,6 +272,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # multiple dropouts + multiple iterations
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="torch-xpu-ops/issues/4851")
     def test_multi_dropout_multi_iterations_parity(self):
         device = torch.device(GPU_TYPE)
 
@@ -468,6 +471,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # nn.Dropout as primitive RNG consumer (should PASS)
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="torch-xpu-ops/issues/4851")
     def test_primitive_nn_dropout_parity(self):
         device = torch.device(GPU_TYPE)
         shape = (BATCH, SEQ_LEN, HIDDEN_DIM)
@@ -493,6 +497,7 @@ class TestDropoutAlignRandomEager(InductorTestCase):
     # Seeds > 2^32 overflow.
     # ───────────────────────────────────────────────────────────
     @requires_gpu()
+    @skipIfXpu(msg="torch-xpu-ops/issues/4851")
     def test_large_seed(self):
         for seed in [2**33 + 1, 2**40 + 12345]:
             with self.subTest(seed=seed):
@@ -503,5 +508,5 @@ class TestDropoutAlignRandomEager(InductorTestCase):
 
 
 if __name__ == "__main__":
-    if IS_LINUX and HAS_CUDA_AND_TRITON:
+    if IS_LINUX and HAS_GPU_AND_TRITON:
         run_tests(needs="filelock")

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     random_matrix_with_scaled_reduction_dim,
     skipIfRocm,
+    skipIfXpu,
     xfailIf,
 )
 from torch.testing._internal.inductor_utils import (
@@ -335,7 +336,6 @@ class TestFP8Types(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm
-    @onlyCUDA
     @parametrize(
         "src_dtype",
         (torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64),
@@ -624,7 +624,7 @@ class TestFP8Types(TestCase):
 class TestFP8Lowering(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_functional_scaled_mm_fullgraph(self, device):
         M, N, K = 128, 128, 128
         x = torch.randn(M, K, device=device, dtype=torch.bfloat16)
@@ -649,7 +649,7 @@ class TestFP8Lowering(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @parametrize(
         "scale_a_shape,scale_b_shape",
         [
@@ -684,7 +684,7 @@ class TestFP8Lowering(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_scaled_mm_rejects_high_rank_scale_b(self, device):
         M = N = K = 64
         x_fp8 = torch.ones(M, K, device=device, dtype=torch.float8_e4m3fn)
@@ -714,7 +714,7 @@ class TestFP8Lowering(TestCase):
     @parametrize(
         "persistent_matmul", [False, True] if has_triton_tma_device() else [False]
     )
-    @onlyOn(["cuda", "xpu", "cpu"])
+    @onlyOn(["cuda", "xpu"])
     def test_tensorwise_scaling(
         self,
         dtype: torch.dtype,
@@ -794,7 +794,7 @@ class TestFP8Lowering(TestCase):
                 self.assertEqual(y_eager, y_compiled, rtol=1e-2, atol=0.05)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    @onlyOn(["cuda", "xpu", "cpu"])
+    @onlyOn(["cuda", "xpu"])
     def test_scaled_mm_preserves_strides(self, device):
         """Test that scaled_mm preserves stride ordering through a custom pass."""
 
@@ -891,7 +891,8 @@ class TestFP8Lowering(TestCase):
             # The clones should be visible in the generated code
             self.assertIn("clone", wrapper.lower())
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
+    @skipIfXpu(msg="torch-xpu-ops/issues/4852")
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @unittest.skipIf(
         not has_triton_tma_device() or not is_big_gpu(),
@@ -1058,7 +1059,8 @@ class TestFP8Lowering(TestCase):
         not has_triton_tma_device() or not is_big_gpu(),
         "Need device-side TMA support in Triton and max-autotune",
     )
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
+    @skipIfXpu(msg="torch-xpu-ops/issues/4852")
     @parametrize("shape", ("16,32,32", "1024,1024,512"))
     @parametrize("use_fast_accum", (False, True))
     def test_rowwise_scaling_tma_template(
@@ -1145,7 +1147,7 @@ class TestFP8Lowering(TestCase):
         _get_torch_cuda_version() < (12, 9),
         "cuBLAS blockwise scaling added in CUDA 12.9",
     )
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @xfailIf(
         torch.cuda.is_available() and torch.cuda.get_device_capability() != (9, 0)
     )  # cuBLAS 128-element blockwise scaling is only supported for CC 9.0
@@ -1617,7 +1619,7 @@ class TestFP8Lowering(TestCase):
                     )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_mxfp8_dtype_view_indexer_e2e(self, device):
         with (
             torch.library._scoped_library("test_fp8", "FRAGMENT") as lib,
@@ -1625,6 +1627,9 @@ class TestFP8Lowering(TestCase):
         ):
             lib.define("dtype_view_indexing_consumer(Tensor x) -> Tensor")
             torch.library.impl(lib, "dtype_view_indexing_consumer", "CUDA")(
+                lambda x: x.clone()
+            )
+            torch.library.impl(lib, "dtype_view_indexing_consumer", "XPU")(
                 lambda x: x.clone()
             )
             torch.library.impl(lib, "dtype_view_indexing_consumer", "Meta")(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyOn,
     skipCUDAIf,
+    skipIfXpu,
 )
 from torch.testing._internal.common_quantized import ceil_div, to_blocked
 from torch.testing._internal.common_utils import (
@@ -42,6 +43,7 @@ from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
     HAS_CUDA_AND_TRITON,
+    HAS_GPU_AND_TRITON,
     is_big_gpu,
 )
 from torch.utils._sympy.symbol import SymT
@@ -294,7 +296,6 @@ class TestFP8Types(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm
-    @onlyCUDA
     @parametrize(
         "src_dtype",
         (torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64),
@@ -583,7 +584,7 @@ class TestFP8Types(TestCase):
 class TestFP8Lowering(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_functional_scaled_mm_fullgraph(self, device):
         M, N, K = 128, 128, 128
         x = torch.randn(M, K, device=device, dtype=torch.bfloat16)
@@ -608,7 +609,7 @@ class TestFP8Lowering(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @parametrize(
         "scale_a_shape,scale_b_shape",
         [
@@ -643,7 +644,7 @@ class TestFP8Lowering(TestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipIfRocm(msg="FP8 scaled_mm tensorwise eager path is not supported by hipBLAS")
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_scaled_mm_rejects_high_rank_scale_b(self, device):
         M = N = K = 64
         x_fp8 = torch.ones(M, K, device=device, dtype=torch.float8_e4m3fn)
@@ -673,7 +674,7 @@ class TestFP8Lowering(TestCase):
     @parametrize(
         "persistent_matmul", [False, True] if has_triton_tma_device() else [False]
     )
-    @onlyOn(["cuda", "xpu", "cpu"])
+    @onlyOn(["cuda", "xpu"])
     def test_tensorwise_scaling(
         self,
         dtype: torch.dtype,
@@ -753,7 +754,7 @@ class TestFP8Lowering(TestCase):
                 self.assertEqual(y_eager, y_compiled, rtol=1e-2, atol=0.05)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    @onlyOn(["cuda", "xpu", "cpu"])
+    @onlyOn(["cuda", "xpu"])
     def test_scaled_mm_preserves_strides(self, device):
         """Test that scaled_mm preserves stride ordering through a custom pass."""
 
@@ -850,7 +851,8 @@ class TestFP8Lowering(TestCase):
             # The clones should be visible in the generated code
             self.assertIn("clone", wrapper.lower())
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
+    @skipIfXpu(msg="torch-xpu-ops/issues/4852")
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @unittest.skipIf(
         not has_triton_tma_device() or not is_big_gpu(),
@@ -1017,7 +1019,8 @@ class TestFP8Lowering(TestCase):
         not has_triton_tma_device() or not is_big_gpu(),
         "Need device-side TMA support in Triton and max-autotune",
     )
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
+    @skipIfXpu(msg="torch-xpu-ops/issues/4852")
     @parametrize("shape", ("16,32,32", "1024,1024,512"))
     @parametrize("use_fast_accum", (False, True))
     def test_rowwise_scaling_tma_template(
@@ -1104,7 +1107,7 @@ class TestFP8Lowering(TestCase):
         _get_torch_cuda_version() < (12, 9),
         "cuBLAS blockwise scaling added in CUDA 12.9",
     )
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @xfailIf(
         torch.cuda.is_available() and torch.cuda.get_device_capability() != (9, 0)
     )  # cuBLAS 128-element blockwise scaling is only supported for CC 9.0
@@ -1576,7 +1579,7 @@ class TestFP8Lowering(TestCase):
                     )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     def test_mxfp8_dtype_view_indexer_e2e(self, device):
         with (
             torch.library._scoped_library("test_fp8", "FRAGMENT") as lib,

--- a/test/inductor/test_fusion_regions.py
+++ b/test/inductor/test_fusion_regions.py
@@ -10,9 +10,10 @@ from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.ops import aten
 from torch.testing._internal.common_utils import xfailIfNoAcceleratorTriton
+from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
-HAS_GPU = torch.cuda.is_available()
+HAS_GPU = torch.cuda.is_available() or torch.xpu.is_available()
 
 
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -21,7 +22,7 @@ class TestFusionRegionDetection(InductorTestCase):
 
     def setUp(self):
         super().setUp()
-        self.device = "cuda"
+        self.device = GPU_TYPE
 
     def test_fusion_region_grouping(self):
         """Test that connected fusible ops are grouped into regions."""

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TestCase,
     xfailIfNoAcceleratorTriton,
+    skipIfXpu
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_BIG_GPU
 from torch.utils._ordered_set import OrderedSet
@@ -144,7 +145,7 @@ class TestScheduler(TestCase):
 
     def test_fuse_two_nodes_propagates_mempool(self):
         scheduler = object.__new__(Scheduler)
-        device = torch.device("cuda", 0)
+        device = torch.device(GPU_TYPE, 0)
         node1 = self._mock_base_snode("node1", device)
         node2 = self._mock_base_snode("node2", device)
         node3 = self._mock_base_snode("node3", device)
@@ -170,7 +171,7 @@ class TestScheduler(TestCase):
     @inductor_config.patch(combo_kernel_max_num_nodes=16)
     def test_combo_kernel_grouping_respects_mempool(self):
         scheduler = Mock()
-        device = torch.device("cuda", 0)
+        device = torch.device(GPU_TYPE, 0)
         pool_node1 = self._mock_base_snode("pool_node1", device)
         pool_node2 = self._mock_base_snode("pool_node2", device)
         default_node = self._mock_base_snode("default_node", device)
@@ -621,6 +622,7 @@ class TestScheduler(TestCase):
         {"force_disable_caches": True, "shape_padding": False}
     )
     @skipIf(not IS_BIG_GPU, "we can't use Triton only as a backend for max autotune")
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     def test_flop_counter_op(self, device, dtype, options):
         if device == "cpu":
             return
@@ -807,7 +809,7 @@ class TestScheduler(TestCase):
         self.assertFalse(can_fuse_prologue(hook_blocks=True))
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    #@onlyCUDA
     def test_index_add_fusion_prevented(self):
         """
         Test that index_add_ (scatter with atomic_add mode) is not fused with
@@ -828,7 +830,7 @@ class TestScheduler(TestCase):
             F_u_at_atom = F_u_mol[batch] + 1e-6
             return f_u / F_u_at_atom
 
-        device = "cuda"
+        device = GPU_TYPE
         f = torch.ones(1024, 1, device=device)
         batch = torch.zeros(1024, dtype=torch.long, device=device)
 
@@ -848,7 +850,7 @@ class TestScheduler(TestCase):
         )
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    #@onlyCUDA
     def test_atomic_add_no_fusion_correctness(self):
         """
         Test that atomic_add operations produce correct results.
@@ -859,7 +861,7 @@ class TestScheduler(TestCase):
             out.index_add_(0, idx, x)  # atomic_add: scatter to shared locations
             return out[idx] + 1.0  # read from same buffer: requires sync
 
-        device = "cuda"
+        device = GPU_TYPE
         x = torch.ones(5, device=device)
         idx = torch.tensor([0, 1, 0, 1, 0], device=device, dtype=torch.long)
 
@@ -879,7 +881,7 @@ class TestScheduler(TestCase):
         )
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    #@onlyCUDA
     def test_expand_reuse_does_not_realize_before_reduction(self):
         def fn(icrd1, icrd2, wcrd, ocrd, meta, input1, input2, weight, output):
             input1_selected = torch.index_select(input1, 2, icrd1)
@@ -905,7 +907,7 @@ class TestScheduler(TestCase):
         U = 4
         V = 4
         W = 4
-        device = "cuda"
+        device = GPU_TYPE
 
         torch.manual_seed(0)
         input1 = torch.rand((B, U, L), dtype=torch.float32, device=device)
@@ -950,7 +952,7 @@ class TestScheduler(TestCase):
         self.assertEqual(metrics.generated_kernel_count, 1)
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    #@onlyCUDA
     def test_expand_reuse_realizes_in_deterministic_mode(self):
         def fn(a, b, c, d, e):
             x = a * b * c * d * e
@@ -967,7 +969,7 @@ class TestScheduler(TestCase):
             self.assertEqual(metrics.ir_nodes_pre_fusion, 2)
             self.assertEqual(metrics.generated_kernel_count, 2)
 
-        device = "cuda"
+        device = GPU_TYPE
         torch.manual_seed(0)
         args = [
             torch.rand((8, 8), dtype=torch.float32, device=device) for _ in range(5)

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_cuda import SM70OrLater
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
+    onlyAccelerator,
     onlyCUDA,
     skipCUDAIf,
 )
@@ -56,6 +57,8 @@ from torch.testing._internal.common_utils import (
     DeterministicGuard,
     parametrize,
     run_tests,
+    skipIfMPS,
+    skipIfXpu,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
@@ -290,7 +293,7 @@ class TestScheduler(TestCase):
 
     def test_fuse_two_nodes_propagates_mempool(self):
         scheduler = object.__new__(Scheduler)
-        device = torch.device("cuda", 0)
+        device = torch.device(GPU_TYPE, 0)
         node1 = self._mock_base_snode("node1", device)
         node2 = self._mock_base_snode("node2", device)
         node3 = self._mock_base_snode("node3", device)
@@ -364,10 +367,11 @@ class TestScheduler(TestCase):
 
         self.assertIsNone(result)
 
+    @skipIfMPS  # MPS is filtered by _filter_nodes_for_combo_kernel_grouping
     @inductor_config.patch(combo_kernel_max_num_nodes=16)
     def test_combo_kernel_grouping_respects_mempool(self):
         scheduler = Mock()
-        device = torch.device("cuda", 0)
+        device = torch.device(GPU_TYPE, 0)
         pool_node1 = self._mock_base_snode("pool_node1", device)
         pool_node2 = self._mock_base_snode("pool_node2", device)
         default_node = self._mock_base_snode("default_node", device)
@@ -1757,6 +1761,7 @@ class TestScheduler(TestCase):
         {"force_disable_caches": True, "shape_padding": False}
     )
     @skipIf(not IS_BIG_GPU, "we can't use Triton only as a backend for max autotune")
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     def test_flop_counter_op(self, device, dtype, options):
         if device == "cpu":
             return
@@ -1940,7 +1945,7 @@ class TestScheduler(TestCase):
         self.assertFalse(can_fuse_prologue(hook_blocks=True))
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    @onlyAccelerator
     def test_index_add_fusion_prevented(self):
         """
         Test that index_add_ (scatter with atomic_add mode) is not fused with
@@ -1961,7 +1966,7 @@ class TestScheduler(TestCase):
             F_u_at_atom = F_u_mol[batch] + 1e-6
             return f_u / F_u_at_atom
 
-        device = "cuda"
+        device = GPU_TYPE
         f = torch.ones(1024, 1, device=device)
         batch = torch.zeros(1024, dtype=torch.long, device=device)
 
@@ -1981,7 +1986,7 @@ class TestScheduler(TestCase):
         )
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    @onlyAccelerator
     def test_atomic_add_no_fusion_correctness(self):
         """
         Test that atomic_add operations produce correct results.
@@ -1992,7 +1997,7 @@ class TestScheduler(TestCase):
             out.index_add_(0, idx, x)  # atomic_add: scatter to shared locations
             return out[idx] + 1.0  # read from same buffer: requires sync
 
-        device = "cuda"
+        device = GPU_TYPE
         x = torch.ones(5, device=device)
         idx = torch.tensor([0, 1, 0, 1, 0], device=device, dtype=torch.long)
 
@@ -2012,7 +2017,7 @@ class TestScheduler(TestCase):
         )
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    @onlyAccelerator
     def test_expand_reuse_does_not_realize_before_reduction(self):
         def fn(icrd1, icrd2, wcrd, ocrd, meta, input1, input2, weight, output):
             input1_selected = torch.index_select(input1, 2, icrd1)
@@ -2038,7 +2043,7 @@ class TestScheduler(TestCase):
         U = 4
         V = 4
         W = 4
-        device = "cuda"
+        device = GPU_TYPE
 
         torch.manual_seed(0)
         input1 = torch.rand((B, U, L), dtype=torch.float32, device=device)
@@ -2083,7 +2088,7 @@ class TestScheduler(TestCase):
         self.assertEqual(metrics.generated_kernel_count, 1)
 
     @xfailIfNoAcceleratorTriton
-    @onlyCUDA
+    @onlyAccelerator
     def test_expand_reuse_realizes_in_deterministic_mode(self):
         def fn(a, b, c, d, e):
             x = a * b * c * d * e
@@ -2100,7 +2105,7 @@ class TestScheduler(TestCase):
             self.assertEqual(metrics.ir_nodes_pre_fusion, 2)
             self.assertEqual(metrics.generated_kernel_count, 2)
 
-        device = "cuda"
+        device = GPU_TYPE
         torch.manual_seed(0)
         args = [
             torch.rand((8, 8), dtype=torch.float32, device=device) for _ in range(5)

--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -11,6 +11,7 @@ from torch._inductor import config, metrics
 from torch._inductor.fx_passes.reduced_atomic_contention import _compute_num_partitions
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -227,11 +228,11 @@ class TestScatterOpt(TestCase):
                 raise unittest.SkipTest(
                     "torch.xpu.reset_peak_memory_stats not implemented."
                 )
-            torch.cuda.reset_peak_memory_stats()
+            torch.accelerator.reset_peak_memory_stats()
             for _ in range(3):
                 opt_f(opt_model, x, label)
             ms = benchmarker.benchmark_gpu(lambda: opt_f(opt_model, x, label))
-            peak_mem = torch.cuda.max_memory_allocated() / 10**9
+            peak_mem = torch.accelerator.max_memory_allocated() / 10**9
             print(f"{ms=:.3f}, {peak_mem=:.3f} GB")
 
 
@@ -540,6 +541,7 @@ class TestPartitionedScatterOpt(TestCase):
             "output_numel instead of scatter_dim_size",
         )
 
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     @unittest.skipUnless(HAS_GPU, "requires GPU for CUDA-aware memory tracking")
     @config.patch(partitioned_scatter_min_contention_ratio=1.0)
     def test_memory_aware_partition_count(self):
@@ -575,7 +577,9 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(out, idx, vals, persistent)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = (
+            torch.xpu.mem_get_info() if GPU_TYPE == "xpu" else torch.cuda.mem_get_info()
+        )
 
         out_bytes = output_size * 4
         baseline_peak = out_bytes + N * 8 + N * 4 + persist_n * 4 + out_bytes
@@ -631,6 +635,7 @@ class TestPartitionedScatterOpt(TestCase):
             "floor=total_gpu: output should still be correct (pass gracefully skips)",
         )
 
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     @unittest.skipUnless(HAS_GPU, "requires GPU for CUDA-aware memory tracking")
     @config.patch(partitioned_scatter_min_contention_ratio=1.0)
     def test_memory_budget_shared_across_scatters(self):
@@ -662,7 +667,9 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(*args)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = (
+            torch.xpu.mem_get_info() if GPU_TYPE == "xpu" else torch.cuda.mem_get_info()
+        )
 
         # Each out dies right after its own scatter, so the peak at every
         # index_put is the three inputs plus that node's 20 MB output.

--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -12,6 +12,7 @@ from torch._inductor.fx_passes.reduced_atomic_contention import _compute_num_par
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_utils import skipIfXpu
 
 
 # set so that metrics appear
@@ -227,11 +228,11 @@ class TestScatterOpt(TestCase):
                 raise unittest.SkipTest(
                     "torch.xpu.reset_peak_memory_stats not implemented."
                 )
-            torch.cuda.reset_peak_memory_stats()
+            torch.accelerator.reset_peak_memory_stats()
             for _ in range(3):
                 opt_f(opt_model, x, label)
             ms = benchmarker.benchmark_gpu(lambda: opt_f(opt_model, x, label))
-            peak_mem = torch.cuda.max_memory_allocated() / 10**9
+            peak_mem = torch.accelerator.max_memory_allocated() / 10**9
             print(f"{ms=:.3f}, {peak_mem=:.3f} GB")
 
 
@@ -540,6 +541,7 @@ class TestPartitionedScatterOpt(TestCase):
             "output_numel instead of scatter_dim_size",
         )
 
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     @unittest.skipUnless(HAS_GPU, "requires GPU for CUDA-aware memory tracking")
     @config.patch(partitioned_scatter_min_contention_ratio=1.0)
     def test_memory_aware_partition_count(self):
@@ -575,7 +577,7 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(out, idx, vals, persistent)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = torch.xpu.mem_get_info() if GPU_TYPE == "xpu" else torch.cuda.mem_get_info()
 
         out_bytes = output_size * 4
         baseline_peak = out_bytes + N * 8 + N * 4 + persist_n * 4 + out_bytes
@@ -631,6 +633,7 @@ class TestPartitionedScatterOpt(TestCase):
             "floor=total_gpu: output should still be correct (pass gracefully skips)",
         )
 
+    @skipIfXpu(msg="torch-xpu-ops/issues/4853")
     @unittest.skipUnless(HAS_GPU, "requires GPU for CUDA-aware memory tracking")
     @config.patch(partitioned_scatter_min_contention_ratio=1.0)
     def test_memory_budget_shared_across_scatters(self):
@@ -662,7 +665,7 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(*args)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = torch.xpu.mem_get_info() if GPU_TYPE == "xpu" else torch.cuda.mem_get_info()
 
         # Each out dies right after its own scatter, so the peak at every
         # index_put is the three inputs plus that node's 20 MB output.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13010,7 +13010,12 @@ op_db: list[OpInfo] = [
            # See https://github.com/pytorch/pytorch/pull/78358
            check_batched_forward_grad=False,
            supports_out=False,
-           sample_inputs_func=sample_inputs_combinations),
+           sample_inputs_func=sample_inputs_combinations,
+           skips=(
+               # torch-xpu-ops/issues/5027
+               DecorateInfo(unittest.skip, 'TestInductorOpInfo', 'test_comprehensive',
+                            device_type='xpu', dtypes=(torch.float16,)),
+           )),
     OpInfo('cartesian_prod',
            op=torch.cartesian_prod,
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),


### PR DESCRIPTION
Enable XPU in inductor tests: 

1. change cuda API to torch.acclerator API
2. change .cuda() to .to(GPU_TYPE)
3. add allow_xpu=True in instantiate_device_type_tests()

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo