### PR TITLE
[TEST] Add `hw_classification` to `test_load_state_dict.py`

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -25,6 +26,8 @@ if TEST_NUMPY:
 
 
 class TestLoadStateDict(NNTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
@@ -595,6 +598,8 @@ class MyWrapperLoadTensor(MyLoadTensor):
 
 
 class TestLoadStateDictSwap(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfCrossRef
     @skipIfTorchDynamo("Can't swap with dynamo as dynamo installs weakrefs")
     @swap([True])

--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -27,6 +27,7 @@ if TEST_NUMPY:
 
 class TestLoadStateDict(NNTestCase):
     hw_classification = HardwareClassification.GENERIC
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to both test classes:
- `TestLoadStateDict` — state_dict loading, strict/non-strict, parameter tying, hooks
- `TestLoadStateDictSwap` — swap-based loading with custom tensor subclasses
- All 29 tests run on CPU — no accelerator dependency, no split needed.

Depends on: #186918

Follows the [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142) ([#185590](https://github.com/pytorch/pytorch/issues/185590)).

## Test Plan

```
python test/nn/test_load_state_dict.py -v Ran 29 tests in 2.337s — OK
```


Co-authored-by: Opus 4.6

cc: @vishalgoyal316 @mansiag05 @RiyaP2508