### PR TITLE
Use keepdim=false in the full-reduction norm_jvp wrapper

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13133,6 +13133,20 @@ class TestAutogradForwardMode(TestCase):
 
             dual = fwAD.make_dual(foo, tangent[1:])
 
+    @parametrize("p", [0, 0.5, 1, 1.5, 2, 3, float("inf")])
+    def test_norm_full_reduction_jvp(self, p):
+        # The no-dim norm overloads return a scalar primal, so their jvp must
+        # fully reduce the tangent instead of keeping singleton dims (#191787)
+        x = torch.randn(2, 3, 4, dtype=torch.double, requires_grad=True)
+
+        ops = [
+            lambda x: torch.ops.aten.norm.Scalar(x, p),
+            lambda x: torch.ops.aten.norm.ScalarOpt_dtype(x, p, dtype=torch.double),
+            lambda x: torch.ops.aten._foreach_norm.Scalar([x], p)[0],
+        ]
+        for op in ops:
+            gradcheck(op, (x,), check_forward_ad=True)
+
     def test_metadata_check_checks_storage_numel(self):
         primal = torch.randn(5)[:4].detach()
         self.assertEqual(len(primal.storage()), 5)
@@ -18387,6 +18401,7 @@ instantiate_device_type_tests(
 )
 
 instantiate_parametrized_tests(TestAutograd)
+instantiate_parametrized_tests(TestAutogradForwardMode)
 instantiate_parametrized_tests(TestNestedCheckpoint)
 
 if __name__ == "__main__":

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1909,12 +1909,6 @@ def check_autodiff_sample(op, sample, dtype, is_inplace):
         or isinstance(sample.args[-1], bool)
     ):
         return False, _BOOL_SUB_ERR_MSG
-    if op.name == "_foreach_norm" and (not is_inplace):
-        return (
-            False,
-            "Trying to set a forward gradient that has a different size than that of the original Tensor, "
-            "this is not supported. Tensor is of size [] while the given forward gradient is of size [1",
-        )
     rhs_arg_has_complex_number = sample.args and (
         (
             isinstance(sample.args[-1], list)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -600,7 +600,7 @@ Tensor norm_jvp(
     const Tensor& self_t,
     const std::optional<Scalar>& p_,
     Tensor norm) {
-  return norm_jvp(self_p, self_t, p_, std::move(norm), {}, true);
+  return norm_jvp(self_p, self_t, p_, std::move(norm), {}, false);
 }
 
 Tensor _nested_from_padded_backward(


### PR DESCRIPTION
Fixes #191787

Forward AD through aten::norm.Scalar raised Trying to set a forward gradient that has a different size than that of the original Tensor for any input with one or more dims. The 4-arg norm_jvp convenience overload in FunctionsManual.cpp forwarded dim={}, keepdim=true, so every branch computed the tangent with .sum({}, /*keepdim=*/true), keeping singleton dims (e.g. [1, 1, 1]) while the primal of the no-dim overloads is a true scalar (their schemas have no keepdim argument). Passing keepdim=false fully reduces the tangent to match. dist, the other full-reduction user of norm_jvp, already passes {}, false explicitly in derivatives.yaml, and the p=inf branch handles !keepdim correctly (its unsqueeze_multiple is a no-op for an empty dim list, and the scalar norm broadcasts).

The same wrapper also serves norm.ScalarOpt_dtype and _foreach_norm.Scalar, which failed identically; all three are fixed and covered by the regression test in test/test_autograd.py (parametrized over p in {0, 0.5, 1, 1.5, 2, 3, inf}, comparing against the already-correct norm.ScalarOpt_dim(x, p, [], False) path). test_foreach.py's check_autodiff_sample had codified the bug as an expected error for _foreach_norm outplace; that block is removed, so its test_autodiff now runs real gradcheck (including forward AD) for the op.