### PR TITLE
[Logging] Add register_log_init_callback and register_log_env_var to torch._logging

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -91,6 +91,160 @@ class LoggingTest(TestCase):
             self.assertIn("issue173759 component log", result.stderr)
             self.assertIn("issue173759 artifact log", result.stderr)
 
+    def test_log_init_callback_invoked_on_set_logs_and_init_logs(self):
+        old_callbacks = list(log_internal._log_init_callbacks)
+        try:
+            log_internal._log_init_callbacks.clear()
+            calls = []
+            log_internal.register_log_init_callback(lambda: calls.append(1))
+
+            _init_logs()
+            self.assertEqual(len(calls), 1)
+
+            log_internal.set_logs(dynamo=logging.DEBUG)
+            self.assertEqual(len(calls), 2)
+        finally:
+            log_internal.set_logs()
+            log_internal._log_init_callbacks[:] = old_callbacks
+            _init_logs()
+
+    def test_log_init_callback_exception_does_not_block_others(self):
+        old_callbacks = list(log_internal._log_init_callbacks)
+        try:
+            log_internal._log_init_callbacks.clear()
+            calls = []
+
+            def bad():
+                raise RuntimeError("boom")
+
+            log_internal.register_log_init_callback(bad)
+            log_internal.register_log_init_callback(lambda: calls.append(1))
+
+            with self.assertLogs(
+                logging.getLogger("torch._logging._internal"), level="WARNING"
+            ):
+                _init_logs()
+            self.assertEqual(len(calls), 1)
+        finally:
+            log_internal._log_init_callbacks[:] = old_callbacks
+            _init_logs()
+
+    def test_register_log_env_var_does_not_modify_log_env_var(self):
+        old_extra = list(log_internal._extra_log_env_vars)
+        try:
+            log_internal._extra_log_env_vars.clear()
+            self.assertEqual(log_internal.LOG_ENV_VAR, "TORCH_LOGS")
+
+            log_internal.register_log_env_var("TORCH_TEST_EXTRA_LOGS")
+            self.assertEqual(log_internal.LOG_ENV_VAR, "TORCH_LOGS")
+            self.assertIn("TORCH_TEST_EXTRA_LOGS", log_internal._extra_log_env_vars)
+        finally:
+            log_internal._extra_log_env_vars[:] = old_extra
+
+    def test_register_log_env_var_triggers_reinit_when_already_set(self):
+        old_extra = list(log_internal._extra_log_env_vars)
+        old_callbacks = list(log_internal._log_init_callbacks)
+        old_env = os.environ.get("TORCH_TEST_EXTRA_LOGS")
+        try:
+            log_internal._extra_log_env_vars.clear()
+            log_internal._log_init_callbacks.clear()
+            os.environ["TORCH_TEST_EXTRA_LOGS"] = "+dynamo"
+
+            calls = []
+            log_internal.register_log_init_callback(lambda: calls.append(1))
+            self.assertEqual(len(calls), 0)
+
+            log_internal.register_log_env_var("TORCH_TEST_EXTRA_LOGS")
+            self.assertEqual(len(calls), 1)
+        finally:
+            if old_env is None:
+                os.environ.pop("TORCH_TEST_EXTRA_LOGS", None)
+            else:
+                os.environ["TORCH_TEST_EXTRA_LOGS"] = old_env
+            log_internal._extra_log_env_vars[:] = old_extra
+            log_internal._log_init_callbacks[:] = old_callbacks
+            _init_logs()
+
+    def test_set_logs_ignores_call_when_extra_env_var_is_set(self):
+        old_extra = list(log_internal._extra_log_env_vars)
+        old_env = os.environ.get("TORCH_TEST_EXTRA_LOGS")
+        try:
+            log_internal._extra_log_env_vars.clear()
+            log_internal._extra_log_env_vars.append("TORCH_TEST_EXTRA_LOGS")
+            os.environ["TORCH_TEST_EXTRA_LOGS"] = "+dynamo"
+
+            with self.assertLogs(
+                logging.getLogger("torch._logging._internal"), level="WARNING"
+            ) as cm:
+                log_internal.set_logs(aot=logging.DEBUG)
+            self.assertTrue(any("TORCH_TEST_EXTRA_LOGS" in msg for msg in cm.output))
+            # set_logs() should have been a true no-op: "aot" must not appear
+            # in log_state, since the call short-circuited before _set_logs().
+            self.assertNotIn(
+                "torch._functorch.aot_autograd",
+                log_internal.log_state.log_qname_to_level,
+            )
+        finally:
+            if old_env is None:
+                os.environ.pop("TORCH_TEST_EXTRA_LOGS", None)
+            else:
+                os.environ["TORCH_TEST_EXTRA_LOGS"] = old_env
+            log_internal._extra_log_env_vars[:] = old_extra
+            _init_logs()
+
+    def test_update_log_state_merges_torch_logs_and_extra_env_var(self):
+        old_extra = list(log_internal._extra_log_env_vars)
+        old_torch_logs = os.environ.get("TORCH_LOGS")
+        old_extra_env = os.environ.get("TORCH_TEST_EXTRA_LOGS")
+        try:
+            log_internal._extra_log_env_vars.clear()
+            log_internal._extra_log_env_vars.append("TORCH_TEST_EXTRA_LOGS")
+            os.environ["TORCH_LOGS"] = "dynamo"
+            os.environ["TORCH_TEST_EXTRA_LOGS"] = "+aot"
+
+            _init_logs()
+            qnames = log_internal.log_state.log_qname_to_level
+            self.assertTrue(any("dynamo" in qname for qname in qnames))
+            self.assertTrue(
+                any("aot" in qname or "functorch" in qname for qname in qnames)
+            )
+        finally:
+            if old_torch_logs is None:
+                os.environ.pop("TORCH_LOGS", None)
+            else:
+                os.environ["TORCH_LOGS"] = old_torch_logs
+            if old_extra_env is None:
+                os.environ.pop("TORCH_TEST_EXTRA_LOGS", None)
+            else:
+                os.environ["TORCH_TEST_EXTRA_LOGS"] = old_extra_env
+            log_internal._extra_log_env_vars[:] = old_extra
+            _init_logs()
+
+    def test_extra_env_var_overrides_torch_logs_on_conflicting_qname(self):
+        old_extra = list(log_internal._extra_log_env_vars)
+        old_torch_logs = os.environ.get("TORCH_LOGS")
+        old_extra_env = os.environ.get("TORCH_TEST_EXTRA_LOGS")
+        try:
+            log_internal._extra_log_env_vars.clear()
+            log_internal._extra_log_env_vars.append("TORCH_TEST_EXTRA_LOGS")
+            os.environ["TORCH_LOGS"] = "dynamo"  # bare -> INFO
+            os.environ["TORCH_TEST_EXTRA_LOGS"] = "+dynamo"  # '+' -> DEBUG
+
+            _init_logs()
+            levels = log_internal.log_state.log_qname_to_level
+            self.assertEqual(levels["torch._dynamo"], logging.DEBUG)
+        finally:
+            if old_torch_logs is None:
+                os.environ.pop("TORCH_LOGS", None)
+            else:
+                os.environ["TORCH_LOGS"] = old_torch_logs
+            if old_extra_env is None:
+                os.environ.pop("TORCH_TEST_EXTRA_LOGS", None)
+            else:
+                os.environ["TORCH_TEST_EXTRA_LOGS"] = old_extra_env
+            log_internal._extra_log_env_vars[:] = old_extra
+            _init_logs()
+
     def testApiUsage(self):
         """
         This test verifies that api usage logging is not triggered via static

--- a/torch/_logging/__init__.py
+++ b/torch/_logging/__init__.py
@@ -14,6 +14,8 @@ from ._internal import (
     getArtifactLogger,
     hide_warnings,
     LazyString,
+    register_log_env_var,
+    register_log_init_callback,
     set_logs,
     trace_structured,
     warning_once,

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -946,15 +946,19 @@ def _update_log_state_from_env() -> None:
         log_setting = os.environ.get(env_var, None)
         if log_setting is None:
             continue
+        # _parse_log_settings is lru_cache'd, so its return value is a shared,
+        # mutable LogState owned by the cache. Copy its fields into a fresh
+        # LogState instead of aliasing/mutating it directly, or later in-place
+        # updates here (or log_state.clear()/enable_log() elsewhere) would
+        # permanently corrupt the cache entry for that settings string.
         parsed = _parse_log_settings(log_setting)
         if new_state is None:
-            new_state = parsed
-        else:
-            # Merge on top of what's already set: registered env vars are
-            # additive to TORCH_LOGS, with later ones winning on conflicting
-            # qnames/artifacts.
-            new_state.log_qname_to_level.update(parsed.log_qname_to_level)
-            new_state.artifact_names.update(parsed.artifact_names)
+            new_state = LogState()
+        # Merge on top of what's already set: registered env vars are
+        # additive to TORCH_LOGS, with later ones winning on conflicting
+        # qnames/artifacts.
+        new_state.log_qname_to_level.update(parsed.log_qname_to_level)
+        new_state.artifact_names.update(parsed.artifact_names)
     if new_state is not None:
         log_state = new_state
 

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -58,6 +58,15 @@ LOG_TRACE_HANDLER: Optional["LazyTraceHandler"] = None
 
 GET_DTRACE_STRUCTURED = False
 
+# Callbacks registered via register_log_init_callback, invoked at the end of
+# every _init_logs() call so backends with a C++ logging subsystem can sync
+# their state to the Python-side log_state.
+_log_init_callbacks: list[Callable[[], None]] = []
+
+# Additional environment variable names registered via register_log_env_var.
+# Checked alongside LOG_ENV_VAR; LOG_ENV_VAR itself is never modified.
+_extra_log_env_vars: list[str] = []
+
 LOG_PREFIX = "dedicated_log_torch_trace_"
 
 
@@ -493,11 +502,13 @@ def set_logs(
         >>> torch._logging.set_logs(modules={"unregistered.module.name": logging.DEBUG})
     """
     # ignore if env var is set
-    if LOG_ENV_VAR in os.environ:
-        log.warning(
-            "Using TORCH_LOGS environment variable for log settings, ignoring call to set_logs"
-        )
-        return
+    for env_var in [LOG_ENV_VAR, *_extra_log_env_vars]:
+        if env_var in os.environ:
+            log.warning(
+                "Using %s environment variable for log settings, ignoring call to set_logs",
+                env_var,
+            )
+            return
 
     log_state.clear()
 
@@ -619,6 +630,31 @@ def register_log(setting_name, log_name) -> None:
         log_name:  the log name that the setting_name is associated with
     """
     log_registry.register_log(setting_name, log_name)
+
+
+def register_log_init_callback(callback: Callable[[], None]) -> None:
+    """
+    Registers a callback to be invoked after every _init_logs() call, e.g. to
+    let a backend with a C++ logging subsystem sync its state from
+    torch._logging._internal.log_state. Called with no arguments. Exceptions
+    raised by the callback are caught and logged as a warning; other
+    registered callbacks still run.
+    """
+    _log_init_callbacks.append(callback)
+
+
+def register_log_env_var(env_var_name: str) -> None:
+    """
+    Registers an additional environment variable name to be checked
+    alongside LOG_ENV_VAR (TORCH_LOGS) by _init_logs()/set_logs(), without
+    modifying LOG_ENV_VAR itself. If env_var_name is already set in
+    os.environ, _init_logs() is re-invoked immediately so late registration
+    (e.g. a backend imported after `import torch` has already run
+    _init_logs() once) still takes effect.
+    """
+    _extra_log_env_vars.append(env_var_name)
+    if env_var_name in os.environ:
+        _init_logs()
 
 
 def register_artifact(
@@ -901,9 +937,11 @@ def _get_module_and_submodules(qname: str) -> Sequence[str] | None:
 
 def _update_log_state_from_env() -> None:
     global log_state
-    log_setting = os.environ.get(LOG_ENV_VAR, None)
-    if log_setting is not None:
-        log_state = _parse_log_settings(log_setting)
+    for env_var in [LOG_ENV_VAR, *_extra_log_env_vars]:
+        log_setting = os.environ.get(env_var, None)
+        if log_setting is not None:
+            log_state = _parse_log_settings(log_setting)
+            break
 
 
 def _has_registered_parent(log_qname) -> bool:
@@ -1241,6 +1279,14 @@ def _init_logs(log_file_name=None) -> None:
     trace_log_handler = _track_handler(LOG_TRACE_HANDLER)
     trace_log_handler.setFormatter(TorchLogsFormatter(trace=True))
     trace_log.addHandler(trace_log_handler)
+
+    for cb in _log_init_callbacks:
+        try:
+            cb()
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "_init_logs callback %s raised an exception", cb, exc_info=True
+            )
 
 
 class LazyTraceHandler(logging.StreamHandler):

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -647,7 +647,11 @@ def register_log_env_var(env_var_name: str) -> None:
     """
     Registers an additional environment variable name to be checked
     alongside LOG_ENV_VAR (TORCH_LOGS) by _init_logs()/set_logs(), without
-    modifying LOG_ENV_VAR itself. If env_var_name is already set in
+    modifying LOG_ENV_VAR itself. If both TORCH_LOGS and one or more
+    registered env vars are set, their settings are merged (log levels and
+    enabled artifacts), with registered env vars taking precedence over
+    TORCH_LOGS on conflicting entries, and later-registered env vars taking
+    precedence over earlier ones. If env_var_name is already set in
     os.environ, _init_logs() is re-invoked immediately so late registration
     (e.g. a backend imported after `import torch` has already run
     _init_logs() once) still takes effect.
@@ -937,11 +941,22 @@ def _get_module_and_submodules(qname: str) -> Sequence[str] | None:
 
 def _update_log_state_from_env() -> None:
     global log_state
+    new_state = None
     for env_var in [LOG_ENV_VAR, *_extra_log_env_vars]:
         log_setting = os.environ.get(env_var, None)
-        if log_setting is not None:
-            log_state = _parse_log_settings(log_setting)
-            break
+        if log_setting is None:
+            continue
+        parsed = _parse_log_settings(log_setting)
+        if new_state is None:
+            new_state = parsed
+        else:
+            # Merge on top of what's already set: registered env vars are
+            # additive to TORCH_LOGS, with later ones winning on conflicting
+            # qnames/artifacts.
+            new_state.log_qname_to_level.update(parsed.log_qname_to_level)
+            new_state.artifact_names.update(parsed.artifact_names)
+    if new_state is not None:
+        log_state = new_state
 
 
 def _has_registered_parent(log_qname) -> bool:


### PR DESCRIPTION
### What this does

Adds two small, additive public APIs to `torch._logging`:

```python
torch._logging.register_log_init_callback(callback)
torch._logging.register_log_env_var(env_var_name)
```

- `register_log_init_callback(callback)` registers a callback invoked (with
  exception isolation — a raising callback is caught and logged as a warning,
  other callbacks still run) at the end of every `_init_logs()` call. Since
  both the `import torch` initialization path and `set_logs()` funnel through
  `_init_logs()`, this is the single choke point where a backend with a C++
  logging subsystem (XPU, PrivateUse1, etc.) can reliably sync its state,
  covering cases a `set_logs()`-only monkey-patch cannot (namely the
  `import torch` path, where `TORCH_LOGS` is parsed directly).
- `register_log_env_var(name)` registers an additional environment variable
  name to be checked alongside `TORCH_LOGS` by `_update_log_state_from_env()`
  and `set_logs()`'s early-return guard — without ever modifying the
  `LOG_ENV_VAR` global. If both `TORCH_LOGS` and one or more registered env
  vars are set, their settings are **merged**, with registered env vars
  taking precedence over `TORCH_LOGS` on conflicting qnames/artifacts (see
  "Why open it" for why merge semantics rather than first-match-wins). Late
  registration (a backend imported after `import torch` has already run
  `_init_logs()` once, the common case for backends that can't use the
  autoload mechanism) is handled by re-invoking `_init_logs()` immediately if
  the registered env var is already set.

### Why open it

Backends with a C++ logging subsystem have no official way to learn that
`TORCH_LOGS`/`set_logs()` changed Python-side log state — `_init_logs()` only
ever configures `logging.Logger` objects. Today they work around this by
monkey-patching `torch._logging.set_logs` and by replacing the internal
`LOG_ENV_VAR` global to point at their own env var name, then manually
re-calling `_init_logs()`. Both hacks are fragile — see the full writeup and
motivation in the RFC: #192481.

### What this PR deliberately does not do

- Does not change `TORCH_LOGS` syntax or `set_logs()`'s signature.
- Does not modify `LOG_ENV_VAR` — it stays `"TORCH_LOGS"` always; registered
  env vars are strictly additive.
- Does not add an unregister API for callbacks/env vars — both are
  append-only module-level lists, matching the RFC's stated scope (deferred
  to a follow-up).
- Does not change `_reset_logs()`'s behavior on re-init — a registered env
  var's late-registration re-init still does a full logger/handler reset via
  `_reset_logs()`, same as the current out-of-tree hack does today. A more
  incremental update is a possible follow-up optimization, not attempted
  here.

### Open questions (from the RFC, unresolved)

- Should callbacks receive `log_state` as an explicit argument instead of
  reaching into `torch._logging._internal.log_state`? This PR keeps the
  no-argument signature from the RFC's sketch; passing state explicitly is a
  public-API commitment worth a second look before this is considered final.
- Should `register_log_env_var()`'s auto re-init be optional (e.g. a
  `reinit=True` parameter)?

### Test plan

```
python test/test_logging.py -v
```

16/16 pass, including 7 new tests added for this change
(`test_log_init_callback_invoked_on_set_logs_and_init_logs`,
`test_log_init_callback_exception_does_not_block_others`,
`test_register_log_env_var_does_not_modify_log_env_var`,
`test_register_log_env_var_triggers_reinit_when_already_set`,
`test_set_logs_ignores_call_when_extra_env_var_is_set`,
`test_update_log_state_merges_torch_logs_and_extra_env_var`,
`test_extra_env_var_overrides_torch_logs_on_conflicting_qname`). Ran the full
file 3x in a row to check for order-dependence given the module-level mutable
state involved.