### PR TITLE
Skip CUPTI graph event-node tests when the driver lacks cudaGraphNodeGetToolsId

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -33,6 +33,7 @@ from torch.profiler._cupti.observers.observation_window import WindowFinalizerMi
 from torch.testing._internal.common_cuda import (
     SM100OrLater,
     TEST_CUDA,
+    TEST_CUDA_GRAPH_TOOLS_ID,
     TEST_CUPTI as TEST_CUPTI_PYTHON,
     TEST_CUPTI_V13_3,
 )
@@ -2424,6 +2425,10 @@ class TestCuptiMonitorCUDA(TestCase):
         self.assertNotIn(sync, monitor._enabled)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_TOOLS_ID,
+        "requires cudaGraphNodeGetToolsId (cuda-bindings >= 13.1 and CUDA driver >= 13.1)",
+    )
     def test_event_node_recorder_arm_before_capture(self):
         # End-to-end usage, and the ordering contract it depends on: the recorder learns a
         # graph's ordered event-record nodes from a graph-INSTANTIATE hook, so it has to be
@@ -2488,6 +2493,10 @@ class TestCuptiMonitorCUDA(TestCase):
         self.assertNotIn(before_exec_id, r.graph_event_nodes)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_TOOLS_ID,
+        "requires cudaGraphNodeGetToolsId (cuda-bindings >= 13.1 and CUDA driver >= 13.1)",
+    )
     def test_event_nodes_on_concurrent_branches_use_node_id_order(self):
         # The serial-chain case above is the one where every candidate ordering agrees. This
         # is the case that separates them: two event nodes on CONCURRENT branches of differing

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -50,6 +50,21 @@ def _cupti_version():
 
 TEST_CUPTI_V13_3 = LazyVal(lambda: TEST_CUPTI and _cupti_version() >= 130300)
 
+
+def _cuda_graph_tools_id_available():
+    # cudaGraphNodeGetToolsId needs cuda-bindings >= 13.1 *and* a CUDA driver
+    # >= 13.1 (or cuda-compat), which is independent of the libcupti version:
+    # a CUDA 13.0 runner can ship libcupti >= 13.3 and still lack the API.
+    # is_available() probes the driver and caches the result.
+    try:
+        from torch.cuda.graph_annotations import is_available
+        return is_available()
+    except Exception:
+        return False
+
+
+TEST_CUDA_GRAPH_TOOLS_ID = LazyVal(_cuda_graph_tools_id_available)
+
 SM53OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (5, 3))
 SM60OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (6, 0))
 SM70OrLater = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() >= (7, 0))


### PR DESCRIPTION
## Symptom

`trunk` and `slow` are red on CUDA 13.0 / 13.2:

```
FAILED CONSISTENTLY: test/profiler/test_cupti_monitor.py::TestCuptiMonitorCUDA::test_event_node_recorder_arm_before_capture
FAILED CONSISTENTLY: test/profiler/test_cupti_monitor.py::TestCuptiMonitorCUDA::test_event_nodes_on_concurrent_branches_use_node_id_order
RuntimeError: get_graph_data requires cudaGraphNodeGetToolsId which needs
  cuda.bindings >= 13.1 and CUDA driver >= 13.1 (or cuda-compat >= 13.1 in LD_LIBRARY_PATH)
```

Affected jobs seen so far — the shard index moves between runs because of dynamic
sharding, which is why it can look like a different failure each time:

| workflow | job |
|---|---|
| trunk | `linux-jammy-cuda13.0-py3.10-gcc11 / test (default, 9, 14)` ([run](https://github.com/pytorch/pytorch/actions/runs/31180669084/job/92878913452)) |
| slow | `linux-jammy-cuda13.0-py3.10-gcc11-sm86 / test (slow, 2, 3)` |
| slow | `linux-jammy-cuda13.2-py3.10-gcc11-sm86 / test (slow, 2, 3)` |

## Why the guard misses it

Both tests were gated on one thing:

```python
@unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
```

`TEST_CUPTI_V13_3` checks the **libcupti** version (`_cupti_version() >= 130300`).
`get_graph_data()` additionally requires **cuda-bindings >= 13.1 and a CUDA driver
>= 13.1**, and those two axes are independent. The CI images ship libcupti >= 13.3
(#189214 / #189307) while the runners report driver **580.159.03 / CUDA 13.0**, so
the guard passes and the call still raises.

## Why it only started failing now

These tests had **never actually executed in CI**. `TEST_CUPTI` requires
`torch.profiler._cupti._cupti_stubs` to be importable:

```python
TEST_CUPTI = (
    _check_module_exists("cupti")
    and _check_module_exists("torch.profiler._cupti._cupti_stubs")
    and not TEST_WITH_ROCM
)
```

That module was generated but gitignored, so scikit-build-core dropped it from the
wheel — as #192260 describes, *"the wheel ships torch/profiler/_cupti/ WITHOUT the
stubs ... editable installs mask it."* So on CI builds `TEST_CUPTI` was `False`,
`TEST_CUPTI_V13_3` was `False`, and the whole class was silently skipped.

#192260 (`d518157a9a73`, Aug 6 14:54 UTC) added the missing install rule, which
flipped `TEST_CUPTI` to `True`, made `_cupti_version()` report the real libcupti
version, and started running these tests for the first time — where they
immediately hit the driver requirement the guard never checked.

**#192260 is correct and should not be reverted**: it fixed a real packaging bug
(wheels shipping a `_cupti_stubs`-less profiler). It only exposed the latent gap in
the test guard from #191689, which added both tests.

## Fix

Add `TEST_CUDA_GRAPH_TOOLS_ID` to `common_cuda.py`, backed by the **public**
`torch.cuda.graph_annotations.is_available()` — which is documented as requiring
"a driver that supports `cudaGraphNodeGetToolsId` (CUDA >= 13.1 or an equivalent
cuda-compat package)", probes the driver, and caches the result. That is exactly
the capability `get_graph_data()` needs. Then guard the two tests with it in
addition to the existing libcupti check.

Scope: these are the **only** two tests that call the real `get_graph_data()`
(`test_recorder_keeps_node_id_order_and_refuses_opaque_bodies` defines its own
stub), so no other test in the file changes behaviour, and nothing changes on
runners that do have driver >= 13.1.

## Test plan

- Both tests now skip with `requires cudaGraphNodeGetToolsId (cuda-bindings >= 13.1
  and CUDA driver >= 13.1)` on the CUDA 13.0/13.2 runners, and still run wherever
  the driver supports the API.
- Verified `LazyVal(_cuda_graph_tools_id_available)` evaluates lazily and yields a
  clean skip rather than a collection error when the import fails: extracted
  `make_lazy_class`/`LazyVal` and exercised the helper with torch absent →
  `bool(flag) == False`, `not flag == True`.
- Both edited files parse; no new lint findings.

Note for follow-up: now that `TEST_CUPTI` is genuinely `True` for the first time,
the rest of `TestCuptiMonitorCUDA` is also executing for the first time. These two
are the ones failing today, but other latent gaps in that class may surface on
runners with different driver/libcupti combinations.
