### PR TITLE
[ROCm] Add amd_smi as a build time dependency on ROCm 7.14 and after

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1101,6 +1101,10 @@ if(USE_ROCM)
     set(Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS
       hip::host MIOpen hiprtc::hiprtc)
 
+    if(TARGET amd_smi)
+      list(APPEND Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS amd_smi)
+    endif()
+
     # Math libraries
     list(APPEND Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS
       roc::hipblas roc::rocblas hip::hipfft hip::hiprand roc::hipsparse roc::hipsolver roc::hipblaslt roc::rocsolver)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -354,6 +354,11 @@ if(PYTORCH_FOUND_HIP)
   # 'REQUIRED' once minimal ROCm version is bumped to 8.0 or later.
   find_package_and_print_version(libhipcxx)
 
+  # amd_smi is linked directly on ROCm >= 7.14; see intra_node_comm.cpp.
+  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "7.14.0")
+    find_package_and_print_version(amd_smi REQUIRED)
+  endif()
+
   list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
 
   if(UNIX)

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
@@ -6,8 +6,8 @@
 #include <amd_smi/amdsmi.h>
 #include <string>
 #if ROCM_VERSION < 71400
-#include <cstdlib>
 #include <dlfcn.h>
+#include <cstdlib>
 #endif
 #endif
 
@@ -42,22 +42,18 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
 #else
   // ROCm >= 7.14: amd_smi is a build-time (DT_NEEDED) dependency, so the plain
   // amdsmi_* names used below resolve directly to the linked extern functions
-  // declared by <amd_smi/amdsmi.h>; nothing shadows them and no setup is needed.
+  // declared by <amd_smi/amdsmi.h>; nothing shadows them and no setup is
+  // needed.
 #if ROCM_VERSION < 71400
   // Load libamd_smi at runtime to avoid linking it into torch_hip (double-load
   // with Python amdsmi causes bus errors). Types/constants from amdsmi.h only.
   static amdsmi_status_t (*amdsmi_init)(uint64_t) = nullptr;
   static amdsmi_status_t (*amdsmi_get_socket_handles)(
-      uint32_t*,
-      amdsmi_socket_handle*) = nullptr;
+      uint32_t*, amdsmi_socket_handle*) = nullptr;
   static amdsmi_status_t (*amdsmi_get_processor_handles)(
-      amdsmi_socket_handle,
-      uint32_t*,
-      amdsmi_processor_handle*) = nullptr;
+      amdsmi_socket_handle, uint32_t*, amdsmi_processor_handle*) = nullptr;
   static amdsmi_status_t (*amdsmi_is_P2P_accessible)(
-      amdsmi_processor_handle,
-      amdsmi_processor_handle,
-      bool*) = nullptr;
+      amdsmi_processor_handle, amdsmi_processor_handle, bool*) = nullptr;
 
   static void* amdsmi_handle = nullptr;
   static bool amdsmi_resolved = false;
@@ -129,8 +125,8 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
   std::vector<amdsmi_processor_handle> processor_handles;
   for (size_t i = 0; i < socket_count; ++i) {
     uint32_t device_count = 0;
-    ret = amdsmi_get_processor_handles(
-        socket_handles[i], &device_count, nullptr);
+    ret =
+        amdsmi_get_processor_handles(socket_handles[i], &device_count, nullptr);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       LOG(ERROR)
           << "IntraNodeComm:: getNvlMesh: amdsmi_get_processor_handles (count) failed, ret="

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
@@ -4,9 +4,11 @@
 
 #if defined(USE_ROCM)
 #include <amd_smi/amdsmi.h>
-#include <dlfcn.h>
-#include <cstdlib>
 #include <string>
+#if ROCM_VERSION < 71400
+#include <cstdlib>
+#include <dlfcn.h>
+#endif
 #endif
 
 namespace c10d::intra_node_comm {
@@ -38,22 +40,26 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
   }
   return nvlMesh;
 #else
+  // ROCm >= 7.14: amd_smi is a build-time (DT_NEEDED) dependency, so the plain
+  // amdsmi_* names used below resolve directly to the linked extern functions
+  // declared by <amd_smi/amdsmi.h>; nothing shadows them and no setup is needed.
+#if ROCM_VERSION < 71400
   // Load libamd_smi at runtime to avoid linking it into torch_hip (double-load
   // with Python amdsmi causes bus errors). Types/constants from amdsmi.h only.
-  struct AmdsmiApi {
-    amdsmi_status_t (*init)(uint64_t);
-    amdsmi_status_t (*get_socket_handles)(uint32_t*, amdsmi_socket_handle*);
-    amdsmi_status_t (*get_processor_handles)(
-        amdsmi_socket_handle,
-        uint32_t*,
-        amdsmi_processor_handle*);
-    amdsmi_status_t (*is_P2P_accessible)(
-        amdsmi_processor_handle,
-        amdsmi_processor_handle,
-        bool*);
-  };
+  static amdsmi_status_t (*amdsmi_init)(uint64_t) = nullptr;
+  static amdsmi_status_t (*amdsmi_get_socket_handles)(
+      uint32_t*,
+      amdsmi_socket_handle*) = nullptr;
+  static amdsmi_status_t (*amdsmi_get_processor_handles)(
+      amdsmi_socket_handle,
+      uint32_t*,
+      amdsmi_processor_handle*) = nullptr;
+  static amdsmi_status_t (*amdsmi_is_P2P_accessible)(
+      amdsmi_processor_handle,
+      amdsmi_processor_handle,
+      bool*) = nullptr;
+
   static void* amdsmi_handle = nullptr;
-  static AmdsmiApi amdsmi = {};
   static bool amdsmi_resolved = false;
 
   if (!amdsmi_resolved) {
@@ -70,38 +76,39 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
                  << dlerror();
       return {};
     }
-    amdsmi.init = reinterpret_cast<decltype(amdsmi.init)>(
+    amdsmi_init = reinterpret_cast<decltype(amdsmi_init)>(
         dlsym(amdsmi_handle, "amdsmi_init"));
-    amdsmi.get_socket_handles =
-        reinterpret_cast<decltype(amdsmi.get_socket_handles)>(
+    amdsmi_get_socket_handles =
+        reinterpret_cast<decltype(amdsmi_get_socket_handles)>(
             dlsym(amdsmi_handle, "amdsmi_get_socket_handles"));
-    amdsmi.get_processor_handles =
-        reinterpret_cast<decltype(amdsmi.get_processor_handles)>(
+    amdsmi_get_processor_handles =
+        reinterpret_cast<decltype(amdsmi_get_processor_handles)>(
             dlsym(amdsmi_handle, "amdsmi_get_processor_handles"));
-    amdsmi.is_P2P_accessible =
-        reinterpret_cast<decltype(amdsmi.is_P2P_accessible)>(
+    amdsmi_is_P2P_accessible =
+        reinterpret_cast<decltype(amdsmi_is_P2P_accessible)>(
             dlsym(amdsmi_handle, "amdsmi_is_P2P_accessible"));
-    if (!amdsmi.init || !amdsmi.get_socket_handles ||
-        !amdsmi.get_processor_handles || !amdsmi.is_P2P_accessible) {
+    if (!amdsmi_init || !amdsmi_get_socket_handles ||
+        !amdsmi_get_processor_handles || !amdsmi_is_P2P_accessible) {
       LOG(ERROR) << "IntraNodeComm:: getNvlMesh: dlsym amdsmi failed";
       return {};
     }
   }
+#endif
 
   NvlMesh nvlMesh = {};
   const auto worldSize = rankToDeviceIdx.size();
 
   uint32_t socket_count = 0;
-  amdsmi_status_t ret = amdsmi.get_socket_handles(&socket_count, nullptr);
+  amdsmi_status_t ret = amdsmi_get_socket_handles(&socket_count, nullptr);
   if (ret == AMDSMI_STATUS_NOT_INIT) {
-    ret = amdsmi.init(AMDSMI_INIT_AMD_GPUS);
+    ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       LOG(ERROR) << "IntraNodeComm:: getNvlMesh: amdsmi_init failed, ret="
                  << static_cast<int>(ret);
       return {};
     }
     socket_count = 0;
-    ret = amdsmi.get_socket_handles(&socket_count, nullptr);
+    ret = amdsmi_get_socket_handles(&socket_count, nullptr);
   }
   if (ret != AMDSMI_STATUS_SUCCESS) {
     LOG(ERROR)
@@ -111,7 +118,7 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
   }
 
   std::vector<amdsmi_socket_handle> socket_handles(socket_count);
-  ret = amdsmi.get_socket_handles(&socket_count, &socket_handles[0]);
+  ret = amdsmi_get_socket_handles(&socket_count, &socket_handles[0]);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     LOG(ERROR)
         << "IntraNodeComm:: getNvlMesh: amdsmi_get_socket_handles (buffer) failed, ret="
@@ -122,8 +129,8 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
   std::vector<amdsmi_processor_handle> processor_handles;
   for (size_t i = 0; i < socket_count; ++i) {
     uint32_t device_count = 0;
-    ret =
-        amdsmi.get_processor_handles(socket_handles[i], &device_count, nullptr);
+    ret = amdsmi_get_processor_handles(
+        socket_handles[i], &device_count, nullptr);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       LOG(ERROR)
           << "IntraNodeComm:: getNvlMesh: amdsmi_get_processor_handles (count) failed, ret="
@@ -131,7 +138,7 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
       return {};
     }
     std::vector<amdsmi_processor_handle> _processor_handles(device_count);
-    ret = amdsmi.get_processor_handles(
+    ret = amdsmi_get_processor_handles(
         socket_handles[i], &device_count, &_processor_handles[0]);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       LOG(ERROR)
@@ -150,7 +157,7 @@ static NvlMesh getNvlMesh(const std::vector<int>& rankToDeviceIdx) {
       if (idx == link)
         continue;
       bool conn = false;
-      ret = amdsmi.is_P2P_accessible(
+      ret = amdsmi_is_P2P_accessible(
           processor_handles[idx], processor_handles[link], &conn);
       if (ret != AMDSMI_STATUS_SUCCESS) {
         LOG(ERROR)


### PR DESCRIPTION
On ROCm 7.2, amd_smi will interfere with rocm_smi symbols (transitively pulled in by RCCL) and cause failures. On ROCm 7.14 and after, RCCL also deprecates rocm_smi and therefore amd_smi can be safely added as a build time dependency.
It's worth noting that although currently this doesn't cause a problem in neither here nor the rock CI, that's only because we either have amd_smi in the wheel, or we have rocm_devel package in the path. If a user has a minimal installation of pytorch, that installation wouldn't be able to correctly find amd_smi.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang