### PR TITLE
[mergebot] Do not refuse docker-affecting merges on tree skew, just warn

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1449,10 +1449,9 @@ class GitHubPR:
                 ghstack_prs=ghstack_prs,
             )
 
-            # Now that the merge commit exists locally, make sure it doesn't
-            # reference docker images that were never built due to a land race.
+            # Log, but do not block on, a docker land race.
             if docker_pr is not None:
-                check_no_docker_merge_skew(repo, docker_pr)
+                warn_on_docker_merge_skew(repo, docker_pr)
 
             repo.push(self.default_branch(), dry_run)
             # When the merge process reaches this part, we can assume that the
@@ -1911,19 +1910,16 @@ def check_docker_builds_ready(pr: GitHubPR) -> None:
         )
 
 
-def check_no_docker_merge_skew(repo: GitRepo, pr: GitHubPR) -> None:
-    """Block merge if a docker-affecting PR raced with another docker change.
+def warn_on_docker_merge_skew(repo: GitRepo, pr: GitHubPR) -> None:
+    """Log when a docker-affecting PR raced with another docker change.
 
-    The CI docker images are tagged by the git tree hash of .ci/docker.  The
-    images built and tested on the PR head are tagged with the PR head's tree
-    hash, but trunk jobs after the merge request the tree hash of the *merge*
-    commit.  If another docker-affecting PR landed on the base branch after this
-    PR's images were built, those two hashes disagree and the images trunk needs
-    were never built or tested.  Refuse the merge and ask for a rebase, which
-    re-runs ciflow/docker against the new base.
+    The CI docker images are tagged by the git tree hash of .ci/docker, so a
+    docker change landing on the base after this PR's images were built leaves
+    the merge commit asking for an untested tree. This used to refuse the merge
+    (#191508); it now only warns, since docker-builds.yml publishes the merged
+    tree's images on push and jobs wait for them.
 
-    Must be called after the merge commit has been created locally but before it
-    is pushed.
+    Must be called after the merge commit has been created locally.
     """
     if not pr.is_docker_affecting():
         return
@@ -1940,15 +1936,14 @@ def check_no_docker_merge_skew(repo: GitRepo, pr: GitHubPR) -> None:
     pr_head_tree = repo.rev_parse(f"{pr_head_sha}:{DOCKER_CI_PATH}")
 
     if merge_commit_tree != pr_head_tree:
-        raise MergeRuleFailedError(
-            "Refusing to merge: this PR modifies the CI docker images, but the "
-            f"{DOCKER_CI_PATH} tree of the merge commit ({merge_commit_tree}) does "
-            f"not match the tree that ciflow/docker built and tested on the PR "
-            f"head ({pr_head_tree}). Another docker-affecting change landed on the "
-            "base branch after your docker images were built, so the images "
-            "required after this merge were never built or tested (a land race). "
-            "Please rebase this PR (e.g. `@pytorchbot rebase`), let the "
-            "`ciflow/docker` builds re-run, and then merge again."
+        print(
+            f"WARNING: docker land race on PR #{pr.pr_num}: the {DOCKER_CI_PATH} "
+            f"tree of the merge commit ({merge_commit_tree}) does not match the "
+            f"tree that ciflow/docker built and tested on the PR head "
+            f"({pr_head_tree}). Another docker-affecting change landed on the base "
+            "branch after these images were built, so the first trunk jobs after "
+            "this merge may wait for docker-builds to publish the merged tree's "
+            "images, or rebuild them locally. Merging anyway."
         )
 
 


### PR DESCRIPTION
Follow-up to #191508.

## What #191508 added, and what changes here

It added two gates for docker-affecting PRs, both in `merge_into` so force merges
cannot bypass them:

1. **`check_docker_builds_ready`** — the PR's own `ciflow/docker` builds must have
   run and passed. **Unchanged by this PR.** Pending builds still raise
   `MandatoryChecksMissingError` so a normal merge waits; missing/failed builds are
   still refused.
2. **`check_no_docker_merge_skew`** — additionally required the `.ci/docker` tree of
   the *merge commit* to equal the tree `ciflow/docker` built on the PR head, and
   refused the merge otherwise. **This PR downgrades it to a warning.**

So the "all the builds are green" requirement is fully retained; what goes away is
the extra requirement that the base branch not have moved.

## Why

Requiring the two trees to match means a docker PR has to win a race against the
base branch, and a rebase only helps until the next docker-affecting PR lands. On
a busy day a PR can bounce indefinitely. #190639 hit it twice in a row — the
PR-head tree moved (`08b9699a` → `75ce86e4`) after a rebase while the merge-commit
tree stayed `ab961773`:

```
Refusing to merge: this PR modifies the CI docker images, but the .ci/docker tree
of the merge commit (ab961773...) does not match the tree that ciflow/docker built
and tested on the PR head (75ce86e4...)
```

**A missing post-merge image is not fatal**, which is the key point:

- `docker-builds.yml` triggers on `push` to `main` / `release/*`, so the merged
  tree's images get built and pushed right after the merge lands.
- test-infra's `calculate-docker-image` polls for the image before giving up —
  `docker manifest inspect` in a loop, `sleep 300` per iteration, up to 120
  minutes for non-docker-build jobs — and then falls through to `rebuild=true`
  and builds it locally.

So a skew costs **time** on the first trunk jobs after the merge (waiting for
docker-builds, or a local rebuild with longer TTS), not a hard failure. Trading
that against docker PRs being unable to land seems like the better default.

## Kept: the diagnostic

The mismatch is still printed to the merge job log, so a slow or rebuilding trunk
job can be correlated with the land race that caused it:

```
WARNING: docker land race on PR #NNNNN: the .ci/docker tree of the merge commit
(...) does not match the tree that ciflow/docker built and tested on the PR head
(...). ... the first trunk jobs after this merge may wait for docker-builds to
publish the merged tree's images, or rebuild them locally. Merging anyway.
```

Renamed `check_no_docker_merge_skew` → `warn_on_docker_merge_skew` so the name
matches the behaviour.

## Test plan

- `python -m pytest .github/scripts/test_trymerge.py` → **74 passed, 2 skipped**
  (the 4 docker-gate tests included; none referenced the renamed function).
- `py_compile` clean; no remaining references to the old name
  (`grep -rn check_no_docker_merge_skew .github/` → empty).
- `MergeRuleFailedError` is still used in 7 other places, so the import is not
  orphaned.

## Trade-off, stated plainly

This intentionally reopens the window that #191508 closed: a docker PR can now
land whose post-merge images were never built or tested, which is the shape of the
#190927 / #186302 land race cited in that PR. The mitigation is that the images
are auto-published by `docker-builds.yml` on the merge and that jobs wait for
them, so the failure mode is latency rather than red trunk. If dev-infra would
rather keep a hard gate, an alternative is to keep refusing only when
`check_docker_builds_ready` did **not** pass, i.e. exactly the unbuilt-image case,
and always allow the pure-skew case — happy to switch to that.
