### PR TITLE
Add type check to THPStream_richcompare instead of casting arbitrary objects

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: tests"]
 
 import gc
+import operator
 import sys
 import unittest
 from contextlib import nullcontext
@@ -84,6 +85,23 @@ class TestAccelerator(TestCase):
             ValueError, "doesn't match the current accelerator"
         ):
             torch.accelerator.current_stream(other_device)
+
+    def test_stream_compare_with_non_stream(self):
+        # Comparing with a non-Stream must not blindly cast it to THPStream*
+        # and read garbage fields (#188033)
+        s1 = torch.Stream()
+        for other in (42, "hello", 3.14, None, object()):
+            self.assertFalse(s1 == other)
+            self.assertTrue(s1 != other)
+        self.assertTrue(s1 in [1, "a", s1])
+        s2 = torch.Stream()
+        for op in (operator.lt, operator.le, operator.gt, operator.ge):
+            with self.assertRaises(TypeError):
+                op(s1, s2)
+        sid, di, dt = s1.stream_id, s1.device_index, s1.device_type
+        same = torch.Stream(stream_id=sid, device_index=di, device_type=dt)
+        self.assertTrue(s1 == same)
+        self.assertFalse(s1 != same)
 
     def test_device_context_manager(self):
         prev_device = torch.accelerator.current_device_index()

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -434,27 +434,21 @@ static PyObject* THPStream_richcompare(
     PyObject* self,
     PyObject* other,
     int op) {
-  PyObject* result = nullptr;
-  if (Py_IsNone(other)) {
-    result = Py_False;
-  } else {
-    switch (op) {
-      case Py_EQ:
-        result = THPStream_eq(
-            reinterpret_cast<THPStream*>(self),
-            reinterpret_cast<THPStream*>(other));
-        break;
-      case Py_NE:
-        result = THPStream_ne(
-            reinterpret_cast<THPStream*>(self),
-            reinterpret_cast<THPStream*>(other));
-        break;
-      default:
-        result = Py_False;
-        break;
-    }
+  if (!THPStream_Check(other)) {
+    Py_RETURN_NOTIMPLEMENTED;
   }
-  return Py_XNewRef(result);
+  switch (op) {
+    case Py_EQ:
+      return THPStream_eq(
+          reinterpret_cast<THPStream*>(self),
+          reinterpret_cast<THPStream*>(other));
+    case Py_NE:
+      return THPStream_ne(
+          reinterpret_cast<THPStream*>(self),
+          reinterpret_cast<THPStream*>(other));
+    default:
+      Py_RETURN_NOTIMPLEMENTED;
+  }
 }
 
 static const std::initializer_list<PyMemberDef> THPStream_members = {


### PR DESCRIPTION
Fixes #188033

`THPStream_richcompare` special-cased only `None` and then `reinterpret_cast` any other Python object to `THPStream*`, so `stream == 42` read `stream_id`/`device_index`/`device_type` through a bogus pointer - past the end of the allocation for small objects. Undefined behavior that happened to return False on most builds. The rewrite follows the `THPDevice_rc` precedent (Device.cpp): non-Stream operands (subclasses covered via the existing `THPStream_Check`) return `NotImplemented` so CPython falls back to identity for `==`/`!=`, and ordering ops also return `NotImplemented` so they raise `TypeError` like other non-orderable types.

Two deterministic bugs in the old code are fixed by the same change: `stream != None` returned False (the None branch ignored the operator), and `stream < other_stream` silently returned False instead of raising. Comparing genuine streams is unchanged, so `__hash__` consistency is unaffected. `torch.cuda.Stream` and other subclasses dispatch through the same slot and are covered by the type check and the regression test in test/test_accelerator.py.