### PR TITLE
Re-land #192368: Back out eager Triton bundle loading

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -61,7 +61,7 @@ from torch._inductor.graph import GraphLowering
 from torch._inductor.mock_cache import global_stats, PatchCaches, Stats
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.utils import clear_caches, fresh_cache, GPU_KERNEL_BIN_EXTS
+from torch._inductor.utils import clear_caches, fresh_cache
 from torch._library import capture_triton
 from torch._subclasses import FakeTensorMode
 from torch.compiler._cache import (
@@ -530,17 +530,6 @@ class TestFxGraphCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
-
-    def _find_triton_kernel_binaries(self):
-        found = []
-        triton_dir = os.path.join(cache_dir(), "triton")
-        device_type = "hip" if torch.version.hip else "cuda"
-        binary_ext = GPU_KERNEL_BIN_EXTS[device_type]
-        for dirpath, _, filenames in os.walk(triton_dir):
-            for filename in filenames:
-                if filename.endswith(binary_ext):
-                    found.append(os.path.join(dirpath, filename))
-        return found
 
     def _check_cpu_thread_count_cache_key_no_input(self, return_expr):
         script = textwrap.dedent(
@@ -1031,55 +1020,6 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
-
-    @requires_cuda_and_triton
-    @config.patch(
-        {
-            "fx_graph_cache": True,
-            "fx_graph_remote_cache": False,
-            "bundle_triton_into_fx_graph_cache": True,
-            "triton.store_cubin": True,
-            "compile_threads": 1,
-        }
-    )
-    def test_cache_artifact_load_emits_triton_bundle(self):
-        def fn(x, y):
-            return (x.sin() + y.cos()).relu()
-
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            mock.patch.dict(
-                os.environ,
-                {
-                    "TORCHINDUCTOR_CACHE_DIR": tmpdir,
-                    "TRITON_CACHE_DIR": os.path.join(tmpdir, "triton"),
-                },
-            ),
-        ):
-            self.reset()
-            CacheArtifactManager.clear()
-
-            x = torch.randn(256, 256, device="cuda")
-            y = torch.randn(256, 256, device="cuda")
-            compiled_fn = torch.compile(fn, dynamic=False)
-
-            self.assertEqual(fn(x, y), compiled_fn(x, y))
-            torch.cuda.synchronize()
-
-            artifacts = torch.compiler.save_cache_artifacts()
-            self.assertIsNotNone(artifacts)
-            artifact_bytes, _ = artifacts
-
-            self.assertGreater(len(self._find_triton_kernel_binaries()), 0)
-
-            self.reset()
-            CacheArtifactManager.clear()
-            shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
-
-            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
-
-            self.assertIsNotNone(cache_info)
-            self.assertGreater(len(self._find_triton_kernel_binaries()), 0)
 
     @requires_triton()
     @config.patch(

--- a/test/inductor/test_compile_to_python.py
+++ b/test/inductor/test_compile_to_python.py
@@ -393,13 +393,8 @@ def call(args):
             )
 
     @config.patch({"compile_threads": 1})
-    def test_warm_load_rehydrates_static_launcher(self):
-        # The cache must let a COLD (fresh-dir) load reuse the compiled kernels AND the
-        # static CUDA launcher, not fall back to the slower dynamic launch. This works only
-        # because compile_to_python defaults keep_static_cubin_raw=True, travelling the raw
-        # cubin in the bundle; with the default False, reload_cubin_path can't find the cubin
-        # file in a fresh dir and the static launcher is silently dropped. Assert the static
-        # autotuner is rehydrated on the warm load (counter > 0) and the result matches eager.
+    def test_warm_load_without_eager_static_launcher_rehydration(self):
+        # A cold load should use JIT instead of eagerly rehydrating the static launcher.
         if config.force_disable_caches or not config.fx_graph_cache:
             self.skipTest("requires inductor FxGraphCache enabled")
         if not config.use_static_cuda_launcher:
@@ -413,7 +408,7 @@ def call(args):
             with torch.no_grad():
                 out = load_from_python(src, cache)(_flat_inputs(m, x))
             rehydrated = counters["inductor"]["triton_bundler_load_static_autotuner"]
-        self.assertGreater(rehydrated, 0)
+        self.assertEqual(rehydrated, 0)
         self.assertEqual(out[0], m(x))
 
 

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -174,14 +174,8 @@ class TestPrecompile(TestCase):
         torch.cuda.is_available(), "needs CUDA + Triton for the kernel cache"
     )
     @torch._inductor.config.patch({"compile_threads": 1})
-    def test_cache_primes_inductor_on_reload(self):
-        # The cache is a pure acceleration. load() feeds it to load_cache_artifacts to
-        # PRIME the inductor kernel caches, then execs the self-contained python_code --
-        # which loads the precompiled Triton kernels instead of recompiling. The composed
-        # python_code runs its inlined kernels directly (no compile_fx re-entry, so no
-        # FxGraphCache lookup); the observable acceleration is the Triton bundler
-        # rehydrating the static autotuner on the cold reload. Mirrors
-        # test/inductor/test_compile_to_python.py test_warm_load_rehydrates_static_launcher.
+    def test_cache_reload_without_eager_static_launcher_rehydration(self):
+        # A cold load should use JIT instead of eagerly rehydrating the static launcher.
         import torch._inductor.config as ind_config
 
         if ind_config.force_disable_caches or not ind_config.fx_graph_cache:
@@ -206,7 +200,7 @@ class TestPrecompile(TestCase):
             counters.clear()
             f_c = torch.compiler.precompile.load(code, cache)
             self.assertEqual(f_c(m, x), m(x))
-            self.assertGreater(
+            self.assertEqual(
                 counters["inductor"]["triton_bundler_load_static_autotuner"], 0
             )
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1991,7 +1991,6 @@ class InductorCacheArtifact(CacheArtifact):
     @override
     def populate_cache(self) -> None:
         FxGraphCache._write_to_local_cache(self.key, self.content)
-        FxGraphCache._emit_triton_bundle(self.content)
 
     @override
     @staticmethod
@@ -2272,15 +2271,6 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         # iterating over all entries in the parent subdir.
         path = os.path.join(subdir, sha256_hash(content))
         write_atomic(path, content, make_dirs=True)
-
-    @staticmethod
-    def _emit_triton_bundle(content: bytes) -> None:
-        if not TritonBundler.is_enabled():
-            return
-
-        graph = pickle.loads(content)
-        if bundle := graph._triton_bundle:
-            TritonBundler.read_and_emit(bundle)
 
     @staticmethod
     def _save_graph(


### PR DESCRIPTION
Rebased version of #192368 from @aorenste with the affected tests updated

Back out eager Triton bundle loading from cache artifact population to avoid races with compilation. Update the affected load-only tests to verify the safe JIT fallback.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo