### PR TITLE
Increase logical CUDA device index limit

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -114,7 +114,7 @@ DLDevice torchDeviceToDLDevice(at::Device device) {
 
   ctx.device_id =
       (device.is_cuda() || device.is_privateuseone() || device.is_mtia())
-      ? static_cast<int32_t>(static_cast<unsigned char>(device.index()))
+      ? static_cast<int32_t>(device.index())
       : 0;
 
   switch (device.type()) {
@@ -193,6 +193,24 @@ Device dlDeviceToTorchDevice(
       TORCH_CHECK_BUFFER(
           false, "Unsupported device_type: ", std::to_string(type));
   }
+}
+
+static c10::DeviceIndex checkedDLDeviceIndex(
+    DLDeviceType type,
+    int32_t device_id) {
+  if (type == DLDeviceType::kDLCPU) {
+    return 0;
+  }
+  TORCH_CHECK_VALUE(
+      device_id >= 0 && device_id < c10::Device::MAX_NUM_DEVICES,
+      "DLPack device id ",
+      device_id,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_id);
 }
 
 ScalarType toScalarType(const DLDataType& dtype) {
@@ -461,7 +479,10 @@ at::Tensor fromDLPackImpl(T* src, std::function<void(void*)> deleter) {
 
   DLTensor& dl_tensor = src->dl_tensor;
   Device device = dlDeviceToTorchDevice(
-      dl_tensor.device.device_type, dl_tensor.device.device_id, dl_tensor.data);
+      dl_tensor.device.device_type,
+      checkedDLDeviceIndex(
+          dl_tensor.device.device_type, dl_tensor.device.device_id),
+      dl_tensor.data);
   ScalarType stype = toScalarType(dl_tensor.dtype);
 
   if (!dl_tensor.strides) {
@@ -536,7 +557,8 @@ Tensor maybeCopyTensor(
   if (optional_dl_device.has_value()) {
     auto device = at::dlDeviceToTorchDevice(
         optional_dl_device->device_type,
-        static_cast<c10::DeviceIndex>(optional_dl_device->device_id));
+        checkedDLDeviceIndex(
+            optional_dl_device->device_type, optional_dl_device->device_id));
 
     if (device != data.device()) {
       TORCH_CHECK_VALUE(

--- a/aten/src/ATen/DeviceAccelerator.cpp
+++ b/aten/src/ATen/DeviceAccelerator.cpp
@@ -81,6 +81,7 @@ c10::DeviceIndex deviceCount() {
 }
 
 void setDeviceIndex(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   impl.setDevice({device_type, device_index});
@@ -105,12 +106,14 @@ void setCurrentStream(c10::Stream stream) {
 }
 
 c10::Stream getCurrentStream(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   return impl.getStream({device_type, device_index});
 }
 
 void synchronizeDevice(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   // impl.synchronizeDevice should can be safely called from any device
@@ -118,12 +121,14 @@ void synchronizeDevice(c10::DeviceIndex device_index) {
 }
 
 c10::DeviceIndex exchangeDevice(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   return impl.exchangeDevice({device_type, device_index}).index();
 }
 
 c10::DeviceIndex maybeExchangeDevice(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   // Avoid creating a new context if the context for the given device_index
@@ -133,6 +138,7 @@ c10::DeviceIndex maybeExchangeDevice(c10::DeviceIndex device_index) {
 }
 
 c10::DeviceCapability getDeviceCapability(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   c10::impl::VirtualGuardImpl impl(device_type);
   return impl.getDeviceCapability({device_type, device_index});
@@ -144,6 +150,7 @@ void emptyHostCache() {
 }
 
 const at::Generator& getDefaultGenerator(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   return at::globalContext()
       .getAcceleratorHooksInterface(device_type)

--- a/aten/src/ATen/DeviceAccelerator.h
+++ b/aten/src/ATen/DeviceAccelerator.h
@@ -1,15 +1,33 @@
 #pragma once
 
 #include <c10/core/CachingDeviceAllocator.h>
+#include <c10/core/Device.h>
 #include <c10/core/DeviceCapability.h>
 #include <c10/core/DeviceType.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
 
 #include <ATen/accelerator/Graph.h>
 #include <ATen/core/Generator.h>
 #include <optional>
 
 namespace at::accelerator {
+
+namespace detail {
+
+inline void checkDeviceIndex(c10::DeviceIndex device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      static_cast<int>(device_index),
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+}
+
+} // namespace detail
 
 // Note [Accelerator Concept]
 // This file defines the top level Accelerator concept for PyTorch.
@@ -94,22 +112,26 @@ TORCH_API void emptyHostCache();
 
 TORCH_API inline at::CachingDeviceAllocator::DeviceStats getDeviceStats(
     c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   return at::getDeviceAllocator(device_type)->getDeviceStats(device_index);
 }
 
 TORCH_API inline void resetAccumulatedStats(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   at::getDeviceAllocator(device_type)->resetAccumulatedStats(device_index);
 }
 
 TORCH_API inline void resetPeakStats(c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   at::getDeviceAllocator(device_type)->resetPeakStats(device_index);
 }
 
 TORCH_API inline std::pair<size_t, size_t> getMemoryInfo(
     c10::DeviceIndex device_index) {
+  detail::checkDeviceIndex(device_index);
   const auto device_type = getAccelerator(true).value();
   return at::getDeviceAllocator(device_type)->getMemoryInfo(device_index);
 }

--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -8,6 +8,7 @@
 #include <c10/util/TypeList.h>
 #include <c10/util/intrusive_ptr.h>
 
+#include <cstdint>
 #include <utility>
 
 namespace c10 {
@@ -85,6 +86,7 @@ namespace impl {
 // Additionally, we support lists, dicts and optionals containing these types.
 using supported_primitive_arg_types = guts::typelist::typelist<
     int64_t,
+    int8_t,
     double,
     bool,
     std::string_view,

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -15,6 +15,7 @@
 #include <c10/core/Device.h>
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <sstream>
@@ -1857,6 +1858,12 @@ template <>
 struct getTypePtr_<c10::complex<double>> final {
   static decltype(auto) call() {
     return ComplexType::get();
+  }
+};
+template <>
+struct getTypePtr_<int8_t> final {
+  static decltype(auto) call() {
+    return IntType::get();
   }
 };
 template <>

--- a/aten/src/ATen/core/op_registration/infer_schema.h
+++ b/aten/src/ATen/core/op_registration/infer_schema.h
@@ -8,6 +8,8 @@
 #include <ATen/core/function_schema.h>
 #include <c10/util/Metaprogramming.h>
 
+#include <cstdint>
+
 namespace c10 {
 namespace detail::infer_schema {
 
@@ -29,14 +31,21 @@ struct bool_t {};
 template<> struct bool_t<true> : std::true_type {};
 template<> struct bool_t<false> : std::false_type {};
 
+template <class T>
+using valid_integral_arg_type = bool_t<
+    !std::is_integral_v<T> || std::is_same_v<T, int8_t> ||
+    std::is_same_v<T, int16_t> || std::is_same_v<T, int64_t> ||
+    std::is_same_v<T, bool>>;
+
 /// Checks the static C++ types `Types` for correctness to catch common error cases.
 template <class... Types>
 constexpr int checkStaticTypes() {
  // Give nice error messages for some of the common error cases.
  // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
  static_assert(std::conjunction_v<
-     bool_t<!std::is_integral_v<Types> || std::is_same_v<Types, int8_t> || std::is_same_v<Types, int64_t> || std::is_same_v<Types, bool>>...
-   >, "INVALID TYPE: Only int8_t, int64_t and bool are supported as an integral argument type");
+     valid_integral_arg_type<Types>...
+   >, "INVALID TYPE: Only int8_t, int16_t, int64_t and bool are supported "
+       "as an integral argument type");
  static_assert(std::conjunction_v<
      bool_t<!std::is_same_v<Types, float>>...
    >, "INVALID TYPE: float is not supported as an argument type, use double instead");

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -48,7 +48,7 @@ cudaDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   initCUDAContextVectors();
   if (device == -1)
     device = c10::cuda::current_device();
-  AT_ASSERT(
+  TORCH_CHECK(
       device >= 0 && device < num_gpus,
       "device=",
       static_cast<int>(device),
@@ -64,13 +64,13 @@ bool canDeviceAccessPeer(
   initCUDAContextVectors();
   if (device == -1)
     device = c10::cuda::current_device();
-  AT_ASSERT(
+  TORCH_CHECK(
       device >= 0 && device < num_gpus,
       "device=",
       static_cast<int>(device),
       ", num_gpus=",
       static_cast<int>(num_gpus));
-  AT_ASSERT(
+  TORCH_CHECK(
       peer_device >= 0 && peer_device < num_gpus,
       "peer_device=",
       static_cast<int>(peer_device),

--- a/aten/src/ATen/cuda/CUDADevice.h
+++ b/aten/src/ATen/cuda/CUDADevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/cuda/Exceptions.h>
+#include <c10/core/Device.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -17,6 +18,10 @@ inline Device getDeviceFromPtr(void* ptr) {
     "The specified pointer resides on host memory and is not registered with any CUDA device.");
 #endif
 
+  TORCH_INTERNAL_ASSERT(
+      attr.device >= 0 && attr.device < c10::Device::MAX_NUM_DEVICES,
+      "cudaPointerGetAttributes returns invalid device ",
+      attr.device);
   return {c10::DeviceType::CUDA, static_cast<DeviceIndex>(attr.device)};
 }
 

--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -47,8 +47,7 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
   ss << static_cast<int>(at::cuda::jit::BinaryFuncVariant::NoScalar);
   ss << extra_args_types;
   ss << vec_size;
-// DeviceIndex, e.g. int8_t, is not treated as a number by the stream, cast to int as a workaround
-  ss << static_cast<int>(dev_idx);
+  ss << dev_idx;
   const std::string cache_key = std::move(ss).str();
 
   static std::mutex _jiterator_mutex;

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -4,7 +4,6 @@
 #include <ATen/Dispatch.h>
 #include <ATen/ScalarType.h>
 #include <ATen/core/Tensor.h>
-#include <ATen/native/utils/ParamsHash.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
@@ -272,10 +271,14 @@ using IndicesT = std::vector<size_t>;
 using nested_optional_tensorvec_t =
     std::vector<std::vector<std::optional<at::Tensor>>>;
 using TensorsAndIndicesT = std::pair<nested_optional_tensorvec_t, IndicesT>;
-using FlatMap = std::unordered_map<
-    DeviceDtypeKey,
-    TensorsAndIndicesT,
-    ParamsHash<DeviceDtypeKey>>;
+struct DeviceDtypeKeyHash {
+  std::size_t operator()(const DeviceDtypeKey& key) const noexcept {
+    return std::hash<at::Device>{}(key.first) ^
+        std::hash<at::ScalarType>{}(key.second);
+  }
+};
+using FlatMap =
+    std::unordered_map<DeviceDtypeKey, TensorsAndIndicesT, DeviceDtypeKeyHash>;
 
 inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
     const nested_optional_tensorvec_t& nested_tensorlist,

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -507,8 +507,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.device().index()};
 
     auto opts = q.options();
 
@@ -728,8 +727,7 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
     const int seqlen_k_rounded = round_multiple(max_seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.device().index()};
 
     auto opts = q.options();
 
@@ -980,8 +978,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x head_si
     bool loop = true;
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.device().index()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, seqlen_q_rounded}, opts.dtype(at::kFloat));
@@ -1197,8 +1194,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     bool loop = true;
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.device().index()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({num_heads, total_q + 128 * batch_size}, opts.dtype(at::kFloat));
@@ -1421,8 +1417,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{static_cast<signed char>(q.get_device())};
+    at::cuda::CUDAGuard device_guard{q.device().index()};
 
     auto opts = q.options();
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -332,7 +332,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
   TORCH_CHECK(!paged_KV, "[ROCm] mha_varlen_fwd: block_table_ must be nullopt");
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -535,8 +535,7 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
         const at::Tensor& philox_seed,
         const at::Tensor& philox_offset) {
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 
@@ -717,8 +716,7 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
   TORCH_CHECK(!alibi_slopes_.has_value(), "[ROCm] mha_varlen_fwd: alibi_slopes_ must be nullopt");
 
   // Otherwise the kernel will be launched from cuda:0 device
-  // Cast to char to avoid compiler warning about narrowing
-  at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+  at::cuda::CUDAGuard device_guard{q.get_device()};
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   check_gpu_arch(stream);
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -455,8 +455,7 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -362,8 +362,7 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     const int head_size_8x = round_multiple(head_size, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -473,8 +473,7 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
         dout_padded = dout;
     }
 
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     auto softmax_d = at::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -303,8 +303,7 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     const int head_size_8x = round_multiple(head_size_og, 8);
 
     // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+    at::cuda::CUDAGuard device_guard{q.get_device()};
 
     auto opts = q.options();
     bool has_lse = true;

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -131,18 +131,26 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
 
   TORCH_CHECK(!has_error, "Invalid device string: '", device_string, "'");
 
-  try {
-    if (!device_index_str.empty()) {
-      index_ = static_cast<c10::DeviceIndex>(std::stoi(device_index_str));
+  if (!device_index_str.empty()) {
+    int64_t parsed_index = -1;
+    try {
+      parsed_index = std::stoll(device_index_str);
+    } catch (const std::exception&) {
+      TORCH_CHECK(
+          false,
+          "Could not parse device index '",
+          device_index_str,
+          "' in device string '",
+          device_string,
+          "'");
     }
-  } catch (const std::exception&) {
     TORCH_CHECK(
-        false,
-        "Could not parse device index '",
-        device_index_str,
-        "' in device string '",
-        device_string,
-        "'");
+        0 <= parsed_index && parsed_index < c10::Device::MAX_NUM_DEVICES,
+        "Device index must be between 0 and ",
+        c10::Device::MAX_NUM_DEVICES - 1,
+        " inclusive, got ",
+        parsed_index);
+    index_ = static_cast<c10::DeviceIndex>(parsed_index);
   }
   type_ = parse_type(device_name);
   validate();

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <iosfwd>
+#include <limits>
 #include <string>
 
 namespace c10 {
@@ -16,7 +17,7 @@ namespace c10 {
 /// A DeviceIndex is not independently meaningful without knowing
 /// the DeviceType it is associated; try to use Device rather than
 /// DeviceIndex directly.
-using DeviceIndex = int8_t;
+using DeviceIndex = int16_t;
 
 /// Represents a compute device on which a tensor is located. A device is
 /// uniquely identified by a type, which specifies the type of machine it is
@@ -29,6 +30,11 @@ using DeviceIndex = int8_t;
 /// represents a specific, concrete device,
 /// 2. When the device type is CPU, the device index must be zero.
 struct C10_API Device final {
+  /// The maximum number of devices that can be represented by DeviceIndex.
+  /// Device indices are valid in the range [0, MAX_NUM_DEVICES - 1].
+  static constexpr DeviceIndex MAX_NUM_DEVICES =
+      std::numeric_limits<DeviceIndex>::max();
+
   using Type = DeviceType;
 
   /// Constructs a new `Device` from a `DeviceType` and an optional device
@@ -60,6 +66,7 @@ struct C10_API Device final {
   /// Sets the device index.
   void set_index(DeviceIndex index) {
     index_ = index;
+    validate();
   }
 
   /// Returns the type of device this is.
@@ -175,8 +182,10 @@ struct C10_API Device final {
     // This is safe to do, because backends that use the DeviceIndex
     // have a later check when we actually try to switch to that device.
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        index_ >= -1,
-        "Device index must be -1 or non-negative, got ",
+        index_ >= -1 && index_ < MAX_NUM_DEVICES,
+        "Device index must be between -1 and ",
+        MAX_NUM_DEVICES - 1,
+        " inclusive, got ",
         static_cast<int>(index_));
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         !is_cpu() || index_ <= 0,
@@ -196,7 +205,7 @@ struct hash<c10::Device> {
     // Are you here because this static assert failed?  Make sure you ensure
     // that the bitmasking code below is updated accordingly!
     static_assert(sizeof(c10::DeviceType) == 1, "DeviceType is not 8-bit");
-    static_assert(sizeof(c10::DeviceIndex) == 1, "DeviceIndex is not 8-bit");
+    static_assert(sizeof(c10::DeviceIndex) == 2, "DeviceIndex is not 16-bit");
     // Note [Hazard when concatenating signed integers]
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // We must first convert to a same-sized unsigned type, before promoting to
@@ -209,7 +218,7 @@ struct hash<c10::Device> {
     // sake.
     uint32_t bits = static_cast<uint32_t>(static_cast<uint8_t>(d.type()))
             << 16 |
-        static_cast<uint32_t>(static_cast<uint8_t>(d.index()));
+        static_cast<uint32_t>(static_cast<uint16_t>(d.index()));
     return std::hash<uint32_t>{}(bits);
   }
 };

--- a/c10/core/Stream.h
+++ b/c10/core/Stream.h
@@ -138,21 +138,20 @@ class C10_API Stream final {
   // the stream is in capture mode, false otherwise.
   bool is_capturing() const;
 
-  // The purpose of this function is to more conveniently permit binding
-  // of Stream to and from Python.  Without packing, I have to setup a whole
-  // class with two fields (device and stream id); with packing I can just
-  // store a single uint64_t.
-  //
-  // The particular way we pack streams into a uint64_t is considered an
-  // implementation detail and should not be relied upon.
+  // The particular way we hash streams is considered an implementation detail
+  // and should not be relied upon.
   uint64_t hash() const noexcept {
-    // Concat these together into a 64-bit integer
-    uint64_t bits = static_cast<uint64_t>(device_type()) << 56 |
-        static_cast<uint64_t>(device_index()) << 48 |
-        // Remove the sign extension part of the 64-bit address because
-        // the id might be used to hold a pointer.
-        (static_cast<uint64_t>(id()) & ((1ull << 48) - 1));
-    return bits;
+    static_assert(sizeof(DeviceType) == 1, "DeviceType is not 8-bit");
+    static_assert(sizeof(DeviceIndex) == 2, "DeviceIndex is not 16-bit");
+    auto combine = [](size_t seed, size_t value) {
+      return seed ^ (value + 0x9e3779b9 + (seed << 6u) + (seed >> 2u));
+    };
+    auto seed = std::hash<StreamId>{}(id());
+    seed = combine(
+        seed, std::hash<uint16_t>{}(static_cast<uint16_t>(device_index())));
+    seed = combine(
+        seed, std::hash<uint8_t>{}(static_cast<uint8_t>(device_type())));
+    return static_cast<uint64_t>(seed);
   }
 
   struct StreamData3 pack3() const {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -3231,7 +3231,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
 #if UINTPTR_MAX == 0xFFFFFFFF
   // This is a 32-bit system
   static constexpr bool check_sizes() {
-    constexpr size_t tsize = 20 * sizeof(int64_t);
+    constexpr size_t tsize = 21 * sizeof(int64_t);
 
     // clang-format off
     are_equal<sizeof(storage_),            4,  FieldNameEnum::storage_>();
@@ -3243,7 +3243,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>();
     are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>();
     are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>();
-    are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>();
+    are_equal<sizeof(device_opt_),         6,  FieldNameEnum::device_opt_>();
     are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>();
     is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>();
     // clang-format on
@@ -3268,7 +3268,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>();
     are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>();
     are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>();
-    are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>();
+    are_equal<sizeof(device_opt_),         6,  FieldNameEnum::device_opt_>();
     are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>();
     is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>();
     // clang-format on

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -537,7 +537,7 @@ struct C10_API TensorOptions {
   // NB: We didn't use std::optional here, because then we can't pack
   // the has_***_ boolean fields.
 
-  Device device_ = at::kCPU; // 16-bit
+  Device device_ = at::kCPU; // 32-bit
   caffe2::TypeMeta dtype_ = caffe2::TypeMeta::Make<float>(); // 16-bit
   Layout layout_ = at::kStrided; // 8-bit
   MemoryFormat memory_format_ = MemoryFormat::Contiguous; // 8-bit

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -401,9 +401,9 @@ class C10_API DeviceGuardImplRegistrar {
       g_##DeviceType)(::c10::DeviceType::DevType, new DeviceGuardImpl());
 
 inline const DeviceGuardImplInterface* getDeviceGuardImpl(DeviceType type) {
-  // Two adjacent int16_t fields DeviceType and DeviceIndex has field access
+  // Two adjacent small fields DeviceType and DeviceIndex have field access
   // miscompiled on NVCC. To workaround this issue, we apply a mask to the
-  // DeviceType. First check if the DeviceType is 16-bit.
+  // DeviceType. First check if the DeviceType is 8-bit.
   // FB employees can see
   //   https://fb.workplace.com/groups/llvm.gcc/permalink/4053565044692080/
   // for more details

--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -1,14 +1,13 @@
 #pragma once
 
+#include <c10/core/Device.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 
 #include <array>
 
 namespace c10::impl {
 
-// FakeGuardImpl is hardcoded to have eight devices.  Not for
-// any good reason, just to simplify code.
-constexpr DeviceIndex kFakeGuardImplMaxDevices = 8;
+constexpr DeviceIndex kFakeGuardImplMaxDevices = Device::MAX_NUM_DEVICES;
 
 /**
  * A fake implementation of DeviceGuardImplInterface suitable for testing.
@@ -26,6 +25,7 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
   }
   Device exchangeDevice(Device d) const override {
     AT_ASSERT(d.type() == type());
+    AT_ASSERT(d.index() >= 0);
     AT_ASSERT(d.index() < kFakeGuardImplMaxDevices);
     Device old_device = getDevice();
     if (old_device.index() != d.index()) {
@@ -97,6 +97,6 @@ thread_local DeviceIndex FakeGuardImpl<T>::current_device_ = 0;
 
 template <DeviceType T>
 thread_local std::array<StreamId, kFakeGuardImplMaxDevices>
-    FakeGuardImpl<T>::current_streams_ = {0, 0, 0, 0, 0, 0, 0, 0};
+    FakeGuardImpl<T>::current_streams_ = {};
 
 } // namespace c10::impl

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -4665,30 +4665,18 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
 
   double getMemoryFraction(c10::DeviceIndex device) override {
-    TORCH_INTERNAL_ASSERT(
-        0 <= device && static_cast<size_t>(device) < device_allocator.size(),
-        "Allocator not initialized for device ",
-        device,
-        ": did you call init?");
+    assertValidDevice(device);
     return device_allocator[device]->getMemoryFraction();
   }
 
   void setMemoryFraction(double fraction, c10::DeviceIndex device) override {
-    TORCH_CHECK(
-        0 <= device && static_cast<size_t>(device) < device_allocator.size(),
-        "Allocator not initialized for device ",
-        device,
-        ": did you call init?");
+    assertValidDevice(device);
     device_allocator[device]->setMemoryFraction(fraction);
   }
 
   std::vector<StreamSegmentSize> getExpandableSegmentSizes(
       c10::DeviceIndex device) override {
-    TORCH_INTERNAL_ASSERT(
-        0 <= device && static_cast<size_t>(device) < device_allocator.size(),
-        "Allocator not initialized for device ",
-        device,
-        ": did you call init?");
+    assertValidDevice(device);
     return device_allocator[device]->getExpandableSegmentSizes();
   }
 
@@ -4791,6 +4779,7 @@ class NativeCachingAllocator : public CUDAAllocator {
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
       const std::unordered_set<void*>& expected_live_allocations) override {
+    assertValidDevice(device);
     return device_allocator[device]->checkPoolLiveAllocations(
         mempool_id, expected_live_allocations);
   }
@@ -4923,6 +4912,7 @@ class NativeCachingAllocator : public CUDAAllocator {
   std::shared_ptr<AllocatorState> getCheckpointState(
       c10::DeviceIndex device,
       MempoolId_t id) override {
+    assertValidDevice(device);
     return device_allocator[device]->getCheckpointState(id);
   }
 
@@ -4941,6 +4931,7 @@ class NativeCachingAllocator : public CUDAAllocator {
   CheckpointDelta setCheckpointPoolState(
       c10::DeviceIndex device,
       std::shared_ptr<AllocatorState> as) override {
+    assertValidDevice(device);
     std::shared_ptr<PrivatePoolState> pps =
         std::dynamic_pointer_cast<PrivatePoolState>(as);
 
@@ -5019,6 +5010,7 @@ class NativeCachingAllocator : public CUDAAllocator {
     }
   }
   void cacheInfo(c10::DeviceIndex device, size_t* largestBlock) override {
+    assertValidDevice(device);
     device_allocator[device]->cacheInfo(largestBlock);
   }
   void assertValidDevice(c10::DeviceIndex device) {

--- a/c10/cuda/CUDAEvent.h
+++ b/c10/cuda/CUDAEvent.h
@@ -307,7 +307,7 @@ class CUDAEventPool {
   // Acquire an event associated with a given device. If device is invalid, fall
   // back to a regular CUDAEvent and no pooling.
   Event get(const DeviceIndex device) {
-    if (device < 0 || device >= (DeviceIndex)pools_.size()) {
+    if (device < 0 || device >= static_cast<int64_t>(pools_.size())) {
       auto deleter = [](CUDAEvent* event) { delete event; };
       return Event(std::make_unique<CUDAEvent>().release(), deleter);
     }

--- a/c10/cuda/CUDAFunctions.cpp
+++ b/c10/cuda/CUDAFunctions.cpp
@@ -110,7 +110,7 @@ DeviceIndex device_count() noexcept {
     try {
       auto result = device_count_impl(/*fail_if_no_driver=*/false);
       TORCH_INTERNAL_ASSERT(
-          result <= std::numeric_limits<DeviceIndex>::max(),
+          result <= c10::Device::MAX_NUM_DEVICES,
           "Too many CUDA devices, DeviceIndex overflowed");
       return result;
     } catch (const c10::Error& ex) {
@@ -129,7 +129,7 @@ DeviceIndex device_count_ensure_non_zero() {
   // Zero gpus doesn't produce a warning in `device_count` but we fail here
   TORCH_CHECK(count, "No CUDA GPUs are available");
   TORCH_INTERNAL_ASSERT(
-      count <= std::numeric_limits<DeviceIndex>::max(),
+      count <= c10::Device::MAX_NUM_DEVICES,
       "Too many CUDA devices, DeviceIndex overflowed");
   return static_cast<DeviceIndex>(count);
 }
@@ -232,8 +232,7 @@ cudaError_t GetDevice(DeviceIndex* device) {
   auto err = cudaGetDevice(&tmp_device);
   if (err == cudaSuccess) {
     TORCH_INTERNAL_ASSERT(
-        tmp_device >= 0 &&
-            tmp_device <= std::numeric_limits<DeviceIndex>::max(),
+        tmp_device >= 0 && tmp_device < c10::Device::MAX_NUM_DEVICES,
         "cudaGetDevice returns invalid device ",
         tmp_device);
     *device = static_cast<DeviceIndex>(tmp_device);
@@ -243,7 +242,11 @@ cudaError_t GetDevice(DeviceIndex* device) {
 
 cudaError_t SetDevice(DeviceIndex device, const bool force) {
   TORCH_CHECK(
-      device >= 0, "device id must be non-negative!", static_cast<int>(device));
+      device >= 0 && device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(device));
   targetDeviceIndex = -1;
   if (force) {
     return cudaSetDevice(device);
@@ -257,6 +260,12 @@ cudaError_t SetDevice(DeviceIndex device, const bool force) {
 }
 
 cudaError_t MaybeSetDevice(DeviceIndex device) {
+  TORCH_CHECK(
+      device >= 0 && device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(device));
   if (hasPrimaryContext(device)) {
     return c10::cuda::SetDevice(device);
   }
@@ -267,11 +276,21 @@ cudaError_t MaybeSetDevice(DeviceIndex device) {
 // This function always initializes the CUDA context
 // on to_device
 DeviceIndex ExchangeDevice(DeviceIndex to_device) {
+  TORCH_CHECK(
+      to_device >= 0 && to_device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(to_device));
   auto cur_device = targetDeviceIndex;
   targetDeviceIndex = -1;
   if (cur_device < 0) {
     int tmp_device = -1;
     C10_CUDA_CHECK(cudaGetDevice(&tmp_device));
+    TORCH_INTERNAL_ASSERT(
+        tmp_device >= 0 && tmp_device < c10::Device::MAX_NUM_DEVICES,
+        "cudaGetDevice returns invalid device ",
+        tmp_device);
     cur_device = static_cast<DeviceIndex>(tmp_device);
     if (to_device == cur_device) {
       return cur_device;
@@ -284,11 +303,16 @@ DeviceIndex ExchangeDevice(DeviceIndex to_device) {
 // This function does not initialize the CUDA context
 // on to_device if it does not already exist
 DeviceIndex MaybeExchangeDevice(DeviceIndex to_device) {
+  TORCH_CHECK(
+      to_device >= 0 && to_device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(to_device));
   int tmp_cur_device = -1;
   C10_CUDA_CHECK(cudaGetDevice(&tmp_cur_device));
   TORCH_INTERNAL_ASSERT(
-      tmp_cur_device >= 0 &&
-          tmp_cur_device <= std::numeric_limits<DeviceIndex>::max(),
+      tmp_cur_device >= 0 && tmp_cur_device < c10::Device::MAX_NUM_DEVICES,
       "cudaGetDevice returns invalid device ",
       tmp_cur_device);
   auto cur_device = static_cast<DeviceIndex>(tmp_cur_device);
@@ -314,8 +338,7 @@ cudaError_t GetDevice(DeviceIndex* device) {
   auto err = cudaGetDevice(&tmp_device);
   if (err == cudaSuccess) {
     TORCH_INTERNAL_ASSERT(
-        tmp_device >= 0 &&
-            tmp_device <= std::numeric_limits<DeviceIndex>::max(),
+        tmp_device >= 0 && tmp_device < c10::Device::MAX_NUM_DEVICES,
         "cudaGetDevice returns invalid device ",
         tmp_device);
     *device = static_cast<DeviceIndex>(tmp_device);
@@ -325,7 +348,11 @@ cudaError_t GetDevice(DeviceIndex* device) {
 
 cudaError_t SetDevice(DeviceIndex device, const bool force) {
   TORCH_CHECK(
-      device >= 0, "device id must be non-negative!", static_cast<int>(device));
+      device >= 0 && device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(device));
   if (force) {
     return cudaSetDevice(device);
   }
@@ -342,6 +369,12 @@ cudaError_t MaybeSetDevice(DeviceIndex device) {
 }
 
 DeviceIndex ExchangeDevice(DeviceIndex to_device) {
+  TORCH_CHECK(
+      to_device >= 0 && to_device < c10::Device::MAX_NUM_DEVICES,
+      "device id must be in [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "] but got ",
+      static_cast<int>(to_device));
   DeviceIndex cur_device = -1;
   C10_CUDA_CHECK(c10::cuda::GetDevice(&cur_device));
   if (to_device == cur_device) {

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -39,10 +39,10 @@
 #endif
 
 /**
- * The maximum number of GPUs that we recognizes. Increasing this beyond the
- * initial limit of 16 broke Caffe2 testing, hence the ifdef guards.
- * This value cannot be more than 128 because our DeviceIndex is a uint8_t.
-o */
+ * Legacy compile-time CUDA GPU count for downstream code that still sizes
+ * static buffers from this macro. It no longer defines the logical DeviceIndex
+ * range; use c10::Device::MAX_NUM_DEVICES for that.
+ */
 #ifdef FBCODE_CAFFE2
 // fbcode depends on this value being 16
 #define C10_COMPILE_TIME_MAX_GPUS 16

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -882,6 +882,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
       c10::DeviceIndex device,
       MempoolId_t mempool_id,
       std::function<bool(cudaStream_t)> /*filter*/) override {
+    assertValidDevice(device);
     std::lock_guard<std::mutex> lk(general_mutex);
 
     TORCH_INTERNAL_ASSERT(capture_free_streams.empty());
@@ -927,6 +928,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
   }
 
   void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) override {
+    assertValidDevice(device);
     // Q: Do we need to do anything special here, like clear long-lived
     //    pointers created during the original capture (for example,
     //    tensors intended as the graph's I/O surface) that might still

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <memory>
 
 namespace c10::cuda {
 
@@ -38,23 +39,25 @@ int max_stream_priorities;
 // the destruction.
 #if !defined(USE_ROCM)
 // CUDA-only: used to initializes the stream pools (once)
-std::array<c10::once_flag, C10_COMPILE_TIME_MAX_GPUS> device_flags;
+using DeviceFlagArray = std::unique_ptr<c10::once_flag[]>; // NOLINT(*-arrays)
+DeviceFlagArray device_flags;
 #endif
-std::array<
-    std::array<std::atomic<uint32_t>, C10_COMPILE_TIME_MAX_GPUS>,
-    c10::cuda::max_compile_time_stream_priorities>
+using PriorityCounter = std::atomic<uint32_t>;
+using PriorityCounterArray =
+    std::unique_ptr<PriorityCounter[]>; // NOLINT(*-arrays)
+std::array<PriorityCounterArray, c10::cuda::max_compile_time_stream_priorities>
     priority_counters;
 
-std::array<
-    std::array<
-        std::array<cudaStream_t, kStreamsPerPool>,
-        C10_COMPILE_TIME_MAX_GPUS>,
-    c10::cuda::max_compile_time_stream_priorities>
+using StreamPool = std::array<cudaStream_t, kStreamsPerPool>;
+using StreamPoolArray = std::unique_ptr<StreamPool[]>; // NOLINT(*-arrays)
+std::array<StreamPoolArray, c10::cuda::max_compile_time_stream_priorities>
     streams;
 #ifdef USE_ROCM
-static c10::once_flag
-    stream_flags[c10::cuda::max_compile_time_stream_priorities]
-                [C10_COMPILE_TIME_MAX_GPUS][kStreamsPerPool];
+using StreamFlagPool = std::array<c10::once_flag, kStreamsPerPool>;
+using StreamFlagPoolArray =
+    std::unique_ptr<StreamFlagPool[]>; // NOLINT(*-arrays)
+std::array<StreamFlagPoolArray, c10::cuda::max_compile_time_stream_priorities>
+    stream_flags;
 #endif
 
 // Note [HIP Lazy Streams]
@@ -174,11 +177,31 @@ void initGlobalStreamState() {
   // Check if the number of GPUs matches the expected compile-time max number
   // of GPUs.
   TORCH_CHECK(
-      num_gpus <= C10_COMPILE_TIME_MAX_GPUS,
-      "Number of CUDA devices on the machine is larger than the compiled "
-      "max number of gpus expected (",
-      C10_COMPILE_TIME_MAX_GPUS,
-      "). Increase that and recompile.");
+      num_gpus <= c10::Device::MAX_NUM_DEVICES,
+      "Number of CUDA devices on the machine is larger than the logical "
+      "device limit (",
+      c10::Device::MAX_NUM_DEVICES,
+      ").");
+  const auto num_devices = static_cast<size_t>(num_gpus);
+#if !defined(USE_ROCM)
+  // NOLINTNEXTLINE(*-arrays)
+  device_flags = std::make_unique<c10::once_flag[]>(num_devices);
+#endif
+  for (const auto p :
+       c10::irange(c10::cuda::max_compile_time_stream_priorities)) {
+    // NOLINTNEXTLINE(*-arrays)
+    priority_counters[p] = std::make_unique<PriorityCounter[]>(num_devices);
+    // NOLINTNEXTLINE(*-arrays)
+    streams[p] = std::make_unique<StreamPool[]>(num_devices);
+#ifdef USE_ROCM
+    // NOLINTNEXTLINE(*-arrays)
+    stream_flags[p] = std::make_unique<StreamFlagPool[]>(num_devices);
+#endif
+    for (const auto device_index : c10::irange(num_devices)) {
+      priority_counters[p][device_index].store(0);
+      streams[p][device_index].fill(nullptr);
+    }
+  }
   int leastPriority = -1, greatestPriority = -1;
   C10_CUDA_CHECK(
       cudaDeviceGetStreamPriorityRange(&leastPriority, &greatestPriority));
@@ -200,7 +223,8 @@ void initGlobalStreamState() {
 // See Note [HIP Lazy Streams]
 void initSingleStream(int p, DeviceIndex device_index, int i) {
   CUDAGuard device_guard(device_index);
-  auto& stream = streams[p][device_index][i];
+  const auto device = static_cast<size_t>(device_index);
+  auto& stream = streams[p][device][i];
   auto pri = -p; // lower number is higher priority
 
   C10_CUDA_CHECK(cudaStreamCreateWithPriority(&stream, kDefaultFlags, pri));
@@ -208,7 +232,7 @@ void initSingleStream(int p, DeviceIndex device_index, int i) {
   if (C10_UNLIKELY(interp)) {
     (*interp)->trace_gpu_stream_creation(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
-    priority_counters[p][device_index] = 0;
+    priority_counters[p][device].store(0);
   }
 }
 
@@ -328,13 +352,15 @@ cudaStream_t CUDAStream::stream() const {
 #ifdef USE_ROCM
     // See Note [HIP Lazy Streams]
     c10::call_once(
-        stream_flags[st.getStreamType() - 1][device_index][si],
+        stream_flags[st.getStreamType() - 1][static_cast<size_t>(device_index)]
+                    [si],
         initSingleStream,
         st.getStreamType() - 1,
         device_index,
         si);
 #endif
-    return streams[st.getStreamType() - 1][device_index][si];
+    return streams[st.getStreamType() - 1][static_cast<size_t>(device_index)]
+                  [si];
   }
 }
 
@@ -352,10 +378,13 @@ CUDAStream getStreamFromPool(const int priority, DeviceIndex device_index) {
   // See Note [HIP Lazy Streams]
   // CUDA-only: Initializes the stream pools (once)
   c10::call_once(
-      device_flags[device_index], initDeviceStreamState, device_index);
+      device_flags[static_cast<size_t>(device_index)],
+      initDeviceStreamState,
+      device_index);
 #endif
   auto pri_idx = std::clamp(-priority, 0, max_stream_priorities - 1);
-  const auto idx = get_idx(priority_counters[pri_idx][device_index]);
+  const auto idx =
+      get_idx(priority_counters[pri_idx][static_cast<size_t>(device_index)]);
   StreamIdType id_type = StreamIdType(pri_idx + 1);
   return CUDAStreamForId(device_index, makeStreamId(id_type, idx));
 }

--- a/c10/test/core/Device_test.cpp
+++ b/c10/test/core/Device_test.cpp
@@ -19,6 +19,7 @@ TEST(DeviceTest, BasicConstruction) {
       {"cpu:0", c10::DeviceType::CPU, 0},
       {"cuda:0", c10::DeviceType::CUDA, 0},
       {"cuda:1", c10::DeviceType::CUDA, 1},
+      {"cuda:32766", c10::DeviceType::CUDA, 32766},
   };
   std::vector<std::string> invalid_device_strings = {
       "cpu:x",
@@ -28,6 +29,7 @@ TEST(DeviceTest, BasicConstruction) {
       "cpu:0:0",
       "cpu:0:",
       "cpu:-1",
+      "cuda:32767",
       "::",
       ":",
       "cpu:00",

--- a/c10/test/core/impl/InlineDeviceGuard_test.cpp
+++ b/c10/test/core/impl/InlineDeviceGuard_test.cpp
@@ -74,6 +74,16 @@ TEST(InlineDeviceGuard, SetDevice) {
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i2);
 }
 
+TEST(InlineDeviceGuard, SetLargeDeviceIndex) {
+  DeviceIndex init_i = 0;
+  TestGuardImpl::setDeviceIndex(init_i);
+  const DeviceIndex i = c10::Device::MAX_NUM_DEVICES - 1;
+  TestGuard g(i);
+  ASSERT_EQ(g.original_device(), dev(init_i));
+  ASSERT_EQ(g.current_device(), dev(i));
+  ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i);
+}
+
 TEST(InlineDeviceGuard, ResetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -2057,11 +2057,14 @@ class NativeCachingAllocator : public XPUAllocator {
   std::vector<std::unique_ptr<DeviceCachingAllocator>> device_allocators;
 
   void init(DeviceIndex device_count) override {
-    const auto size = static_cast<DeviceIndex>(device_allocators.size());
-    if (size < device_count) {
-      device_allocators.resize(device_count);
-      for (const auto i : c10::irange(size, device_count)) {
-        device_allocators[i] = std::make_unique<DeviceCachingAllocator>(i);
+    TORCH_CHECK(device_count >= 0, "Invalid XPU device count ", device_count);
+    const auto size = device_allocators.size();
+    const auto target_size = static_cast<size_t>(device_count);
+    if (size < target_size) {
+      device_allocators.resize(target_size);
+      for (const auto i : c10::irange(size, target_size)) {
+        device_allocators[i] = std::make_unique<DeviceCachingAllocator>(
+            static_cast<DeviceIndex>(i));
       }
     }
   }
@@ -2078,7 +2081,7 @@ class NativeCachingAllocator : public XPUAllocator {
     TORCH_INTERNAL_ASSERT(
         0 <= device && static_cast<size_t>(device) < device_allocators.size(),
         "Allocator not initialized for device ",
-        static_cast<int16_t>(device),
+        static_cast<int>(device),
         ": did you call init?");
     Block* block = device_allocators[device]->malloc(device, size, queue);
     add_allocated_block(block);

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -116,7 +116,7 @@ inline void initGlobalDevicePoolState() {
   // Ensures that the number of GPU devices does not exceed the maximum
   // allowable value for DeviceIndex.
   TORCH_CHECK(
-      gDevicePool.devices.size() <= std::numeric_limits<DeviceIndex>::max(),
+      gDevicePool.devices.size() <= c10::Device::MAX_NUM_DEVICES,
       "Too many XPU devices, DeviceIndex overflowed!");
   // Check each device's architecture and issue a warning if it is older than
   // the officially supported range (Intel GPUs starting from Arc (Alchemist)

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegDeviceAllocator.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegDeviceAllocator.cpp
@@ -170,18 +170,20 @@ at::DataPtr OpenRegDeviceAllocator::allocate(size_t nbytes) {
   int current_device_index = -1;
   auto ret = orGetDevice(&current_device_index);
   TORCH_CHECK(ret == orSuccess, "Failed to get current OpenReg device");
+  c10::openreg::check_device_index(current_device_index);
+  const auto current_device =
+      static_cast<c10::DeviceIndex>(current_device_index);
 
-  auto curr_device =
-      c10::Device(c10::DeviceType::PrivateUse1, current_device_index);
+  auto curr_device = c10::Device(c10::DeviceType::PrivateUse1, current_device);
 
   void* data = nullptr;
   if (nbytes > 0) {
     // Allocate memory via device-specific allocator
-    data = device_allocators_[current_device_index]->malloc(nbytes);
+    data = device_allocators_[current_device]->malloc(nbytes);
 
     // Track which device owns this pointer
     std::lock_guard<std::recursive_mutex> lock(mutex_);
-    allocated_blocks_[data] = current_device_index;
+    allocated_blocks_[data] = current_device;
   }
 
   return {data, data, &deleteOpenRegMemory, curr_device};
@@ -246,14 +248,17 @@ void OpenRegDeviceAllocator::freeMemory(void* ptr) {
 
 c10::CachingDeviceAllocator::DeviceStats OpenRegDeviceAllocator::
     getDeviceStats(c10::DeviceIndex device) {
+  c10::openreg::check_device_index(device);
   return device_allocators_[device]->getStats();
 }
 
 void OpenRegDeviceAllocator::resetAccumulatedStats(c10::DeviceIndex device) {
+  c10::openreg::check_device_index(device);
   device_allocators_[device]->resetAccumulatedStats();
 }
 
 void OpenRegDeviceAllocator::resetPeakStats(c10::DeviceIndex device) {
+  c10::openreg::check_device_index(device);
   device_allocators_[device]->resetPeakStats();
 }
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegFunctions.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegFunctions.cpp
@@ -5,6 +5,20 @@
 #include "OpenRegFunctions.h"
 
 namespace c10::openreg {
+namespace {
+
+c10::DeviceIndex checked_device_index_from_int(int device) {
+  TORCH_CHECK(
+      device >= 0 && device < c10::Device::MAX_NUM_DEVICES,
+      "OpenReg device index ",
+      device,
+      " is out of range for DeviceIndex [0, ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device);
+}
+
+} // namespace
 
 orError_t GetDeviceCount(int* dev_count) {
   return orGetDeviceCount(dev_count);
@@ -13,7 +27,9 @@ orError_t GetDeviceCount(int* dev_count) {
 orError_t GetDevice(DeviceIndex* device) {
   int tmp_device = -1;
   auto err = orGetDevice(&tmp_device);
-  *device = static_cast<DeviceIndex>(tmp_device);
+  if (err == orSuccess) {
+    *device = checked_device_index_from_int(tmp_device);
+  }
   return err;
 }
 // LITERALINCLUDE START: OPENREG SetDevice FUNCTION
@@ -39,7 +55,7 @@ OPENREG_EXPORT DeviceIndex device_count() noexcept {
     try {
       auto result = device_count_impl();
       TORCH_CHECK(
-          result <= std::numeric_limits<DeviceIndex>::max(),
+          result <= c10::Device::MAX_NUM_DEVICES,
           "Too many devices, DeviceIndex overflowed");
       return result;
     } catch (const Error& ex) {
@@ -66,14 +82,15 @@ OPENREG_EXPORT void set_device(DeviceIndex device) {
 // LITERALINCLUDE END: OPENREG set_device FUNCTION
 
 OPENREG_EXPORT DeviceIndex ExchangeDevice(DeviceIndex device) {
+  check_device_index(device);
   int current_device = -1;
-  orGetDevice(&current_device);
+  OPENREG_CHECK(orGetDevice(&current_device));
 
   if (device != current_device) {
-    orSetDevice(device);
+    OPENREG_CHECK(orSetDevice(device));
   }
 
-  return current_device;
+  return checked_device_index_from_int(current_device);
 }
 
 OPENREG_EXPORT DeviceIndex maybe_exchange_device(DeviceIndex to_device) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegStream.cpp
@@ -199,10 +199,12 @@ OpenRegStream OpenRegStreamForId(DeviceIndex device_index, StreamId stream_id) {
 
 // See Note [StreamId assignment]
 orStream_t OpenRegStream::stream() const {
+  initOpenRegStreamsOnce();
   c10::DeviceIndex device_index = stream_.device_index();
   StreamId stream_id = stream_.id();
   StreamIdType st = streamIdType(stream_id);
   size_t si = streamIdIndex(stream_id);
+  check_device(device_index);
   // OpenReg does not support a default stream natively.
   // Here, we designate stream 0 from the priority 0 stream pool to serve as the default stream.
   if(st.isDefault()){
@@ -232,6 +234,7 @@ OpenRegStream getStreamFromPool(const int priority, DeviceIndex device_index) {
   if (device_index == -1) {
     device_index = current_device();
   }
+  check_device(device_index);
   auto pri_idx = std::clamp(priority, 0, max_stream_priorities - 1);
   const auto idx = get_idx(priority_counters[device_index][pri_idx]);
   auto id_type = static_cast<StreamIdType>(pri_idx);
@@ -247,6 +250,8 @@ OpenRegStream getStreamFromPool(const bool isHighPriority, DeviceIndex device) {
 OpenRegStream getStreamFromExternal(
     orStream_t ext_stream,
     DeviceIndex device_index) {
+  initOpenRegStreamsOnce();
+  check_device(device_index);
   return OpenRegStreamForId(
       device_index, reinterpret_cast<int64_t>(ext_stream));
 }
@@ -272,6 +277,7 @@ OpenRegStream getCurrentOpenRegStream(DeviceIndex device_index) {
 
 void setCurrentOpenRegStream(OpenRegStream stream) {
   initOpenRegStreamsOnce();
+  check_device(stream.device_index());
   current_streams[stream.device_index()] = stream.id();
 }
 

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -496,6 +496,11 @@ class TestLibtorchAgnostic(TestCase):
         out = libtorch_agnostic.ops.test_device_guard(device_index)
         self.assertEqual(out, device_index)
 
+        with self.assertRaisesRegex(
+            RuntimeError, "Device index 32767 is out of range for DeviceIndex"
+        ):
+            libtorch_agnostic.ops.test_device_guard(32767)
+
     @onlyCUDA
     @deviceCountAtLeast(2)
     def test_device_guard_set_index(self, device):
@@ -518,6 +523,10 @@ class TestLibtorchAgnostic(TestCase):
             stream_id = libtorch_agnostic.ops.test_stream(device)
 
         self.assertEqual(stream_id, expected_stream_id)
+        with self.assertRaisesRegex(
+            RuntimeError, "Device index 32767 is out of range for DeviceIndex"
+        ):
+            libtorch_agnostic.ops.test_stream(32767)
 
     @skipIfTorchVersionLessThan(2, 13)
     @onlyCUDA
@@ -739,17 +748,22 @@ class TestLibtorchAgnostic(TestCase):
             libtorch_agnostic.ops.test_device_equality(cpu_device, cuda_device)
         )
 
+        cuda_129_device = libtorch_agnostic.ops.test_device_constructor(
+            is_cuda=True, index=129, use_str=False
+        )
+        self.assertEqual(cuda_129_device, torch.device("cuda:129"))
+
         with self.assertRaisesRegex(
-            RuntimeError, "Device index 129 is out of range for int8_t"
+            RuntimeError, "Device index 32767 is out of range for DeviceIndex"
         ):
             libtorch_agnostic.ops.test_device_constructor(
-                is_cuda=True, index=129, use_str=False
+                is_cuda=True, index=32767, use_str=False
             )
 
         with self.assertRaisesRegex(
-            RuntimeError, "Device index 129 is out of range for int8_t"
+            RuntimeError, "Device index 32767 is out of range for DeviceIndex"
         ):
-            libtorch_agnostic.ops.test_device_set_index(cuda_device, 129)
+            libtorch_agnostic.ops.test_device_set_index(cuda_device, 32767)
 
     @skipIfTorchVersionLessThan(2, 10)
     @onlyCUDA

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -11974,6 +11974,29 @@ graph():
 
         check_device_and_fake_mode()
 
+    @unittest.skipIf(not torch.cuda._is_compiled(), "requires CUDA-compiled PyTorch")
+    def test_export_fake_cuda_device_uses_logical_device_limit(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        with FakeTensorMode():
+            x = torch.empty(1, device="cuda:32766")
+            exported_program = torch.export.export(Model(), (x,))
+            out = exported_program.module()(x)
+            all_meta_val = [
+                node.meta["val"]
+                for node in exported_program.graph_module.graph.nodes
+                if "val" in node.meta
+            ]
+
+        self.assertEqual(out.device, torch.device("cuda:32766"))
+        self.assertTrue(
+            all(
+                val.device == x.device for val in all_meta_val if hasattr(val, "device")
+            )
+        )
+
     def test_run_decomposition_supports_user_input_mutation(self):
         class SingleOp(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -35,6 +35,19 @@ class TestAccelerator(TestCase):
         ):
             torch.accelerator.set_device_index("cpu")
 
+    def test_logical_device_index_upper_bound(self):
+        out_of_range = 32767
+        msg = "Device index 32767 is out of range for DeviceIndex"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.accelerator.set_device_index(out_of_range)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.accelerator.current_stream(out_of_range)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.accelerator.synchronize(out_of_range)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            with torch.accelerator.device_index(out_of_range):
+                pass
+
     @unittest.skipIf(not TEST_MULTIACCELERATOR, "only one accelerator detected")
     def test_generic_multi_device_behavior(self):
         orig_device = torch.accelerator.current_device_index()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3476,6 +3476,17 @@ def foo(x):
             else:
                 cu.define(full)
 
+    def test_int16_device_index(self):
+        tensor = torch.tensor([1.0])
+        cu = torch.jit.CompilationUnit()
+        cu.define(
+            """
+def fn(x):
+    return x.device
+            """
+        )
+        self.assertEqual(cu.fn(tensor), tensor.device)
+
     def test_namedtuple_python(self):
         global MyTuple, MyMod  # see [local resolution in python]
         MyTuple = namedtuple('MyTuple', ['a'])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -857,6 +857,18 @@ class TestDeviceUtils(TestCase):
         self.assertEqual(x.device.type, "meta")
         self.assertEqual(dev, torch.device("meta"))
 
+    def test_large_device_index(self):
+        large_index = 32766
+        self.assertEqual(torch.device("meta", large_index).index, large_index)
+        self.assertEqual(torch.device(f"meta:{large_index}").index, large_index)
+
+    def test_device_index_out_of_bounds(self):
+        error_msg = "Device index must be between 0 and 32766 inclusive"
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            torch.device("meta", 32767)
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            torch.device("meta:32767")
+
     def test_decorator(self):
         @set_device("meta")
         def f():

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -282,6 +282,8 @@ if __name__ == "__main__":
         self.assertEqual(_parse_visible_devices("2, +3, -0, 5"), [2, 3, 0, 5])
         # Purely alphabetic tokens make the entire list invalid
         self.assertEqual(_parse_visible_devices("one, two, 3, 4"), [])
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(len(torch.xpu._parse_visible_devices()), 32767)
 
         # Valid masks should work the same with strict=True
         self.assertEqual(_parse_visible_devices("0, 1, 2", strict=True), [0, 1, 2])
@@ -420,14 +422,14 @@ print(f"{{r1}}, {{r2}}")
                 .splitlines()[-1]
             )
 
-        # Index 128 is out of range → both return 0
-        self.assertEqual(_run("128"), "0, 0")
-        # COMPOSITE-style mask → _device_count_zes returns -1
+        # Index 32767 is out of range, so both return 0
+        self.assertEqual(_run("32767"), "0, 0")
+        # COMPOSITE-style mask makes _device_count_zes return -1
         self.assertEqual(_run("0.0").split(",")[0].strip(), "-1")
-        # Valid mask selecting device 0 on a single-GPU system → both return 1
+        # Valid mask selecting device 0 on a single-GPU system makes both return 1
         self.assertEqual(_run("0"), "1, 1")
         if TEST_MULTIXPU:
-            # Valid mask selecting device 1 on a multi-GPU system → both return 1
+            # Valid mask selecting device 1 on a multi-GPU system makes both return 1
             self.assertEqual(_run("1"), "1, 1")
 
     @unittest.skipIf(not TEST_MULTIXPU, "requires multiple devices")

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -28,10 +28,7 @@ static PyObject* THPDevice_repr(THPDevice* self) {
   std::ostringstream oss;
   oss << "device(type=\'" << self->device.type() << '\'';
   if (self->device.has_index()) {
-    // `self->device.index()` returns uint8_t which is treated as ascii while
-    // printing, hence casting it to uint16_t.
-    // https://stackoverflow.com/questions/19562103/uint8-t-cant-be-printed-with-cout
-    oss << ", index=" << static_cast<uint16_t>(self->device.index());
+    oss << ", index=" << static_cast<int>(self->device.index());
   }
   oss << ')';
   return THPUtils_packString(std::move(oss).str().c_str());
@@ -75,7 +72,12 @@ static PyObject* THPDevice_pynew(
       device_index = r.toInt64(1);
       // -1 is allowed in ATen/C++, to mean the default device, but not in
       // Python.
-      TORCH_CHECK(device_index >= 0, "Device index must not be negative");
+      TORCH_CHECK(
+          device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+          "Device index must be between 0 and ",
+          c10::Device::MAX_NUM_DEVICES - 1,
+          " inclusive, got ",
+          device_index);
     }
     at::Device device(
         as_device.type(), static_cast<c10::DeviceIndex>(device_index));

--- a/torch/csrc/DeviceAccelerator.cpp
+++ b/torch/csrc/DeviceAccelerator.cpp
@@ -1,7 +1,25 @@
 #include <c10/core/AllocatorConfig.h>
+#include <c10/core/Device.h>
 #include <torch/csrc/DeviceAccelerator.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/device_lazy_init.h>
+
+namespace {
+
+c10::DeviceIndex checkedDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
+} // namespace
 
 namespace torch::accelerator {
 
@@ -18,14 +36,15 @@ void initModule(PyObject* module) {
     }
   });
 
-  m.def("_accelerator_setDeviceIndex", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_setDeviceIndex", [](int64_t device_index) {
     // If device index is negative, no-op
     if (device_index < 0) {
       return;
     }
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    at::accelerator::setDeviceIndex(device_index);
+    at::accelerator::setDeviceIndex(c10_device_index);
   });
 
   m.def("_accelerator_getDeviceIndex", []() {
@@ -34,10 +53,11 @@ void initModule(PyObject* module) {
     return at::accelerator::getDeviceIndex();
   });
 
-  m.def("_accelerator_getDeviceCapability", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_getDeviceCapability", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    auto caps = at::accelerator::getDeviceCapability(device_index);
+    auto caps = at::accelerator::getDeviceCapability(c10_device_index);
 
     py::dict dict;
 
@@ -63,14 +83,16 @@ void initModule(PyObject* module) {
     at::accelerator::setCurrentStream(stream);
   });
 
-  m.def("_accelerator_getStream", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_getStream", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    return at::accelerator::getCurrentStream(device_index);
+    return at::accelerator::getCurrentStream(c10_device_index);
   });
 
-  m.def("_accelerator_synchronizeDevice", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_synchronizeDevice", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     if (torch::utils::is_device_lazy_init_supported(device_type) &&
         !torch::utils::is_device_initialized(device_type)) {
       return;
@@ -78,20 +100,22 @@ void initModule(PyObject* module) {
     torch::utils::maybe_initialize_device(device_type);
     {
       py::gil_scoped_release no_gil;
-      at::accelerator::synchronizeDevice(device_index);
+      at::accelerator::synchronizeDevice(c10_device_index);
     }
   });
 
-  m.def("_accelerator_exchangeDevice", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_exchangeDevice", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    return at::accelerator::exchangeDevice(device_index);
+    return at::accelerator::exchangeDevice(c10_device_index);
   });
 
-  m.def("_accelerator_maybeExchangeDevice", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_maybeExchangeDevice", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    return at::accelerator::maybeExchangeDevice(device_index);
+    return at::accelerator::maybeExchangeDevice(c10_device_index);
   });
 
   m.def("_accelerator_isAllocatorInitialized", []() {
@@ -110,13 +134,14 @@ void initModule(PyObject* module) {
     at::accelerator::emptyHostCache();
   });
 
-  m.def("_accelerator_getDeviceStats", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_getDeviceStats", [](int64_t device_index) {
     using c10::CachingAllocator::Stat;
     using c10::CachingAllocator::StatArray;
     using c10::CachingAllocator::StatType;
     using c10::CachingDeviceAllocator::DeviceStats;
 
-    const auto stats = at::accelerator::getDeviceStats(device_index);
+    const auto c10_device_index = checkedDeviceIndex(device_index);
+    const auto stats = at::accelerator::getDeviceStats(c10_device_index);
     const auto stat_to_dict = [](const Stat& stat) -> py::dict {
       py::dict dict;
       dict["current"] = stat.current;
@@ -158,20 +183,20 @@ void initModule(PyObject* module) {
     return result;
   });
 
-  m.def(
-      "_accelerator_resetAccumulatedStats", [](c10::DeviceIndex device_index) {
-        at::accelerator::resetAccumulatedStats(device_index);
-      });
-
-  m.def("_accelerator_resetPeakStats", [](c10::DeviceIndex device_index) {
-    at::accelerator::resetPeakStats(device_index);
+  m.def("_accelerator_resetAccumulatedStats", [](int64_t device_index) {
+    at::accelerator::resetAccumulatedStats(checkedDeviceIndex(device_index));
   });
 
-  m.def("_accelerator_getMemoryInfo", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_resetPeakStats", [](int64_t device_index) {
+    at::accelerator::resetPeakStats(checkedDeviceIndex(device_index));
+  });
+
+  m.def("_accelerator_getMemoryInfo", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
     py::gil_scoped_release no_gil;
-    return at::accelerator::getMemoryInfo(device_index);
+    return at::accelerator::getMemoryInfo(c10_device_index);
   });
 
   m.def("_accelerator_getAllocatorSettings", []() {
@@ -182,10 +207,11 @@ void initModule(PyObject* module) {
     c10::CachingAllocator::setAllocatorSettings(env);
   });
 
-  m.def("_accelerator_getDefaultGenerator", [](c10::DeviceIndex device_index) {
+  m.def("_accelerator_getDefaultGenerator", [](int64_t device_index) {
     const auto device_type = at::accelerator::getAccelerator(true).value();
+    const auto c10_device_index = checkedDeviceIndex(device_index);
     torch::utils::maybe_initialize_device(device_type);
-    return at::accelerator::getDefaultGenerator(device_index);
+    return at::accelerator::getDefaultGenerator(c10_device_index);
   });
 
   // Accelerator Graph class binding

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -731,6 +731,24 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
   }
 
  private:
+  static c10::DeviceIndex CheckedDLDeviceIndex(
+      DLDeviceType device_type,
+      int32_t device_id) {
+    if (device_type == DLDeviceType::kDLCPU) {
+      return 0;
+    }
+    TORCH_CHECK(
+        device_id >= 0 && device_id < c10::Device::MAX_NUM_DEVICES,
+        "DLPack device id ",
+        device_id,
+        " is out of range for DeviceIndex [",
+        0,
+        ", ",
+        c10::Device::MAX_NUM_DEVICES - 1,
+        "]");
+    return static_cast<c10::DeviceIndex>(device_id);
+  }
+
   // Fast non-owning PyObject→DLTensor conversion
   static int DLTensorFromPyObjectNoSync(void* py_obj, DLTensor* out) {
     try {
@@ -784,12 +802,13 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
     try {
       at::IntArrayRef shape(
           prototype->shape, prototype->shape + prototype->ndim);
-      at::TensorOptions options =
-          at::TensorOptions()
-              .dtype(at::toScalarType(prototype->dtype))
-              .device(at::dlDeviceToTorchDevice(
-                  prototype->device.device_type,
-                  static_cast<c10::DeviceIndex>(prototype->device.device_id)));
+      at::TensorOptions options = at::TensorOptions()
+                                      .dtype(at::toScalarType(prototype->dtype))
+                                      .device(at::dlDeviceToTorchDevice(
+                                          prototype->device.device_type,
+                                          CheckedDLDeviceIndex(
+                                              prototype->device.device_type,
+                                              prototype->device.device_id)));
       at::Tensor tensor = at::empty(shape, options);
       *out = at::toDLPackVersioned(tensor);
       return 0;
@@ -812,7 +831,7 @@ struct TorchDLPackExchangeAPI : public DLPackExchangeAPI {
       }
       if (at::torchDeviceToDLDevice(*acc_type).device_type == device_type) {
         *out_stream = at::accelerator::getCurrentStream(
-                          static_cast<c10::DeviceIndex>(device_id))
+                          CheckedDLDeviceIndex(device_type, device_id))
                           .native_handle();
       }
       return 0;
@@ -2492,6 +2511,19 @@ void _initCrashHandler() {
   *_getOldHandler(SIGSEGV) = std::signal(SIGSEGV, _signalHandler);
 }
 
+c10::DeviceIndex checkedAcceleratorHooksDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
 } // anonymous namespace
 
 extern "C" TORCH_PYTHON_API PyObject* initModule();
@@ -3184,13 +3216,14 @@ Call this whenever a new thread is created in order to propagate values from
   });
 
   py_module.def(
-      "_accelerator_hooks_set_current_device",
-      [](c10::DeviceIndex device_index) {
+      "_accelerator_hooks_set_current_device", [](int64_t device_index) {
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
+          const auto c10_device_index =
+              checkedAcceleratorHooksDeviceIndex(device_index);
           at::globalContext()
               .getAcceleratorHooksInterface(device_type)
-              .setCurrentDevice(device_index);
+              .setCurrentDevice(c10_device_index);
         }
       });
 
@@ -3204,25 +3237,27 @@ Call this whenever a new thread is created in order to propagate values from
     return static_cast<c10::DeviceIndex>(-1);
   });
 
-  py_module.def(
-      "_accelerator_hooks_exchange_device", [](c10::DeviceIndex device_index) {
-        auto device_type = at::getAccelerator();
-        if (device_type.has_value()) {
-          return at::globalContext()
-              .getAcceleratorHooksInterface(device_type)
-              .exchangeDevice(device_index);
-        }
-        return static_cast<c10::DeviceIndex>(-1);
-      });
+  py_module.def("_accelerator_hooks_exchange_device", [](int64_t device_index) {
+    auto device_type = at::getAccelerator();
+    if (device_type.has_value()) {
+      const auto c10_device_index =
+          checkedAcceleratorHooksDeviceIndex(device_index);
+      return at::globalContext()
+          .getAcceleratorHooksInterface(device_type)
+          .exchangeDevice(c10_device_index);
+    }
+    return static_cast<c10::DeviceIndex>(-1);
+  });
 
   py_module.def(
-      "_accelerator_hooks_maybe_exchange_device",
-      [](c10::DeviceIndex device_index) {
+      "_accelerator_hooks_maybe_exchange_device", [](int64_t device_index) {
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
+          const auto c10_device_index =
+              checkedAcceleratorHooksDeviceIndex(device_index);
           return at::globalContext()
               .getAcceleratorHooksInterface(device_type)
-              .maybeExchangeDevice(device_index);
+              .maybeExchangeDevice(c10_device_index);
         }
         return static_cast<c10::DeviceIndex>(-1);
       });

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -5,6 +5,7 @@
 #include <structmember.h>
 
 #include <c10/core/CPUAllocator.h>
+#include <c10/core/Device.h>
 #include <libshm.h>
 #include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
@@ -31,6 +32,22 @@
 #include <torch/csrc/utils/python_numbers.h>
 #include <atomic>
 #include <string>
+
+#ifdef USE_CUDA
+static c10::DeviceIndex THPStorage_unpackSharedCudaDeviceIndex(PyObject* obj) {
+  const auto device_index = THPUtils_unpackLong(obj);
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+#endif
 
 static PyObject* THPStorage_sharedDecref(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
@@ -446,8 +463,7 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
   ptrdiff_t storage_offset_bytes =
       static_cast<ptrdiff_t>(THPUtils_unpackLong(_offset_bytes));
 
-  const auto device = c10::checked_convert<c10::DeviceIndex>(
-      THPUtils_unpackLong(_device), "c10::DeviceIndex");
+  const auto device = THPStorage_unpackSharedCudaDeviceIndex(_device);
   at::cuda::CUDAGuard device_guard(device);
 
   if (PyObject_IsTrue(_event_sync_required)) {

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/utils/pycfunction_helpers.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 
+#include <c10/core/Device.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/Stream.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
@@ -13,6 +14,19 @@
 #include <cstdint>
 
 PyTypeObject* THPStreamClass = nullptr;
+
+static c10::DeviceIndex checked_stream_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 static PyObject* THPStream_pynew(
     PyTypeObject* type,
@@ -55,7 +69,7 @@ static PyObject* THPStream_pynew(
     priority = r.toInt64WithDefault(1, 0);
   } else if (r.idx == 1) {
     stream_id = r.toInt64WithDefault(0, -1);
-    device_index = static_cast<c10::DeviceIndex>(r.toInt64WithDefault(1, 0));
+    device_index = checked_stream_device_index(r.toInt64WithDefault(1, 0));
     device_type = static_cast<c10::DeviceType>(
         r.toInt64WithDefault(2, static_cast<int64_t>(c10::DeviceType::CPU)));
     priority = r.toInt64WithDefault(3, 0);

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -1,6 +1,7 @@
 #include <torch/cuda.h>
 
 #include <ATen/Context.h>
+#include <c10/core/Device.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/irange.h>
 
@@ -50,6 +51,15 @@ void manual_seed_all(uint64_t seed) {
 
 void synchronize(int64_t device_index) {
   TORCH_CHECK(is_available(), "No CUDA GPUs are available");
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
   auto num_gpus = cuda::device_count();
   TORCH_CHECK(
       device_index < 0 || device_index < num_gpus,

--- a/torch/csrc/api/src/xpu.cpp
+++ b/torch/csrc/api/src/xpu.cpp
@@ -1,4 +1,5 @@
 #include <ATen/Context.h>
+#include <c10/core/Device.h>
 #include <torch/xpu.h>
 
 namespace torch::xpu {
@@ -38,6 +39,15 @@ void manual_seed_all(uint64_t seed) {
 
 void synchronize(int64_t device_index) {
   TORCH_CHECK(is_available(), "No XPU are available");
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
   at::detail::getXPUHooks().deviceSynchronize(
       static_cast<c10::DeviceIndex>(device_index));
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1603,8 +1603,7 @@ auto Engine::ready_queue(
   } else {
     TORCH_INTERNAL_ASSERT(
         0 <= device.index() &&
-        device.index() <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
+        device.index() < static_cast<int64_t>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
     return device_ready_queues_.at(device.index());
   }
@@ -1620,8 +1619,7 @@ auto Engine::ready_queue_by_index(
   } else {
     TORCH_INTERNAL_ASSERT(
         0 <= device_index &&
-        device_index <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
+        device_index < static_cast<int64_t>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
     // NB: This function would become obsolete if we truly allocated a CPU
     // thread per device, rather than colocate.

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -16,6 +16,7 @@
 
 #include <ATen/record_function.h>
 #include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <c10/util/irange.h>
@@ -23,6 +24,23 @@
 #include <iostream>
 
 namespace torch::autograd::profiler {
+
+namespace {
+
+c10::DeviceIndex checkedLegacyProfilerDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
+} // namespace
 
 // We decompose the profiler logic into the following components:
 //
@@ -523,7 +541,7 @@ void LegacyEvent::record(bool record_cuda) {
       ivalues.get(EventIValueIdx::CPU_NS).toInt(), // cpu_ns
       ivalues.get(EventIValueIdx::CUDA_RECORDED).toBool(), // was cuda recorded
       ivalues.get(EventIValueIdx::CUDA_MEM_USAGE).toInt(), // cuda memory usage
-      c10::DeviceIndex(
+      checkedLegacyProfilerDeviceIndex(
           ivalues.get(EventIValueIdx::CUDA_DEVICE).toInt()), // device
       static_cast<double>(
           ivalues.get(EventIValueIdx::CUDA_US).toInt()) // cuda_us

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -60,6 +60,19 @@ void* getCurrentCUDASolverDnHandleLazy();
 
 using namespace torch;
 
+static c10::DeviceIndex checked_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CUDA management methods
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,7 +83,7 @@ PyObject* THCPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   auto device = THPUtils_unpackLong(arg);
 
   torch::utils::device_lazy_init(at::kCUDA);
-  c10::cuda::set_device(static_cast<c10::DeviceIndex>(device), /*force*/ true);
+  c10::cuda::set_device(checked_device_index(device), /*force*/ true);
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -248,7 +261,7 @@ PyObject* THCPModule_setStream_wrap(
 
   auto stream = at::cuda::CUDAStream::unpack3(
       stream_id,
-      static_cast<c10::DeviceIndex>(device_index),
+      checked_device_index(device_index),
       static_cast<c10::DeviceType>(device_type));
 
   auto device = c10::cuda::current_device();
@@ -1446,8 +1459,9 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   m.def(
       "_cuda_getCheckpointState",
-      [](c10::DeviceIndex device, c10::cuda::MempoolId_t id) {
-        return c10::cuda::CUDACachingAllocator::getCheckpointState(device, id);
+      [](int64_t device, c10::cuda::MempoolId_t id) {
+        return c10::cuda::CUDACachingAllocator::getCheckpointState(
+            checked_device_index(device), id);
       });
 
   m.def("_free_And_Remove_DeleterFn", [](size_t storage_impl_ptr) {
@@ -1507,29 +1521,33 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   m.def(
       "_cuda_beginAllocateCurrentStreamToPool",
-      [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        auto stream = at::cuda::getCurrentCUDAStream(device);
+      [](int64_t device, at::cuda::MempoolId_t mempool_id) {
+        const auto device_index = checked_device_index(device);
+        auto stream = at::cuda::getCurrentCUDAStream(device_index);
         TORCH_CHECK(stream, "Expected stream capture to be under way");
         c10::cuda::CUDACachingAllocator::beginAllocateToPool(
-            device, mempool_id, [stream](cudaStream_t target) {
+            device_index, mempool_id, [stream](cudaStream_t target) {
               return target == stream;
             });
       });
 
   m.def(
       "_cuda_beginAllocateToPool",
-      [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
+      [](int64_t device, at::cuda::MempoolId_t mempool_id) {
         c10::cuda::CUDACachingAllocator::beginAllocateToPool(
-            device, mempool_id, [](cudaStream_t) { return true; });
+            checked_device_index(device), mempool_id, [](cudaStream_t) {
+              return true;
+            });
       });
 
   m.def(
       "_cuda_beginAllocateCurrentThreadToPool",
-      [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
+      [](int64_t device, at::cuda::MempoolId_t mempool_id) {
+        const auto device_index = checked_device_index(device);
         auto tid = std::this_thread::get_id();
 
         c10::cuda::CUDACachingAllocator::beginAllocateToPool(
-            device, mempool_id, [=](cudaStream_t) {
+            device_index, mempool_id, [=](cudaStream_t) {
               auto current_tid = std::this_thread::get_id();
               return current_tid == tid;
             });
@@ -1537,19 +1555,21 @@ static void registerCudaPluggableAllocator(PyObject* module) {
 
   m.def(
       "_cuda_endAllocateToPool",
-      [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        c10::cuda::CUDACachingAllocator::endAllocateToPool(device, mempool_id);
+      [](int64_t device, at::cuda::MempoolId_t mempool_id) {
+        c10::cuda::CUDACachingAllocator::endAllocateToPool(
+            checked_device_index(device), mempool_id);
       });
 
   m.def(
       "_cuda_releasePool",
-      [](c10::DeviceIndex device, at::cuda::MempoolId_t mempool_id) {
-        c10::cuda::CUDACachingAllocator::releasePool(device, mempool_id);
+      [](int64_t device, at::cuda::MempoolId_t mempool_id) {
+        c10::cuda::CUDACachingAllocator::releasePool(
+            checked_device_index(device), mempool_id);
       });
 
   m.def(
       "_cuda_checkPoolLiveAllocations",
-      [](c10::DeviceIndex device,
+      [](int64_t device,
          at::cuda::MempoolId_t mempool_id,
          const py::set& expected_live_allocations) {
         std::unordered_set<void*> allocations;
@@ -1559,15 +1579,16 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           allocations.insert(reinterpret_cast<void*>(py::cast<size_t>(elem)));
         }
         return c10::cuda::CUDACachingAllocator::checkPoolLiveAllocations(
-            device, mempool_id, allocations);
+            checked_device_index(device), mempool_id, allocations);
       });
 
   m.def(
       "_cuda_setCheckpointPoolState",
-      [](c10::DeviceIndex device,
+      [](int64_t device,
          std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState> pps,
          const std::vector<size_t>& stale_storages_ptr,
          const std::vector<size_t>& storages_to_add_deleters_to_ptr = {}) {
+        const auto device_index = checked_device_index(device);
         std::unordered_set<c10::StorageImpl*> ptr_set;
         // iterate on std::vector for determinism
         std::vector<c10::StorageImpl*> ptrs;
@@ -1580,7 +1601,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           }
         }
         auto delta = c10::cuda::CUDACachingAllocator::setCheckpointPoolState(
-            device, std::move(pps));
+            device_index, std::move(pps));
         auto& freed_pointers = delta.ptrs_freed;
 
         std::unordered_set<void*> allocd_set;
@@ -1622,8 +1643,8 @@ static void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_get_device_properties",
-      [](c10::DeviceIndex device) -> cudaDeviceProp* {
-        return at::cuda::getDeviceProperties(device);
+      [](int64_t device) -> cudaDeviceProp* {
+        return at::cuda::getDeviceProperties(checked_device_index(device));
       },
       py::return_value_policy::reference);
 }
@@ -2191,12 +2212,12 @@ static void initCudaMethodBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_cuda_getStreamFromExternal",
-      [](uintptr_t data_ptr, c10::DeviceIndex device_index) {
+      [](uintptr_t data_ptr, int64_t device_index) {
         cudaStream_t ext_stream =
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
             reinterpret_cast<cudaStream_t>(reinterpret_cast<void*>(data_ptr));
-        at::cuda::CUDAStream stream =
-            c10::cuda::getStreamFromExternal(ext_stream, device_index);
+        at::cuda::CUDAStream stream = c10::cuda::getStreamFromExternal(
+            ext_stream, checked_device_index(device_index));
         return std::make_tuple(
             stream.id(), stream.device_index(), stream.device_type());
       });

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -6,12 +6,26 @@
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_numbers.h>
 
+#include <c10/core/Device.h>
 #include <c10/cuda/CUDAGuard.h>
 
 #include <cuda_runtime_api.h>
 #include <structmember.h>
 
 PyObject* THCPStreamClass = nullptr;
+
+static c10::DeviceIndex checked_stream_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 static PyObject* THCPStream_pynew(
     PyTypeObject* type,
@@ -78,7 +92,7 @@ static PyObject* THCPStream_pynew(
   at::cuda::CUDAStream stream = (stream_id || device_index || device_type)
       ? at::cuda::CUDAStream::unpack3(
             stream_id,
-            static_cast<c10::DeviceIndex>(device_index),
+            checked_stream_device_index(device_index),
             static_cast<c10::DeviceType>(device_type))
       : stream_ptr_provided ? at::cuda::getStreamFromExternal(
                                   // NOLINTNEXTLINE(performance-no-int-to-ptr)

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -10,6 +10,7 @@
 #include <ATen/ATen.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/core/Device.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/variable.h>
@@ -21,6 +22,19 @@
 namespace torch::cuda {
 using namespace at;
 using namespace torch::autograd;
+
+static DeviceIndex checked_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<DeviceIndex>(device_index);
+}
 
 // Some operations can be performed more efficiently if we're handling tensors
 // of a single type only. Adding this logic directly in the loop makes it a bit
@@ -97,14 +111,12 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntArrayRef devices) {
   std::vector<Tensor> diff_device_dst_tensors;
   diff_device_dst_tensors.reserve(devices.size());
   for (auto device : devices) {
-    TORCH_CHECK(
-        device >= 0, "Expected non-negative device index, but got ", device);
-    if (device != tensor.get_device()) {
+    const auto device_index = checked_device_index(device);
+    if (device_index != tensor.get_device()) {
       diff_device_dst_tensors.emplace_back(at::empty(
           tensor.sizes(),
           tensor.options().device(at::Device(
-              DeviceType::CUDA,
-              static_cast<DeviceIndex>(device))))); // preserve memory format
+              DeviceType::CUDA, device_index)))); // preserve memory format
     }
   }
   _broadcast_out_impl(tensor, diff_device_dst_tensors);
@@ -112,8 +124,9 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntArrayRef devices) {
   dst_tensors.reserve(devices.size());
   auto it = diff_device_dst_tensors.begin();
   for (auto device : devices) {
+    const auto device_index = checked_device_index(device);
     // NOLINTNEXTLINE(bugprone-branch-clone)
-    if (device != tensor.get_device()) {
+    if (device_index != tensor.get_device()) {
       dst_tensors.emplace_back(*it++);
     } else {
       dst_tensors.emplace_back(tensor);
@@ -176,7 +189,7 @@ tensor_list2d broadcast_coalesced(
     o.reserve(tensors.size());
 
   unique_type_checker type_checker;
-  at::cuda::CUDAGuard device_guard(static_cast<DeviceIndex>(devices[0]));
+  at::cuda::CUDAGuard device_guard(checked_device_index(devices[0]));
   for (auto& chunk : torch::utils::take_tensors(tensors, buffer_size)) {
     auto type_id = chunk.type_id();
     type_checker.show(type_id);
@@ -187,7 +200,7 @@ tensor_list2d broadcast_coalesced(
       auto broadcast_values = broadcast(flat_tuple.second, devices);
       results.reserve(devices.size());
       for (size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
-        device_guard.set_index(static_cast<DeviceIndex>(devices[i]));
+        device_guard.set_index(checked_device_index(devices[i]));
         auto& device_outputs = outputs[i];
         auto& inds = broadcast_indices[i];
         auto& vals = broadcast_values[i];
@@ -201,7 +214,7 @@ tensor_list2d broadcast_coalesced(
       auto results = broadcast(
           torch::utils::flatten_dense_tensors(chunk.tensors), devices);
       for (size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
-        device_guard.set_index(static_cast<DeviceIndex>(devices[i]));
+        device_guard.set_index(checked_device_index(devices[i]));
         auto& device_outputs = outputs[i];
         for (auto& var :
              torch::utils::unflatten_dense_tensors(results[i], chunk.tensors)) {
@@ -292,7 +305,7 @@ std::vector<at::Tensor>& scatter_out(
           ") ",
           "to match the device supplied at that index ",
           "(expected ",
-          static_cast<int16_t>(device_index),
+          static_cast<int>(device_index),
           ")");
       cuda_guard.reset_stream(*(*streams)[i]);
     }
@@ -329,7 +342,7 @@ std::vector<at::Tensor> scatter(
             /*chunks=*/static_cast<int64_t>(devices.size()), /*dim=*/dim);
   at::cuda::OptionalCUDAStreamGuard cuda_guard;
   for (const auto i : c10::irange(chunks.size())) {
-    const auto device_index = static_cast<int16_t>(devices[i]);
+    const auto device_index = checked_device_index(devices[i]);
     if (device_index != tensor.get_device()) {
       if (i < (streams ? streams->size() : 0U) && (*streams)[i]) {
         TORCH_CHECK(
@@ -345,10 +358,6 @@ std::vector<at::Tensor> scatter(
             ")");
         cuda_guard.reset_stream(*(*streams)[i]);
       }
-      TORCH_CHECK(
-          device_index >= 0,
-          "Expected non-negative device index, but got ",
-          device_index);
       chunks[i] = chunks[i].to(
           {DeviceType::CUDA, device_index},
           /*non_blocking=*/true,
@@ -488,7 +497,7 @@ at::Tensor gather(
   if (!destination_index || *destination_index != -1) {
     device = at::Device(
         DeviceType::CUDA,
-        destination_index ? static_cast<DeviceIndex>(*destination_index)
+        destination_index ? checked_device_index(*destination_index)
                           : DeviceIndex(-1));
   }
 

--- a/torch/csrc/cuda/device_set.h
+++ b/torch/csrc/cuda/device_set.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <c10/cuda/CUDAMacros.h>
+#include <c10/core/Device.h>
 #include <bitset>
 #include <cstddef>
 
 namespace torch {
 
-using device_set = std::bitset<C10_COMPILE_TIME_MAX_GPUS>;
+using device_set = std::bitset<c10::Device::MAX_NUM_DEVICES>;
 
 } // namespace torch

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -8,10 +8,29 @@
 #endif
 
 #include <ATen/core/CachingHostAllocator.h>
+#include <c10/core/Device.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Exception.h>
 
 namespace torch::cuda::shared {
+
+namespace {
+
+c10::DeviceIndex checkedDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
+} // namespace
 
 #ifdef USE_ROCM
 namespace {
@@ -115,8 +134,8 @@ void initCudartBindings(PyObject* module) {
   cudart.def(
       "cuda"
       "MemGetInfo",
-      [](c10::DeviceIndex device) -> std::pair<size_t, size_t> {
-        c10::cuda::CUDAGuard guard(device);
+      [](int64_t device) -> std::pair<size_t, size_t> {
+        c10::cuda::CUDAGuard guard(checkedDeviceIndex(device));
         size_t device_free = 0;
         size_t device_total = 0;
         py::gil_scoped_release no_gil;

--- a/torch/csrc/cuda/shim_common.cpp
+++ b/torch/csrc/cuda/shim_common.cpp
@@ -34,7 +34,8 @@ AOTITorchError torch_set_current_cuda_stream(
     int32_t device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::cuda::setCurrentCUDAStream(at::cuda::getStreamFromExternal(
-        static_cast<cudaStream_t>(stream), device_index));
+        static_cast<cudaStream_t>(stream),
+        torch::aot_inductor::checked_device_index(device_index)));
   });
 }
 
@@ -43,8 +44,9 @@ AOTITorchError torch_get_cuda_stream_from_pool(
     int32_t device_index,
     void** ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *(cudaStream_t*)(ret_stream) =
-        at::cuda::getStreamFromPool(isHighPriority, device_index);
+    *(cudaStream_t*)(ret_stream) = at::cuda::getStreamFromPool(
+        isHighPriority,
+        torch::aot_inductor::checked_device_index(device_index, true));
   });
 }
 
@@ -53,7 +55,8 @@ AOTITorchError torch_cuda_stream_synchronize(
     int32_t device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::cuda::getStreamFromExternal(
-        static_cast<cudaStream_t>(stream), device_index)
+        static_cast<cudaStream_t>(stream),
+        torch::aot_inductor::checked_device_index(device_index))
         .synchronize();
   });
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -12,6 +12,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGraph.h>
+#include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDAException.h>
@@ -44,6 +45,19 @@ constexpr const char* const kNCCLAbortedCommStoreKey = "NCCLABORTEDCOMM";
 using FlightRecorderCUDA = FlightRecorder<at::cuda::CUDAEvent>;
 
 namespace {
+
+c10::DeviceIndex checkedDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 // NCCL op mapping
 const std::map<ReduceOp::RedOpType, ncclRedOp_t> ncclOp = {
@@ -5310,7 +5324,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::barrier(const BarrierOptions& opts) {
   // 1st choice: Use user defined GPU device ids if provided
   if (!opts.device_ids.empty()) {
     // Use the first device id because PG NCCL is single-device now
-    barDevIdx = static_cast<c10::DeviceIndex>(opts.device_ids[0]);
+    barDevIdx = checkedDeviceIndex(opts.device_ids[0]);
   } else {
     // 2nd choice: Use the bound or used GPU device id if available.
     barDevIdx = guessDeviceId();

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_C10D_UCC
 
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/core/Device.h>
 #include <c10/util/CallOnce.h>
 #include <c10/util/env.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
@@ -15,6 +16,19 @@
 namespace c10d {
 
 namespace {
+
+c10::DeviceIndex checkedDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 const std::map<c10::DeviceType, ucc_memory_type_t> ucc_mtype_map = {
     {c10::kCPU, UCC_MEMORY_TYPE_HOST},
@@ -1190,14 +1204,15 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::barrier(const BarrierOptions& opts) {
 #ifdef USE_CUDA
   auto numGPUs = c10::cuda::device_count();
   if (!opts.device_ids.empty()) {
-    device = c10::Device(c10::DeviceType::CUDA, opts.device_ids.front());
+    device = c10::Device(
+        c10::DeviceType::CUDA, checkedDeviceIndex(opts.device_ids.front()));
   } else if (comm && comm->cuda_device_index != TORCH_UCC_DEVICE_NOT_SET) {
     device = c10::Device(c10::DeviceType::CUDA, comm->cuda_device_index);
   } else if (numGPUs > 0) {
-    int8_t deviceIdx = static_cast<int8_t>(c10::cuda::current_device());
+    c10::DeviceIndex deviceIdx = c10::cuda::current_device();
     // if current device is 0, likely the device is not set, use the best guess
     if (0 == (int)deviceIdx) {
-      deviceIdx = static_cast<int8_t>(this->getRank() % numGPUs);
+      deviceIdx = static_cast<c10::DeviceIndex>(this->getRank() % numGPUs);
     }
     TORCH_UCC_LOG_INFO(
         TORCH_UCC_COLL_POST,

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp>
 
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/core/Device.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
@@ -23,6 +24,19 @@
 namespace c10d::nccl2 {
 
 namespace {
+
+c10::DeviceIndex checkedDeviceIndex(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 std::vector<uint64_t> normalizeSplitSizes(
     const std::vector<int64_t>& split_sizes,
@@ -628,8 +642,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::barrier(
     at::Device dev = at::Device(
         at::kCUDA, static_cast<c10::DeviceIndex>(getRank() % device_count));
     if (!opts.device_ids.empty()) {
-      dev = at::Device(
-          at::kCUDA, static_cast<c10::DeviceIndex>(opts.device_ids[0]));
+      dev = at::Device(at::kCUDA, checkedDeviceIndex(opts.device_ids[0]));
     } else if (getBoundDeviceId().has_value()) {
       dev = getBoundDeviceId().value();
     }

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
@@ -2,8 +2,8 @@
 
 #ifdef USE_TENSORPIPE
 
+#include <c10/core/Device.h>
 #include <c10/util/irange.h>
-#include <limits>
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated")
 #include <tensorpipe/tensorpipe.h>
@@ -270,8 +270,8 @@ std::pair<tensorpipe::Allocation, TensorpipeReadBuffers> tensorpipeAllocate(
 
     TORCH_INTERNAL_ASSERT(tpAllocation.tensors.size() == tensorIdx);
     TORCH_INTERNAL_ASSERT(
-        tensor.targetDevice->index <=
-        std::numeric_limits<c10::DeviceIndex>::max());
+        0 <= tensor.targetDevice->index &&
+        tensor.targetDevice->index < c10::Device::MAX_NUM_DEVICES);
     at::DataPtr dataPtr = converter->allocateTensorForReceiving(
         static_cast<c10::DeviceIndex>(tensor.targetDevice->index),
         tensor.length,

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1,5 +1,6 @@
 #include <ATen/PythonTorchFunctionTLS.h>
 #include <ATen/autocast_mode.h>
+#include <c10/core/Device.h>
 #include <c10/core/SafePyObject.h>
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/util/Exception.h>
@@ -7434,8 +7435,18 @@ static void* _torchinductor_pyobject_tensor_data_ptr(PyObject* obj) {
 static PyObject* _torchinductor_thp_device_new(
     int device_type,
     int device_index) {
-  return THPDevice_New(
-      c10::Device(static_cast<c10::DeviceType>(device_type), device_index));
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return THPDevice_New(c10::Device(
+      static_cast<c10::DeviceType>(device_type),
+      static_cast<c10::DeviceIndex>(device_index)));
 }
 
 static PyObject* _torchinductor_get_thp_dtype(int dtype) {

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -16,6 +16,7 @@
 
 #include <ATen/Functions.h>
 #include <ATen/core/jit_type.h>
+#include <c10/core/Device.h>
 
 namespace torch::inductor {
 
@@ -328,7 +329,16 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
     // Access the fields of each metadata dict
     auto is_dynamic = metadata["is_dynamic"].cast<bool>();
     auto device_type = metadata["device_type"].cast<std::string>();
-    auto device_index = metadata["device_index"].cast<int8_t>();
+    auto device_index = metadata["device_index"].cast<int64_t>();
+    TORCH_CHECK(
+        device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+        "Device index ",
+        device_index,
+        " is out of range for DeviceIndex [",
+        -1,
+        ", ",
+        c10::Device::MAX_NUM_DEVICES - 1,
+        "]");
     auto data_type_obj = metadata["dtype"].cast<py::object>();
     TORCH_INTERNAL_ASSERT(THPDtype_Check(data_type_obj.ptr()));
     auto data_type =
@@ -341,7 +351,7 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
     auto dispatch_key_set = c10::DispatchKeySet(
         c10::DispatchKeySet::RAW, dispatch_key_set_raw_repr);
     auto device = c10::Device(device_type);
-    device.set_index(device_index);
+    device.set_index(static_cast<c10::DeviceIndex>(device_index));
 
     auto tensor_metadata = TensorMetadata(
         is_dynamic,
@@ -447,8 +457,18 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
         auto device = c10::Device(device_type_value);
         if (!Py_IsNone(metadata["device_index_value"].ptr())) {
           auto device_index_value =
-              metadata["device_index_value"].cast<c10::DeviceIndex>();
-          device.set_index(device_index_value);
+              metadata["device_index_value"].cast<int64_t>();
+          TORCH_CHECK(
+              device_index_value >= -1 &&
+                  device_index_value < c10::Device::MAX_NUM_DEVICES,
+              "Device index ",
+              device_index_value,
+              " is out of range for DeviceIndex [",
+              -1,
+              ", ",
+              c10::Device::MAX_NUM_DEVICES - 1,
+              "]");
+          device.set_index(static_cast<c10::DeviceIndex>(device_index_value));
         }
         parameter_metadata_list.emplace_back(device, arg_idx);
       } else if (is_layout) {

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -72,7 +72,7 @@ static c10::Device c10_device(int32_t device_type, int32_t device_index) {
   } else {
     return c10::Device(
         static_cast<c10::DeviceType>(device_type),
-        static_cast<c10::DeviceIndex>(device_index));
+        checked_device_index(device_index, true));
   }
 }
 } // namespace
@@ -400,7 +400,7 @@ AOTITorchError aoti_torch_get_device_index(
     int32_t* ret_device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::Tensor* t = tensor_handle_to_tensor_pointer(tensor);
-    *ret_device_index = static_cast<int16_t>(t->device().index());
+    *ret_device_index = static_cast<int32_t>(t->device().index());
   });
 }
 
@@ -1491,7 +1491,7 @@ AOTITorchError aoti_torch_create_device_guard(
     // checked=true will fail if no accelerator is available
     const auto device_type =
         at::accelerator::getAccelerator(/*checked=*/true).value();
-    c10::Device device(device_type, device_index);
+    c10::Device device(device_type, checked_device_index(device_index, true));
     c10::DeviceGuard* guard = new c10::DeviceGuard(device);
     *ret_guard = reinterpret_cast<DeviceGuardHandle>(guard);
   });
@@ -1505,8 +1505,10 @@ AOTITorchError aoti_torch_delete_device_guard(DeviceGuardHandle guard) {
 AOTITorchError aoti_torch_device_guard_set_index(
     DeviceGuardHandle guard,
     int32_t device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { reinterpret_cast<c10::DeviceGuard*>(guard)->set_index(device_index); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    reinterpret_cast<c10::DeviceGuard*>(guard)->set_index(
+        checked_device_index(device_index, true));
+  });
 }
 
 AOTITorchError aoti_torch_delete_stream(StreamHandle stream) {
@@ -1529,7 +1531,8 @@ AOTITorchError aoti_torch_get_current_stream(
     int32_t device_index,
     StreamHandle* ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::Stream stream = at::accelerator::getCurrentStream(device_index);
+    c10::Stream stream =
+        at::accelerator::getCurrentStream(checked_device_index(device_index));
     c10::Stream* stream_ptr = new c10::Stream(stream);
     *ret_stream = reinterpret_cast<StreamHandle>(stream_ptr);
   });

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -6,12 +6,15 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 
+using namespace torch::aot_inductor;
+
 AOTITorchError aoti_torch_create_cuda_guard(
     int32_t device_index,
     CUDAGuardHandle* ret_guard // returns new reference
 ) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::cuda::CUDAGuard* guard = new at::cuda::CUDAGuard(device_index);
+    at::cuda::CUDAGuard* guard =
+        new at::cuda::CUDAGuard(checked_device_index(device_index, true));
     *ret_guard = reinterpret_cast<CUDAGuardHandle>(guard);
   });
 }
@@ -25,7 +28,8 @@ AOTITorchError aoti_torch_cuda_guard_set_index(
     CUDAGuardHandle guard,
     int32_t device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    reinterpret_cast<at::cuda::CUDAGuard*>(guard)->set_index(device_index);
+    reinterpret_cast<at::cuda::CUDAGuard*>(guard)->set_index(
+        checked_device_index(device_index, true));
   });
 }
 
@@ -36,7 +40,8 @@ AOTITorchError aoti_torch_create_cuda_stream_guard(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::cuda::CUDAStreamGuard* guard =
         new at::cuda::CUDAStreamGuard(at::cuda::getStreamFromExternal(
-            static_cast<cudaStream_t>(stream), device_index));
+            static_cast<cudaStream_t>(stream),
+            checked_device_index(device_index)));
     *ret_guard = reinterpret_cast<CUDAStreamGuardHandle>(guard);
   });
 }
@@ -51,7 +56,8 @@ AOTITorchError aoti_torch_get_current_cuda_stream(
     int32_t device_index,
     void** ret_stream) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *(cudaStream_t*)(ret_stream) = at::cuda::getCurrentCUDAStream(device_index);
+    *(cudaStream_t*)(ret_stream) = at::cuda::getCurrentCUDAStream(
+        checked_device_index(device_index, true));
   });
 }
 

--- a/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
@@ -14,8 +14,8 @@ AOTITorchError aoti_torch_create_xpu_guard(
     XPUGuardHandle* ret_guard // returns new reference
 ) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    at::DeviceGuard* guard =
-        new at::DeviceGuard(at::Device(at::DeviceType::XPU, device_index));
+    at::DeviceGuard* guard = new at::DeviceGuard(at::Device(
+        at::DeviceType::XPU, checked_device_index(device_index, true)));
     *ret_guard = reinterpret_cast<XPUGuardHandle>(guard);
   });
 }
@@ -28,8 +28,10 @@ AOTITorchError aoti_torch_delete_xpu_guard(XPUGuardHandle guard) {
 AOTITorchError aoti_torch_xpu_guard_set_index(
     XPUGuardHandle guard,
     int32_t device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { reinterpret_cast<at::DeviceGuard*>(guard)->set_index(device_index); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    reinterpret_cast<at::DeviceGuard*>(guard)->set_index(
+        checked_device_index(device_index, true));
+  });
 }
 
 AOTITorchError aoti_torch_create_xpu_stream_guard(
@@ -40,7 +42,8 @@ AOTITorchError aoti_torch_create_xpu_stream_guard(
     assert(stream);
     at::StreamGuard* guard =
         new at::StreamGuard(at::xpu::getStreamFromExternal(
-                                static_cast<sycl::queue*>(stream), device_index)
+                                static_cast<sycl::queue*>(stream),
+                                checked_device_index(device_index))
                                 .unwrap());
     *ret_guard = reinterpret_cast<XPUStreamGuardHandle>(guard);
   });
@@ -54,26 +57,26 @@ AOTITorchError aoti_torch_delete_xpu_stream_guard(XPUStreamGuardHandle guard) {
 AOTITorchError aoti_torch_get_current_xpu_stream(
     int32_t device_index,
     void** ret_stream) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_stream = &(at::xpu::getCurrentXPUStream(device_index).queue()); });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    *ret_stream =
+        &(at::xpu::getCurrentXPUStream(checked_device_index(device_index, true))
+              .queue());
+  });
 }
 
 AOTITorchError aoti_torch_get_current_xpu_device(int32_t* device_index) {
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *device_index =
-        static_cast<int32_t>(static_cast<uint16_t>(c10::xpu::current_device()));
-  });
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { *device_index = static_cast<int32_t>(c10::xpu::current_device()); });
 }
 
 AOTITorchError aoti_torch_set_current_xpu_device(const int32_t& device_index) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { c10::xpu::set_device(static_cast<int8_t>(device_index)); });
+      { c10::xpu::set_device(checked_device_index(device_index)); });
 }
 
 AOTITorchError aoti_torch_get_current_sycl_queue(void** ret) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    int32_t device_index =
-        static_cast<int32_t>(static_cast<uint16_t>(c10::xpu::current_device()));
+    auto device_index = c10::xpu::current_device();
     *ret = &(at::xpu::getCurrentXPUStream(device_index).queue());
   });
 }

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -3,7 +3,7 @@
 #include <ATen/Generator.h>
 #include <ATen/Tensor.h>
 #include <ATen/core/List.h>
-#include <c10/core/DeviceType.h>
+#include <c10/core/Device.h>
 #include <c10/core/SymIntArrayRef.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Logging.h>
@@ -41,6 +41,23 @@ TORCH_API void set_last_error(const char* msg);
   return AOTI_TORCH_SUCCESS;
 
 namespace torch::aot_inductor {
+
+inline c10::DeviceIndex checked_device_index(
+    int32_t device_index,
+    bool allow_default = false) {
+  const int32_t lower_bound = allow_default ? -1 : 0;
+  TORCH_CHECK(
+      device_index >= lower_bound &&
+          device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      lower_bound,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 inline at::Tensor* tensor_handle_to_tensor_pointer(AtenTensorHandle handle) {
   return reinterpret_cast<at::Tensor*>(handle);
@@ -154,7 +171,7 @@ inline std::optional<c10::Device> pointer_to_optional_device(
     int32_t device_index) {
   return device_type ? std::make_optional(c10::Device(
                            static_cast<c10::DeviceType>(*device_type),
-                           static_cast<c10::DeviceIndex>(device_index)))
+                           checked_device_index(device_index, true)))
                      : std::nullopt;
 }
 

--- a/torch/csrc/inductor/static_launcher/xpu.cpp
+++ b/torch/csrc/inductor/static_launcher/xpu.cpp
@@ -17,6 +17,7 @@
 
 #include <ATen/Context.h>
 #include <ATen/xpu/level_zero_stub/ATenLevelZero.h>
+#include <c10/core/Device.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/csrc/inductor/static_launcher/xpu.h>
@@ -193,6 +194,15 @@ inline ze_module_handle_t _createModule(
     const uint8_t* binaryPtr,
     size_t binarySize,
     const int device_idx) {
+  TORCH_CHECK(
+      device_idx >= 0 && device_idx < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_idx,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
   auto& syclDevice =
       c10::xpu::get_raw_device(static_cast<c10::DeviceIndex>(device_idx));
   auto& syclContext = c10::xpu::get_device_context();

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -4,6 +4,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/symbol.h>
 #include <ATen/core/type_factory.h>
+#include <c10/core/Device.h>
 #include <torch/csrc/jit/frontend/lexer.h>
 #include <torch/csrc/jit/frontend/parse_string_literal.h>
 #include <torch/custom_class.h>
@@ -242,7 +243,14 @@ std::optional<c10::Device> SchemaTypeParser::tryToParseDeviceType() {
       L.expect(':');
       const std::string& num = L.expect(TK_NUMBER).text();
       try {
-        device_idx = static_cast<c10::DeviceIndex>(std::stoi(num));
+        int64_t parsed_device_idx = std::stoll(num);
+        if (parsed_device_idx < 0 ||
+            parsed_device_idx >= c10::Device::MAX_NUM_DEVICES) {
+          throw(
+              ErrorReport(L.cur())
+              << "Device index is out of range for DeviceIndex");
+        }
+        device_idx = static_cast<c10::DeviceIndex>(parsed_device_idx);
       } catch (const std::invalid_argument&) {
         throw(
             ErrorReport(L.cur())

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
+#include <c10/core/Device.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/Export.h>
@@ -55,12 +56,10 @@ struct ArgumentInfo {
  private:
   unsigned defined_ : 1;
   unsigned requires_grad_ : 1;
-  unsigned : 5;
   unsigned dim_ : 8;
-  unsigned device_ : 8;
+  signed device_ : sizeof(c10::DeviceIndex) * 8;
   unsigned type_ : 8;
   unsigned dev_type_ : 16;
-  unsigned : 16;
 };
 
 static_assert(
@@ -68,7 +67,7 @@ static_assert(
     "ArgumentInfo is to be a POD struct");
 static_assert(
     sizeof(ArgumentInfo) == sizeof(ArgumentInfo::plain_data_type),
-    "ArgumentInfo is expected to be a 32-bit struct");
+    "ArgumentInfo is expected to fit in its plain data type");
 
 struct ArgumentSpec {
   ArgumentSpec(size_t num_flat_tensor_inputs, size_t num_flat_optional_inputs)
@@ -220,8 +219,8 @@ struct CompleteArgumentInfoPOD {
   unsigned type : 8; // scalar type
   unsigned defined : 1;
   unsigned requires_grad : 1;
-  signed device : 14;
-  unsigned dev_type : 16;
+  signed dev_type : sizeof(c10::DeviceType) * 8;
+  signed device : sizeof(c10::DeviceIndex) * 8;
   unsigned
       total_dims : 16; // all TensorInfoPODs are in CompleteArgumentSpec's
                        // tensor_info() array. total_dims is the total number of

--- a/torch/csrc/jit/runtime/register_cuda_ops.cpp
+++ b/torch/csrc/jit/runtime/register_cuda_ops.cpp
@@ -1,5 +1,6 @@
 // This file registers special JIT operators used to implement the PyTorch CUDA
 // API in TorchScript.
+#include <c10/core/Device.h>
 #include <torch/csrc/jit/cuda/cuda.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/custom_operator.h>
@@ -13,7 +14,24 @@ c10::AliasAnalysisKind aliasAnalysisFromSchema() {
   return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
-void _device_synchronize(int64_t device_index) {
+c10::DeviceIndex checked_device_index(
+    int64_t device_index,
+    bool allow_default = false) {
+  const int64_t lower_bound = allow_default ? -1 : 0;
+  TORCH_CHECK(
+      device_index >= lower_bound &&
+          device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      lower_bound,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
+void _device_synchronize(c10::DeviceIndex device_index) {
   // This is a helper API which synchronizes the device identified
   // by the device index. The device index of the device is passed as an
   // argument to this API.
@@ -48,9 +66,10 @@ RegisterOperators const reg({
     Operator(
         "cuda::current_stream.int(int? val) -> __torch__.torch.classes.cuda.Stream",
         [](Stack& stack) {
-          auto idx = pop(stack).toOptional<c10::DeviceIndex>();
-          c10::DeviceIndex device_index =
-              idx.has_value() ? idx.value() : c10::cuda::current_device();
+          auto idx = pop(stack).toOptional<int64_t>();
+          c10::DeviceIndex device_index = idx.has_value()
+              ? checked_device_index(idx.value(), true)
+              : c10::cuda::current_device();
           auto s = c10::cuda::getCurrentCUDAStream(device_index);
           auto st = make_custom_class<torch::jit::CUDAStream>(s);
           push(stack, IValue(st));
@@ -71,9 +90,10 @@ RegisterOperators const reg({
     Operator(
         "cuda::default_stream.int(int? val) -> __torch__.torch.classes.cuda.Stream",
         [](Stack& stack) {
-          auto idx = pop(stack).toOptional<c10::DeviceIndex>();
-          c10::DeviceIndex device_index =
-              idx.has_value() ? idx.value() : c10::cuda::current_device();
+          auto idx = pop(stack).toOptional<int64_t>();
+          c10::DeviceIndex device_index = idx.has_value()
+              ? checked_device_index(idx.value(), true)
+              : c10::cuda::current_device();
           auto s = c10::cuda::getDefaultCUDAStream(device_index);
           auto st = make_custom_class<torch::jit::CUDAStream>(s);
           push(stack, IValue(st));
@@ -96,7 +116,7 @@ RegisterOperators const reg({
             return;
           }
           auto prev_idx = c10::cuda::current_device();
-          c10::cuda::set_device(static_cast<c10::DeviceIndex>(idx));
+          c10::cuda::set_device(checked_device_index(idx));
           push(stack, static_cast<int>(prev_idx));
         },
         // cuda::set_device has side effects.
@@ -110,7 +130,8 @@ RegisterOperators const reg({
             push(stack, -1);
             return;
           }
-          int prev_idx = c10::cuda::MaybeExchangeDevice(static_cast<int>(idx));
+          int prev_idx =
+              c10::cuda::MaybeExchangeDevice(checked_device_index(idx));
           push(stack, prev_idx);
         },
         c10::AliasAnalysisKind::CONSERVATIVE),
@@ -119,7 +140,7 @@ RegisterOperators const reg({
         [](Stack& stack) {
           int64_t idx = -1;
           pop(stack, idx);
-          c10::cuda::set_device(static_cast<c10::DeviceIndex>(idx));
+          c10::cuda::set_device(checked_device_index(idx));
         },
         aliasAnalysisFromSchema()),
     Operator(
@@ -176,9 +197,10 @@ RegisterOperators const reg({
     Operator(
         "cuda::synchronize.int(int? val) -> ()",
         [](Stack& stack) {
-          auto idx = pop(stack).toOptional<c10::DeviceIndex>();
-          c10::DeviceIndex device_index =
-              idx.has_value() ? idx.value() : c10::cuda::current_device();
+          auto idx = pop(stack).toOptional<int64_t>();
+          c10::DeviceIndex device_index = idx.has_value()
+              ? checked_device_index(idx.value())
+              : c10::cuda::current_device();
           _device_synchronize(device_index);
         },
         aliasAnalysisFromSchema()),

--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -50,6 +50,9 @@ BackendDevice atenDeviceToBackendDevice(const c10::Device& device) {
 
 // TODO(whc) refactor this: we need to support non 1 on 1 mapping for torch/XLA.
 c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
+  TORCH_CHECK(
+      device.ordinal() >= -1 && device.ordinal() < c10::Device::MAX_NUM_DEVICES,
+      "Device ordinal out of range for DeviceIndex");
   return c10::Device(
       at::kLazy, static_cast<c10::DeviceIndex>(device.ordinal()));
 }

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/lazy/core/tensor_impl.h>
 
+#include <c10/core/Device.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
@@ -58,8 +59,11 @@ struct LTCGuardImpl : public c10::impl::DeviceGuardImplInterface {
       return 0;
     }
 
-    return static_cast<c10::DeviceIndex>(
-        getBackend()->GetBackendDevices().size());
+    const auto device_count = getBackend()->GetBackendDevices().size();
+    TORCH_CHECK(
+        device_count <= c10::Device::MAX_NUM_DEVICES,
+        "Too many Lazy devices, DeviceIndex overflowed");
+    return static_cast<c10::DeviceIndex>(device_count);
   }
 };
 

--- a/torch/csrc/mtia/Module.cpp
+++ b/torch/csrc/mtia/Module.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/Stream.h>
 #include <torch/csrc/Generator.h>
@@ -9,6 +10,23 @@
 #include <torch/csrc/utils/pybind.h>
 
 namespace torch::mtia {
+
+namespace {
+
+c10::DeviceIndex checked_mtia_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
+
+} // namespace
 
 struct _MTIAGraph {
   // MTIA use accelerator hooks to connect pytorch and outside.
@@ -79,14 +97,16 @@ void initModule(PyObject* module) {
     return torch::utils::is_device_in_bad_fork(at::kMTIA);
   });
 
-  m.def("_mtia_getCurrentStream", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_getCurrentStream", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     torch::utils::device_lazy_init(at::kMTIA);
-    return at::detail::getMTIAHooks().getCurrentStream(device_index);
+    return at::detail::getMTIAHooks().getCurrentStream(c10_device_index);
   });
 
-  m.def("_mtia_getCurrentRawStream", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_getCurrentRawStream", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     torch::utils::device_lazy_init(at::kMTIA);
-    return at::detail::getMTIAHooks().getCurrentRawStream(device_index);
+    return at::detail::getMTIAHooks().getCurrentRawStream(c10_device_index);
   });
 
   m.def("_mtia_deviceSynchronize", []() {
@@ -95,34 +115,36 @@ void initModule(PyObject* module) {
         at::detail::getMTIAHooks().getCurrentDevice());
   });
 
-  m.def("_mtia_exchangeDevice", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_exchangeDevice", [](int64_t device_index) {
     if (device_index < 0) {
       return static_cast<c10::DeviceIndex>(-1);
     }
-    return at::detail::getMTIAHooks().exchangeDevice(device_index);
+    return at::detail::getMTIAHooks().exchangeDevice(
+        checked_mtia_device_index(device_index));
   });
 
-  m.def("_mtia_maybeExchangeDevice", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_maybeExchangeDevice", [](int64_t device_index) {
     if (device_index < 0) {
       return static_cast<c10::DeviceIndex>(-1);
     }
-    return at::detail::getMTIAHooks().maybeExchangeDevice(device_index);
+    return at::detail::getMTIAHooks().maybeExchangeDevice(
+        checked_mtia_device_index(device_index));
   });
 
-  m.def("_mtia_getDefaultStream", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_getDefaultStream", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     torch::utils::device_lazy_init(at::kMTIA);
-    return at::detail::getMTIAHooks().getDefaultStream(device_index);
+    return at::detail::getMTIAHooks().getDefaultStream(c10_device_index);
   });
 
   m.def(
       "_mtia_setStream",
-      [](int64_t stream_id,
-         c10::DeviceIndex device_index,
-         int64_t device_type) {
+      [](int64_t stream_id, int64_t device_index, int64_t device_type) {
+        const auto c10_device_index = checked_mtia_device_index(device_index);
         torch::utils::device_lazy_init(at::kMTIA);
         at::detail::getMTIAHooks().setCurrentStream(c10::Stream::unpack3(
             stream_id,
-            device_index,
+            c10_device_index,
             static_cast<c10::DeviceType>(device_type)));
       });
 
@@ -135,21 +157,24 @@ void initModule(PyObject* module) {
     at::detail::getMTIAHooks().setCurrentStream(stream);
   });
 
-  m.def("_mtia_memoryStats", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_memoryStats", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     PyObject* raw_pyobject =
-        at::detail::getMTIAHooks().memoryStats(device_index);
+        at::detail::getMTIAHooks().memoryStats(c10_device_index);
     return py::reinterpret_steal<py::object>(raw_pyobject);
   });
 
-  m.def("_mtia_getDeviceCapability", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_getDeviceCapability", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     PyObject* raw_pyobject =
-        at::detail::getMTIAHooks().getDeviceCapability(device_index);
+        at::detail::getMTIAHooks().getDeviceCapability(c10_device_index);
     return py::reinterpret_steal<py::object>(raw_pyobject);
   });
 
-  m.def("_mtia_getDeviceProperties", [](c10::DeviceIndex device_index) {
+  m.def("_mtia_getDeviceProperties", [](int64_t device_index) {
+    const auto c10_device_index = checked_mtia_device_index(device_index);
     PyObject* raw_pyobject =
-        at::detail::getMTIAHooks().getDeviceProperties(device_index);
+        at::detail::getMTIAHooks().getDeviceProperties(c10_device_index);
     return py::reinterpret_steal<py::object>(raw_pyobject);
   });
 
@@ -183,12 +208,14 @@ void initModule(PyObject* module) {
     return at::detail::getMTIAHooks().getCurrentDevice();
   });
 
-  m.def("_mtia_setDevice", [](c10::DeviceIndex device_index) {
-    at::detail::getMTIAHooks().setCurrentDevice(device_index);
+  m.def("_mtia_setDevice", [](int64_t device_index) {
+    at::detail::getMTIAHooks().setCurrentDevice(
+        checked_mtia_device_index(device_index));
   });
 
-  m.def("_mtia_resetPeakMemoryStats", [](c10::DeviceIndex device_index) {
-    at::detail::getMTIAHooks().resetPeakMemoryStats(device_index);
+  m.def("_mtia_resetPeakMemoryStats", [](int64_t device_index) {
+    at::detail::getMTIAHooks().resetPeakMemoryStats(
+        checked_mtia_device_index(device_index));
   });
 
   m.def("_mtia_graphPoolHandle", []() {

--- a/torch/csrc/shim_common.cpp
+++ b/torch/csrc/shim_common.cpp
@@ -225,17 +225,16 @@ static c10::IValue to_ivalue(
           static_cast<c10::DeviceType>(static_cast<int8_t>(
               static_cast<uint32_t>((stable_ivalue >> 32) & 0xFFFFFFFF)));
       TORCH_CHECK(
-          device_index >= std::numeric_limits<int8_t>::min() &&
-              device_index <= std::numeric_limits<int8_t>::max(),
+          device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
           "Device index ",
           device_index,
-          " is out of range for int8_t [",
-          static_cast<int>(std::numeric_limits<int8_t>::min()),
+          " is out of range for DeviceIndex [",
+          -1,
           ", ",
-          static_cast<int>(std::numeric_limits<int8_t>::max()),
+          c10::Device::MAX_NUM_DEVICES - 1,
           "]");
-      return c10::IValue(
-          c10::Device(device_type, static_cast<int8_t>(device_index)));
+      return c10::IValue(c10::Device(
+          device_type, static_cast<c10::DeviceIndex>(device_index)));
     }
     case c10::TypeKind::LayoutType: {
       return c10::IValue(torch::stable::detail::_to<c10::Layout>(
@@ -742,7 +741,9 @@ AOTI_TORCH_EXPORT AOTITorchError torch_from_blob(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::IntArrayRef sizes(sizes_ptr, ndim);
     c10::IntArrayRef strides(strides_ptr, ndim);
-    c10::Device device(static_cast<c10::DeviceType>(device_type), device_index);
+    c10::Device device(
+        static_cast<c10::DeviceType>(device_type),
+        torch::aot_inductor::checked_device_index(device_index, true));
     c10::TensorOptions options = c10::TensorOptions().device(device).dtype(
         static_cast<c10::ScalarType>(dtype));
     at::Tensor tensor;
@@ -882,7 +883,7 @@ AOTITorchError torch_generator_get_device(
         torch::aot_inductor::generator_handle_to_generator_pointer(generator)
             ->device();
     *ret_device_type = static_cast<int32_t>(device.type());
-    *ret_device_index = static_cast<int16_t>(device.index());
+    *ret_device_index = static_cast<int32_t>(device.index());
   });
 }
 

--- a/torch/csrc/stable/tensor_struct.h
+++ b/torch/csrc/stable/tensor_struct.h
@@ -9,6 +9,7 @@
 #include <torch/headeronly/util/HeaderOnlyArrayRef.h>
 #include <torch/headeronly/util/shim_utils.h>
 #include <climits>
+#include <limits>
 #include <memory>
 
 #include <torch/csrc/stable/accelerator.h>
@@ -61,7 +62,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   Tensor() {
-    AtenTensorHandle ret;
+    AtenTensorHandle ret{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&ret));
     ath_ = std::shared_ptr<AtenTensorOpaque>(ret, [](AtenTensorHandle ath) {
       STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_delete_tensor_object(ath));
@@ -125,7 +126,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   void* data_ptr() const {
-    void* data_ptr;
+    void* data_ptr{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_data_ptr(ath_.get(), &data_ptr));
     return data_ptr;
@@ -207,7 +208,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   int64_t dim() const {
-    int64_t dim;
+    int64_t dim{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_dim(ath_.get(), &dim));
     return dim;
   }
@@ -220,7 +221,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   int64_t numel() const {
-    int64_t numel;
+    int64_t numel{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_numel(ath_.get(), &numel));
     return numel;
   }
@@ -242,7 +243,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   IntHeaderOnlyArrayRef sizes() const {
-    int64_t* sizes;
+    int64_t* sizes{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_sizes(ath_.get(), &sizes));
     return IntHeaderOnlyArrayRef(sizes, dim());
   }
@@ -258,7 +259,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   IntHeaderOnlyArrayRef strides() const {
-    int64_t* strides;
+    int64_t* strides{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(ath_.get(), &strides));
     return IntHeaderOnlyArrayRef(strides, dim());
   }
@@ -275,7 +276,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   bool is_contiguous() const {
-    bool is_contiguous;
+    bool is_contiguous{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_is_contiguous(ath_.get(), &is_contiguous));
     return is_contiguous;
@@ -290,7 +291,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   int64_t stride(int64_t dim) const {
-    int64_t stride;
+    int64_t stride{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_stride(ath_.get(), dim, &stride));
     return stride;
@@ -301,7 +302,7 @@ class Tensor {
   // range of int8_t.
   /// \private
   int8_t get_device() const {
-    int32_t device_index;
+    int32_t device_index{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_device_index(ath_.get(), &device_index));
     STD_TORCH_CHECK(
@@ -314,8 +315,7 @@ class Tensor {
   // The same as get_device but with two differences:
   // 1. it has a more suiting name
   // 2. it returns a DeviceIndex, which is int32_t in this world
-  //    that should be more stable than the likely shifting
-  //    DeviceIndex in libtorch (it is int8_t that might become int16_t)
+  //    that should be more stable than DeviceIndex in libtorch
   /**
    * @brief Returns the device index of the tensor.
    *
@@ -324,7 +324,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   DeviceIndex get_device_index() const {
-    int32_t device_index;
+    int32_t device_index{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_device_index(ath_.get(), &device_index));
     return device_index;
@@ -338,7 +338,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   bool is_cuda() const {
-    int32_t device_type;
+    int32_t device_type{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_device_type(ath_.get(), &device_type));
     return device_type == aoti_torch_device_type_cuda();
@@ -352,7 +352,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   bool is_cpu() const {
-    int32_t device_type;
+    int32_t device_type{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_device_type(ath_.get(), &device_type));
     return device_type == aoti_torch_device_type_cpu();
@@ -367,7 +367,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   int64_t size(int64_t dim) const {
-    int64_t size;
+    int64_t size{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_size(ath_.get(), dim, &size));
     return size;
   }
@@ -380,7 +380,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   bool defined() const {
-    bool defined;
+    bool defined{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_is_defined(ath_.get(), &defined));
     return defined;
   }
@@ -414,7 +414,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   int64_t storage_offset() const {
-    int64_t storage_offset;
+    int64_t storage_offset{};
     STABLE_TORCH_ERROR_CODE_CHECK(
         aoti_torch_get_storage_offset(ath_.get(), &storage_offset));
     return storage_offset;
@@ -428,7 +428,7 @@ class Tensor {
    * Minimum compatible version: PyTorch 2.9.
    */
   size_t element_size() const {
-    int32_t dtype;
+    int32_t dtype{};
     STABLE_TORCH_ERROR_CODE_CHECK(aoti_torch_get_dtype(ath_.get(), &dtype));
     return aoti_torch_dtype_element_size(dtype);
   }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -847,7 +847,12 @@ inline std::optional<at::Layout> PythonArgs::layoutOptional(int i) {
 }
 
 inline at::Device deviceFromLong(int64_t device_index) {
-  TORCH_CHECK(device_index >= 0, "Device index must not be negative");
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index must be between 0 and ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      " inclusive, got ",
+      device_index);
   return at::Device(
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       at::getAccelerator(true).value(),

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -204,6 +204,12 @@ inline c10::DeviceIndex THPUtils_unpackDeviceIndex(PyObject* obj) {
       value <= std::numeric_limits<c10::DeviceIndex>::max() &&
           value >= std::numeric_limits<c10::DeviceIndex>::min(),
       "Overflow when unpacking DeviceIndex");
+  TORCH_CHECK(
+      value < c10::Device::MAX_NUM_DEVICES,
+      "Device index must be less than ",
+      c10::Device::MAX_NUM_DEVICES,
+      ", got ",
+      value);
   return (c10::DeviceIndex)value;
 }
 

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -16,7 +16,22 @@
 #include <torch/csrc/xpu/XPUPluggableAllocator.h>
 #include <torch/csrc/xpu/memory_snapshot.h>
 
+#include <c10/core/Device.h>
+
 using namespace torch;
+
+static c10::DeviceIndex checked_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      0,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 // XPU management methods
 
@@ -162,7 +177,7 @@ static PyObject* THXPModule_setStream_wrap(
 
   auto stream = at::xpu::XPUStream::unpack3(
       stream_id,
-      static_cast<c10::DeviceIndex>(device_index),
+      checked_device_index(device_index),
       static_cast<c10::DeviceType>(device_type));
 
   auto device = c10::xpu::current_device();
@@ -432,40 +447,42 @@ static void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_get_device_properties",
-      [](c10::DeviceIndex device) -> c10::xpu::DeviceProp* {
-        return at::xpu::getDeviceProperties(device);
+      [](int64_t device) -> c10::xpu::DeviceProp* {
+        return at::xpu::getDeviceProperties(checked_device_index(device));
       },
       py::return_value_policy::reference);
 }
 
 static void initXpuMethodBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
-  m.def("_xpu_getMemoryInfo", [](c10::DeviceIndex device_index) {
+  m.def("_xpu_getMemoryInfo", [](int64_t device_index) {
     py::gil_scoped_release no_gil;
-    return at::getDeviceAllocator(at::kXPU)->getMemoryInfo(device_index);
+    return at::getDeviceAllocator(at::kXPU)->getMemoryInfo(
+        checked_device_index(device_index));
   });
   m.def(
       "_xpu_getStreamFromExternal",
-      [](uintptr_t data_ptr, c10::DeviceIndex device_index) {
+      [](uintptr_t data_ptr, int64_t device_index) {
         sycl::queue* ext_queue =
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
             reinterpret_cast<sycl::queue*>(reinterpret_cast<void*>(data_ptr));
-        at::xpu::XPUStream stream =
-            c10::xpu::getStreamFromExternal(ext_queue, device_index);
+        at::xpu::XPUStream stream = c10::xpu::getStreamFromExternal(
+            ext_queue, checked_device_index(device_index));
         return std::make_tuple(
             stream.id(), stream.device_index(), stream.device_type());
       });
-  m.def(
-      "_xpu_canDeviceAccessPeer",
-      [](c10::DeviceIndex device, c10::DeviceIndex peer) {
-        return at::xpu::canDeviceAccessPeer(device, peer);
-      });
-  m.def("_xpu_sleep", [](uint64_t cycles) { at::xpu::sleep(cycles); });
-  m.def("_xpu_getMemoryFraction", [](c10::DeviceIndex device) {
-    return c10::xpu::XPUCachingAllocator::getMemoryFraction(device);
+  m.def("_xpu_canDeviceAccessPeer", [](int64_t device, int64_t peer) {
+    return at::xpu::canDeviceAccessPeer(
+        checked_device_index(device), checked_device_index(peer));
   });
-  m.def("_xpu_setMemoryFraction", [](double fraction, c10::DeviceIndex device) {
-    c10::xpu::XPUCachingAllocator::setMemoryFraction(fraction, device);
+  m.def("_xpu_sleep", [](uint64_t cycles) { at::xpu::sleep(cycles); });
+  m.def("_xpu_getMemoryFraction", [](int64_t device) {
+    return c10::xpu::XPUCachingAllocator::getMemoryFraction(
+        checked_device_index(device));
+  });
+  m.def("_xpu_setMemoryFraction", [](double fraction, int64_t device) {
+    c10::xpu::XPUCachingAllocator::setMemoryFraction(
+        fraction, checked_device_index(device));
   });
   m.def("_xpu_memorySnapshot", [](std::optional<c10::MempoolId_t> mempool_id) {
     using c10::CachingDeviceAllocator::BlockInfo;
@@ -633,24 +650,26 @@ static void initXpuMethodBindings(PyObject* module) {
   m.def("_xpu_recordMemoryHistory", &torch::xpu::_record_memory_history);
   m.def(
       "_xpu_beginAllocateCurrentThreadToPool",
-      [](c10::DeviceIndex device, at::xpu::MempoolId_t mempool_id) {
+      [](int64_t device, at::xpu::MempoolId_t mempool_id) {
+        const auto device_index = checked_device_index(device);
         auto tid = std::this_thread::get_id();
 
         c10::xpu::XPUCachingAllocator::beginAllocateToPool(
-            device, mempool_id, [=](sycl::queue*) {
+            device_index, mempool_id, [=](sycl::queue*) {
               auto current_tid = std::this_thread::get_id();
               return current_tid == tid;
             });
       });
   m.def(
       "_xpu_endAllocateToPool",
-      [](c10::DeviceIndex device, at::xpu::MempoolId_t mempool_id) {
-        c10::xpu::XPUCachingAllocator::endAllocateToPool(device, mempool_id);
+      [](int64_t device, at::xpu::MempoolId_t mempool_id) {
+        c10::xpu::XPUCachingAllocator::endAllocateToPool(
+            checked_device_index(device), mempool_id);
       });
   m.def(
-      "_xpu_releasePool",
-      [](c10::DeviceIndex device, at::xpu::MempoolId_t mempool_id) {
-        c10::xpu::XPUCachingAllocator::releasePool(device, mempool_id);
+      "_xpu_releasePool", [](int64_t device, at::xpu::MempoolId_t mempool_id) {
+        c10::xpu::XPUCachingAllocator::releasePool(
+            checked_device_index(device), mempool_id);
       });
 }
 

--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -6,9 +6,23 @@
 #include <torch/csrc/xpu/Module.h>
 #include <torch/csrc/xpu/Stream.h>
 
+#include <c10/core/Device.h>
 #include <structmember.h>
 
 PyObject* THXPStreamClass = nullptr;
+
+static c10::DeviceIndex checked_stream_device_index(int64_t device_index) {
+  TORCH_CHECK(
+      device_index >= -1 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index ",
+      device_index,
+      " is out of range for DeviceIndex [",
+      -1,
+      ", ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      "]");
+  return static_cast<c10::DeviceIndex>(device_index);
+}
 
 static PyObject* THXPStream_pynew(
     PyTypeObject* type,
@@ -47,7 +61,7 @@ static PyObject* THXPStream_pynew(
   at::xpu::XPUStream stream = (stream_id || device_index || device_type)
       ? at::xpu::XPUStream::unpack3(
             stream_id,
-            static_cast<c10::DeviceIndex>(device_index),
+            checked_stream_device_index(device_index),
             static_cast<c10::DeviceType>(device_type))
       : at::xpu::getStreamFromPool(priority, current_device);
 

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -1188,9 +1188,8 @@ c10::Device convertDevice(std::string_view symbol) {
   TORCH_CHECK(indexValue.has_value(), "Invalid device index format");
   int64_t deviceIndex = indexValue.value();
   TORCH_CHECK(
-      deviceIndex >= std::numeric_limits<c10::DeviceIndex>::min() &&
-          deviceIndex <= std::numeric_limits<c10::DeviceIndex>::max(),
-      "Device index out of range for int8_t");
+      deviceIndex >= -1 && deviceIndex < c10::Device::MAX_NUM_DEVICES,
+      "Device index out of range for DeviceIndex");
   device.set_index(static_cast<c10::DeviceIndex>(deviceIndex));
   return device;
 }

--- a/torch/nativert/graph/TensorMeta.cpp
+++ b/torch/nativert/graph/TensorMeta.cpp
@@ -94,6 +94,9 @@ c10::Layout convertJsonLayout(const torch::_export::Layout& layout) {
 c10::Device convertJsonDevice(const torch::_export::Device& device) {
   c10::Device d(device.get_type());
   if (auto index = device.get_index()) {
+    TORCH_CHECK(
+        *index >= -1 && *index < c10::Device::MAX_NUM_DEVICES,
+        "Device index out of range for DeviceIndex");
     d.set_index(static_cast<at::DeviceIndex>(*index));
   }
   return d;

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -92,8 +92,8 @@ def _parse_visible_devices(strict=False) -> list[int]:
     r"""Parse ``ZE_AFFINITY_MASK`` and return visible device ordinals.
 
     Returns a list of non-negative device ordinals specified by the mask.
-    When the mask is unset, returns ``[0, 1, ..., 127]`` (the maximum range
-    for ``int8_t`` device indices).  Returns an empty list for unsupported
+    When the mask is unset, returns the full logical ``DeviceIndex`` range.
+    Returns an empty list for unsupported
     COMPOSITE-style masks (e.g. ``"0.0,0.1"``).
 
     Args:
@@ -103,9 +103,7 @@ def _parse_visible_devices(strict=False) -> list[int]:
     """
     var = os.getenv("ZE_AFFINITY_MASK")
     if var is None:
-        # DeviceIndex is stored as int8_t, so valid indices are 0–127
-        # (up to 128 devices). Return the full range when no mask is set.
-        return list(range(128))
+        return list(range(32767))
 
     visible_devices: list[int] = []
     for elem in var.split(","):


### PR DESCRIPTION
This PR is being opened as a draft only so I can review the implementation and CI results before submitting it for real review.

> AI-generated draft PR text, reviewed before submission.
>
> ## Issue
>
> Fixes #115331
>
> ## Summary
>
> PyTorch still had several int8_t-era device-index assumptions and fixed-size CUDA stream structures that effectively limited logical CUDA device indices. This widens the internal `DeviceIndex` representation to `int16_t`, adds explicit range checks at Python/C++/stable ABI boundaries, and removes CUDA stream state from the old compile-time GPU array limit.
>
> The stable ABI keeps the legacy `Tensor::get_device()` int8_t accessor with a range check and directs callers to `get_device_index()` for wider values.
>
> ## Checklist
>
> - [ ] Passes lint (`spin fixlint`)
> - [x] Added/updated tests
> - [ ] Updated documentation (if applicable)
> - [ ] Included benchmark results (for PRs impacting perf)
>
> ## BC-breaking?
>
> No.
>
> ## Test Plan
>
> Focused tests passed locally:
>
> ```bash
> python test/export/test_export.py -k test_export_fake_cuda_device_uses_logical_device_limit
> python test/test_utils.py -k large_device_index
> python test/test_utils.py -k device_index_out_of_bounds
> python test/test_jit.py -k test_int16_device_index
> ```
>
> CUDA+CPU editable build previously passed with `USE_CUDA=1`, `USE_ROCM=0`, `USE_XPU=0`. A post-lint-cleanup rebuild was attempted but timed out locally without compiler errors in the log. Full local test suite could not complete because distributed/process-group tests hung during interpreter shutdown; CUDA runtime tests were limited because this machine has no visible CUDA device.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98