### PR TITLE
[Inductor] Improve looped reduction codegen (relocate/skip mask, drop no-op broadcast) (#192529)

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -106,6 +106,31 @@ def xfail_if_tensor_descriptor(fn):
     return fn
 
 
+# (name, op, atol) for the reductions exercised by the grid-split tests. Kept in
+# one table so the parametrisations below name ops instead of repeating lambdas.
+_GRID_SPLIT_REDUCTIONS = (
+    ("sum", torch.Tensor.sum, 1e-2),
+    ("amax", torch.Tensor.amax, 0),
+    ("amin", torch.Tensor.amin, 0),
+    ("prod", torch.Tensor.prod, 1e-2),
+    ("mean", torch.Tensor.mean, 1e-3),
+)
+
+
+def _reduce(t: torch.Tensor, op: Callable[..., Any], dim: Any) -> torch.Tensor:
+    """Reduce over ``dim``, or over the whole tensor when ``dim`` is None."""
+    return op(t) if dim is None else op(t, dim)
+
+
+def _reduction_subtests(*names: str) -> list[Any]:
+    """``(op, atol)`` subtests for the named reductions, or all of them if unnamed."""
+    return [
+        subtest((op, atol), name=name)
+        for name, op, atol in _GRID_SPLIT_REDUCTIONS
+        if not names or name in names
+    ]
+
+
 class BlockDescriptorTestBase(InductorTestCase):
     block_descriptor_constructor_str = "tl.make_block_ptr"
 
@@ -139,6 +164,22 @@ class BlockDescriptorTestBase(InductorTestCase):
 
     def _get_lines_containing_substr(self, code: str, substr: str) -> str:
         return "\n".join(line for line in code.split("\n") if substr in line)
+
+    def _assert_grid_split_reduction(self, code):
+        # rsplit_start is unique to the grid-dim-split path. No-op on the
+        # tensor-descriptor backends, which fall back off TMA for the partial store.
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            joined = "\n".join(code)
+            self.assertIn("rsplit_start", joined)
+            self.assertIn("boundary_check", joined)
+
+    def _skip_if_host_side_tma(self):
+        # Pre-existing, unrelated: make_tensordesc_arg arity mismatch in
+        # static_triton_launcher fails all host-TMA descriptor kernels.
+        if config.triton.enable_host_side_tma:
+            raise unittest.SkipTest(
+                "host-side TMA static-launcher arg mismatch (pre-existing, unrelated)"
+            )
 
     def _run_and_compare(
         self: InductorTestCase,
@@ -1596,6 +1637,346 @@ class CommonTemplate:
                 self.assertTrue("boundary_check=[0, 1, 2]" in code)
                 # Loading b
                 self.assertTrue("boundary_check=[0, 1]" in code)
+
+    # Each split partition is its own grid program reducing a slice of the true
+    # reduction axis, so stage-1 loads stay real-extent block_ptrs.
+    #
+    # Ranks 1-4 with the reduced dim at every position. Extents are prime, so the
+    # split factor cannot divide them and every case exercises the boundary-checked
+    # tail; 2d_pow2 is the control where the split does divide evenly. A scalar
+    # output has no block_ptr store, hence 3 descriptors instead of 4.
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize("reduction_fn,atol", _reduction_subtests())
+    @parametrize(
+        "shape,dim,expected_num_block_pointers",
+        [
+            subtest(((100003,), 0, 3), name="1d"),
+            subtest(((8, 100003), 1, 4), name="2d_inner"),
+            subtest(((100003, 8), 0, 4), name="2d_outer"),
+            subtest(((8, 131072), 1, 4), name="2d_pow2"),
+            subtest(((4, 8, 20011), 2, 4), name="3d_inner"),
+            subtest(((4, 20011, 8), 1, 4), name="3d_middle"),
+            subtest(((20011, 4, 8), 0, 4), name="3d_outer"),
+            subtest(((2, 4, 8, 20011), 3, 4), name="4d_inner"),
+            subtest(((2, 4, 20011, 8), 2, 4), name="4d_middle2"),
+            subtest(((2, 20011, 4, 8), 1, 4), name="4d_middle1"),
+            subtest(((20011, 2, 4, 8), 0, 4), name="4d_outer"),
+        ],
+    )
+    def test_grid_split_reduction_block_ptr(
+        self, reduction_fn, atol, shape, dim, expected_num_block_pointers
+    ):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: _reduce(t, reduction_fn, dim),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=expected_num_block_pointers,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    # The split occupies x as a grid-only axis, so every dim that was not reduced
+    # keeps its own tile on y/z and its index stays affine. Were they instead
+    # flattened onto a single axis, the descriptor would have to recover them as
+    # `offsets=[yoffset // K, yoffset % K, ...]` for an innermost kept extent K, and
+    # match_mod_div_block only accepts that when K is a power of two.
+    #
+    # Every shape in test_grid_split_reduction_block_ptr above has a pow2 innermost
+    # kept extent (2, 4, 8), so it cannot observe that distinction; these use 10.
+    # Two or more kept dims are required -- a single kept dim gets its own axis
+    # either way, so e.g. (100003, 10) dim=0 was never affected.
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((4, 20011, 10), 1), name="3d_middle"),
+            subtest(((2, 4, 20011, 10), 2), name="4d_middle2"),
+        ],
+    )
+    def test_grid_split_reduction_non_pow2_kept_dim(self, shape, dim):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003, 4, 8), 0), name="3d_outer"),
+            subtest(((4, 100003, 8), 1), name="3d_middle"),
+            subtest(((2, 100003, 4, 8), 1), name="4d_middle"),
+            subtest(((2, 4, 100003, 8), 2), name="4d_middle2"),
+        ],
+    )
+    def test_grid_split_reduction_large_extent_int32(self, shape, dim):
+        self._skip_if_host_side_tma()
+        # The split inflates the stage-1 iteration numel past int32 even though the
+        # data fits, and an int64 fallback would disable the block_ptr gate.
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            input_block_ptrs = self._get_lines_containing_substr(
+                "\n".join(code), "tl.make_block_ptr(in_ptr0"
+            )
+            self.assertIn(str(shape[dim]), input_block_ptrs)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize(
+        "reduction_fn,make_input,atol,rtol",
+        [
+            subtest(
+                (torch.Tensor.amax, lambda s, d: -torch.rand(*s, device=d) - 1.0, 0, 0),
+                name="amax_all_negative",
+            ),
+            subtest(
+                (torch.Tensor.amin, lambda s, d: torch.rand(*s, device=d) + 1.0, 0, 0),
+                name="amin_all_positive",
+            ),
+            subtest(
+                (
+                    torch.Tensor.prod,
+                    lambda s, d: torch.rand(*s, device=d) * 2e-3 + 0.999,
+                    0,
+                    1e-3,
+                ),
+                name="prod_near_one",
+            ),
+        ],
+    )
+    def test_grid_split_reduction_zero_padding_does_not_leak(
+        self, reduction_fn, make_input, atol, rtol
+    ):
+        self._skip_if_host_side_tma()
+        # block_ptr can only pad with zero, which is not the identity for these ops.
+        # The inputs are chosen so a leaked padding lane changes the answer: 0 beats
+        # every element of an all-negative amax, loses to an all-positive amin, and
+        # zeroes a product of near-1 values. Correctness here comes from the
+        # accumulator mask, not from the padding value.
+        x = make_input((8, 100003), self.device)
+        _, code = self._run_and_compare(
+            lambda t: _reduce(t, reduction_fn, 1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize(
+        "dtype,atol,rtol",
+        [
+            subtest((torch.float32, 1e-2, 1e-2), name="fp32"),
+            subtest((torch.bfloat16, 1.0, 1e-1), name="bf16"),
+            subtest((torch.float16, 0.5, 1e-1), name="fp16"),
+        ],
+    )
+    def test_grid_split_reduction_dtypes(self, dtype, atol, rtol):
+        self._skip_if_host_side_tma()
+        x = torch.randn(8, 100003, device=self.device, dtype=dtype)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            # cast bool->int so _run_and_compare's allclose works on the output
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+        ],
+    )
+    def test_grid_split_reduction_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=2, expected_num_block_pointers=4
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    def test_grid_split_reduction_int(self):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": False,
+            # Pad every stride, not just those over the default 1024
+            # threshold. A threshold landing between two consecutive strides
+            # pads only the outer one, breaking
+            # `outer_stride == inner_extent * inner_stride` so the dims stop
+            # being mergeable and a flattened axis loses its block descriptor.
+            # Results stay correct either way; these tests assert descriptors.
+            "padding_stride_threshold": 0,
+            # Give each kept dim its own tile, so no flattened pointwise axis
+            # has to be recovered with FloorDiv/ModularIndexing.
+            **tiled_reduction_config,
+        }
+    )
+    def test_grid_split_reduction_disabled_by_default(self):
+        self._skip_if_host_side_tma()
+        # With the flag off, split reductions use the classic reshape path and must
+        # NOT emit the grid-split markers -- confirms the feature is fully gated.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=3,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
 
 
 @unittest.skipIf(not HAS_GPU, "requires triton GPU backend")

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -173,6 +173,16 @@ class BlockDescriptorTestBase(InductorTestCase):
             self.assertIn("rsplit_start", joined)
             self.assertIn("boundary_check", joined)
 
+    def _assert_no_accumulator_mask(self, code) -> None:
+        # No per-iteration accumulator mask (`_tmp<n> = tl.where(...)`); guarded to
+        # the make_block_ptr backend, which is the one that tags the zero-padded load.
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            self.assertNotRegex("\n".join(code), r"_tmp\d+ = tl\.where\(")
+
+    def _assert_has_accumulator_mask(self, code) -> None:
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            self.assertRegex("\n".join(code), r"_tmp\d+ = tl\.where\(")
+
     def _skip_if_host_side_tma(self):
         # Pre-existing, unrelated: make_tensordesc_arg arity mismatch in
         # static_triton_launcher fails all host-TMA descriptor kernels.
@@ -1975,6 +1985,193 @@ class CommonTemplate:
             expected_num_block_pointers=3,
             atol=1e-2,
             rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
+
+    # -------- mask_reduction_value_not_accumulator (value mask, not accumulator) -----
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+            subtest((lambda t, d: t.amax(d) if d is not None else t.amax(), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d) if d is not None else t.amin(), 0), name="amin"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003,), None), name="1d_full"),
+            subtest(((8, 100003), 1), name="2d_inner"),
+            subtest(((4, 8, 20000), 2), name="3d_inner"),
+        ],
+    )
+    def test_grid_split_reduction_masks_value_not_accumulator(
+        self, reduction_fn, atol, shape, dim
+    ):
+        self._skip_if_host_side_tma()
+        # Non-zero identity (prod/amax/amin): correct numerics with no accumulator
+        # mask proves the value was masked to the identity (a 0 tail would corrupt).
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_no_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    def test_grid_split_reduction_skips_sum_accumulator_mask(self):
+        self._skip_if_host_side_tma()
+        # identity-0 (sum): the zero pad is the identity, so the accumulator mask is
+        # dropped (default-on, independent of mask_reduction_value_not_accumulator).
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_no_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": False,
+        }
+    )
+    def test_grid_split_reduction_prod_keeps_accumulator_mask_when_flag_off(self):
+        self._skip_if_host_side_tma()
+        # Gating guard: with the flag off, prod (identity 1 != zero pad) keeps its
+        # per-iteration accumulator mask -- exactly what the flag relocates.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.prod(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_has_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    def test_grid_split_reduction_fused_mixed_identity(self):
+        self._skip_if_host_side_tma()
+        # Different identities over one buffer (sum skipped, amax value-masked):
+        # guards per-load identity-padding disambiguation.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1) + t.amax(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+        ],
+    )
+    def test_grid_split_reduction_value_mask_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            subtest(lambda t: t.sum(dim=1), name="sum"),
+            subtest(lambda t: t.amax(dim=1), name="amax"),
+            subtest(lambda t: t.amin(dim=1), name="amin"),
+        ],
+    )
+    def test_grid_split_reduction_value_mask_int(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t: t.sum(dim=1), 1e-3), name="sum"),
+            subtest((lambda t: t.prod(dim=1), 1e-3), name="prod"),
+            subtest((lambda t: t.amax(dim=1), 0), name="amax"),
+        ],
+    )
+    def test_grid_split_reduction_persistent_flag(self, reduction_fn, atol):
+        self._skip_if_host_side_tma()
+        # Small reduction stays persistent (not grid-split); exercises the flag's
+        # no-op-broadcast skip on the persistent path, which keeps its own broadcast.
+        x = torch.randn(8, 100, device=self.device)
+        _, code = self._run_and_compare(
+            reduction_fn,
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-3,
         )
         self.assertNotIn("rsplit_start", "\n".join(code))
 

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -151,6 +151,16 @@ class BlockDescriptorTestBase(InductorTestCase):
             self.assertIn("rsplit_start", joined)
             self.assertIn("boundary_check", joined)
 
+    def _assert_no_accumulator_mask(self, code) -> None:
+        # No per-iteration accumulator mask (`_tmp<n> = tl.where(...)`); guarded to
+        # the make_block_ptr backend, which is the one that tags the zero-padded load.
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            self.assertNotRegex("\n".join(code), r"_tmp\d+ = tl\.where\(")
+
+    def _assert_has_accumulator_mask(self, code) -> None:
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            self.assertRegex("\n".join(code), r"_tmp\d+ = tl\.where\(")
+
     def _skip_if_host_side_tma(self):
         # Host-side TMA is broken by a pre-existing Triton static-launcher arg-count
         # mismatch (runtime/static_triton_launcher.py: make_tensordesc_arg is called
@@ -1821,6 +1831,193 @@ class CommonTemplate:
             expected_num_triton_kernels=None,
             atol=1e-2,
             rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
+
+    # -------- mask_reduction_value_not_accumulator (value mask, not accumulator) -----
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+            subtest((lambda t, d: t.amax(d) if d is not None else t.amax(), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d) if d is not None else t.amin(), 0), name="amin"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003,), None), name="1d_full"),
+            subtest(((8, 100003), 1), name="2d_inner"),
+            subtest(((4, 8, 20000), 2), name="3d_inner"),
+        ],
+    )
+    def test_grid_split_reduction_masks_value_not_accumulator(
+        self, reduction_fn, atol, shape, dim
+    ):
+        self._skip_if_host_side_tma()
+        # Non-zero identity (prod/amax/amin): correct numerics with no accumulator
+        # mask proves the value was masked to the identity (a 0 tail would corrupt).
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_no_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    def test_grid_split_reduction_skips_sum_accumulator_mask(self):
+        self._skip_if_host_side_tma()
+        # identity-0 (sum): the zero pad is the identity, so the accumulator mask is
+        # dropped (default-on, independent of mask_reduction_value_not_accumulator).
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_no_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": False,
+        }
+    )
+    def test_grid_split_reduction_prod_keeps_accumulator_mask_when_flag_off(self):
+        self._skip_if_host_side_tma()
+        # Gating guard: with the flag off, prod (identity 1 != zero pad) keeps its
+        # per-iteration accumulator mask -- exactly what the flag relocates.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.prod(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        self._assert_has_accumulator_mask(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    def test_grid_split_reduction_fused_mixed_identity(self):
+        self._skip_if_host_side_tma()
+        # Different identities over one buffer (sum skipped, amax value-masked):
+        # guards per-load identity-padding disambiguation.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1) + t.amax(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+        ],
+    )
+    def test_grid_split_reduction_value_mask_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            subtest(lambda t: t.sum(dim=1), name="sum"),
+            subtest(lambda t: t.amax(dim=1), name="amax"),
+            subtest(lambda t: t.amin(dim=1), name="amin"),
+        ],
+    )
+    def test_grid_split_reduction_value_mask_int(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+            "mask_reduction_value_not_accumulator": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t: t.sum(dim=1), 1e-3), name="sum"),
+            subtest((lambda t: t.prod(dim=1), 1e-3), name="prod"),
+            subtest((lambda t: t.amax(dim=1), 0), name="amax"),
+        ],
+    )
+    def test_grid_split_reduction_persistent_flag(self, reduction_fn, atol):
+        self._skip_if_host_side_tma()
+        # Small reduction stays persistent (not grid-split); exercises the flag's
+        # no-op-broadcast skip on the persistent path, which keeps its own broadcast.
+        x = torch.randn(8, 100, device=self.device)
+        _, code = self._run_and_compare(
+            reduction_fn,
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-3,
         )
         self.assertNotIn("rsplit_start", "\n".join(code))
 

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -140,6 +140,27 @@ class BlockDescriptorTestBase(InductorTestCase):
     def _get_lines_containing_substr(self, code: str, substr: str) -> str:
         return "\n".join(line for line in code.split("\n") if substr in line)
 
+    def _assert_grid_split_reduction(self, code):
+        # rsplit_start only appears on the grid-dim-split path, so its presence
+        # proves the split was lowered as a grid dim (not the classic reshape);
+        # boundary_check confirms the real-extent block_ptr. Guarded to the
+        # make_block_ptr backend (no-op on the tensor-descriptor backends, which
+        # fall back off TMA for the single-element partial store).
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            joined = "\n".join(code)
+            self.assertIn("rsplit_start", joined)
+            self.assertIn("boundary_check", joined)
+
+    def _skip_if_host_side_tma(self):
+        # Host-side TMA is broken by a pre-existing Triton static-launcher arg-count
+        # mismatch (runtime/static_triton_launcher.py: make_tensordesc_arg is called
+        # with 3 args but the installed Triton backend takes 2), which fails ALL
+        # host-TMA descriptor kernels regardless of split reductions.
+        if config.triton.enable_host_side_tma:
+            raise unittest.SkipTest(
+                "host-side TMA static-launcher arg mismatch (pre-existing, unrelated)"
+            )
+
     def _run_and_compare(
         self: InductorTestCase,
         func: Callable[..., Any],
@@ -147,7 +168,7 @@ class BlockDescriptorTestBase(InductorTestCase):
         compile_kwargs: dict | None = None,
         expected_num_block_pointers: int | None = None,
         expected_num_programs: int = 1,
-        expected_num_triton_kernels: int = 1,
+        expected_num_triton_kernels: int | None = 1,
         config_patches: dict | None = None,
         rtol: float | None = None,
         atol: float | None = None,
@@ -1596,6 +1617,212 @@ class CommonTemplate:
                 self.assertTrue("boundary_check=[0, 1, 2]" in code)
                 # Loading b
                 self.assertTrue("boundary_check=[0, 1]" in code)
+
+    # -------- force_split_reduction_as_grid_dim (split lowered as a grid dim) -------
+    # This path lowers a split reduction so each split partition is a grid program
+    # (program_id(0)) reducing its slice [rsplit_start, rsplit_end) of the TRUE
+    # reduction axis into buf0[..., partition]; stage-2 combines over the split
+    # axis. Every stage-1 load stays a real-extent, boundary-checked block_ptr
+    # (no [split, block_size] over-covering staircase / OOB read).
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d) if d is not None else t.sum(), 1e-2), name="sum"),
+            subtest((lambda t, d: t.amax(d) if d is not None else t.amax(), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d) if d is not None else t.amin(), 0), name="amin"),
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+            subtest((lambda t, d: t.mean(d) if d is not None else t.mean(), 1e-3), name="mean"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003,), None), name="1d_full"),
+            subtest(((1, 100003), None), name="2d_full"),
+            subtest(((8, 100003), 1), name="2d_inner"),
+            subtest(((100003, 8), 0), name="2d_outer"),
+            subtest(((4, 8, 20000), 2), name="3d_inner"),
+            subtest(((4, 20000, 8), 1), name="3d_middle"),
+            subtest(((20000, 4, 8), 0), name="3d_outer"),
+        ],
+    )
+    def test_grid_split_reduction_block_ptr(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d), 1e-2), name="sum"),
+            subtest((lambda t, d: t.amax(d), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d), 0), name="amin"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((8, 16, 4000), (1, 2)), name="3d_inner2"),
+            subtest(((4, 8, 6000), (0, 1, 2)), name="3d_full"),
+            subtest(((4, 50000, 8), (0, 1)), name="3d_outer2"),
+            subtest(((2, 4, 8, 3000), (1, 2, 3)), name="4d"),
+        ],
+    )
+    def test_grid_split_reduction_multi_axis(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d) if d is not None else t.sum(), 1e-2), name="sum"),
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((99991,), None), name="1d_prime"),
+            subtest(((3, 99991), 1), name="2d_inner_prime"),
+            subtest(((99991, 3), 0), name="2d_outer_prime"),
+        ],
+    )
+    def test_grid_split_reduction_non_divisible(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        # Prime reduction lengths: the partition chunk does not divide the axis, so
+        # the last partition's boundary-checked tail is exercised.
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "dtype,atol,rtol",
+        [
+            subtest((torch.float32, 1e-2, 1e-2), name="fp32"),
+            subtest((torch.bfloat16, 1.0, 1e-1), name="bf16"),
+            subtest((torch.float16, 0.5, 1e-1), name="fp16"),
+        ],
+    )
+    def test_grid_split_reduction_dtypes(self, dtype, atol, rtol):
+        self._skip_if_host_side_tma()
+        x = torch.randn(8, 100003, device=self.device, dtype=dtype)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            # cast bool->int so _run_and_compare's allclose works on the output
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+        ],
+    )
+    def test_grid_split_reduction_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    def test_grid_split_reduction_int(self):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1), x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": False,
+        }
+    )
+    def test_grid_split_reduction_disabled_by_default(self):
+        self._skip_if_host_side_tma()
+        # With the flag off, split reductions use the classic reshape path and must
+        # NOT emit the grid-split markers -- confirms the feature is fully gated.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
 
 
 @unittest.skipIf(not HAS_GPU, "requires triton GPU backend")

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -35,7 +35,7 @@ from .virtualized import V
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
     from functools import partial
 
     from triton import Config as TritonConfig

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2287,6 +2287,9 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
         self.store_buffer_names: OrderedSet[str] = OrderedSet()
         self._load_mask: str | None = None
         self._load_other: None | int | float = None
+        # Maps a zero-padded load's cse_var to the identity its OOB lanes hold (0),
+        # so a reduction over it can skip its accumulator mask.
+        self._identity_padding_values: dict[str, bool | int | float] = {}
         # OrderedSet in set_current_node
         self.current_node: SchedulerNode | None = None
         self.node_to_bounds: dict[torch.fx.Node, ValueRanges[Any]] | None = None

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -534,6 +534,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         override_cooperative_reduction: bool | None = None,
         tiling_scores: dict[str, sympy.Expr] | None = None,
         mix_order_reduction: bool = False,
+        split_as_grid_reduction: bool = False,
     ) -> None:
         if pid_cache is None:
             pid_cache = {}
@@ -562,6 +563,15 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             else self.should_use_persistent_reduction()
         )
         self.mix_order_reduction: bool = mix_order_reduction
+        # True when the split is lowered as an extra grid dim (see
+        # Reduction.create_multilayer_split_as_grid); the split count is read from
+        # the x numel in codegen. Sits with the other reduction-mode flags above.
+        self.split_as_grid_reduction: bool = split_as_grid_reduction
+        if self.split_as_grid_reduction and self.persistent_reduction:
+            # The per-partition [rsplit_start, rsplit_end) bounds are only emitted on
+            # the looped path, so force looped (a persistent kernel drops them and
+            # each program would reduce the full axis).
+            self.persistent_reduction = False
         self.no_x_dim = self.want_no_x_dim()
         self.code_hash: str | None = None
         # Info to enable multiple store_output calls for epilogue subtiling
@@ -4807,6 +4817,20 @@ class SIMDScheduling(BaseScheduling):
                     range_r = node_ranges[1]  # (K)
                     tiling = cls.create_tiling(range_y_x, range_r)
                     return _TilingSelection(tiling, None, None)
+
+        # Split-as-grid-dim reduction: put the split on x (its own grid dim) and any
+        # kept rows on y (affine), rather than flattening rows*split into one x (which
+        # would force `xindex // split`, a non-affine index off the block_ptr path).
+        # For a full/1-D reduction (numel == split) the split is the only pointwise dim.
+        for node in EnableReduction.filter(node_schedule):
+            if isinstance(node.node, ir.ComputedBuffer):
+                split = getattr(node.node, "_grid_split_factor", 0)
+                if not split:
+                    continue
+                if V.graph.sizevars.statically_known_equals(numel, split):
+                    return cls.create_tiling([split], [reduction_numel]), None
+                rows = numel // split
+                return cls.create_tiling([rows, split], [reduction_numel]), None
 
         # # TODO: enable by default
         if (

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -534,6 +534,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         override_cooperative_reduction: bool | None = None,
         tiling_scores: dict[str, sympy.Expr] | None = None,
         mix_order_reduction: bool = False,
+        split_as_grid_reduction: bool = False,
     ) -> None:
         if pid_cache is None:
             pid_cache = {}
@@ -562,6 +563,18 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             else self.should_use_persistent_reduction()
         )
         self.mix_order_reduction: bool = mix_order_reduction
+        # Split lowered as an extra grid dim; the count is read from the x numel.
+        self.split_as_grid_reduction: bool = split_as_grid_reduction
+        if self.split_as_grid_reduction and self.cooperative_reduction:
+            # Both partition the reduction with their own rsplit_* bounds off
+            # program_id(0); the second definition would silently shadow the first.
+            raise AssertionError(
+                "split_as_grid_reduction and cooperative_reduction are mutually exclusive"
+            )
+        if self.split_as_grid_reduction and self.persistent_reduction:
+            # Only the looped path emits the per-partition bounds; a persistent
+            # kernel would drop them and reduce the full axis in every program.
+            self.persistent_reduction = False
         self.no_x_dim = self.want_no_x_dim()
         self.code_hash: str | None = None
         # Info to enable multiple store_output calls for epilogue subtiling
@@ -673,7 +686,12 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         pointwise_tensor_dims = list(reversed(grid_dims))
         reduction_dims = ["r0_", "r1_"]
         if no_x_dim:
-            tensor_dims = reduction_dims
+            # `x` becomes a grid-only axis: it keeps its grid dim but has no tensor
+            # dim. Any other pointwise dims keep theirs. For kernels whose only
+            # pointwise dim is `x` this is identical to dropping them all.
+            tensor_dims = [
+                dim for dim in pointwise_tensor_dims if dim != "x"
+            ] + reduction_dims
         elif no_r_dim:
             tensor_dims = pointwise_tensor_dims
         else:
@@ -4772,6 +4790,49 @@ class SIMDScheduling(BaseScheduling):
         return selection.tiling, selection.tiling_scores
 
     @classmethod
+    def _grid_split_tiling(
+        cls,
+        node: NodeScheduleEntry,
+        numel: sympy.Expr,
+        reduction_numel: sympy.Expr,
+        split: int,
+    ) -> immutable_dict[str, sympy.Expr]:
+        """Pointwise tiling for a split-as-grid stage-1 kernel.
+
+        Stage-1's ranges are ``[*kept, split]``. Each kept dim gets its own tile so
+        its index stays affine, and the split goes last so it lands on x, which for
+        these kernels carries no tensor dim. Falls back to the flat
+        ``[numel // split, split]`` tiling whenever the kept dims cannot be laid out
+        that way -- never worse than the previous behaviour.
+        """
+        sizevars = V.graph.sizevars
+        if sizevars.statically_known_equals(numel, split):
+            return cls.create_tiling([split], [reduction_numel])
+
+        fallback = cls.create_tiling([numel // split, split], [reduction_numel])
+
+        pointwise_ranges = list(node.get_ranges()[0])
+        if not pointwise_ranges or not sizevars.statically_known_equals(
+            pointwise_ranges[-1], split
+        ):
+            return fallback
+
+        kept = [
+            rng
+            for rng in pointwise_ranges[:-1]
+            if not sizevars.statically_known_equals(rng, 1)
+        ]
+        if not kept:
+            return fallback
+        # x belongs to the split, leaving y and z for the kept dims.
+        if len(kept) > 2:
+            kept = [sympy_product(kept[:-1]), kept[-1]]
+        if not sizevars.statically_known_equals(sympy_product(kept) * split, numel):
+            return fallback
+
+        return cls.create_tiling([*kept, split], [reduction_numel])
+
+    @classmethod
     def select_tiling_with_memory(
         cls,
         node_schedule,
@@ -4807,6 +4868,19 @@ class SIMDScheduling(BaseScheduling):
                     range_r = node_ranges[1]  # (K)
                     tiling = cls.create_tiling(range_y_x, range_r)
                     return _TilingSelection(tiling, None, None)
+
+        # The split takes x, which for these kernels is a grid-only axis with no
+        # tensor dim (see want_no_x_dim). The dims that were not reduced keep their
+        # own tiles on y/z, so their index stays affine; flattening them into one
+        # axis would force `yindex // K`, which the block_ptr matcher rejects unless
+        # K is a power of two.
+        for node in EnableReduction.filter(node_schedule):
+            if isinstance(node.node, ir.ComputedBuffer):
+                split = node.node._grid_split_factor
+                if not split:
+                    continue
+                tiling = cls._grid_split_tiling(node, numel, reduction_numel, split)
+                return _TilingSelection(tiling, None, None)
 
         # # TODO: enable by default
         if (

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -296,6 +296,18 @@ class SIMDKernelFeatures:
             reduction_hint_val = ReductionHint.DEFAULT
         return reduction_hint_val
 
+    def get_grid_split(self) -> int:
+        """
+        If this kernel's stage-1 reduction was tagged for split-as-grid-dim
+        lowering, return the split factor; otherwise 0. The tag is set on the
+        realized stage-1 buffer by ``Reduction.create_multilayer_split_as_grid``.
+        """
+        for n in self.reduction_nodes():
+            factor = getattr(n.node, "_grid_split_factor", 0)
+            if factor:
+                return factor
+        return 0
+
     @cache_on_self
     def buffer_read_counts(self) -> dict[str, int]:
         """Counts how many times each buffer is read within the kernel"""

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -212,6 +212,13 @@ class SIMDKernelFeatures:
         # conservative here.
         total_numel = self.numel * self.reduction_numel
 
+        # The split is a pointwise dim while the reduction axis keeps its true
+        # extent, so total_numel counts each element `split` times. Divide it out;
+        # storage_size() and any_index_expr_overflows_int32() still bound the rest.
+        grid_split = self.get_grid_split()
+        if grid_split:
+            total_numel = FloorDiv(total_numel, grid_split)
+
         from .simd import SIMDScheduling
 
         if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
@@ -322,6 +329,13 @@ class SIMDKernelFeatures:
         else:
             reduction_hint_val = ReductionHint.DEFAULT
         return reduction_hint_val
+
+    def get_grid_split(self) -> int:
+        """The grid split factor, or 0 if this kernel is not split as a grid dim."""
+        for n in self.reduction_nodes():
+            if isinstance(n.node, ir.ComputedBuffer) and n.node._grid_split_factor:
+                return n.node._grid_split_factor
+        return 0
 
     @cache_on_self
     def buffer_read_counts(self) -> dict[str, int]:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -572,8 +572,13 @@ class BlockDescriptorOptions:
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def compute_boundary_check(
@@ -809,8 +814,13 @@ class BlockPtrOptions(BlockDescriptorOptions):
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def format(self, name: str, roffset=True) -> str:
@@ -2959,13 +2969,13 @@ class TMACompatibilityChecker:
             )
             return False
 
-        # `no_x_dim` => XBLOCK=1, and for reductions this means only one element
-        # is to be stored . However the TMA API requires that
-        # the store will be 16 byte aligned, which is not attainable with a single
-        # element
-        if self.for_store and self.kernel.no_x_dim:
+        # no_x_dim / split_as_grid_reduction => XBLOCK==1, so a reduction store is a
+        # single element and can't meet TMA's 16-byte alignment; fall back off TMA.
+        if self.for_store and (
+            self.kernel.no_x_dim or self.kernel.split_as_grid_reduction
+        ):
             log.debug(
-                "%s stores with `no_x_dim` cannot load 16 bytes.",
+                "%s single-element stores cannot load 16 bytes.",
                 self.failed_debug_prefix,
             )
             return False
@@ -3331,6 +3341,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if self.cooperative_reduction:
             self.init_cooperative_reduction()
 
+        if self.split_as_grid_reduction:
+            self.init_split_as_grid_reduction()
+
         self.codegen_range_tree()
 
         if self.cooperative_reduction:
@@ -3685,6 +3698,37 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.body.writeline(
                 "rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)"
             )
+
+    def init_split_as_grid_reduction(self):
+        """Emit per-partition reduction bounds for a split-as-grid-dim reduction.
+
+        The split is the x grid dim (one program per partition via program_id(0),
+        XBLOCK == 1); each program reduces [rsplit_start, rsplit_end) of the true
+        axis into buf0[..., program_id(0)] and stage-2 combines over the split axis.
+        rsplit_chunk is a multiple of RBLOCK so partitions never overlap.
+        """
+        if not self.split_as_grid_reduction:
+            raise AssertionError("expected split_as_grid_reduction")
+        # The split count is the x dim extent (see get_tiling_and_scores).
+        split = self.numels["x"]
+        # The flat [rsplit_start, rsplit_end) bounds assume a single reduction dim;
+        # more would silently misapply them, so fail loudly.
+        reduction_trees = [t for t in self.range_trees if t.is_reduction]
+        if len(reduction_trees) != 1:
+            raise AssertionError(
+                "split_as_grid_reduction requires exactly one reduction dimension, "
+                f"got {len(reduction_trees)}"
+            )
+        self.body.splice(
+            f"""\
+            rsplit_id = tl.program_id(0)
+            num_rblocks = (rnumel + RBLOCK - 1) // RBLOCK
+            rsplit_chunk = (num_rblocks + {split} - 1) // {split} * RBLOCK
+            rsplit_start = rsplit_chunk * rsplit_id
+            rsplit_end = rsplit_chunk * (rsplit_id + 1)
+            rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)
+            """,
+        )
 
     def init_cooperative_reduction_mask(self):
         rsplit_arange = "tl.arange(0, RSPLIT_NEXT_POWER_OF_2)"
@@ -6097,6 +6141,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            if isinstance(indexing, TensorDescriptorOptions):
+                # store_reduction emits the descriptor store inline (not through
+                # codegen_block_ptr), so record that a device-side TMA was emitted.
+                # Otherwise the tma_min_block_sizes strip in codegen_kernel drops the
+                # innermost-block >=16-byte floor for this store, the autotuner keeps
+                # XBLOCK==1, and the descriptor fails to compile ("at least 16 bytes
+                # in the last dimension").
+                self._emitted_device_tma = True
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,
@@ -6587,10 +6639,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for level, tree in enumerate(loop_trees):
                 with self.body.indent(offset=level):
                     prefix = tree.prefix
-                    loop_start = "rsplit_start" if self.cooperative_reduction else "0"
-                    loop_end = (
-                        "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
+                    partitioned = (
+                        self.cooperative_reduction or self.split_as_grid_reduction
                     )
+                    loop_start = "rsplit_start" if partitioned else "0"
+                    loop_end = "rsplit_end" if partitioned else f"{prefix}numel"
                     # Conditionalize pipelining on HIP for Triton due to
                     # reports of numerical inaccuracies on older Triton
                     if torch.version.hip and get_triton_version() > (3, 2):
@@ -6970,6 +7023,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         }
         if self.mix_order_reduction:
             out["RSPLIT_SIZE"] = self.rsplit_size
+        if self.split_as_grid_reduction:
+            # Clamp the x (split) grid axis to XBLOCK == 1 so each program owns one
+            # partition; R0_BLOCK is still autotuned.
+            out["split_as_grid_reduction"] = True
         if config.deterministic or config.test_configs.force_filter_reduction_configs:
             out["has_loadstore_with_contiguous_rdim"] = (
                 self.has_load_with_contiguous_rdim
@@ -8304,6 +8361,9 @@ class TritonScheduling(SIMDScheduling):
             kernel_kwargs["override_cooperative_reduction"] = False
 
         kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
+
+        if kernel_features.get_grid_split():
+            kernel_kwargs["split_as_grid_reduction"] = True
 
         kernel_kwargs = V.choices.triton_kernel_kwargs(
             kernel_type, kernel_features, kernel_args, kernel_kwargs

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -491,12 +491,17 @@ class BlockDescriptorOptions:
         # Compute the final shape, adjusting for special kernel types.
         final_shape = [TritonSymbols.get_block_size(tree) for tree in range_trees]
         if V.kernel.no_x_dim:
-            if range_trees[0].prefix != "x":
+            # x carries no tensor dim. It is not necessarily first: a split-as-grid
+            # kernel keeps y/z tensor dims for the dims it did not reduce.
+            x_positions = [
+                idx for idx, tree in enumerate(range_trees) if tree.prefix == "x"
+            ]
+            if len(x_positions) != 1:
                 raise AssertionError(
-                    f"expected first range tree prefix to be 'x', got "
-                    f"{range_trees[0].prefix!r}"
+                    f"expected exactly one 'x' range tree, got "
+                    f"{[tree.prefix for tree in range_trees]}"
                 )
-            final_shape.pop(0)
+            final_shape.pop(x_positions[0])
 
         # Check to see which of the final shape dimensions are included in this parameter
         # e.g. if block shape is [XBLOCK // 2, XBLOCK % 2], but the kernel shape
@@ -573,8 +578,13 @@ class BlockDescriptorOptions:
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def compute_boundary_check(
@@ -810,8 +820,13 @@ class BlockPtrOptions(BlockDescriptorOptions):
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def format(self, name: str, roffset=True) -> str:
@@ -2956,11 +2971,11 @@ class TMACompatibilityChecker:
             )
             return False
 
-        # Strict multirow reductions are forced persistent and can settle on
-        # XBLOCK=1 after the initial TMA probe. Their output store must therefore
-        # use the scalar fallback rather than a 16-byte tensor descriptor.
+        # These all settle on XBLOCK=1, so the store cannot reach TMA's 16-byte
+        # minimum and must fall back off the tensor descriptor.
         if self.for_store and (
-            self.kernel.no_x_dim or self.kernel.features.has_strict_multirow_reduction()
+            self.kernel.no_x_dim or self.kernel.split_as_grid_reduction
+            or self.kernel.features.has_strict_multirow_reduction()
         ):
             log.debug(
                 "%s stores with XBLOCK=1 cannot transfer 16 bytes.",
@@ -3339,6 +3354,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if self.cooperative_reduction:
             self.init_cooperative_reduction()
 
+        if self.split_as_grid_reduction:
+            self.init_split_as_grid_reduction()
+
         self.codegen_range_tree()
 
         if self.cooperative_reduction:
@@ -3696,6 +3714,37 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 "rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)"
             )
 
+    def init_split_as_grid_reduction(self):
+        """Emit per-partition reduction bounds for a split-as-grid-dim reduction.
+
+        The split is the x grid dim (one program per partition via program_id(0),
+        XBLOCK == 1); each program reduces [rsplit_start, rsplit_end) of the true
+        axis into buf0[..., program_id(0)] and stage-2 combines over the split axis.
+        rsplit_chunk is a multiple of RBLOCK so partitions never overlap.
+        """
+        if not self.split_as_grid_reduction:
+            raise AssertionError("expected split_as_grid_reduction")
+        # The split count is the x dim extent (see get_tiling_and_scores).
+        split = self.numels["x"]
+        # The flat [rsplit_start, rsplit_end) bounds assume a single reduction dim;
+        # more would silently misapply them, so fail loudly.
+        reduction_trees = [t for t in self.range_trees if t.is_reduction]
+        if len(reduction_trees) != 1:
+            raise AssertionError(
+                "split_as_grid_reduction requires exactly one reduction dimension, "
+                f"got {len(reduction_trees)}"
+            )
+        self.body.splice(
+            f"""\
+            rsplit_id = tl.program_id(0)
+            num_rblocks = (rnumel + RBLOCK - 1) // RBLOCK
+            rsplit_chunk = (num_rblocks + {split} - 1) // {split} * RBLOCK
+            rsplit_start = rsplit_chunk * rsplit_id
+            rsplit_end = rsplit_chunk * (rsplit_id + 1)
+            rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)
+            """,
+        )
+
     def init_cooperative_reduction_mask(self):
         rsplit_arange = "tl.arange(0, RSPLIT_NEXT_POWER_OF_2)"
         if not self.no_x_dim:
@@ -3774,6 +3823,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return self.features.strict_reduction_rblock()
 
     def want_no_x_dim(self):
+        if self.split_as_grid_reduction:
+            # The split owns x purely as a grid dim -- one partition per program,
+            # never a tensor axis. This keeps the kept dims on their own tiles
+            # instead of being flattened into a single axis to make room for it.
+            return True
         return (
             self.persistent_reduction
             and len(self.numels) == self.num_reduction_dims + 1
@@ -6281,6 +6335,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            if isinstance(indexing, TensorDescriptorOptions):
+                # store_reduction bypasses codegen_block_ptr, so without this
+                # codegen_kernel strips the >=16-byte floor and the store won't compile.
+                self._emitted_device_tma = True
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,
@@ -6771,10 +6829,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for level, tree in enumerate(loop_trees):
                 with self.body.indent(offset=level):
                     prefix = tree.prefix
-                    loop_start = "rsplit_start" if self.cooperative_reduction else "0"
-                    loop_end = (
-                        "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
+                    partitioned = (
+                        self.cooperative_reduction or self.split_as_grid_reduction
                     )
+                    loop_start = "rsplit_start" if partitioned else "0"
+                    loop_end = "rsplit_end" if partitioned else f"{prefix}numel"
                     # Conditionalize pipelining on HIP for Triton due to
                     # reports of numerical inaccuracies on older Triton
                     if torch.version.hip and get_triton_version() > (3, 2):
@@ -7154,6 +7213,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         }
         if self.mix_order_reduction:
             out["RSPLIT_SIZE"] = self.rsplit_size
+        if self.split_as_grid_reduction:
+            # Clamp the x (split) grid axis to XBLOCK == 1 so each program owns one
+            # partition; R0_BLOCK is still autotuned.
+            out["split_as_grid_reduction"] = True
         if config.deterministic or config.test_configs.force_filter_reduction_configs:
             out["has_loadstore_with_contiguous_rdim"] = (
                 self.has_load_with_contiguous_rdim
@@ -8503,6 +8566,9 @@ class TritonScheduling(SIMDScheduling):
             kernel_kwargs["override_cooperative_reduction"] = False
 
         kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
+
+        if kernel_features.get_grid_split():
+            kernel_kwargs["split_as_grid_reduction"] = True
 
         kernel_kwargs = V.choices.triton_kernel_kwargs(
             kernel_type, kernel_features, kernel_args, kernel_kwargs

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5046,6 +5046,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         append_broadcast = None
         shape: BlockShapeType = None
+        # Set when the block_ptr load boundary-pads OOB elements with zero, so a
+        # reduction over it can skip its accumulator mask when 0 is the identity.
+        block_ptr_zero_padded = False
 
         if should_unwrap_unspec_arg(name):
             line = var
@@ -5060,10 +5063,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         else:
             if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+                # A zero `other` default plus a boundary_check makes
+                # codegen_block_ptr zero-pad OOB elements. Detect from the
+                # structured signals, not the formatted load string.
+                zero_default = other == ", other=0.0"
                 block_descriptor, other = self.codegen_block_ptr(
                     name, var, indexing, other
                 )
                 if isinstance(indexing, BlockPtrOptions):
+                    block_ptr_zero_padded = zero_default and indexing.has_mask()
                     line = f"tl.load({block_descriptor}{other}{ep}{cachemod})"
                 else:
                     line = self.codegen_descriptor_load_line(block_descriptor, indexing)
@@ -5166,6 +5174,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             and not reduction_axes_omitted
         ):
             self.outside_loop_vars.add(result_var)
+
+        if block_ptr_zero_padded:
+            V.kernel._identity_padding_values[str(result_var)] = 0.0
 
         return result_var
 
@@ -5421,6 +5432,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         do_upcast = pytree.tree_any(lambda v: should_upcast(v.dtype), value)
         original_dtype = dtype
         original_src_dtype = src_dtype
+
+        # Per-load identity padding recorded at the load() site (e.g. a zero-padded
+        # block_ptr load); looked up on the pre-upcast value var.
+        identity_padding = (
+            self._identity_padding_values.get(str(value))
+            if isinstance(value, CSEVariable)
+            else None
+        )
+
         if do_upcast:
             # Only promote FB16/BF16; do not promote other integer/boolean dtypes
             value = pytree.tree_map(maybe_upcast, value)
@@ -5473,15 +5493,38 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # tmp0 in the triton code is either a scalar, or single-element tensor
         # so if we emit tl.sum directly, it will only give 1 instead of RBLOCK * 1
         # To avoid this, we broadcast to the expected shape first.
-        value = self._map_tuple_or_scalar(
-            lambda v: self.cse.generate(
+        acc_default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
+        cond = " & ".join(masks)
+        # The looped combine re-broadcasts the value, so the explicit broadcast is
+        # redundant here; persistent reductions still need it.
+        defer_value_broadcast = (
+            config.mask_reduction_value_not_accumulator
+            and not self.persistent_reduction
+            and bool(cond)
+            and not isinstance(acc_default, tuple)
+            and not reduction_type.startswith("arg")
+            and not is_welford_reduction(reduction_type)
+            and reduction_type not in ("online_softmax_reduce", "dot")
+        )
+
+        def _broadcast_reduction_value(v: CSEVariable) -> CSEVariable:
+            if defer_value_broadcast:
+                return v
+            # Skip a no-op broadcast (value already at the dense size).
+            if (
+                config.mask_reduction_value_not_accumulator
+                and v.shape is not None
+                and triton_shape_dims(v.shape) == triton_shape_dims(value_shape)
+            ):
+                return v
+            return self.cse.generate(
                 self.compute,
                 f"tl.broadcast_to({v}, {dense_size_str})",
                 dtype=v.dtype,
                 shape=value_shape,
-            ),
-            value,
-        )
+            )
+
+        value = self._map_tuple_or_scalar(_broadcast_reduction_value, value)
 
         arg_index_reduction_types = ("argmax", "argmin")
         arg_value_reduction_types = ("argmax_value", "argmin_value")
@@ -5645,8 +5688,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             result_var.mask_vars = result_mask_vars
         cond = " & ".join(masks)
 
+        # Drop the accumulator mask when the load's OOB pad is already the reduction
+        # identity (safe only for zero-padded block_ptr loads; see diff summary).
+        acc_default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
+        skip_accumulator_masking = (
+            not isinstance(acc_default, tuple)
+            and identity_padding is not None
+            and acc_default == identity_padding
+        )
+
         def where_cond(tval, fval):
-            if not cond:
+            if not cond or skip_accumulator_masking:
                 return tval
             return TritonKernelOverrides.where(cond, tval, fval)
 
@@ -5945,10 +5997,31 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self.post_loop_combine.writeline(f"{result_var} = {accumulator}")
             else:
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
-                updated = combine_fn(accumulator, value)
                 if reduction_type == "dot":
-                    self.compute.writeline(f"{accumulator} = {updated}")
+                    self.compute.writeline(
+                        f"{accumulator} = {combine_fn(accumulator, value)}"
+                    )
+                elif (
+                    config.mask_reduction_value_not_accumulator
+                    and cond
+                    and not skip_accumulator_masking
+                    and isinstance(value, CSEVariable)
+                    and not isinstance(acc_default, tuple)
+                ):
+                    # Mask the loaded value to the identity, then combine
+                    # unconditionally (value-mask instead of accumulator-mask).
+                    default_str = self._map_tuple_or_scalar(constant_repr, acc_default)
+                    masked_value = self.cse.generate(
+                        self.compute,
+                        where_cond(value, default_str),
+                        dtype=value.dtype,
+                        shape=value_shape,
+                    )
+                    self.compute.writeline(
+                        f"{accumulator} = {combine_fn(accumulator, masked_value)}"
+                    )
                 else:
+                    updated = combine_fn(accumulator, value)
                     self.compute.writeline(
                         f"{accumulator} = {where_cond(updated, accumulator)}"
                     )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4912,6 +4912,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         append_broadcast = None
         shape: BlockShapeType = None
+        # Set when the block_ptr load boundary-pads OOB elements with zero, so a
+        # reduction over it can skip its accumulator mask when 0 is the identity.
+        block_ptr_zero_padded = False
 
         if should_unwrap_unspec_arg(name):
             line = var
@@ -4926,10 +4929,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         else:
             if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+                # A zero `other` default plus a boundary_check makes
+                # codegen_block_ptr zero-pad OOB elements. Detect from the
+                # structured signals, not the formatted load string.
+                zero_default = other == ", other=0.0"
                 block_descriptor, other = self.codegen_block_ptr(
                     name, var, indexing, other
                 )
                 if isinstance(indexing, BlockPtrOptions):
+                    block_ptr_zero_padded = zero_default and indexing.has_mask()
                     line = f"tl.load({block_descriptor}{other}{ep}{cachemod})"
                 else:
                     line = self.codegen_descriptor_load_line(block_descriptor, indexing)
@@ -5026,6 +5034,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
             self.outside_loop_vars.add(result_var)
+
+        if block_ptr_zero_padded:
+            V.kernel._identity_padding_values[str(result_var)] = 0.0
 
         return result_var
 
@@ -5281,6 +5292,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         do_upcast = pytree.tree_any(lambda v: should_upcast(v.dtype), value)
         original_dtype = dtype
         original_src_dtype = src_dtype
+
+        # Per-load identity padding recorded at the load() site (e.g. a zero-padded
+        # block_ptr load); looked up on the pre-upcast value var.
+        identity_padding = (
+            self._identity_padding_values.get(str(value))
+            if isinstance(value, CSEVariable)
+            else None
+        )
+
         if do_upcast:
             # Only promote FB16/BF16; do not promote other integer/boolean dtypes
             value = pytree.tree_map(maybe_upcast, value)
@@ -5323,15 +5343,38 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # tmp0 in the triton code is either a scalar, or single-element tensor
         # so if we emit tl.sum directly, it will only give 1 instead of RBLOCK * 1
         # To avoid this, we broadcast to the expected shape first.
-        value = self._map_tuple_or_scalar(
-            lambda v: self.cse.generate(
+        acc_default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
+        cond = " & ".join(masks)
+        # The looped combine re-broadcasts the value, so the explicit broadcast is
+        # redundant here; persistent reductions still need it.
+        defer_value_broadcast = (
+            config.mask_reduction_value_not_accumulator
+            and not self.persistent_reduction
+            and bool(cond)
+            and not isinstance(acc_default, tuple)
+            and not reduction_type.startswith("arg")
+            and not is_welford_reduction(reduction_type)
+            and reduction_type not in ("online_softmax_reduce", "dot")
+        )
+
+        def _broadcast_reduction_value(v: CSEVariable) -> CSEVariable:
+            if defer_value_broadcast:
+                return v
+            # Skip a no-op broadcast (value already at the dense size).
+            if (
+                config.mask_reduction_value_not_accumulator
+                and v.shape is not None
+                and triton_shape_dims(v.shape) == triton_shape_dims(value_shape)
+            ):
+                return v
+            return self.cse.generate(
                 self.compute,
                 f"tl.broadcast_to({v}, {dense_size_str})",
                 dtype=v.dtype,
                 shape=value_shape,
-            ),
-            value,
-        )
+            )
+
+        value = self._map_tuple_or_scalar(_broadcast_reduction_value, value)
 
         arg_index_reduction_types = ("argmax", "argmin")
         arg_value_reduction_types = ("argmax_value", "argmin_value")
@@ -5484,8 +5527,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             result_var.mask_vars = result_mask_vars
         cond = " & ".join(masks)
 
+        # Drop the accumulator mask when the load's OOB pad is already the reduction
+        # identity (safe only for zero-padded block_ptr loads; see diff summary).
+        acc_default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
+        skip_accumulator_masking = (
+            not isinstance(acc_default, tuple)
+            and identity_padding is not None
+            and acc_default == identity_padding
+        )
+
         def where_cond(tval, fval):
-            if not cond:
+            if not cond or skip_accumulator_masking:
                 return tval
             return TritonKernelOverrides.where(cond, tval, fval)
 
@@ -5751,10 +5803,31 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 )
             else:
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
-                updated = combine_fn(accumulator, value)
                 if reduction_type == "dot":
-                    self.compute.writeline(f"{accumulator} = {updated}")
+                    self.compute.writeline(
+                        f"{accumulator} = {combine_fn(accumulator, value)}"
+                    )
+                elif (
+                    config.mask_reduction_value_not_accumulator
+                    and cond
+                    and not skip_accumulator_masking
+                    and isinstance(value, CSEVariable)
+                    and not isinstance(acc_default, tuple)
+                ):
+                    # Mask the loaded value to the identity, then combine
+                    # unconditionally (value-mask instead of accumulator-mask).
+                    default_str = self._map_tuple_or_scalar(constant_repr, acc_default)
+                    masked_value = self.cse.generate(
+                        self.compute,
+                        where_cond(value, default_str),
+                        dtype=value.dtype,
+                        shape=value_shape,
+                    )
+                    self.compute.writeline(
+                        f"{accumulator} = {combine_fn(accumulator, masked_value)}"
+                    )
                 else:
+                    updated = combine_fn(accumulator, value)
                     self.compute.writeline(
                         f"{accumulator} = {where_cond(updated, accumulator)}"
                     )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1058,6 +1058,13 @@ force_red_split_dim_as_grid_dim = (
     os.getenv("TORCHINDUCTOR_FORCE_RED_SPLIT_DIM_AS_GRID_DIM", "0") == "1"
 )
 
+# In a looped reduction, mask the loaded value to the reduction identity and
+# combine unconditionally (instead of masking the accumulator), so block_ptr
+# backends can fuse the boundary-padded load + where into one DMA. Experimental.
+mask_reduction_value_not_accumulator = (
+    os.getenv("TORCHINDUCTOR_MASK_REDUCTION_VALUE_NOT_ACCUMULATOR", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1062,6 +1062,13 @@ force_split_reduction_as_grid_dim = (
     os.getenv("TORCHINDUCTOR_FORCE_SPLIT_REDUCTION_AS_GRID_DIM", "0") == "1"
 )
 
+# In a looped reduction, mask the loaded value to the reduction identity and
+# combine unconditionally (instead of masking the accumulator), so block_ptr
+# backends can fuse the boundary-padded load + where into one DMA. Experimental.
+mask_reduction_value_not_accumulator = (
+    os.getenv("TORCHINDUCTOR_MASK_REDUCTION_VALUE_NOT_ACCUMULATOR", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1052,6 +1052,12 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
+# Lower a split reduction as an extra grid dim rather than reshaping the reduction
+# axis, so stage-1 loads stay block_ptr-eligible. Requires split_reductions.
+force_red_split_dim_as_grid_dim = (
+    os.getenv("TORCHINDUCTOR_FORCE_RED_SPLIT_DIM_AS_GRID_DIM", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1052,6 +1052,16 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
+# Lower a split reduction as an extra grid dimension instead of reshaping the
+# reduction axis into a synthetic [split, block_size] tile.  Reserving a grid dim
+# for the split lets stage-1 keep the reduction axis at its true extent, so its
+# loads stay real-extent, boundary-checked block_ptr tiles (no over-covering
+# staircase / out-of-bounds read) on block_ptr backends.  Experimental; only
+# affects codegen when split_reductions is also enabled.
+force_split_reduction_as_grid_dim = (
+    os.getenv("TORCHINDUCTOR_FORCE_SPLIT_REDUCTION_AS_GRID_DIM", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -126,6 +126,7 @@ def _adapt_config_for_tiling(
         register_intensive=register_intensive,
         waves_per_eu=waves_per_eu,
         warp_size=warp_size,
+        z=block_sizes.get("z"),
     )
 
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2311,6 +2311,25 @@ class Reduction(Loops):
         # TODO(jansel): realize the reduction so we can do dynamic indexing
         reduction_numel = sympy_product(reduction_ranges)
         block_size = FloorDiv(reduction_numel + (split - 1), split)
+
+        # strict_sum needs the classic lowering's fixed summation order.
+        if (
+            config.force_red_split_dim_as_grid_dim
+            and is_triton(device)
+            and not strict_sum
+        ):
+            return cls.create_multilayer_split_as_grid(
+                device,
+                dst_dtype,
+                src_dtype,
+                inner_fn,
+                ranges,
+                reduction_ranges,
+                reduction_type,
+                split,
+                reduction_hint,
+            )
+
         default = cls.default_value(reduction_type, dst_dtype)
         wrapper_fn = cls._multilayer_wrap_loader(
             inner_fn,
@@ -2335,6 +2354,89 @@ class Reduction(Loops):
             split,
             reduction_hint,
             strict_reduction,
+        )
+
+    @classmethod
+    def create_multilayer_split_as_grid(
+        cls,
+        device: torch.device,
+        dst_dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        inner_fn: Callable[..., Any],
+        ranges: Sequence[_IntLike],
+        reduction_ranges: Sequence[_IntLike],
+        reduction_type: ReductionType,
+        split: _IntLike,
+        reduction_hint: ReductionHint,
+    ) -> TensorBox:
+        """
+        Split a reduction using an extra grid dimension for the split factor.
+
+        Unlike ``create_multilayer``, stage-1 keeps the reduction axis at its true
+        extent (no ``[split, block_size]`` reshape) and drops the split index from
+        the load, so each stage-1 load stays a real-extent, boundary-checked
+        block_ptr. Each split partition ``p`` reduces one contiguous chunk of the
+        reduction axis (bounded in codegen via ``rsplit_start``/``rsplit_end``,
+        keyed on the split grid dim) and stores its partial to ``buf0[..., p]``;
+        stage-2 combines over the appended split axis.
+        """
+        intermediate_dtype = (
+            dst_dtype
+            if dst_dtype not in (torch.float16, torch.bfloat16)
+            else torch.float
+        )
+
+        def wrapper_fn(
+            index: Sequence[Symbol], reduction_index: Sequence[Symbol]
+        ) -> OpsValue:
+            # Drop the trailing split index from the load; the split partition is
+            # applied by the per-program reduction loop bounds in codegen.
+            *new_index, _split_block = index
+            return inner_fn(new_index, reduction_index)
+
+        intermediate = TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=intermediate_dtype,
+                inner_fn=wrapper_fn,
+                ranges=[*ranges, split],
+                reduction_ranges=[*reduction_ranges],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
+        )
+        intermediate.realize()
+        # Tag the realized stage-1 buffer so its kernel lowers the split axis as a
+        # grid dim; the tag is what bounds each partition's loop to its own slice.
+        stage1_buf = V.graph.name_to_buffer.get(intermediate.get_name())
+        if not isinstance(stage1_buf, ComputedBuffer):
+            raise AssertionError(
+                "split-as-grid stage-1 must realize to a ComputedBuffer, got "
+                f"{type(stage1_buf).__name__}"
+            )
+        stage1_buf._grid_split_factor = split
+        intermediate_loader = intermediate.make_loader()
+
+        def intermediate_fn(
+            index: Sequence[_IntLike], reduction_index: Sequence[_IntLike]
+        ) -> OpsValue:
+            return intermediate_loader([*index, *reduction_index])
+
+        numel_hint = V.graph.sizevars.optimization_hint(sympy_product(ranges))
+        return TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=dst_dtype,
+                inner_fn=intermediate_fn,
+                ranges=ranges,
+                reduction_ranges=[split],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=cls._multilayer_second_step_hint(
+                    split, numel_hint, reduction_hint
+                ),
+            )
         )
 
     @classmethod
@@ -5542,6 +5644,9 @@ class ComputedBuffer(OperationBuffer):
     _original_inner_fn: Callable[..., Any] | None = None
     _original_ranges: Sequence[_IntLike] | None = None
     _original_reduction_ranges: Sequence[_IntLike] | None = None
+    # split factor when the split is lowered as a grid dim (0 = not split-as-grid);
+    # see Reduction.create_multilayer_split_as_grid, read by get_grid_split.
+    _grid_split_factor: int = 0
 
     @contextlib.contextmanager
     def with_original_inner_fn(self) -> Iterator[None]:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2212,6 +2212,20 @@ class Reduction(Loops):
         # TODO(jansel): realize the reduction so we can do dynamic indexing
         reduction_numel = sympy_product(reduction_ranges)
         block_size = FloorDiv(reduction_numel + (split - 1), split)
+
+        if config.force_split_reduction_as_grid_dim and is_triton(device):
+            return cls.create_multilayer_split_as_grid(
+                device,
+                dst_dtype,
+                src_dtype,
+                inner_fn,
+                ranges,
+                reduction_ranges,
+                reduction_type,
+                split,
+                reduction_hint,
+            )
+
         default = cls.default_value(reduction_type, dst_dtype)
         wrapper_fn = cls._multilayer_wrap_loader(
             inner_fn,
@@ -2235,6 +2249,86 @@ class Reduction(Loops):
             reduction_type,
             split,
             reduction_hint,
+        )
+
+    @classmethod
+    def create_multilayer_split_as_grid(
+        cls,
+        device: torch.device,
+        dst_dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        inner_fn: Callable[..., Any],
+        ranges: Sequence[_IntLike],
+        reduction_ranges: Sequence[_IntLike],
+        reduction_type: ReductionType,
+        split: _IntLike,
+        reduction_hint: ReductionHint,
+    ) -> TensorBox:
+        """
+        Split a reduction using an extra grid dimension for the split factor.
+
+        Unlike ``create_multilayer``, stage-1 keeps the reduction axis at its true
+        extent (no ``[split, block_size]`` reshape) and drops the split index from
+        the load, so each stage-1 load stays a real-extent, boundary-checked
+        block_ptr. Each split partition ``p`` reduces one contiguous chunk of the
+        reduction axis (bounded in codegen via ``rsplit_start``/``rsplit_end``,
+        keyed on the split grid dim) and stores its partial to ``buf0[..., p]``;
+        stage-2 combines over the appended split axis.
+        """
+        intermediate_dtype = (
+            dst_dtype
+            if dst_dtype not in (torch.float16, torch.bfloat16)
+            else torch.float
+        )
+
+        def wrapper_fn(
+            index: Sequence[Symbol], reduction_index: Sequence[Symbol]
+        ) -> OpsValue:
+            # Drop the trailing split index from the load; the split partition is
+            # applied by the per-program reduction loop bounds in codegen.
+            *new_index, _split_block = index
+            return inner_fn(new_index, reduction_index)
+
+        intermediate = TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=intermediate_dtype,
+                inner_fn=wrapper_fn,
+                ranges=[*ranges, split],
+                reduction_ranges=[*reduction_ranges],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
+        )
+        intermediate.realize()
+        # Tag the realized stage-1 buffer so its kernel lowers the split axis as a
+        # grid dim; the tag is what bounds each partition's loop to its own slice.
+        stage1_buf = V.graph.name_to_buffer.get(intermediate.get_name())
+        if not isinstance(stage1_buf, ComputedBuffer):
+            raise AssertionError(
+                "split-as-grid stage-1 must realize to a ComputedBuffer, got "
+                f"{type(stage1_buf).__name__}"
+            )
+        stage1_buf._grid_split_factor = split
+        intermediate_loader = intermediate.make_loader()
+
+        def intermediate_fn(
+            index: Sequence[_IntLike], reduction_index: Sequence[_IntLike]
+        ) -> OpsValue:
+            return intermediate_loader([*index, *reduction_index])
+
+        return TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=dst_dtype,
+                inner_fn=intermediate_fn,
+                ranges=ranges,
+                reduction_ranges=[split],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
         )
 
     @classmethod
@@ -5442,6 +5536,9 @@ class ComputedBuffer(OperationBuffer):
     _original_inner_fn: Callable[..., Any] | None = None
     _original_ranges: Sequence[_IntLike] | None = None
     _original_reduction_ranges: Sequence[_IntLike] | None = None
+    # split factor when the split is lowered as a grid dim (0 = not split-as-grid);
+    # see Reduction.create_multilayer_split_as_grid, read by get_grid_split.
+    _grid_split_factor: int = 0
 
     @contextlib.contextmanager
     def with_original_inner_fn(self) -> Iterator[None]:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4688,7 +4688,8 @@ def reduction(
     """args to @triton.heuristics()"""
     inductor_meta = {} if inductor_meta is None else inductor_meta
     inductor_meta["reduction_hint"] = reduction_hint
-    if inductor_meta.get("no_x_dim"):
+    if inductor_meta.get("no_x_dim") or inductor_meta.get("split_as_grid_reduction"):
+        # Pin the split (x) grid axis to XBLOCK == 1: one partition per program.
         size_hints["x"] = 1
 
     if triton_meta is None:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4325,11 +4325,15 @@ def triton_config_tiled_reduction(
     waves_per_eu=None,
     *,
     warp_size: int = 32,
+    z: int | None = None,
 ):
     """
     Construct a tile reduction triton config with some adjustment
     heuristics based on size_hints. Size_hints is a tuple of numels in
     each tile dimension and will be rounded up to the nearest power of 2.
+
+    ``z`` is only passed for three-dimensional pointwise tilings; leaving it
+    ``None`` reproduces the two-dimensional behaviour exactly.
     """
     # Convert the linear reduction numel into a multi-dimensional block.
     rnumels = _get_nd_reduction_numels(r, size_hints)
@@ -4337,9 +4341,12 @@ def triton_config_tiled_reduction(
     # shrink sizes to size hints
     x = min(x, size_hints["x"])
     y = min(y, size_hints["y"])
+    if z is not None:
+        z = min(z, size_hints["z"])
 
     def total_numel() -> int:
-        return conditional_product(x, y, *rnumels.values())
+        pointwise = (x, y) if z is None else (x, y, z)
+        return conditional_product(*pointwise, *rnumels.values())
 
     target = total_numel()
     if conditional_product(*size_hints.values()) < target:
@@ -4353,8 +4360,11 @@ def triton_config_tiled_reduction(
             rnumels[prefix] *= 2
     while y < size_hints["y"] and total_numel() < target:
         y *= 2
+    while z is not None and z < size_hints["z"] and total_numel() < target:
+        z *= 2
 
-    cfg = _get_config({"x": x, "y": y, **rnumels})
+    pointwise_numels = {"x": x, "y": y} if z is None else {"z": z, "y": y, "x": x}
+    cfg = _get_config({**pointwise_numels, **rnumels})
     num_warps = _num_warps(total_numel() // 256, min_num_warps=1, warp_size=warp_size)
     num_warps = _num_warps(
         num_warps,
@@ -4362,7 +4372,12 @@ def triton_config_tiled_reduction(
         register_intensive=register_intensive,
         warp_size=warp_size,
     )
-    check_config(cfg, xnumel=size_hints["x"], ynumel=size_hints["y"])
+    check_config(
+        cfg,
+        xnumel=size_hints["x"],
+        ynumel=size_hints["y"],
+        znumel=size_hints["z"] if z is not None else None,
+    )
     check_max_block(cfg)
     config = Config(cfg, num_warps=num_warps, num_stages=num_stages)
     if torch.version.hip:
@@ -4703,7 +4718,8 @@ def reduction(
     """args to @triton.heuristics()"""
     inductor_meta = {} if inductor_meta is None else inductor_meta
     inductor_meta["reduction_hint"] = reduction_hint
-    if inductor_meta.get("no_x_dim"):
+    if inductor_meta.get("no_x_dim") or inductor_meta.get("split_as_grid_reduction"):
+        # Pin the split (x) grid axis to XBLOCK == 1: one partition per program.
         size_hints["x"] = 1
 
     if triton_meta is None:


### PR DESCRIPTION
Summary:

Improvements to looped reduction codegen on hardware that prefers DMA / block_ptr
loads, where a boundary-checked load zero-pads its out-of-bounds tail.

## What changes

1. **Skip the redundant accumulator mask (identity-0: sum, any).** When a load's
   OOB tail is padded with the reduction identity and 0 IS the identity, the
   per-iteration `tl.where(rmask & xmask, combine(acc, val), acc)` is a no-op and
   is dropped. A per-load tag `_identity_padding_values` (set in `load()` for
   zero-padded block_ptr loads) is looked up in `reduction()`;
   `skip_accumulator_masking` fires when the padding equals the accumulator
   default. **NOTE: this behavior is NOT gated on the flag below -- it is on by
   default** for zero-padded block_ptr loads on all block_ptr backends (only 2/3
   are flag-gated). The tag requires BOTH `padding_option='zero'` AND a
   boundary_check, so a boundary-checked-but-not-zero-padded load (or a stride-0
   broadcast reduction axis, which is a `broadcast_to` not a zero-padded load) is
   never tagged and keeps its mask.

2. **Mask the value, not the accumulator (new flag, default off).**
   `mask_reduction_value_not_accumulator`
   (`TORCHINDUCTOR_MASK_REDUCTION_VALUE_NOT_ACCUMULATOR`). For reducers whose
   identity differs from the zero pad (prod=1, amax=-inf, amin=+inf), mask the
   loaded value to the identity (`where(mask, val, identity)`) and combine
   unconditionally, keeping the mask off the loop-carried accumulator.

3. **Drop the explicit value broadcast in the looped path** (same flag). The
   loaded value is left un-broadcast; the combine broadcasts it anyway -- a value
   mask's dense `where` (prod/min/max) or the elementwise combine's implicit
   broadcast (sum/any) -- so the standalone `tl.broadcast_to` is redundant. This
   also makes `tl.load` the `where`'s direct operand (fold-friendly for a block_ptr
   backend). Persistent reductions keep the broadcast (their direct `tl.reduce`
   needs a dense, scalar-safe value); no-op broadcasts (value already dense) are
   skipped too.

With the flag off, codegen is byte-identical to before except (1), which applies
to sum/any on zero-padded block_ptr loads.

## Before / after codegen (stage-1 looped combine, with the load)

Both ops load with `padding_option='zero'` (OOB tail = 0). **sum**'s identity IS 0
so no `tl.where` is needed; **prod**'s identity is 1 so a `tl.where` rewrites the
OOB tail. Under the flag, both drop the explicit `broadcast_to`.

### sum -- no `tl.where` (identity 0 == zero pad)
1-D `x.sum()`:
```
# before (flag off): explicit broadcast, then accumulate
tmp0 = tl.load(block_ptr0, boundary_check=[0], padding_option='zero', ...)[None, :]
tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
tmp3 = _tmp2 + tmp1
_tmp2 = tmp3
# after (flag on): combine broadcasts the load implicitly, no broadcast_to
tmp0 = tl.load(block_ptr0, boundary_check=[0], padding_option='zero', ...)[None, :]
tmp2 = _tmp1 + tmp0
_tmp1 = tmp2
```
2-D `x.sum(dim=1)`:
```
# before (flag off)
tmp0 = tl.load(block_ptr0, boundary_check=[0, 1], padding_option='zero', ...)[:, None, :]
tmp1 = tl.broadcast_to(tmp0, [YBLOCK, XBLOCK, R0_BLOCK])
tmp3 = _tmp2 + tmp1
_tmp2 = tmp3
# after (flag on)
tmp0 = tl.load(block_ptr0, boundary_check=[0, 1], padding_option='zero', ...)[:, None, :]
tmp2 = _tmp1 + tmp0
_tmp1 = tmp2
```
3-D `x.sum(dim=2)`: identical to 2-D (the two kept dims flatten onto `y`).

### prod -- needs `tl.where` (identity 1 != zero pad)
1-D `x.prod()`:
```
# before (flag off): broadcast, multiply, mask the ACCUMULATOR
tmp0 = tl.load(block_ptr0, boundary_check=[0], padding_option='zero', ...)[None, :]
tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
tmp3 = _tmp2 * tmp1
_tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
# after (flag on): mask the LOAD to identity 1, multiply, accumulate unconditionally
tmp0 = tl.load(block_ptr0, boundary_check=[0], padding_option='zero', ...)[None, :]
tmp2 = tl.where(r0_mask & xmask, tmp0, 1)
tmp3 = _tmp1 * tmp2
_tmp1 = tmp3
```
2-D `x.prod(dim=1)`:
```
# before (flag off)
tmp0 = tl.load(block_ptr0, boundary_check=[0, 1], padding_option='zero', ...)[:, None, :]
tmp1 = tl.broadcast_to(tmp0, [YBLOCK, XBLOCK, R0_BLOCK])
tmp3 = _tmp2 * tmp1
_tmp2 = tl.where(r0_mask & xmask & ymask, tmp3, _tmp2)
# after (flag on)
tmp0 = tl.load(block_ptr0, boundary_check=[0, 1], padding_option='zero', ...)[:, None, :]
tmp2 = tl.where(r0_mask & xmask & ymask, tmp0, 1)
tmp3 = _tmp1 * tmp2
_tmp1 = tmp3
```
3-D `x.prod(dim=2)`: identical to 2-D.

`amax`/`amin` match prod with the identity swapped to `float("-inf")` /
`float("inf")`. `any` takes the value-mask path too (its reduced value is a derived
`x != 0`, so the identity-padding tag does not carry through): a `where(..., False)`
on that value, no broadcast.

## Detail (for review)

- All behaviors live in `TritonKernel.reduction()`. `_broadcast_reduction_value`
  defers the value broadcast for the looped path (any reducer) and skips a no-op
  broadcast; the looped generic combine masks the value via the existing
  `where_cond` when the flag is on, else keeps the accumulator mask. No new
  ops-handler op is introduced.
- Correctness: the `where` (or the zero pad, for sum/any) sets OOB reduction lanes
  to the identity so combining them is a no-op; OOB output rows use the full `cond`
  but are never stored. Deferring the broadcast is safe because the looped combine
  broadcasts the value anyway (dense `where` or elementwise op); persistent
  reductions keep the broadcast (their direct `tl.reduce` needs a dense value).
  Flag-off is byte-identical except behavior (1).
- Scope: looped reductions. Persistent (stage-2) reductions keep broadcast-then-mask
  except the no-op-broadcast skip. Not `arg*`/welford/online_softmax/dot.
- This is an enabler: on GPU the reorder is perf-neutral (Triton optimizes both
  forms equivalently -- see Test Plan); the payoff is letting a block_ptr backend
  fold `load + where(mask, ., identity)` into a single identity-padded DMA.

Load-bearing invariants (both commented in code):
- The sum/any skip is safe under a semantic `_load_mask` only because block_ptr
  indexing is disabled while `_load_mask` is active, so a masked load is never
  identity-padding-tagged. Do not relax that guard.
- The value-mask branch relies on `acc_default` being the combine's identity (true
  for every non-tuple reducer reaching it; arg*/welford/online_softmax/dot are
  routed earlier).

This change was developed with the assistance of an AI coding agent.

Test Plan:
H100 (devgpu025), `use_block_ptr` backend.

## Unit tests (new, in test_torchinductor_strided_blocks.py)
```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:torchinductor_strided_blocks -- \
  --regex "grid_split_reduction_(masks_value_not_accumulator|skips_sum_accumulator_mask|prod_keeps_accumulator_mask)"
```
New tests (all pass; skips = host-side-TMA + CPU backends):
- `test_grid_split_reduction_masks_value_not_accumulator` (prod/amax/amin x 1d/2d/3d):
  numerics vs eager + asserts the accumulator mask is gone (`_tmp<n> = tl.where`
  absent), proving the value was masked to the identity.
- `test_grid_split_reduction_skips_sum_accumulator_mask`: identity-0 sum drops the
  accumulator mask.
- `test_grid_split_reduction_prod_keeps_accumulator_mask_when_flag_off`: gating
  guard -- flag off keeps prod's accumulator mask.
- `test_grid_split_reduction_fused_mixed_identity`: sum (skip) + amax (value-mask)
  fused over one buffer -- guards per-load identity-padding disambiguation.
- `test_grid_split_reduction_value_mask_bool` (any/all) and `_value_mask_int`
  (sum/amax/amin int32): bool/int dtype identities.
- `test_grid_split_reduction_persistent_flag` (sum/prod/amax, small shape):
  persistent path with the flag on (no-op-broadcast skip), asserts not grid-split.

## Numerics sweep
`scripts/nanzha/blockptr:sweep` (both flags on, ranks 1-6, all ops/dtypes):
268/268 valid configs OK, 0 MISMATCH. The 24 ERR are eager-unsupported
`mean(int32)` / `prod(tuple dim)`, present at baseline.

## Codegen dumps
`scripts/nanzha/blockptr:dump_kernel` on sum/amax/amin/prod, 1-D/2-D/3-D:
`allclose=True` with the flag on (mask on the load, no broadcast between) and
byte-identical codegen with the flag off.

## GPU perf (before vs after)
`scripts/nanzha/blockptr:profile_sweep` (triton do_bench, flag off vs on, 8 shapes
x 4 ops = 32 configs): geomean off/on ratio 0.9986, every config within ~1%.
Perf-neutral on GPU, as expected -- the change is a codegen-shape refactor; the
payoff is for a future block_ptr-backend DMA fold, not GPU.

## Regression
`buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:torchinductor_strided_blocks`:
293 pass. The 152 failures are all `TritonHostSideTMATestCUDA` failing with
`make_tensordesc_arg() takes 2 positional arguments but 3 were given`, a
pre-existing Triton TMA-frontend arity mismatch on this checkout, unrelated to
this change.

## Adversarial multi-model review
Reviewed by Codex + 3 Claude reviewers (distinct lenses: degenerate/persistent,
shape/dtype/multi-axis, gating/fused/exclusions). Verdict: no correctness bug. One
HIGH candidate (sum/any skip over a stride-0 `expand` reduction axis over-counting)
was empirically refuted -- `scripts/nanzha/blockptr:repro_stride0` shows
`allclose=True` for single-axis broadcast and multi-axis mixed real+broadcast
reductions; the tag requires `padding_option='zero'` (a broadcast axis is a
`broadcast_to`, not a zero-padded load), so it is never tagged and keeps its mask.
Review-consensus hardening applied in this diff: the two invariant comments above
and the added fused/bool/int/persistent coverage tests.

`arc lint` clean; fbcode <-> xplat mirrors byte-identical (auto-synced).

Differential Revision: D114358833
