### PR TITLE
[aot_autograd] Set `val` meta on the control_deps sync wrapper

### DIFF
--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -188,7 +188,7 @@ def handle_synced_deallocation(
     if not torch.accelerator.is_available():
         # fallback to record_stream in this case
         with graph.inserting_after(node):
-            graph.call_function(
+            rs = graph.call_function(
                 torch.ops.streams.record_stream.default,
                 (
                     node,
@@ -196,7 +196,7 @@ def handle_synced_deallocation(
                 ),
                 {},
             )
-        node.meta["partitioner_tag"] = "must_be_in_backward"
+        rs.meta["partitioner_tag"] = "must_be_in_backward"
 
     allocating_stream_trace = populate_stream_timeline(
         stream_to_exec_trace, graph, allocating_stream
@@ -223,12 +223,12 @@ def handle_synced_deallocation(
     wait_event = new_event()
     record_node = insert_record_event_after_node(graph, last_usage, wait_event)
     with graph.inserting_after(max(alloc_ptr, record_node)):
-        graph.call_function(
+        sd = graph.call_function(
             torch.ops.streams.sync_dealloc.default,
             (wait_event, get_stream_or_current_stream(alloc_ptr), node),
             {},
         )
-        node.meta["partitioner_tag"] = "must_be_in_backward"
+        sd.meta["partitioner_tag"] = "must_be_in_backward"
 
 
 def insert_sync(
@@ -520,6 +520,13 @@ def _wrap_sync_node(
     visited.add(control_deps_node)
 
     # The output is (sync_result, *deps_with_uses_after_sync)
+    # Reuse the val the subgraph output already carries: the min-cut
+    # partitioner's _size_of() raises on any node without `val`, and its escape
+    # hatch covers only get_attr and zero-return OpOverloads, not a schema-less
+    # HOP.  The subgraph output is unwrapped when it has no pass-through deps.
+    sg_val = subgraph_module.graph.output_node().meta.get("val")
+    control_deps_node.meta["val"] = sg_val if isinstance(sg_val, tuple) else (sg_val,)
+
     # Create getitem nodes only for dependencies that have uses after sync
     replacements: dict[Node, Node] = {}
     with graph.inserting_after(control_deps_node):


### PR DESCRIPTION
Summary:
`_wrap_sync_node` builds the `control_deps` HOP node that wraps a CUDA stream
sync op, but populates only `partitioner_tag` on it -- never `meta["val"]`. Any
graph that reaches the min-cut partitioner carrying one of these nodes dies at
compile time:

```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: Node control_deps didn't have `val` metadata; we should always
have `val` metadata on the nodes.
  partitioners.py:2719  solve_min_cut
  partitioners.py:2590  should_ban_recomputation -> _size_of(node)
  partitioners.py:1878  _size_of
```

`_size_of` requires `val`, and its escape hatch at `partitioners.py:1873` covers
only `get_attr` nodes and `OpOverload` targets with zero schema returns. That
hatch was the earlier fix for the bare `Node wait_stream didn't have 'val'`
form, but `control_deps` is a `HigherOrderOperator` with no `_schema`, so it
falls straight through to the raise.

The omission is old; #189096 is what made it reachable. Before that change, a
sync whose `deps_before_sync` came out empty stayed unwrapped and produced no
`control_deps` node at all. `_collect_sync_forward_deps` and
`_collect_full_barrier_deps` now supply deps to exactly those syncs, so they
take the wrap branch and `control_deps` nodes show up in graphs that previously
had none.

The fix copies `val` off the subgraph's output node at the creation site rather
than widening the `_size_of` escape hatch, because the partitioner already
assumes this tuple exists -- only the producer was missing.
`_create_subgraph_for_node` has already computed the exact value:
`control_dependencies.py:289` writes
`tuple(output.meta.get("val") for output in outputs)` over
`(result, *dep_placeholders)`. Reading it back keeps a single source of truth
(per aorenste). The wrapper only re-wraps the degenerate no-pass-through-deps
case, where `control_dependencies.py:291-293` stores the bare sync result
instead of a 1-tuple.

The node's min-cut weight is untouched: `partitioners.py:2724` classifies it
through `is_non_tensor_node`, which is true both for a missing `val` and for a
tuple `val`, so `get_node_weight` is not reached in either case. Inside
`should_ban_recomputation` the node's output size now equals its input size,
since the outputs are the pass-through deps, so the `ban_if_reduction`
heuristic does not fire.

Found on an APS WISDOM CVR training job, MAST `aps-f1122616007-1122629400`,
running a package built from master on 2026-08-06. Every earlier run of this
model family used a package predating #189096.

# Also in this diff

Two `partitioner_tag` writes in `handle_synced_deallocation` target the wrong
node -- pre-existing, unrelated to the `val` bug, folded in here at aorenste's
request on V1 (flagged to mlazos). Both write onto `node`, the allocating
tensor, instead of onto the `record_stream` / `sync_dealloc` node created
immediately above. Two consequences, neither intended:

- The new node ends up untagged, so `is_bwd_node` (`streams.py:82`) and
  `_must_be_in_backward` (`partitioners.py:751`) both read False on it and it
  is never pinned into the backward graph.
- `node` is already a backward node -- `handle_synced_deallocation` asserts
  `is_bwd_node(node)` on entry -- so the write silently upgrades its existing
  `is_backward` tag to `must_be_in_backward`. That routes it through
  `partitioners.py:2690`, which adds an infinite-capacity edge to the sink and
  `continue`s past the `_in -> _out` weight edge, making the tensor
  structurally ineligible as a saved activation.

Reviewer note: the `record_stream` branch at `streams.py:188` also has no
`return`, so when `torch.accelerator.is_available()` is False the function
inserts the `record_stream` fallback *and* then falls through and inserts the
`sync_dealloc` path as well. That looks wrong too, but it is a control-flow
change rather than a metadata fix, so I left it alone -- happy to take it in a
follow-up if you agree.

fbcode and xplat copies kept in sync.

Authored with Claude Code.

Test Plan:
`arc f` and `arc lint` -- clean on both changed files.

Pyrefly on `fbcode/caffe2/torch/_functorch/_aot_autograd/streams.py`: 34
diagnostics, all pre-existing `unknown-argument-type`, none on the changed
lines (191, 199, 226, 231, 527-528). Same count as V1.

```
buck2 test mode/opt //caffe2/test/dynamo:test_streams
```
Pass 83. Fail 0. Skip 6. Omit 1.
https://www.internalfb.com/intern/testinfra/testrun/34902897136225796

That is the suite #189096 extended by ~750 lines, so it is the direct
regression gate for `_wrap_sync_node`. Every sync-wrapping case it covers
(`test_external_wait_event_anchors_record`,
`test_full_barrier_forward_deps_respect_partition`,
`test_leading_synchronize_stream_orders_following_work`, `test_record_stream`,
`test_record_stream_inductor_output_code`, `test_record_stream_problem_basic`,
`test_record_stream_problem_interleaved`) now runs with a populated `val` on
the `control_deps` node. The `record_stream` tests also cover the retagged
`sync_dealloc` path.

The shape of the written `val` is verified against its producer and its two
consumers rather than by a new test, since all three already encode the
contract:

- `control_dependencies.py:286-293` -- the producer. With pass-through deps it
  writes `tuple(output.meta.get("val") for output in (result, *deps))`; with
  none it writes the bare `result.meta["val"]`, or nothing when the sync node
  itself has no `val`. Hence the `isinstance(sg_val, tuple)` re-wrap, which
  yields `(None,)` in the degenerate case -- byte-identical to what V1
  recomputed.
- `partitioners.py:489` -- `sg.output((None, *sg_placeholders))` builds the
  same `(sync_result, *deps)` layout, confirming index 0 is the sync result.
- `partitioners.py:505-509` -- `_rebuild_control_deps_for_extract` reads
  `orig_val[0]` and `orig_val[i + 1]`, so the partitioner already expects
  exactly this tuple on a `control_deps` node.
- `partitioners.py:1852` -- `_size_of` folds a tuple `val` through
  `sum(object_nbytes(n) for n in val)`; `object_nbytes` returns 0 for the
  `None` at index 0 and the fake-tensor size for each pass-through dep.

`subgraph_module` is a `_LazyGraphModule`; reading `.graph` does not trigger
`real_recompile()` -- only calling `forward` does
(`torch/fx/_lazy_graph_module.py:127-135`) -- so this adds no compile work.

Not reproduced locally: the original failure is a 96-GPU APS training job (MAST
`aps-f1122616007-1122629400`), and the end-to-end check is rebuilding that
package on this commit and relaunching. Not yet run.

Differential Revision: D115113991


