### PR TITLE
[symmetric_memory] Re-enable multicast tests

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -67,10 +67,6 @@ from torch.testing._internal.common_utils import (
 
 test_contexts = [nullcontext, _test_mode]
 
-# Set environment variable to disable multicast for all tests in this module
-os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
-
-
 @contextmanager
 def _enable_multicast_for_test(test_case: TestCase, device_index: int):
     old_disable_multicast = os.environ.pop("TORCH_SYMM_MEM_DISABLE_MULTICAST", None)

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -67,6 +67,7 @@ from torch.testing._internal.common_utils import (
 
 test_contexts = [nullcontext, _test_mode]
 
+
 @contextmanager
 def _enable_multicast_for_test(test_case: TestCase, device_index: int):
     old_disable_multicast = os.environ.pop("TORCH_SYMM_MEM_DISABLE_MULTICAST", None)


### PR DESCRIPTION
## Summary

PR #159323 added a module-level `os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"` that silently disabled multicast for **every** test in `test/distributed/test_symmetric_memory.py`. This was not called out in the PR description and went unnoticed for over a year.

Tests decorated with `@requires_multicast_support()` and wrapped in `_enable_multicast_for_test` will now actually exercise multicast code paths (and skip gracefully on hardware that lacks multicast support), rather than running with multicast forcibly turned off.

## Test Plan

- [X] Run `python test/distributed/test_symmetric_memory.py` on hardware with multicast support and verify multicast tests pass
Human Update: 
Before this PR, H100 job: https://github.com/pytorch/pytorch/actions/runs/31130799402/job/92723980092 
2026-08-06T23:56:42.5737566Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_out_shape0 SKIPPED [0.0004s] (multicast support is not available) [  8%]
2026-08-06T23:56:42.5738890Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_out_shape1 SKIPPED [0.0003s] (multicast support is not available) [  9%]
2026-08-06T23:56:42.5740443Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape0_symm_mem_input_False SKIPPED [0.0003s] (multicast support is not available) [  9%]
2026-08-06T23:56:42.5742035Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape0_symm_mem_input_True SKIPPED [0.0003s] (multicast support is not available) [ 10%]
2026-08-06T23:56:42.5743483Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape1_symm_mem_input_False SKIPPED [0.0003s] (multicast support is not available) [ 11%]
2026-08-06T23:56:42.5744936Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape1_symm_mem_input_True SKIPPED [0.0002s] (multicast support is not available) [ 12%]

This PR's H100 job (https://github.com/pytorch/pytorch/actions/runs/31223332504/job/93016974609?pr=192539) 
2026-08-07T22:58:37.7227572Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape0_symm_mem_input_False PASSED [0.1286s] [ 10%]
2026-08-07T22:58:37.7228753Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape0_symm_mem_input_True PASSED [0.0042s] [ 11%]
2026-08-07T22:58:37.7229929Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape1_symm_mem_input_False PASSED [0.0034s] [ 11%]
2026-08-07T22:58:37.7231101Z distributed/test_symmetric_memory.py::SymmetricMemoryTest::test_low_contention_all_gather_ce_multicast_shape1_symm_mem_input_True PASSED [0.0039s] [ 12%]

 
- [] Run on hardware without multicast support and verify multicast tests are skipped via `@requires_multicast_support()`
Human update: I am not aware of symmetric memory tests running on hardware without multicast support.  

> **Note:** This PR was authored with the assistance of an AI assistant. Content above is human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)