### PR TITLE
[ROCm] Enable kernel asserts by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ option(USE_VULKAN_RELAXED_PRECISION
        "Vulkan - Use relaxed precision math in the kernels (mediump)" OFF)
 # option USE_XNNPACK: try to enable xnnpack by default.
 option(USE_XNNPACK "Use XNNPACK" OFF)
-option(USE_ROCM_KERNEL_ASSERT "Use Kernel Assert for ROCm" OFF)
+option(USE_ROCM_KERNEL_ASSERT "Use Kernel Assert for ROCm" ON)
 # Ensure that an ITT build is the default for x86 CPUs
 cmake_dependent_option(USE_ITT "Use Intel(R) VTune Profiler ITT functionality"
                        ON "CPU_INTEL" OFF)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1118,8 +1118,8 @@ if(USE_ROCM)
     endif()
 
     # ---[ Kernel asserts
-    # Kernel asserts is disabled for ROCm by default.
-    # It can be turned on by turning on the env USE_ROCM_KERNEL_ASSERT to the build system.
+    # Kernel asserts are enabled for ROCm by default.
+    # Set USE_ROCM_KERNEL_ASSERT=0 in the environment to disable them.
     if(USE_ROCM_KERNEL_ASSERT)
       message(STATUS "Enabling Kernel Assert for ROCm")
     else()

--- a/cmake/EnvVarForwarding.cmake
+++ b/cmake/EnvVarForwarding.cmake
@@ -51,7 +51,7 @@
 #   USE_STATIC_MKL           prefer to link MKL statically (Unix only)
 #   USE_FLASH_ATTENTION=0    disables flash attention for scaled dot product attn
 #   USE_MEM_EFF_ATTENTION=0  disables memory efficient attention for SDPA
-#   USE_ROCM_KERNEL_ASSERT=1 enables kernel assert on ROCm
+#   USE_ROCM_KERNEL_ASSERT=0 disables kernel assert on ROCm (enabled by default)
 #   USE_ROCM_CK_GEMM=1       builds the CK GEMM backend on ROCm
 #   USE_ROCM_CK_SDPA=1       builds the CK SDPA backend on ROCm
 #   USE_LAYERNORM_FAST_RECIPROCAL  fast reciprocals for layer norm (default on)

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -179,8 +179,9 @@ Enabling kernel asserts
 -----------------------
 
 Kernel asserts are **enabled by default** on ROCm builds. When enabled,
-device-side assert failures are reported through the OCKL device printf path,
-which adds compile-time and runtime overhead even when asserts never fire.
+device-side assert failures are reported through the OCKL device printf path.
+That path increases register pressure (VGPR/SGPR) in kernels that emit assert
+branches, which can reduce occupancy even when asserts never fire.
 
 To disable them when building from source, set the environment variable or
 CMake option::

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -178,9 +178,9 @@ For any sections not listed here, please refer to the CUDA semantics doc: :ref:`
 Enabling kernel asserts
 -----------------------
 
-Kernel asserts are **enabled by default** on ROCm builds. Device-side failures
-use HIP ``__assert_fail`` (OCKL printf), which adds compile-time and runtime
-overhead even when asserts never fire.
+Kernel asserts are **enabled by default** on ROCm builds. When enabled,
+device-side assert failures are reported through the OCKL device printf path,
+which adds compile-time and runtime overhead even when asserts never fire.
 
 To disable them when building from source, set the environment variable or
 CMake option::

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -178,12 +178,18 @@ For any sections not listed here, please refer to the CUDA semantics doc: :ref:`
 Enabling kernel asserts
 -----------------------
 
-Kernel asserts are supported on ROCm, but they are disabled due to performance overhead. It can be enabled
-by recompiling the PyTorch from source.
+Kernel asserts are **enabled by default** on ROCm builds. Device-side failures
+use HIP ``__assert_fail`` (OCKL printf), which adds compile-time and runtime
+overhead even when asserts never fire.
 
-Please add below line as an argument to cmake command parameters::
+To disable them when building from source, set the environment variable or
+CMake option::
 
-    -DROCM_FORCE_ENABLE_GPU_ASSERTS:BOOL=ON
+    USE_ROCM_KERNEL_ASSERT=0
+
+or::
+
+    -DUSE_ROCM_KERNEL_ASSERT=OFF
 
 Enabling/Disabling ROCm Composable Kernel
 -----------------------------------------

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -531,11 +531,10 @@ __host__ __device__
 #endif // __SYCL_DEVICE_ONLY__
 }
 #endif // NDEBUG
-// ROCm disables kernel assert by default for performance considerations.
-// Though ROCm supports __assert_fail, it uses kernel printf which has
-// a non-negligible performance impact even if the assert condition is
-// never triggered. We choose to use abort() instead which will still
-// terminate the application but without a more useful error message.
+// Kernel asserts are enabled for ROCm by default (USE_ROCM_KERNEL_ASSERT=ON).
+// When disabled, CUDA_KERNEL_ASSERT uses abort() without a useful error message.
+// When enabled, device asserts use __assert_fail / OCKL printf, which has
+// a non-negligible performance impact even if the assert condition is never triggered.
 #if !defined(C10_USE_ROCM_KERNEL_ASSERT) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond) \
   if C10_UNLIKELY (!(cond)) {    \

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -532,10 +532,10 @@ __host__ __device__
 }
 #endif // NDEBUG
 // Kernel asserts are enabled for ROCm by default (USE_ROCM_KERNEL_ASSERT=ON).
-// When disabled, CUDA_KERNEL_ASSERT uses abort() without a useful error message.
-// When enabled, device asserts use the OCKL device printf path, which raises
-// register pressure (VGPR/SGPR) and may reduce occupancy even if the assert
-// condition is never triggered.
+// When disabled, CUDA_KERNEL_ASSERT uses abort() without a useful error
+// message. When enabled, device asserts use the OCKL device printf path, which
+// raises register pressure (VGPR/SGPR) and may reduce occupancy even if the
+// assert condition is never triggered.
 #if !defined(C10_USE_ROCM_KERNEL_ASSERT) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond) \
   if C10_UNLIKELY (!(cond)) {    \

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -533,8 +533,9 @@ __host__ __device__
 #endif // NDEBUG
 // Kernel asserts are enabled for ROCm by default (USE_ROCM_KERNEL_ASSERT=ON).
 // When disabled, CUDA_KERNEL_ASSERT uses abort() without a useful error message.
-// When enabled, device asserts use the OCKL device printf path, which has
-// a non-negligible performance impact even if the assert condition is never triggered.
+// When enabled, device asserts use the OCKL device printf path, which raises
+// register pressure (VGPR/SGPR) and may reduce occupancy even if the assert
+// condition is never triggered.
 #if !defined(C10_USE_ROCM_KERNEL_ASSERT) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond) \
   if C10_UNLIKELY (!(cond)) {    \

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -533,7 +533,7 @@ __host__ __device__
 #endif // NDEBUG
 // Kernel asserts are enabled for ROCm by default (USE_ROCM_KERNEL_ASSERT=ON).
 // When disabled, CUDA_KERNEL_ASSERT uses abort() without a useful error message.
-// When enabled, device asserts use __assert_fail / OCKL printf, which has
+// When enabled, device asserts use the OCKL device printf path, which has
 // a non-negligible performance impact even if the assert condition is never triggered.
 #if !defined(C10_USE_ROCM_KERNEL_ASSERT) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond) \


### PR DESCRIPTION
## Summary

Enable `USE_ROCM_KERNEL_ASSERT` by default for ROCm builds.

- Flip CMake default: `option(USE_ROCM_KERNEL_ASSERT ... ON)`
- Update build comments (`Dependencies.cmake`, `EnvVarForwarding.cmake`, `Macros.h`)
- Fix `docs/source/notes/hip.rst` to document the correct opt-out knob (`USE_ROCM_KERNEL_ASSERT=0` / `-DUSE_ROCM_KERNEL_ASSERT=OFF`); remove stale `ROCM_FORCE_ENABLE_GPU_ASSERTS` reference

## Dependency / merge order

**Waiting on:** [#191062](https://github.com/pytorch/pytorch/pull/191062) ([ROCm] flattened literal OCKL path for device kernel asserts).

That PR improves device-side `CUDA_KERNEL_ASSERT` codegen when asserts are enabled. This PR only changes the default; it should land **after** #191062 so CI and users get the optimized assert path by default.

Until #191062 merges, this can be reviewed in parallel. Expect a small rebase conflict in `torch/headeronly/macros/Macros.h` (comment block only).

## Opt out

```bash
USE_ROCM_KERNEL_ASSERT=0 python -m build --wheel --no-isolation
```

or `-DUSE_ROCM_KERNEL_ASSERT=OFF` at configure time.

## Test plan

- [ ] ROCm CI builds with `USE_ROCM_KERNEL_ASSERT=ON` by default
- [ ] `USE_ROCM_KERNEL_ASSERT=0` still selects the abort-only assert path

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang