### PR TITLE
Remove the deprecated use_cuda option from the profiler

### DIFF
--- a/benchmarks/profiler_benchmark/profiler_bench.py
+++ b/benchmarks/profiler_benchmark/profiler_bench.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
             def payload():
                 x = None
                 with torch.autograd.profiler.profile(
-                    use_cuda=args.with_cuda,
+                    use_device="cuda" if args.with_cuda else None,
                     with_stack=args.with_stack,
                     use_kineto=args.use_kineto,
                     use_cpu=not args.cuda_only,

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -124,9 +124,6 @@ class profile:
     Args:
         enabled (bool, optional): Setting this to False makes this context manager a no-op.
 
-        use_cuda (bool, optional): Enables timing of CUDA events as well
-            using the cudaEvent API. (will be deprecated)
-
         use_device (str, optional): Enables timing of device events.
             Adds approximately 4us of overhead to each tensor operation when use cuda.
             The valid devices options are 'cuda', 'xpu', 'mtia' and 'privateuseone'.
@@ -214,7 +211,6 @@ class profile:
         self,
         enabled=True,
         *,
-        use_cuda=False,  # Deprecated
         use_device=None,
         record_shapes=False,
         with_flops=False,
@@ -232,17 +228,7 @@ class profile:
         self.enabled: bool = enabled
         if not self.enabled:
             return
-        self.use_cuda = use_cuda
-        if self.use_cuda:
-            warn(
-                "The attribute `use_cuda` will be deprecated soon, "
-                "please use ``use_device = 'cuda'`` instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            self.use_device: str | None = "cuda"
-        else:
-            self.use_device = use_device
+        self.use_device: str | None = use_device
         # TODO Consider changing _function_events into data structure with size cap
         self._function_events: EventList | None = None
         self._old_function_events: EventList | None = None
@@ -304,7 +290,6 @@ class profile:
 
             if self.use_device == "cuda" and not torch.cuda.is_available():
                 warn("CUDA is not available, disabling CUDA profiling", stacklevel=2)
-                self.use_cuda = False
                 self.use_device = None
 
             if self.use_device == "xpu" and not torch.xpu.is_available():

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -917,9 +917,6 @@ class profile(_KinetoProfile):
         custom_trace_id_callback (Callable[[], str], optional): User-supplied trace ID generator,
             invoked once per profiling cycle. Defaults to a random UUID; retrieve via
             :meth:`get_trace_id`.
-        use_cuda (bool):
-            .. deprecated:: 1.8.1
-                use ``activities`` instead.
 
     .. note::
         Use :func:`~torch.profiler.schedule` to generate the callable schedule.
@@ -1031,31 +1028,13 @@ class profile(_KinetoProfile):
         experimental_config: _ExperimentalConfig | None = None,
         execution_trace_observer: _ITraceObserver | None = None,
         acc_events: bool = False,
-        # deprecated:
-        use_cuda: bool | None = None,
         custom_trace_id_callback: Callable[[], str] | None = None,
         post_processing_timeout_s: float | None = None,
     ) -> None:
-        # Extract activities for the use_cuda deprecation check.
         if activities is not None:
-            activities_set: set[ProfilerActivity] = set()
-            for item in activities:
-                if isinstance(item, ProfilerActivity):
-                    activities_set.add(item)
-                elif isinstance(item, dict):
-                    activities_set.update(item.keys())
+            activities_set, _ = _parse_activities(activities)
         else:
             activities_set = supported_activities()
-        if use_cuda is not None:
-            warn(
-                "`use_cuda` is deprecated, use `activities` argument instead",
-                FutureWarning,
-                stacklevel=2,
-            )
-            if use_cuda:
-                activities_set.add(ProfilerActivity.CUDA)
-            elif ProfilerActivity.CUDA in activities_set:
-                activities_set.remove(ProfilerActivity.CUDA)
         if len(activities_set) == 0:
             raise AssertionError("No valid profiler activities found")
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -168,7 +168,8 @@ PROFILING_SUPPORTED_BACKENDS = [
     dist.Backend.UCC,
 ]
 
-# Allowlist of distributed backends where profiling is supported with use_cuda=True
+# Allowlist of distributed backends where profiling collectives with a CUDA
+# device is supported.
 CUDA_PROFILING_SUPPORTED_BACKENDS = [
     dist.Backend.GLOO,
     dist.Backend.MPI,
@@ -2605,7 +2606,7 @@ class DistributedTest:
                 op_calls.append(secondary_op_call)
 
             autograd_profiler_ctx = torch.autograd.profiler.profile(
-                use_cuda=profile_cuda, record_shapes=True
+                use_device="cuda" if profile_cuda else None, record_shapes=True
             )
 
             # TODO: move this test to use torch.profiler once kineto issues are

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -169,7 +169,10 @@ PROFILING_SUPPORTED_BACKENDS = [
 ]
 
 # Allowlist of distributed backends where profiling collectives with a CUDA
-# device is supported.
+# device is supported. This filters nothing today. The one branch that consults
+# it is reachable only from the three CUDA all_reduce tests, and all three skip
+# unless the backend is Gloo or NCCL, so the MPI and UCC entries below are
+# unreachable and the membership test always passes.
 CUDA_PROFILING_SUPPORTED_BACKENDS = [
     dist.Backend.GLOO,
     dist.Backend.MPI,
@@ -2678,7 +2681,8 @@ class DistributedTest:
                     async_op=async_op,
                     tensor_shapes=tensor_shapes,
                 )
-                # Currently, only Gloo backend has profiling tested with CUDA enabled.
+                # Gloo and NCCL are the only backends that reach here; every other
+                # backend skips the enclosing tests.
                 # Only run cuda profiling test for one rank to speed up since
                 # running with different src_rank does not affect the correctness.
                 if (


### PR DESCRIPTION
**Motivation**

`torch.profiler.profile` has carried a deprecated `use_cuda` argument since 1.8.1, superseded by `activities=[ProfilerActivity.CUDA]`. The autograd profiler it delegates to, `torch.autograd.profiler.profile`, carries the same argument, superseded by `use_device="cuda"`. Both have emitted a FutureWarning for years.

In `torch.profiler.profile` the argument was already inert. It mutated a local `activities_set`, but that set was never handed to `_KinetoProfile.__init__`, which receives the untouched `activities` argument instead.

**Approach**

Remove the flag and docstrings.

The legacy profilers, `torch.autograd.profiler_legacy.profile` and the `_server_process_global_profile` that subclasses it, deliberately keep their `use_cuda`. They have no `use_device` parameter, so there it is the only CUDA switch rather than a deprecated alias; dropping it would delete legacy CUDA profiling outright and force deleting `CudaRpcTest`. That belongs in its own change.

This is BC breaking, but we've been raising a warning for years. Removing this is fair game.

Authored with assistance from Claude Code.