### PR TITLE
Fix expm1 backward for large negative inputs

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -125,15 +125,6 @@ class TestAutograd(TestCase):
         torch.autograd._force_original_view_tracking(False)
         super().tearDown()
 
-    def test_expm1_backward_large_negative(self):
-        x = torch.tensor(-40.0, dtype=torch.float64, requires_grad=True)
-
-        y = torch.expm1(x)
-        y.backward()
-
-        expected = x.detach().exp()
-        self.assertEqual(x.grad, expected)
-
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -125,6 +125,15 @@ class TestAutograd(TestCase):
         torch.autograd._force_original_view_tracking(False)
         super().tearDown()
 
+    def test_expm1_backward_large_negative(self):
+        x = torch.tensor(-40.0, dtype=torch.float64, requires_grad=True)
+
+        y = torch.expm1(x)
+        y.backward()
+
+        expected = x.detach().exp()
+        self.assertEqual(x.grad, expected)
+    
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -133,7 +133,7 @@ class TestAutograd(TestCase):
 
         expected = x.detach().exp()
         self.assertEqual(x.grad, expected)
-    
+
     def test_copy_slices_graph_task_updates(self):
         def f1(x, y):
             out = x.clone().view(-1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -659,7 +659,7 @@
   result: auto_element_wise
 
 - name: expm1(Tensor self) -> Tensor
-  self: grad * (result.conj() + 1)
+  self: grad * self.exp().conj()
   result: auto_element_wise
 
 # TODO: this derivative is not SymInt safe, need sum_to support

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11772,7 +11772,7 @@ def sample_inputs_expm1(op_info, device, dtype, requires_grad, op_kwargs=None, *
     if dtype == torch.float64:
         yield SampleInput(
             torch.tensor(
-                -40.0,
+                [[-40.0]],
                 device=device,
                 dtype=dtype,
                 requires_grad=requires_grad,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11764,6 +11764,21 @@ def sample_inputs_alias_copy(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_tensor((S,), dtype=dtype, device=device, requires_grad=requires_grad))
     yield SampleInput(make_tensor((), dtype=dtype, device=device, requires_grad=requires_grad))
 
+def sample_inputs_expm1(op_info, device, dtype, requires_grad, op_kwargs=None, **kwargs):
+    yield from sample_inputs_elementwise_unary(
+        op_info, device, dtype, requires_grad, op_kwargs=op_kwargs, **kwargs
+    )
+
+    if dtype == torch.float64:
+        yield SampleInput(
+            torch.tensor(
+                -40.0,
+                device=device,
+                dtype=dtype,
+                requires_grad=requires_grad,
+            )
+        )
+
 def sample_inputs_abs(op_info, device, dtype, requires_grad, op_kwargs=None, **kwargs):
     yield from sample_inputs_elementwise_unary(op_info, device, dtype, requires_grad, op_kwargs=None, **kwargs)
     if dtype == torch.cfloat:
@@ -18797,6 +18812,7 @@ op_db: list[OpInfo] = [
                    aliases=('special.expm1', ),
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.expm1),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
+                   sample_inputs_func=sample_inputs_expm1,
                    supports_forward_ad=True,
                    supports_fwgrad_bwgrad=True,
                    supports_sparse=True,


### PR DESCRIPTION
## Summary

Fixes #192406.

The backward formula for `torch.expm1` currently computes the gradient as:

```python
grad * (result.conj() + 1)
```

Although mathematically equivalent to `exp(self)`, this formulation suffers from catastrophic cancellation for large negative inputs because `expm1(x)` approaches `-1`. As a result, `result + 1` can round to zero, producing an incorrect gradient.

This change computes the gradient directly as:

```python
grad * self.exp().conj()
```

which avoids the loss of precision while remaining mathematically equivalent.

A regression test has also been added to verify that the backward gradient of `torch.expm1(-40.0)` matches `torch.exp(-40.0)` for `float64`.

## Test Plan

```bash
python test/test_autograd.py -k expm1
```