### PR TITLE
Fix skipped logic and wrong casts for fp16/bf16 for fused sgd cpu

### DIFF
--- a/aten/src/ATen/native/cpu/FusedAdagradKernel.cpp
+++ b/aten/src/ATen/native/cpu/FusedAdagradKernel.cpp
@@ -45,18 +45,18 @@ std::enable_if_t<
       grad_vec2 = grad_vec2 * fVec(opmath_t(-1.0));
     }
     if (weight_decay != 0.0){
-      grad_vec1 += param_vec1 * fVec(scalar_t(weight_decay));
-      grad_vec2 += param_vec2 * fVec(scalar_t(weight_decay));
+      grad_vec1 += param_vec1 * fVec(opmath_t(weight_decay));
+      grad_vec2 += param_vec2 * fVec(opmath_t(weight_decay));
     }
     auto [state_sum_vec1, state_sum_vec2] = vec::convert_to_float<scalar_t>(lpVec::loadu(state_sum_ptr + d));
     state_sum_vec1 += grad_vec1 * grad_vec1;
     state_sum_vec2 += grad_vec2 * grad_vec2;
     vec::convert_from_float<scalar_t>(state_sum_vec1, state_sum_vec2).store(state_sum_ptr + d);
 
-    fVec std_vec1 = state_sum_vec1.sqrt() + fVec(scalar_t(eps));
-    fVec std_vec2 = state_sum_vec2.sqrt() + fVec(scalar_t(eps));
-    param_vec1 = param_vec1 - fVec(scalar_t(clr)) * grad_vec1 / std_vec1;
-    param_vec2 = param_vec2 - fVec(scalar_t(clr)) * grad_vec2 / std_vec2;
+    fVec std_vec1 = state_sum_vec1.sqrt() + fVec(opmath_t(eps));
+    fVec std_vec2 = state_sum_vec2.sqrt() + fVec(opmath_t(eps));
+    param_vec1 = param_vec1 - fVec(opmath_t(clr)) * grad_vec1 / std_vec1;
+    param_vec2 = param_vec2 - fVec(opmath_t(clr)) * grad_vec2 / std_vec2;
     vec::convert_from_float<scalar_t>(param_vec1, param_vec2).store(param_ptr + d);
   }
   for (; d < size; d++) {

--- a/aten/src/ATen/native/cpu/FusedSGDKernel.cpp
+++ b/aten/src/ATen/native/cpu/FusedSGDKernel.cpp
@@ -48,8 +48,8 @@ std::enable_if_t<
       grad_vec2 = grad_vec2 * fVec(opmath_t(-1.0));
     }
     if (weight_decay != 0.0){
-      grad_vec1 = vec::fmadd(param_vec1, fVec(scalar_t(weight_decay)), grad_vec1);
-      grad_vec2 = vec::fmadd(param_vec2, fVec(scalar_t(weight_decay)), grad_vec2);
+      grad_vec1 = vec::fmadd(param_vec1, fVec(opmath_t(weight_decay)), grad_vec1);
+      grad_vec2 = vec::fmadd(param_vec2, fVec(opmath_t(weight_decay)), grad_vec2);
     }
     if (momentum != 0.0) {
       fVec momentum_vec1, momentum_vec2;
@@ -57,20 +57,25 @@ std::enable_if_t<
         momentum_vec1 = grad_vec1;
         momentum_vec2 = grad_vec2;
       } else {
-        momentum_vec1 = fVec::loadu(momentum_buf_ptr + d) * fVec(scalar_t(momentum));
-        momentum_vec2 = fVec::loadu(momentum_buf_ptr + d + fVec::size()) * fVec(scalar_t(momentum));
-        momentum_vec1 = vec::fmadd(fVec(scalar_t(1 - dampening)), grad_vec1, momentum_vec1);
-        momentum_vec2 = vec::fmadd(fVec(scalar_t(1 - dampening)), grad_vec2, momentum_vec2);
+        lpVec momentum_lpvec = lpVec::loadu(momentum_buf_ptr + d);
+        std::tie(momentum_vec1, momentum_vec2) = vec::convert_to_float<scalar_t>(momentum_lpvec);
+        momentum_vec1 = momentum_vec1 * fVec(opmath_t(momentum));
+        momentum_vec2 = momentum_vec2 * fVec(opmath_t(momentum));
+        momentum_vec1 = vec::fmadd(fVec(opmath_t(1 - dampening)), grad_vec1, momentum_vec1);
+        momentum_vec2 = vec::fmadd(fVec(opmath_t(1 - dampening)), grad_vec2, momentum_vec2);
       }
-      vec::convert_from_float<scalar_t>(momentum_vec1, momentum_vec2).store(momentum_buf_ptr + d);;
+      vec::convert_from_float<scalar_t>(momentum_vec1, momentum_vec2).store(momentum_buf_ptr + d);
       if (nesterov) {
-        grad_vec1 = vec::fmadd(momentum_vec1, fVec(scalar_t(momentum)), grad_vec1);
-        grad_vec2 = vec::fmadd(momentum_vec2, fVec(scalar_t(momentum)), grad_vec2);
+        grad_vec1 = vec::fmadd(momentum_vec1, fVec(opmath_t(momentum)), grad_vec1);
+        grad_vec2 = vec::fmadd(momentum_vec2, fVec(opmath_t(momentum)), grad_vec2);
       } else {
         grad_vec1 = momentum_vec1;
         grad_vec2 = momentum_vec2;
       }
     }
+    param_vec1 = vec::fmadd(grad_vec1, fVec(opmath_t(-lr)), param_vec1);
+    param_vec2 = vec::fmadd(grad_vec2, fVec(opmath_t(-lr)), param_vec2);
+    vec::convert_from_float<scalar_t>(param_vec1, param_vec2).store(param_ptr + d);
   }
   for (; d < size; d++) {
     opmath_t grad_val = grad_ptr[d];

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1156,6 +1156,51 @@ class TestOptimRenewed(TestCase):
             )
         self._test_derived_optimizers(device, dtype, optim_info, "fused")
 
+    # Test vectorization path splits for fused kernels. Ensure the scalar path
+    # and vectorized path compute the same thing.
+    # See https://github.com/pytorch/pytorch/issues/165632.
+    # fp64 is left out so this runs on MPS; it shares the same code w/ fp32
+    @optims(
+        [optim for optim in optim_db if "fused" in optim.supported_impls],
+        dtypes=(torch.float32, torch.float16, torch.bfloat16),
+    )
+    # Vectorized::size() is at most 32 elements (AVX512, bf16/fp16), so 64 tests
+    # two full blocks with no remainder, and 65 adds a scalar remainder.
+    @parametrize("numel", [64, 65])
+    def test_fused_vectorized_block_matches_scalar(
+        self, device, dtype, optim_info, numel
+    ):
+        if _get_device_type(device) not in optim_info.supports_fused_on:
+            self.skipTest(
+                f"{device} is not supported for fused on {optim_info.optim_cls.__name__}"
+            )
+        optim_cls = optim_info.optim_cls
+        for optim_input in optim_info.optim_inputs_func(device=device, dtype=dtype):
+            kwargs = deepcopy(optim_input.kwargs)
+            if kwargs.get("capturable", False) and _get_device_type(device) == "cpu":
+                # capturable is not supported on CPU
+                continue
+            param_numel, param_single = (
+                torch.nn.Parameter(torch.full((n,), 0.25, device=device, dtype=dtype))
+                for n in (numel, 1)
+            )
+            opt_numel = optim_cls([param_numel], fused=True, **kwargs)
+            opt_single = optim_cls([param_single], fused=True, **kwargs)
+            for step in range(3):
+                grad_value = 0.125 * (step + 1)
+                param_numel.grad = torch.full_like(param_numel, grad_value)
+                param_single.grad = torch.full_like(param_single, grad_value)
+                opt_numel.step()
+                opt_single.step()
+                self.assertEqual(param_numel, param_single.expand(numel))
+                state = opt_numel.state[param_numel]
+                ref_state = opt_single.state[param_single]
+                self.assertEqual(state.keys(), ref_state.keys())
+                for k, v in state.items():
+                    # the shape guard skips step and SGD's None momentum_buffer
+                    if torch.is_tensor(v) and v.shape == param_numel.shape:
+                        self.assertEqual(v, ref_state[k].expand(numel))
+
     @optims(
         [optim for optim in optim_db if "fused" in optim.supported_impls],
         dtypes=(torch.float32,),

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1158,7 +1158,7 @@ class TestOptimRenewed(TestCase):
 
     # Test vectorization path splits for fused kernels. Ensure the scalar path
     # and vectorized path compute the same thing.
-    # See https://github.com/pytorch/pytorch/issues/165632.
+    # See https://github.com/pytorch/pytorch/issues/191763.
     # fp64 is left out so this runs on MPS; it shares the same code w/ fp32
     @optims(
         [optim for optim in optim_db if "fused" in optim.supported_impls],


### PR DESCRIPTION
Fixes #191763 

Also fixes:
- Use opmath_t for compute and not scalar_t
- momentum path was writing trash

Adds a new test case. I was trying to fold it into existing tests, but
- fused vs forloop diverged too much due to intermediates being opmath and not scalar_t
- fused cpu vs cuda diverges cuz CPU is different for Linear than GPU
- this is the most straightforward test

Perf is not affected, if anything it became faster? 
<img width="425" height="274" alt="image" src="https://github.com/user-attachments/assets/81153440-206f-4709-a853-d4e728d0cd5d" />

Script to run before and after the change:
```
import json, sys, time
import torch

LABEL = sys.argv[1]
CASES = [
    ("Adagrad", torch.optim.Adagrad, {"lr": 0.1, "eps": 1e-10}),
    ("Adagrad_wd", torch.optim.Adagrad, {"lr": 0.1, "eps": 1e-10, "weight_decay": 0.1}),
    ("SGD_mom", torch.optim.SGD, {"lr": 0.01, "momentum": 0.9}),
    ("SGD_wd_mom", torch.optim.SGD, {"lr": 0.01, "momentum": 0.9, "weight_decay": 0.1}),
]
DTYPES = [("bf16", torch.bfloat16), ("fp16", torch.float16)]
N = 4096          # accuracy: many vector blocks plus a remainder
NPERF = 1 << 22   # perf: 4.2M elements
STEPS = 5

def accuracy(optim_cls, kwargs, dtype):
    """Intra-kernel vec-vs-scalar gap, and error against an fp64 reference."""
    # every slot identical -> the size-1 param is the exact expected value
    big = torch.nn.Parameter(torch.full((N + 1,), 0.25, dtype=dtype))
    one = torch.nn.Parameter(torch.full((1,), 0.25, dtype=dtype))
    ref64 = torch.nn.Parameter(torch.full((1,), 0.25, dtype=torch.float64))
    ob = optim_cls([big], fused=True, **kwargs)
    oo = optim_cls([one], fused=True, **kwargs)
    o64 = optim_cls([ref64], **kwargs)
    for s in range(STEPS):
        gv = 0.125 * (s + 1)
        for p, o in ((big, ob), (one, oo), (ref64, o64)):
            p.grad = torch.full_like(p, gv)
            o.step()
    vec_vs_scalar = (big.detach().double() - one.detach().double()).abs().max().item()
    err_vs_fp64 = (big.detach().double() - ref64.detach()).abs().max().item()
    return vec_vs_scalar, err_vs_fp64

def perf(optim_cls, kwargs, dtype):
    p = torch.nn.Parameter(torch.full((NPERF,), 0.25, dtype=dtype))
    o = optim_cls([p], fused=True, **kwargs)
    g = torch.full_like(p, 0.01)
    for _ in range(3):
        p.grad = g.clone()
        o.step()
    best = float("inf")
    for _ in range(7):
        p.grad = g.clone()
        t0 = time.perf_counter()
        o.step()
        best = min(best, time.perf_counter() - t0)
    return NPERF / best / 1e6

out = {}
for cname, cls, kw in CASES:
    for dname, dt in DTYPES:
        v, e = accuracy(cls, kw, dt)
        out[f"{cname}/{dname}"] = {
            "vec_vs_scalar": v,
            "err_vs_fp64": e,
            "Melem_s": perf(cls, kw, dt),
        }
print(json.dumps({"label": LABEL, "results": out}, indent=1))
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01