### PR TITLE
[BE] Move Aten files to be CLANG-FORMATTED and do it

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -51,6 +51,7 @@ code = 'CLANGFORMAT'
 include_patterns = [
     'aten/src/ATen/*.h',
     'aten/src/ATen/cpu/vec/**/*.h',
+    'aten/src/ATen/cuda/Atomic.cuh',
     'aten/src/ATen/accelerator/**/*.h',
     'aten/src/ATen/accelerator/**/*.cpp',
     'aten/src/ATen/mps/**/*.mm',
@@ -65,6 +66,7 @@ include_patterns = [
     'aten/src/ATen/native/mps/**/*.h',
     'aten/src/ATen/native/vulkan/**/*.h',
     'aten/src/ATen/native/vulkan/**/*.cpp',
+    'aten/src/ATen/native/cuda/KernelUtils.cuh',
     'aten/src/ATen/native/cuda/MultiTensorApply.cuh',
     'aten/src/ATen/native/**/Foreach*.*',
     'aten/src/ATen/native/cuda/fused*.*',

--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cuda.h>
-#include <c10/util/Half.h>
 #include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+#include <cuda.h>
 
 #include <ATen/NumericUtils.h>
 
@@ -20,9 +20,12 @@ struct AtomicFPOp;
 template <>
 struct AtomicFPOp<at::Half> {
   template <typename func_t>
-  inline __device__ at::Half operator() (at::Half *address, at::Half val, const func_t& func) {
-    unsigned int * address_as_ui =
-      (unsigned int *) ((char *)address - ((size_t)address & 2));
+  inline __device__ at::Half operator()(
+      at::Half* address,
+      at::Half val,
+      const func_t& func) {
+    unsigned int* address_as_ui =
+        (unsigned int*)((char*)address - ((size_t)address & 2));
     unsigned int old = *address_as_ui;
     unsigned int assumed;
 
@@ -31,7 +34,8 @@ struct AtomicFPOp<at::Half> {
       assumed = old;
       hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       hsum = func(hsum, val);
-      old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
+      old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16)
+                                : (old & 0xffff0000) | hsum.x;
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
     hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
@@ -42,9 +46,12 @@ struct AtomicFPOp<at::Half> {
 template <>
 struct AtomicFPOp<at::BFloat16> {
   template <typename func_t>
-  inline __device__ at::BFloat16 operator() (at::BFloat16 *address, at::BFloat16 val, const func_t& func) {
-    unsigned int * address_as_ui =
-      (unsigned int *) ((char *)address - ((size_t)address & 2));
+  inline __device__ at::BFloat16 operator()(
+      at::BFloat16* address,
+      at::BFloat16 val,
+      const func_t& func) {
+    unsigned int* address_as_ui =
+        (unsigned int*)((char*)address - ((size_t)address & 2));
     unsigned int old = *address_as_ui;
     unsigned int assumed;
 
@@ -53,7 +60,8 @@ struct AtomicFPOp<at::BFloat16> {
       assumed = old;
       bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       bsum = func(bsum, val);
-      old = (size_t)address & 2 ? (old & 0xffff) | (bsum.x << 16) : (old & 0xffff0000) | bsum.x;
+      old = (size_t)address & 2 ? (old & 0xffff) | (bsum.x << 16)
+                                : (old & 0xffff0000) | bsum.x;
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
     bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
@@ -64,7 +72,10 @@ struct AtomicFPOp<at::BFloat16> {
 template <>
 struct AtomicFPOp<double> {
   template <typename func_t>
-  inline __device__ double operator() (double * address, double val, const func_t& func) {
+  inline __device__ double operator()(
+      double* address,
+      double val,
+      const func_t& func) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull;
     unsigned long long int assumed;
@@ -72,165 +83,161 @@ struct AtomicFPOp<double> {
     do {
       assumed = old;
       old = atomicCAS(address_as_ull, assumed, func(val, assumed));
-      // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+      // Note: uses integer comparison to avoid hang in case of NaN (since NaN
+      // != NaN)
     } while (assumed != old);
 
     return __longlong_as_double(old);
   }
 };
 
-#define ATOMIC_INTEGER_IMPL(NAME)                                                                                      \
-template <typename T, size_t n>                                                                                        \
-struct Atomic##NAME##IntegerImpl;                                                                                      \
-                                                                                                                       \
-template<typename T>                                                                                                   \
-struct Atomic##NAME##IntegerImpl<T, 1> {                                                                               \
-  template <typename func_t>                                                                                           \
-  inline __device__ void operator()(T *address, T val, const func_t& func) {                                           \
-    size_t offset = (size_t)address & 3;                                                                               \
-    uint32_t * address_as_ui = (uint32_t *)((char *)address - offset);                                                 \
-    uint32_t old = *address_as_ui;                                                                                     \
-    uint32_t shift = offset * 8;                                                                                       \
-    uint32_t old_byte;                                                                                                 \
-    uint32_t newval;                                                                                                   \
-    uint32_t assumed;                                                                                                  \
-                                                                                                                       \
-    do {                                                                                                               \
-      assumed = old;                                                                                                   \
-      old_byte = (old >> shift) & 0xff;                                                                                \
-      newval = static_cast<uint8_t>(func(val, static_cast<T>(old_byte)));                                              \
-      newval = (old & ~(0x000000ff << shift)) | (newval << shift);                                                     \
-      old = atomicCAS(address_as_ui, assumed, newval);                                                                 \
-    } while (assumed != old);                                                                                          \
-  }                                                                                                                    \
-};                                                                                                                     \
-                                                                                                                       \
-template<typename T>                                                                                                   \
-struct Atomic##NAME##IntegerImpl<T, 2> {                                                                               \
-  template <typename func_t>                                                                                           \
-  inline __device__ void operator()(T *address, T val, const func_t& func) {                                           \
-    size_t offset = (size_t)address & 2;                                                                               \
-    uint32_t * address_as_ui = (uint32_t *)((char *)address - offset);                                                 \
-    bool is_32_align = offset;                                                                                         \
-    uint32_t old = *address_as_ui;                                                                                     \
-    uint32_t old_bytes;                                                                                                \
-    uint32_t newval;                                                                                                   \
-    uint32_t assumed;                                                                                                  \
-                                                                                                                       \
-    do {                                                                                                               \
-      assumed = old;                                                                                                   \
-      old_bytes = is_32_align ? old >> 16 : old & 0xffff;                                                              \
-      newval = static_cast<uint16_t>(func(val, static_cast<T>(old_bytes)));                                            \
-      newval = is_32_align ? (old & 0xffff) | (newval << 16) : (old & 0xffff0000) | newval;                            \
-      old = atomicCAS(address_as_ui, assumed, newval);                                                                 \
-    } while (assumed != old);                                                                                          \
-  }                                                                                                                    \
-};                                                                                                                     \
-                                                                                                                       \
-template<typename T>                                                                                                   \
-struct Atomic##NAME##IntegerImpl<T, 4> {                                                                               \
-  template <typename func_t>                                                                                           \
-  inline __device__ void operator()(T *address, T val, const func_t& func) {                                           \
-    uint32_t * address_as_ui = (uint32_t *) (address);                                                                 \
-    uint32_t old = *address_as_ui;                                                                                     \
-    uint32_t newval;                                                                                                   \
-    uint32_t assumed;                                                                                                  \
-                                                                                                                       \
-    do {                                                                                                               \
-      assumed = old;                                                                                                   \
-      newval = static_cast<uint32_t>(func(val, static_cast<T>(old)));                                                  \
-      old = atomicCAS(address_as_ui, assumed, newval);                                                                 \
-    } while (assumed != old);                                                                                          \
-  }                                                                                                                    \
-};                                                                                                                     \
-                                                                                                                       \
-template<typename T>                                                                                                   \
-struct Atomic##NAME##IntegerImpl<T, 8> {                                                                               \
-  template <typename func_t>                                                                                           \
-  inline __device__ void operator()(T *address, T val, const func_t& func) {                                           \
-    unsigned long long * address_as_ui = (unsigned long long *) (address);                                             \
-    unsigned long long old = *address_as_ui;                                                                           \
-    unsigned long long newval;                                                                                         \
-    unsigned long long assumed;                                                                                        \
-                                                                                                                       \
-    do {                                                                                                               \
-      assumed = old;                                                                                                   \
-      newval = static_cast<uint64_t>(func(val, static_cast<T>(old)));                                                  \
-      old = atomicCAS(address_as_ui, assumed, newval);                                                                 \
-    } while (assumed != old);                                                                                          \
-  }                                                                                                                    \
-};
+#define ATOMIC_INTEGER_IMPL(NAME)                                              \
+  template <typename T, size_t n>                                              \
+  struct Atomic##NAME##IntegerImpl;                                            \
+                                                                               \
+  template <typename T>                                                        \
+  struct Atomic##NAME##IntegerImpl<T, 1> {                                     \
+    template <typename func_t>                                                 \
+    inline __device__ void operator()(T* address, T val, const func_t& func) { \
+      size_t offset = (size_t)address & 3;                                     \
+      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);          \
+      uint32_t old = *address_as_ui;                                           \
+      uint32_t shift = offset * 8;                                             \
+      uint32_t old_byte;                                                       \
+      uint32_t newval;                                                         \
+      uint32_t assumed;                                                        \
+                                                                               \
+      do {                                                                     \
+        assumed = old;                                                         \
+        old_byte = (old >> shift) & 0xff;                                      \
+        newval = static_cast<uint8_t>(func(val, static_cast<T>(old_byte)));    \
+        newval = (old & ~(0x000000ff << shift)) | (newval << shift);           \
+        old = atomicCAS(address_as_ui, assumed, newval);                       \
+      } while (assumed != old);                                                \
+    }                                                                          \
+  };                                                                           \
+                                                                               \
+  template <typename T>                                                        \
+  struct Atomic##NAME##IntegerImpl<T, 2> {                                     \
+    template <typename func_t>                                                 \
+    inline __device__ void operator()(T* address, T val, const func_t& func) { \
+      size_t offset = (size_t)address & 2;                                     \
+      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);          \
+      bool is_32_align = offset;                                               \
+      uint32_t old = *address_as_ui;                                           \
+      uint32_t old_bytes;                                                      \
+      uint32_t newval;                                                         \
+      uint32_t assumed;                                                        \
+                                                                               \
+      do {                                                                     \
+        assumed = old;                                                         \
+        old_bytes = is_32_align ? old >> 16 : old & 0xffff;                    \
+        newval = static_cast<uint16_t>(func(val, static_cast<T>(old_bytes)));  \
+        newval = is_32_align ? (old & 0xffff) | (newval << 16)                 \
+                             : (old & 0xffff0000) | newval;                    \
+        old = atomicCAS(address_as_ui, assumed, newval);                       \
+      } while (assumed != old);                                                \
+    }                                                                          \
+  };                                                                           \
+                                                                               \
+  template <typename T>                                                        \
+  struct Atomic##NAME##IntegerImpl<T, 4> {                                     \
+    template <typename func_t>                                                 \
+    inline __device__ void operator()(T* address, T val, const func_t& func) { \
+      uint32_t* address_as_ui = (uint32_t*)(address);                          \
+      uint32_t old = *address_as_ui;                                           \
+      uint32_t newval;                                                         \
+      uint32_t assumed;                                                        \
+                                                                               \
+      do {                                                                     \
+        assumed = old;                                                         \
+        newval = static_cast<uint32_t>(func(val, static_cast<T>(old)));        \
+        old = atomicCAS(address_as_ui, assumed, newval);                       \
+      } while (assumed != old);                                                \
+    }                                                                          \
+  };                                                                           \
+                                                                               \
+  template <typename T>                                                        \
+  struct Atomic##NAME##IntegerImpl<T, 8> {                                     \
+    template <typename func_t>                                                 \
+    inline __device__ void operator()(T* address, T val, const func_t& func) { \
+      unsigned long long* address_as_ui = (unsigned long long*)(address);      \
+      unsigned long long old = *address_as_ui;                                 \
+      unsigned long long newval;                                               \
+      unsigned long long assumed;                                              \
+                                                                               \
+      do {                                                                     \
+        assumed = old;                                                         \
+        newval = static_cast<uint64_t>(func(val, static_cast<T>(old)));        \
+        old = atomicCAS(address_as_ui, assumed, newval);                       \
+      } while (assumed != old);                                                \
+    }                                                                          \
+  };
 
-
-# define GPU_ATOMIC_INTEGER(NAME, OP, DTYPE)                                                                           \
-inline __device__ void gpuAtomic##NAME(DTYPE *address, DTYPE val) {                                             \
-Atomic##NAME##IntegerImpl<DTYPE, sizeof(DTYPE)>()(address,                                                             \
-                                                      val,                                                             \
-                                                      [](DTYPE a, DTYPE b) {                                           \
-                                                          return OP;                                                   \
-                                                      });                                                              \
-}                                                                                                                      \
+#define GPU_ATOMIC_INTEGER(NAME, OP, DTYPE)                           \
+  inline __device__ void gpuAtomic##NAME(DTYPE* address, DTYPE val) { \
+    Atomic##NAME##IntegerImpl<DTYPE, sizeof(DTYPE)>()(                \
+        address, val, [](DTYPE a, DTYPE b) { return OP; });           \
+  }
 
 ATOMIC_INTEGER_IMPL(Add)
 GPU_ATOMIC_INTEGER(Add, a || b, bool)
 
-// Don't instantiate gpuAtomicAdd with the macro as it seems non-standard (see int32, int64)
-inline __device__ void gpuAtomicAdd(uint8_t *address, uint8_t val) {
-  AtomicAddIntegerImpl<uint8_t, sizeof(uint8_t)>()(address,
-                                                   val,
-                                                   [](uint8_t a, uint8_t b) {
-                                                      return a + b;
-                                                   });
+// Don't instantiate gpuAtomicAdd with the macro as it seems non-standard (see
+// int32, int64)
+inline __device__ void gpuAtomicAdd(uint8_t* address, uint8_t val) {
+  AtomicAddIntegerImpl<uint8_t, sizeof(uint8_t)>()(
+      address, val, [](uint8_t a, uint8_t b) { return a + b; });
 }
 
-inline  __device__ void gpuAtomicAdd(int8_t *address, int8_t val) {
-  AtomicAddIntegerImpl<int8_t, sizeof(int8_t)>()(address,
-                                                 val,
-                                                 [](int8_t a, int8_t b) {
-                                                   return a + b;
-                                                 });
+inline __device__ void gpuAtomicAdd(int8_t* address, int8_t val) {
+  AtomicAddIntegerImpl<int8_t, sizeof(int8_t)>()(
+      address, val, [](int8_t a, int8_t b) { return a + b; });
 }
 
-inline  __device__ void gpuAtomicAdd(int16_t *address, int16_t val) {
-  AtomicAddIntegerImpl<int16_t, sizeof(int16_t)>()(address,
-                                                   val,
-                                                   [](int16_t a, int16_t b) {
-                                                     return a + b;
-                                                   });
+inline __device__ void gpuAtomicAdd(int16_t* address, int16_t val) {
+  AtomicAddIntegerImpl<int16_t, sizeof(int16_t)>()(
+      address, val, [](int16_t a, int16_t b) { return a + b; });
 }
 
-inline __device__ int32_t gpuAtomicAdd(int32_t *address, int32_t val) {
+inline __device__ int32_t gpuAtomicAdd(int32_t* address, int32_t val) {
   return atomicAdd(address, val);
 }
 
-inline __device__ void gpuAtomicAdd(int64_t *address, int64_t val) {
+inline __device__ void gpuAtomicAdd(int64_t* address, int64_t val) {
 #if defined(USE_ROCM)
   __atomic_fetch_add(address, val, __ATOMIC_RELAXED);
 #else
-  static_assert(sizeof(unsigned long long int) == sizeof(int64_t), "bitwidth change is not allowed");
-  atomicAdd(reinterpret_cast<unsigned long long int *>(address), static_cast<unsigned long long int>(val));
+  static_assert(
+      sizeof(unsigned long long int) == sizeof(int64_t),
+      "bitwidth change is not allowed");
+  atomicAdd(
+      reinterpret_cast<unsigned long long int*>(address),
+      static_cast<unsigned long long int>(val));
 #endif
 }
 
-inline  __device__ at::Half gpuAtomicAdd(at::Half *address, at::Half val) {
+inline __device__ at::Half gpuAtomicAdd(at::Half* address, at::Half val) {
 #if defined(USE_ROCM) || ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
-  return AtomicFPOp<at::Half>()(address, val,
-                                [](at::Half hsum, at::Half val) {
-                                  return hsum + val;
-                                });
+  return AtomicFPOp<at::Half>()(
+      address, val, [](at::Half hsum, at::Half val) { return hsum + val; });
 #else
   return atomicAdd(reinterpret_cast<__half*>(address), val);
 #endif
 }
 
-inline __device__ at::BFloat16 gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 val) {
+inline __device__ at::BFloat16 gpuAtomicAdd(
+    at::BFloat16* address,
+    at::BFloat16 val) {
 #if defined(USE_ROCM) || ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)))
-return AtomicFPOp<at::BFloat16>()(address, val,
-                                  [](at::BFloat16 bsum, at::BFloat16 val) {
-                                    return bsum + val;
-                                  });
+  return AtomicFPOp<at::BFloat16>()(
+      address, val, [](at::BFloat16 bsum, at::BFloat16 val) {
+        return bsum + val;
+      });
 #else
-  __nv_bfloat16 r = atomicAdd(reinterpret_cast<__nv_bfloat16*>(address), *reinterpret_cast<__nv_bfloat16*>(&val));
+  __nv_bfloat16 r = atomicAdd(
+      reinterpret_cast<__nv_bfloat16*>(address),
+      *reinterpret_cast<__nv_bfloat16*>(&val));
   return *reinterpret_cast<c10::BFloat16*>(&r);
 #endif
 }
@@ -246,10 +253,10 @@ inline __device__ double atomicAdd(double* address, double val)
 #endif
 {
 
-  return AtomicFPOp<double>()(address, val,
-                              [](double val, unsigned long long int assumed) {
-                                return __double_as_longlong(val + __longlong_as_double(assumed));
-                              });
+  return AtomicFPOp<double>()(
+      address, val, [](double val, unsigned long long int assumed) {
+        return __double_as_longlong(val + __longlong_as_double(assumed));
+      });
 }
 #elif defined(USE_ROCM) || !(defined(__CUDA_ARCH__))
 
@@ -264,21 +271,23 @@ inline __device__ double atomicAdd(double* address, double val)
  */
 
 #if defined(USE_ROCM) && __hcc_workweek__ < 18312 && !__HIP__
-  // This needs to be defined for the host side pass
-  inline  __device__  double atomicAdd(double *address, double val) { }
+// This needs to be defined for the host side pass
+inline __device__ double atomicAdd(double* address, double val) {}
 #endif
 #endif
 
-inline __device__ double gpuAtomicAdd(double *address, double val) {
+inline __device__ double gpuAtomicAdd(double* address, double val) {
   return atomicAdd(address, val);
 }
 
-inline __device__ float gpuAtomicAdd(float *address, float val) {
+inline __device__ float gpuAtomicAdd(float* address, float val) {
   return atomicAdd(address, val);
 }
 
-template<typename T>
-inline __device__ void gpuAtomicAdd(c10::complex<T> *address, c10::complex<T> val) {
+template <typename T>
+inline __device__ void gpuAtomicAdd(
+    c10::complex<T>* address,
+    c10::complex<T> val) {
   gpuAtomicAdd(&address->real_, val.real_);
   gpuAtomicAdd(&address->imag_, val.imag_);
 }
@@ -286,54 +295,79 @@ inline __device__ void gpuAtomicAdd(c10::complex<T> *address, c10::complex<T> va
 /* Note [gpuAtomicAdd vs atomicAdd]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * Some extensions such as torchvision call atomicAdd()
- * directly and require non-library provided data type support. Only for these, we
- * continue to provide atomicAdd overloads.
+ * directly and require non-library provided data type support. Only for these,
+ * we continue to provide atomicAdd overloads.
  */
-inline __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
+inline __device__ at::Half atomicAdd(at::Half* address, at::Half val) {
   return gpuAtomicAdd(address, val);
 }
 
-inline __device__ at::BFloat16 atomicAdd(at::BFloat16 *address, at::BFloat16 val) {
+inline __device__ at::BFloat16 atomicAdd(
+    at::BFloat16* address,
+    at::BFloat16 val) {
   return gpuAtomicAdd(address, val);
 }
 
-inline __device__ void atomicAdd(uint8_t *address, uint8_t val) {
+inline __device__ void atomicAdd(uint8_t* address, uint8_t val) {
   gpuAtomicAdd(address, val);
 }
 
-inline  __device__ void atomicAdd(int8_t *address, int8_t val) {
+inline __device__ void atomicAdd(int8_t* address, int8_t val) {
   gpuAtomicAdd(address, val);
 }
 
-inline  __device__ void atomicAdd(int16_t *address, int16_t val) {
+inline __device__ void atomicAdd(int16_t* address, int16_t val) {
   gpuAtomicAdd(address, val);
 }
 
-inline __device__ void atomicAdd(int64_t *address, int64_t val) {
+inline __device__ void atomicAdd(int64_t* address, int64_t val) {
   gpuAtomicAdd(address, val);
 }
 
-inline __device__ void atomicAdd(bool *address, bool val) {
+inline __device__ void atomicAdd(bool* address, bool val) {
   gpuAtomicAdd(address, val);
 }
 
 /* Note [explicitly non-returning atomics]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * AMD's MI100 (gfx908) provides an optimized fp32 atomicAdd, exposed via atomicAddNoRet().
- * Due to compiler limitations, callers must opt-in to guarantee the optimized instruction.
- * This non-returning atomicAddNoRet cannot be used to implement the returning atomicAdd,
- * therefore we need a new API 'gpuAtomicAddNoReturn'.
+ * AMD's MI100 (gfx908) provides an optimized fp32 atomicAdd, exposed via
+ * atomicAddNoRet(). Due to compiler limitations, callers must opt-in to
+ * guarantee the optimized instruction. This non-returning atomicAddNoRet cannot
+ * be used to implement the returning atomicAdd, therefore we need a new API
+ * 'gpuAtomicAddNoReturn'.
  */
-template<typename T>
-inline __device__ void gpuAtomicAddNoReturn(c10::complex<T> *address, c10::complex<T> val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(uint8_t *address, uint8_t val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(int8_t *address, int8_t val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(int16_t *address, int16_t val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(int32_t *address, int32_t val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(int64_t *address, int64_t val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(bool *address, bool val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(at::Half *address, at::Half val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BFloat16 val) { gpuAtomicAdd(address, val); }
+template <typename T>
+inline __device__ void gpuAtomicAddNoReturn(
+    c10::complex<T>* address,
+    c10::complex<T> val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(uint8_t* address, uint8_t val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(int8_t* address, int8_t val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(int16_t* address, int16_t val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(int32_t* address, int32_t val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(int64_t* address, int64_t val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(bool* address, bool val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(at::Half* address, at::Half val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(
+    at::BFloat16* address,
+    at::BFloat16 val) {
+  gpuAtomicAdd(address, val);
+}
 
 /* Note [HIP unsafeAtomicAdd]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -347,60 +381,67 @@ inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BFloat16 
  * under the LLVM compiler directory.
  */
 #if defined(USE_ROCM)
-inline __device__ void gpuAtomicAddNoReturn(float *address, float val) {
+inline __device__ void gpuAtomicAddNoReturn(float* address, float val) {
   if (__builtin_amdgcn_processor_is("gfx908"))
     return atomicAddNoRet(address, val);
   (void)unsafeAtomicAdd(address, val);
 }
-inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { (void)unsafeAtomicAdd(address, val); }
+inline __device__ void gpuAtomicAddNoReturn(double* address, double val) {
+  (void)unsafeAtomicAdd(address, val);
+}
 #else
-inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
-inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
+inline __device__ void gpuAtomicAddNoReturn(float* address, float val) {
+  gpuAtomicAdd(address, val);
+}
+inline __device__ void gpuAtomicAddNoReturn(double* address, double val) {
+  gpuAtomicAdd(address, val);
+}
 #endif
 
 // Atomic multiplication implementation.
 
 ATOMIC_INTEGER_IMPL(Mul)
-GPU_ATOMIC_INTEGER(Mul, a * b, uint8_t)
-GPU_ATOMIC_INTEGER(Mul, a * b, int8_t)
-GPU_ATOMIC_INTEGER(Mul, a * b, int16_t)
-GPU_ATOMIC_INTEGER(Mul, a * b, int32_t)
-GPU_ATOMIC_INTEGER(Mul, a * b, int64_t)
+GPU_ATOMIC_INTEGER(Mul, a* b, uint8_t)
+GPU_ATOMIC_INTEGER(Mul, a* b, int8_t)
+GPU_ATOMIC_INTEGER(Mul, a* b, int16_t)
+GPU_ATOMIC_INTEGER(Mul, a* b, int32_t)
+GPU_ATOMIC_INTEGER(Mul, a* b, int64_t)
 
-inline __device__ at::Half gpuAtomicMul(at::Half * address, at::Half val) {
-  return AtomicFPOp<at::Half>()(address, val,
-                                [](at::Half bsum, at::Half val) {
-                                  return bsum * val;
-                                });
+inline __device__ at::Half gpuAtomicMul(at::Half* address, at::Half val) {
+  return AtomicFPOp<at::Half>()(
+      address, val, [](at::Half bsum, at::Half val) { return bsum * val; });
 }
 
-inline __device__ at::BFloat16 gpuAtomicMul(at::BFloat16 * address, at::BFloat16 val) {
-  return AtomicFPOp<at::BFloat16>()(address, val,
-                                    [](at::BFloat16 bsum, at::BFloat16 val) {
-                                      return bsum * val;
-                                    });
+inline __device__ at::BFloat16 gpuAtomicMul(
+    at::BFloat16* address,
+    at::BFloat16 val) {
+  return AtomicFPOp<at::BFloat16>()(
+      address, val, [](at::BFloat16 bsum, at::BFloat16 val) {
+        return bsum * val;
+      });
 }
 
-inline __device__ double gpuAtomicMul(double * address, double val) {
-  return AtomicFPOp<double>()(address, val,
-                              [](double val, unsigned long long int assumed) {
-                                return __double_as_longlong(val * __longlong_as_double(assumed));
-                              });
+inline __device__ double gpuAtomicMul(double* address, double val) {
+  return AtomicFPOp<double>()(
+      address, val, [](double val, unsigned long long int assumed) {
+        return __double_as_longlong(val * __longlong_as_double(assumed));
+      });
 }
 
-// Dont use a templated function for this since the addition function defaults to the CUDA built-in.
-inline __device__ float gpuAtomicMul (float * address, float val) {
+// Dont use a templated function for this since the addition function defaults
+// to the CUDA built-in.
+inline __device__ float gpuAtomicMul(float* address, float val) {
   unsigned int* address_as_ull = (unsigned int*)address;
   unsigned int old = *address_as_ull;
   unsigned int assumed;
 
   do {
     assumed = old;
-    old = atomicCAS(address_as_ull, assumed,
-                    __float_as_int(val *
-                                   __int_as_float(assumed)));
+    old = atomicCAS(
+        address_as_ull, assumed, __float_as_int(val * __int_as_float(assumed)));
 
-    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN !=
+    // NaN)
   } while (assumed != old);
 
   return __int_as_float(old);
@@ -421,39 +462,45 @@ GPU_ATOMIC_INTEGER(Max, safe_max(a, b), int16_t)
 GPU_ATOMIC_INTEGER(Max, safe_max(a, b), int32_t)
 GPU_ATOMIC_INTEGER(Max, safe_max(a, b), int64_t)
 
-inline __device__ at::Half gpuAtomicMax(at::Half * address, at::Half val) {
-  return AtomicFPOp<at::Half>()(address, val,
-                                [](at::Half bsum, at::Half val) {
-                                  return safe_max(bsum, val);
-                                });
+inline __device__ at::Half gpuAtomicMax(at::Half* address, at::Half val) {
+  return AtomicFPOp<at::Half>()(address, val, [](at::Half bsum, at::Half val) {
+    return safe_max(bsum, val);
+  });
 }
 
-inline __device__ at::BFloat16 gpuAtomicMax(at::BFloat16 * address, at::BFloat16 val) {
-  return AtomicFPOp<at::BFloat16>()(address, val,
-                                    [](at::BFloat16 bsum, at::BFloat16 val) {
-                                      return safe_max(bsum, val);
-                                    });
+inline __device__ at::BFloat16 gpuAtomicMax(
+    at::BFloat16* address,
+    at::BFloat16 val) {
+  return AtomicFPOp<at::BFloat16>()(
+      address, val, [](at::BFloat16 bsum, at::BFloat16 val) {
+        return safe_max(bsum, val);
+      });
 }
 
-inline __device__ double gpuAtomicMax(double * address, double val) {
-  return AtomicFPOp<double>()(address, val,
-                              [](double val, unsigned long long int assumed) {
-                                return __double_as_longlong(safe_max(val, __longlong_as_double(assumed)));
-                              });
+inline __device__ double gpuAtomicMax(double* address, double val) {
+  return AtomicFPOp<double>()(
+      address, val, [](double val, unsigned long long int assumed) {
+        return __double_as_longlong(
+            safe_max(val, __longlong_as_double(assumed)));
+      });
 }
 
-// Dont use a templated function for this since the addition function defaults to the CUDA built-in.
-inline __device__ float gpuAtomicMax(float * address, float val) {
+// Dont use a templated function for this since the addition function defaults
+// to the CUDA built-in.
+inline __device__ float gpuAtomicMax(float* address, float val) {
   unsigned int* address_as_ull = (unsigned int*)address;
   unsigned int old = *address_as_ull;
   unsigned int assumed;
 
   do {
     assumed = old;
-    old = atomicCAS(address_as_ull, assumed,
-                    __float_as_int(safe_max(val, __int_as_float(assumed))));
+    old = atomicCAS(
+        address_as_ull,
+        assumed,
+        __float_as_int(safe_max(val, __int_as_float(assumed))));
 
-    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN !=
+    // NaN)
   } while (assumed != old);
 
   return __int_as_float(old);
@@ -474,39 +521,45 @@ GPU_ATOMIC_INTEGER(Min, safe_min(a, b), int16_t)
 GPU_ATOMIC_INTEGER(Min, safe_min(a, b), int32_t)
 GPU_ATOMIC_INTEGER(Min, safe_min(a, b), int64_t)
 
-inline __device__ at::Half gpuAtomicMin(at::Half * address, at::Half val) {
-  return AtomicFPOp<at::Half>()(address, val,
-                                [](at::Half bsum, at::Half val) {
-                                  return safe_min(bsum, val);
-                                });
+inline __device__ at::Half gpuAtomicMin(at::Half* address, at::Half val) {
+  return AtomicFPOp<at::Half>()(address, val, [](at::Half bsum, at::Half val) {
+    return safe_min(bsum, val);
+  });
 }
 
-inline __device__ at::BFloat16 gpuAtomicMin(at::BFloat16 * address, at::BFloat16 val) {
-  return AtomicFPOp<at::BFloat16>()(address, val,
-                                    [](at::BFloat16 bsum, at::BFloat16 val) {
-                                      return safe_min(bsum, val);
-                                    });
+inline __device__ at::BFloat16 gpuAtomicMin(
+    at::BFloat16* address,
+    at::BFloat16 val) {
+  return AtomicFPOp<at::BFloat16>()(
+      address, val, [](at::BFloat16 bsum, at::BFloat16 val) {
+        return safe_min(bsum, val);
+      });
 }
 
-inline __device__ double gpuAtomicMin(double * address, double val) {
-  return AtomicFPOp<double>()(address, val,
-                              [](double val, unsigned long long int assumed) {
-                                return __double_as_longlong(safe_min(val, __longlong_as_double(assumed)));
-                              });
+inline __device__ double gpuAtomicMin(double* address, double val) {
+  return AtomicFPOp<double>()(
+      address, val, [](double val, unsigned long long int assumed) {
+        return __double_as_longlong(
+            safe_min(val, __longlong_as_double(assumed)));
+      });
 }
 
-// Dont use a templated function for this since the addition function defaults to the CUDA built-in.
-inline __device__ float gpuAtomicMin(float * address, float val) {
+// Dont use a templated function for this since the addition function defaults
+// to the CUDA built-in.
+inline __device__ float gpuAtomicMin(float* address, float val) {
   unsigned int* address_as_ull = (unsigned int*)address;
   unsigned int old = *address_as_ull;
   unsigned int assumed;
 
   do {
     assumed = old;
-    old = atomicCAS(address_as_ull, assumed,
-                    __float_as_int(safe_min(val, __int_as_float(assumed))));
+    old = atomicCAS(
+        address_as_ull,
+        assumed,
+        __float_as_int(safe_min(val, __int_as_float(assumed))));
 
-    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN !=
+    // NaN)
   } while (assumed != old);
 
   return __int_as_float(old);

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -8,13 +8,15 @@
 // ROCm 6.3 is planned to have these functions, but until then here they are.
 #if defined(USE_ROCM)
 #include <device_functions.h>
-#include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
 
 #include <ATen/cuda/detail/ROCmMacros.cuh>
 
 #if ROCM_VERSION < 60400
-__device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
+__device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(
+    __hip_bfloat162* address,
+    __hip_bfloat162 value) {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16)) {
     typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
     static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));
@@ -22,7 +24,8 @@ __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* addre
       __hip_bfloat162_raw bf162_raw;
       vec_short2 vs2;
     } u{static_cast<__hip_bfloat162_raw>(value)};
-    u.vs2 = __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
+    u.vs2 =
+        __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
     return static_cast<__hip_bfloat162>(u.bf162_raw);
   } else {
     static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
@@ -31,26 +34,34 @@ __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* addre
       unsigned int u32;
     };
     u_hold old_val, new_val;
-    old_val.u32 = __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    old_val.u32 = __hip_atomic_load(
+        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     do {
       new_val.h2r = __hadd2(old_val.h2r, value);
     } while (!__hip_atomic_compare_exchange_strong(
-          (unsigned int*)address, &old_val.u32, new_val.u32,
-          __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT));
+        (unsigned int*)address,
+        &old_val.u32,
+        new_val.u32,
+        __ATOMIC_RELAXED,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT));
     return old_val.h2r;
   }
 }
 
-__device__ inline __half2 preview_unsafeAtomicAdd(__half2* address, __half2 value) {
-  if(__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16)) {
+__device__ inline __half2 preview_unsafeAtomicAdd(
+    __half2* address,
+    __half2 value) {
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16)) {
     // The api expects an ext_vector_type of half
     typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
     static_assert(sizeof(vec_fp162) == sizeof(__half2_raw));
     union {
       __half2_raw h2r;
       vec_fp162 fp16;
-    } u {static_cast<__half2_raw>(value)};
-    u.fp16 = __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
+    } u{static_cast<__half2_raw>(value)};
+    u.fp16 =
+        __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
     return static_cast<__half2>(u.h2r);
   } else {
     static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
@@ -59,12 +70,17 @@ __device__ inline __half2 preview_unsafeAtomicAdd(__half2* address, __half2 valu
       unsigned int u32;
     };
     u_hold old_val, new_val;
-    old_val.u32 = __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    old_val.u32 = __hip_atomic_load(
+        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     do {
       new_val.h2r = __hadd2(old_val.h2r, value);
     } while (!__hip_atomic_compare_exchange_strong(
-          (unsigned int*)address, &old_val.u32, new_val.u32,
-          __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT));
+        (unsigned int*)address,
+        &old_val.u32,
+        new_val.u32,
+        __ATOMIC_RELAXED,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT));
     return old_val.h2r;
   }
 }
@@ -78,7 +94,7 @@ __device__ inline __half2 preview_unsafeAtomicAdd(__half2* address, __half2 valu
 #define NATIVE_ZERO_BF16 __int2bfloat16_rz(0)
 #endif
 
-namespace at:: native {
+namespace at::native {
 
 __device__ __forceinline__ size_t
 idx(const size_t nc,
@@ -91,11 +107,14 @@ idx(const size_t nc,
 
 // for channels-last
 template <typename index_t = size_t>
-__device__ __forceinline__ index_t
-idx_cl(
-  const index_t n, const index_t h, const index_t w, const index_t c,
-  const index_t height, const index_t width, const index_t channel
-) {
+__device__ __forceinline__ index_t idx_cl(
+    const index_t n,
+    const index_t h,
+    const index_t w,
+    const index_t c,
+    const index_t height,
+    const index_t width,
+    const index_t channel) {
   return ((n * height + h) * width + w) * channel + c;
 }
 
@@ -113,8 +132,7 @@ idx_cl(
 template <
     typename scalar_t,
     typename index_t,
-    typename std::enable_if_t<std::is_same_v<c10::Half, scalar_t>>* =
-        nullptr>
+    typename std::enable_if_t<std::is_same_v<c10::Half, scalar_t>>* = nullptr>
 __device__ __forceinline__ void fastSpecializedAtomicAdd(
     scalar_t* tensor,
     index_t index,
@@ -125,9 +143,11 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
       reinterpret_cast<at::Half*>(tensor) + index,
       static_cast<at::Half>(value));
 #else
-  // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32 bit aligned)
+  // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32
+  // bit aligned)
   __half* target_addr = reinterpret_cast<__half*>(tensor + index);
-  bool low_byte = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
+  bool low_byte =
+      (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
 
   if (low_byte && index < (numel - 1)) {
     __half2 value2;
@@ -144,7 +164,8 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
   } else {
 #ifdef USE_ROCM
     gpuAtomicAddNoReturn(
-        reinterpret_cast<at::Half*>(tensor) + index, static_cast<at::Half>(value));
+        reinterpret_cast<at::Half*>(tensor) + index,
+        static_cast<at::Half>(value));
 #else
     atomicAdd(
         reinterpret_cast<__half*>(tensor) + index, static_cast<__half>(value));
@@ -168,9 +189,12 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
       reinterpret_cast<at::BFloat16*>(tensor) + index,
       static_cast<at::BFloat16>(value));
 #else
-  // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32 bit aligned)
+  // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32
+  // bit aligned)
   __nv_bfloat16* target_addr = reinterpret_cast<__nv_bfloat16*>(tensor + index);
-  bool low_byte = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__nv_bfloat162) == 0);
+  bool low_byte =
+      (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__nv_bfloat162) ==
+       0);
 
   if (low_byte && index < (numel - 1)) {
     __nv_bfloat162 value2;
@@ -187,21 +211,23 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
   } else {
 #ifdef USE_ROCM
     gpuAtomicAddNoReturn(
-        reinterpret_cast<at::BFloat16*>(tensor) + index, static_cast<at::BFloat16>(value));
+        reinterpret_cast<at::BFloat16*>(tensor) + index,
+        static_cast<at::BFloat16>(value));
 #else
     atomicAdd(
-        reinterpret_cast<__nv_bfloat16*>(tensor) + index, *reinterpret_cast<__nv_bfloat16*>(&value));
+        reinterpret_cast<__nv_bfloat16*>(tensor) + index,
+        *reinterpret_cast<__nv_bfloat16*>(&value));
 #endif
   }
 #endif
 }
 
-
 template <
     typename scalar_t,
     typename index_t,
-    typename std::enable_if_t<!std::is_same_v<c10::Half, scalar_t> && !std::is_same_v<c10::BFloat16, scalar_t>>* =
-        nullptr>
+    typename std::enable_if_t<
+        !std::is_same_v<c10::Half, scalar_t> &&
+        !std::is_same_v<c10::BFloat16, scalar_t>>* = nullptr>
 __device__ __forceinline__ void fastSpecializedAtomicAdd(
     scalar_t* tensor,
     index_t index,
@@ -224,7 +250,6 @@ __device__ __forceinline__ void fastAtomicAdd(
   }
 }
 
-
 #ifdef USE_ROCM
 // This function implements a committed store.
 // Upon returning, the store is committed to global memory.
@@ -233,48 +258,65 @@ __device__ __forceinline__ void fastAtomicAdd(
 // waiting for commit for all but the last store.
 template <typename T, bool wait_for_commit = true>
 __device__ inline void cmtdStore(void* address, T value) {
-      int constexpr num_long_per_val = sizeof(value)/sizeof(long);
-      int constexpr num_int_per_val = sizeof(value)/sizeof(int);
-      int constexpr num_short_per_val = sizeof(value)/sizeof(short);
-      int constexpr num_char_per_val = sizeof(value)/sizeof(char);
-      union pnr { T v;
-                  long l[num_long_per_val];
-                  int i[num_int_per_val];
-                  short s[num_short_per_val];
-                  char c[num_char_per_val]; }
-            _pnr = {.v = value };
-      if constexpr (num_long_per_val*sizeof(long) == sizeof(value))
-        for (int i=0; i<num_long_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<long *>(address)+i, _pnr.l[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_int_per_val*sizeof(int) == sizeof(value))
-        for (int i=0; i<num_int_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<int *>(address)+i, _pnr.i[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_short_per_val*sizeof(short) == sizeof(value))
-        for (int i=0; i<num_short_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<short *>(address)+i, _pnr.s[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
-        for (int i=0; i<num_char_per_val; i++)
-          __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      if constexpr (wait_for_commit)
-      {
-        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  int constexpr num_long_per_val = sizeof(value) / sizeof(long);
+  int constexpr num_int_per_val = sizeof(value) / sizeof(int);
+  int constexpr num_short_per_val = sizeof(value) / sizeof(short);
+  int constexpr num_char_per_val = sizeof(value) / sizeof(char);
+  union pnr {
+    T v;
+    long l[num_long_per_val];
+    int i[num_int_per_val];
+    short s[num_short_per_val];
+    char c[num_char_per_val];
+  } _pnr = {.v = value};
+  if constexpr (num_long_per_val * sizeof(long) == sizeof(value))
+    for (int i = 0; i < num_long_per_val; i++)
+      __hip_atomic_store(
+          reinterpret_cast<long*>(address) + i,
+          _pnr.l[i],
+          __ATOMIC_RELAXED,
+          __HIP_MEMORY_SCOPE_AGENT);
+  else if constexpr (num_int_per_val * sizeof(int) == sizeof(value))
+    for (int i = 0; i < num_int_per_val; i++)
+      __hip_atomic_store(
+          reinterpret_cast<int*>(address) + i,
+          _pnr.i[i],
+          __ATOMIC_RELAXED,
+          __HIP_MEMORY_SCOPE_AGENT);
+  else if constexpr (num_short_per_val * sizeof(short) == sizeof(value))
+    for (int i = 0; i < num_short_per_val; i++)
+      __hip_atomic_store(
+          reinterpret_cast<short*>(address) + i,
+          _pnr.s[i],
+          __ATOMIC_RELAXED,
+          __HIP_MEMORY_SCOPE_AGENT);
+  else if constexpr (num_char_per_val * sizeof(char) == sizeof(value))
+    for (int i = 0; i < num_char_per_val; i++)
+      __hip_atomic_store(
+          reinterpret_cast<char*>(address) + i,
+          _pnr.c[i],
+          __ATOMIC_RELAXED,
+          __HIP_MEMORY_SCOPE_AGENT);
+  if constexpr (wait_for_commit) {
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
 #if defined(__GFX12__)
-        asm volatile("s_wait_storecnt(0)" ::: "memory");
+    asm volatile("s_wait_storecnt(0)" ::: "memory");
 #elif defined(__GFX10__) || defined(__GFX11__)
-        asm volatile("s_waitcnt_vscnt null, 0" ::: "memory");
+    asm volatile("s_waitcnt_vscnt null, 0" ::: "memory");
 #else
-        // Older architectures have only 'vmcnt' counter.
-        asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+    // Older architectures have only 'vmcnt' counter.
+    asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
 #endif
-        __atomic_signal_fence(__ATOMIC_SEQ_CST);
-      }
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  }
 }
 
 // This function implements warp-level opportunistic fastatomics
-// To reduce contention on an atomicAdd, this replaces per-thread atomicAdd with a per-warp atomicAdd.
-// We identify all the threads within a warp that will perform an atomicAdd on the same destination
-// address and perform the addition on the CU. Each warp elects a leader thread which does the
-// atomicAdd to the destination address.
+// To reduce contention on an atomicAdd, this replaces per-thread atomicAdd with
+// a per-warp atomicAdd. We identify all the threads within a warp that will
+// perform an atomicAdd on the same destination address and perform the addition
+// on the CU. Each warp elects a leader thread which does the atomicAdd to the
+// destination address.
 template <class scalar_t, class index_t>
 __device__ __forceinline__ void opportunistic_fastAtomicAdd(
     scalar_t* self_ptr,
@@ -284,66 +326,80 @@ __device__ __forceinline__ void opportunistic_fastAtomicAdd(
   // TODO: move the builtin checks around the point-of-use, and implement a
   //       fallback for their absence, so as to allow targets that implement a
   //       subset to derive some benefit at least
-  if(!__builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp) ||
-     !__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16) ||
-     !__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16))
+  if (!__builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp) ||
+      !__builtin_amdgcn_is_invocable(
+          __builtin_amdgcn_flat_atomic_fadd_v2bf16) ||
+      !__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16))
     return;
   scalar_t* dst = self_ptr + index;
 
-  //pack coalesced bf16 and fp16
-  if constexpr (std::is_same<scalar_t, c10::BFloat16>::value || std::is_same<scalar_t, c10::Half>::value)
-  {
-      typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
-      union ill { unsigned int i[2]; int64_t il; };
-      ill iil_, ill_oneUpDst = {};
-      iil_.il = (int64_t)dst;
-      ill_oneUpDst.i[0] = __builtin_amdgcn_mov_dpp(iil_.i[0], 0x130, 0xf, 0xf, 0);
-      ill_oneUpDst.i[1] = __builtin_amdgcn_mov_dpp(iil_.i[1], 0x130, 0xf, 0xf, 0);
-      union bfi {scalar_t bf; short s; } bfi_ = { .bf = value  }; bfi bfi_oneUpVal;
+  // pack coalesced bf16 and fp16
+  if constexpr (
+      std::is_same<scalar_t, c10::BFloat16>::value ||
+      std::is_same<scalar_t, c10::Half>::value) {
+    typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
+    union ill {
+      unsigned int i[2];
+      int64_t il;
+    };
+    ill iil_, ill_oneUpDst = {};
+    iil_.il = (int64_t)dst;
+    ill_oneUpDst.i[0] = __builtin_amdgcn_mov_dpp(iil_.i[0], 0x130, 0xf, 0xf, 0);
+    ill_oneUpDst.i[1] = __builtin_amdgcn_mov_dpp(iil_.i[1], 0x130, 0xf, 0xf, 0);
+    union bfi {
+      scalar_t bf;
+      short s;
+    } bfi_ = {.bf = value};
+    bfi bfi_oneUpVal;
 
-      bfi_oneUpVal.s = __builtin_amdgcn_mov_dpp(bfi_.s, 0x130, 0xf, 0xf, 0);
-      auto oneUpVal = bfi_oneUpVal.bf;
+    bfi_oneUpVal.s = __builtin_amdgcn_mov_dpp(bfi_.s, 0x130, 0xf, 0xf, 0);
+    auto oneUpVal = bfi_oneUpVal.bf;
 
-      __half* target_addr = reinterpret_cast<__half*>(self_ptr + index);
-      bool low_byte = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
-      bool canCombnUp = (bool)(__activemask()&(1<<(threadIdx.x+1))) &&
-                               (low_byte && index < (numel - 1)) &&
-                               (ill_oneUpDst.il - reinterpret_cast<int64_t>(dst) == sizeof(scalar_t));
-      bool canCombnDn = (__builtin_amdgcn_mov_dpp(canCombnUp, 0x138, 0xf, 0xf, 0));
+    __half* target_addr = reinterpret_cast<__half*>(self_ptr + index);
+    bool low_byte =
+        (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
+    bool canCombnUp = (bool)(__activemask() & (1 << (threadIdx.x + 1))) &&
+        (low_byte && index < (numel - 1)) &&
+        (ill_oneUpDst.il - reinterpret_cast<int64_t>(dst) == sizeof(scalar_t));
+    bool canCombnDn =
+        (__builtin_amdgcn_mov_dpp(canCombnUp, 0x138, 0xf, 0xf, 0));
 
-      if (__lane_id()%2==0)
-      {
-        if (canCombnUp) {
-          typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
-          union bfvs { scalar_t bf[2]; vec_short2 vs2; vec_fp162 df16;  };
-          bfvs bfvs_ = {};
-          bfvs_.bf[0] = value;
-          bfvs_.bf[1] = oneUpVal;
-          if constexpr (std::is_same<scalar_t, c10::BFloat16>::value)
-            __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)dst, bfvs_.vs2);
-          else
-            __builtin_amdgcn_flat_atomic_fadd_v2f16((__half2*)dst, bfvs_.df16);
-          return;
-        }
+    if (__lane_id() % 2 == 0) {
+      if (canCombnUp) {
+        typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
+        union bfvs {
+          scalar_t bf[2];
+          vec_short2 vs2;
+          vec_fp162 df16;
+        };
+        bfvs bfvs_ = {};
+        bfvs_.bf[0] = value;
+        bfvs_.bf[1] = oneUpVal;
+        if constexpr (std::is_same<scalar_t, c10::BFloat16>::value)
+          __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)dst, bfvs_.vs2);
+        else
+          __builtin_amdgcn_flat_atomic_fadd_v2f16((__half2*)dst, bfvs_.df16);
+        return;
       }
-      else
-      {
-        if (canCombnDn)
-          return;
-      }
+    } else {
+      if (canCombnDn)
+        return;
+    }
   }
 
   // not coalesced, so now let try to capture lane-matches...
 
-  if (numel > 16 /*<-hueristic threshold*/ * 64 ) {
+  if (numel > 16 /*<-hueristic threshold*/ * 64) {
     // well shucks, unlikely to capture same-dest atomics in a wave.
     // fall back to direct fastAtomic...
     fastAtomicAdd(self_ptr, index, numel, value, true);
     return;
   }
 
-  // __activemask() -- finds the set of threads in the warp that are about to perform atomicAdd
-  // __match_any_sync() -- returns bit mask of the threads that have same dest addr
+  // __activemask() -- finds the set of threads in the warp that are about to
+  // perform atomicAdd
+  // __match_any_sync() -- returns bit mask of the threads that have same dest
+  // addr
   auto mask = __match_any_sync(__activemask(), (int64_t)dst);
 
   // select a leader thread
@@ -355,57 +411,66 @@ __device__ __forceinline__ void opportunistic_fastAtomicAdd(
 
   // __shfl is limited in the dtypes it accepts
   // That's why, we need these if/else to correctly do the addition on the CU
-  if constexpr(sizeof(scalar_t) <= sizeof(int)) {
-    union punner { int l; scalar_t s; };
+  if constexpr (sizeof(scalar_t) <= sizeof(int)) {
+    union punner {
+      int l;
+      scalar_t s;
+    };
     punner pnr = {};
     pnr.s = value;
     while (crnt_msk != 0) {
       if (crnt_msk & 1) {
         punner add_val = {};
-        add_val.l = __shfl(pnr.l ,crnt_idx);
+        add_val.l = __shfl(pnr.l, crnt_idx);
         crnt_val += add_val.s;
       }
       crnt_idx++;
       crnt_msk = crnt_msk >> 1;
     }
-  }
-  else if constexpr(sizeof(scalar_t) <= sizeof(long)) {
-    union punner { long l; scalar_t s; };
+  } else if constexpr (sizeof(scalar_t) <= sizeof(long)) {
+    union punner {
+      long l;
+      scalar_t s;
+    };
     punner pnr = {};
     pnr.s = value;
     while (crnt_msk != 0) {
       if (crnt_msk & 1) {
-          punner add_val = {};
-        add_val.l = __shfl(pnr.l ,crnt_idx);
+        punner add_val = {};
+        add_val.l = __shfl(pnr.l, crnt_idx);
         crnt_val += add_val.s;
       }
       crnt_idx++;
       crnt_msk = crnt_msk >> 1;
     }
-  }
-  else if constexpr(sizeof(scalar_t) <= sizeof(long long)) {
-    union punner { long long l; scalar_t s; };
+  } else if constexpr (sizeof(scalar_t) <= sizeof(long long)) {
+    union punner {
+      long long l;
+      scalar_t s;
+    };
     punner pnr = {};
     pnr.s = value;
     while (crnt_msk != 0) {
       if (crnt_msk & 1) {
-          punner add_val = {};
-        add_val.l = __shfl(pnr.l ,crnt_idx);
+        punner add_val = {};
+        add_val.l = __shfl(pnr.l, crnt_idx);
         crnt_val += add_val.s;
       }
       crnt_idx++;
       crnt_msk = crnt_msk >> 1;
     }
-  }
-  else {
-    union punner { long long l[2]; scalar_t s; };
+  } else {
+    union punner {
+      long long l[2];
+      scalar_t s;
+    };
     punner pnr = {};
     pnr.s = value;
     while (crnt_msk != 0) {
       if (crnt_msk & 1) {
-          punner add_val = {};
-        add_val.l[0] = __shfl(pnr.l[0] ,crnt_idx);
-        add_val.l[1] = __shfl(pnr.l[1] ,crnt_idx);
+        punner add_val = {};
+        add_val.l[0] = __shfl(pnr.l[0], crnt_idx);
+        add_val.l[1] = __shfl(pnr.l[1], crnt_idx);
         crnt_val += add_val.s;
       }
       crnt_idx++;
@@ -413,8 +478,8 @@ __device__ __forceinline__ void opportunistic_fastAtomicAdd(
     }
   }
 
-
-  //Once the correct crnt_val is determined, only the leader thread does the update to the dest addr
+  // Once the correct crnt_val is determined, only the leader thread does the
+  // update to the dest addr
   if (__lane_id() == leader) {
     fastAtomicAdd(self_ptr, index, numel, crnt_val, true);
   }


### PR DESCRIPTION
I manually verified nothing changed except spacing and header include order.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192557
* #192552
* #192548
* #192547
* __->__ #192546

