### PR TITLE
[BE] Delete old ROCm branches that apply to ROCM < 6.4

### DIFF
--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -258,22 +258,6 @@ inline __device__ double atomicAdd(double* address, double val)
         return __double_as_longlong(val + __longlong_as_double(assumed));
       });
 }
-#elif defined(USE_ROCM) || !(defined(__CUDA_ARCH__))
-
-/* Note [hip-clang differences to hcc]
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * The upcoming hip-clang compiler for ROCm differs from hcc in a few details.
- * It exports the __HIP__ macro, we can hence differentiate between hcc and
- * hip-clang. In the below, hcc only received support for atomicAdd with double
- * typing after work week 18312. hip-clang had support from the first version.
- * In general, the code-visible differences between hip-clang and hcc will be
- * minimal.
- */
-
-#if defined(USE_ROCM) && __hcc_workweek__ < 18312 && !__HIP__
-// This needs to be defined for the host side pass
-inline __device__ double atomicAdd(double* address, double val) {}
-#endif
 #endif
 
 inline __device__ double gpuAtomicAdd(double* address, double val) {

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -5,7 +5,6 @@
 #include <cuda_bf16.h>
 #endif
 
-// ROCm 6.3 is planned to have these functions, but until then here they are.
 #if defined(USE_ROCM)
 #include <device_functions.h>
 #include <hip/hip_bf16.h>
@@ -13,81 +12,7 @@
 
 #include <ATen/cuda/detail/ROCmMacros.cuh>
 
-#if ROCM_VERSION < 60400
-__device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(
-    __hip_bfloat162* address,
-    __hip_bfloat162 value) {
-  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16)) {
-    typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
-    static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));
-    union {
-      __hip_bfloat162_raw bf162_raw;
-      vec_short2 vs2;
-    } u{static_cast<__hip_bfloat162_raw>(value)};
-    u.vs2 =
-        __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
-    return static_cast<__hip_bfloat162>(u.bf162_raw);
-  } else {
-    static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
-    union u_hold {
-      __hip_bfloat162_raw h2r;
-      unsigned int u32;
-    };
-    u_hold old_val, new_val;
-    old_val.u32 = __hip_atomic_load(
-        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    do {
-      new_val.h2r = __hadd2(old_val.h2r, value);
-    } while (!__hip_atomic_compare_exchange_strong(
-        (unsigned int*)address,
-        &old_val.u32,
-        new_val.u32,
-        __ATOMIC_RELAXED,
-        __ATOMIC_RELAXED,
-        __HIP_MEMORY_SCOPE_AGENT));
-    return old_val.h2r;
-  }
-}
-
-__device__ inline __half2 preview_unsafeAtomicAdd(
-    __half2* address,
-    __half2 value) {
-  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16)) {
-    // The api expects an ext_vector_type of half
-    typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
-    static_assert(sizeof(vec_fp162) == sizeof(__half2_raw));
-    union {
-      __half2_raw h2r;
-      vec_fp162 fp16;
-    } u{static_cast<__half2_raw>(value)};
-    u.fp16 =
-        __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
-    return static_cast<__half2>(u.h2r);
-  } else {
-    static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
-    union u_hold {
-      __half2_raw h2r;
-      unsigned int u32;
-    };
-    u_hold old_val, new_val;
-    old_val.u32 = __hip_atomic_load(
-        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    do {
-      new_val.h2r = __hadd2(old_val.h2r, value);
-    } while (!__hip_atomic_compare_exchange_strong(
-        (unsigned int*)address,
-        &old_val.u32,
-        new_val.u32,
-        __ATOMIC_RELAXED,
-        __ATOMIC_RELAXED,
-        __HIP_MEMORY_SCOPE_AGENT));
-    return old_val.h2r;
-  }
-}
-#define ATOMICADD preview_unsafeAtomicAdd
-#else
 #define ATOMICADD unsafeAtomicAdd
-#endif
 #define NATIVE_ZERO_BF16 __float2bfloat16(0.0f)
 #else
 #define ATOMICADD atomicAdd


### PR DESCRIPTION
2.13 supports ROCm 7.2 at min.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192557
* #192552
* #192548
* __->__ #192547
* #192546



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang