### PR TITLE
Avoid Tensor refcount churn during c10::List<optional<Tensor>> iteration

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -618,8 +618,11 @@ void sync(ITensorListRef t_list) {
   }
 }
 void sync(const c10::List<::std::optional<Tensor>>& t_list) {
-  for (const auto i : c10::irange(t_list.size())) {
-    sync(t_list[i]);
+  for (const auto& element : t_list) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      sync(ivalue.toTensor());
+    }
   }
 }
 
@@ -720,11 +723,13 @@ bool isFunctionalTensor(const std::optional<Tensor>& t) {
 bool isFunctionalTensor(const c10::List<::std::optional<Tensor>>& t_list) {
   if (t_list.empty()) { return false; }
   auto functional_count = 0;
-  for (const auto i : c10::irange(t_list.size())) {
-    auto const & e= t_list[i];
-    if (!e.has_value() || !e->defined()) { continue; }
-    if (isFunctionalTensor(e)) {
-      ++functional_count;
+  for (const auto& element : t_list) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      const Tensor& tensor = ivalue.toTensor();
+      if (tensor.defined() && isFunctionalTensor(tensor)) {
+        ++functional_count;
+      }
     }
   }
   return functional_count > 0;

--- a/aten/src/ATen/TensorSubclassLikeUtils.h
+++ b/aten/src/ATen/TensorSubclassLikeUtils.h
@@ -64,13 +64,13 @@ inline bool areAnyOptionalTensorSubclassLike(
     const c10::List<std::optional<Tensor>>& tensors) {
   if (c10::impl::dispatch_mode_enabled())
     return true;
-  return std::any_of(
-      tensors.begin(),
-      tensors.end(),
-      [](const std::optional<Tensor>& opt_tensor) {
-        return (
-            opt_tensor.has_value() && isTensorSubclassLike(opt_tensor.value()));
-      });
+  for (const auto& element : tensors) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone() && isTensorSubclassLike(ivalue.toTensor())) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Helper function to deal testing truthfulness of a scalar tensor

--- a/aten/src/ATen/core/TorchDispatchUtils.cpp
+++ b/aten/src/ATen/core/TorchDispatchUtils.cpp
@@ -18,9 +18,9 @@ bool tensorlist_has_dispatch(at::ITensorListRef li) {
 }
 
 bool tensorlist_has_dispatch(const c10::List<std::optional<at::Tensor>>& li) {
-  for (auto i : c10::irange(li.size())) {
-    auto t = li.get(i);
-    if (t && tensor_has_dispatch(*t)) {
+  for (const auto& element : li) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone() && tensor_has_dispatch(ivalue.toTensor())) {
       return true;
     }
   }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -68,9 +68,10 @@ struct MultiDispatchKeySet : at::IterArgs<MultiDispatchKeySet> {
   }
   // Tensor?[] translates to this case.
   void operator()(const c10::List<std::optional<at::Tensor>>& xs) {
-    for (std::optional<at::Tensor> x : xs) {
-      if (x.has_value()) {
-        ts = ts | x.value().key_set();
+    for (const auto& x : xs) {
+      const IValue& ivalue = x.get();
+      if (!ivalue.isNone()) {
+        ts = ts | ivalue.toTensor().key_set();
       }
     }
   }

--- a/aten/src/ATen/core/op_registration/adaption.h
+++ b/aten/src/ATen/core/op_registration/adaption.h
@@ -74,8 +74,11 @@ inline void check_and_update_common_device(std::optional<Device>& common_device,
 }
 
 inline void check_and_update_common_device(std::optional<Device>& common_device, const List<std::optional<at::Tensor>>& tensors, at::CheckedFrom methodName, at::CheckedFrom argName) {
-  for (const auto& tensor : tensors) {
-    check_and_update_common_device(common_device, tensor, methodName, argName);
+  for (const auto& element : tensors) {
+    const IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      check_and_update_common_device(common_device, ivalue.toTensor(), methodName, argName);
+    }
   }
 }
 } // namespace c10::impl

--- a/aten/src/ATen/functorch/PlumbingHelper.cpp
+++ b/aten/src/ATen/functorch/PlumbingHelper.cpp
@@ -72,9 +72,9 @@ bool isBatchedAtLevel(ITensorListRef tensors, int64_t level) {
 }
 
 bool isBatchedAtLevel(const c10::List<std::optional<Tensor>>& maybe_tensors, int64_t level) {
-  for (const auto idx : c10::irange(0, maybe_tensors.size())) {
-    const auto& maybe_tensor = maybe_tensors.get(idx);
-    if (isBatchedAtLevel(maybe_tensor, level)) {
+  for (const auto& element : maybe_tensors) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone() && isBatchedAtLevel(ivalue.toTensor(), level)) {
       return true;
     }
   }

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -746,10 +746,10 @@ Tensor _unsafe_index(
     const Tensor& self,
     const torch::List<std::optional<Tensor>>& indices) {
   // Disallow boolean indexing since it leads to dynamic output shapes
-  for (auto i : c10::irange(indices.size())) {
-    auto index = indices.get(i);
-    if (index.has_value()) {
-      auto dtype = index->scalar_type();
+  for (const auto& element : indices) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      auto dtype = ivalue.toTensor().scalar_type();
       TORCH_CHECK(
           dtype == kLong || dtype == kInt,
           "_unsafe_index found unexpected index type ",
@@ -990,10 +990,10 @@ Tensor& _index_put_impl_(
     value_ = value.to(self.device());
   }
   at::assert_no_overlap(self, value);
-  // NOLINTNEXTLINE(performance-implicit-conversion-in-loop)
-  for (const std::optional<Tensor>& index : indices) {
-    if (index.has_value()) {
-      at::assert_no_overlap(self, *index);
+  for (const auto& element : indices) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      at::assert_no_overlap(self, ivalue.toTensor());
     }
   }
   if ((self.device().type() == DeviceType::CUDA ||

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -33,24 +33,25 @@ inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
   int64_t num_ind = 0;
   Tensor mask;
   auto self_device = self.device();
-  for (const std::optional<Tensor>& i : indices) {
-    if (!i.has_value() || !(*i).defined()) {
+  for (const auto& element : indices) {
+    const c10::IValue& ivalue = element.get();
+    const Tensor* index = ivalue.isNone() ? nullptr : &ivalue.toTensor();
+    if (index == nullptr || !index->defined()) {
       if (!mask.defined()) {
         num_ind++;
       }
     } else {
-      const Tensor& index = *i;
-      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
-          index.device() != self_device || mask.defined()) {
+      if ((index->scalar_type() != kByte && index->scalar_type() != kBool) ||
+          index->device() != self_device || mask.defined()) {
         return std::make_tuple(false, Tensor());
       } else {
-        mask = index;
-        for (const auto j : c10::irange(index.dim())) {
+        mask = *index;
+        for (const auto j : c10::irange(index->dim())) {
           int64_t srcIdx = num_ind + j;
           TORCH_CHECK_INDEX(
-              index.size(j) == self.size(srcIdx),
+              index->size(j) == self.size(srcIdx),
               "The shape of the mask ",
-              index.sizes(),
+              index->sizes(),
               " at index ",
               j,
               " does not match the shape of the indexed tensor ",

--- a/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
@@ -136,9 +136,10 @@ Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<std::opt
     value_ = value.to(self.device());
   }
   at::assert_no_overlap(self, value);
-  for (const std::optional<Tensor>& index: indices) {
-    if (index.has_value()) {
-      at::assert_no_overlap(self, *index);
+  for (const auto& element : indices) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      at::assert_no_overlap(self, ivalue.toTensor());
     }
   }
 
@@ -173,10 +174,10 @@ Tensor& _index_put_impl_quantized_cuda_(Tensor & self, const torch::List<std::op
   TORCH_CHECK(value.device() == self.device(), "expected device ", self.device(), " but got device ", value.device(), " for value tensor");
 
   at::assert_no_overlap(self, value);
-  // NOLINTNEXTLINE(performance-implicit-conversion-in-loop)
-  for (const std::optional<Tensor>& index: indices) {
-    if (index.has_value()) {
-      at::assert_no_overlap(self, *index);
+  for (const auto& element : indices) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      at::assert_no_overlap(self, ivalue.toTensor());
     }
   }
 

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -335,9 +335,11 @@ inline void check_no_requires_grad(
   if (!GradMode::is_enabled()) {
     return;
   }
-  for (std::optional<at::Tensor> tensor : tensors) {
-    if (tensor.has_value()) {
-      check_no_requires_grad(*tensor, name, fn_name, /*check_grad_mode*/ false);
+  for (const auto& element : tensors) {
+    const c10::IValue& ivalue = element.get();
+    if (!ivalue.isNone()) {
+      check_no_requires_grad(
+          ivalue.toTensor(), name, fn_name, /*check_grad_mode*/ false);
     }
   }
 }

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -110,9 +110,9 @@ inline bool isFwGradDefinedTensorList(const at::ITensorListRef& variables) {
 inline bool isFwGradDefinedTensorList(
     const c10::List<std::optional<at::Tensor>>& li) {
   bool ret = false;
-  for (auto i : c10::irange(li.size())) {
-    auto t = li.get(i);
-    ret |= isFwGradDefined(t);
+  for (const auto& element : li) {
+    const c10::IValue& ivalue = element.get();
+    ret |= !ivalue.isNone() && isFwGradDefined(ivalue.toTensor());
   }
   return ret;
 }


### PR DESCRIPTION
The original iteration logic constructed an optional<Tensor>
from the IValue's contained in c10::List. This increments
the Tensor's internal refcount and decrements it on destruction.

This commit changes it to just borrow the IValue and avoid the
count changes.

I see a small 5-10% improvement in this code path after the changes.

Assisted-by: GPT 5.6 Sol