### PR TITLE
[PrismNet][inductor] addmm autotune: handle a bias example input with 0 rows (#192553)

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -1147,6 +1147,82 @@ class TestGetInputsStorageSizeCheck(TestCase):
             self.assertEqual(extern_inputs[0].shape, torch.Size(node_size))
 
 
+class TestGetInputsAddmmBias(TestCase):
+    """
+    Aten addmm benchmarks the original 1D bias while the Triton template
+    benchmarks the bias expanded to [M, N], so get_inputs recovers the former
+    from row 0 of the latter.  These drive that path directly: an M whose hint
+    is 0 has no row 0 to recover from.
+    """
+
+    N = 8
+    K = 4
+
+    def _get_inputs(self, m):
+        from torch._inductor import ir
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        mock_graph = unittest.mock.MagicMock()
+        mock_graph.sizevars.optimization_hints_with_override = (
+            lambda exprs, hint_override=None: tuple(int(e) for e in exprs)
+        )
+        mock_graph.sizevars.optimization_hint_with_override = (
+            lambda expr, hint_override=None: int(expr)
+        )
+        mock_graph.sizevars.optimization_hint = (
+            lambda expr, fallback=None: int(expr) if expr is not None else fallback
+        )
+        mock_graph.buffer_layout_constraints = {}
+        mock_graph.get_allocation_size = lambda node: node.get_size()
+
+        def buf(name, size, stride):
+            return ir.Buffer(
+                name=name,
+                layout=ir.FixedLayout(
+                    device=device, dtype=dtype, size=size, stride=stride
+                ),
+            )
+
+        with V.set_graph_handler(mock_graph):
+            # The expanded bias and the 1D bias are distinct buffers, which is
+            # what makes get_inputs reconcile the two.
+            bias_2d = buf("bias_expanded", [m, self.N], [0, 1])
+            bias_1d = buf("bias", [self.N], [1])
+            mat1 = buf("mat1", [m, self.K], [self.K, 1])
+            mat2 = buf("mat2", [self.K, self.N], [self.N, 1])
+
+            extern_choice = unittest.mock.create_autospec(
+                select_algorithm.ExternKernelCaller, instance=True
+            )
+            extern_choice.name = "addmm"
+            extern_choice.input_nodes = [bias_1d, mat1, mat2]
+
+            return select_algorithm.AlgorithmSelectorCache.get_inputs(
+                choices=[extern_choice],
+                input_nodes=[bias_2d, mat1, mat2],
+                layout=ir.FixedLayout(
+                    device=device, dtype=dtype, size=[m, self.N], stride=[self.N, 1]
+                ),
+                input_gen_fns=None,
+            )
+
+    def test_addmm_1d_bias(self):
+        args = self._get_inputs(m=4)
+        triton_bias = args.triton.input_tensors[0]
+        extern_bias = args.extern.input_tensors[0]
+        self.assertEqual(triton_bias.shape, torch.Size([4, self.N]))
+        self.assertEqual(extern_bias.shape, torch.Size([self.N]))
+        # Both choices must benchmark the same bias values.
+        self.assertEqual(extern_bias, triton_bias[0])
+
+    def test_addmm_1d_bias_zero_rows(self):
+        args = self._get_inputs(m=0)
+        self.assertEqual(args.triton.input_tensors[0].shape, torch.Size([0, self.N]))
+        self.assertEqual(args.extern.input_tensors[0].shape, torch.Size([self.N]))
+
+
 class TestTemplateRender(TestCase):
     @staticmethod
     def _template_kernel_has_atomic_add(code):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4958,8 +4958,13 @@ class AlgorithmSelectorCache(PersistentCache):
                 # benchmarks the expanded 2D input; keep both backed by the
                 # same values by making all rows identical.
                 global_tensor = unique_example_inputs[input_node.get_name()]
-                global_tensor[:] = global_tensor[0:1].expand_as(global_tensor)
-                additional_example_inputs[extern_name] = global_tensor[0].contiguous()
+                if global_tensor.shape[0] == 0:
+                    # No row to copy, and the 1D bias does not depend on M.
+                    bias = cls.benchmark_example_value(extern_node, hint_override)
+                else:
+                    global_tensor[:] = global_tensor[0:1].expand_as(global_tensor)
+                    bias = global_tensor[0].contiguous()
+                additional_example_inputs[extern_name] = bias
 
             return {
                 **unique_example_inputs,


### PR DESCRIPTION
Summary:

`AlgorithmSelectorCache.get_inputs` hands ATen `addmm` a 1D bias and the Triton
template the same bias expanded to `[M, N]`, keeping both backed by identical
values -- every row flattened to row 0, then `global_tensor[0]` for ATen -- so the
cross-choice `VERIFY` check can compare their outputs.

`M` is a size hint, and an `addmm` whose M is a data-dependent sub-batch can hint
to 0. `global_tensor[0]` on the resulting `(0, N)` bias then raises
`IndexError: index 0 is out of bounds for dimension 0 with size 0`, failing the
whole compile during autotuning.

At `M == 0` both choices output `[0, N]`, so there is nothing for `VERIFY` to
disagree about and no row to copy. Generate the 1D bias from the extern node
instead, the way every other benchmark input is generated. The non-zero path is
unchanged.

Found on an early-exit ads ranking model whose per-exit heads run on
`[count_e, 2048]` sub-batches: the autotuner built a `(0, 2048)` example bias.

Test Plan:
```
buck2 run @//mode/opt fbcode//caffe2/test/inductor:select_algorithm -- \
  caffe2.test.inductor.test_select_algorithm.TestGetInputsAddmmBias
```
Without the fix, `test_addmm_1d_bias_zero_rows` fails with `IndexError: index 0
is out of bounds for dimension 0 with size 0`. With it, `Ran 2 tests -- OK`.

Whole file `Ran 44 tests in 330.823s -- OK`. The existing addmm / zero-size
autotune tests in `:max_autotune` `Ran 7 tests -- OK`.

Verified on a real AOTI publish, same model and config with only `ien.lower.cg1`
rebuilt: snapshot 10 hit the same `IndexError` in
`addmm_unique_example_inputs_extern`; snapshot 11 compiled and published.
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-mixformer_four_layers_joint_eager_region-fd71b430b3

Reviewed By: kqfu

Differential Revision: D115152622




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo