### PR TITLE
Simplify FlexAttention overload signatures

### DIFF
--- a/docs/source/nn.attention.flex_attention.md
+++ b/docs/source/nn.attention.flex_attention.md
@@ -11,8 +11,9 @@
 ```{eval-rst}
 .. py:module:: torch.nn.attention.flex_attention
 ```
+<!-- Sphinx otherwise expands every typing overload into a separate signature. -->
 ```{eval-rst}
-.. autofunction:: flex_attention
+.. autofunction:: flex_attention(query: Tensor, key: Tensor, value: Tensor, score_mod: Callable[[Tensor, Tensor, Tensor, Tensor, Tensor], Tensor] | None = None, block_mask: BlockMask | None = None, scale: float | None = None, enable_gqa: bool = False, return_lse: bool = False, kernel_options: FlexKernelOptions | None = None, *, return_aux: AuxRequest | None = None) -> Tensor | tuple[Tensor, Tensor] | tuple[Tensor, AuxOutput]
 ```
 ```{eval-rst}
 .. autoclass:: AuxOutput
@@ -49,8 +50,12 @@
 
 ## BlockMask
 
+<!-- Document as_tuple separately so Sphinx does not expand its typing overloads. -->
 ```{eval-rst}
 .. autoclass:: BlockMask
     :members:
     :undoc-members:
+    :exclude-members: as_tuple
+
+.. automethod:: BlockMask.as_tuple(flatten: bool = True) -> tuple[Any, ...]
 ```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192556

Human Note
I noticed that the doc page for flex and block mask loosk really confusing due tothe overrides for returns it is well doucmetn belwo lets at least mkeit look cleaner / better

Agent note
This commit was prepared with an AI assistant.

Sphinx expands each typing overload for `flex_attention` and `BlockMask.as_tuple`, producing several
long signatures whose differences are mostly flag-dependent return types. Override those two API
entries with their canonical runtime signatures while retaining inline annotations, so the rendered
types remain linkable. The Python overloads stay unchanged for type checkers, and APIs with genuinely
distinct call forms continue to render their overloads.

Test Plan:

```bash
spin quicklint docs/source/nn.attention.flex_attention.md
lintrunner -a
git diff --check
```

A rendered documentation build was not run because Sphinx is not installed in the active environment.