### PR TITLE
Fix cmake_prefix_path for editable installs

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -34,9 +34,11 @@ def get_pytorch_dir():
     # We only need to get the PyTorch installation directory, so whether the accelerator is loaded or not is irrelevant
     # If the accelerator has been previously built and not uninstalled, importing torch will cause a circular import error
     os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
-    import torch
+    from torch._utils_internal import get_file_path
 
-    return os.path.dirname(os.path.realpath(torch.__file__))
+    # Not derived from torch.__file__: editable installs redirect that to the
+    # source tree, which holds no lib/, include/ or share/cmake.
+    return get_file_path("torch")
 
 
 def build_deps():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -961,6 +961,12 @@ instantiate_device_type_tests(TestDeviceUtils, globals())
 
 
 class TestCppExtensionUtils(TestCase):
+    @unittest.skipIf(IS_FBCODE, "CMake package files are not shipped in fbcode")
+    def test_cmake_prefix_path(self):
+        prefix = torch.utils.cmake_prefix_path
+        config = os.path.join(prefix, "Torch", "TorchConfig.cmake")
+        self.assertTrue(os.path.isfile(config), f"{config} does not exist")
+
     def test_cpp_compiler_is_ok(self):
         self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform("c++"))
 

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
 
 import copyreg
-import os.path as _osp
 import weakref
 
 import torch
+from torch._utils_internal import get_file_path
 from torch.utils import (
     backcompat as backcompat,
     collect_env as collect_env,
@@ -29,7 +29,11 @@ def set_module(obj, mod):
     obj.__module__ = mod
 
 
-cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), "share", "cmake")
+# Editable installs using scikit-build-core redirect mode install share/cmake
+# into the package directory rather than the source tree this file loads from,
+# so resolve it the same way torch.utils.cpp_extension resolves lib/ and
+# include/ instead of from this file's location.
+cmake_prefix_path = get_file_path("torch", "share", "cmake")
 
 
 def swap_tensors(t1, t2):


### PR DESCRIPTION
torch.utils.cmake_prefix_path was derived from torch/utils/__init__.py's own __file__. In a scikit-build-core editable install (redirect mode, which is what pyproject.toml configures) the Python modules are redirected to the source checkout while the CMake install tree (bin/, lib/, include/, share/cmake/) ships in the editable wheel and lands in site-packages. The public prefix therefore pointed at a directory that does not exist, and any find_package(Torch) using it failed.

Resolve it through torch._utils_internal.get_file_path instead, which returns the physical package root. torch/utils/cpp_extension.py already uses that helper to locate lib/ and include/ for exactly this reason, so this keeps the two in step; deriving the path from torch._C.__file__ would have worked too, but it would have introduced a second convention and would not be overridable in the FB build environment, where _utils_internal.py is replaced.

OpenReg's setup.py had the same bug at its own call site: it passed -DPYTORCH_INSTALL_DIR=os.path.dirname(torch.__file__), so its find_package(Torch REQUIRED) failed in an editable install as well. It now uses the same helper.

The new regression test asserts that Torch/TorchConfig.cmake exists under the prefix rather than only that the parent directory does.

Test Plan:

CPU-only Release editable build on Linux x86_64, Python 3.13, gcc 13.4:

```bash
USE_CUDA=0 USE_ROCM=0 USE_XPU=0 BUILD_TEST=0 CMAKE_BUILD_TYPE=Release \
MAX_JOBS=96 pip install -e . -v --no-build-isolation
```

The new test fails before the change (TorchConfig.cmake does not exist under the checkout) and passes after:

```bash
python test/test_utils.py TestCppExtensionUtils
python test/test_utils.py
python test/run_test.py --openreg
lintrunner torch/utils/__init__.py test/test_utils.py \
  test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
```

A minimal find_package(Torch REQUIRED) consumer configured with torch.utils.cmake_prefix_path fails before the change and finds libtorch.so after it.