### PR TITLE
[testintro] Add the test-introspection engine

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -21,6 +21,10 @@ project-includes = [
     "test/test_utils.py",
 ]
 project-excludes = [
+  # Intentionally monkeypatches torch internals (probes, module-level test flags) to
+  # simulate platforms; type-checking those dynamic assignments adds no value, same as
+  # torch/testing/_internal below.
+  "tools/testing/introspection/**",
   "torch/_inductor/runtime/triton_heuristics.py",
   "torch/_inductor/runtime/triton_helpers.py",
   "torch/_inductor/runtime/halide_helpers.py",

--- a/tools/testing/introspection/__init__.py
+++ b/tools/testing/introspection/__init__.py
@@ -1,0 +1,6 @@
+"""Test-introspection tool: enumerate the concrete tests (incl. generated/synthetic)
+and per-platform run/skip status of PyTorch test files, by importing them under a
+simulated platform descriptor rather than requiring the target hardware.
+
+See platforms.py for the platform descriptors and collector.py for the engine.
+"""

--- a/tools/testing/introspection/collector.py
+++ b/tools/testing/introspection/collector.py
@@ -1,0 +1,811 @@
+"""Collector engine.
+
+In-process worker: apply a platform descriptor, import a test file (optionally with
+test bodies gutted), and either enumerate concrete tests or observe run/skip status.
+Parent helpers spawn the worker in a subprocess (descriptor globals are import-time
+single-shot, so one process per (file, platform)).
+
+Run directly as a worker (by path, so the wheel torch isn't shadowed by repo/torch):
+    python tools/testing/introspection/collector.py <platform/config> <select|enumerate|status> [relpath]
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import inspect
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+
+# This file is also executed directly as a worker subprocess (see _run_worker). When
+# run by path, the package root is not importable, so append it -- appending (not
+# prepending) keeps the wheel-installed torch in site-packages ahead of any torch/
+# source tree in the repo, which is essential for a wheel-installed torch in CI.
+if not __package__:
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from tools.testing.introspection.platforms import get_job, Job, Platform
+
+
+REPO = Path(__file__).resolve().parents[3]
+_COLLECTOR = str(Path(__file__).resolve())
+_SENTINEL = "__INTROSPECT_JSON__"
+
+
+def _root() -> Path:
+    """Test-tree root to read test files / run_test from. Defaults to this checkout;
+    B1 (diff) points it at a per-ref git worktree via TESTINTRO_ROOT. torch itself
+    always comes from the installed (current) build, so a single build serves all
+    refs whose native/codegen surface is unchanged."""
+    return Path(os.environ.get("TESTINTRO_ROOT") or str(REPO))
+
+
+_SM_ORLATER = {
+    "SM53OrLater": (5, 3),
+    "SM60OrLater": (6, 0),
+    "SM70OrLater": (7, 0),
+    "SM75OrLater": (7, 5),
+    "SM80OrLater": (8, 0),
+    "SM89OrLater": (8, 9),
+    "SM90OrLater": (9, 0),
+    "SM100OrLater": (10, 0),
+    "SM120OrLater": (12, 0),
+}
+_SM_EXACT = {"IS_SM89": (8, 9), "IS_SM90": (9, 0), "IS_SM100": (10, 0)}
+
+
+# --------------------------------------------------------------------------- #
+# Descriptor application (the validated monkeypatch surface)
+# --------------------------------------------------------------------------- #
+def apply_descriptor(platform: Platform) -> None:
+    import torch
+    import torch.testing._internal.common_device_type as cdt
+    import torch.testing._internal.common_utils as cu
+
+    # Pre-import the inductor flag module while the subprocess still sees no
+    # accelerator, so its import-time LazyVals don't touch a real driver; we override
+    # its flags to the platform's declared values afterward.
+    iu = _safe_import("torch.testing._internal.inductor_utils")
+
+    # jit test files assert GRAPH_EXECUTOR is set (normally via parse_cmd_line_args).
+    if hasattr(cu, "ProfilingMode") and getattr(cu, "GRAPH_EXECUTOR", None) is None:
+        cu.GRAPH_EXECUTOR = cu.ProfilingMode.PROFILING
+
+    # The gut-and-run (status) path drives TestCase.run; TEST_SAVE_XML defaults to ""
+    # (not None), which pulls in the optional xmlrunner dep on the early-stop path.
+    # We never emit XML, so disable it.
+    if hasattr(cu, "TEST_SAVE_XML"):
+        cu.TEST_SAVE_XML = None
+
+    if platform.device_type == "cpu":
+        torch.cuda.is_available = lambda: False
+        cdt.device_type_test_bases = [cdt.CPUTestBase]
+        return
+
+    if platform.device_type == "cuda":
+        _apply_cuda(platform, torch, cdt, cu)
+        _override_inductor_utils(iu, platform, "cuda")
+        _patch_has_triton()
+        return
+
+    if platform.device_type == "mps":
+        if hasattr(torch.backends, "mps"):
+            torch.backends.mps.is_available = lambda: True
+            torch.backends.mps.is_built = lambda: True
+        cdt.TEST_MPS = True
+        cu.TEST_MPS = True
+        _stub_macos_probes()
+        cdt.device_type_test_bases = [cdt.CPUTestBase]
+        return
+
+    if platform.device_type == "xpu":
+        torch.xpu.is_available = lambda: True
+        torch.xpu.device_count = lambda: 1
+        torch.xpu.current_device = lambda: 0
+        cdt.TEST_XPU = True
+        cu.TEST_XPU = True
+        try:
+            import torch.testing._internal.common_xpu as cx
+
+            for n in dir(cx):
+                if n.startswith("PLATFORM_SUPPORTS_"):
+                    setattr(cx, n, True)
+        except Exception:
+            pass
+        cdt.device_type_test_bases = [cdt.CPUTestBase]
+        _override_inductor_utils(iu, platform, "xpu")
+        _patch_has_triton()
+        return
+
+    raise ValueError(f"unsupported device_type {platform.device_type!r}")
+
+
+def _stub_macos_probes() -> None:
+    # test_mps.py reads total RAM at import via `sysctl -n hw.memsize` (macOS-only),
+    # which errors on a non-Mac simulation host. Fake just that probe; pass the rest
+    # through. The value only feeds test sizing heuristics, never a real allocation.
+    import torch
+
+    real = subprocess.check_output
+
+    def fake(cmd, *args, **kwargs):
+        # Only substitute when the real (macOS-only) probe is unavailable, so this is a
+        # strict no-op on an actual Mac.
+        if isinstance(cmd, (list, tuple)) and "hw.memsize" in cmd:
+            try:
+                return real(cmd, *args, **kwargs)
+            except Exception:
+                return b"17179869184"  # 16 GiB
+        return real(cmd, *args, **kwargs)
+
+    subprocess.check_output = fake
+
+    # MPS C APIs are macOS-only and absent from a non-Mac build; fake the ones test
+    # files call at import/decorator time (in method bodies they don't run here).
+    if not hasattr(torch._C, "_mps_isCaptureEnabled"):
+        torch._C._mps_isCaptureEnabled = lambda *a, **k: False
+    if not hasattr(torch._C, "_mps_maxBufferLength"):
+        torch._C._mps_maxBufferLength = lambda *a, **k: 1 << 34
+
+
+def _patch_has_triton() -> None:
+    # triton_utils.py defines add_kernel et al. only `if has_triton():`, which is
+    # False when the GPU is hidden. Declare triton present so those helpers exist
+    # (triton itself is installed; only device detection is what fails).
+    t = _safe_import("torch.utils._triton")
+    if t is not None:
+        t.has_triton = lambda: True
+
+
+def _safe_import(name: str):
+    try:
+        import importlib
+
+        return importlib.import_module(name)
+    except Exception:
+        return None
+
+
+def _override_inductor_utils(iu, platform: Platform, gpu_type: str) -> None:
+    if iu is None:
+        return
+    cap = platform.cuda_capability or (8, 0)
+    vals = {
+        "HAS_CPU": True,
+        "HAS_TRITON": True,
+        "HAS_CUDA_AND_TRITON": gpu_type == "cuda",
+        "HAS_XPU_AND_TRITON": gpu_type == "xpu",
+        "HAS_MPS": gpu_type == "mps",
+        "HAS_GPU": True,
+        "HAS_GPU_AND_TRITON": True,
+        "GPU_TYPE": gpu_type,
+        "RUN_GPU": True,
+        "RUN_CPU": True,
+        "HAS_MULTIGPU": False,
+        "IS_A100": gpu_type == "cuda" and cap == (8, 0),
+        "IS_H100": gpu_type == "cuda" and cap == (9, 0),
+        "IS_BIG_GPU": gpu_type == "cuda",
+    }
+    for k, v in vals.items():
+        if hasattr(iu, k):
+            setattr(iu, k, v)
+
+
+def _apply_cuda(platform: Platform, torch, cdt, cu) -> None:
+    import torch.testing._internal.common_cuda as cc
+
+    cap = platform.cuda_capability or (8, 0)
+
+    class _Props:
+        major, minor = cap
+        total_memory = 80 * 1024**3
+        name = "Simulated"
+        multi_processor_count = 108
+        gcnArchName = "gfx942" if platform.rocm else ""
+
+    torch.cuda.is_available = lambda: True
+    torch.cuda.get_device_capability = lambda *a, **k: cap
+    torch.cuda.get_device_properties = lambda *a, **k: _Props()
+    torch.cuda.device_count = lambda: 1
+    torch.cuda.current_device = lambda: 0
+    torch.cuda.is_initialized = lambda: True
+
+    cu.TEST_CUDA = True
+    cc.TEST_CUDA = True
+    cc.CUDA_DEVICE = torch.device("cuda:0")
+    cc.TEST_CUDNN = True
+    cc.TEST_CUDNN_VERSION = platform.cudnn_version
+    for name, sm in _SM_ORLATER.items():
+        if hasattr(cc, name):
+            setattr(cc, name, cap >= sm)
+    for name, sm in _SM_EXACT.items():
+        if hasattr(cc, name):
+            setattr(cc, name, cap == sm)
+    for name in ["IS_SM12X"]:
+        if hasattr(cc, name):
+            setattr(cc, name, cap[0] == 12)
+    for name in ["IS_THOR", "IS_JETSON"]:
+        if hasattr(cc, name):
+            setattr(cc, name, False)
+    for name, val in platform.caps.items():
+        if hasattr(cc, name):
+            setattr(cc, name, val)
+
+    if platform.rocm:
+        cu.TEST_WITH_ROCM = True
+        if hasattr(cc, "TEST_WITH_ROCM"):
+            cc.TEST_WITH_ROCM = True
+
+    # setUpClass runs at generation time and does real device work; its outputs feed
+    # runtime skips, not the generated name set.
+    def _fake_setupclass(klass):
+        klass.no_magma = False
+        klass.no_cudnn = False
+        klass.cudnn_version = platform.cudnn_version
+        klass.primary_device = "cuda:0"
+
+    cdt.CUDATestBase.setUpClass = classmethod(_fake_setupclass)
+    cdt.device_type_test_bases = [cdt.CPUTestBase, cdt.CUDATestBase]
+
+    # The gut-and-run path would otherwise run the cuda memory-leak / stream checks
+    # (real cuda APIs) around each test and can trip the early-stop suite logic.
+    cdt.CUDATestBase._do_cuda_memory_leak_check = False
+    cdt.CUDATestBase._do_cuda_non_default_stream = False
+    cdt.CUDATestBase._should_stop_test_suite = lambda self: False
+
+    # inductor's device interface binds get_device_properties/current_device as
+    # staticmethods to the ORIGINAL torch.cuda.* at its import, bypassing the patches
+    # above (e.g. is_big_gpu() -> DeviceProperties.create). Re-point them.
+    di = _safe_import("torch._dynamo.device_interface")
+    if di is not None and hasattr(di, "CudaInterface"):
+        di.CudaInterface.get_device_properties = staticmethod(lambda *a, **k: _Props())
+        di.CudaInterface.current_device = staticmethod(lambda *a, **k: 0)
+        di.CudaInterface.device_count = staticmethod(lambda *a, **k: 1)
+
+
+# --------------------------------------------------------------------------- #
+# Import + harvest + gut-and-run
+# --------------------------------------------------------------------------- #
+_GUT_METHODS = {"setUp", "tearDown"}
+_GUT_MODULE = {"setUpModule", "tearDownModule"}
+
+
+class _Gut(ast.NodeTransformer):
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
+        for stmt in node.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if stmt.name.startswith("test") or stmt.name in _GUT_METHODS:
+                    stmt.body = [ast.Pass()]
+        self.generic_visit(node)
+        return node
+
+
+def _import_target(
+    relpath: str, gut: bool, mod_name: str = "introspect_target_mod"
+) -> ModuleType:
+    path = str(_root() / relpath)
+    # Mimic running the file directly: its own directory is on sys.path, so sibling
+    # imports (e.g. functorch's `from attn_ft import ...`) resolve. Dedup so warm
+    # batching doesn't grow sys.path unboundedly.
+    parent = str((_root() / relpath).parent)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    with open(path) as f:
+        src = f.read()
+    if gut:
+        tree = ast.parse(src, filename=path)
+        _Gut().visit(tree)
+        for stmt in tree.body:
+            if (
+                isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and stmt.name in _GUT_MODULE
+            ):
+                stmt.body = [ast.Pass()]
+        ast.fix_missing_locations(tree)
+        code = compile(tree, path, "exec")
+        mod = ModuleType(mod_name)
+        mod.__file__ = path
+        sys.modules[mod_name] = mod
+        exec(code, mod.__dict__)
+        return mod
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _testcase_classes(mod: ModuleType) -> dict[str, type]:
+    return {
+        obj.__name__: obj
+        for obj in vars(mod).values()
+        if isinstance(obj, type) and issubclass(obj, unittest.TestCase)
+    }
+
+
+def _enumerate(mod: ModuleType) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for name, cls in _testcase_classes(mod).items():
+        methods = unittest.defaultTestLoader.getTestCaseNames(cls)
+        if methods:
+            out[name] = sorted(methods)
+    return out
+
+
+def _locate(mod: ModuleType) -> dict[str, list]:
+    """{"Class::method": [relfile, lineno]} for tests whose definition lives in the
+    test tree (TESTINTRO_ROOT). Generated/parametrized variants resolve to their
+    template function's def; tests defined outside the tree (e.g. torch-internal
+    mixins) are omitted, so the renderer leaves them unlinked."""
+    root = str(_root())
+    out: dict[str, list] = {}
+    for cname, cls in _testcase_classes(mod).items():
+        for mname in unittest.defaultTestLoader.getTestCaseNames(cls):
+            fn = getattr(cls, mname, None)
+            if fn is None:
+                continue
+            try:
+                fn = inspect.unwrap(fn)
+                src = inspect.getsourcefile(fn)
+                line = inspect.getsourcelines(fn)[1]
+            except (TypeError, OSError):
+                continue
+            if not src:
+                continue
+            ap = os.path.abspath(src)
+            if ap == root or ap.startswith(root + os.sep):
+                out[f"{cname}::{mname}"] = [os.path.relpath(ap, root), line]
+    return out
+
+
+class _Recorder(unittest.TestResult):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ran: set[str] = set()
+        self.skipped_reasons: dict[str, str] = {}
+
+    @staticmethod
+    def _key(test: unittest.TestCase) -> str:
+        return f"{type(test).__name__}::{test._testMethodName}"
+
+    def addSuccess(self, test):
+        self.ran.add(self._key(test))
+
+    def addError(self, test, err):
+        self.ran.add(self._key(test))
+
+    def addFailure(self, test, err):
+        self.ran.add(self._key(test))
+
+    def addExpectedFailure(self, test, err):
+        self.ran.add(self._key(test))
+
+    def addUnexpectedSuccess(self, test):
+        self.ran.add(self._key(test))
+
+    def addSkip(self, test, reason):
+        self.skipped_reasons[self._key(test)] = reason
+
+
+def _status(mod: ModuleType) -> dict:
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for cls in _testcase_classes(mod).values():
+        tests = loader.loadTestsFromTestCase(cls)
+        if tests.countTestCases():
+            suite.addTests(tests)
+    result = _Recorder()
+    suite.run(result)
+    return {
+        "ran": sorted(result.ran),
+        "skipped": sorted(result.skipped_reasons.items()),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# File selection (reuse run_test.get_selected_tests)
+# --------------------------------------------------------------------------- #
+def _select(job: Job) -> dict:
+    """Compute the test files this job runs, reusing run_test.get_selected_tests.
+    Returns repo-relative .py paths (existing only) plus any that map to no file."""
+    import run_test  # on sys.path via REPO/test
+
+    saved_argv = sys.argv
+    sys.argv = ["run_test"]
+    try:
+        options = run_test.parse_args()
+    finally:
+        sys.argv = saved_argv
+    for key, val in job.config.options.items():
+        setattr(options, key, val)
+
+    modules = run_test.get_selected_tests(options)
+    files, missing = [], []
+    for m in modules:
+        rel = f"test/{m}.py"
+        if (_root() / rel).exists():
+            files.append(rel)
+        else:
+            missing.append(m)  # cpp tests, special handlers, etc.
+    return {"files": files, "missing": missing}
+
+
+def _collect_one(relpath: str, op: str, mod_name: str) -> dict:
+    if op in ("enumerate", "enumloc"):
+        mod = _import_target(relpath, gut=False, mod_name=mod_name)
+        out = {"classes": _enumerate(mod)}
+        if op == "enumloc":
+            out["locations"] = _locate(mod)
+        return out
+    if op == "status":
+        return _status(_import_target(relpath, gut=True, mod_name=mod_name))
+    raise SystemExit(f"unknown op {op!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Worker entrypoint
+# --------------------------------------------------------------------------- #
+def _emit(payload: dict) -> None:
+    print(_SENTINEL + json.dumps(payload))
+    sys.stdout.flush()
+
+
+def _worker_main(argv: list[str]) -> int:
+    job_name, op, *rest = argv
+    job = get_job(job_name)
+    sys.path.insert(0, str(_root() / "test"))
+    apply_descriptor(job.platform)
+
+    if op == "select":
+        _emit({**_select(job), "job": job_name, "op": op})
+        return 0
+
+    if op == "batch":
+        # rest = [inner_op, filelist_path]. Warm op_db once, then stream per file.
+        inner_op, filelist = rest
+        with open(filelist) as f:
+            files = json.load(f)
+        _safe_import("torch.testing._internal.common_methods_invocations")  # warm op_db
+        test_root = str(_root() / "test")
+        for i, relpath in enumerate(files):
+            name = f"introspect_target_{i}"
+            before_paths = list(sys.path)
+            before_mods = set(sys.modules)
+            try:
+                payload = _collect_one(relpath, inner_op, name)
+                _emit({"file": relpath, **payload})
+            except (Exception, SystemExit) as e:
+                _emit({"file": relpath, "error": repr(e).splitlines()[0][:300]})
+            finally:
+                # Per-file isolation: restore sys.path so a prior file's directory
+                # can't shadow a later file's sibling import (e.g. test/export's
+                # test_sparse shadowing the top-level test_sparse), and drop test-tree
+                # modules so the next file re-imports its siblings fresh. torch.* and
+                # stdlib stay warm.
+                sys.path[:] = before_paths
+                for m in set(sys.modules) - before_mods:
+                    mod = sys.modules.get(m)
+                    f = getattr(mod, "__file__", None) or ""
+                    if m == name or f.startswith(test_root):
+                        sys.modules.pop(m, None)
+        return 0
+
+    # Single-file ops (the --file fast path / isolated retry).
+    _emit(
+        {
+            **_collect_one(rest[0], op, "introspect_target_mod"),
+            "job": job_name,
+            "op": op,
+        }
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Parent-side API
+# --------------------------------------------------------------------------- #
+# Bump when descriptor/collection logic changes in a way that invalidates cached
+# results (the cache key already includes job name + file content hash).
+CACHE_VERSION = "1"
+CACHE_DIR = Path(
+    os.environ.get("TESTINTRO_CACHE", str(Path.home() / ".cache" / "testintro"))
+)
+
+
+def _job_env(job: Job) -> dict[str, str]:
+    env = dict(os.environ)
+    env.update(job.subprocess_env())
+    # Each worker imports torch, whose OpenMP/MKL pools default to all cores. With
+    # many parallel workers that is N*cores threads -> catastrophic oversubscription.
+    # Collection doesn't run test bodies, so pin every worker to a single thread.
+    env.update(
+        OMP_NUM_THREADS="1",
+        MKL_NUM_THREADS="1",
+        OPENBLAS_NUM_THREADS="1",
+        NUMEXPR_NUM_THREADS="1",
+    )
+    return env
+
+
+def _run_worker(
+    job: Job, op: str, relpath: str | None = None, timeout: int = 1800
+) -> dict:
+    """Single-payload ops: select / enumerate / status (one file, isolated)."""
+    # Run by path, not `-m`: `-m` puts cwd (REPO) on sys.path[0], so `import torch`
+    # would load the repo's torch/ source instead of the installed wheel.
+    cmd = [sys.executable, _COLLECTOR, job.name, op]
+    if relpath is not None:
+        cmd.append(relpath)
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO),
+        env=_job_env(job),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith(_SENTINEL):
+            return json.loads(line[len(_SENTINEL) :])
+    tail = "\n".join(proc.stderr.strip().splitlines()[-15:])
+    raise RuntimeError(
+        f"collector worker failed (op={op}, target={relpath}, job={job.name}, rc={proc.returncode}).\n"
+        f"Often means the platform descriptor is missing a probe.\nstderr tail:\n{tail}"
+    )
+
+
+def _select_signature() -> str:
+    """Cheap, torch-free signature of what selection depends on: the set of test
+    files (catches add/remove) plus the selection-logic sources (catches blocklist
+    edits). Lets a fully-cached run avoid importing torch entirely."""
+    import glob
+
+    h = hashlib.sha256()
+    root = _root()
+    # Relative paths: absolute paths include the ephemeral worktree dir, which would
+    # make the key differ every run and defeat the cache.
+    names = sorted(
+        os.path.relpath(p, root)
+        for p in glob.glob(str(root / "test" / "**" / "*.py"), recursive=True)
+    )
+    h.update("\n".join(names).encode())
+    for rel in ["test/run_test.py", "tools/testing/discover_tests.py"]:
+        try:
+            h.update((_root() / rel).read_bytes())
+        except Exception:
+            pass
+    return h.hexdigest()[:16]
+
+
+def select_files(job: Job, use_cache: bool = True) -> dict:
+    if use_cache:
+        sig = _select_signature()
+        key = hashlib.sha256(
+            f"select|{CACHE_VERSION}|{job.name}|{sig}".encode()
+        ).hexdigest()
+        path = CACHE_DIR / f"{key}.json"
+        if path.exists():
+            try:
+                return json.loads(path.read_text())
+            except Exception:
+                pass
+        res = _run_worker(job, "select")
+        try:
+            CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(res))
+        except Exception:
+            pass
+        return res
+    return _run_worker(job, "select")
+
+
+# ---- content-hash cache -------------------------------------------------- #
+def _cache_path(job: Job, op: str, relpath: str) -> Path:
+    sha = hashlib.sha256((_root() / relpath).read_bytes()).hexdigest()
+    key = hashlib.sha256(
+        f"{CACHE_VERSION}|{job.name}|{op}|{relpath}|{sha}".encode()
+    ).hexdigest()
+    return CACHE_DIR / f"{key}.json"
+
+
+def _cache_get(job: Job, op: str, relpath: str) -> dict | None:
+    p = _cache_path(job, op, relpath)
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            return None
+    return None
+
+
+def _cache_put(job: Job, op: str, relpath: str, payload: dict) -> None:
+    try:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        _cache_path(job, op, relpath).write_text(json.dumps(payload))
+    except Exception:
+        pass
+
+
+# ---- warm batch workers -------------------------------------------------- #
+def _run_batch_worker(
+    job: Job, inner_op: str, files: list[str], timeout: int = 3600, on_done=None
+) -> dict:
+    """One warm worker (torch + op_db imported once) over `files` in order. Returns
+    {relpath: payload} for every file that completed before the process exited -- a
+    prefix, since the worker is sequential, so a hard crash leaves a clean boundary."""
+    tf = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)  # noqa: SIM115
+    json.dump(files, tf)
+    tf.close()
+    out: dict[str, dict] = {}
+    try:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                _COLLECTOR,  # by path, not -m (avoid REPO/torch shadowing the wheel)
+                job.name,
+                "batch",
+                inner_op,
+                tf.name,
+            ],
+            cwd=str(REPO),
+            env=_job_env(job),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        for line in proc.stdout:  # type: ignore[union-attr]
+            if line.startswith(_SENTINEL):
+                d = json.loads(line[len(_SENTINEL) :])
+                out[d.pop("file")] = d
+                if on_done:
+                    on_done()
+        proc.wait(timeout=timeout)
+    finally:
+        os.unlink(tf.name)
+    return out
+
+
+def _warm_chunk(job: Job, inner_op: str, files: list[str], on_done=None) -> dict:
+    """Process a chunk in a warm worker; if the worker dies on a file (hard crash,
+    not a caught exception), isolate that file in its own process and continue."""
+    out: dict[str, dict] = {}
+    remaining = list(files)
+    while remaining:
+        got = _run_batch_worker(job, inner_op, remaining, on_done=on_done)
+        done = [f for f in remaining if f in got]
+        for f in done:
+            out[f] = got[f]
+        if len(done) == len(remaining):
+            break
+        culprit = remaining[len(done)]  # first file with no emitted result
+        try:
+            out[culprit] = _run_worker(job, inner_op, culprit)
+        except Exception as e:
+            out[culprit] = {"error": str(e).splitlines()[0]}
+        if on_done:
+            on_done()  # count the isolated file
+        remaining = remaining[len(done) + 1 :]
+    return out
+
+
+def _default_workers() -> int:
+    """Concurrent collector subprocesses. Kept modest on purpose: the parent parses
+    each worker's per-file JSON (large for op_db/inductor files) under the GIL, so
+    too many parallel streams contend and anti-scale. Overridable via
+    TESTINTRO_WORKERS for idle, many-core boxes."""
+    override = os.environ.get("TESTINTRO_WORKERS")
+    if override:
+        return max(1, int(override))
+    return max(1, min(16, (os.cpu_count() or 4) - 2))
+
+
+def collect(
+    job: Job,
+    op: str,
+    files: list[str],
+    use_cache: bool = True,
+    max_workers: int | None = None,
+    on_progress=None,
+) -> dict:
+    """Collect `op` (enumerate|status) for many files: cache hits returned directly,
+    misses processed across warm workers. Returns {relpath: payload-or-{'error':...}}.
+    on_progress(done, total) is called as files complete (thread-safe)."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    total = len(files)
+    done = [0]
+    lock = threading.Lock()
+
+    def bump() -> None:
+        if on_progress is None:
+            return
+        with lock:
+            done[0] += 1
+            on_progress(done[0], total)
+
+    results: dict[str, dict] = {}
+    todo: list[str] = []
+    for f in files:
+        cached = _cache_get(job, op, f) if use_cache else None
+        if cached is not None:
+            results[f] = cached
+            bump()
+        else:
+            todo.append(f)
+
+    if todo:
+        n = max_workers or _default_workers()
+        chunks = [todo[i::n] for i in range(n)]  # round-robin balances slow files
+        chunks = [c for c in chunks if c]
+        with ThreadPoolExecutor(max_workers=len(chunks)) as ex:
+            for part in ex.map(lambda c: _warm_chunk(job, op, c, on_done=bump), chunks):
+                for f, r in part.items():
+                    results[f] = r
+                    if use_cache and "error" not in r:
+                        _cache_put(job, op, f, r)
+    return results
+
+
+def enumerate_tests(
+    relpath: str, job: Job, use_cache: bool = True
+) -> dict[str, list[str]]:
+    """{ClassName: [method, ...]} of concrete tests generated for the job."""
+    r = collect(job, "enumerate", [relpath], use_cache)[relpath]
+    if "error" in r:
+        raise RuntimeError(r["error"])
+    return r["classes"]
+
+
+def status(relpath: str, job: Job, use_cache: bool = True) -> dict:
+    """{'ran': [Class::method,...], 'skipped': [[Class::method, reason],...]}"""
+    r = collect(job, "status", [relpath], use_cache)[relpath]
+    if "error" in r:
+        raise RuntimeError(r["error"])
+    return r
+
+
+def list_job(
+    job: Job,
+    with_status: bool = False,
+    files_filter: str | None = None,
+    use_cache: bool = True,
+    max_workers: int | None = None,
+) -> dict:
+    """Behavior 3: aggregate concrete tests (and optionally run/skip status) across
+    every file the job selects, using warm batched workers + the content-hash cache.
+    Per-file failures are captured as {'error': ...} rather than aborting the run."""
+    sel = select_files(job, use_cache=use_cache)
+    files = sel["files"]
+    if files_filter:
+        files = [f for f in files if files_filter in f]
+
+    op = "status" if with_status else "enumerate"
+    raw = collect(job, op, files, use_cache, max_workers)
+    results: dict[str, dict] = {}
+    for f in files:
+        r = raw.get(f, {"error": "no result"})
+        if "error" in r:
+            results[f] = {"error": r["error"]}
+        elif with_status:
+            results[f] = {"status": r}
+        else:
+            results[f] = {"classes": r["classes"]}
+    return {
+        "job": job.name,
+        "files": files,
+        "missing": sel["missing"],
+        "results": results,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(_worker_main(sys.argv[1:]))

--- a/tools/testing/introspection/collector.py
+++ b/tools/testing/introspection/collector.py
@@ -159,10 +159,11 @@ def _stub_macos_probes() -> None:
 
 def _patch_has_triton() -> None:
     # triton_utils.py defines add_kernel et al. only `if has_triton():`, which is
-    # False when the GPU is hidden. Declare triton present so those helpers exist
-    # (triton itself is installed; only device detection is what fails).
+    # False when the GPU is hidden, so declare triton present to keep those helpers.
+    # Only safe when triton really is installed: claiming otherwise turns a skip
+    # into an ImportError at `import triton` further down the same file.
     t = _safe_import("torch.utils._triton")
-    if t is not None:
+    if t is not None and _safe_import("triton") is not None:
         t.has_triton = lambda: True
 
 

--- a/tools/testing/introspection/diff.py
+++ b/tools/testing/introspection/diff.py
@@ -1,0 +1,412 @@
+"""Behavior 1: tests added / removed between two git refs.
+
+Collects the concrete test set for the affected files at each ref and set-diffs them.
+Each ref's test files are read from a throwaway git worktree (via TESTINTRO_ROOT)
+while torch comes from the current build -- so a single build serves both refs for
+the common test-only / OpInfo-unchanged diff. Changes that touch native/codegen or
+the test infra (common_*, run_test, conftest) are treated as broad and widen the
+scope to the whole selected file set (with a warning), since they can change
+generation anywhere.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import TYPE_CHECKING
+
+from tools.testing.introspection import collector
+
+
+if TYPE_CHECKING:
+    from tools.testing.introspection.platforms import Job
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(collector.REPO),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _gh(*args: str) -> str:
+    return subprocess.run(
+        ["gh", *args],
+        cwd=str(collector.REPO),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _sha_present(sha: str) -> bool:
+    try:
+        _git("cat-file", "-e", f"{sha}^{{commit}}")
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def resolve_pr(pr: int) -> tuple[str, str]:
+    """Resolve a GitHub PR to (base_sha, head_sha), fetching objects only if missing.
+
+    base is the fork point (merge-base of the PR head and its base branch) so the
+    diff reflects only the PR's own changes, not unrelated base-branch movement.
+    """
+    info = json.loads(_gh("pr", "view", str(pr), "--json", "headRefOid,baseRefName"))
+    head, base_branch = info["headRefOid"], info["baseRefName"]
+    if not _sha_present(head):
+        _git("fetch", "origin", f"pull/{pr}/head")
+    try:
+        _git("rev-parse", "--verify", f"origin/{base_branch}")
+    except subprocess.CalledProcessError:
+        _git("fetch", "origin", base_branch)
+    base = _git("merge-base", head, f"origin/{base_branch}").strip()
+    return base, head
+
+
+def _changed_files(a: str, b: str) -> list[str]:
+    return [ln for ln in _git("diff", "--name-only", a, b).splitlines() if ln]
+
+
+def _is_test_py(path: str) -> bool:
+    return path.startswith("test/") and path.endswith(".py") and "/test_" in f"/{path}"
+
+
+# Generation/selection surface: changes here can alter which tests EXIST (the only
+# thing B1 reports), anywhere. Other torch/ source changes only affect behavior/skips,
+# not the test set, so they are not broad for an added/removed diff.
+_GEN_PREFIXES = ("torch/testing/_internal/", "tools/testing/")
+
+
+def _is_broad(path: str) -> bool:
+    if path.startswith("test/"):
+        # Non-.py files under test/ (expected-failure lists, json, data) affect
+        # xfail/skip at runtime, not which tests exist -> not broad.
+        if not path.endswith(".py"):
+            return False
+        base = path.rsplit("/", 1)[-1]
+        # A .py helper/base (not a test_*.py file) can change generation broadly.
+        return base in ("run_test.py", "conftest.py") or not base.startswith("test_")
+    if path.startswith(_GEN_PREFIXES):
+        return True
+    # Codegen inputs that synthesize ops/tests.
+    return path.endswith((".yaml", ".yml")) and (
+        "native_functions" in path or "deriv" in path
+    )
+
+
+def _module_ids(relpath: str) -> tuple[str, str]:
+    rel = relpath[len("test/") : -len(".py")]
+    return rel.replace("/", "."), rel.split("/")[-1]
+
+
+def _import_graph(b: str, files: list[str], root) -> dict[str, set[str]]:
+    """Import graph for ref `b`, disk-cached by the resolved sha (contents are fixed
+    per sha), so repeat diffs of the same head skip the ~15s AST pass."""
+    try:
+        bsha = _git("rev-parse", b).strip()
+    except subprocess.CalledProcessError:
+        bsha = b
+    import hashlib
+
+    key = hashlib.sha256(
+        f"graph|{collector.CACHE_VERSION}|{bsha}|{len(files)}".encode()
+    ).hexdigest()
+    path = collector.CACHE_DIR / f"{key}.json"
+    if path.exists():
+        try:
+            return {k: set(v) for k, v in json.loads(path.read_text()).items()}
+        except Exception:
+            pass
+    g = _build_import_graph(files, root)
+    try:
+        collector.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({k: sorted(v) for k, v in g.items()}))
+    except Exception:
+        pass
+    return g
+
+
+def _build_import_graph(files: list[str], root) -> dict[str, set[str]]:
+    """{relpath: set of module tokens it imports}, by AST (no torch). Depends only on
+    file contents, so it can be built once and reused across jobs/platforms."""
+    imports_of: dict[str, set[str]] = {}
+    for f in files:
+        try:
+            tree = ast.parse((root / f).read_text())
+        except Exception:
+            continue
+        toks: set[str] = set()
+        for n in ast.walk(tree):
+            if isinstance(n, ast.ImportFrom) and n.module:
+                toks.add(n.module)
+            elif isinstance(n, ast.Import):
+                for a in n.names:
+                    toks.add(a.name)
+        imports_of[f] = toks
+    return imports_of
+
+
+def _scope(
+    changed_tests: list[str], selected: list[str], imports_of: dict[str, set[str]]
+) -> set[str]:
+    """Affected = changed test files + any selected file that (transitively) imports a
+    changed test module (catches synthetic subclassers, e.g. test_jit_legacy).
+    `imports_of` is a prebuilt import graph (see _build_import_graph)."""
+    targets: set[str] = set()
+    for f in changed_tests:
+        targets.update(_module_ids(f))
+    affected = set(changed_tests)
+    grew = True
+    while grew:
+        grew = False
+        for f, toks in imports_of.items():
+            if f in affected:
+                continue
+            if toks & targets:
+                affected.add(f)
+                targets.update(_module_ids(f))
+                grew = True
+    return (affected & set(selected)) | set(changed_tests)
+
+
+def _worktree(ref: str) -> str:
+    d = tempfile.mkdtemp(prefix="testintro_wt_")
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", "-f", d, ref],
+        cwd=str(collector.REPO),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return d
+
+
+def _remove_worktree(d: str) -> None:
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", d],
+        cwd=str(collector.REPO),
+        capture_output=True,
+        text=True,
+    )
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def _root_env(path: str):
+    prev = os.environ.get("TESTINTRO_ROOT")
+    os.environ["TESTINTRO_ROOT"] = path
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("TESTINTRO_ROOT", None)
+        else:
+            os.environ["TESTINTRO_ROOT"] = prev
+
+
+def _collect_job_files(
+    job: Job, files: list[str], max_workers: int, op: str = "enumerate"
+) -> tuple[dict[str, set[str]], set[str], dict[str, dict]]:
+    """Collect `files` for one job at the currently-set TESTINTRO_ROOT. Returns
+    ({relpath: {Class::method,...}}, errored, {relpath: {Class::method: [file, line]}}).
+    Locations are present only when op == 'enumloc'."""
+    present = [f for f in files if (collector._root() / f).exists()]
+    raw = collector.collect(job, op, present, max_workers=max_workers)
+    out: dict[str, set[str]] = {}
+    errored: set[str] = set()
+    locs: dict[str, dict] = {}
+    for f in files:
+        r = raw.get(f)
+        if r and "error" not in r:
+            out[f] = {f"{c}::{m}" for c, ms in r["classes"].items() for m in ms}
+            if "locations" in r:
+                locs[f] = r["locations"]
+        elif r and "error" in r:
+            out[f] = set()
+            errored.add(f)
+        else:
+            out[f] = set()  # absent at this root
+    return out, errored, locs
+
+
+def _collect_phase(
+    root: str,
+    jobs: list[Job],
+    affected_by_job: dict[str, list[str]],
+    label: str,
+    op: str = "enumerate",
+) -> dict[str, tuple]:
+    """Collect all jobs at one ref `root`, in parallel. The root is identical for
+    every job in the phase, so it is set once (no per-thread env mutation), and the
+    worker budget is split across jobs to avoid oversubscription."""
+    from concurrent.futures import as_completed, ThreadPoolExecutor
+
+    cap = collector._default_workers()
+    per_job_workers = max(1, cap // max(1, len(jobs)))
+    results: dict[str, tuple] = {}
+    with _root_env(root):
+        with ThreadPoolExecutor(max_workers=max(1, len(jobs))) as ex:
+            futs = {
+                ex.submit(
+                    _collect_job_files,
+                    job,
+                    affected_by_job[job.name],
+                    per_job_workers,
+                    op,
+                ): job
+                for job in jobs
+            }
+            for k, fut in enumerate(as_completed(futs), 1):
+                results[futs[fut].name] = fut.result()
+                print(
+                    f"\r  {label}: {k}/{len(jobs)} platforms   ",
+                    end="",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    print(file=sys.stderr)
+    return results
+
+
+def diff(
+    jobs: list[Job],
+    a: str,
+    b: str,
+    files_filter: str | None = None,
+    full: bool = False,
+    locations: bool = False,
+) -> dict:
+    """Tests added/removed between refs a and b, for each job. Both refs are
+    materialized once as git worktrees and reused across all jobs. Selection (varies
+    only by config+rocm) and the import graph (content-only) are computed once and
+    reused; collection fans out across jobs in parallel per ref."""
+    changed = _changed_files(a, b)
+    changed_tests = [f for f in changed if _is_test_py(f)]
+    broad = full or any(_is_broad(f) for f in changed)
+    scope_reason = (
+        "broad change (native/codegen/test-infra) -> full scope"
+        if broad
+        else "test-only change -> scoped to changed files + importers"
+    )
+
+    wt_a, wt_b = _worktree(a), _worktree(b)
+    try:
+        # Selection + import graph depend on the head tree, not the platform (modulo
+        # the rocm blocklist), so compute each once and share across jobs.
+        sel_by_key: dict[tuple, list[str]] = {}
+        with _root_env(wt_b):
+            for job in jobs:
+                key = (job.config.name, job.platform.rocm)
+                if key not in sel_by_key:
+                    print(f"selecting files {key}...", file=sys.stderr, flush=True)
+                    sel_by_key[key] = collector.select_files(job)["files"]
+            imports_of: dict[str, set[str]] = {}
+            if not broad:
+                union = sorted(set().union(*sel_by_key.values()))
+                print(
+                    f"building import graph ({len(union)} files)...",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                imports_of = _import_graph(b, union, collector._root())
+
+        affected_by_job: dict[str, list[str]] = {}
+        for job in jobs:
+            selected = sel_by_key[(job.config.name, job.platform.rocm)]
+            if broad:
+                affected = sorted(set(selected) | set(changed_tests))
+            else:
+                affected = sorted(_scope(changed_tests, selected, imports_of))
+            if files_filter:
+                affected = [f for f in affected if files_filter in f]
+            affected_by_job[job.name] = affected
+
+        op = "enumloc" if locations else "enumerate"
+        at_a = _collect_phase(wt_a, jobs, affected_by_job, "collecting base", op)
+        at_b = _collect_phase(wt_b, jobs, affected_by_job, "collecting head", op)
+
+        per_job = {}
+        # Locations key on the comment's test id "file::Class::method": added tests are
+        # located at the head (b), removed at the base (a), since each exists only there.
+        added_loc: dict[str, list] = {}
+        removed_loc: dict[str, list] = {}
+        for job in jobs:
+            affected = affected_by_job[job.name]
+            sa_map, err_a, loc_a = at_a[job.name]
+            sb_map, err_b, loc_b = at_b[job.name]
+            errored = err_a | err_b
+            per_file = {}
+            for f in affected:
+                if f in errored:
+                    continue  # unreliable at a ref -> don't report a fake diff
+                added = sorted(sb_map[f] - sa_map[f])
+                removed = sorted(sa_map[f] - sb_map[f])
+                if added or removed:
+                    per_file[f] = {"added": added, "removed": removed}
+                for t in added:
+                    loc = loc_b.get(f, {}).get(t)
+                    if loc:
+                        added_loc[f"{f}::{t}"] = loc
+                for t in removed:
+                    loc = loc_a.get(f, {}).get(t)
+                    if loc:
+                        removed_loc[f"{f}::{t}"] = loc
+            per_job[job.name] = {
+                "scope_reason": scope_reason,
+                "n_affected": len(affected),
+                "uncomparable": sorted(errored),
+                "per_file": per_file,
+            }
+    finally:
+        _remove_worktree(wt_a)
+        _remove_worktree(wt_b)
+
+    result = {"from": a, "to": b, "per_job": per_job}
+    if locations:
+        result["added_loc"] = added_loc
+        result["removed_loc"] = removed_loc
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Result shaping shared by the CLI text view and the PR-comment renderer
+# --------------------------------------------------------------------------- #
+def invert_per_job(
+    res: dict,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], list[str]]:
+    """From a diff() result, return (added, removed, job_names) where added/removed map
+    a concrete test id "file::Class::method" -> the set of jobs it was added/removed on."""
+    job_names = list(res["per_job"])
+    added: dict[str, set[str]] = {}
+    removed: dict[str, set[str]] = {}
+    for job_name, jr in res["per_job"].items():
+        for f, v in jr["per_file"].items():
+            for t in v["added"]:
+                added.setdefault(f"{f}::{t}", set()).add(job_name)
+            for t in v["removed"]:
+                removed.setdefault(f"{f}::{t}", set()).add(job_name)
+    return added, removed, job_names
+
+
+def group_by_platform_set(
+    m: dict[str, set[str]], all_jobs: set[str]
+) -> list[tuple[frozenset[str], list[str]]]:
+    """Group test ids by the set of jobs they apply to; all-platforms group first."""
+    groups: dict[frozenset[str], list[str]] = {}
+    for test, plats in m.items():
+        groups.setdefault(frozenset(plats), []).append(test)
+    return [
+        (fs, sorted(groups[fs]))
+        for fs in sorted(groups, key=lambda fs: (fs != all_jobs, sorted(fs)))
+    ]

--- a/tools/testing/introspection/platforms.py
+++ b/tools/testing/introspection/platforms.py
@@ -1,0 +1,186 @@
+"""Platform descriptors.
+
+A Platform is a declarative description of a CI target. Applying it (see
+collector.apply_descriptor) monkeypatches the small, centralized device-capability
+surface -- `torch.cuda`/`torch.xpu` probes, the `common_cuda` SM / PLATFORM_SUPPORTS_*
+flags, the device `*TestBase.setUpClass`, and `device_type_test_bases` -- so that test
+generation and skip evaluation run as pure Python for the declared platform, with no
+real-driver calls. This lets one host answer for many platforms.
+
+The descriptor surface was validated to be bounded and centralized: see the spike
+results in the design doc. A missing entry fails loudly (a real driver call raising),
+so descriptors are discoverable and maintainable, never silently wrong.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Platform:
+    name: str
+    # Primary accelerator device for this platform. CPU device-generic tests are also
+    # generated/run on accelerator platforms (a CUDA box has a CPU too), matching CI.
+    device_type: str  # "cpu" | "cuda" | "mps" | "xpu"  (rocm uses device_type "cuda")
+    rocm: bool = False
+    # CUDA/ROCm compute capability the descriptor declares (drives SMxxOrLater gates).
+    cuda_capability: tuple[int, int] | None = None
+    cudnn_version: int = 90100
+    # common_cuda PLATFORM_SUPPORTS_* overrides (name -> bool). Defaults are filled by
+    # the factories below from the declared capability.
+    caps: dict[str, bool] = field(default_factory=dict)
+    # Extra subprocess env (e.g. PYTORCH_TEST_WITH_ROCM=1).
+    env: dict[str, str] = field(default_factory=dict)
+
+    def subprocess_env(self) -> dict[str, str]:
+        # Hide any real accelerator so an un-stubbed probe fails loudly instead of
+        # silently using the host device (keeps simulation deterministic + descriptors
+        # honest). The in-process descriptor supplies the simulated values.
+        e = {"CUDA_VISIBLE_DEVICES": "", "HIP_VISIBLE_DEVICES": ""}
+        e.update(self.env)
+        return e
+
+
+# Attention/fp8 capability defaults as a function of CUDA SM version. These mirror the
+# common_cuda evaluate_* predicates closely enough for generation; exact build-flag
+# nuances can be overridden per platform via caps=.
+def _cuda_caps(capability: tuple[int, int], rocm: bool) -> dict[str, bool]:
+    sm = capability
+    flash = sm >= (8, 0) or rocm
+    mem_eff = sm >= (5, 0) or rocm
+    cudnn_attn = sm >= (8, 0)
+    return {
+        "PLATFORM_SUPPORTS_FLASH_ATTENTION": flash,
+        "PLATFORM_SUPPORTS_MEM_EFF_ATTENTION": mem_eff,
+        "PLATFORM_SUPPORTS_CUDNN_ATTENTION": cudnn_attn,
+        "PLATFORM_SUPPORTS_FUSED_ATTENTION": flash or mem_eff or cudnn_attn,
+        "PLATFORM_SUPPORTS_FUSED_SDPA": not rocm,
+        "PLATFORM_SUPPORTS_CK_SDPA": rocm,
+        "PLATFORM_SUPPORTS_BF16": sm >= (8, 0) or rocm,
+        "PLATFORM_SUPPORTS_BF16_ATOMICS": sm >= (8, 0),
+        "PLATFORM_SUPPORTS_HALF_ATOMICS": sm >= (6, 0),
+        "PLATFORM_SUPPORTS_FP8": sm >= (8, 9) and not rocm,
+        "PLATFORM_SUPPORTS_FP8_SPARSE": False,
+        "PLATFORM_SUPPORTS_FP8_GROUPED_GEMM": sm >= (9, 0) and not rocm,
+        "PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM": sm >= (10, 0) and not rocm,
+        "PLATFORM_SUPPORTS_MX_GEMM": sm >= (10, 0) and not rocm,
+        "PLATFORM_SUPPORTS_GREEN_CONTEXT": False,
+        "PLATFORM_SUPPORTS_WORKQUEUE_CONFIG": False,
+    }
+
+
+def cpu(name: str = "linux-cpu") -> Platform:
+    return Platform(name=name, device_type="cpu")
+
+
+def cuda(name: str, capability: tuple[int, int] = (8, 0), **caps: bool) -> Platform:
+    d = _cuda_caps(capability, rocm=False)
+    d.update(caps)
+    return Platform(name=name, device_type="cuda", cuda_capability=capability, caps=d)
+
+
+def rocm(name: str = "linux-rocm", capability: tuple[int, int] = (9, 4)) -> Platform:
+    d = _cuda_caps(capability, rocm=True)
+    return Platform(
+        name=name,
+        device_type="cuda",
+        rocm=True,
+        cuda_capability=capability,
+        caps=d,
+        env={"PYTORCH_TEST_WITH_ROCM": "1"},
+    )
+
+
+def mps(name: str = "macos-mps") -> Platform:
+    return Platform(name=name, device_type="mps")
+
+
+def xpu(name: str = "linux-xpu") -> Platform:
+    return Platform(name=name, device_type="xpu")
+
+
+# Built-in registry. Extend / generate from .github workflows later.
+REGISTRY: dict[str, Platform] = {
+    p.name: p
+    for p in [
+        cpu("linux-cpu"),
+        cuda("linux-cuda-sm80", (8, 0)),
+        cuda("linux-cuda-sm86", (8, 6)),
+        cuda("linux-cuda-sm90", (9, 0)),
+        cuda("linux-cuda-sm100", (10, 0)),
+        rocm("linux-rocm"),
+        mps("macos-mps"),
+        xpu("linux-xpu"),
+    ]
+}
+
+
+def get(name: str) -> Platform:
+    if name not in REGISTRY:
+        raise KeyError(
+            f"unknown platform {name!r}; known: {', '.join(sorted(REGISTRY))}"
+        )
+    return REGISTRY[name]
+
+
+@dataclass(frozen=True)
+class Config:
+    """The CI TEST_CONFIG dimension: which files are selected, and the env flags
+    (PYTORCH_TEST_WITH_*) that change generation/skip. `options` are run_test
+    arg-namespace overrides consumed by run_test.get_selected_tests."""
+
+    name: str
+    options: dict[str, object] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+
+
+CONFIGS: dict[str, Config] = {
+    c.name: c
+    for c in [
+        Config("default"),
+        Config("distributed", options={"distributed_tests": True}),
+        Config("functorch", options={"functorch": True}),
+        Config("inductor", options={"include_inductor_core_tests": True}),
+        Config(
+            "dynamo",
+            options={"include_dynamo_core_tests": True},
+            env={"PYTORCH_TEST_WITH_DYNAMO": "1"},
+        ),
+        Config("slow", env={"PYTORCH_TEST_WITH_SLOW": "1"}),
+        Config("crossref", env={"PYTORCH_TEST_WITH_CROSSREF": "1"}),
+        Config("mps", options={"mps": True}),
+    ]
+}
+
+
+def get_config(name: str) -> Config:
+    if name not in CONFIGS:
+        raise KeyError(f"unknown config {name!r}; known: {', '.join(sorted(CONFIGS))}")
+    return CONFIGS[name]
+
+
+@dataclass(frozen=True)
+class Job:
+    """A CI target = (platform device descriptor, config). Names as 'platform/config'."""
+
+    platform: Platform
+    config: Config
+
+    @property
+    def name(self) -> str:
+        return f"{self.platform.name}/{self.config.name}"
+
+    def subprocess_env(self) -> dict[str, str]:
+        e = self.platform.subprocess_env()
+        e.update(self.config.env)
+        return e
+
+
+def get_job(name: str) -> Job:
+    """Parse 'platform/config' (config defaults to 'default')."""
+    if "/" in name:
+        pname, cname = name.rsplit("/", 1)
+    else:
+        pname, cname = name, "default"
+    return Job(get(pname), get_config(cname))

--- a/tools/testing/introspection/platforms.py
+++ b/tools/testing/introspection/platforms.py
@@ -42,29 +42,22 @@ class Platform:
         return e
 
 
-# Attention/fp8 capability defaults as a function of CUDA SM version. These mirror the
-# common_cuda evaluate_* predicates closely enough for generation; exact build-flag
-# nuances can be overridden per platform via caps=.
+# Overrides for the PLATFORM_SUPPORTS_* flags that the descriptor cannot let
+# common_cuda compute for itself. Everything else is deliberately absent: those
+# predicates read only torch.cuda.get_device_capability and the SM* LazyVals, all
+# of which collector.apply_descriptor patches, so they self-heal to the right
+# value for the simulated capability. Re-deriving them here would be a second
+# copy of common_cuda's truth table, free to drift without anything noticing.
 def _cuda_caps(capability: tuple[int, int], rocm: bool) -> dict[str, bool]:
-    sm = capability
-    flash = sm >= (8, 0) or rocm
-    mem_eff = sm >= (5, 0) or rocm
-    cudnn_attn = sm >= (8, 0)
     return {
-        "PLATFORM_SUPPORTS_FLASH_ATTENTION": flash,
-        "PLATFORM_SUPPORTS_MEM_EFF_ATTENTION": mem_eff,
-        "PLATFORM_SUPPORTS_CUDNN_ATTENTION": cudnn_attn,
-        "PLATFORM_SUPPORTS_FUSED_ATTENTION": flash or mem_eff or cudnn_attn,
+        # A plain bool, not a LazyVal: frozen at common_cuda import time, when the
+        # descriptor has hidden the GPU, so it cannot self-heal.
         "PLATFORM_SUPPORTS_FUSED_SDPA": not rocm,
         "PLATFORM_SUPPORTS_CK_SDPA": rocm,
-        "PLATFORM_SUPPORTS_BF16": sm >= (8, 0) or rocm,
-        "PLATFORM_SUPPORTS_BF16_ATOMICS": sm >= (8, 0),
-        "PLATFORM_SUPPORTS_HALF_ATOMICS": sm >= (6, 0),
-        "PLATFORM_SUPPORTS_FP8": sm >= (8, 9) and not rocm,
+        # Read the build, not the device: torch.__config__.show() / cusparselt.
+        "PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM": capability >= (10, 0) and not rocm,
         "PLATFORM_SUPPORTS_FP8_SPARSE": False,
-        "PLATFORM_SUPPORTS_FP8_GROUPED_GEMM": sm >= (9, 0) and not rocm,
-        "PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM": sm >= (10, 0) and not rocm,
-        "PLATFORM_SUPPORTS_MX_GEMM": sm >= (10, 0) and not rocm,
+        # Probe the driver via green_contexts._ensure_supported().
         "PLATFORM_SUPPORTS_GREEN_CONTEXT": False,
         "PLATFORM_SUPPORTS_WORKQUEUE_CONFIG": False,
     }

--- a/tools/testing/introspection/platforms.py
+++ b/tools/testing/introspection/platforms.py
@@ -42,22 +42,22 @@ class Platform:
         return e
 
 
-# Overrides for the PLATFORM_SUPPORTS_* flags that the descriptor cannot let
-# common_cuda compute for itself. Everything else is deliberately absent: those
-# predicates read only torch.cuda.get_device_capability and the SM* LazyVals, all
-# of which collector.apply_descriptor patches, so they self-heal to the right
-# value for the simulated capability. Re-deriving them here would be a second
-# copy of common_cuda's truth table, free to drift without anything noticing.
+# Overrides for the PLATFORM_SUPPORTS_* flags that common_cuda cannot compute for
+# itself under a descriptor. Everything else is deliberately absent: those
+# predicates read only torch.cuda.get_device_capability and the SM* LazyVals,
+# which collector.apply_descriptor patches, so they self-heal for the simulated
+# capability. Re-deriving them here would be a second copy of common_cuda's truth
+# table, free to drift without anything noticing -- which is exactly what happened
+# to PLATFORM_SUPPORTS_FP8_GROUPED_GEMM.
 def _cuda_caps(capability: tuple[int, int], rocm: bool) -> dict[str, bool]:
     return {
-        # A plain bool, not a LazyVal: frozen at common_cuda import time, when the
-        # descriptor has hidden the GPU, so it cannot self-heal.
+        # Plain bools, not LazyVals, so they are fixed when common_cuda is imported
+        # -- which apply_descriptor does before patching torch.cuda.is_available.
+        # Derivable in principle; it needs that ordering changed first.
         "PLATFORM_SUPPORTS_FUSED_SDPA": not rocm,
         "PLATFORM_SUPPORTS_CK_SDPA": rocm,
-        # Read the build, not the device: torch.__config__.show() / cusparselt.
-        "PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM": capability >= (10, 0) and not rocm,
-        "PLATFORM_SUPPORTS_FP8_SPARSE": False,
-        # Probe the driver via green_contexts._ensure_supported().
+        # Probe the host driver via green_contexts._ensure_supported(), which says
+        # nothing about a simulated platform.
         "PLATFORM_SUPPORTS_GREEN_CONTEXT": False,
         "PLATFORM_SUPPORTS_WORKQUEUE_CONFIG": False,
     }

--- a/tools/testing/introspection/test_introspection.py
+++ b/tools/testing/introspection/test_introspection.py
@@ -1,0 +1,148 @@
+# Owner(s): ["module: ci"]
+"""Tests for the test-introspection collector.
+
+Fast tests cover the platform/descriptor logic. The collector smoke tests import a
+real (small) test file in a subprocess and are marked slow.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+from tools.testing.introspection import collector, diff, platforms
+
+from torch.testing._internal.common_utils import run_tests, slowTest, TestCase
+
+
+INDUCTOR = "test/inductor/test_torchinductor.py"
+
+
+class TestPlatforms(TestCase):
+    def test_registry_get(self):
+        self.assertEqual(platforms.get("linux-cpu").device_type, "cpu")
+        with self.assertRaises(KeyError):
+            platforms.get("does-not-exist")
+
+    def test_cuda_caps_sm_derived(self):
+        sm80 = platforms.get("linux-cuda-sm80")
+        sm90 = platforms.get("linux-cuda-sm90")
+        # FP8 needs SM89+, so it is off for SM80 and on for SM90.
+        self.assertFalse(sm80.caps["PLATFORM_SUPPORTS_FP8"])
+        self.assertTrue(sm90.caps["PLATFORM_SUPPORTS_FP8"])
+        # Flash attention is SM80+.
+        self.assertTrue(sm80.caps["PLATFORM_SUPPORTS_FLASH_ATTENTION"])
+
+    def test_subprocess_env_hides_accelerators(self):
+        env = platforms.get("linux-rocm").subprocess_env()
+        self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "")
+        self.assertEqual(env["PYTORCH_TEST_WITH_ROCM"], "1")
+
+
+class TestCollector(TestCase):
+    @slowTest
+    def test_worker_does_not_shadow_torch_from_cwd(self):
+        # In CI torch is wheel-installed (site-packages) while the repo tree still has
+        # a torch/ source dir. The worker must import the installed torch, not the repo
+        # source. Reproduce by running the worker from a cwd containing a poison torch/
+        # package; it must still import the real torch (worker runs by path, so cwd is
+        # not on sys.path[0]).
+        with tempfile.TemporaryDirectory() as td:
+            (pathlib.Path(td) / "torch").mkdir()
+            (pathlib.Path(td) / "torch" / "__init__.py").write_text(
+                "raise RuntimeError('poison torch on path')\n"
+            )
+            env = dict(os.environ)
+            env.update(platforms.get_job("linux-cpu").subprocess_env())
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    collector._COLLECTOR,
+                    "linux-cpu/default",
+                    "enumerate",
+                    "test/test_bundled_inputs.py",
+                ],
+                cwd=td,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            self.assertNotIn("poison torch", proc.stderr)
+            self.assertTrue(
+                any(
+                    line.startswith(collector._SENTINEL)
+                    for line in proc.stdout.splitlines()
+                ),
+                msg=f"worker failed:\n{proc.stderr[-2000:]}",
+            )
+
+    @slowTest
+    def test_device_gating(self):
+        # GPU classes appear only on the cuda platform, not on cpu.
+        cpu = collector.enumerate_tests(
+            INDUCTOR, platforms.get_job("linux-cpu"), use_cache=False
+        )
+        cuda = collector.enumerate_tests(
+            INDUCTOR, platforms.get_job("linux-cuda-sm80"), use_cache=False
+        )
+        self.assertNotIn("GPUTests", cpu)
+        self.assertIn("GPUTests", cuda)
+        self.assertIn("CpuTests", cpu)
+
+    @slowTest
+    def test_status_consistency(self):
+        # ran union skipped must equal the enumerated set.
+        job = platforms.get_job("linux-cpu")
+        enum = collector.enumerate_tests(INDUCTOR, job, use_cache=False)
+        enumerated = {f"{c}::{m}" for c, ms in enum.items() for m in ms}
+        st = collector.status(INDUCTOR, job, use_cache=False)
+        observed = set(st["ran"]) | {k for k, _ in st["skipped"]}
+        self.assertEqual(enumerated, observed)
+
+
+class TestDiff(TestCase):
+    def test_is_test_py(self):
+        self.assertTrue(diff._is_test_py("test/test_x.py"))
+        self.assertTrue(diff._is_test_py("test/nn/test_pooling.py"))
+        self.assertFalse(diff._is_test_py("test/helper.py"))
+        self.assertFalse(diff._is_test_py("torch/x.py"))
+
+    def test_is_broad(self):
+        # Generation/selection surface + test infra are broad.
+        self.assertTrue(diff._is_broad("torch/testing/_internal/common_utils.py"))
+        self.assertTrue(diff._is_broad("tools/testing/discover_tests.py"))
+        self.assertTrue(diff._is_broad("test/run_test.py"))
+        self.assertTrue(diff._is_broad("test/conftest.py"))
+        # Behavior-only source changes can't add/remove tests -> not broad.
+        self.assertFalse(diff._is_broad("torch/csrc/foo.cpp"))
+        self.assertFalse(diff._is_broad("torch/utils/flop_counter.py"))
+        self.assertFalse(diff._is_broad("test/test_x.py"))
+        self.assertFalse(diff._is_broad("test/nn/test_pooling.py"))
+        # Non-.py data under test/ (xfail lists) marks xfails, not existence.
+        self.assertFalse(
+            diff._is_broad("test/inductor/pallas_expected_failures/CpuTests.test_foo")
+        )
+
+    def test_module_ids(self):
+        self.assertEqual(
+            diff._module_ids("test/inductor/test_x.py"), ("inductor.test_x", "test_x")
+        )
+
+    def test_scope_pulls_importers(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "test").mkdir()
+            (root / "test" / "test_base.py").write_text("class A:\n    pass\n")
+            (root / "test" / "test_dep.py").write_text("from test_base import A\n")
+            (root / "test" / "test_other.py").write_text("import os\n")
+            sel = ["test/test_base.py", "test/test_dep.py", "test/test_other.py"]
+            graph = diff._build_import_graph(sel, root)
+            aff = diff._scope(["test/test_base.py"], sel, graph)
+            self.assertIn("test/test_dep.py", aff)  # synthetic dependent pulled in
+            self.assertNotIn("test/test_other.py", aff)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tools/testing/introspection/test_introspection.py
+++ b/tools/testing/introspection/test_introspection.py
@@ -26,20 +26,27 @@ class TestPlatforms(TestCase):
             platforms.get("does-not-exist")
 
     def test_cuda_caps_only_overrides_underivable_flags(self):
-        # Capability-derived flags are deliberately absent so common_cuda computes
-        # them; only flags reading the build or driver are pinned here.
-        for name in ("linux-cuda-sm80", "linux-cuda-sm86", "linux-cuda-sm90"):
-            caps = platforms.get(name).caps
-            self.assertNotIn("PLATFORM_SUPPORTS_FP8", caps)
-            self.assertNotIn("PLATFORM_SUPPORTS_FLASH_ATTENTION", caps)
-            self.assertTrue(caps["PLATFORM_SUPPORTS_FUSED_SDPA"])
+        # Every other PLATFORM_SUPPORTS_* must be absent so common_cuda computes it
+        # for the simulated capability. A hardcoded copy silently diverges: an
+        # earlier one claimed FP8_GROUPED_GEMM was `sm >= (9, 0)` when the real
+        # predicate is `SM90OrLater and not SM100OrLater`, so B200 results were wrong.
+        underivable = {
+            "PLATFORM_SUPPORTS_FUSED_SDPA",
+            "PLATFORM_SUPPORTS_CK_SDPA",
+            "PLATFORM_SUPPORTS_GREEN_CONTEXT",
+            "PLATFORM_SUPPORTS_WORKQUEUE_CONFIG",
+        }
+        for name in (
+            "linux-cuda-sm80",
+            "linux-cuda-sm86",
+            "linux-cuda-sm90",
+            "linux-cuda-sm100",
+        ):
+            self.assertEqual(set(platforms.get(name).caps), underivable, name)
 
     def test_registry_covers_the_ciflow_runner_capabilities(self):
         self.assertEqual(platforms.get("linux-cuda-sm86").cuda_capability, (8, 6))
         self.assertEqual(platforms.get("linux-cuda-sm100").cuda_capability, (10, 0))
-        # MXFP8 grouped gemm reads the build, so it stays an explicit override.
-        sm100 = platforms.get("linux-cuda-sm100").caps
-        self.assertTrue(sm100["PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM"])
 
     def test_subprocess_env_hides_accelerators(self):
         env = platforms.get("linux-rocm").subprocess_env()

--- a/tools/testing/introspection/test_introspection.py
+++ b/tools/testing/introspection/test_introspection.py
@@ -25,14 +25,21 @@ class TestPlatforms(TestCase):
         with self.assertRaises(KeyError):
             platforms.get("does-not-exist")
 
-    def test_cuda_caps_sm_derived(self):
-        sm80 = platforms.get("linux-cuda-sm80")
-        sm90 = platforms.get("linux-cuda-sm90")
-        # FP8 needs SM89+, so it is off for SM80 and on for SM90.
-        self.assertFalse(sm80.caps["PLATFORM_SUPPORTS_FP8"])
-        self.assertTrue(sm90.caps["PLATFORM_SUPPORTS_FP8"])
-        # Flash attention is SM80+.
-        self.assertTrue(sm80.caps["PLATFORM_SUPPORTS_FLASH_ATTENTION"])
+    def test_cuda_caps_only_overrides_underivable_flags(self):
+        # Capability-derived flags are deliberately absent so common_cuda computes
+        # them; only flags reading the build or driver are pinned here.
+        for name in ("linux-cuda-sm80", "linux-cuda-sm86", "linux-cuda-sm90"):
+            caps = platforms.get(name).caps
+            self.assertNotIn("PLATFORM_SUPPORTS_FP8", caps)
+            self.assertNotIn("PLATFORM_SUPPORTS_FLASH_ATTENTION", caps)
+            self.assertTrue(caps["PLATFORM_SUPPORTS_FUSED_SDPA"])
+
+    def test_registry_covers_the_ciflow_runner_capabilities(self):
+        self.assertEqual(platforms.get("linux-cuda-sm86").cuda_capability, (8, 6))
+        self.assertEqual(platforms.get("linux-cuda-sm100").cuda_capability, (10, 0))
+        # MXFP8 grouped gemm reads the build, so it stays an explicit override.
+        sm100 = platforms.get("linux-cuda-sm100").caps
+        self.assertTrue(sm100["PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM"])
 
     def test_subprocess_env_hides_accelerators(self):
         env = platforms.get("linux-rocm").subprocess_env()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192570
* __->__ #192560

Copied from @aorenste's unlanded #187754 (tools/testing/introspection), with his
permission, so that it can be used by the GPU coverage checker in the next
commit. Original design and implementation are his; this commit is a port, not
new work. If #187754 lands first this should be dropped in favour of it.

The engine enumerates the concrete tests a CI target generates by importing test
files with a small device-capability descriptor monkeypatched over the real torch
build, rather than running them on the target hardware. Because skip predicates
are evaluated rather than pattern-matched, it answers "does this test run at
compute capability X" exactly, including generated tests
(instantiate_device_type_tests, parametrize, OpInfo, copy_tests) that never
appear in a diff.

Two changes from the original:

- Added linux-cuda-sm86 and linux-cuda-sm100 to the platform registry. The
  coverage checker needs a10g (the capability most of CI runs at) as the
  baseline, and B200 as the upper target. Note the registry must be edited here
  rather than mutated at runtime: collector workers are subprocesses that
  re-import this module, so parent-process additions are invisible to them.
- pyrefly excludes the package, matching the original.

Only the enumeration engine is ported. #187755's CI comment product
(render_comment/post_comment/workflows) is not, since the coverage checker
consumes the engine directly.

Test Plan:

Differential enumeration works against a real build, simulating capabilities the
host does not have (this box is sm90):

```
python -c "
import sys; sys.path.insert(0,'.')
from tools.testing.introspection import platforms as P, collector as C
r86 = C.status('test/test_linalg.py', P.get_job('linux-cuda-sm86/default'))
r90 = C.status('test/test_linalg.py', P.get_job('linux-cuda-sm90/default'))
a, b = set(r86['ran']), set(r90['ran'])
print('sm86 ran', len(a), '| sm90 ran', len(b))
print('needs sm90:', len(b - a), '| breaks on sm90:', len(a - b))
"
```

```
sm86 ran 2339 | sm90 ran 2323
needs sm90: 0 | breaks on sm90: 16
```

The 16 are all test__int_mm, gated by
`@unittest.skipIf(SM90OrLater and not TEST_WITH_ROCM, "Expected failure on sm90")`
-- i.e. the engine correctly reports them as *broken on* sm90 rather than
*requiring* it, which is the distinction a decorator-text scan cannot make.

Co-authored-by: Aaron Orenstein <aorenste@meta.com>
Authored with assistance from Claude Code.