### PR TITLE
[CI] Fail PRs that add H100/B200-only tests without adding them to the smoke lists

### DIFF
--- a/.github/workflows/_gpu-coverage.yml
+++ b/.github/workflows/_gpu-coverage.yml
@@ -1,0 +1,89 @@
+name: gpu-coverage
+
+# Fails when a PR adds a test that needs an H100/B200 but does not add it to the
+# corresponding smoke list in .ci/pytorch/test.sh, so the test would silently skip
+# wherever CI happens to run it.
+#
+# Needs a torch build because it measures which tests are enabled at a simulated
+# compute capability (see tools/testing/introspection) rather than pattern-matching
+# skip decorators. It reuses an existing build artifact, so it adds no build.
+#
+# Structure mirrors _test-diff.yml: a container job on an ARC runner, matching
+# _linux-test.yml's `test-osdc`. The classic EC2 pool is not provisioned in ARC mode,
+# so a plain `runs-on: linux.4xlarge` job would hang waiting for a runner.
+
+on:
+  workflow_call:
+    inputs:
+      build-environment:
+        required: true
+        type: string
+        description: Build artifact / environment to reuse (e.g. linux-jammy-py3.10-gcc11).
+      docker-image:
+        required: true
+        type: string
+        description: Docker image to run in (the build's image).
+      runner_prefix:
+        required: false
+        type: string
+        default: ""
+      runner:
+        required: false
+        type: string
+        default: "l-x86iavx512-8-64"
+        description: ARC runner label (without prefix) to run on.
+      s3-bucket:
+        required: false
+        type: string
+        default: "gha-artifacts"
+
+jobs:
+  gpu-coverage:
+    if: github.repository_owner == 'pytorch' && github.event_name == 'pull_request'
+    runs-on: ${{ inputs.runner_prefix }}${{ inputs.runner }}
+    container:
+      image: ${{ inputs.docker-image }}
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          use-arc: true
+          # merge-base against the base branch needs full history; a treeless clone
+          # would lazy-fetch per blob.
+          checkout-mode: normal
+          submodules: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Download build artifacts
+        uses: pytorch/pytorch/.github/actions/download-build-artifacts@main
+        with:
+          name: ${{ inputs.build-environment }}
+          s3-bucket: ${{ inputs.s3-bucket }}
+          use-gha: ${{ steps.aws-creds.outcome != 'success' }}
+
+      - name: Check GPU smoke-list coverage
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          TESTINTRO_CACHE: ${{ runner.temp }}/testintro-cache
+        run: |
+          set -ex
+          git config --global --add safe.directory '*'
+          # gpu_coverage imports no torch itself; the wheel is imported only by
+          # collector worker subprocesses, which are launched by path.
+          pip install "$(echo dist/*.whl)[opt-einsum]"
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          python tools/testing/gpu_coverage.py --changed

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -243,6 +243,20 @@ jobs:
   # preview can go up as soon as the docs finish, without waiting for the rest
   # of this workflow to conclude.
 
+  gpu-coverage:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' gpu-coverage ') }}
+    name: gpu-coverage
+    uses: ./.github/workflows/_gpu-coverage.yml
+    needs:
+      - linux-jammy-py3_10-gcc11-build
+      - get-label-type
+      - job-filter
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+    secrets: inherit
+
   # ╠══════════════════════════════════════════════════════════════════════╣
   # ║ linux-jammy-py3.10-gcc11-no-ops (build only)                         ║
   # ╠══════════════════════════════════════════════════════════════════════╣

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -135,6 +135,20 @@ def regenerate_type_stubs():
 
 
 @click.command()
+@click.option("--write", is_flag=True, help="Apply the fix to .ci/pytorch/test.sh.")
+@click.option("--changed", is_flag=True, help="Check this branch's changed test files.")
+@click.argument("files", nargs=-1)
+def gpu_coverage(write, changed, files):
+    """Check H100/B200 smoke lists cover tests that need those GPUs."""
+    cmd = [sys.executable, "tools/testing/gpu_coverage.py"]
+    if write:
+        cmd.append("--write")
+    if changed:
+        cmd.append("--changed")
+    spin.util.run(cmd + list(files))
+
+
+@click.command()
 def regenerate_clangtidy_files():
     """Regenerate clang-tidy files."""
     cmd = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -676,6 +676,7 @@ package = 'torch'
   ".spin/cmds.py:fixlint",
   ".spin/cmds.py:quicklint",
   ".spin/cmds.py:quickfix",
+  ".spin/cmds.py:gpu_coverage",
 ]
 "Regenerate" = [
   ".spin/cmds.py:regenerate_version",

--- a/tools/testing/gpu_coverage.py
+++ b/tools/testing/gpu_coverage.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Check that tests requiring an H100/B200 are selected by the smoke runs.
+
+A test gated on a GPU architecture only runs if `.ci/pytorch/test.sh` selects it
+in the function the ciflow/h100 or ciflow/b200 job dispatches to. Nothing links
+that list to the gate, so it drifts and the tests silently skip on the a10g/A100
+runners that serve most of CI.
+
+Which tests need which capability is *measured*, not inferred from decorator
+text: tools/testing/introspection imports each file under a simulated capability
+and records what ran. A test that runs at sm90 but not at sm86 needs an H100; one
+that merely fails on sm90 does not, and a decorator scan cannot tell those apart.
+
+Running the GPU jobs stays a manual ciflow label. This only decides what those
+jobs cover, and only ever edits .ci/pytorch/test.sh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOT = REPO_ROOT / "test"
+TEST_SH = REPO_ROOT / ".ci" / "pytorch" / "test.sh"
+
+sys.path.insert(0, str(REPO_ROOT))
+
+# The capability a10g provides; most of CI runs here, so anything that already
+# runs at this level needs no GPU-specific job.
+BASELINE_JOB = "linux-cuda-sm86/default"
+
+# (label, job simulating that label's runner, test.sh function it dispatches to)
+TARGETS = [
+    ("ciflow/h100", "linux-cuda-sm90/default", "test_python_smoke"),
+    ("ciflow/b200", "linux-cuda-sm100/default", "test_python_smoke_b200"),
+]
+
+# Functions reachable from each label's job, for deciding existing coverage. Read
+# off the test-matrix configs in .github/workflows/test-{h100,b200}.yml. Only the
+# `smoke` configs are keyed to the bare ciflow/h100 and ciflow/b200 tags -- the
+# cutlass/distributed/symm-mem jobs have their own ciflow labels and do not run
+# when those are applied.
+COVERING_FUNCTIONS = {
+    "ciflow/h100": ["test_python_smoke"],
+    "ciflow/b200": ["test_python_smoke_b200"],
+}
+
+
+def relpath(path: str) -> str | None:
+    """Absolute or repo-relative path -> path relative to the repo root."""
+    p = Path(path).resolve()
+    try:
+        rel = p.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+    return str(rel) if p.is_file() else None
+
+
+def parse_smoke_includes(text: str, function: str) -> dict[str, list[str | None]]:
+    """{run_test.py file: [-k expr, ...]} for one test.sh function.
+
+    A None entry means some include runs the whole file.
+    """
+    body = re.search(rf"^{function}\(\) \{{\n(.*?)^\}}", text, re.DOTALL | re.MULTILINE)
+    if not body:
+        raise SystemExit(f"gpu_coverage: could not find {function}() in {TEST_SH}")
+    out: dict[str, list[str | None]] = {}
+    for line in re.sub(r"\\\n\s*", " ", body.group(1)).splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        m = re.search(r"--include\s+(.+?)(?:\s+\$|\s*$)", line)
+        if not m:
+            continue
+        rest, kexpr = m.group(1), None
+        if " -k " in rest:
+            rest, _, kexpr = rest.partition(" -k ")
+            kexpr = kexpr.strip().strip("\"'")
+        for f in rest.split():
+            out.setdefault(f.removesuffix(".py"), []).append(kexpr)
+    return out
+
+
+def base_names(test_file: Path, tests: set[str], locations: dict) -> set[str]:
+    """Concrete test ids -> the `def` names a -k expression should carry.
+
+    Parametrized variants share their template function's def line, so grouping
+    by location collapses them to the one name that -k substring-matches.
+    """
+    try:
+        tree = ast.parse(test_file.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return {t.split("::")[-1] for t in tests}
+    by_line = {
+        n.lineno: n.name
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    names = set()
+    for t in sorted(tests):
+        loc = locations.get(t)
+        # _locate points at the decorator-stripped def; scan down a few lines to
+        # tolerate the offset rather than guessing from the mangled test id.
+        name = None
+        if loc:
+            for probe in range(loc[1], loc[1] + 8):
+                if probe in by_line:
+                    name = by_line[probe]
+                    break
+        names.add(name or t.split("::")[-1])
+    return names
+
+
+def measure(rel: str) -> dict[str, set[str]]:
+    """{label: concrete tests in `rel` that need that label's runner}."""
+    from tools.testing.introspection import collector, platforms
+
+    ran = {}
+    for job in [BASELINE_JOB] + [j for _, j, _ in TARGETS]:
+        ran[job] = set(collector.status(rel, platforms.get_job(job))["ran"])
+
+    baseline = ran[BASELINE_JOB]
+    needs: dict[str, set[str]] = {}
+    seen = set(baseline)
+    for label, job, _ in TARGETS:
+        # Runs here but not at any cheaper capability we have already accounted for.
+        needs[label] = ran[job] - seen
+        seen |= ran[job]
+    return needs
+
+
+def locations_for(rel: str) -> dict:
+    from tools.testing.introspection import collector, platforms
+
+    job = platforms.get_job(TARGETS[-1][1])
+    return collector.collect(job, "enumloc", [rel])[rel].get("locations", {})
+
+
+def uncovered(rel: str) -> list[tuple[str, str, set[str]]]:
+    """-> [(label, test.sh function, base names needing to be added)]"""
+    smoke_text = TEST_SH.read_text(encoding="utf-8")
+    include_name = rel[len("test/") : -len(".py")]
+    test_file = REPO_ROOT / rel
+
+    needs = measure(rel)
+    if not any(needs.values()):
+        return []
+    locations = locations_for(rel)
+
+    gaps = []
+    for label, _, insert_into in TARGETS:
+        if not needs[label]:
+            continue
+        selected: list[str | None] = []
+        for fn in COVERING_FUNCTIONS[label]:
+            selected += parse_smoke_includes(smoke_text, fn).get(include_name, [])
+        names = base_names(test_file, needs[label], locations)
+        missing = {
+            n
+            for n in names
+            if not any(
+                e is None or any(p.strip() in n for p in e.split(" or "))
+                for e in selected
+            )
+        }
+        if missing:
+            gaps.append((label, insert_into, missing))
+    return gaps
+
+
+def smoke_line(include_name: str, names: set[str]) -> str:
+    kexpr = " or ".join(sorted(names))
+    return (
+        f'  time python test/run_test.py --include {include_name} -k "{kexpr}" '
+        f"$PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running\n"
+    )
+
+
+def add_lines(text: str, function: str, line: str) -> str:
+    m = re.search(
+        rf"^({function}\(\) \{{\n)(.*?)(^\}})", text, re.DOTALL | re.MULTILINE
+    )
+    if not m:
+        raise SystemExit(f"gpu_coverage: could not find {function}() in {TEST_SH}")
+    body = m.group(2)
+    anchor = "  assert_git_not_dirty\n"
+    body = body.replace(anchor, line + anchor, 1) if anchor in body else body + line
+    return text[: m.start(2)] + body + text[m.end(2) :]
+
+
+def changed_test_files() -> list[str]:
+    # ghstack PRs are based on gh/<user>/<n>/base, not main.
+    base_ref = os.environ.get("BASE_REF", "main")
+    base = subprocess.run(
+        ["git", "merge-base", "HEAD", f"origin/{base_ref}"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    ).stdout.strip()
+    if not base:
+        return []
+    out = subprocess.run(
+        ["git", "diff", "--name-only", base, "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    ).stdout
+    return [
+        f
+        for f in out.splitlines()
+        if f.startswith("test/")
+        and f.endswith(".py")
+        and os.path.basename(f).startswith("test_")
+        and (REPO_ROOT / f).is_file()
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--write", action="store_true", help="apply the fix to test.sh")
+    ap.add_argument("--changed", action="store_true", help="use the PR's changed files")
+    ap.add_argument("files", nargs="*")
+    args = ap.parse_args()
+
+    files = args.files or (changed_test_files() if args.changed else [])
+    files = [r for r in (relpath(f) for f in files) if r and r.startswith("test/")]
+    if not files:
+        print("gpu_coverage: no test files to check")
+        return 0
+
+    text = TEST_SH.read_text(encoding="utf-8")
+    failures = 0
+    for rel in files:
+        for label, insert_into, names in uncovered(rel):
+            failures += 1
+            include_name = rel[len("test/") : -len(".py")]
+            line = smoke_line(include_name, names)
+            if args.write:
+                text = add_lines(text, insert_into, line)
+                print(f"{rel}: added {len(names)} test(s) to {insert_into}()")
+                continue
+            print(f"\nGPU coverage gap: {rel}")
+            for n in sorted(names):
+                print(f"    {n}  -- runs on {label.split('/')[1]}, not on a10g")
+            print(f"  not selected by {insert_into}() in .ci/pytorch/test.sh")
+            print(f"\n  Add to .ci/pytorch/test.sh:\n{line}")
+            print(f"  Or run:  python tools/testing/gpu_coverage.py --write {rel}\n")
+
+    if args.write and failures:
+        TEST_SH.write_text(text, encoding="utf-8")
+        return 0
+    if failures:
+        print(
+            f"{failures} gap(s). These tests will silently skip wherever CI runs them.\n"
+            f"Note this only makes the job cover them; running it still needs the\n"
+            f"ciflow label applied manually."
+        )
+        return 1
+    print(f"gpu_coverage: {len(files)} file(s) OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192561
* #192560

A test gated on a GPU architecture only runs if .ci/pytorch/test.sh selects it in
the function the ciflow/h100 or ciflow/b200 job dispatches to. Nothing links that
list to the gate, so it drifts, and the tests skip silently on the a10g/A100
runners that serve most of CI. A skipped test is a green test, so nothing
surfaces it -- see #192465.

Which tests need which capability is measured, not inferred. The previous
approach pattern-matched skip decorators, and that cannot distinguish "requires
sm90" from "broken on sm90". Concretely, test_linalg's test__int_mm is gated by
`@unittest.skipIf(SM90OrLater and not TEST_WITH_ROCM, "Expected failure on sm90")`
and a text scan reads it as a requirement, producing a fix that adds 16 tests to
the H100 run where they are skipped by construction.

Instead this imports each file at a simulated capability via the introspection
engine and records what actually ran:

    needs h100 = ran@sm90 - ran@sm86
    needs b200 = ran@sm100 - ran@sm86 - ran@sm90

That is also why there is no baseline or grandfather file: correctness is
recomputed, and the check is scoped to the PR's changed files, so pre-existing
gaps in files a PR happens to touch are not reported at it.

Scope: this only ever edits .ci/pytorch/test.sh. It does not touch
.github/labeler.yml, so running the H100/B200 jobs still requires applying the
ciflow label by hand -- deliberately, since those runners are scarce. This only
decides what the jobs cover once someone runs them.

The CI job reuses the existing linux-jammy-py3.10-gcc11 build artifact, so it
adds no build. It needs a torch build because it imports test modules, which is
why this is a workflow job rather than a lintrunner adapter: the lint image is
deliberately torch-free (.ci/docker/build.sh:76) and no lintrunner adapter
imports torch.

Known limitation: the descriptor simulates compute capability, not the presence
of optional dependencies. A gate like has_triton_tma_device() is
`capability >= 9.0 AND <triton has the symbol>`; the simulation fixes the first
term and inherits the second from the host. On a host missing Triton, CuTeDSL or
cupti-python those tests skip at every capability and are silently not reported.
That under-reports rather than over-reports, and the CI image has the deps, but
it means local runs are not authoritative.

Test Plan:

Positive control -- a file already in both smoke lists reports clean:

```
python tools/testing/gpu_coverage.py test/test_matmul_cuda.py
```
```
gpu_coverage: 1 file(s) OK
```

Negative control -- temporarily remove test_matmul_cuda from both smoke lists:

```
python tools/testing/gpu_coverage.py test/test_matmul_cuda.py
```
```
GPU coverage gap: test/test_matmul_cuda.py
    test_grouped_gemm_compiled  -- runs on h100, not on a10g
    test_legacy_cublas_honors_sm_carveout  -- runs on h100, not on a10g
    test_sm_carveout_invalid_value_throws  -- runs on h100, not on a10g
  not selected by test_python_smoke() in .ci/pytorch/test.sh

GPU coverage gap: test/test_matmul_cuda.py
    test_cublas_batch_invariance_blackwell  -- runs on b200, not on a10g
  not selected by test_python_smoke_b200() in .ci/pytorch/test.sh
```

34 concrete h100 tests and 4 b200 tests collapse to 3 and 1 base names
respectively, via the template def line, so the generated -k stays readable and
still selects every @parametrize variant.

Autofix converges:

```
python tools/testing/gpu_coverage.py --write test/test_matmul_cuda.py
python tools/testing/gpu_coverage.py test/test_matmul_cuda.py   # OK
```

Polarity, the case the decorator scan got backwards:

```
python tools/testing/gpu_coverage.py test/test_linalg.py
```
```
gpu_coverage: 1 file(s) OK
```

Runtime: ~16 s for one uncovered file cold (3 status + 1 enumloc subprocess
imports); the engine's content-hash cache makes reruns cheap.

Authored with assistance from Claude Code.