### PR TITLE
docs: render inline math on the autograd mechanics page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,8 +77,17 @@ extensions = [
 myst_enable_extensions = [
     "colon_fence",
     "deflist",
+    "dollarmath",
     "html_image",
 ]
+
+# dollarmath's default delimiter matching treats any pair of `$` as an equation,
+# which swallows literal shell variables in prose: the `$XDG_CACHE_HOME` and
+# `$HOME` pair in notes/cuda.md parses as one formula. Requiring the delimiters
+# to sit flush against the content keeps those as text while every real formula
+# still renders.
+myst_dmath_allow_space = False
+myst_dmath_allow_digits = False
 
 # Don't execute notebooks during the docs build. Notebook correctness is
 # verified by the separate docs_test CI job; re-executing them here just

--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -699,11 +699,11 @@ derivatives on complex functions.  However, we still need to
 compute $\frac{\partial s}{\partial z}$ and $\frac{\partial s}{\partial z^*}$.
 There are two ways you could do this:
 
-    - The first way is to just use the definition of Wirtinger derivatives directly and calculate $\frac{\partial s}{\partial z}$ and $\frac{\partial s}{\partial z^*}$ by
-      using $\frac{\partial s}{\partial x}$ and $\frac{\partial s}{\partial y}$
-      (which you can compute in the normal way).
-    - The second way is to use the change of variables trick and rewrite $f(z)$ as a two variable function $f(z, z^*)$, and compute
-      the conjugate Wirtinger derivatives by treating $z$ and $z^*$ as independent variables. This is often easier; for example, if the function in question is holomorphic, only $z$ will be used (and $\frac{\partial s}{\partial z^*}$ will be zero).
+- The first way is to just use the definition of Wirtinger derivatives directly and calculate $\frac{\partial s}{\partial z}$ and $\frac{\partial s}{\partial z^*}$ by
+  using $\frac{\partial s}{\partial x}$ and $\frac{\partial s}{\partial y}$
+  (which you can compute in the normal way).
+- The second way is to use the change of variables trick and rewrite $f(z)$ as a two variable function $f(z, z^*)$, and compute
+  the conjugate Wirtinger derivatives by treating $z$ and $z^*$ as independent variables. This is often easier; for example, if the function in question is holomorphic, only $z$ will be used (and $\frac{\partial s}{\partial z^*}$ will be zero).
 
 Let's consider the function $f(z = x + yj) = c * z = c * (x+yj)$ as an example, where $c \in ℝ$.
 


### PR DESCRIPTION
Fixes #192405.

Inline `$...$` math on the autograd mechanics page renders as literal text. `dollarmath` is not in `myst_enable_extensions`, so MyST has no parsing rule for `$`. The RST to Markdown migration converted the `:math:` roles in `notes/autograd.rst` into `$...$` without enabling the extension. Block equations were unaffected because the math directive is resolved by Sphinx.

`myst_dmath_allow_space = False` is needed alongside it, or the `$XDG_CACHE_HOME` and `$HOME` pair in `notes/cuda.md:1155` parses as a single equation. `myst_dmath_allow_digits = False` does the same for `$250K+` in `torch.compiler_faq.md:62`.

Verified with a full `sphinx-build` of `docs/source`: build succeeded, 3478 pages, and no warning references either changed file. `notes/autograd.html` goes from 72 to 291 KaTeX nodes and from 146 to 0 literal `$` in reader-visible text. `notes/cuda.md` is unchanged.

Happy to convert the page to `{math}` roles instead if you would rather not enable the extension globally.

Authored with AI assistance (Claude).
