### PR TITLE
Stop always-dirty CMake placeholder sources forcing a full relink

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -959,7 +959,9 @@ else()
   set(DUMMY_FILE_CONTENT "")
 endif()
 
-file(WRITE ${DUMMY_EMPTY_FILE} ${DUMMY_FILE_CONTENT})
+# file(GENERATE) is copy-if-different, so re-configuring does not bump the
+# mtime and force a torch_cpu/torch relink.
+file(GENERATE OUTPUT ${DUMMY_EMPTY_FILE} CONTENT "${DUMMY_FILE_CONTENT}")
 
 # Wrapper library for people who link against torch and expect both CPU and CUDA support
 # Contains "torch_cpu" and "torch_cuda"

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -954,12 +954,14 @@ endif(USE_LLVM AND LLVM_FOUND)
 set(DUMMY_EMPTY_FILE ${CMAKE_BINARY_DIR}/empty.cpp)
 
 if(MSVC)
-  set(DUMMY_FILE_CONTENT "__declspec(dllexport) int ignore_this_library_placeholder(){return 0\\;}")
+  set(DUMMY_FILE_CONTENT "__declspec(dllexport) int ignore_this_library_placeholder(){return 0;}")
 else()
   set(DUMMY_FILE_CONTENT "")
 endif()
 
-file(WRITE ${DUMMY_EMPTY_FILE} ${DUMMY_FILE_CONTENT})
+# file(GENERATE) is copy-if-different, so re-configuring does not bump the
+# mtime and force a torch_cpu/torch relink.
+file(GENERATE OUTPUT ${DUMMY_EMPTY_FILE} CONTENT "${DUMMY_FILE_CONTENT}")
 
 # Wrapper library for people who link against torch and expect both CPU and CUDA support
 # Contains "torch_cpu" and "torch_cuda"

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -726,6 +726,20 @@ if(USE_FBGEMM)
     endif()
     target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
     target_compile_options_if_supported(asmjit -Wno-unused-variable)
+
+    # fbgemm's cpp_library() gives source-less aggregate targets (like fbgemm
+    # itself) a placeholder .cc named via STRING(RANDOM) and rewritten with
+    # file(WRITE) on every configure. Since we reconfigure on every build, that
+    # placeholder is a perpetually-dirty torch_cpu dependency and forces a full
+    # relink of libtorch_cpu.so and everything downstream. Swap in a stable one.
+    get_target_property(FBGEMM_SRCS fbgemm SOURCES)
+    if(FBGEMM_SRCS MATCHES "gen_placeholder_")
+      set(FBGEMM_STABLE_PLACEHOLDER "${CMAKE_BINARY_DIR}/fbgemm_placeholder.cc")
+      file(GENERATE OUTPUT "${FBGEMM_STABLE_PLACEHOLDER}" CONTENT "")
+      list(FILTER FBGEMM_SRCS EXCLUDE REGEX "gen_placeholder_")
+      list(APPEND FBGEMM_SRCS "${FBGEMM_STABLE_PLACEHOLDER}")
+      set_property(TARGET fbgemm PROPERTY SOURCES ${FBGEMM_SRCS})
+    endif()
   endif()
   if(USE_FBGEMM)
     list(APPEND Caffe2_DEPENDENCY_LIBS fbgemm)


### PR DESCRIPTION
A no-op `pip install -e . --no-build-isolation` took ~2m34s, of which ~104s was ninja relinking 41 targets, including a 77s relink of libtorch_cpu.so, taking 2+ minutes. With this diff it's ~50s which is still not great but better. 

Root cause: two source files are handed to CMake targets via file(WRITE), which writes unconditionally and so bumps the file's mtime on every configure. Both are empty placeholders that exist only to satisfy add_library()'s requirement of at least one source:

  - build/empty.cpp, for the `torch` wrapper target.
  - fbgemm's cpp_library() synthesizes one for source-less aggregate targets such as `fbgemm` itself, and additionally names it with STRING(RANDOM), so the filename changes on every configure too.

Neither mattered before the scikit-build-core migration (#180247), because the old setup.py skipped CMake configure entirely when CMakeCache.txt and build.ninja were both present. 

fbgemm relink issue is solved here rather than in fbgemm, given how fbgemm is deprecated

One cosmetic residue remains: fbgemm still deposits a randomly-named gen_placeholder_*.cc in the build directory on each configure. It is no longer a build input, so it is inert; suppressing it would require touching the submodule.



Authored with assistance from Claude Code.