### PR TITLE
[dynamo] Type the SideEffects opaque-object surface as object instead of Any

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -215,7 +215,7 @@ class SideEffects:
     id_to_variable: dict[int, VariableTracker]
     store_attr_mutations: dict[VariableTracker, dict[str, VariableTracker]]
     attr_mutation_kinds: dict[VariableTracker, dict[str, AttrMutationKind]]
-    keepalive: list[Any]
+    keepalive: list[object]
     # Maps variable tracker to list of user stacks (StackSummary objects, formatted lazily)
     mutation_user_stacks: dict[VariableTracker, list[traceback.StackSummary]]
 
@@ -229,7 +229,7 @@ class SideEffects:
         | None = None,
         mutation_user_stacks: dict[VariableTracker, list[traceback.StackSummary]]
         | None = None,
-        keepalive: list[Any] | None = None,
+        keepalive: list[object] | None = None,
         save_for_backward: list[
             tuple[AutogradFunctionContextVariable, list[VariableTracker]]
         ]
@@ -276,7 +276,7 @@ class SideEffects:
         # Deferred side-effect checking for nullified attribute mutations.
         # Maps (vt_id, attr_name) → (original_value, current_value).
         # On validation, we check original == current.
-        self.deferred_attr_mutations: dict[tuple[int, str], tuple[Any, Any]] = {}
+        self.deferred_attr_mutations: dict[tuple[int, str], tuple[object, object]] = {}
 
     def ignore_mutations_on(self, var: VariableTracker) -> None:
         """Mutations to this variable will be executed but not tracked,
@@ -425,10 +425,10 @@ class SideEffects:
             tensor_hooks=self.tensor_hooks,
         )
 
-    def __contains__(self, item: Any) -> bool:
+    def __contains__(self, item: object) -> bool:
         return id(item) in self.id_to_variable
 
-    def __getitem__(self, item: Any) -> VariableTracker:
+    def __getitem__(self, item: object) -> VariableTracker:
         return self.id_to_variable[id(item)]
 
     def should_allow_externally_visible_side_effects_in_subtracer(self) -> bool:
@@ -739,7 +739,7 @@ class SideEffects:
 
     def _track_obj(
         self,
-        item: Any,
+        item: object,
         variable: VariableTracker,
         mutation_type_cls: type = ValueMutationExisting,
     ) -> VariableTracker:
@@ -762,7 +762,7 @@ class SideEffects:
 
     def track_object_existing(
         self,
-        item: Any,
+        item: object,
         variable: VariableTracker,
     ) -> VariableTracker:
         # TODO: Modify this API so that we preserve type info of
@@ -978,7 +978,7 @@ class SideEffects:
         self.keepalive.append(cell)
         return variable
 
-    def track_global_existing(self, source: Source, item: Any) -> VariableTracker:
+    def track_global_existing(self, source: Source, item: object) -> VariableTracker:
         variable = variables.NewGlobalVariable(
             mutation_type=AttributeMutationExisting(),
             source=source,


### PR DESCRIPTION
`SideEffects` tracks arbitrary user objects purely by identity: it stores them in `keepalive` to pin their lifetimes and keys `id_to_variable` by `id()`. Nothing on that surface ever inspects, calls, or subscripts the tracked value, so `Any` buys no expressiveness and only disables checking for callers.

This annotates that surface as `object`:

- `keepalive` (the attribute and the constructor parameter)
- the `item` parameter of `_track_obj` (and therefore its `track_mutable` alias), `track_object_existing`, and `track_global_existing`
- the `item` parameter of `SideEffects.__contains__` / `__getitem__`
- the value tuple of `deferred_attr_mutations`, whose entries are only compared with `!=` and formatted with `{!r}`

No call site changes and no cast is introduced, but the two halves of the change are not equally safe and it is worth being precise about which is which.

Widening the `item` parameters is unconditional: `object` accepts strictly more than the call sites were already passing.

`keepalive` is the interesting one. `list[T]` is **invariant**, so declaring the constructor parameter `list[object]` genuinely constrains callers -- it would reject a `list[VariableTracker]` that `list[Any]` accepted. That is fine here because the sole caller of the keyword is `clone()`, which passes `list(self.keepalive)`, and the attribute is widened in the same commit so the inferred argument type matches exactly. `SideEffects` has no subclasses, its only other construction (`torch/_dynamo/output_graph.py:821`) passes no `keepalive`, and nothing outside `side_effects.py` reads the attribute. The trade-off is deliberate: a future caller wanting to seed `keepalive` from a more specific list type will have to widen at the call site rather than silently relying on `Any`.

`variable_cls` / `user_cls` (a `type[...]` that gets called) and `options` (a `**`-splat kwargs bag) in the same file are deliberately left alone -- those want real types, not `object`.

## Test plan

Type checking over the whole project, plus every linter that applies to the changed file:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 torch/_dynamo/side_effects.py
lintrunner torch/_dynamo/side_effects.py
```

Dynamo suites that exercise object tracking, global tracking, deferred side-effect validation in higher-order ops, and mutation replay:

```
python test/dynamo/test_misc.py
python test/dynamo/test_functions.py
python test/dynamo/test_repros.py
python test/dynamo/test_higher_order_ops.py
python test/dynamo/test_export_mutations.py
python test/dynamo/test_global.py
python test/dynamo/test_subclasses.py
python test/dynamo/test_ctx_manager.py
python test/dynamo/test_autograd_function.py
python test/dynamo/test_modules.py
```

All pass. The single `test_repros` error (`test_aot_autograd_runtime_wrapper_prologue_profiled`) reproduces on the unmodified base in the same environment and is a local build-artifact skew, not a regression.

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98