### PR TITLE
[CI] Fail PRs that add H100/B200-only tests without adding them to the smoke lists

### DIFF
--- a/.github/workflows/_gpu-coverage.yml
+++ b/.github/workflows/_gpu-coverage.yml
@@ -1,0 +1,103 @@
+name: gpu-coverage
+
+# Fails when a PR adds a test that needs an H100/B200 but does not add it to the
+# corresponding smoke list in .ci/pytorch/test.sh, so the test would silently skip
+# wherever CI happens to run it.
+#
+# Needs a torch build because it measures which tests are enabled at a simulated
+# compute capability (see tools/testing/introspection) rather than pattern-matching
+# skip decorators. It reuses an existing build artifact, so it adds no build.
+#
+# Structure mirrors _test-diff.yml: a container job on an ARC runner, matching
+# _linux-test.yml's `test-osdc`. The classic EC2 pool is not provisioned in ARC mode,
+# so a plain `runs-on: linux.4xlarge` job would hang waiting for a runner.
+
+on:
+  workflow_call:
+    inputs:
+      build-environment:
+        required: true
+        type: string
+        description: Build artifact / environment to reuse (e.g. linux-jammy-py3.10-gcc11).
+      docker-image:
+        required: true
+        type: string
+        description: Docker image to run in (the build's image).
+      runner_prefix:
+        required: false
+        type: string
+        default: ""
+      runner:
+        required: false
+        type: string
+        default: "l-x86iavx512-8-64"
+        description: ARC runner label (without prefix) to run on.
+      s3-bucket:
+        required: false
+        type: string
+        default: "gha-artifacts"
+
+jobs:
+  gpu-coverage:
+    if: github.repository_owner == 'pytorch' && github.event_name == 'pull_request'
+    runs-on: ${{ inputs.runner_prefix }}${{ inputs.runner }}
+    container:
+      image: ${{ inputs.docker-image }}
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          use-arc: true
+          # merge-base against the base branch needs full history; a treeless clone
+          # would lazy-fetch per blob.
+          checkout-mode: normal
+          submodules: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Collect changed test files
+        id: changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -ex
+          git config --global --add safe.directory '*'
+          # NOT --depth=1: a shallow fetch grafts the base tip as parentless, so
+          # merge-base fails and the check would silently pass having read nothing.
+          git fetch --no-tags origin "$BASE_REF"
+          base=$(git merge-base HEAD "origin/$BASE_REF")
+          git diff --name-only "$base" HEAD > all_changed.txt
+          { grep -E '^test/(.*/)?test_[^/]*\.py$' all_changed.txt || true; } > changed.txt
+          echo "count=$(wc -l < changed.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Download build artifacts
+        if: steps.changed.outputs.count != '0'
+        uses: pytorch/pytorch/.github/actions/download-build-artifacts@main
+        with:
+          name: ${{ inputs.build-environment }}
+          s3-bucket: ${{ inputs.s3-bucket }}
+          use-gha: ${{ steps.aws-creds.outcome != 'success' }}
+
+      - name: Check GPU smoke-list coverage
+        if: steps.changed.outputs.count != '0'
+        env:
+          TESTINTRO_CACHE: ${{ runner.temp }}/testintro-cache
+        run: |
+          set -ex
+          # gpu_coverage imports no torch itself; the wheel is imported only by
+          # collector worker subprocesses, which are launched by path.
+          pip install "$(echo dist/*.whl)[opt-einsum]"
+          xargs python tools/testing/gpu_coverage.py < changed.txt

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -70,7 +70,7 @@ jobs:
   # ╠══════════════════════════════════════════════════════════════════════╣
 
   linux-jammy-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11 ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' gpu-coverage ') }}
     name: linux-jammy-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -242,6 +242,20 @@ jobs:
   # Docs are built and the preview is published by docs-build.yml so the
   # preview can go up as soon as the docs finish, without waiting for the rest
   # of this workflow to conclude.
+
+  gpu-coverage:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' gpu-coverage ') }}
+    name: gpu-coverage
+    uses: ./.github/workflows/_gpu-coverage.yml
+    needs:
+      - linux-jammy-py3_10-gcc11-build
+      - get-label-type
+      - job-filter
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+    secrets: inherit
 
   # ╠══════════════════════════════════════════════════════════════════════╣
   # ║ linux-jammy-py3.10-gcc11-no-ops (build only)                         ║

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -135,6 +135,20 @@ def regenerate_type_stubs():
 
 
 @click.command()
+@click.option("--write", is_flag=True, help="Apply the fix to .ci/pytorch/test.sh.")
+@click.option("--changed", is_flag=True, help="Check this branch's changed test files.")
+@click.argument("files", nargs=-1)
+def gpu_coverage(write, changed, files):
+    """Check H100/B200 smoke lists cover tests that need those GPUs."""
+    cmd = [sys.executable, "tools/testing/gpu_coverage.py"]
+    if write:
+        cmd.append("--write")
+    if changed:
+        cmd.append("--changed")
+    spin.util.run(cmd + list(files))
+
+
+@click.command()
 def regenerate_clangtidy_files():
     """Regenerate clang-tidy files."""
     cmd = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -676,6 +676,7 @@ package = 'torch'
   ".spin/cmds.py:fixlint",
   ".spin/cmds.py:quicklint",
   ".spin/cmds.py:quickfix",
+  ".spin/cmds.py:gpu_coverage",
 ]
 "Regenerate" = [
   ".spin/cmds.py:regenerate_version",

--- a/tools/testing/gpu_coverage.py
+++ b/tools/testing/gpu_coverage.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Check that tests requiring an H100/B200 are selected by the smoke runs.
+
+Reports gaps in .ci/pytorch/test.sh; --write inserts the missing run_test.py lines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_SH = REPO_ROOT / ".ci" / "pytorch" / "test.sh"
+
+sys.path.insert(0, str(REPO_ROOT))
+
+# a10g capability: anything that already runs here needs no GPU-specific job.
+BASELINE_JOB = "linux-cuda-sm86/default"
+
+# (ciflow label, job simulating its runner, test.sh function it dispatches to).
+# Only the `smoke` configs are keyed to the bare ciflow/h100 and ciflow/b200 tags;
+# the cutlass/distributed/symm-mem jobs carry their own labels.
+TARGETS = [
+    ("ciflow/h100", "linux-cuda-sm90/default", "test_python_smoke"),
+    ("ciflow/b200", "linux-cuda-sm100/default", "test_python_smoke_b200"),
+]
+
+
+def function_body(text: str, function: str) -> re.Match[str]:
+    m = re.search(
+        rf"^({function}\(\) \{{\n)(.*?)(^\}})", text, re.DOTALL | re.MULTILINE
+    )
+    if not m:
+        raise SystemExit(f"gpu_coverage: could not find {function}() in {TEST_SH}")
+    return m
+
+
+def smoke_patterns(text: str, function: str) -> dict[str, list[str | None]]:
+    """{run_test.py file: [-k expr, ...]} for one test.sh function.
+
+    A None entry means some include runs the whole file.
+    """
+    out: dict[str, list[str | None]] = {}
+    body = re.sub(r"\\\n\s*", " ", function_body(text, function).group(2))
+    for line in body.split("\n"):
+        try:
+            toks = shlex.split(line, comments=True)
+        except ValueError:
+            continue
+        if "--include" not in toks:
+            continue
+        files = []
+        for tok in toks[toks.index("--include") + 1 :]:
+            if tok.startswith("-"):
+                break
+            files.append(tok.removesuffix(".py"))
+        kexpr = toks[toks.index("-k") + 1] if "-k" in toks[:-1] else None
+        for f in files:
+            out.setdefault(f, []).append(kexpr)
+    return out
+
+
+def selects(patterns: list[str | None], test_id: str) -> bool:
+    """Would any of these -k expressions select this Class::method id?"""
+    for expr in patterns:
+        if expr is None:
+            return True
+        # Only ` or ` is understood. A pattern using `and`/`not` is opaque and
+        # assumed not to select, so we over-report rather than silently skip.
+        if any(p and p.strip() in test_id for p in expr.split(" or ")):
+            return True
+    return False
+
+
+def measure(files: list[str]) -> tuple[dict[str, dict[str, set[str]]], dict[str, str]]:
+    """-> ({file: {label: concrete tests needing that label}}, {file: error})"""
+    from tools.testing.introspection import collector, platforms
+
+    ran: dict[str, dict[str, set[str]]] = {}
+    errors: dict[str, str] = {}
+    for job in [BASELINE_JOB] + [j for _, j, _ in TARGETS]:
+        results = collector.collect(platforms.get_job(job), "status", files)
+        for rel, payload in results.items():
+            if "error" in payload:
+                errors.setdefault(rel, str(payload["error"]))
+            else:
+                ran.setdefault(rel, {})[job] = set(payload["ran"])
+
+    needs: dict[str, dict[str, set[str]]] = {}
+    for rel, by_job in ran.items():
+        if len(by_job) != len(TARGETS) + 1:
+            errors.setdefault(rel, "incomplete measurement across capabilities")
+            continue
+        # ciflow/h100 and ciflow/b200 are independent labels, so a test needing
+        # sm90+ belongs in both smoke lists: a b200-labelled PR runs only the b200
+        # list and would otherwise skip it.
+        needs[rel] = {
+            label: by_job[job] - by_job[BASELINE_JOB] for label, job, _ in TARGETS
+        }
+    return needs, errors
+
+
+def locations(files: list[str]) -> dict[str, dict[str, list]]:
+    """{file: {Class::method: [defining file, first decorator line]}}"""
+    from tools.testing.introspection import collector, platforms
+
+    job = platforms.get_job(TARGETS[-1][1])  # widest capability: most tests exist
+    out = {}
+    for rel, payload in collector.collect(job, "enumloc", files).items():
+        # A file whose status measured fine can still fail enumloc (different
+        # import path); fall back to concrete ids rather than aborting.
+        out[rel] = {} if "error" in payload else payload.get("locations", {})
+    return out
+
+
+def decorator_starts(path: Path) -> dict[int, str]:
+    """{line a function's decorator stack starts on: function name}.
+
+    inspect.getsourcelines, which the engine uses for locations, reports that
+    line rather than the `def`.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return {}
+    return {
+        min([d.lineno for d in n.decorator_list] + [n.lineno]): n.name
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def base_names(tests: set[str], locs: dict[str, list]) -> set[str]:
+    """Concrete test ids -> the `def` names a -k expression should carry.
+
+    Parametrized variants share a def, so grouping by location collapses them.
+    """
+    cache: dict[str, dict[int, str]] = {}
+    names = set()
+    for t in tests:
+        loc = locs.get(t)
+        name = None
+        if loc:
+            defs = cache.setdefault(loc[0], decorator_starts(REPO_ROOT / loc[0]))
+            name = defs.get(loc[1])
+        # Falling back to the concrete id happens for tests defined outside the
+        # test tree; it is a valid -k token but pins the parametrize values.
+        names.add(name or t.split("::")[-1])
+    return names
+
+
+def smoke_line(rel: str, names: set[str]) -> str:
+    include = rel[len("test/") : -len(".py")]
+    kexpr = " or ".join(sorted(names))
+    return (
+        f"  time python test/run_test.py --include {include} "
+        f'-k "{kexpr}" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running\n'
+    )
+
+
+def insert(text: str, function: str, line: str) -> str:
+    m = function_body(text, function)
+    anchor = "  assert_git_not_dirty\n"
+    body = m.group(2)
+    if anchor not in body:
+        raise SystemExit(f"gpu_coverage: no insertion anchor in {function}()")
+    return (
+        text[: m.start(2)] + body.replace(anchor, line + anchor, 1) + text[m.end(2) :]
+    )
+
+
+def is_test_file(rel: str) -> bool:
+    return (
+        rel.startswith("test/")
+        and rel.endswith(".py")
+        and os.path.basename(rel).startswith("test_")
+        and (REPO_ROOT / rel).is_file()
+    )
+
+
+def changed_test_files() -> list[str]:
+    # ghstack PRs are based on gh/<user>/<n>/base, not main.
+    base_ref = os.environ.get("BASE_REF", "main")
+    merge_base = subprocess.run(
+        ["git", "merge-base", "HEAD", f"origin/{base_ref}"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if merge_base.returncode or not merge_base.stdout.strip():
+        # Returning nothing here would silently make the whole check a no-op, so
+        # it is fatal. A shallow fetch of the base branch is the usual cause.
+        raise SystemExit(
+            f"gpu_coverage: no merge-base with origin/{base_ref} "
+            f"({merge_base.stderr.strip() or 'unknown error'}); "
+            f"the base branch must be fetched unshallowed"
+        )
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", merge_base.stdout.strip(), "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return [f for f in diff.stdout.split() if is_test_file(f)]
+
+
+def resolve(paths: list[str]) -> list[str]:
+    out = []
+    for p in paths:
+        try:
+            rel = str(Path(p).resolve().relative_to(REPO_ROOT))
+        except ValueError:
+            raise SystemExit(f"gpu_coverage: {p} is not inside {REPO_ROOT}") from None
+        if not is_test_file(rel):
+            raise SystemExit(f"gpu_coverage: {p} is not an existing test/**/test_*.py")
+        out.append(rel)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--write", action="store_true", help="apply the fix to test.sh")
+    ap.add_argument("--changed", action="store_true", help="use the PR's changed files")
+    ap.add_argument("files", nargs="*")
+    args = ap.parse_args()
+
+    files = set(resolve(args.files))
+    if args.changed:
+        files |= set(changed_test_files())
+    if not files:
+        print("gpu_coverage: no test files to check")
+        return 0
+
+    text = TEST_SH.read_text(encoding="utf-8")
+    selected = {fn: smoke_patterns(text, fn) for _, _, fn in TARGETS}
+    needs, errors = measure(sorted(files))
+    locs = locations(sorted(needs)) if needs else {}
+
+    gaps = 0
+    for rel in sorted(needs):
+        include = rel[len("test/") : -len(".py")]
+        for label, _, function in TARGETS:
+            missing = {
+                t
+                for t in needs[rel][label]
+                if not selects(selected[function].get(include, []), t)
+            }
+            if not missing:
+                continue
+            gaps += 1
+            names = base_names(missing, locs.get(rel, {}))
+            line = smoke_line(rel, names)
+            if args.write:
+                text = insert(text, function, line)
+                print(f"{rel}: added {len(names)} test(s) to {function}()")
+                continue
+            runner = label.split("/")[1]
+            print(
+                f"::error file={rel},title=GPU coverage gap::"
+                f"{', '.join(sorted(names))} run on {runner} but not on a10g, and "
+                f"{function}() in .ci/pytorch/test.sh does not select them. Run "
+                f"`python tools/testing/gpu_coverage.py --write {rel}` to fix."
+            )
+            print(f"\nGPU coverage gap: {rel}")
+            for n in sorted(names):
+                print(f"    {n}  -- runs on {runner}, not on a10g")
+            print(f"  not selected by {function}() in .ci/pytorch/test.sh")
+            print(f"\n  Add to .ci/pytorch/test.sh:\n{line}")
+            print(f"  Or run:  python tools/testing/gpu_coverage.py --write {rel}\n")
+
+    for rel, err in sorted(errors.items()):
+        print(f"::warning file={rel},title=GPU coverage not measured::{err}")
+        print(f"gpu_coverage: could not measure {rel}: {err}")
+
+    if args.write:
+        TEST_SH.write_text(text, encoding="utf-8")
+        return 0
+    if gaps:
+        print(
+            f"\n{gaps} gap(s). These tests skip silently wherever CI runs them.\n"
+            f"This only makes the job cover them; running it still needs the "
+            f"ciflow label applied manually."
+        )
+        return 1
+    print(f"gpu_coverage: {len(files)} file(s) OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/testing/gpu_coverage.py
+++ b/tools/testing/gpu_coverage.py
@@ -271,7 +271,7 @@ def main() -> int:
             for n in sorted(names):
                 print(f"    {n}  -- runs on {runner}, not on a10g")
             print(f"  not selected by {function}() in .ci/pytorch/test.sh")
-            print(f"\n  Add to .ci/pytorch/test.sh:\n{line}")
+            print(f"\n  Add to {function}() in .ci/pytorch/test.sh:\n{line}")
             print(f"  Or run:  python tools/testing/gpu_coverage.py --write {rel}\n")
 
     for rel, err in sorted(errors.items()):

--- a/tools/testing/gpu_coverage.py
+++ b/tools/testing/gpu_coverage.py
@@ -26,7 +26,7 @@ BASELINE_JOB = "linux-cuda-sm86/default"
 
 # (ciflow label, job simulating its runner, test.sh function it dispatches to).
 # Only the `smoke` configs are keyed to the bare ciflow/h100 and ciflow/b200 tags;
-# the cutlass/distributed/symm-mem jobs carry their own labels.
+# the cutlass / distributed / symm-mem jobs carry their own labels.
 TARGETS = [
     ("ciflow/h100", "linux-cuda-sm90/default", "test_python_smoke"),
     ("ciflow/b200", "linux-cuda-sm100/default", "test_python_smoke_b200"),
@@ -43,13 +43,10 @@ def function_body(text: str, function: str) -> re.Match[str]:
 
 
 def smoke_patterns(text: str, function: str) -> dict[str, list[str | None]]:
-    """{run_test.py file: [-k expr, ...]} for one test.sh function.
-
-    A None entry means some include runs the whole file.
-    """
+    """{run_test.py file: [-k expr, ...]}; a None entry runs the whole file."""
     out: dict[str, list[str | None]] = {}
-    body = re.sub(r"\\\n\s*", " ", function_body(text, function).group(2))
-    for line in body.split("\n"):
+    joined = re.sub(r"\\\n\s*", " ", function_body(text, function).group(2))
+    for line in joined.split("\n"):
         try:
             toks = shlex.split(line, comments=True)
         except ValueError:
@@ -68,39 +65,42 @@ def smoke_patterns(text: str, function: str) -> dict[str, list[str | None]]:
 
 
 def selects(patterns: list[str | None], test_id: str) -> bool:
-    """Would any of these -k expressions select this Class::method id?"""
+    """Would any of these -k expressions select this Class::method id?
+
+    Matching the whole id, rather than the method name, is what makes a
+    class-scoped filter such as `-k TestForeachMM` count as coverage.
+    """
     for expr in patterns:
         if expr is None:
             return True
-        # Only ` or ` is understood. A pattern using `and`/`not` is opaque and
-        # assumed not to select, so we over-report rather than silently skip.
+        # Only ` or ` is understood. A pattern using `and`/`not` is treated as
+        # opaque, so we over-report a gap rather than miss one.
         if any(p and p.strip() in test_id for p in expr.split(" or ")):
             return True
     return False
 
 
 def measure(files: list[str]) -> tuple[dict[str, dict[str, set[str]]], dict[str, str]]:
-    """-> ({file: {label: concrete tests needing that label}}, {file: error})"""
+    """-> ({file: {label: concrete tests needing it}}, {file: why not measured})"""
     from tools.testing.introspection import collector, platforms
 
     ran: dict[str, dict[str, set[str]]] = {}
     errors: dict[str, str] = {}
     for job in [BASELINE_JOB] + [j for _, j, _ in TARGETS]:
-        results = collector.collect(platforms.get_job(job), "status", files)
-        for rel, payload in results.items():
+        for rel, payload in collector.collect(
+            platforms.get_job(job), "status", files
+        ).items():
             if "error" in payload:
                 errors.setdefault(rel, str(payload["error"]))
             else:
                 ran.setdefault(rel, {})[job] = set(payload["ran"])
 
-    needs: dict[str, dict[str, set[str]]] = {}
+    needs = {}
     for rel, by_job in ran.items():
-        if len(by_job) != len(TARGETS) + 1:
-            errors.setdefault(rel, "incomplete measurement across capabilities")
+        if rel in errors:
             continue
-        # ciflow/h100 and ciflow/b200 are independent labels, so a test needing
-        # sm90+ belongs in both smoke lists: a b200-labelled PR runs only the b200
-        # list and would otherwise skip it.
+        # h100 and b200 are independent labels, so a test needing sm90+ belongs in
+        # both lists: a b200-labelled PR runs only the b200 list.
         needs[rel] = {
             label: by_job[job] - by_job[BASELINE_JOB] for label, job, _ in TARGETS
         }
@@ -108,23 +108,23 @@ def measure(files: list[str]) -> tuple[dict[str, dict[str, set[str]]], dict[str,
 
 
 def locations(files: list[str]) -> dict[str, dict[str, list]]:
-    """{file: {Class::method: [defining file, first decorator line]}}"""
+    """{file: {Class::method: [defining file, line its decorators start on]}}"""
     from tools.testing.introspection import collector, platforms
 
     job = platforms.get_job(TARGETS[-1][1])  # widest capability: most tests exist
     out = {}
     for rel, payload in collector.collect(job, "enumloc", files).items():
-        # A file whose status measured fine can still fail enumloc (different
-        # import path); fall back to concrete ids rather than aborting.
-        out[rel] = {} if "error" in payload else payload.get("locations", {})
+        if "error" in payload:
+            raise SystemExit(f"gpu_coverage: cannot locate tests in {rel}: {payload}")
+        out[rel] = payload.get("locations", {})
     return out
 
 
 def decorator_starts(path: Path) -> dict[int, str]:
     """{line a function's decorator stack starts on: function name}.
 
-    inspect.getsourcelines, which the engine uses for locations, reports that
-    line rather than the `def`.
+    inspect.getsourcelines, which the engine uses, reports that line and not the
+    `def`, so this is the key its locations are expressed in.
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -150,8 +150,8 @@ def base_names(tests: set[str], locs: dict[str, list]) -> set[str]:
         if loc:
             defs = cache.setdefault(loc[0], decorator_starts(REPO_ROOT / loc[0]))
             name = defs.get(loc[1])
-        # Falling back to the concrete id happens for tests defined outside the
-        # test tree; it is a valid -k token but pins the parametrize values.
+        # Without a location the test is defined outside the test tree; its
+        # concrete id is still a valid -k token, just a brittle one.
         names.add(name or t.split("::")[-1])
     return names
 
@@ -160,20 +160,18 @@ def smoke_line(rel: str, names: set[str]) -> str:
     include = rel[len("test/") : -len(".py")]
     kexpr = " or ".join(sorted(names))
     return (
-        f"  time python test/run_test.py --include {include} "
-        f'-k "{kexpr}" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running\n'
+        f'  time python test/run_test.py --include {include} -k "{kexpr}" '
+        f"$PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running\n"
     )
 
 
 def insert(text: str, function: str, line: str) -> str:
     m = function_body(text, function)
     anchor = "  assert_git_not_dirty\n"
-    body = m.group(2)
-    if anchor not in body:
+    if anchor not in m.group(2):
         raise SystemExit(f"gpu_coverage: no insertion anchor in {function}()")
-    return (
-        text[: m.start(2)] + body.replace(anchor, line + anchor, 1) + text[m.end(2) :]
-    )
+    body = m.group(2).replace(anchor, line + anchor, 1)
+    return text[: m.start(2)] + body + text[m.end(2) :]
 
 
 def is_test_file(rel: str) -> bool:
@@ -193,15 +191,13 @@ def changed_test_files() -> list[str]:
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
-        check=False,
     )
     if merge_base.returncode or not merge_base.stdout.strip():
-        # Returning nothing here would silently make the whole check a no-op, so
-        # it is fatal. A shallow fetch of the base branch is the usual cause.
+        # Returning nothing here would make the whole check a silent no-op. A
+        # shallow fetch of the base branch is the usual cause.
         raise SystemExit(
-            f"gpu_coverage: no merge-base with origin/{base_ref} "
-            f"({merge_base.stderr.strip() or 'unknown error'}); "
-            f"the base branch must be fetched unshallowed"
+            f"gpu_coverage: no merge-base with origin/{base_ref}: "
+            f"{merge_base.stderr.strip() or 'unknown'}"
         )
     diff = subprocess.run(
         ["git", "diff", "--name-only", merge_base.stdout.strip(), "HEAD"],
@@ -219,7 +215,7 @@ def resolve(paths: list[str]) -> list[str]:
         try:
             rel = str(Path(p).resolve().relative_to(REPO_ROOT))
         except ValueError:
-            raise SystemExit(f"gpu_coverage: {p} is not inside {REPO_ROOT}") from None
+            raise SystemExit(f"gpu_coverage: {p} is outside {REPO_ROOT}") from None
         if not is_test_file(rel):
             raise SystemExit(f"gpu_coverage: {p} is not an existing test/**/test_*.py")
         out.append(rel)
@@ -233,16 +229,17 @@ def main() -> int:
     ap.add_argument("files", nargs="*")
     args = ap.parse_args()
 
-    files = set(resolve(args.files))
+    files = resolve(args.files)
     if args.changed:
-        files |= set(changed_test_files())
+        files += changed_test_files()
+    files = sorted(set(files))
     if not files:
         print("gpu_coverage: no test files to check")
         return 0
 
     text = TEST_SH.read_text(encoding="utf-8")
-    selected = {fn: smoke_patterns(text, fn) for _, _, fn in TARGETS}
-    needs, errors = measure(sorted(files))
+    patterns = {fn: smoke_patterns(text, fn) for _, _, fn in TARGETS}
+    needs, errors = measure(files)
     locs = locations(sorted(needs)) if needs else {}
 
     gaps = 0
@@ -252,7 +249,7 @@ def main() -> int:
             missing = {
                 t
                 for t in needs[rel][label]
-                if not selects(selected[function].get(include, []), t)
+                if not selects(patterns[function].get(include, []), t)
             }
             if not missing:
                 continue
@@ -265,10 +262,10 @@ def main() -> int:
                 continue
             runner = label.split("/")[1]
             print(
-                f"::error file={rel},title=GPU coverage gap::"
-                f"{', '.join(sorted(names))} run on {runner} but not on a10g, and "
-                f"{function}() in .ci/pytorch/test.sh does not select them. Run "
-                f"`python tools/testing/gpu_coverage.py --write {rel}` to fix."
+                f"::error file={rel},title=GPU coverage gap::{', '.join(sorted(names))} "
+                f"run on {runner} but not on a10g, and {function}() in "
+                f".ci/pytorch/test.sh does not select them. Fix: python "
+                f"tools/testing/gpu_coverage.py --write {rel}"
             )
             print(f"\nGPU coverage gap: {rel}")
             for n in sorted(names):
@@ -288,7 +285,7 @@ def main() -> int:
         print(
             f"\n{gaps} gap(s). These tests skip silently wherever CI runs them.\n"
             f"This only makes the job cover them; running it still needs the "
-            f"ciflow label applied manually."
+            f"ciflow label applied by hand."
         )
         return 1
     print(f"gpu_coverage: {len(files)} file(s) OK")

--- a/tools/testing/introspection/collector.py
+++ b/tools/testing/introspection/collector.py
@@ -159,10 +159,11 @@ def _stub_macos_probes() -> None:
 
 def _patch_has_triton() -> None:
     # triton_utils.py defines add_kernel et al. only `if has_triton():`, which is
-    # False when the GPU is hidden. Declare triton present so those helpers exist
-    # (triton itself is installed; only device detection is what fails).
+    # False when the GPU is hidden, so declare triton present to keep those helpers.
+    # Only safe when triton really is installed: claiming otherwise turns a skip
+    # into an ImportError at `import triton` further down the same file.
     t = _safe_import("torch.utils._triton")
-    if t is not None:
+    if t is not None and _safe_import("triton") is not None:
         t.has_triton = lambda: True
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192570
* #192560

A test gated on a GPU architecture only runs if .ci/pytorch/test.sh selects it in
the function the ciflow/h100 or ciflow/b200 job dispatches to. Nothing links that
list to the gate, so it drifts, and the tests skip silently on the a10g/A100
runners that serve most of CI. A skipped test is a green test, so nothing
surfaces it -- see #192465.

Which tests need which capability is measured, not inferred. Pattern-matching
skip decorators cannot distinguish "requires sm90" from "broken on sm90":
test_linalg's test__int_mm is gated by
`@unittest.skipIf(SM90OrLater and not TEST_WITH_ROCM, "Expected failure on sm90")`,
which a text scan reads as a requirement, producing a fix that adds 16 tests to
the H100 run where they are skipped by construction. Instead this imports each
file at a simulated capability via the introspection engine and records what ran:

    needs h100 = ran@sm90 - ran@sm86
    needs b200 = ran@sm100 - ran@sm86

ciflow/h100 and ciflow/b200 are independent labels, not a hierarchy, so a test
needing sm90+ is required in *both* lists: a PR labelled only ciflow/b200 runs
only test_python_smoke_b200 and would otherwise skip it.

There is no baseline or grandfather file. Correctness is recomputed each run, and
the check is scoped to the PR's changed files, so pre-existing gaps in a file a
PR happens to touch are not reported at it.

Scope: this only ever edits .ci/pytorch/test.sh. It does not touch
.github/labeler.yml, so running the H100/B200 jobs still requires applying the
ciflow label by hand -- deliberately, since those runners are scarce.

Why a workflow job and not a lintrunner adapter: importing test modules needs a
torch build, and the lint image is deliberately torch-free
(.ci/docker/build.sh:76); no lintrunner adapter imports torch. The job reuses the
existing linux-jammy-py3.10-gcc11 build artifact, so it adds no build, and it
computes the changed-file list before downloading that artifact so the common
case of a PR touching no test files costs nothing.

Two correctness details worth review:

The base branch is fetched unshallowed. A `--depth=1` fetch grafts the base tip
as parentless, which makes `git merge-base` fail; combined with a tolerant
caller that would have made the whole check a silent no-op passing every PR. An
unresolvable merge-base is now fatal rather than an empty file list.

Locations from the engine point at the first *decorator* line, not the `def`
(inspect.getsourcelines), so base names are recovered by keying an AST scan on
each function's decorator-stack start and matching exactly, using the file the
engine reports rather than assuming the changed file. Guessing with a fixed
line window mis-resolved 61% of names on test_matmul_cuda.py and produced a
147 KB -k expression.

Known limitation: the descriptor simulates compute capability, not optional
dependencies. A gate like has_triton_tma_device() is
`capability >= 9.0 AND <triton has the symbol>`; the simulation fixes the first
term and inherits the second. The chosen build image has no Triton, so
triton-gated tests currently skip at every capability and are reported as
unmeasured warnings rather than gaps. That under-reports, never over-reports.
Pointing the job at a Triton-bearing build is the obvious follow-up.

Test Plan:

Positive control -- a file already in both smoke lists is clean:

```
python tools/testing/gpu_coverage.py test/test_matmul_cuda.py
```
```
gpu_coverage: 1 file(s) OK
```

Negative control -- remove test_matmul_cuda from both smoke lists:

```
GPU coverage gap: test/test_matmul_cuda.py
    test_grouped_gemm_compiled  -- runs on h100, not on a10g
    test_legacy_cublas_honors_sm_carveout  -- runs on h100, not on a10g
    test_sm_carveout_invalid_value_throws  -- runs on h100, not on a10g
  not selected by test_python_smoke() in .ci/pytorch/test.sh

GPU coverage gap: test/test_matmul_cuda.py
    test_cublas_batch_invariance_blackwell  -- runs on b200, not on a10g
    test_grouped_gemm_compiled  -- runs on b200, not on a10g
    test_legacy_cublas_honors_sm_carveout  -- runs on b200, not on a10g
    test_sm_carveout_invalid_value_throws  -- runs on b200, not on a10g
  not selected by test_python_smoke_b200() in .ci/pytorch/test.sh
```

The three sm90+ tests appear under both labels; the Blackwell-only one under
b200 only. 38 concrete tests collapse to 4 base names.

Polarity, the case a decorator scan gets backwards:

```
python tools/testing/gpu_coverage.py test/test_linalg.py   # OK, no gap
```

Autofix converges, and duplicate arguments do not duplicate lines:

```
python tools/testing/gpu_coverage.py --write test/test_matmul_cuda.py ./test/test_matmul_cuda.py
git diff .ci/pytorch/test.sh | grep -c '^+.*--include test_matmul_cuda'   # 2
python tools/testing/gpu_coverage.py test/test_matmul_cuda.py            # OK
```

Exit codes:

```
gpu_coverage.py test/test_does_not_exist.py   -> 1
gpu_coverage.py /etc/hostname                 -> 1
BASE_REF=does-not-exist gpu_coverage.py --changed -> 1
gpu_coverage.py test/test_matmul_cuda.py      -> 0
```

Runtime ~16 s for one file cold.

Authored with assistance from Claude Code.