### PR TITLE
[ROCm] Fix bfe() bit-field extraction in the quantized CUDA EmbeddingBag kernel (#192571)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
@@ -24,11 +24,14 @@ namespace at::native {
 // BEGIN QUANTIZE HELPER FUNCTIONS
 __device__ __forceinline__ float bfe(uint32_t val, uint32_t pos, uint32_t len) {
 #ifdef USE_ROCM
-  return *reinterpret_cast<float*>((val >> pos) && ((1u << len) - 1u ));
+  // Extract the [pos, pos+len) bit field and convert to float. Use bitwise-AND
+  // (`&`), not logical-AND (`&&`): the logical form yielded a bool that the
+  // prior code reinterpret_cast to float* and dereferenced, faulting on ROCm.
+  return __uint2float_rn((val >> pos) & ((1u << len) - 1u));
 #else
   uint32_t ret;
   // Get the bit field of [pos, pos+len) bits from val:
-  // (val >> pos) && ( (1u << len) - 1u )
+  // (val >> pos) & ((1u << len) - 1u)
   asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
   return __uint2float_rn(ret);
 #endif

--- a/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
@@ -22,16 +22,19 @@
 namespace at::native {
 
 // BEGIN QUANTIZE HELPER FUNCTIONS
+// Get the bit field of [pos, pos+len) bits from val, i.e.
+// (val >> pos) & ((1u << len) - 1u), and return it as a float.
 __device__ __forceinline__ float bfe(uint32_t val, uint32_t pos, uint32_t len) {
-#ifdef USE_ROCM
-  return *reinterpret_cast<float*>((val >> pos) && ((1u << len) - 1u ));
-#else
   uint32_t ret;
-  // Get the bit field of [pos, pos+len) bits from val:
-  // (val >> pos) && ( (1u << len) - 1u )
+#ifdef USE_ROCM
+  // Bitwise-AND (`&`), not logical-AND (`&&`): the logical form yields a bool,
+  // which the previous implementation reinterpret_cast to float* and
+  // dereferenced, faulting on ROCm.
+  ret = (val >> pos) & ((1u << len) - 1u);
+#else
   asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
-  return __uint2float_rn(ret);
 #endif
+  return __uint2float_rn(ret);
 }
 
 // FMA with constant scale/bias for all 4 floats in fa

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -5423,6 +5423,39 @@ class TestQuantizedEmbeddingOps(TestCase):
                                                sparsity=sparsity,
                                                atol=1.0, rtol=1e-1)
 
+    """ Tests that the CUDA quantized embedding_bag operators agree with their
+        CPU counterparts. This covers the bit-field extraction the dequantization
+        path is built on, which is shared by both bit widths. """
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_rowwise_offsets_cuda(self):
+        # 24 satisfies both ops: the byte op requires D % 4 == 0, the 4-bit op
+        # requires D % 8 == 0.
+        num_embeddings, embedding_dim = 32, 24
+        weights = torch.from_numpy((np.random.random_sample(
+            (num_embeddings, embedding_dim)) + 1).astype(np.float32))
+        indices = torch.tensor([3, 1, 4, 1, 5, 9, 2, 6], dtype=torch.int)
+        offsets = torch.tensor([0, 3, 5], dtype=torch.int)
+
+        for bit_rate, prepack_op, op, atol in (
+            (8, torch.ops.quantized.embedding_bag_byte_prepack,
+             torch.ops.quantized.embedding_bag_byte_rowwise_offsets, 0.005),
+            (4, torch.ops.quantized.embedding_bag_4bit_prepack,
+             torch.ops.quantized.embedding_bag_4bit_rowwise_offsets, 0.1),
+        ):
+            q_weights = prepack_op(weights)
+
+            def run(device, q_weights=q_weights, op=op):
+                return op(q_weights.to(device), indices.to(device),
+                          offsets.to(device), mode=0, pruned_weights=False,
+                          include_last_offset=False)
+
+            cuda_result = run("cuda").cpu()
+            self.assertTrue(
+                torch.isfinite(cuda_result).all(),
+                f"{bit_rate}-bit CUDA output is not finite: {cuda_result}")
+            torch.testing.assert_close(
+                run("cpu"), cuda_result, atol=atol, rtol=1e-2)
+
     """ Tests the correctness of the quantized 8 bit embedding lookup operator """
     @given(num_embeddings=st.integers(10, 100),
            embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0))


### PR DESCRIPTION
Summary:

`bfe()` in aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu extracts the
[pos, pos+len) bit field of a packed word and returns it as a float. It is the
inner primitive of `dequantize_intx()`, so every
`quantized::embedding_bag_{byte,4bit}_rowwise_offsets` call on a GPU goes
through it.

The `#ifdef USE_ROCM` branch read:

    return *reinterpret_cast<float*>((val >> pos) && ((1u << len) - 1u));

which has two defects:

- `&&` (logical AND) is used where `&` (bitwise AND) was intended, so the
  expression collapses to 0 or 1 instead of the requested bit field.
- the resulting `bool` is then reinterpreted as a `float*` and dereferenced,
  i.e. a load from address 0 or 1.

This is not a subtle numerical issue: on an AMD GPU the null load aborts the
process with

    Memory access fault by GPU node-2 (Agent handle: 0x...) on address (nil).

so quantized embedding-bag lookups could never have run on ROCm. The line has
been unchanged since the file was added in July 2021.

Use the bitwise AND and convert with `__uint2float_rn`, which yields the same
value the CUDA branch computes with the `bfe.u32` PTX instruction. Both branches
end in that same conversion, so only the bit-field extraction itself stays under
the `#ifdef` and the conversion is shared between them. NVIDIA codegen and the
CPU implementations are unchanged.

The explanatory comment carried the same `&&` typo and is most likely where the
ROCm expression was copied from; it is corrected and hoisted to describe the
function as a whole rather than just one branch.

Test Plan:
New test `test_embedding_bag_rowwise_offsets_cuda` in
`test/quantization/core/test_quantized_op.py` runs
`quantized::embedding_bag_byte_rowwise_offsets` and
`quantized::embedding_bag_4bit_rowwise_offsets` on GPU and asserts the output is
finite and agrees with the CPU implementation. Both bit widths are covered
because `bfe()` is shared by them through `dequantize_intx()`, with a different
`len`.

    python test/quantization/core/test_quantized_op.py -k test_embedding_bag_rowwise_offsets_cuda

Run on an AMD GPU (ROCm): passes. The whole `TestQuantizedEmbeddingOps` class
passes as well (7 tests).

As a negative control, reverting just this fix makes the new test abort with the
GPU memory fault quoted in the summary, so the test does pin the behaviour it
claims to.

Differential Revision: D115065161


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang