### PR TITLE
[CUDA][ROCm] Support pruned lookups in quantized embedding_bag_byte_rowwise_offsets (#192573)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
@@ -17,6 +17,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_native.h>
 #include <ATen/ops/resize_native.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at::native {
@@ -206,10 +207,6 @@ at::Tensor& embedding_bag_byte_impl(
   if (per_sample_weights_.has_value()) {
     TORCH_CHECK(per_sample_weights_.value().device() == weight.device());
   }
-  if (compressed_indices_mapping.has_value()) {
-    TORCH_CHECK(compressed_indices_mapping.value().device() == weight.device());
-  }
-
   TORCH_CHECK(weight.dtype() == at::kByte);
   TORCH_CHECK(weight.dim() == 2);
 
@@ -226,10 +223,6 @@ at::Tensor& embedding_bag_byte_impl(
               "Per sample weights expected scalar type ", at::kFloat, " but got ",
               per_sample_weights_.value().scalar_type());
   }
-  TORCH_CHECK(
-      !compressed_indices_mapping.has_value(),
-      "Compressed indices mapping not yet implemented for embedding_bag_byte_rowwise_offsets_cuda");
-
   const auto maxThreads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
 
   int64_t output_size = include_last_offset ? M - 1 : M;
@@ -243,6 +236,9 @@ at::Tensor& embedding_bag_byte_impl(
 
   const std::vector<int64_t> shape = {output_size, D};
   at::native::resize_(output, shape, std::nullopt);
+  const at::Tensor offsets_k = offsets.scalar_type() == indices.scalar_type()
+      ? offsets
+      : offsets.to(indices.scalar_type());
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "embedding_bag_byte_rowwise_offsets_kernel", ([&] {
         embedding_bag_nbits_rowwise_offsets_kernel<index_t, 8><<<
@@ -252,7 +248,7 @@ at::Tensor& embedding_bag_byte_impl(
             at::cuda::getCurrentCUDAStream()>>>(
             weight.packed_accessor64<uint8_t, 2, RestrictPtrTraits>(),
             indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets_k.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
             false /* pruned_weights */,
             sample_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
             compressed_indices_mapping,
@@ -270,20 +266,134 @@ Tensor embedding_bag_byte_rowwise_offsets(
     const Tensor& weight,
     const Tensor& indices,
     const std::optional<Tensor>& offsets_in,
-    const bool /* scale_grad_by_freq */,
-    const int64_t /* mode */,
+    const bool scale_grad_by_freq,
+    const int64_t mode,
     bool pruned_weights,
     const std::optional<Tensor>& per_sample_weights_,
     const std::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
-  bool is_embedding_op = false;
-  auto output = create_empty_from(weight, at::kFloat);
-
-  c10::MaybeOwned<at::Tensor> offsets;
+  // Screen the caller's tensors before anything below can rewrite them. The
+  // pruned path re-enters this function with translated indices and synthesized
+  // per-sample weights, and returns early when every row was pruned, so a check
+  // placed further down would either inspect the rewritten tensors or be skipped
+  // altogether.
+  TORCH_CHECK(weight.is_cuda());
+  TORCH_CHECK(indices.is_cuda());
+  TORCH_CHECK(indices.device() == weight.device());
+  TORCH_CHECK(weight.dtype() == at::kByte);
+  TORCH_CHECK(weight.dim() == 2);
+  // NB: -8 to account for scale and bias. The lower bound is not implied by the
+  // remainder: (0 - 8) % 4 and (4 - 8) % 4 are both 0, and the negative D that
+  // follows only surfaces much later as an overflow or a negative dimension.
+  TORCH_CHECK(weight.size(1) >= 8 && (weight.size(1) - 8) % 4 == 0);
   TORCH_CHECK(
       indices.dim() == 1 || indices.dim() == 2,
       "qembedding/qembedding_bag operator supports 1 or 2d indices, got ",
       indices.dim());
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
+      "Expect 32 or 64 bit indices, but found ",
+      indices.scalar_type(),
+      " instead.");
+  if (offsets_in.has_value()) {
+    const auto& offsets_arg = offsets_in.value();
+    TORCH_CHECK(offsets_arg.is_cuda());
+    TORCH_CHECK(offsets_arg.device() == weight.device());
+    TORCH_CHECK(
+        offsets_arg.dim() == 1, "Expect 1D offsets, got ", offsets_arg.dim());
+    TORCH_CHECK(
+        offsets_arg.scalar_type() == at::kInt ||
+            offsets_arg.scalar_type() == at::kLong,
+        "Expect 32 or 64 bit offsets, but found ",
+        offsets_arg.scalar_type(),
+        " instead.");
+  }
+  TORCH_CHECK(
+      weight.is_contiguous() && indices.is_contiguous() &&
+          (!offsets_in.has_value() || offsets_in.value().is_contiguous()),
+      "Expect weight, indices, and offsets to be contiguous.");
+  if (per_sample_weights_.has_value()) {
+    TORCH_CHECK(per_sample_weights_.value().device() == weight.device());
+    TORCH_CHECK(
+        per_sample_weights_.value().scalar_type() == at::kFloat,
+        "Per sample weights expected scalar type ",
+        at::kFloat,
+        " but got ",
+        per_sample_weights_.value().scalar_type());
+  }
+
+  // The kernel takes compressed_indices_mapping but ignores it, so remap the
+  // indices here and re-enter as a dense lookup, mirroring the CPU op.
+  if (compressed_indices_mapping.has_value()) {
+    const auto& mapping = compressed_indices_mapping.value();
+    Tensor eff_indices = indices;
+    std::optional<Tensor> eff_per_sample_weights = per_sample_weights_;
+    // A single-entry mapping is the "not pruned" sentinel: {0} by CPU's
+    // spelling, {-1} by that of at least one out-of-tree producer. CPU honours
+    // only {0}; it reads any other single value as a real one-row mapping and
+    // indexes through it, rejecting ids >= 1 as out of bounds. Telling the two
+    // apart needs a device read, i.e. a sync on every call, so every
+    // single-entry mapping is taken as the sentinel and looked up densely.
+    if (pruned_weights && mapping.numel() != 1) {
+      TORCH_CHECK_TYPE(
+          mapping.scalar_type() == at::kInt,
+          "compressed_indices_mapping must have dtype Int, got ",
+          mapping.scalar_type());
+      TORCH_CHECK(
+          mapping.device() == weight.device(),
+          "compressed_indices_mapping must be on the same device as weight; got ",
+          mapping.device(),
+          " vs ",
+          weight.device());
+      // Not redundant: index_select would fault device-side, unrecoverably.
+      TORCH_CHECK_VALUE(
+          mapping.numel() > 0, "compressed_indices_mapping must not be empty");
+      // CPU accepts 2-D indices by synthesizing offsets for them; on CUDA that
+      // path is already dead (host-side at::arange), so reject rather than
+      // carry reshape logic for it.
+      TORCH_CHECK(
+          indices.dim() == 1,
+          "compressed_indices_mapping requires 1D indices, got ",
+          indices.dim());
+      // Out-of-range ids fault device-side (a bare abort() on ROCm) rather than
+      // raising CPU's clean error; screening on the host would sync every call.
+      const auto remapped = mapping.reshape({-1}).index_select(0, indices);
+      // Every row pruned away, so the result is all zeros, as on CPU; clamp_min
+      // below would instead read row 0 of an empty table. The caller's tensors
+      // were screened at the top of the function, so returning here skips none
+      // of the checks above.
+      if (weight.size(0) == 0) {
+        TORCH_CHECK(
+            offsets_in.has_value(),
+            "embedding_bag_byte expects offsets to be set for 1D indices.");
+        const auto num_bags = offsets_in.value().size(0);
+        return at::zeros(
+            {include_last_offset ? num_bags - 1 : num_bags, weight.size(1) - 8},
+            weight.options().dtype(at::kFloat));
+      }
+      // CPU skips pruned rows (-1); the dense kernel cannot, so cancel them with a
+      // zero per-sample weight. Exact for finite rows and weights: 0 * inf = NaN.
+      const auto keep = remapped.ge(0).to(at::kFloat);
+      eff_per_sample_weights = per_sample_weights_.has_value()
+          ? per_sample_weights_.value().mul(keep)
+          : keep;
+      eff_indices = remapped.clamp_min(0).to(indices.scalar_type());
+    }
+    return embedding_bag_byte_rowwise_offsets(
+        weight,
+        eff_indices,
+        offsets_in,
+        scale_grad_by_freq,
+        mode,
+        /*pruned_weights=*/false,
+        eff_per_sample_weights,
+        /*compressed_indices_mapping=*/std::nullopt,
+        include_last_offset);
+  }
+  bool is_embedding_op = false;
+  auto output = create_empty_from(weight, at::kFloat);
+
+  c10::MaybeOwned<at::Tensor> offsets;
   // For embedding_bag operator with 2D indices, we set the offsets explicitly
   // here.
   if (indices.dim() == 2 && !is_embedding_op) {
@@ -301,23 +411,14 @@ Tensor embedding_bag_byte_rowwise_offsets(
     offsets = c10::MaybeOwned<at::Tensor>::borrowed(offsets_in.value());
   }
 
-  TORCH_CHECK(
-      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
-      "Expect 32 or 64 bit indices, but found ",
-      indices.scalar_type(),
-      " instead.");
-  TORCH_CHECK(
-      offsets->scalar_type() == at::kInt || offsets->scalar_type() == at::kLong,
-      "Expect 32 or 64 bit offsets, but found ",
-      offsets->scalar_type(),
-      " instead.");
-  TORCH_CHECK(
-      weight.is_contiguous() && indices.is_contiguous() &&
-          offsets->is_contiguous(),
-      "Expect weight, indices, and offsets to be contiguous.");
+  // Only the synthesized 2-D offsets are unchecked above; they are Int/Long and
+  // contiguous by construction, but at::arange builds them on the host, so the
+  // device check in embedding_bag_byte_impl is what catches that (pre-existing;
+  // the same device-less at::arange call sits in the 4-bit function).
 
-  // Using helper function to support different type combination without the
-  // need to cast, which can be additional performance overhead
+  // IndexType/OffsetType are unused in embedding_bag_byte_impl -- all four
+  // instantiations are identical, and the impl casts offsets to the index type
+  // before launching.
   if (indices.scalar_type() == at::kInt && offsets->scalar_type() == at::kInt) {
     return embedding_bag_byte_impl<int, int>(
         output,
@@ -410,7 +511,7 @@ at::Tensor& embedding_bag_4bit_impl(
   }
   TORCH_CHECK(
       !compressed_indices_mapping.has_value(),
-      "Compressed indices mapping not yet implemented for embedding_bag_byte_rowwise_offsets_cuda");
+      "Compressed indices mapping not yet implemented for embedding_bag_4bit_rowwise_offsets_cuda");
 
   const auto maxThreads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
 
@@ -425,6 +526,9 @@ at::Tensor& embedding_bag_4bit_impl(
 
   const std::vector<int64_t> shape = {output_size, D};
   at::native::resize_(output, shape, std::nullopt);
+  const at::Tensor offsets_k = offsets.scalar_type() == indices.scalar_type()
+      ? offsets
+      : offsets.to(indices.scalar_type());
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "embedding_bag_4bit_rowwise_offsets_kernel", ([&] {
         embedding_bag_nbits_rowwise_offsets_kernel<index_t, 4><<<
@@ -434,7 +538,7 @@ at::Tensor& embedding_bag_4bit_impl(
             at::cuda::getCurrentCUDAStream()>>>(
             weight.packed_accessor64<uint8_t, 2, RestrictPtrTraits>(),
             indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets_k.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
             false /* pruned_weights */,
             sample_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
             compressed_indices_mapping,

--- a/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
@@ -24,11 +24,14 @@ namespace at::native {
 // BEGIN QUANTIZE HELPER FUNCTIONS
 __device__ __forceinline__ float bfe(uint32_t val, uint32_t pos, uint32_t len) {
 #ifdef USE_ROCM
-  return *reinterpret_cast<float*>((val >> pos) && ((1u << len) - 1u ));
+  // Extract the [pos, pos+len) bit field and convert to float. Use bitwise-AND
+  // (`&`), not logical-AND (`&&`): the logical form yielded a bool that the
+  // prior code reinterpret_cast to float* and dereferenced, faulting on ROCm.
+  return __uint2float_rn((val >> pos) & ((1u << len) - 1u));
 #else
   uint32_t ret;
   // Get the bit field of [pos, pos+len) bits from val:
-  // (val >> pos) && ( (1u << len) - 1u )
+  // (val >> pos) & ((1u << len) - 1u)
   asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
   return __uint2float_rn(ret);
 #endif

--- a/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/quantized/cuda/EmbeddingBag.cu
@@ -243,6 +243,15 @@ at::Tensor& embedding_bag_byte_impl(
 
   const std::vector<int64_t> shape = {output_size, D};
   at::native::resize_(output, shape, std::nullopt);
+  // The kernel below reads `offsets` through the SAME `index_t` as
+  // `indices` (both packed_accessor32<index_t>), so offsets must share indices'
+  // dtype. The dispatch keys only on indices' dtype, so a mismatched offsets
+  // (e.g. Int indices + Long offsets, which occurs on the pruned->remapped path)
+  // would fault the accessor with "expected scalar type Int but found Long".
+  // Cast offsets to match; offset values (cumulative bag sizes) fit index_t.
+  const at::Tensor offsets_k = offsets.scalar_type() == indices.scalar_type()
+      ? offsets
+      : offsets.to(indices.scalar_type());
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "embedding_bag_byte_rowwise_offsets_kernel", ([&] {
         embedding_bag_nbits_rowwise_offsets_kernel<index_t, 8><<<
@@ -252,7 +261,7 @@ at::Tensor& embedding_bag_byte_impl(
             at::cuda::getCurrentCUDAStream()>>>(
             weight.packed_accessor64<uint8_t, 2, RestrictPtrTraits>(),
             indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets_k.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
             false /* pruned_weights */,
             sample_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
             compressed_indices_mapping,
@@ -270,12 +279,65 @@ Tensor embedding_bag_byte_rowwise_offsets(
     const Tensor& weight,
     const Tensor& indices,
     const std::optional<Tensor>& offsets_in,
-    const bool /* scale_grad_by_freq */,
-    const int64_t /* mode */,
+    const bool scale_grad_by_freq,
+    const int64_t mode,
     bool pruned_weights,
     const std::optional<Tensor>& per_sample_weights_,
     const std::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
+  // Pruned lookups (compressed_indices_mapping) on CUDA/ROCm.
+  //
+  // The kernel below has no notion of a compressed mapping, so when one is
+  // supplied we translate the indices into the compressed row space here and
+  // then re-enter as an ordinary dense lookup. This mirrors the semantics of
+  // the CPU op in native/quantized/cpu/qembeddingbag.cpp.
+  if (weight.is_cuda() && compressed_indices_mapping.has_value()) {
+    const auto& mapping = compressed_indices_mapping.value();
+    Tensor eff_indices = indices;
+    std::optional<Tensor> eff_per_sample_weights = per_sample_weights_;
+    // The mapping is only meaningful alongside pruned_weights; the CPU op
+    // ignores it otherwise, so drop it and fall through to a dense lookup.
+    //
+    // A real mapping holds one entry per uncompressed row, so a single-entry
+    // mapping is instead the "this table is not pruned" sentinel and the
+    // indices already address the weight rows directly. The CPU op spells that
+    // sentinel {0} and rejects {-1}; both spellings are in circulation and
+    // neither can be a meaningful mapping except for a single-row table, so
+    // accept either here.
+    if (pruned_weights && mapping.numel() != 1) {
+      const auto cim = mapping.to(weight.device());
+      // index_select bounds-checks the gather on device, so an out-of-range
+      // index is reported rather than silently folded onto a valid row. The
+      // CPU op rejects the same input with "Invalid indices data for Sparse
+      // Op.".
+      const auto remapped = cim.index_select(0, indices.reshape({-1}));
+      // The mapping marks a pruned-away row with -1, and such an entry must
+      // contribute nothing to its bag -- the CPU op simply skips it. The dense
+      // kernel cannot skip, so point the index at a valid row and cancel its
+      // contribution with a zero per-sample weight instead. Computed
+      // branchlessly: testing for pruned rows on the host would force a device
+      // synchronization on every call.
+      const auto keep = remapped.ge(0).to(at::kFloat);
+      eff_per_sample_weights = per_sample_weights_.has_value()
+          ? per_sample_weights_.value().reshape({-1}).mul(keep)
+          : keep;
+      // The kernel reads indices as Int32. Remapped ids address the compressed
+      // row space, which is no larger than the original, so emit kInt
+      // explicitly rather than inheriting a possibly-Int64 input dtype.
+      eff_indices =
+          remapped.clamp_min(0).to(at::kInt).reshape(indices.sizes());
+    }
+    return embedding_bag_byte_rowwise_offsets(
+        weight,
+        eff_indices,
+        offsets_in,
+        scale_grad_by_freq,
+        mode,
+        /*pruned_weights=*/false,
+        eff_per_sample_weights,
+        /*compressed_indices_mapping=*/std::nullopt,
+        include_last_offset);
+  }
   bool is_embedding_op = false;
   auto output = create_empty_from(weight, at::kFloat);
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -53,13 +53,11 @@ from torch.testing._internal.common_quantized import (
     supported_qengines,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
     IS_MACOS,
     IS_PPC,
     IS_SANDCASTLE,
-    parametrize,
     raise_on_run_directly,
     TestCase,
 )
@@ -5160,7 +5158,6 @@ class TestQuantizedLinear(TestCase):
 
 
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")
-@instantiate_parametrized_tests
 class TestQuantizedEmbeddingOps(TestCase):
 
     def _test_embedding_bag_unpack_impl(self, pack_fn, unpack_fn, bit_rate, optimized_qparams, weights):
@@ -5543,163 +5540,168 @@ class TestQuantizedEmbeddingOps(TestCase):
         return q_pruned, mapping
 
     """ Tests that CUDA embedding_bag_byte matches CPU on a pruned table """
-    @parametrize("include_last_offset", [False, True])
-    @parametrize("use_weights", [False, True])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_byte_cuda_pruned(self, include_last_offset, use_weights):
-        _, _, q_pruned, mapping = self._pruned_byte_table()
-        # CPU and CUDA factor the dequantization and the per-sample-weight
-        # multiply differently, so these agree to float32 rounding rather than
-        # bitwise; the measured worst case is 8.9e-08, below one float32 ulp at
-        # these magnitudes. That the remap adds no error of its own is a
-        # separate, stronger claim, asserted on-device in
-        # test_embedding_bag_byte_cuda_pruned_remap_is_exact.
-        indices, offsets = self._pruned_bags(include_last_offset)
-        weights = self._sample_weights(indices.numel()) if use_weights else None
-        self.assertEqual(
-            self._byte_rowwise_offsets(
-                q_pruned, indices, offsets, "cuda", mapping, weights,
-                include_last_offset=include_last_offset).cpu(),
-            self._byte_rowwise_offsets(
-                q_pruned, indices, offsets, "cpu", mapping, weights,
-                include_last_offset=include_last_offset),
-            rtol=0, atol=1e-6)
+    def test_embedding_bag_byte_cuda_pruned(self):
+        for include_last_offset in (False, True):
+            for use_weights in (False, True):
+                with self.subTest(include_last_offset=include_last_offset, use_weights=use_weights):
+                    _, _, q_pruned, mapping = self._pruned_byte_table()
+                    # CPU and CUDA factor the dequantization and the per-sample-weight
+                    # multiply differently, so these agree to float32 rounding rather than
+                    # bitwise; the measured worst case is 8.9e-08, below one float32 ulp at
+                    # these magnitudes. That the remap adds no error of its own is a
+                    # separate, stronger claim, asserted on-device in
+                    # test_embedding_bag_byte_cuda_pruned_remap_is_exact.
+                    indices, offsets = self._pruned_bags(include_last_offset)
+                    weights = self._sample_weights(indices.numel()) if use_weights else None
+                    self.assertEqual(
+                        self._byte_rowwise_offsets(
+                            q_pruned, indices, offsets, "cuda", mapping, weights,
+                            include_last_offset=include_last_offset).cpu(),
+                        self._byte_rowwise_offsets(
+                            q_pruned, indices, offsets, "cpu", mapping, weights,
+                            include_last_offset=include_last_offset),
+                        rtol=0, atol=1e-6)
 
-        # Bag 2 is ids [6, 9], both pruned, so it must come out as zeros -- the
-        # case the zero-weight trick exists for, asserted directly.
-        indices, offsets = self._pruned_bags()
-        all_pruned_bag = self._byte_rowwise_offsets(
-            q_pruned, indices, offsets, "cuda", mapping)[2]
-        self.assertEqual(all_pruned_bag, torch.zeros_like(all_pruned_bag),
-                         rtol=0, atol=0)
+                    # Bag 2 is ids [6, 9], both pruned, so it must come out as zeros -- the
+                    # case the zero-weight trick exists for, asserted directly.
+                    indices, offsets = self._pruned_bags()
+                    all_pruned_bag = self._byte_rowwise_offsets(
+                        q_pruned, indices, offsets, "cuda", mapping)[2]
+                    self.assertEqual(all_pruned_bag, torch.zeros_like(all_pruned_bag),
+                                     rtol=0, atol=0)
 
     """ Tests that translating the indices adds no numeric error of its own """
-    @parametrize("use_weights", [False, True])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_byte_cuda_pruned_remap_is_exact(self, use_weights):
-        # Compared against the same kernel on the same device, fed the pruned
-        # ids dropped and the kept ids already translated. A CPU reference could
-        # not make this point: it would additionally assert that FBGEMM and the
-        # CUDA kernel contract their multiply-adds identically, which is a
-        # property of the build and the GPU architecture, not of this remap.
-        _, _, q_pruned, mapping = self._pruned_byte_table()
-        indices, offsets = self._pruned_bags()
-        weights = self._sample_weights(indices.numel()) if use_weights else None
-        ref_indices, ref_offsets, ref_weights = self._drop_pruned(
-            indices, offsets, mapping, weights)
-        self.assertEqual(
-            self._byte_rowwise_offsets(
-                q_pruned, indices, offsets, "cuda", mapping, weights),
-            self._byte_rowwise_offsets(
-                q_pruned, ref_indices, ref_offsets, "cuda",
-                per_sample_weights=ref_weights, pruned_weights=False),
-            rtol=0, atol=0)
+    def test_embedding_bag_byte_cuda_pruned_remap_is_exact(self):
+        for use_weights in (False, True):
+            with self.subTest(use_weights=use_weights):
+                # Compared against the same kernel on the same device, fed the pruned
+                # ids dropped and the kept ids already translated. A CPU reference could
+                # not make this point: it would additionally assert that FBGEMM and the
+                # CUDA kernel contract their multiply-adds identically, which is a
+                # property of the build and the GPU architecture, not of this remap.
+                _, _, q_pruned, mapping = self._pruned_byte_table()
+                indices, offsets = self._pruned_bags()
+                weights = self._sample_weights(indices.numel()) if use_weights else None
+                ref_indices, ref_offsets, ref_weights = self._drop_pruned(
+                    indices, offsets, mapping, weights)
+                self.assertEqual(
+                    self._byte_rowwise_offsets(
+                        q_pruned, indices, offsets, "cuda", mapping, weights),
+                    self._byte_rowwise_offsets(
+                        q_pruned, ref_indices, ref_offsets, "cuda",
+                        per_sample_weights=ref_weights, pruned_weights=False),
+                    rtol=0, atol=0)
 
     """ Tests the single-entry "table is not pruned" sentinel mapping """
-    @parametrize("use_weights", [False, True])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_byte_cuda_pruned_sentinel(self, use_weights):
-        _, q_weights, _, _ = self._pruned_byte_table()
-        indices, offsets = self._pruned_bags()
-        zero = torch.tensor([0], dtype=torch.int32)
-        minus_one = torch.tensor([-1], dtype=torch.int32)
-        weights = self._sample_weights(indices.numel()) if use_weights else None
+    def test_embedding_bag_byte_cuda_pruned_sentinel(self):
+        for use_weights in (False, True):
+            with self.subTest(use_weights=use_weights):
+                _, q_weights, _, _ = self._pruned_byte_table()
+                indices, offsets = self._pruned_bags()
+                zero = torch.tensor([0], dtype=torch.int32)
+                minus_one = torch.tensor([-1], dtype=torch.int32)
+                weights = self._sample_weights(indices.numel()) if use_weights else None
 
-        # {0} means "not pruned", so the ids address the full table.
-        self.assertEqual(
-            self._byte_rowwise_offsets(
-                q_weights, indices, offsets, "cuda", zero, weights).cpu(),
-            self._byte_rowwise_offsets(
-                q_weights, indices, offsets, "cpu", zero, weights),
-            rtol=0, atol=1e-6)
+                # {0} means "not pruned", so the ids address the full table.
+                self.assertEqual(
+                    self._byte_rowwise_offsets(
+                        q_weights, indices, offsets, "cuda", zero, weights).cpu(),
+                    self._byte_rowwise_offsets(
+                        q_weights, indices, offsets, "cpu", zero, weights),
+                    rtol=0, atol=1e-6)
 
-        # {-1} is a single entry too, so it takes the same sentinel path here.
-        # CPU honours only {0} and reads {-1} as a real one-row mapping,
-        # rejecting these ids against its length. Telling the two apart on CUDA
-        # needs a device read, i.e. a synchronization on every call, so every
-        # single-entry mapping is taken as the sentinel. Pinned on both sides so
-        # the divergence cannot change unnoticed.
-        self.assertEqual(
-            self._byte_rowwise_offsets(
-                q_weights, indices, offsets, "cuda", minus_one, weights),
-            self._byte_rowwise_offsets(
-                q_weights, indices, offsets, "cuda", zero, weights),
-            rtol=0, atol=0)
-        # FBGEMM and the non-FBGEMM fallback word the rejection differently.
-        with self.assertRaisesRegex(
-                RuntimeError, "out of bounds|Invalid indices data"):
-            self._byte_rowwise_offsets(
-                q_weights, indices, offsets, "cpu", minus_one, weights)
+                # {-1} is a single entry too, so it takes the same sentinel path here.
+                # CPU honours only {0} and reads {-1} as a real one-row mapping,
+                # rejecting these ids against its length. Telling the two apart on CUDA
+                # needs a device read, i.e. a synchronization on every call, so every
+                # single-entry mapping is taken as the sentinel. Pinned on both sides so
+                # the divergence cannot change unnoticed.
+                self.assertEqual(
+                    self._byte_rowwise_offsets(
+                        q_weights, indices, offsets, "cuda", minus_one, weights),
+                    self._byte_rowwise_offsets(
+                        q_weights, indices, offsets, "cuda", zero, weights),
+                    rtol=0, atol=0)
+                # FBGEMM and the non-FBGEMM fallback word the rejection differently.
+                with self.assertRaisesRegex(
+                        RuntimeError, "out of bounds|Invalid indices data"):
+                    self._byte_rowwise_offsets(
+                        q_weights, indices, offsets, "cpu", minus_one, weights)
 
     """ Tests a mapping that prunes away every row of the table """
-    @parametrize("include_last_offset", [False, True])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_byte_cuda_pruned_all_rows(self, include_last_offset):
-        # Both backends must return zeros rather than index the empty table.
-        empty, mapping = self._pruned_table_of("all_pruned")
-        indices, offsets = self._pruned_bags(include_last_offset)
-        cuda = self._byte_rowwise_offsets(
-            empty, indices, offsets, "cuda", mapping,
-            include_last_offset=include_last_offset)
-        self.assertEqual(
-            cuda.cpu(),
-            self._byte_rowwise_offsets(
-                empty, indices, offsets, "cpu", mapping,
-                include_last_offset=include_last_offset),
-            rtol=0, atol=0)
-        self.assertEqual(cuda, torch.zeros_like(cuda), rtol=0, atol=0)
+    def test_embedding_bag_byte_cuda_pruned_all_rows(self):
+        for include_last_offset in (False, True):
+            with self.subTest(include_last_offset=include_last_offset):
+                # Both backends must return zeros rather than index the empty table.
+                empty, mapping = self._pruned_table_of("all_pruned")
+                indices, offsets = self._pruned_bags(include_last_offset)
+                cuda = self._byte_rowwise_offsets(
+                    empty, indices, offsets, "cuda", mapping,
+                    include_last_offset=include_last_offset)
+                self.assertEqual(
+                    cuda.cpu(),
+                    self._byte_rowwise_offsets(
+                        empty, indices, offsets, "cpu", mapping,
+                        include_last_offset=include_last_offset),
+                    rtol=0, atol=0)
+                self.assertEqual(cuda, torch.zeros_like(cuda), rtol=0, atol=0)
 
     """ Tests the inputs a lookup carrying a mapping must reject """
-    @parametrize("table", ["populated", "all_pruned"])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_byte_cuda_pruned_input_checks(self, table):
-        # Run against both table shapes: returning early for a fully pruned
-        # table must not let anything through that a populated one rejects.
-        weight, mapping = self._pruned_table_of(table)
-        indices, offsets = self._pruned_bags()
+    def test_embedding_bag_byte_cuda_pruned_input_checks(self):
+        for table in ("populated", "all_pruned"):
+            with self.subTest(table=table):
+                # Run against both table shapes: returning early for a fully pruned
+                # table must not let anything through that a populated one rejects.
+                weight, mapping = self._pruned_table_of(table)
+                indices, offsets = self._pruned_bags()
 
-        def call(mapping_tensor=None, idx=None, off=None, psw=None):
-            # Overrides are passed through untouched: a .to() here would make
-            # the sliced case contiguous again and move the CPU mapping case.
-            return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
-                weight.cuda(),
-                indices.cuda() if idx is None else idx,
-                offsets.cuda() if off is None else off, mode=0,
-                pruned_weights=True, per_sample_weights=psw,
-                compressed_indices_mapping=(mapping.cuda()
-                                            if mapping_tensor is None
-                                            else mapping_tensor),
-                include_last_offset=False)
+                def call(mapping_tensor=None, idx=None, off=None, psw=None):
+                    # Overrides are passed through untouched: a .to() here would make
+                    # the sliced case contiguous again and move the CPU mapping case.
+                    return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+                        weight.cuda(),
+                        indices.cuda() if idx is None else idx,
+                        offsets.cuda() if off is None else off, mode=0,
+                        pruned_weights=True, per_sample_weights=psw,
+                        compressed_indices_mapping=(mapping.cuda()
+                                                    if mapping_tensor is None
+                                                    else mapping_tensor),
+                        include_last_offset=False)
 
-        with self.assertRaisesRegex(TypeError, "must have dtype Int"):
-            call(mapping.long().cuda())
-        with self.assertRaisesRegex(RuntimeError, "same device as weight"):
-            call(mapping)  # left on CPU
-        with self.assertRaisesRegex(ValueError, "must not be empty"):
-            call(torch.empty(0, dtype=torch.int32, device="cuda"))
-        with self.assertRaisesRegex(RuntimeError, "1D indices"):
-            call(idx=indices.reshape(2, 6).cuda())
-        with self.assertRaisesRegex(RuntimeError, "contiguous"):
-            # Sliced after the transfer on purpose: slicing first would hand the
-            # op a contiguous copy and the check would never fire.
-            call(idx=indices.cuda().repeat_interleave(2)[::2])
-        with self.assertRaisesRegex(RuntimeError, "Per sample weights"):
-            call(psw=torch.ones(indices.numel(), dtype=torch.half,
-                                device="cuda"))
-        with self.assertRaisesRegex(RuntimeError, "32 or 64 bit indices"):
-            call(idx=indices.float().cuda())
-        with self.assertRaisesRegex(RuntimeError, "32 or 64 bit offsets"):
-            call(off=offsets.float().cuda())
-        with self.assertRaisesRegex(RuntimeError, "1D offsets"):
-            call(off=offsets.reshape(1, -1).cuda())
-        # A row narrower than the scale and bias satisfies the remainder check
-        # -- (4 - 8) % 4 is 0 -- so the lower bound has to be its own condition.
-        with self.assertRaisesRegex(RuntimeError, r"weight\.size\(1\) >= 8"):
-            torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
-                torch.zeros((2, 4), dtype=torch.uint8, device="cuda"),
-                indices.cuda(), offsets.cuda(), mode=0, pruned_weights=False,
-                per_sample_weights=None, compressed_indices_mapping=None,
-                include_last_offset=False)
+                with self.assertRaisesRegex(TypeError, "must have dtype Int"):
+                    call(mapping.long().cuda())
+                with self.assertRaisesRegex(RuntimeError, "same device as weight"):
+                    call(mapping)  # left on CPU
+                with self.assertRaisesRegex(ValueError, "must not be empty"):
+                    call(torch.empty(0, dtype=torch.int32, device="cuda"))
+                with self.assertRaisesRegex(RuntimeError, "1D indices"):
+                    call(idx=indices.reshape(2, 6).cuda())
+                with self.assertRaisesRegex(RuntimeError, "contiguous"):
+                    # Sliced after the transfer on purpose: slicing first would hand the
+                    # op a contiguous copy and the check would never fire.
+                    call(idx=indices.cuda().repeat_interleave(2)[::2])
+                with self.assertRaisesRegex(RuntimeError, "Per sample weights"):
+                    call(psw=torch.ones(indices.numel(), dtype=torch.half,
+                                        device="cuda"))
+                with self.assertRaisesRegex(RuntimeError, "32 or 64 bit indices"):
+                    call(idx=indices.float().cuda())
+                with self.assertRaisesRegex(RuntimeError, "32 or 64 bit offsets"):
+                    call(off=offsets.float().cuda())
+                with self.assertRaisesRegex(RuntimeError, "1D offsets"):
+                    call(off=offsets.reshape(1, -1).cuda())
+                # A row narrower than the scale and bias satisfies the remainder check
+                # -- (4 - 8) % 4 is 0 -- so the lower bound has to be its own condition.
+                with self.assertRaisesRegex(RuntimeError, r"weight\.size\(1\) >= 8"):
+                    torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+                        torch.zeros((2, 4), dtype=torch.uint8, device="cuda"),
+                        indices.cuda(), offsets.cuda(), mode=0, pruned_weights=False,
+                        per_sample_weights=None, compressed_indices_mapping=None,
+                        include_last_offset=False)
 
     """ Tests that a mapping is ignored unless pruned_weights is set """
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
@@ -5722,37 +5724,37 @@ class TestQuantizedEmbeddingOps(TestCase):
             rtol=0, atol=1e-6)
 
     """ Tests that indices and offsets are allowed to differ in dtype """
-    @parametrize("indices_dtype,offsets_dtype",
-                 [(torch.int64, torch.int), (torch.int, torch.int64)])
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
-    def test_embedding_bag_cuda_mixed_index_offset_dtypes(
-            self, indices_dtype, offsets_dtype):
-        # Both are read through the same index_t accessor, but the dispatch keys
-        # only on indices, so the op casts offsets to the index dtype; without
-        # the cast a mismatched pair throws from the accessor. How the pair was
-        # spelled must not change the answer, so compare against the matched
-        # call on the same device -- bitwise, and free of any CPU reference.
-        weights, _, q_pruned, mapping = self._pruned_byte_table()
-        indices, offsets = self._pruned_bags()
-        q_4bit = torch.ops.quantized.embedding_bag_4bit_prepack(weights)
+    def test_embedding_bag_cuda_mixed_index_offset_dtypes(self):
+        for indices_dtype, offsets_dtype in (
+                (torch.int64, torch.int), (torch.int, torch.int64)):
+            with self.subTest(indices_dtype=indices_dtype, offsets_dtype=offsets_dtype):
+                # Both are read through the same index_t accessor, but the dispatch keys
+                # only on indices, so the op casts offsets to the index dtype; without
+                # the cast a mismatched pair throws from the accessor. How the pair was
+                # spelled must not change the answer, so compare against the matched
+                # call on the same device -- bitwise, and free of any CPU reference.
+                weights, _, q_pruned, mapping = self._pruned_byte_table()
+                indices, offsets = self._pruned_bags()
+                q_4bit = torch.ops.quantized.embedding_bag_4bit_prepack(weights)
 
-        def run_4bit(idx, off):
-            return torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(
-                q_4bit.cuda(), idx.cuda(), off.cuda(), mode=0,
-                pruned_weights=False, per_sample_weights=None,
-                compressed_indices_mapping=None, include_last_offset=False)
+                def run_4bit(idx, off):
+                    return torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(
+                        q_4bit.cuda(), idx.cuda(), off.cuda(), mode=0,
+                        pruned_weights=False, per_sample_weights=None,
+                        compressed_indices_mapping=None, include_last_offset=False)
 
-        # The 4-bit op has no mapping support, so it is only reachable as a
-        # dense lookup; the 8-bit call goes through the remap.
-        byte_matched = self._byte_rowwise_offsets(
-            q_pruned, indices, offsets, "cuda", mapping)
-        bit4_matched = run_4bit(indices, offsets)
-        idx = indices.to(indices_dtype)
-        off = offsets.to(offsets_dtype)
-        self.assertEqual(
-            self._byte_rowwise_offsets(q_pruned, idx, off, "cuda", mapping),
-            byte_matched, rtol=0, atol=0)
-        self.assertEqual(run_4bit(idx, off), bit4_matched, rtol=0, atol=0)
+                # The 4-bit op has no mapping support, so it is only reachable as a
+                # dense lookup; the 8-bit call goes through the remap.
+                byte_matched = self._byte_rowwise_offsets(
+                    q_pruned, indices, offsets, "cuda", mapping)
+                bit4_matched = run_4bit(indices, offsets)
+                idx = indices.to(indices_dtype)
+                off = offsets.to(offsets_dtype)
+                self.assertEqual(
+                    self._byte_rowwise_offsets(q_pruned, idx, off, "cuda", mapping),
+                    byte_matched, rtol=0, atol=0)
+                self.assertEqual(run_4bit(idx, off), bit4_matched, rtol=0, atol=0)
 
     """ Tests that the 4-bit CUDA op still rejects a compressed mapping """
     @unittest.skipIf(not TEST_CUDA, "CUDA is not available")

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -5456,6 +5456,73 @@ class TestQuantizedEmbeddingOps(TestCase):
             torch.testing.assert_close(
                 run("cpu"), cuda_result, atol=atol, rtol=1e-2)
 
+    """ Tests that the CUDA embedding_bag_byte operator agrees with the CPU one
+        on pruned tables, i.e. when a compressed_indices_mapping is supplied """
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned(self):
+        num_embeddings, embedding_dim = 32, 16
+
+        weights = torch.from_numpy(np.random.uniform(
+            low=-1, high=1, size=[num_embeddings, embedding_dim]).astype(np.float32))
+        q_weights = torch.ops.quantized.embedding_bag_byte_prepack(weights)
+
+        # Prune every third row, and build the mapping from the original row
+        # space onto the compressed one. Pruned rows are marked -1.
+        mapping = np.zeros(num_embeddings, dtype=np.int32)
+        kept_rows = []
+        for i in range(num_embeddings):
+            if i % 3 == 0:
+                mapping[i] = -1
+            else:
+                mapping[i] = len(kept_rows)
+                kept_rows.append(i)
+        q_pruned = q_weights[kept_rows].contiguous()
+
+        # Bags deliberately mix kept and pruned ids, including a bag whose
+        # every id was pruned away (which must come out as zeros).
+        indices = torch.tensor(
+            [1, 2, 0, 4, 5, 3, 6, 9, 7, 8, 31, 30], dtype=torch.int)
+        offsets = torch.tensor([0, 3, 6, 8, 10], dtype=torch.int)
+        per_sample_weights = torch.from_numpy(np.random.uniform(
+            low=0.01, high=0.5, size=[indices.numel()]).astype(np.float32))
+
+        def run(device, weight, mapping_arg, weights_arg):
+            return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+                weight.to(device),
+                indices.to(device),
+                offsets.to(device),
+                mode=0,
+                pruned_weights=True,
+                per_sample_weights=(
+                    weights_arg.to(device) if weights_arg is not None else None),
+                compressed_indices_mapping=(
+                    None if mapping_arg is None
+                    else torch.from_numpy(mapping_arg).to(device)),
+                include_last_offset=False)
+
+        for weights_arg in (None, per_sample_weights):
+            # A real mapping: the indices address the original row space and
+            # are translated onto the pruned table.
+            torch.testing.assert_close(
+                run("cpu", q_pruned, mapping, weights_arg),
+                run("cuda", q_pruned, mapping, weights_arg).cpu(),
+                atol=0.005, rtol=1e-3)
+
+            # The {0} sentinel means "not pruned", so the indices address the
+            # full table directly.
+            zero_sentinel = np.array([0], dtype=np.int32)
+            torch.testing.assert_close(
+                run("cpu", q_weights, zero_sentinel, weights_arg),
+                run("cuda", q_weights, zero_sentinel, weights_arg).cpu(),
+                atol=0.005, rtol=1e-3)
+
+            # The {-1} spelling of that sentinel is rejected by the CPU op, so
+            # there is nothing to compare against; check instead that CUDA
+            # treats it as the dense lookup it denotes.
+            torch.testing.assert_close(
+                run("cuda", q_weights, np.array([-1], dtype=np.int32), weights_arg),
+                run("cuda", q_weights, None, weights_arg))
+
     """ Tests the correctness of the quantized 8 bit embedding lookup operator """
     @given(num_embeddings=st.integers(10, 100),
            embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0))

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -53,11 +53,13 @@ from torch.testing._internal.common_quantized import (
     supported_qengines,
 )
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
     IS_MACOS,
     IS_PPC,
     IS_SANDCASTLE,
+    parametrize,
     raise_on_run_directly,
     TestCase,
 )
@@ -5158,6 +5160,7 @@ class TestQuantizedLinear(TestCase):
 
 
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")
+@instantiate_parametrized_tests
 class TestQuantizedEmbeddingOps(TestCase):
 
     def _test_embedding_bag_unpack_impl(self, pack_fn, unpack_fn, bit_rate, optimized_qparams, weights):
@@ -5455,6 +5458,317 @@ class TestQuantizedEmbeddingOps(TestCase):
                 f"{bit_rate}-bit CUDA output is not finite: {cuda_result}")
             torch.testing.assert_close(
                 run("cpu"), cuda_result, atol=atol, rtol=1e-2)
+
+    # Fixtures and helpers shared by the pruned-lookup tests below.
+    _PRUNED_ROWS, _PRUNED_DIM = 32, 16
+
+    def _pruned_byte_table(self):
+        """A byte-quantized table with every third row pruned away.
+
+        Returns the float weights, the packed full table, the packed table with
+        the pruned rows removed, and the mapping from a row of the full table
+        onto a row of the pruned one (-1 marking a pruned row).
+        """
+        weights = torch.from_numpy(np.random.uniform(
+            low=-1, high=1,
+            size=[self._PRUNED_ROWS, self._PRUNED_DIM]).astype(np.float32))
+        q_weights = torch.ops.quantized.embedding_bag_byte_prepack(weights)
+        mapping = torch.empty(self._PRUNED_ROWS, dtype=torch.int32)
+        kept_rows = []
+        for i in range(self._PRUNED_ROWS):
+            if i % 3 == 0:
+                mapping[i] = -1
+            else:
+                mapping[i] = len(kept_rows)
+                kept_rows.append(i)
+        return weights, q_weights, q_weights[kept_rows].contiguous(), mapping
+
+    @staticmethod
+    def _pruned_bags(include_last_offset=False):
+        """Five bags mixing kept and pruned ids; bag 2 is entirely pruned."""
+        indices = torch.tensor(
+            [1, 2, 0, 4, 5, 3, 6, 9, 7, 8, 31, 30], dtype=torch.int)
+        offsets = [0, 3, 6, 8, 10]
+        if include_last_offset:
+            offsets.append(indices.numel())
+        return indices, torch.tensor(offsets, dtype=torch.int)
+
+    @staticmethod
+    def _byte_rowwise_offsets(weight, indices, offsets, device, mapping=None,
+                              per_sample_weights=None, pruned_weights=None,
+                              include_last_offset=False):
+        if pruned_weights is None:
+            # pruned_weights with no mapping is bad_optional_access on CPU.
+            pruned_weights = mapping is not None
+        return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+            weight.to(device), indices.to(device), offsets.to(device), mode=0,
+            pruned_weights=pruned_weights,
+            per_sample_weights=(None if per_sample_weights is None
+                                else per_sample_weights.to(device)),
+            compressed_indices_mapping=(None if mapping is None
+                                        else mapping.to(device)),
+            include_last_offset=include_last_offset)
+
+    @staticmethod
+    def _sample_weights(n):
+        return torch.from_numpy(np.random.uniform(
+            low=0.01, high=0.5, size=[n]).astype(np.float32))
+
+    @staticmethod
+    def _drop_pruned(indices, offsets, mapping, per_sample_weights=None):
+        """Rewrite the lookup with the pruned ids removed and the kept ids
+        translated into compressed row space -- the dense lookup that the remap
+        must reproduce."""
+        bounds = offsets.tolist() + [indices.numel()]
+        new_indices, new_offsets, new_weights = [], [], []
+        for bag in range(offsets.numel()):
+            new_offsets.append(len(new_indices))
+            for pos in range(bounds[bag], bounds[bag + 1]):
+                row = int(mapping[int(indices[pos])])
+                if row != -1:
+                    new_indices.append(row)
+                    if per_sample_weights is not None:
+                        new_weights.append(float(per_sample_weights[pos]))
+        return (torch.tensor(new_indices, dtype=indices.dtype),
+                torch.tensor(new_offsets, dtype=offsets.dtype),
+                (None if per_sample_weights is None
+                 else torch.tensor(new_weights, dtype=torch.float)))
+
+    def _pruned_table_of(self, kind):
+        """Either a partially or a fully pruned table, with its mapping."""
+        _, q_weights, q_pruned, mapping = self._pruned_byte_table()
+        if kind == "all_pruned":
+            return (q_weights[[]].contiguous(),
+                    torch.full((self._PRUNED_ROWS,), -1, dtype=torch.int32))
+        return q_pruned, mapping
+
+    """ Tests that CUDA embedding_bag_byte matches CPU on a pruned table """
+    @parametrize("include_last_offset", [False, True])
+    @parametrize("use_weights", [False, True])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned(self, include_last_offset, use_weights):
+        _, _, q_pruned, mapping = self._pruned_byte_table()
+        # CPU and CUDA factor the dequantization and the per-sample-weight
+        # multiply differently, so these agree to float32 rounding rather than
+        # bitwise; the measured worst case is 8.9e-08, below one float32 ulp at
+        # these magnitudes. That the remap adds no error of its own is a
+        # separate, stronger claim, asserted on-device in
+        # test_embedding_bag_byte_cuda_pruned_remap_is_exact.
+        indices, offsets = self._pruned_bags(include_last_offset)
+        weights = self._sample_weights(indices.numel()) if use_weights else None
+        self.assertEqual(
+            self._byte_rowwise_offsets(
+                q_pruned, indices, offsets, "cuda", mapping, weights,
+                include_last_offset=include_last_offset).cpu(),
+            self._byte_rowwise_offsets(
+                q_pruned, indices, offsets, "cpu", mapping, weights,
+                include_last_offset=include_last_offset),
+            rtol=0, atol=1e-6)
+
+        # Bag 2 is ids [6, 9], both pruned, so it must come out as zeros -- the
+        # case the zero-weight trick exists for, asserted directly.
+        indices, offsets = self._pruned_bags()
+        all_pruned_bag = self._byte_rowwise_offsets(
+            q_pruned, indices, offsets, "cuda", mapping)[2]
+        self.assertEqual(all_pruned_bag, torch.zeros_like(all_pruned_bag),
+                         rtol=0, atol=0)
+
+    """ Tests that translating the indices adds no numeric error of its own """
+    @parametrize("use_weights", [False, True])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned_remap_is_exact(self, use_weights):
+        # Compared against the same kernel on the same device, fed the pruned
+        # ids dropped and the kept ids already translated. A CPU reference could
+        # not make this point: it would additionally assert that FBGEMM and the
+        # CUDA kernel contract their multiply-adds identically, which is a
+        # property of the build and the GPU architecture, not of this remap.
+        _, _, q_pruned, mapping = self._pruned_byte_table()
+        indices, offsets = self._pruned_bags()
+        weights = self._sample_weights(indices.numel()) if use_weights else None
+        ref_indices, ref_offsets, ref_weights = self._drop_pruned(
+            indices, offsets, mapping, weights)
+        self.assertEqual(
+            self._byte_rowwise_offsets(
+                q_pruned, indices, offsets, "cuda", mapping, weights),
+            self._byte_rowwise_offsets(
+                q_pruned, ref_indices, ref_offsets, "cuda",
+                per_sample_weights=ref_weights, pruned_weights=False),
+            rtol=0, atol=0)
+
+    """ Tests the single-entry "table is not pruned" sentinel mapping """
+    @parametrize("use_weights", [False, True])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned_sentinel(self, use_weights):
+        _, q_weights, _, _ = self._pruned_byte_table()
+        indices, offsets = self._pruned_bags()
+        zero = torch.tensor([0], dtype=torch.int32)
+        minus_one = torch.tensor([-1], dtype=torch.int32)
+        weights = self._sample_weights(indices.numel()) if use_weights else None
+
+        # {0} means "not pruned", so the ids address the full table.
+        self.assertEqual(
+            self._byte_rowwise_offsets(
+                q_weights, indices, offsets, "cuda", zero, weights).cpu(),
+            self._byte_rowwise_offsets(
+                q_weights, indices, offsets, "cpu", zero, weights),
+            rtol=0, atol=1e-6)
+
+        # {-1} is a single entry too, so it takes the same sentinel path here.
+        # CPU honours only {0} and reads {-1} as a real one-row mapping,
+        # rejecting these ids against its length. Telling the two apart on CUDA
+        # needs a device read, i.e. a synchronization on every call, so every
+        # single-entry mapping is taken as the sentinel. Pinned on both sides so
+        # the divergence cannot change unnoticed.
+        self.assertEqual(
+            self._byte_rowwise_offsets(
+                q_weights, indices, offsets, "cuda", minus_one, weights),
+            self._byte_rowwise_offsets(
+                q_weights, indices, offsets, "cuda", zero, weights),
+            rtol=0, atol=0)
+        # FBGEMM and the non-FBGEMM fallback word the rejection differently.
+        with self.assertRaisesRegex(
+                RuntimeError, "out of bounds|Invalid indices data"):
+            self._byte_rowwise_offsets(
+                q_weights, indices, offsets, "cpu", minus_one, weights)
+
+    """ Tests a mapping that prunes away every row of the table """
+    @parametrize("include_last_offset", [False, True])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned_all_rows(self, include_last_offset):
+        # Both backends must return zeros rather than index the empty table.
+        empty, mapping = self._pruned_table_of("all_pruned")
+        indices, offsets = self._pruned_bags(include_last_offset)
+        cuda = self._byte_rowwise_offsets(
+            empty, indices, offsets, "cuda", mapping,
+            include_last_offset=include_last_offset)
+        self.assertEqual(
+            cuda.cpu(),
+            self._byte_rowwise_offsets(
+                empty, indices, offsets, "cpu", mapping,
+                include_last_offset=include_last_offset),
+            rtol=0, atol=0)
+        self.assertEqual(cuda, torch.zeros_like(cuda), rtol=0, atol=0)
+
+    """ Tests the inputs a lookup carrying a mapping must reject """
+    @parametrize("table", ["populated", "all_pruned"])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_pruned_input_checks(self, table):
+        # Run against both table shapes: returning early for a fully pruned
+        # table must not let anything through that a populated one rejects.
+        weight, mapping = self._pruned_table_of(table)
+        indices, offsets = self._pruned_bags()
+
+        def call(mapping_tensor=None, idx=None, off=None, psw=None):
+            # Overrides are passed through untouched: a .to() here would make
+            # the sliced case contiguous again and move the CPU mapping case.
+            return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+                weight.cuda(),
+                indices.cuda() if idx is None else idx,
+                offsets.cuda() if off is None else off, mode=0,
+                pruned_weights=True, per_sample_weights=psw,
+                compressed_indices_mapping=(mapping.cuda()
+                                            if mapping_tensor is None
+                                            else mapping_tensor),
+                include_last_offset=False)
+
+        with self.assertRaisesRegex(TypeError, "must have dtype Int"):
+            call(mapping.long().cuda())
+        with self.assertRaisesRegex(RuntimeError, "same device as weight"):
+            call(mapping)  # left on CPU
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            call(torch.empty(0, dtype=torch.int32, device="cuda"))
+        with self.assertRaisesRegex(RuntimeError, "1D indices"):
+            call(idx=indices.reshape(2, 6).cuda())
+        with self.assertRaisesRegex(RuntimeError, "contiguous"):
+            # Sliced after the transfer on purpose: slicing first would hand the
+            # op a contiguous copy and the check would never fire.
+            call(idx=indices.cuda().repeat_interleave(2)[::2])
+        with self.assertRaisesRegex(RuntimeError, "Per sample weights"):
+            call(psw=torch.ones(indices.numel(), dtype=torch.half,
+                                device="cuda"))
+        with self.assertRaisesRegex(RuntimeError, "32 or 64 bit indices"):
+            call(idx=indices.float().cuda())
+        with self.assertRaisesRegex(RuntimeError, "32 or 64 bit offsets"):
+            call(off=offsets.float().cuda())
+        with self.assertRaisesRegex(RuntimeError, "1D offsets"):
+            call(off=offsets.reshape(1, -1).cuda())
+        # A row narrower than the scale and bias satisfies the remainder check
+        # -- (4 - 8) % 4 is 0 -- so the lower bound has to be its own condition.
+        with self.assertRaisesRegex(RuntimeError, r"weight\.size\(1\) >= 8"):
+            torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+                torch.zeros((2, 4), dtype=torch.uint8, device="cuda"),
+                indices.cuda(), offsets.cuda(), mode=0, pruned_weights=False,
+                per_sample_weights=None, compressed_indices_mapping=None,
+                include_last_offset=False)
+
+    """ Tests that a mapping is ignored unless pruned_weights is set """
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_byte_cuda_mapping_ignored_when_not_pruned(self):
+        # CPU reads the mapping only under `if (pruned_weights)`, so a mapping
+        # passed with pruned_weights=False is a plain dense lookup on the full
+        # table. Match that rather than translating the ids anyway.
+        _, q_weights, _, mapping = self._pruned_byte_table()
+        indices, offsets = self._pruned_bags()
+        with_mapping = self._byte_rowwise_offsets(
+            q_weights, indices, offsets, "cuda", mapping, pruned_weights=False)
+        self.assertEqual(
+            with_mapping,
+            self._byte_rowwise_offsets(q_weights, indices, offsets, "cuda"),
+            rtol=0, atol=0)
+        self.assertEqual(
+            with_mapping.cpu(),
+            self._byte_rowwise_offsets(q_weights, indices, offsets, "cpu",
+                                       mapping, pruned_weights=False),
+            rtol=0, atol=1e-6)
+
+    """ Tests that indices and offsets are allowed to differ in dtype """
+    @parametrize("indices_dtype,offsets_dtype",
+                 [(torch.int64, torch.int), (torch.int, torch.int64)])
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_cuda_mixed_index_offset_dtypes(
+            self, indices_dtype, offsets_dtype):
+        # Both are read through the same index_t accessor, but the dispatch keys
+        # only on indices, so the op casts offsets to the index dtype; without
+        # the cast a mismatched pair throws from the accessor. How the pair was
+        # spelled must not change the answer, so compare against the matched
+        # call on the same device -- bitwise, and free of any CPU reference.
+        weights, _, q_pruned, mapping = self._pruned_byte_table()
+        indices, offsets = self._pruned_bags()
+        q_4bit = torch.ops.quantized.embedding_bag_4bit_prepack(weights)
+
+        def run_4bit(idx, off):
+            return torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(
+                q_4bit.cuda(), idx.cuda(), off.cuda(), mode=0,
+                pruned_weights=False, per_sample_weights=None,
+                compressed_indices_mapping=None, include_last_offset=False)
+
+        # The 4-bit op has no mapping support, so it is only reachable as a
+        # dense lookup; the 8-bit call goes through the remap.
+        byte_matched = self._byte_rowwise_offsets(
+            q_pruned, indices, offsets, "cuda", mapping)
+        bit4_matched = run_4bit(indices, offsets)
+        idx = indices.to(indices_dtype)
+        off = offsets.to(offsets_dtype)
+        self.assertEqual(
+            self._byte_rowwise_offsets(q_pruned, idx, off, "cuda", mapping),
+            byte_matched, rtol=0, atol=0)
+        self.assertEqual(run_4bit(idx, off), bit4_matched, rtol=0, atol=0)
+
+    """ Tests that the 4-bit CUDA op still rejects a compressed mapping """
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_4bit_cuda_rejects_mapping(self):
+        weights, _, _, mapping = self._pruned_byte_table()
+        indices, offsets = self._pruned_bags()
+        q_4bit = torch.ops.quantized.embedding_bag_4bit_prepack(weights)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "not yet implemented for "
+                "embedding_bag_4bit_rowwise_offsets_cuda"):
+            torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(
+                q_4bit.cuda(), indices.cuda(), offsets.cuda(), mode=0,
+                pruned_weights=True, per_sample_weights=None,
+                compressed_indices_mapping=mapping.cuda(),
+                include_last_offset=False)
 
     """ Tests the correctness of the quantized 8 bit embedding lookup operator """
     @given(num_embeddings=st.integers(10, 100),

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -5423,6 +5423,39 @@ class TestQuantizedEmbeddingOps(TestCase):
                                                sparsity=sparsity,
                                                atol=1.0, rtol=1e-1)
 
+    """ Tests that the CUDA quantized embedding_bag operators agree with their
+        CPU counterparts. This covers the bit-field extraction the dequantization
+        path is built on, which is shared by both bit widths. """
+    @unittest.skipIf(not TEST_CUDA, "CUDA is not available")
+    def test_embedding_bag_rowwise_offsets_cuda(self):
+        # 24 satisfies both ops: the byte op requires D % 4 == 0, the 4-bit op
+        # requires D % 8 == 0.
+        num_embeddings, embedding_dim = 32, 24
+        weights = torch.from_numpy((np.random.random_sample(
+            (num_embeddings, embedding_dim)) + 1).astype(np.float32))
+        indices = torch.tensor([3, 1, 4, 1, 5, 9, 2, 6], dtype=torch.int)
+        offsets = torch.tensor([0, 3, 5], dtype=torch.int)
+
+        for bit_rate, prepack_op, op, atol in (
+            (8, torch.ops.quantized.embedding_bag_byte_prepack,
+             torch.ops.quantized.embedding_bag_byte_rowwise_offsets, 0.005),
+            (4, torch.ops.quantized.embedding_bag_4bit_prepack,
+             torch.ops.quantized.embedding_bag_4bit_rowwise_offsets, 0.1),
+        ):
+            q_weights = prepack_op(weights)
+
+            def run(device, q_weights=q_weights, op=op):
+                return op(q_weights.to(device), indices.to(device),
+                          offsets.to(device), mode=0, pruned_weights=False,
+                          include_last_offset=False)
+
+            cuda_result = run("cuda").cpu()
+            self.assertTrue(
+                torch.isfinite(cuda_result).all(),
+                f"{bit_rate}-bit CUDA output is not finite: {cuda_result}")
+            torch.testing.assert_close(
+                run("cpu"), cuda_result, atol=atol, rtol=1e-2)
+
     """ Tests the correctness of the quantized 8 bit embedding lookup operator """
     @given(num_embeddings=st.integers(10, 100),
            embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0))


### PR DESCRIPTION
Summary:

`quantized::embedding_bag_byte_rowwise_offsets` takes an optional
`compressed_indices_mapping`: a table mapping an index in the original,
uncompressed row space onto a row of a pruned weight table, with `-1` marking a
pruned row. The CUDA/ROCm path never supported it — the kernel accepts the
argument and ignores it, and `embedding_bag_byte_impl` bails out with
"Compressed indices mapping not yet implemented", so pruned quantized embedding
tables were CPU-only.

## How

Translate the indices into the compressed row space, then re-enter this entry
point as an ordinary dense lookup, so the kernel is reused unchanged. This
mirrors the CPU op in `native/quantized/cpu/qembeddingbag.cpp`.

- Rows marked pruned (`-1`) must contribute nothing. CPU skips them; the dense
  kernel cannot, so the index is clamped to a valid row and its contribution
  cancelled with a zero per-sample weight. Branchless: testing for pruned rows
  on the host would synchronize the device on every call.
- A fully pruned table has no row to index, so the all-zero result is returned
  directly, which is what CPU produces.
- The caller's tensors are screened in one block at the top of the entry point.
  The remap re-enters with rewritten tensors and returns early for a fully
  pruned table, so a check left further down would inspect the wrong tensors or
  be skipped entirely.
- The mapping must be `Int` — CPU enforces that implicitly by reading it through
  `const_data_ptr<int32_t>()`, whereas here it is `index_select`'s `self`, which
  takes any dtype and would silently truncate — and must be on the weight's
  device, since a per-call host-to-device copy of a table with one entry per
  uncompressed row is not a cost to hide inside an operator.
- `indices` must be 1-D when a mapping is given. CPU accepts 2-D and synthesizes
  offsets, but that path is already dead on CUDA: `at::arange` builds those
  offsets on the host and then trips `TORCH_CHECK(offsets.is_cuda())`.

Only the 8-bit op is covered; `embedding_bag_4bit_rowwise_offsets` still rejects
a mapping.

## Deliberate divergences from CPU

All three follow from keeping a device synchronization out of the forward pass.

1. **Any single-entry mapping is read as the "not pruned" sentinel.** Two
   spellings circulate: `{0}`, which CPU honours, and `{-1}`, which at least one
   out-of-tree producer emits for "no pruning was performed". CPU reads any
   non-`{0}` single value as a genuine one-row mapping. Telling them apart needs
   a device read, so for such a mapping this does a dense lookup where CPU would
   index through it, or reject ids `>= 1` against its length. Pinned by tests on
   both sides.
2. **Out-of-range indices fault device-side** rather than raising CPU's
   "... is out of bounds: ...". Not pinned by a test: on ROCm the failure is a
   bare `abort()` that kills the process instead of raising.
3. **A pruned entry yields NaN when the data is not finite.** Cancelling with a
   zero weight is exact only for finite values, and the clamped row is still
   read, so `0 * inf = NaN` where CPU skips the entry outright.

## Cost

The remap keeps two per-index tensors alive across the launch: the translated
ids, and a float32 weight vector, because cancelling pruned rows turns an
unweighted call into a weighted one. Peak device memory grows by 8 bytes per
index for `Int` indices, 16 for `Long`. Doing the lookup inside the kernel would
remove that, but its `compressed_indices_mapping` parameter arrives as a host
`std::optional<Tensor>&` and would have to become a device accessor first, so
that is left as a follow-up.

## Also in this PR

Small fixes in the same file, each surfaced by the change or by reading around it:

- Both `embedding_bag_byte_impl` and `embedding_bag_4bit_impl` built their
  `offsets` accessor from the index type deduced from `indices`, so the
  mismatched dtype pairs their own dispatch tables enumerate threw from the
  accessor. Both now cast `offsets` first.
- The byte path's unreachable "not yet implemented" check and the device check
  beside it are removed; the 4-bit copy of that message named the 8-bit op and
  is corrected.
- `#include <ATen/ops/zeros.h>`, which the per-operator-header build needs for
  the new `at::zeros`.
- An `offsets.dim() == 1` check, and a `weight.size(1) >= 8` bound that the
  existing `(weight.size(1) - 8) % 4 == 0` does not imply, since `(4 - 8) % 4`
  is also 0.

`IndexType`/`OffsetType` are unused in both impls, so the four-way dispatch could
collapse to one call each. That is a pure deletion, but ~90 lines across two
functions, so it is left as a follow-up rather than folded in here.

Test Plan:
Eight new CUDA tests in `TestQuantizedEmbeddingOps`
(`test/quantization/core/test_quantized_op.py`), covering: CUDA against CPU on a
pruned table, across per-sample weights and `include_last_offset`; that the remap
adds no numeric error of its own, asserted bitwise on-device; the `{0}` and
`{-1}` sentinels, with CPU's divergent rejection pinned; a fully pruned table;
the input guards via `assertRaisesRegex`, over both a populated and a fully
pruned table, so the early return cannot start letting input through; a mapping
passed with `pruned_weights=False`; mixed `indices`/`offsets` dtypes for the
8-bit and the 4-bit op; and that the 4-bit op still rejects a mapping.

CPU comparisons on a populated table use `rtol=0, atol=1e-6`. They are not
bitwise, because the two kernels factor the dequant and the per-sample-weight
multiply differently, so the remaining bitwise assertions are on-device -- the
exception is the fully pruned table, where both sides are exactly zero. The worst measured CPU-vs-CUDA
difference is one float32 ulp: 8.9e-08 on AMD, 1.2e-07 on NVIDIA.

These are device-pair tests for a single operator, so they are deliberately not
`OpInfo`-based or device-generic; the adjacent pre-existing CUDA test in this
class uses the same style.

Axes such as `include_last_offset` and the per-sample weights run as `subTest`
rather than `parametrize`, so the method names stay stable: parametrization
renames them, which breaks name-based test selection and disable lists.

    python test/test_quantization.py TestQuantizedEmbeddingOps

Passes on both an AMD GPU (ROCm) and an NVIDIA H100 (sm_90, CUDA 12.4): 15 tests,
none skipped.

Reviewed By: sacdroid

Differential Revision: D115070363




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang