### PR TITLE
[Testcase Refactoring] Refactor triton extension backend tests with hw_classification

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -8,7 +8,7 @@ import torch
 import torch._dynamo
 import torch.utils.cpp_extension
 from torch._C import FileCheck
-from torch.testing._internal.common_utils import skipIfWindows
+from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
 from torch.testing._internal.inductor_utils import has_cpp_wrapper_for_device
 
 
@@ -36,9 +36,9 @@ from torch._inductor.codegen.common import (
 )
 from torch._inductor.codegen.cpu_device_op_overrides import CpuDeviceOpOverrides
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     IS_FBCODE,
     IS_MACOS,
+    instantiate_parametrized_tests,
     parametrize,
     xfailIfS390X,
 )
@@ -114,7 +114,10 @@ class BaseExtensionBackendTests(TestCase):
 
 
 @unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+@instantiate_parametrized_tests
 class ExtensionBackendTests(BaseExtensionBackendTests):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfWindows
     def test_open_device_registration(self):
         torch.utils.rename_privateuse1_backend("extension_device")
@@ -196,9 +199,6 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
             ExtensionCppWrapperCodegen,
         )
         self.assertTrue(has_cpp_wrapper_for_device(device))
-
-
-instantiate_parametrized_tests(ExtensionBackendTests)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -42,20 +42,27 @@ from torch._dynamo import device_interface
 from torch._inductor import codegen, ir, metrics
 from torch._inductor.codegen import common
 from torch._inductor.codegen.common import (
+    IndentedBuffer,
     get_scheduling_for_device,
     get_wrapper_codegen_for_device,
-    IndentedBuffer,
     register_backend_for_device,
     register_device_op_overrides,
 )
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.utils import get_triton_code, run_and_get_triton_code
-from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import (
+    IS_FBCODE,
+    IS_MACOS,
+    HardwareClassification,
+)
 from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
     HAS_CPU,
-    HAS_GPU_AND_TRITON,
+    HAS_TRITON,
     TRITON_HAS_CPU,
+    requires_triton,
 )
 
 
@@ -64,18 +71,9 @@ try:
 except ImportError:
     from test_extension_backend import BaseExtensionBackendTests
 
-if TRITON_HAS_CPU or HAS_GPU_AND_TRITON:
+if HAS_TRITON:
     import triton
     import triton.language as tl
-
-    if TRITON_HAS_CPU:
-        TRITON_DEVICE_TYPE = "cpu"
-    else:
-        TRITON_DEVICE_TYPE = GPU_TYPE
-
-requires_triton_backend = unittest.skipUnless(
-    HAS_GPU_AND_TRITON or TRITON_HAS_CPU, "Requires Triton backend."
-)
 
 
 def mock_triton_hash_with_backend(*args, **kwargs):
@@ -85,10 +83,13 @@ def mock_triton_hash_with_backend(*args, **kwargs):
 
 
 @unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
-class TritonExtensionBackendTests(BaseExtensionBackendTests):
+class TritonExtensionBackendGenericTests(BaseExtensionBackendTests):
     """
     Test creating a backend for inductor with Triton scheduling.
+    Device-agnostic tests that do not require a specific accelerator.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -151,6 +152,38 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             "tl_math.sin"
         ).check("device_str='privateuseone'").run(code)
 
+
+@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+class TritonExtensionBackendAcceleratorTests(BaseExtensionBackendTests):
+    """
+    Test creating a backend for inductor with Triton scheduling.
+    Device-specific tests that run on an accelerator (CUDA/NPU).
+    """
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if config.cpp_wrapper:
+            raise unittest.SkipTest(
+                "Not possible to fix until CppWrapperCpu supports triton for CPU"
+            )
+
+        # Store the default backends and reset later
+        common.init_backend_registration()
+
+        default_backend_patch = unittest.mock.patch.dict(inductor_lowering.lowerings)
+        default_backend_patch.start()
+        cls._default_backend_patch = default_backend_patch
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        # Restore the default backend.
+        cls._default_backend_patch.stop()
+
     def _register_custom_backend_with_heuristics(self, device):
         path_to_ext_heuristics = str(
             Path(__file__).parent / "extension_backends" / "triton"
@@ -211,14 +244,14 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             device, ExtensionTritonScheduling, ExtensionPythonWrapperCodegen
         )
 
-    @requires_triton_backend
-    def test_codegen_with_custom_heuristics_module(self):
-        self._register_custom_backend_with_heuristics(TRITON_DEVICE_TYPE)
+    @requires_triton
+    def test_codegen_with_custom_heuristics_module(self, device):
+        self._register_custom_backend_with_heuristics(device)
 
         def add(x, y):
             return x + y
 
-        x = torch.zeros((32,), device=GPU_TYPE)
+        x = torch.zeros((32,), device=device)
         y = x
         compiled_add = torch.compile(add)
 
@@ -227,9 +260,9 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             f"{EXTENSION_TRITON_META_FIELD}"
         ).check("@triton.jit").run(code)
 
-    @requires_triton_backend
-    def test_codegen_with_custom_heuristics_module_udtk(self):
-        self._register_custom_backend_with_heuristics(TRITON_DEVICE_TYPE)
+    @requires_triton
+    def test_codegen_with_custom_heuristics_module_udtk(self, device):
+        self._register_custom_backend_with_heuristics(device)
 
         @triton.jit
         def add_kernel(
@@ -258,12 +291,20 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
             return output
 
-        args = [torch.randn(32, device=GPU_TYPE) for _ in range(2)]
+        args = [torch.randn(32, device=device) for _ in range(2)]
         code = run_and_get_triton_code(torch.compile(add), *args)
 
         FileCheck().check("import extension_triton_heuristics").check(
             "@triton.jit"
         ).run(code)
+
+
+instantiate_device_type_tests(
+    TritonExtensionBackendAcceleratorTests,
+    globals(),
+    except_for=None if TRITON_HAS_CPU else "cpu",
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -50,11 +50,17 @@ from torch._inductor.codegen.common import (
 )
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.utils import get_triton_code, run_and_get_triton_code
-from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    IS_MACOS,
+)
 from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
     HAS_CPU,
-    HAS_GPU_AND_TRITON,
+    HAS_GPU,
+    HAS_TRITON,
+    requires_triton,
     TRITON_HAS_CPU,
 )
 
@@ -64,18 +70,9 @@ try:
 except ImportError:
     from test_extension_backend import BaseExtensionBackendTests
 
-if TRITON_HAS_CPU or HAS_GPU_AND_TRITON:
+if HAS_TRITON:
     import triton
     import triton.language as tl
-
-    if TRITON_HAS_CPU:
-        TRITON_DEVICE_TYPE = "cpu"
-    else:
-        TRITON_DEVICE_TYPE = GPU_TYPE
-
-requires_triton_backend = unittest.skipUnless(
-    HAS_GPU_AND_TRITON or TRITON_HAS_CPU, "Requires Triton backend."
-)
 
 
 def mock_triton_hash_with_backend(*args, **kwargs):
@@ -85,10 +82,14 @@ def mock_triton_hash_with_backend(*args, **kwargs):
 
 
 @unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
-class TritonExtensionBackendTests(BaseExtensionBackendTests):
+@unittest.skipUnless(HAS_GPU, "Requires intree GPU device")
+class TritonExtensionBackendGenericTests(BaseExtensionBackendTests):
     """
     Test creating a backend for inductor with Triton scheduling.
+    Device-agnostic tests that do not require a specific accelerator.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -151,6 +152,38 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             "tl_math.sin"
         ).check("device_str='privateuseone'").run(code)
 
+
+@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+class TritonExtensionBackendAcceleratorTests(BaseExtensionBackendTests):
+    """
+    Test creating a backend for inductor with Triton scheduling.
+    Device-specific tests that run on an accelerator (CUDA/NPU).
+    """
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if config.cpp_wrapper:
+            raise unittest.SkipTest(
+                "Not possible to fix until CppWrapperCpu supports triton for CPU"
+            )
+
+        # Store the default backends and reset later
+        common.init_backend_registration()
+
+        default_backend_patch = unittest.mock.patch.dict(inductor_lowering.lowerings)
+        default_backend_patch.start()
+        cls._default_backend_patch = default_backend_patch
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        # Restore the default backend.
+        cls._default_backend_patch.stop()
+
     def _register_custom_backend_with_heuristics(self, device):
         path_to_ext_heuristics = str(
             Path(__file__).parent / "extension_backends" / "triton"
@@ -211,14 +244,14 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             device, ExtensionTritonScheduling, ExtensionPythonWrapperCodegen
         )
 
-    @requires_triton_backend
-    def test_codegen_with_custom_heuristics_module(self):
-        self._register_custom_backend_with_heuristics(TRITON_DEVICE_TYPE)
+    @requires_triton()
+    def test_codegen_with_custom_heuristics_module(self, device):
+        self._register_custom_backend_with_heuristics(device)
 
         def add(x, y):
             return x + y
 
-        x = torch.zeros((32,), device=GPU_TYPE)
+        x = torch.zeros((32,), device=device)
         y = x
         compiled_add = torch.compile(add)
 
@@ -227,9 +260,9 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             f"{EXTENSION_TRITON_META_FIELD}"
         ).check("@triton.jit").run(code)
 
-    @requires_triton_backend
-    def test_codegen_with_custom_heuristics_module_udtk(self):
-        self._register_custom_backend_with_heuristics(TRITON_DEVICE_TYPE)
+    @requires_triton()
+    def test_codegen_with_custom_heuristics_module_udtk(self, device):
+        self._register_custom_backend_with_heuristics(device)
 
         @triton.jit
         def add_kernel(
@@ -258,12 +291,21 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
             add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
             return output
 
-        args = [torch.randn(32, device=GPU_TYPE) for _ in range(2)]
+        args = [torch.randn(32, device=device) for _ in range(2)]
         code = run_and_get_triton_code(torch.compile(add), *args)
 
         FileCheck().check("import extension_triton_heuristics").check(
             "@triton.jit"
         ).run(code)
+
+
+instantiate_device_type_tests(
+    TritonExtensionBackendAcceleratorTests,
+    globals(),
+    except_for=None if TRITON_HAS_CPU else "cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Refactor test_triton_extension_backend.py into GENERIC and ACCELERATOR
classes using hw_classification, and migrate accelerator tests to
instantiate_device_type_tests with device parameter injection. Also add
hw_classification to test_extension_backend.py for consistency.

### Changes

- Add HardwareClassification.GENERIC to ExtensionBackendTests in
  test_extension_backend.py, moving instantiate_parametrized_tests to
  a class decorator
- Split TritonExtensionBackendTests into TritonExtensionBackendGenericTests
  (GENERIC) and TritonExtensionBackendAcceleratorTests (ACCELERATOR)
- Replace HAS_GPU_AND_TRITON / TRITON_HAS_CPU module-level guard with
  HAS_TRITON, and requires_triton_backend with @requires_triton
- Migrate test_codegen_with_custom_heuristics_module and
  test_codegen_with_custom_heuristics_module_udtk to take device parameter
  injected by instantiate_device_type_tests, replacing GPU_TYPE /
  TRITON_DEVICE_TYPE hardcoding
- Add instantiate_device_type_tests for AcceleratorTests with
  except_for / allow_xpu support

### Motivation

The original test class hard-coded GPU_TYPE and TRITON_DEVICE_TYPE, tying
tests to a single device. By splitting into GENERIC and ACCELERATOR and
using instantiate_device_type_tests, accelerator tests run on CUDA, XPU,
and registered privateuse1 backends with no per-backend code duplication.

### Test Plan

```
python test/inductor/test_triton_extension_backend.py
python test/inductor/test_extension_backend.py
```