### PR TITLE
[Inductor] Account for in-place buffer reuse in peak memory estimates

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -320,6 +320,43 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 # succ nodes should be forwarded to pre mutation buffer
                 self.assertTrue(buffer_info[post][2] <= buffer_info[pre][2])
 
+    @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
+    def test_inplace_buffer_reuse_peak_memory_estimate(self):
+        def f(x, weight, bias):
+            return torch.relu(torch.nn.functional.linear(x, weight, bias))
+
+        n, k = 64, 8
+        x = torch.randn(n, k, device=GPU_TYPE)
+        weight = torch.randn(n, k, device=GPU_TYPE)
+        bias = torch.randn(n, device=GPU_TYPE)
+        buffer_size = n * n * torch.float32.itemsize
+        original_estimate = memory.estimate_peak_memory
+        cases = ((True, buffer_size), (False, 2 * buffer_size))
+
+        for inplace_buffers, expected_peak in cases:
+            estimates = []
+
+            def record_estimate(*args, **kwargs):
+                result = original_estimate(*args, **kwargs)
+                estimates.append(result[0])
+                return result
+
+            torch._dynamo.reset()
+            with (
+                config.patch(
+                    inplace_buffers=inplace_buffers,
+                    combo_kernels=False,
+                    force_disable_caches=True,
+                ),
+                mock.patch.object(memory, "estimate_peak_memory", record_estimate),
+            ):
+                code = run_and_get_triton_code(
+                    torch.compile(f, fullgraph=True), x, weight, bias
+                )
+
+            self.assertEqual(estimates[-1], expected_peak)
+            self.assertEqual("# reuse" in code, inplace_buffers)
+
     def test_fusing_reductions_increase_peak_memory(self):
         @torch.compile
         def f(a, b, c):

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -364,6 +364,26 @@ class TestOperatorReorderForPeakMemory(TestCase):
             [(100, 100), (100, 100)],
         )
 
+    def test_inplace_reuse_ignores_other_graphs(self):
+        def buffer_info(name):
+            buffer = mock.Mock()
+            buffer.get_name.return_value = name
+            return memory.BufferInfo(buffer, 100, 100, 0, 0)
+
+        infos = [buffer_info("source"), buffer_info("destination")]
+        memory._apply_inplace_reuses(
+            infos,
+            {
+                "destination": "source",
+                "other_graph_destination": "other_graph_source",
+            },
+        )
+
+        self.assertEqual(
+            [(info.size_alloc, info.size_free) for info in infos],
+            [(100, 0), (0, 100)],
+        )
+
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
     def test_inplace_buffer_reuse_peak_memory_estimate(self):
         def f(x, weight, bias):

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -320,6 +320,50 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 # succ nodes should be forwarded to pre mutation buffer
                 self.assertTrue(buffer_info[post][2] <= buffer_info[pre][2])
 
+    def test_inplace_reuse_transfers_physical_size(self):
+        def buffer_info(name, size, step):
+            buffer = mock.Mock()
+            buffer.get_name.return_value = name
+            return memory.BufferInfo(buffer, size, size, step, step)
+
+        infos = [
+            buffer_info("source", 100, 0),
+            buffer_info("middle", 98, 1),
+            buffer_info("destination", 95, 2),
+            buffer_info("later", 100, 3),
+        ]
+        memory._apply_inplace_reuses(
+            infos,
+            {
+                "destination": "middle",
+                "middle": "source",
+            },
+        )
+
+        self.assertEqual(
+            [(info.size_alloc, info.size_free) for info in infos],
+            [(100, 0), (0, 0), (0, 100), (100, 100)],
+        )
+        self.assertEqual(
+            memory.peak_memory_from_buf_info_list(infos, 4),
+            (100, [100, 100, 100, 100, 0]),
+        )
+
+    def test_inplace_reuse_rejects_cycle(self):
+        def buffer_info(name):
+            buffer = mock.Mock()
+            buffer.get_name.return_value = name
+            return memory.BufferInfo(buffer, 100, 100, 0, 0)
+
+        infos = [buffer_info("a"), buffer_info("b")]
+        with self.assertRaisesRegex(AssertionError, "must not contain a cycle"):
+            memory._apply_inplace_reuses(infos, {"a": "b", "b": "a"})
+
+        self.assertEqual(
+            [(info.size_alloc, info.size_free) for info in infos],
+            [(100, 100), (100, 100)],
+        )
+
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
     def test_inplace_buffer_reuse_peak_memory_estimate(self):
         def f(x, weight, bias):

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -384,6 +384,18 @@ class TestOperatorReorderForPeakMemory(TestCase):
             [(100, 0), (0, 100)],
         )
 
+    def test_inplace_reuse_of_untracked_input(self):
+        buffer = mock.Mock()
+        buffer.get_name.return_value = "destination"
+        infos = [memory.BufferInfo(buffer, 100, 100, 0, 0)]
+
+        memory._apply_inplace_reuses(infos, {"destination": "graph_input"})
+
+        self.assertEqual(
+            [(info.size_alloc, info.size_free) for info in infos],
+            [(0, 0)],
+        )
+
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
     def test_inplace_buffer_reuse_peak_memory_estimate(self):
         def f(x, weight, bias):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -18544,9 +18544,9 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     @staticmethod
     def _is_triggering_buffer_reuse(fn, *inputs):
-        with config.patch(allow_buffer_reuse=True):
+        with config.patch(allow_buffer_reuse=True, inplace_buffers=False):
             _, (code_allowed,) = run_and_get_code(fn, *inputs)
-        with config.patch(allow_buffer_reuse=False):
+        with config.patch(allow_buffer_reuse=False, inplace_buffers=False):
             _, (code_disallowed,) = run_and_get_code(fn, *inputs)
         code_allowed = re.sub(r"AOT ID: .*", "AOT ID: ['test']", code_allowed)
         code_disallowed = re.sub(r"AOT ID: .*", "AOT ID: ['test']", code_disallowed)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -961,6 +961,7 @@ class EfficientPeakEstimate:
             scheduler_nodes,
             names_to_freeable_bufs,
             graph_outputs,
+            inplace_reuses=V.graph.wrapper_code.reuses,
         )
 
         from .segmented_tree import SegmentedTree

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -347,6 +347,7 @@ def compute_memory_timeline(
     nodes: list[BaseSchedulerNode],
     name_to_freeable_input_buf: dict[str, FreeableInputBuffer],
     graph_outputs: OrderedSet[str],
+    inplace_reuses: dict[str, str] | None = None,
 ) -> tuple[
     list[BufferInfo],
     dict[BaseSchedulerNode, int],
@@ -432,6 +433,15 @@ def compute_memory_timeline(
                 )
             )
 
+    if inplace_reuses:
+        reused_inputs = OrderedSet(inplace_reuses.values())
+        for buf_info in buf_info_list:
+            name = buf_info.buffer.get_name()
+            if name in inplace_reuses:
+                buf_info.size_alloc = 0
+            if name in reused_inputs:
+                buf_info.size_free = 0
+
     return buf_info_list, node_to_step, buf_to_snode_last_use
 
 
@@ -487,6 +497,7 @@ def estimate_peak_memory(
     nodes: list[BaseSchedulerNode],
     name_to_freeable_input_buf: dict[str, FreeableInputBuffer],
     graph_outputs: OrderedSet[str],
+    inplace_reuses: dict[str, str] | None = None,
 ) -> tuple[int, list[int]]:
     """
     Given a list of nodes in their execution order, estimate the peak memory, by
@@ -497,7 +508,7 @@ def estimate_peak_memory(
         List[int]: memory usage at each node (or each step).
     """
     buf_info_list, _, _ = compute_memory_timeline(
-        nodes, name_to_freeable_input_buf, graph_outputs
+        nodes, name_to_freeable_input_buf, graph_outputs, inplace_reuses
     )
     return peak_memory_from_buf_info_list(buf_info_list, len(nodes))
 

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -348,6 +348,11 @@ def _apply_inplace_reuses(
 ) -> None:
     """Transfer physical allocation ownership through in-place reuse chains."""
     name_to_buf_info = {info.buffer.get_name(): info for info in buf_info_list}
+    inplace_reuses = {
+        output_name: input_name
+        for output_name, input_name in inplace_reuses.items()
+        if output_name in name_to_buf_info
+    }
     original_size_free = {
         name: info.size_free for name, info in name_to_buf_info.items()
     }

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -374,12 +374,13 @@ def _apply_inplace_reuses(
     for output_name in inplace_reuses:
         name_to_buf_info[output_name].size_alloc = 0
     for input_name in reused_inputs:
-        name_to_buf_info[input_name].size_free = 0
+        if input_name in name_to_buf_info:
+            name_to_buf_info[input_name].size_free = 0
 
     for output_name in inplace_reuses.keys() - reused_inputs:
-        name_to_buf_info[output_name].size_free = original_size_free[
-            sources[output_name]
-        ]
+        name_to_buf_info[output_name].size_free = original_size_free.get(
+            sources[output_name], 0
+        )
 
 
 def compute_memory_timeline(

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -343,6 +343,40 @@ class BufferInfo:
     end_step: int
 
 
+def _apply_inplace_reuses(
+    buf_info_list: list[BufferInfo], inplace_reuses: dict[str, str]
+) -> None:
+    """Transfer physical allocation ownership through in-place reuse chains."""
+    name_to_buf_info = {info.buffer.get_name(): info for info in buf_info_list}
+    original_size_free = {
+        name: info.size_free for name, info in name_to_buf_info.items()
+    }
+    reused_inputs = OrderedSet(inplace_reuses.values())
+    sources: dict[str, str] = {}
+
+    for output_name in inplace_reuses:
+        source_name = output_name
+        path = OrderedSet[str]()
+        while source_name in inplace_reuses and source_name not in sources:
+            if source_name in path:
+                raise AssertionError("in-place reuse chain must not contain a cycle")
+            path.add(source_name)
+            source_name = inplace_reuses[source_name]
+        source_name = sources.get(source_name, source_name)
+        for name in path:
+            sources[name] = source_name
+
+    for output_name in inplace_reuses:
+        name_to_buf_info[output_name].size_alloc = 0
+    for input_name in reused_inputs:
+        name_to_buf_info[input_name].size_free = 0
+
+    for output_name in inplace_reuses.keys() - reused_inputs:
+        name_to_buf_info[output_name].size_free = original_size_free[
+            sources[output_name]
+        ]
+
+
 def compute_memory_timeline(
     nodes: list[BaseSchedulerNode],
     name_to_freeable_input_buf: dict[str, FreeableInputBuffer],
@@ -434,13 +468,7 @@ def compute_memory_timeline(
             )
 
     if inplace_reuses:
-        reused_inputs = OrderedSet(inplace_reuses.values())
-        for buf_info in buf_info_list:
-            name = buf_info.buffer.get_name()
-            if name in inplace_reuses:
-                buf_info.size_alloc = 0
-            if name in reused_inputs:
-                buf_info.size_free = 0
+        _apply_inplace_reuses(buf_info_list, inplace_reuses)
 
     return buf_info_list, node_to_step, buf_to_snode_last_use
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192578

Inductor’s final wrapper peak-memory estimate counted in-place-reused buffers as separate allocations. The confirmed reuse map was available after code generation but was not included in memory timeline construction.

Pass the reuse map to the final estimate and transfer allocation/free ownership across reuse edges. Pre-codegen scheduler estimates remain conservative.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo