### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_functionalization.py

### DIFF
--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -19,6 +19,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.passes.reinplace import reinplace
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
@@ -83,6 +84,7 @@ def _functionalize(
     TEST_WITH_TORCHDYNAMO, "https://github.com/pytorch/pytorch/issues/81457"
 )
 class TestFunctionalization(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     crossref = False
 
     def get_logs(self, func, *inpts, reapply_views=False, run_reinplace=False):
@@ -2359,10 +2361,12 @@ def forward(self, arg0_1):
     TEST_WITH_TORCHDYNAMO, "dynamo-ing code with proxy + fake doesn't work well"
 )
 class TestCrossRefFunctionalization(TestFunctionalization):
+    hw_classification = HardwareClassification.GENERIC
     crossref = True
 
 
 class TestViewMetaSerialization(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     # Exercise to_serializable_tuple() via as_tuple() and pickle, covering each
     # element kind that used to be a dangling reference: std::vector (resize_/
     # _unsafe_view_), const at::Tensor& (_make_dual), and const


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestFunctionalization, TestCrossRefFunctionalization, TestViewMetaSerialization as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/test_functionalization.py : import HardwareClassification, and add hw_classification to TestFunctionalization, TestCrossRefFunctionalization, TestViewMetaSerialization classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/test_functionalization.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.