### PR TITLE
[Testcase Refactoring] Add HardwareClassification for test_fake_backend_new_group

### DIFF
--- a/test/distributed/test_fake_backend_new_group.py
+++ b/test/distributed/test_fake_backend_new_group.py
@@ -19,10 +19,16 @@ import os
 
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class FakeBackendNewGroupTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
         os.environ.setdefault("MASTER_PORT", "29517")


### PR DESCRIPTION
## Summary
Add `HardwareClassification` (GENERIC) to `test_fake_backend_new_group` to label its tests as device-agnostic.

## Changes
- Add `hw_classification = HardwareClassification.GENERIC` to `FakeBackendNewGroupTest`; the suite exercises fake-backend subgroup routing with gloo as the setup vehicle (not the system under test) and touches no accelerator, so it classifies as device-agnostic.

## Motivation
Part of the test case refactoring initiative to label tests by hardware classification so device-generic logic tests are discoverable and filterable, independent of any specific accelerator backend.

## Notes
This is part of the test case refactoring initiative tracked in #185590.