### PR TITLE
[Testcase Refactoring] Add HardwareClassification for test_c10d_hooks

### DIFF
--- a/test/distributed/test_c10d_hooks.py
+++ b/test/distributed/test_c10d_hooks.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 from torch._C._distributed_c10d import HookOpName
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.testing._internal.common_distributed import MultiProcessTestCase
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 class TestProcessGroupHooks(MultiProcessTestCase):
@@ -20,6 +20,8 @@ class TestProcessGroupHooks(MultiProcessTestCase):
     pure-Python or fake ProcessGroup overrides the collective methods and
     dispatches without going through the c10d ops, so it bypasses these hooks.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary
Add `HardwareClassification` (GENERIC) to `test_c10d_hooks` to label its tests as device-agnostic.

## Changes
- Add `hw_classification = HardwareClassification.GENERIC` to `TestProcessGroupHooks`; the suite verifies c10d dispatcher hook dispatch over a gloo process group used as the vehicle (not the system under test) and touches no accelerator, so it classifies as device-agnostic.

## Motivation
Part of the test case refactoring initiative to label tests by hardware classification so device-generic logic tests are discoverable and filterable, independent of any specific accelerator backend.

## Notes
This is part of the test case refactoring initiative tracked in #185590.