### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_z3_gradual_types.py 

### DIFF
--- a/test/fx/test_z3_gradual_types.py
+++ b/test/fx/test_z3_gradual_types.py
@@ -29,7 +29,7 @@ from torch.fx.experimental.migrate_gradual_types.transform_to_z3 import (
 from torch.fx.experimental.migrate_gradual_types.z3_types import D, tensor_type, z3_dyn
 from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.tensor_type import Dyn, TensorType
-from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 try:
@@ -49,7 +49,7 @@ except ImportError:
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 
-class TorchDynamoUseCases(unittest.TestCase):
+class TorchDynamoUseCases(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_dim(self):
@@ -89,7 +89,7 @@ class TorchDynamoUseCases(unittest.TestCase):
         # print(s.model()[dim])
 
 
-class HFOperations(unittest.TestCase):
+class HFOperations(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_eq_dim(self):
@@ -1224,7 +1224,7 @@ class HFOperations(unittest.TestCase):
         self.assertEqual(negative, z3.sat)
 
 
-class ComposeOperationsGradualTypes(unittest.TestCase):
+class ComposeOperationsGradualTypes(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_masked_fill(self):
@@ -1501,7 +1501,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         self.assertEqual(solver.check(), z3.unsat)
 
 
-class GradualTypes(unittest.TestCase):
+class GradualTypes(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_conv_reshape_unsat(self):
@@ -1699,7 +1699,7 @@ class GradualTypes(unittest.TestCase):
             )
 
 
-class TestSingleOperation(unittest.TestCase):
+class TestSingleOperation(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_conv_wrong_example(self):
@@ -2601,7 +2601,7 @@ class TestSingleOperation(unittest.TestCase):
         self.assertEqual(solver.check(), z3.unsat)
 
 
-class ConstraintGeneration(unittest.TestCase):
+class ConstraintGeneration(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_add_reshape(self):
@@ -2660,7 +2660,7 @@ class ConstraintGeneration(unittest.TestCase):
             )
 
 
-class TestInternalConstraints(unittest.TestCase):
+class TestInternalConstraints(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_precision(self):
@@ -2711,7 +2711,7 @@ class TestInternalConstraints(unittest.TestCase):
 
 
 @skipIfNoTorchVision
-class TestResNet(unittest.TestCase):
+class TestResNet(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_resnet50_unsat(self):
@@ -2792,7 +2792,7 @@ class TestResNet(unittest.TestCase):
 
 
 @skipIfNoTorchVision
-class TestAlexNet(unittest.TestCase):
+class TestAlexNet(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_alexnet1(self):
@@ -2905,4 +2905,4 @@ class TestAlexNet(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    run_tests()

--- a/test/fx/test_z3_gradual_types.py
+++ b/test/fx/test_z3_gradual_types.py
@@ -29,6 +29,7 @@ from torch.fx.experimental.migrate_gradual_types.transform_to_z3 import (
 from torch.fx.experimental.migrate_gradual_types.z3_types import D, tensor_type, z3_dyn
 from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.tensor_type import Dyn, TensorType
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 try:
@@ -49,6 +50,8 @@ skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 
 class TorchDynamoUseCases(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dim(self):
         class BasicBlock(torch.nn.Module):
             def forward(self, x: TensorType([1, 2])):
@@ -87,6 +90,8 @@ class TorchDynamoUseCases(unittest.TestCase):
 
 
 class HFOperations(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_eq_dim(self):
         """
         test dimensions and equalities
@@ -1220,6 +1225,8 @@ class HFOperations(unittest.TestCase):
 
 
 class ComposeOperationsGradualTypes(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_masked_fill(self):
         class BasicBlock(torch.nn.Module):
             def forward(self, x: TensorType([2, 4])):
@@ -1495,6 +1502,8 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
 
 
 class GradualTypes(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_conv_reshape_unsat(self):
         class BasicBlock(torch.nn.Module):
             def __init__(
@@ -1691,6 +1700,8 @@ class GradualTypes(unittest.TestCase):
 
 
 class TestSingleOperation(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_conv_wrong_example(self):
         class BasicBlock(torch.nn.Module):
             def __init__(self) -> None:
@@ -2591,6 +2602,8 @@ class TestSingleOperation(unittest.TestCase):
 
 
 class ConstraintGeneration(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_add_reshape(self):
         class BasicBlock(torch.nn.Module):
             def forward(self, x: Dyn, y: Dyn):
@@ -2648,6 +2661,8 @@ class ConstraintGeneration(unittest.TestCase):
 
 
 class TestInternalConstraints(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_precision(self):
         c1 = BinConstraintT(Dyn, TVar("x"), op_precision)
         transformed, _ = transform_constraint(c1, 0)
@@ -2697,6 +2712,8 @@ class TestInternalConstraints(unittest.TestCase):
 
 @skipIfNoTorchVision
 class TestResNet(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_resnet50_unsat(self):
         traced = symbolic_trace(models.resnet50())
         for n in traced.graph.nodes:
@@ -2776,6 +2793,8 @@ class TestResNet(unittest.TestCase):
 
 @skipIfNoTorchVision
 class TestAlexNet(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_alexnet1(self):
         alexnet = models.alexnet()
         symbolic_traced: torch.fx.GraphModule = symbolic_trace(alexnet)

--- a/test/fx/test_z3_gradual_types.py
+++ b/test/fx/test_z3_gradual_types.py
@@ -29,7 +29,11 @@ from torch.fx.experimental.migrate_gradual_types.transform_to_z3 import (
 from torch.fx.experimental.migrate_gradual_types.z3_types import D, tensor_type, z3_dyn
 from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.tensor_type import Dyn, TensorType
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 try:


### PR DESCRIPTION
## Summary
add hw_classification attribute (TorchDynamoUseCases, HFOperations, ComposeOperationsGradualTypes, GradualTypes, TestSingleOperation, ConstraintGeneration, TestInternalConstraints, TestResNet, TestAlexNet as GENERIC classes), enabling hardware-based test classification and filtering.

## Changes
test/fx/test_z3_gradual_types.py : import HardwareClassification, and add hw_classification to TorchDynamoUseCases, HFOperations, ComposeOperationsGradualTypes, GradualTypes, TestSingleOperation, ConstraintGeneration, TestInternalConstraints, TestResNet, TestAlexNet classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/fx/test_z3_gradual_types.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.