### PR TITLE
[Testcase Refactoring] Add hw_classification in test/higher_order_ops/test_print.py

### DIFF
--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -710,10 +710,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         return 4
 
     @with_comms
-    def test_print_dtensor_basic(self):
+    def test_print_dtensor_basic(self, device):
         """Sharded DTensor prints local shard on all ranks."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(8, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -731,10 +731,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(output, expected)
 
     @with_comms
-    def test_print_dtensor_replicate(self):
+    def test_print_dtensor_replicate(self, device):
         """Replicated DTensor prints full tensor on all ranks."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.tensor([1.0, 2.0, 3.0], device=self.device_type)
+        full_tensor = torch.tensor([1.0, 2.0, 3.0], device=device)
         dtensor = DTensor.from_local(full_tensor, device_mesh, [Replicate()])
 
         def f(x):
@@ -758,10 +758,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(compiled_output, expected)
 
     @with_comms
-    def test_print_dtensor_format_str(self):
+    def test_print_dtensor_format_str(self, device):
         """Test both positional and keyword sharded DTensor args in format strings."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(4, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -783,10 +783,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(kw_output, f"[rank {self.rank}] kw: {local_shard}\n")
 
     @with_comms
-    def test_print_dtensor_mixed_args(self):
+    def test_print_dtensor_mixed_args(self, device):
         """Mix sharded DTensor and scalar args in a single print call."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(4, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -800,10 +800,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(output, f"[rank {self.rank}] dt: {local_shard} scalar: 42\n")
 
     @with_comms
-    def test_print_dtensor_multiple_prints(self):
+    def test_print_dtensor_multiple_prints(self, device):
         """Multiple sharded DTensor prints with intermediate computations."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(4, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -825,10 +825,10 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(output, expected)
 
     @with_comms
-    def test_print_dtensor_kwargs(self):
+    def test_print_dtensor_kwargs(self, device):
         """Sharded DTensor print with kwargs."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(4, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -846,10 +846,10 @@ class TestHopPrintDTensor(DTensorTestBase):
 
     @with_comms
     @skipIfTorchDynamo("Skipped under Dynamo")
-    def test_print_dtensor_inductor_output_code(self):
+    def test_print_dtensor_inductor_output_code(self, device):
         """Verify inductor generated code contains print for replicated DTensor."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(8, dtype=torch.float, device=device)
         dtensor = DTensor.from_local(full_tensor, device_mesh, [Replicate()])
 
         def f(x):
@@ -875,10 +875,10 @@ class TestHopPrintDTensor(DTensorTestBase):
 
     @with_comms
     @skipIfTorchDynamo("Skipped under Dynamo")
-    def test_print_dtensor_compiled_sharded(self):
+    def test_print_dtensor_compiled_sharded(self, device):
         """Verify compiled sharded DTensor prints match eager output per rank."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
+        full_tensor = torch.arange(8, dtype=torch.float, device=device)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 

--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
-
 if torch.distributed.is_available():
     from torch.distributed.tensor import DTensor, Replicate, Shard
     from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -29,6 +28,8 @@ if torch.distributed.is_available():
 else:
     DTensorTestBase = TestCase  # type: ignore[assignment, misc]
     with_comms = lambda fn: fn  # type: ignore[assignment]  # noqa: E731
+
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 
 @instantiate_parametrized_tests
@@ -902,6 +903,7 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(compiled_result.to_local(), eager_result.to_local())
         self.assertEqual(compiled_output, expected)
 
+instantiate_device_type_tests(TestHopPrintDTensor, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -714,7 +714,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_basic(self, device):
         """Sharded DTensor prints local shard on all ranks."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=device)
+        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -735,7 +735,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_replicate(self, device):
         """Replicated DTensor prints full tensor on all ranks."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.tensor([1.0, 2.0, 3.0], device=device)
+        full_tensor = torch.tensor([1.0, 2.0, 3.0], device=self.device_type)
         dtensor = DTensor.from_local(full_tensor, device_mesh, [Replicate()])
 
         def f(x):
@@ -762,7 +762,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_format_str(self, device):
         """Test both positional and keyword sharded DTensor args in format strings."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=device)
+        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -787,7 +787,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_mixed_args(self, device):
         """Mix sharded DTensor and scalar args in a single print call."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=device)
+        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -804,7 +804,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_multiple_prints(self, device):
         """Multiple sharded DTensor prints with intermediate computations."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=device)
+        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -829,7 +829,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_kwargs(self, device):
         """Sharded DTensor print with kwargs."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(4, dtype=torch.float, device=device)
+        full_tensor = torch.arange(4, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 
@@ -850,7 +850,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_inductor_output_code(self, device):
         """Verify inductor generated code contains print for replicated DTensor."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=device)
+        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
         dtensor = DTensor.from_local(full_tensor, device_mesh, [Replicate()])
 
         def f(x):
@@ -879,7 +879,7 @@ class TestHopPrintDTensor(DTensorTestBase):
     def test_print_dtensor_compiled_sharded(self, device):
         """Verify compiled sharded DTensor prints match eager output per rank."""
         device_mesh = self.build_device_mesh()
-        full_tensor = torch.arange(8, dtype=torch.float, device=device)
+        full_tensor = torch.arange(8, dtype=torch.float, device=self.device_type)
         local_shard = full_tensor.chunk(self.world_size)[self.rank]
         dtensor = DTensor.from_local(local_shard, device_mesh, [Shard(0)])
 

--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -10,6 +10,7 @@ from torch._functorch.aot_autograd import aot_export_module
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -32,6 +33,8 @@ else:
 
 @instantiate_parametrized_tests
 class TestHopPrint(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -699,6 +702,8 @@ def forward(self, arg1_1):
     not torch.distributed.is_available(), "torch.distributed not available"
 )
 class TestHopPrintDTensor(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4

--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
+
 if torch.distributed.is_available():
     from torch.distributed.tensor import DTensor, Replicate, Shard
     from torch.testing._internal.distributed._tensor.common_dtensor import (

--- a/test/higher_order_ops/test_print.py
+++ b/test/higher_order_ops/test_print.py
@@ -904,6 +904,7 @@ class TestHopPrintDTensor(DTensorTestBase):
         self.assertEqual(compiled_result.to_local(), eager_result.to_local())
         self.assertEqual(compiled_output, expected)
 
+
 instantiate_device_type_tests(TestHopPrintDTensor, globals())
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
add hw_classification attribute (TestHopPrint as GENERIC; TestHopPrintDTensor as ACCELERATOR classes), enabling hardware-based test classification and filtering.

## Changes
test/higher_order_ops/test_print.py : import HardwareClassification, and add hw_classification to TestHopPrint, TestHopPrintDTensor classes.

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python -m pytest -q test/higher_order_ops/test_print.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.