### PR TITLE
Reject overlapping out= tensors in torch.linalg.qr

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/Dispatch.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
 #include <ATen/TensorSubclassLikeUtils.h>
@@ -707,6 +708,17 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
   at::native::checkIsMatrix(A, "linalg.qr");
   at::native::checkFloatingOrComplex(A, "linalg.qr");
   auto [compute_q, reduced_mode] = at::native::_parse_qr_mode(mode);
+
+  // Aliased out= tensors would silently corrupt the result (gh-180377). This
+  // must be checked before set_output_strided: after it, maybe_get_output may
+  // return a freshly allocated proxy instead of the user-provided tensor.
+  const auto& Q_out = maybe_get_output(0);
+  const auto& R_out = maybe_get_output(1);
+  if (Q_out.defined() && R_out.defined()) {
+    at::assert_no_internal_overlap(Q_out);
+    at::assert_no_internal_overlap(R_out);
+    at::assert_no_overlap(Q_out, R_out);
+  }
 
   auto A_shape = A.sizes().vec();
   const auto m = A_shape.cend()[-2];

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4476,6 +4476,38 @@ class TestLinalg(TestCase):
         with self.assertRaisesRegex(RuntimeError, "qr received unrecognized mode 'hello'"):
             torch.linalg.qr(t2, mode='hello')
 
+    @skipCPUIfNoLapack
+    @skipCUDAIfNoCusolver
+    @dtypes(torch.float)
+    def test_qr_out_overlapping(self, device, dtype):
+        # Overlapping out= tensors used to silently corrupt the result or hit
+        # an internal assert instead of raising a proper error (gh-180377)
+        overlap_msg = "refer to a single memory location"
+        for shape in ((4, 4), (3, 5)):
+            A = torch.randn(shape, device=device, dtype=dtype)
+            B = torch.zeros_like(A)
+            with self.assertRaisesRegex(RuntimeError, overlap_msg):
+                torch.linalg.qr(A, out=(B, B))
+        A = torch.randn(4, 4, device=device, dtype=dtype)
+        # F-contiguous outs take the impl path with no stride proxies
+        B = torch.zeros(4, 4, device=device, dtype=dtype).t()
+        with self.assertRaisesRegex(RuntimeError, overlap_msg):
+            torch.linalg.qr(A, out=(B, B))
+        A = torch.randn(2, 2, device=device, dtype=dtype)
+        buf = torch.zeros(6, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, overlap_msg):
+            torch.linalg.qr(A, out=(buf[0:4].view(2, 2), buf[2:6].view(2, 2)))
+        A = torch.randn(4, 4, device=device, dtype=dtype)
+        expanded = torch.zeros((1, 4), device=device, dtype=dtype).expand(4, 4)
+        with self.assertRaisesRegex(RuntimeError, "more than one element of the written-to tensor"):
+            torch.linalg.qr(A, out=(torch.zeros_like(A), expanded))
+        # the conventional empty Q of mode='r' never overlaps R
+        A = torch.randn(3, 3, device=device, dtype=dtype)
+        Q = torch.empty(0, device=device, dtype=dtype)
+        R = torch.empty_like(A)
+        torch.linalg.qr(A, mode='r', out=(Q, R))
+        self.assertEqual(R, torch.linalg.qr(A, mode='r').R)
+
     def _check_einsum(self, *args, np_args=None):
         if np_args is None:
             np_args = [arg.cpu().numpy() if isinstance(arg, torch.Tensor) else arg for arg in args]


### PR DESCRIPTION
Fixes #180377. Also fixes the internal assert crash from #154356 (same root cause).

torch.linalg.qr(X, out=(B, B)) silently returned wrong results when the same tensor was passed for Q and R. For C-contiguous B the structured-kernel stride proxies compute correct Q and R separately and then both get copied back into the same tensor, so B ends up holding only R and Q is lost. For F-contiguous B the impl sees the aliasing directly, takes the workspace branch meant for "packed QR lives in R", triu_()s away the Householder vectors and then orgqr reconstructs Q from zeros. For non-square inputs it hits TORCH_INTERNAL_ASSERT(Q.size(-1) == m), which is the crash in #154356.

This adds the standard overlap checks (assert_no_overlap between Q and R plus assert_no_internal_overlap on each) at the top of the qr meta function, the same pattern the gather/scatter metas use. The check has to run before set_output_strided: after that point maybe_get_output can return a freshly allocated stride proxy instead of the user tensor, so the aliasing would be invisible. The conventional empty Q used with mode='r' still works since zero-numel tensors never report overlap.

Scope note: this intentionally only checks the two out tensors against each other, not against the input. qr(X, out=(X, R)) with square X currently produces correct results (the workspace design tolerates it), so forbidding input aliasing would be a behavior change beyond this issue.

Known limitations, all shared with the other assert_no_overlap users (gather etc.) and all requiring more contrived inputs than the reported bug: non-dense overlapping views report MemOverlapStatus::TooHard and pass; outs that only start overlapping after resize_out (zero-numel or wrong-sized views into one buffer, already deprecated usage) are checked pre-resize because post-set_output the meta only sees the stride proxies; conj-view outs are materialized by the MathBits fallback before the meta runs; and the Python meta registration (fake/meta tracing) does not model the check, matching other ops - real executions under torch.compile still raise at runtime.