### PR TITLE
[fx] CSEPass: compare constants bitwise and type-tag hashed args

### DIFF
--- a/test/fx/test_cse_pass.py
+++ b/test/fx/test_cse_pass.py
@@ -243,6 +243,33 @@ class TestCSEPass(TestCase):
         check(self, f, t, 0, P=P_ban_add)  # check that add is banned
         check(self, f, t, 1)  # check that add is not banned by default
 
+    def test_nan_dedup(self):
+        def f(x):
+            a = torch.full_like(x, float("nan"))
+            b = torch.full_like(x, float("nan"))
+            return a + b
+
+        t = torch.randn(2, 2)
+        check(self, f, t, 1, check_val=False)
+
+    def test_neg_zero_not_merged(self):
+        def f(x):
+            a = torch.full_like(x, 0.0)
+            b = torch.full_like(x, -0.0)
+            return torch.stack([a.reciprocal(), b.reciprocal()])
+
+        t = torch.randn(2, 2)
+        check(self, f, t, 0)
+
+    def test_int_float_not_merged(self):
+        def f(x):
+            a = x + 1
+            b = x + 1.0
+            return a + b
+
+        t = torch.randint(0, 10, (2, 2))
+        check(self, f, t, 0)
+
     def test_rand_like(self):
         def f(x):
             a = torch.rand_like(x)

--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -1,3 +1,5 @@
+import dataclasses
+import struct
 from typing import Any
 
 import torch
@@ -8,6 +10,22 @@ from torch.utils._pytree import tree_flatten
 
 
 aten = torch.ops.aten
+
+
+@dataclasses.dataclass(frozen=True)
+class _ScalarKey:
+    tag: str
+    bits: bytes
+
+
+def _normalize_cse_arg(val: Any) -> Any:
+    # Python float hash/eq is not value-identity: nan != nan (hash(nan) is
+    # id-based) while -0.0 == 0.0 and hashes equal. Key by bit pattern instead.
+    if type(val) is float:
+        return _ScalarKey("float", struct.pack(">d", val))
+    if type(val) is complex:
+        return _ScalarKey("complex", struct.pack(">dd", val.real, val.imag))
+    return val
 
 
 # stateful ops are banned from CSE
@@ -121,6 +139,7 @@ class CSEPass(PassBase):
                         v = arg_list[i]
                         if isinstance(v, Node) and v in env:
                             arg_list[i] = env[v]
+                        arg_list[i] = _normalize_cse_arg(arg_list[i])
                     return tuple(arg_list), spec
 
                 args, args_spec = substitute(n.args)
@@ -137,7 +156,14 @@ class CSEPass(PassBase):
                 }
 
                 # hash substituted args to a number, do not hash specs because specs are not hashable
-                hash_arg = hash((args, kwargs))
+                # We need to add type into hash to avoid situations like:
+                # hash((primals_2, 1.0)) == hash((primals_2, 1))
+                hash_arg = hash(
+                    (
+                        tuple((a, type(a)) for a in args),
+                        tuple((a, type(a)) for a in kwargs),
+                    )
+                )
                 hash_val = (n.target, hash_arg)
 
                 # check if a node has a substitute and can be eliminated


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192597

Python float eq/hash is not value-identity: nan != nan (and hash(nan) is
id-based, so distinct NaN objects hash differently) while -0.0 == 0.0 (and
they hash equal). CSEPass keyed nodes on hash((args, kwargs)) and confirmed
with dict equality on the raw args, so mul(x, 0.0) and mul(x, -0.0) were
wrongly merged (changes numerics for reciprocal/copysign/atan2), add(x, 1)
and add(x, 1.0) were wrongly merged (dtype promotion differs), and identical
NaN constants were never deduplicated.

Fix mirrors the fx_graph_cse fix from #191173: normalize float/complex args
to an IEEE-754 bit-pattern key (_ScalarKey) before hashing/comparison, and
type-tag args in the hash.

Test Plan:

```
python test/test_fx.py TestCSEPass
```

New tests: test_nan_dedup, test_neg_zero_not_merged, test_int_float_not_merged.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>