### PR TITLE
[fx] SubgraphMatcher: match float literals bitwise

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -123,6 +123,40 @@ class TestMatcher(JitTestCase):
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 1)
 
+    def test_subgraph_matcher_nan_literal(self):
+        def original(x):
+            return x.clamp(min=float("nan")) + 1
+
+        original_graph = make_fx(original)(torch.ones(3, 3)).graph
+        original_graph.eliminate_dead_code()
+
+        def pattern(x):
+            return x.clamp(min=float("nan"))
+
+        pattern_graph = make_fx(pattern)(torch.ones(4, 4)).graph
+        pattern_graph.eliminate_dead_code()
+
+        subgraph_matcher = SubgraphMatcher(pattern_graph)
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 1)
+
+    def test_subgraph_matcher_neg_zero_literal(self):
+        def original(x):
+            return x.clamp(min=-0.0) + 1
+
+        original_graph = make_fx(original)(torch.ones(3, 3)).graph
+        original_graph.eliminate_dead_code()
+
+        def pattern(x):
+            return x.clamp(min=0.0)
+
+        pattern_graph = make_fx(pattern)(torch.ones(4, 4)).graph
+        pattern_graph.eliminate_dead_code()
+
+        subgraph_matcher = SubgraphMatcher(pattern_graph)
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 0)
+
     def test_variatic_arg_matching(self):
         inputs = (torch.randn(20, 16, 50, 32),)
 

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import struct
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any
@@ -11,6 +12,17 @@ from torch.fx._compatibility import compatibility
 
 
 __all__ = ["SubgraphMatcher", "InternalMatch"]
+
+
+def _literal_eq(a: Any, b: Any) -> bool:
+    # Python float eq is not value-identity: nan != nan while -0.0 == 0.0.
+    # Match constants by bit pattern so a nan pattern literal can match and
+    # 0.0 does not spuriously match -0.0.
+    if type(a) is float and type(b) is float:
+        return struct.pack(">d", a) == struct.pack(">d", b)
+    if type(a) is complex and type(b) is complex:
+        return struct.pack(">dd", a.real, a.imag) == struct.pack(">dd", b.real, b.imag)
+    return a == b
 
 
 # Set`PYTORCH_MATCHER_LOGLEVEL=INFO` to see debug logs
@@ -210,7 +222,7 @@ class SubgraphMatcher:
                 # Check if we've already matched these nodes in the current
                 # traversal
                 if pn in match.nodes_map:
-                    return match.nodes_map[pn] == gn
+                    return _literal_eq(match.nodes_map[pn], gn)
 
                 match.nodes_map[pn] = gn
                 return True
@@ -219,7 +231,7 @@ class SubgraphMatcher:
         elif not isinstance(pn, Node) and isinstance(gn, Node):
             return False
         else:
-            return type(gn) is type(pn) and gn == pn
+            return type(gn) is type(pn) and _literal_eq(gn, pn)
 
     def _match_nodes(
         self, pn: Node, gn: Node, match: InternalMatch, node_name_match: str = ""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192598

Python float eq is not value-identity: nan != nan while -0.0 == 0.0.
SubgraphMatcher._match_literals compared literal constants with ==, so a
pattern containing a NaN literal could never match any graph (silently dead
pattern for subgraph_rewriter.replace_pattern and quantization pattern
matching), while a 0.0 pattern literal wrongly matched a -0.0 graph literal,
letting replace_pattern rewrite numerics (1/-0.0 is -inf, 1/0.0 is +inf).

Fix: compare float/complex literals by IEEE-754 bit pattern (_literal_eq),
both for the direct literal comparison and for re-verification of an
already-bound placeholder literal.

Test Plan:

```
python test/test_fx.py TestMatcher
```

New tests: test_subgraph_matcher_nan_literal (NaN pattern now matches),
test_subgraph_matcher_neg_zero_literal (0.0 pattern no longer matches -0.0).

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>