### PR TITLE
[inductor] Pattern matcher: compare scalar constants bitwise

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -777,6 +777,28 @@ class TestPatternMatcher(TestCase):
     # called in test_gpu_cpp_wrapper
     test_cat_slice_cat_xpu = test_cat_slice_cat_cuda
 
+    def test_scalar_literal_bitwise_match(self):
+        # Float literals in patterns must match by bit pattern: a nan literal
+        # should match a nan graph constant (nan != nan under IEEE eq), and a
+        # 0.0 literal should not match -0.0 (they compare equal under IEEE eq).
+        def f_nan(x):
+            return aten.mul.Tensor(x, float("nan"))
+
+        def f_negzero(x):
+            return aten.mul.Tensor(x, -0.0)
+
+        x = torch.randn(4)
+        nan_pattern = CallFunction(aten.mul.Tensor, KeywordArg("x"), float("nan"))
+        zero_pattern = CallFunction(aten.mul.Tensor, KeywordArg("x"), 0.0)
+
+        gm_nan = make_fx(f_nan)(x)
+        (node,) = (n for n in gm_nan.graph.nodes if n.op == "call_function")
+        self.assertTrue(bool(nan_pattern.match(node)))
+
+        gm_negzero = make_fx(f_negzero)(x)
+        (node,) = (n for n in gm_negzero.graph.nodes if n.op == "call_function")
+        self.assertFalse(bool(zero_pattern.match(node)))
+
     def test_pointless_view_pair(self):
         def f(x):
             x = aten.view.default(x, [3, 5, 7])

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -46,6 +46,7 @@ import math
 import operator
 import os
 import re
+import struct
 import textwrap
 import typing
 from abc import ABC, abstractmethod
@@ -91,6 +92,18 @@ prims = torch.ops.prims
 
 Constant = Any
 NodeOrConstant = Constant | torch.fx.Node
+
+
+def _scalar_constants_equal(a: Any, b: Any) -> bool:
+    # Python float eq is not value-identity: nan != nan while -0.0 == 0.0.
+    # Compare scalar constants by bit pattern so nan literals in patterns can
+    # match and 0.0 does not spuriously match -0.0.
+    if type(a) is float and type(b) is float:
+        return struct.pack(">d", a) == struct.pack(">d", b)
+    if type(a) is complex and type(b) is complex:
+        return struct.pack(">dd", a.real, a.imag) == struct.pack(">dd", b.real, b.imag)
+    return a == b
+
 
 backend = os.environ.get("TORCHINDUCTOR_PATTERN_MATCH_BACKEND", "inductor")
 
@@ -277,7 +290,7 @@ class Match:
     def extend(self, other: Match) -> None:
         if self.kwargs:
             for key in OrderedSet(self.kwargs.keys()) & OrderedSet(other.kwargs.keys()):
-                if self.kwargs[key] != other.kwargs[key]:
+                if not _scalar_constants_equal(self.kwargs[key], other.kwargs[key]):
                     raise FailedMatch("kwarg mismatch: {}", key)
         self.args.extend(other.args)
         self.nodes.extend(other.nodes)
@@ -505,7 +518,7 @@ class MatchContext:
     def match(self, pattern: PatternExpr, node: NodeOrConstant) -> MatchResult:
         """wrapper to check reused nodes in patterns"""
         if pattern in self.pattern_to_node:
-            if self.pattern_to_node[pattern] == node:
+            if _scalar_constants_equal(self.pattern_to_node[pattern], node):
                 return Match(self, pattern)  # already checked this node
             else:
                 return FailedMatch("repeated pattern differs")
@@ -590,15 +603,16 @@ def _get_fake_tensor_constant(value: torch.Tensor) -> torch.Tensor | None:
 
 
 def _tensor_values_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
-    if torch.equal(a, b):
-        return True
     if a.dtype.is_complex:
         return _tensor_values_equal(a.real, b.real) and _tensor_values_equal(
             a.imag, b.imag
         )
     if a.dtype.is_floating_point:
-        return bool(((a == b) | (torch.isnan(a) & torch.isnan(b))).all().item())
-    return False
+        # Constant identity: treat any nan as equal to any nan, but do not
+        # conflate -0.0 with 0.0 (the signbit check only differs at +-0.0).
+        same = (a == b) & (torch.signbit(a) == torch.signbit(b))
+        return bool((same | (torch.isnan(a) & torch.isnan(b))).all().item())
+    return torch.equal(a, b)
 
 
 def _constant_values_equal(a: Any, b: Any) -> bool:
@@ -628,7 +642,7 @@ def _constant_values_equal(a: Any, b: Any) -> bool:
             return False
 
     try:
-        result = a == b
+        result = _scalar_constants_equal(a, b)
     except (RuntimeError, TypeError, ValueError):
         return False
     return result if isinstance(result, bool) else False
@@ -1007,7 +1021,9 @@ class _TargetArgsExpr(_TargetExpr):
                 if not is_match(child_match):
                     return child_match
                 m.extend(child_match)
-            elif isinstance(child_node, torch.fx.Node) or child_node != pattern:
+            elif isinstance(child_node, torch.fx.Node) or not _scalar_constants_equal(
+                child_node, pattern
+            ):
                 return FailedMatch(
                     "constant_args: {} {!r}!={pattern!r}",
                     node,
@@ -1049,7 +1065,9 @@ class _TargetArgsExpr(_TargetExpr):
             super().pattern_eq(other)
             and self.flat_args_kwargs[1] == other.flat_args_kwargs[1]
             and all(
-                a.pattern_eq(b) if isinstance(a, PatternExpr) else a == b
+                a.pattern_eq(b)
+                if isinstance(a, PatternExpr)
+                else _scalar_constants_equal(a, b)
                 for a, b in zip(self.flat_args_kwargs[0], other.flat_args_kwargs[0])
             )
         )
@@ -1228,7 +1246,9 @@ class MultiOutputPattern(PatternExpr):
             super().pattern_eq(other)
             and len(self.outputs) == len(other.outputs)
             and all(
-                a.pattern_eq(b) if isinstance(a, PatternExpr) else a == b
+                a.pattern_eq(b)
+                if isinstance(a, PatternExpr)
+                else _scalar_constants_equal(a, b)
                 for a, b in zip(self.outputs, other.outputs)
             )
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192599

Python float eq is not value-identity: nan != nan while -0.0 == 0.0. The
pattern matcher compared scalar constants with == in five places, so a
pattern with a NaN literal never matched (dead pattern), a repeated
KeywordArg capture bound to NaN twice spuriously failed the consistency
check, and -0.0 wrongly matched 0.0 (the replacement then bakes in the
wrong sign of zero, changing reciprocal/copysign/atan2).

Fix: add _scalar_constants_equal (IEEE-754 bit-pattern comparison for
float/complex, == for everything else) and use it in
_TargetArgsExpr._match literal args, Match.extend and MatchContext.match
repeated-capture checks, the _constant_values_equal scalar fallback, and
pattern_eq. Also fix _tensor_values_equal for GetAttr tensor constants: it
already treated NaN as equal to NaN, but torch.equal conflated -0.0 with
0.0; a signbit check now keeps them distinct.

Test Plan:

```
python test/inductor/test_pattern_matcher.py -k match
```

plus direct checks that a CallFunction pattern with a nan literal matches a
nan graph node and a 0.0 pattern does not match a -0.0 node.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo