### PR TITLE
[inductor] _resolve_name_collision: compare constants bitwise

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -46,6 +46,38 @@ from torch.utils._sympy.functions import Identity
 
 
 class TestUtils(TestCase):
+    def test_resolve_name_collision_bitwise(self):
+        # _resolve_name_collision must treat constants as "the same" only if
+        # they are bitwise identical: identical nan constants should not be
+        # renamed, while a -0.0 constant colliding with a 0.0 buffer must be.
+        from torch._inductor.compile_fx import _resolve_name_collision
+
+        def make_mod_gm(mod_value, gm_value):
+            class Mod(torch.nn.Module):
+                def __init__(self, value):
+                    super().__init__()
+                    self._tensor_constant0 = value
+
+                def forward(self, x):
+                    return x + self._tensor_constant0
+
+            def trace(m):
+                gm = torch.fx.symbolic_trace(m)
+                return gm
+
+            return Mod(mod_value), trace(Mod(gm_value))
+
+        nan = torch.tensor([float("nan")])
+        mod, gm = make_mod_gm(nan, nan.clone())
+        _resolve_name_collision(mod, gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "get_attr"]
+        self.assertEqual(targets, ["_tensor_constant0"])
+
+        mod, gm = make_mod_gm(torch.tensor([0.0]), torch.tensor([-0.0]))
+        _resolve_name_collision(mod, gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "get_attr"]
+        self.assertEqual(targets, ["_tensor_constant1"])
+
     def test_python_subprocess_env_prioritizes_loaded_torch(self):
         torch_package_root = os.path.dirname(
             os.path.dirname(os.path.abspath(torch.__file__))

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -338,6 +338,18 @@ def _warn_tf32_disabled() -> None:
         )
 
 
+def _tensors_bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    # Compare bitwise (uint8 view) so identical NaN constants are recognized
+    # and -0.0 is not conflated with 0.0. Assumes dtype/shape already match.
+    # Quantized/sparse tensors don't support uint8 views (torch.equal on a
+    # uint8 view of a quantized tensor hangs), so fall back to torch.equal.
+    if a.layout != torch.strided or a.is_quantized:
+        return torch.equal(a, b)
+    a_bits = a.contiguous().flatten().view(torch.uint8)
+    b_bits = b.contiguous().flatten().view(torch.uint8)
+    return torch.equal(a_bits, b_bits)
+
+
 def _resolve_name_collision(mod: GraphModule, gm: GraphModule) -> None:
     """
     In aot_export_module (make_fx), we create get_attr nodes with name prefix
@@ -395,7 +407,8 @@ def _resolve_name_collision(mod: GraphModule, gm: GraphModule) -> None:
             elif (
                 gm_target.device == model_target.device
                 and gm_target.dtype == model_target.dtype
-                and torch.equal(gm_target, model_target)
+                and gm_target.shape == model_target.shape
+                and _tensors_bitwise_equal(gm_target, model_target)
             ):
                 # If tensors with same name from gm and model are indeed the same, we don't need to rename
                 # Check device first, to avoid torch.equal(wrapper_CUDA__equal) raise when different device


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192600

_resolve_name_collision used torch.equal to decide whether a gm constant
and a same-named module buffer are interchangeable (skip rename). IEEE
equality is wrong for constant identity in both directions: constants
containing NaN were always renamed even when genuinely identical (extra
constant attrs), and constants differing only in the sign of zero
(torch.equal(-0.0, 0.0) is True) were treated as the same, so a get_attr
could silently resolve to a bitwise-different tensor.

Fix: new _tensors_bitwise_equal compares uint8 views of the flattened
contiguous tensors. Quantized and non-strided tensors fall back to
torch.equal because they do not support uint8 views (calling torch.equal
on a uint8 view of a quantized tensor hangs, which is a separate
pre-existing bug).

Test Plan:

```
python -c "from torch._inductor.compile_fx import _tensors_bitwise_equal as c; import torch; \
assert c(torch.tensor(float('nan')), torch.tensor(float('nan'))); \
assert not c(torch.tensor([0.0]), torch.tensor([-0.0]))"
python test/inductor/test_pattern_matcher.py -k match
```

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo