### PR TITLE
[fake_tensor] Key dispatch cache floats by bit pattern

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3650,6 +3650,41 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
+    def test_cache_hit_nan_scalar(self):
+        """
+        Distinct nan float objects must produce the same cache key
+        (hash(nan) is id-based in CPython, so raw float keys never hit).
+        """
+        with FakeTensorMode():
+            x = torch.randn(4, 3)
+
+            FakeTensorMode.cache_clear()
+            self.assertHitsMisses(0, 0)
+            res1 = torch.ops.aten.mul.Scalar(x, float("nan"))
+            self.assertHitsMisses(0, 1)
+            res2 = torch.ops.aten.mul.Scalar(x, float("nan"))
+            self.assertHitsMisses(1, 1)
+
+            self.assertEqual(
+                extract_tensor_metadata(res1),
+                extract_tensor_metadata(res2),
+            )
+
+    def test_cache_neg_zero_scalar_distinct(self):
+        """
+        -0.0 and 0.0 must not share a cache key (they are == and hash
+        equal in Python but are different constants bitwise).
+        """
+        with FakeTensorMode():
+            x = torch.randn(4, 3)
+
+            FakeTensorMode.cache_clear()
+            self.assertHitsMisses(0, 0)
+            torch.ops.aten.mul.Scalar(x, 0.0)
+            self.assertHitsMisses(0, 1)
+            torch.ops.aten.mul.Scalar(x, -0.0)
+            self.assertHitsMisses(0, 2)
+
     def test_cache_bypass_prims_as_strided(self):
         x = torch.empty(0, 8)
         y = torch.empty(0, 8)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -7,6 +7,7 @@ import functools
 import logging
 import math
 import os
+import struct
 import threading
 import traceback
 import types
@@ -2068,6 +2069,14 @@ class FakeTensorMode(TorchDispatchMode):
                 result.append(type(arg))
                 result.append(hash(arg))
                 id_hashed_objects.append(arg.orig_callable)
+            elif type(arg) is float:
+                # hash(nan) is id-based in CPython so distinct nan objects
+                # never cache-hit; key floats by bit pattern instead.
+                result.append(float)
+                result.append(struct.pack("<d", arg))
+            elif type(arg) is complex:
+                result.append(complex)
+                result.append(struct.pack("<dd", arg.real, arg.imag))
             else:
                 # It's important to capture the type of the arg since, e.g., 1 and 1.0
                 # hash to the same value, but can produce different dtypes for the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192601

hash(nan) is id-based in CPython, so every fresh NaN literal produced a
distinct dispatch-cache key and ops like torch.full(shape, float("nan"))
missed the FakeTensor dispatch cache on every call. The existing comment in
_prep_args_for_hash only handled the 1-vs-1.0 type collision.

Fix: key float/complex args by their IEEE-754 bit pattern (struct.pack).
This makes NaN keys stable and, defensively, keeps -0.0 distinct from 0.0
(today the cached output is metadata-only so the conflation was benign, but
the key should not rely on that).

Test Plan:

```
python test/test_fake_tensor.py -k Cache
```

plus a direct check that a second aten.mul.Scalar(t, float("nan")) call
with a fresh NaN object is a cache hit.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>