### PR TITLE
[dynamo] Bitwise float compare for guard snapshots and subgraph reuse

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -178,6 +178,7 @@ from .types import (  # noqa: F401
 from .utils import (
     builtin_dict_keys,
     common_constant_types,
+    constants_identical,
     dataclass_fields,
     dict_keys,
     get_current_stream,
@@ -2767,7 +2768,7 @@ class GuardBuilder(GuardBuilderBase):
 
     @register_guard_check_spec(
         get_metadata_fn=lambda guard, value: value,
-        eval_fn=lambda value, metadata: value == metadata,
+        eval_fn=lambda value, metadata: constants_identical(value, metadata),
     )
     def EQUALS_MATCH(self, guard: Guard, recompile_hint: str | None = None) -> None:
         ref = self.arg_ref(guard)
@@ -2884,7 +2885,7 @@ class GuardBuilder(GuardBuilderBase):
 
     @register_guard_check_spec(
         get_metadata_fn=lambda guard, value: value,
-        eval_fn=lambda value, metadata: value == metadata,
+        eval_fn=lambda value, metadata: constants_identical(value, metadata),
     )
     def CONSTANT_MATCH(self, guard: Guard) -> None:
         val = self.get(guard)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -34,6 +34,7 @@ import math
 import operator
 import os
 import re
+import struct
 import sys
 import textwrap
 import threading
@@ -1201,6 +1202,17 @@ def istype(obj: object, allowed_types: Any) -> bool:
     if isinstance(allowed_types, (tuple, list, set)):
         return type(obj) in allowed_types
     return type(obj) is allowed_types
+
+
+def constants_identical(a: Any, b: Any) -> bool:
+    """Value-identity comparison for specialized constants. Python float eq is
+    not value-identity: nan != nan while -0.0 == 0.0, so compare float/complex
+    by IEEE-754 bit pattern instead."""
+    if type(a) is float and type(b) is float:
+        return struct.pack(">d", a) == struct.pack(">d", b)
+    if type(a) is complex and type(b) is complex:
+        return struct.pack(">dd", a.real, a.imag) == struct.pack(">dd", b.real, b.imag)
+    return a == b
 
 
 _builtin_final_typing_classes: tuple[Any, ...] = tuple()

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -23,7 +23,7 @@ from torch._dynamo.guards import (
     UnsupportedGuardCheckSpec,
 )
 from torch._dynamo.source import SyntheticLocalSource
-from torch._dynamo.utils import _make_inlined, unpack_iterable
+from torch._dynamo.utils import _make_inlined, constants_identical, unpack_iterable
 from torch._dynamo.variables.base import VariableTracker
 from torch._dynamo.variables.constant import ConstantVariable
 from torch._dynamo.variables.functions import UserFunctionVariable
@@ -636,7 +636,7 @@ def is_reusable(
                 raise AssertionError(
                     f"expected ConstantVariable for CONSTANT tag, got {type(cur_vt).__name__}"
                 )
-            if cur_vt.value != cached_val:
+            if not constants_identical(cur_vt.value, cached_val):
                 # If both the cached and current arg have sources, source
                 # replacement in stamp_out will resolve the correct value.
                 cached_src = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192602

Python float eq is not value-identity: nan != nan while -0.0 == 0.0. Two
reuse paths compared specialized float constants with ==:

- The EQUALS_MATCH/CONSTANT_MATCH GuardCheckSpec eval_fns (used to
  re-evaluate snapshotted guards for invoke_subgraph reuse) rejected any
  entry whose guarded value is NaN and accepted -0.0 against 0.0.
- The invoke_subgraph constant-input check (cur_vt.value != cached_val)
  had the same problem: a NaN constant input killed reuse, and a -0.0
  input reused a subgraph traced with 0.0 baked in.

Fix: add constants_identical() to torch/_dynamo/utils.py (IEEE-754
bit-pattern comparison for float/complex, == otherwise) and use it at both
sites.

Test Plan:

```
python test/dynamo/test_guard_manager.py
```

plus a nested_compile_region smoke test with repeated and NaN float
constants.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98