### PR TITLE
[onnx] Exporter: key constant_farm floats by bit pattern

### DIFF
--- a/test/onnx/exporter/test_building.py
+++ b/test/onnx/exporter/test_building.py
@@ -50,6 +50,25 @@ class TestOpRecorder(common_utils.TestCase):
         )
         self.assertEqual(tracer.nodes[1].op_type, "Reshape")
 
+    def test_constant_farm_keys_floats_bitwise(self):
+        input_x = _tensors.SymbolicTensor(
+            opset=self.opset, name="input_x", shape=ir.Shape([2, 3])
+        )
+
+        with onnxscript.evaluator.default_as(tracer := self.recorder):
+            # Distinct nan objects must share one Constant; -0.0 and 0.0
+            # must get distinct Constants (Python: nan != nan, -0.0 == 0.0).
+            _ = self.opset.Add(input_x, float("nan"))
+            _ = self.opset.Add(input_x, float("nan"))
+            _ = self.opset.Add(input_x, 0.0)
+            _ = self.opset.Add(input_x, -0.0)
+
+        constants = [n for n in tracer.nodes if n.op_type == "Constant"]
+        values = [c.attributes["value"].value.numpy().item() for c in constants]
+        self.assertEqual(len(constants), 3)
+        self.assertTrue(np.isnan(values[0]))
+        self.assertEqual(np.signbit(values[1:]).tolist(), [False, True])
+
     def test_process_python_sequence_with_allowed_sequence_type(self):
         input_x = _tensors.SymbolicTensor(
             opset=self.opset, name="input_x", shape=ir.Shape([2, 3])

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
+import struct
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, TYPE_CHECKING
 
@@ -283,11 +284,23 @@ def _get_or_create_constant(
         # pyrefly: ignore [bad-argument-type]
         arg = tuple(arg)
 
-    constant_value = constant_farm.get((arg, dtype))  # type: ignore[arg-type]
+    # Python float eq/hash is not value-identity (nan != nan, -0.0 == 0.0),
+    # so key floats by bit pattern to dedup nan constants deterministically
+    # and keep -0.0 distinct from 0.0.
+    if isinstance(arg, float):
+        key_arg = struct.pack("<d", arg)
+    elif isinstance(arg, tuple):
+        key_arg = tuple(
+            struct.pack("<d", v) if isinstance(v, float) else v for v in arg
+        )
+    else:
+        key_arg = arg
+
+    constant_value = constant_farm.get((key_arg, dtype))  # type: ignore[arg-type]
     if constant_value is None:
         constant_tensor = ir.tensor(value=arg, dtype=dtype)
         constant_value = opset.Constant(value=constant_tensor)
-        constant_farm[(arg, dtype)] = constant_value  # type: ignore[arg-type,index]
+        constant_farm[(key_arg, dtype)] = constant_value  # type: ignore[arg-type,index]
     return constant_value  # type: ignore[return-value]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192603

_get_or_create_constant deduplicated ONNX Constant nodes with a dict keyed
on the raw Python scalar. Python float semantics break this in both
directions: -0.0 == 0.0 (and hash equal), so a model using both got a
single shared Constant with the wrong sign of zero for one use site; and
hash(nan) is id-based, so NaN constants deduplicated only when the same
float object was reused, making the exported graph structure
nondeterministic.

Fix: key floats (and floats inside tuple args) by their IEEE-754 bit
pattern via struct.pack. The stored tensor value is still built from the
original arg.

Test Plan: onnxscript is not available in this environment; verified by
inspection and py_compile. Relying on CI onnx exporter tests
(test/onnx/exporter).

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>