### PR TITLE
[jit] Constant pooling/CSE: compare float attributes bitwise

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5257,6 +5257,41 @@ a")
         graph_str = str(test.graph)
         self.assertTrue(graph_str.count("NoneType = prim::Constant") == 1)
 
+    def test_constant_pooling_float_bitwise(self):
+        # Constant pooling must compare float constants bitwise: identical
+        # nan constants pool into one node (IEEE nan != nan would keep both),
+        # while 0.0 and -0.0 stay distinct (IEEE -0.0 == 0.0 would merge
+        # them, flipping the sign of 1/x downstream).
+        @torch.jit.script
+        def nan_fn(x):
+            a = x.clamp(min=float("nan"))
+            b = x.clamp(min=float("nan"))
+            return a + b
+
+        self.run_pass("constant_pooling", nan_fn.graph)
+        nan_consts = [
+            n
+            for n in nan_fn.graph.findAllNodes("prim::Constant")
+            if n.hasAttribute("value") and n.kindOf("value") == "f"
+        ]
+        self.assertEqual(len(nan_consts), 1)
+
+        @torch.jit.script
+        def zero_fn(x):
+            a = x * 0.0
+            b = x * (-0.0)
+            return a.reciprocal() + b.reciprocal()
+
+        self.run_pass("constant_pooling", zero_fn.graph)
+        zero_consts = [
+            n
+            for n in zero_fn.graph.findAllNodes("prim::Constant")
+            if n.hasAttribute("value") and n.kindOf("value") == "f"
+        ]
+        self.assertEqual(len(zero_consts), 2)
+        # 1/(1*0.0) + 1/(1*-0.0) = inf + -inf = nan; a wrong merge gives inf
+        self.assertTrue(torch.isnan(zero_fn(torch.ones(2))).all())
+
     def test_constant_pooling_same_identity(self):
         def foo():
             a = torch.tensor([4])

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/frontend/tree_views.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/bit_cast.h>
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
@@ -601,12 +602,41 @@ struct Environment {
   ValueTable value_table;
 };
 
-template <class T, class Hash>
+// Constant identity is bitwise for floats: -0.0 == 0.0 under IEEE eq, but
+// memoizing them to one constant changes numerics (reciprocal/copysign);
+// nan keys would never match. Key float/complex memo maps by bit pattern.
+struct BitwiseDoubleHash {
+  size_t operator()(double val) const {
+    return std::hash<int64_t>{}(c10::bit_cast<int64_t>(val));
+  }
+};
+
+struct BitwiseDoubleEq {
+  bool operator()(double lhs, double rhs) const {
+    return c10::bit_cast<int64_t>(lhs) == c10::bit_cast<int64_t>(rhs);
+  }
+};
+
+struct BitwiseComplexHash {
+  size_t operator()(c10::complex<double> val) const {
+    return c10::get_hash(
+        c10::bit_cast<int64_t>(val.real()), c10::bit_cast<int64_t>(val.imag()));
+  }
+};
+
+struct BitwiseComplexEq {
+  bool operator()(c10::complex<double> lhs, c10::complex<double> rhs) const {
+    return BitwiseDoubleEq()(lhs.real(), rhs.real()) &&
+        BitwiseDoubleEq()(lhs.imag(), rhs.imag());
+  }
+};
+
+template <class T, class Hash, class KeyEqual>
 static Value* materializeConstant(
     T val,
     Graph& graph,
     const SourceRange& r,
-    std::unordered_map<T, Value*, Hash>& map) {
+    std::unordered_map<T, Value*, Hash, KeyEqual>& map) {
   auto existing_constant = map.find(val);
   if (existing_constant != map.end()) {
     return existing_constant->second;
@@ -696,11 +726,13 @@ struct to_ir {
   std::shared_ptr<Graph> graph;
   ResolverPtr resolver;
   std::unordered_map<int64_t, Value*, std::hash<int64_t>> integral_constants;
-  std::unordered_map<double, Value*, std::hash<double>> fp_constants;
+  std::unordered_map<double, Value*, BitwiseDoubleHash, BitwiseDoubleEq>
+      fp_constants;
   std::unordered_map<
       c10::complex<double>,
       Value*,
-      c10::hash<c10::complex<double>>>
+      BitwiseComplexHash,
+      BitwiseComplexEq>
       complex_constants;
   std::unordered_set<Block*> exit_blocks;
   ScriptTypeParser typeParser_;

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/core/symbol.h>
 #include <c10/util/Exception.h>
+#include <c10/util/bit_cast.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/node_hashing.h>
@@ -42,9 +43,47 @@ bool typeListEqual(
   return true;
 }
 
-template <typename attribute_type> // int64_t, bool, double
+template <typename attribute_type> // int64_t, bool
 bool attributesEqual(attribute_type a1, attribute_type a2) {
   return a1 == a2;
+}
+
+// Constant identity for CSE/constant pooling must be bitwise: IEEE eq would
+// never merge NaN constants and would wrongly merge -0.0 with 0.0.
+bool attributesEqual(double a1, double a2) {
+  return c10::bit_cast<int64_t>(a1) == c10::bit_cast<int64_t>(a2);
+}
+
+bool attributesEqual(c10::complex<double> a1, c10::complex<double> a2) {
+  return attributesEqual(a1.real(), a2.real()) &&
+      attributesEqual(a1.imag(), a2.imag());
+}
+
+bool attributesEqual(
+    const std::vector<double>& a1,
+    const std::vector<double>& a2) {
+  if (a1.size() != a2.size()) {
+    return false;
+  }
+  return std::equal(
+      a1.begin(), a1.end(), a2.begin(), [](double x, double y) {
+        return attributesEqual(x, y);
+      });
+}
+
+bool attributesEqual(
+    const std::vector<c10::complex<double>>& a1,
+    const std::vector<c10::complex<double>>& a2) {
+  if (a1.size() != a2.size()) {
+    return false;
+  }
+  return std::equal(
+      a1.begin(),
+      a1.end(),
+      a2.begin(),
+      [](c10::complex<double> x, c10::complex<double> y) {
+        return attributesEqual(x, y);
+      });
 }
 
 bool attributesEqual(const at::Tensor& a1, const at::Tensor& a2) {
@@ -91,7 +130,10 @@ bool ivaluesEqual(const IValue& a1, const IValue& a2) {
     return a1.toBool() == a2.toBool();
   }
   if (a1.isDouble()) {
-    return a1.toDouble() == a2.toDouble();
+    return attributesEqual(a1.toDouble(), a2.toDouble());
+  }
+  if (a1.isComplexDouble()) {
+    return attributesEqual(a1.toComplexDouble(), a2.toComplexDouble());
   }
   if (a1.isTensor()) {
     return attributesEqual(a1.toTensor(), a2.toTensor());

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -65,10 +65,9 @@ bool attributesEqual(
   if (a1.size() != a2.size()) {
     return false;
   }
-  return std::equal(
-      a1.begin(), a1.end(), a2.begin(), [](double x, double y) {
-        return attributesEqual(x, y);
-      });
+  return std::equal(a1.begin(), a1.end(), a2.begin(), [](double x, double y) {
+    return attributesEqual(x, y);
+  });
 }
 
 bool attributesEqual(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192605

Node attribute equality (attributesEqual / ivaluesEqual in
node_hashing.cpp) compared double attributes with IEEE ==, and constant
pooling / CSE key on it via EqualNode. So prim::Constant[value=0.0] and
prim::Constant[value=-0.0] were pooled into a single node (wrong numerics
for reciprocal/copysign/atan2 downstream), while two identical NaN
constants were never pooled (nan != nan; only a graph-size miss).

Fix: compare double and complex-double attributes (scalars and the fs/cs
vector variants) by bit pattern via c10::bit_cast, and add the missing
complex-double branch to ivaluesEqual. The hash side is unchanged:
std::hash<double> collides -0.0 with 0.0, which is now merely a hash
collision resolved by the corrected equality, and hashes NaN
deterministically, which is consistent with bitwise equality for pooling
purposes.

Test Plan:

```
python test/test_jit.py -k constant_pooling
python test/test_jit.py -k cse
```

plus direct checks: after _jit_pass_constant_pooling, a graph using 0.0 and
-0.0 keeps both constants (x*0.0 reciprocal + x*(-0.0) reciprocal is nan),
and a graph with two nan constants pools them into one.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>