### PR TITLE
[lazy] CanBeReused: compare double args bitwise, consistent with node hash

### DIFF
--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -157,5 +157,44 @@ class TestLazyReuseIr(TestCase):
         torch._lazy.ir_cache.reset()
 
 
+    def testDoubleArgReuseIsBitwise(self):
+        # CanBeReused must compare double args bitwise: a nan eps still
+        # allows node reuse (IEEE nan != nan would block it forever), while
+        # eps=0.0 and eps=-0.0 are different constants and must not share
+        # one IR node.
+        device = get_test_device()
+        x = torch.randn(2, 3, 8, 8, device=device).to(device="lazy")
+        weight = torch.randn(3, device=device).to(device="lazy")
+        bias = torch.randn(3, device=device).to(device="lazy")
+
+        for _ in range(10):
+            z, _, _ = torch.ops.aten.native_batch_norm(
+                x, weight, bias, None, None, True, 0.1, float("nan")
+            )
+            torch._lazy.mark_step()
+
+        reused = (
+            metrics.counter_value("IrNodeReused_torch::lazy::NativeBatchNorm") or 0
+        )
+        if reused < 7:
+            raise AssertionError(
+                f"Expected at least 7 reused nan-eps NativeBatchNorm nodes, got {reused}"
+            )
+        metrics.reset()
+        torch._lazy.ir_cache.reset()
+
+        z1, _, _ = torch.ops.aten.native_batch_norm(
+            x, weight, bias, None, None, True, 0.1, 0.0
+        )
+        z2, _, _ = torch.ops.aten.native_batch_norm(
+            x, weight, bias, None, None, True, 0.1, -0.0
+        )
+        torch._lazy.mark_step()
+        reused = metrics.counter_value("IrNodeReused_torch::lazy::NativeBatchNorm")
+        self.assertFalse(reused)
+        metrics.reset()
+        torch._lazy.ir_cache.reset()
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -9,6 +9,7 @@
 #include <c10/util/int128.h>
 #include <torch/csrc/Export.h>
 #include <cstring>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -63,6 +64,44 @@ static inline hash_t StringHash(const char* data) {
 template <typename T, std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
 hash_t Hash(const T& value) {
   return DataHash(&value, sizeof(value));
+}
+
+// Value-identity comparison consistent with the bitwise Hash above: IEEE eq
+// would never match NaN args (so nodes with a NaN scalar are never reused)
+// and would conflate -0.0 with 0.0 (wrong node reuse).
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+bool BitwiseEqual(const T& lhs, const T& rhs) {
+  return std::memcmp(&lhs, &rhs, sizeof(T)) == 0;
+}
+
+template <
+    typename T,
+    std::enable_if_t<!std::is_floating_point_v<T>>* = nullptr>
+bool BitwiseEqual(const T& lhs, const T& rhs) {
+  return lhs == rhs;
+}
+
+template <typename T>
+bool BitwiseEqual(
+    const std::optional<T>& lhs,
+    const std::optional<T>& rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+  return !lhs.has_value() || BitwiseEqual(*lhs, *rhs);
+}
+
+template <typename T>
+bool BitwiseEqual(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!BitwiseEqual(lhs[i], rhs[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 // added because on macos builds the vector<bool> specialization

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -20,6 +20,7 @@ from torchgen.api.types import (
     Binding,
     deviceT,
     DispatcherSignature,
+    doubleT,
     kernel_signature,
     NativeSignature,
     OptionalCType,
@@ -380,7 +381,18 @@ class GenTSLazyIR(GenLazyIR):
             else:
                 value_comparison.append(f"operand(i++) == {arg.name}")
         for arg in itertools.chain(schema.positional_scalars, schema.keyword_scalars):
-            if isinstance(arg.lazy_type, OptionalCType):
+            # BitwiseEqual for floating-point scalars, not ==: IEEE eq never
+            # matches NaN (node would never be reused) and conflates -0.0
+            # with 0.0 (wrong reuse), inconsistent with the bitwise node hash.
+            is_double = arg.lazy_type == BaseCType(doubleT) or (
+                isinstance(arg.lazy_type, OptionalCType)
+                and arg.lazy_type.elem == BaseCType(doubleT)
+            )
+            if is_double:
+                value_comparison.append(
+                    f"torch::lazy::BitwiseEqual(this->{arg.name}, {arg.name})"
+                )
+            elif isinstance(arg.lazy_type, OptionalCType):
                 value_comparison.append(
                     f"((!this->{arg.name}&&!{arg.name}) || (this->{arg.name}&&{arg.name} && *(this->{arg.name}) == *{arg.name}))"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192606

Lazy IR node hashing is bitwise (torch::lazy::Hash for arithmetic types
uses DataHash on the raw bytes), but the generated CanBeReused methods
compared scalar args with IEEE ==. The TrieCache reuses a node when
CanBeReused is true, so a node whose double arg is NaN was never reused
(nan != nan, inconsistent with its stable bitwise hash), and two ops
differing only by -0.0 vs 0.0 in a double arg wrongly reused one node.

Fix: add torch::lazy::BitwiseEqual (memcmp for floating-point, == for
other types, with optional<T> and vector<T> overloads) to hash.h and have
torchgen emit it for double and optional<double> scalars in CanBeReused.
Other scalar types keep the existing == codegen; non-floating types
compile to the same behavior either way.

Test Plan:

```
python test/lazy/test_reuse_ir.py
```

Regenerated LazyIr.h compiles and the existing reuse tests pass.

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>