### PR TITLE
[onnx] DeduplicateInitializersByValue: compare bitwise

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1797,6 +1797,37 @@ class TestUtilityFuns(_BaseTestCase):
     def test_deduplicate_initializers_torchscript(self):
         self._test_deduplicate_initializers(torchscript=True)
 
+    def test_deduplicate_initializers_bitwise(self):
+        # Value-based dedup (eval mode) must be bitwise: identical nan
+        # initializers dedup (IEEE nan != nan would keep both), while
+        # initializers differing only in sign of zero must NOT merge
+        # (IEEE -0.0 == 0.0 would merge them).
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.nan1 = torch.nn.Parameter(torch.tensor([float("nan"), 1.0]))
+                self.nan2 = torch.nn.Parameter(torch.tensor([float("nan"), 1.0]))
+                self.zero = torch.nn.Parameter(torch.tensor([0.0, 1.0]))
+                self.negzero = torch.nn.Parameter(torch.tensor([-0.0, 1.0]))
+
+            def forward(self, x):
+                return x + self.nan1 + self.nan2 + self.zero + self.negzero
+
+        model = MyModule()
+        model.eval()
+        f = io.BytesIO()
+        torch.onnx.export(
+            model,
+            (torch.randn(2),),
+            f,
+            opset_version=self.opset_version,
+            dynamo=False,
+        )
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+        self.assertSetEqual(
+            {i.name for i in graph.graph.initializer}, {"nan1", "zero", "negzero"}
+        )
+
     @skipIfNoCuda
     def test_deduplicate_initializers_diff_devices(self):
         class Model(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
+++ b/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp
@@ -139,11 +139,19 @@ static bool DeduplicateInitializersByValue(at::Tensor& t1, at::Tensor& t2) {
     return false;
   }
 
+  // Compare bitwise (uint8 view): IEEE eq would never dedup initializers
+  // containing NaN and would wrongly merge ones differing only in the sign
+  // of zero.
+  auto bitwise = [](const at::Tensor& a, const at::Tensor& b) {
+    return a.contiguous().flatten().view(at::kByte).equal(
+        b.contiguous().flatten().view(at::kByte));
+  };
+
   if (t1.device() != t2.device()) {
-    return t1.to("cpu").equal(t2.to("cpu"));
+    return bitwise(t1.to("cpu"), t2.to("cpu"));
   }
 
-  return t1.equal(t2);
+  return bitwise(t1, t2);
 }
 
 void DeduplicateInitializers(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192607

The value-based initializer dedup pass (inference export) used at::equal,
which is IEEE elementwise equality: initializers differing only in the
sign of zero were merged into one (wrong numerics for
reciprocal/copysign/atan2 consumers), and initializers containing any NaN
were never deduplicated (only a model-size miss).

Fix: compare uint8 views of the flattened contiguous tensors so the dedup
decision is bitwise, matching the "same constant" intent.

Test Plan: covered by existing ONNX export tests in CI
(test_pytorch_onnx_no_runtime.py test_duplicated_output_node etc.);
verified the uint8-view comparison semantics directly in Python (nan
initializers equal, -0.0 vs 0.0 not equal).

This PR was authored with an AI assistant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>