### PR TITLE
Fix torch.fft.fftfreq writing wrong values and clobbering memory with a non-contiguous out=

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -728,7 +728,11 @@ Tensor& fft_fftfreq_out(int64_t n, double d, Tensor& out) {
               "fftfreq requires a floating point or complex dtype");
   // TODO: arange doesn't have complex support
   at::arange_out(out, n);
-  auto right_slice = out.slice(0, (n + 1) / 2, 0);
+  // No end argument: the negative frequencies run to the end of out. Passing
+  // 0 made this slice empty, so the arange below resized it into a fresh
+  // contiguous run, which for a non-contiguous out both misplaces the values
+  // and writes into storage that is not part of out.
+  auto right_slice = out.slice(0, (n + 1) / 2);
   at::arange_out(right_slice, -(n/2), 0, 1);
   return out.mul_(1.0 / (n * d));  // Slightly faster than div_(n*d)
 }

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -748,6 +748,25 @@ class TestFFT(TestCase):
                 func(n=100, d=.5, out=actual)
             self.assertEqual(actual, expect)
 
+    @skipCPUIfNoFFT
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.double)
+    def test_fftfreq_out_noncontiguous(self, device, dtype):
+        for func in (torch.fft.fftfreq, torch.fft.rfftfreq):
+            for n in (4, 5, 8, 100):
+                expect = func(n=n, d=.5, device=device, dtype=dtype)
+                size = expect.numel()
+                # Every other element of a buffer, so out has stride 2 and the
+                # elements between its own are not part of it.
+                buffer = torch.full((2 * size,), -1, device=device, dtype=dtype)
+                actual = buffer[::2]
+                self.assertFalse(actual.is_contiguous())
+
+                func(n=n, d=.5, out=actual)
+
+                self.assertEqual(actual, expect)
+                self.assertEqual(buffer[1::2], torch.full_like(buffer[1::2], -1))
+
 
     @skipCPUIfNoFFT
     @onlyNativeDeviceTypes


### PR DESCRIPTION
`fft_fftfreq_out` slices the negative-frequency half with an explicit `end` of `0`:

```cpp
auto right_slice = out.slice(0, (n + 1) / 2, 0);
```

`Tensor::slice` clamps `end` up to `start`, so this is an empty view, not a to-the-end
sentinel. `at::arange_out(right_slice, -(n/2), 0, 1)` then finds a 0-element output where it
needs `n/2` elements, resizes it, and a resize of an empty view produces a fresh contiguous
run over the storage starting at that view's offset.

For a contiguous `out` the fresh run happens to land exactly on the right elements, which is
why this has gone unnoticed. For a non-contiguous `out` it lands on the wrong ones, and it
runs off into storage that is not part of `out` at all.

## Repro

```python
import torch

tbl = torch.zeros(8, 3)
torch.fft.fftfreq(8, out=tbl[:, 0])

print(tbl[:, 0].tolist())
# [0.0, 0.125, 0.25, 0.375, -0.5, -0.125, 0.75, 0.875]     wrong
print(torch.fft.fftfreq(8).tolist())
# [0.0, 0.125, 0.25, 0.375, -0.5, -0.375, -0.25, -0.125]   expected

print(tbl[:, 1].tolist())
# [0.0, 0.0, 0.0, 0.0, -3.0, 0.0, 0.0, 0.0]                clobbered, was all zeros
```

Filling one column of a preallocated table is ordinary usage, and a non-contiguous `out` is a
supported case that `test_ops.py::test_out` exercises generally. The second effect is the worse
one: `tbl[:, 1]` is a tensor the caller never passed to the op. The value left there is unscaled
because the trailing `out.mul_(1.0 / (n * d))` walks only `out`'s own strides, so the write went
somewhere `mul_` does not reach.

## Fix

Drop the `end` argument so the slice really does run to the end of `out`. `right_slice` then has
`numel() == n/2`, which matches what `arange_out` computes, so no resize happens and the values
are written through `out`'s real strides.

The existing `test_fftfreq_out` still passes: it uses a 0-dim `out`, and `at::arange_out(out, n)`
on the line above resizes that to a contiguous `(n,)` before the slice is taken.

## Test

`test/test_spectral_ops.py::TestFFT::test_fftfreq_out_noncontiguous` builds `out` as every other
element of a `-1`-filled buffer, checks the values against the functional result, and checks that
the interleaved elements are still `-1`. It covers `fftfreq` and `rfftfreq` over both even and odd
`n`. It fails on the current `main` on both assertions and passes with this change.

I do not have a machine that can build ATen, so I validated the fix by transcribing
`fft_fftfreq_out` line for line into Python and re-registering it through the real dispatcher with
`torch.library.Library("aten", "IMPL")`. The transcription of the current code reproduces the
wrong values and the out-of-bounds write above exactly; with the one-line change it matches
`torch.fft.fftfreq` for every case in the new test. CI is the real check here, and I will follow up
on anything it turns up.

This is self-found rather than tied to an existing issue. Happy to open one first if you would
prefer that route.


cc @mruberry