### PR TITLE
[ROCm][CUDA] Fix hipErrorInvalidConfiguration for large batched linear algebra operations (#192508)

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -791,11 +791,17 @@ static void apply_cholesky_cusolver_potrfBatched(const Tensor& self_working_copy
 
   // cusolver batched kernels require input be "device array of device pointers"
   Tensor self_working_copy_array = get_device_pointers<scalar_t>(self_working_copy);
+  auto self_working_copy_array_ptr = reinterpret_cast<scalar_t**>(self_working_copy_array.data_ptr());
+  auto infos_ptr = infos.data_ptr<int>();
 
-  at::cuda::solver::potrfBatched<scalar_t>(
-    handle, uplo, n,
-    reinterpret_cast<scalar_t**>(self_working_copy_array.data_ptr()),
-    lda, infos.data_ptr<int>(), batch_size);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    at::cuda::solver::potrfBatched<scalar_t>(
+      handle, uplo, n,
+      &self_working_copy_array_ptr[mini_idx],
+      lda, &infos_ptr[mini_idx], cur_batch_size);
+  }
 }
 
 void cholesky_helper_cusolver(const Tensor& input, bool upper, const Tensor& info) {
@@ -895,18 +901,24 @@ static void apply_cholesky_cusolver_potrsBatched(Tensor& self_working_copy, cons
 
   auto self_ptr_array = get_device_pointers<scalar_t>(self_working_copy);
   auto A_ptr_array = get_device_pointers<scalar_t>(A_column_major_copy);
+  auto self_ptr_array_data = reinterpret_cast<scalar_t**>(self_ptr_array.data_ptr());
+  auto A_ptr_array_data = reinterpret_cast<scalar_t**>(A_ptr_array.data_ptr());
 
-  at::cuda::solver::potrsBatched(
-    handle, uplo,
-    cuda_int_cast(n, "n"),
-    cuda_int_cast(nrhs, "nrhs"),
-    reinterpret_cast<scalar_t**>(A_ptr_array.data_ptr()),
-    cuda_int_cast(lda, "lda"),
-    reinterpret_cast<scalar_t**>(self_ptr_array.data_ptr()),
-    cuda_int_cast(ldb, "ldb"),
-    infos_ptr,
-    cuda_int_cast(batch_size, "batch_size")
-  );
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    at::cuda::solver::potrsBatched(
+      handle, uplo,
+      cuda_int_cast(n, "n"),
+      cuda_int_cast(nrhs, "nrhs"),
+      &A_ptr_array_data[mini_idx],
+      cuda_int_cast(lda, "lda"),
+      &self_ptr_array_data[mini_idx],
+      cuda_int_cast(ldb, "ldb"),
+      infos_ptr,
+      cur_batch_size
+    );
+  }
 }
 
 void _cholesky_solve_helper_cuda_cusolver(Tensor& self, const Tensor& A, bool upper) {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -91,11 +91,12 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
 
   int info;
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  at::cuda::blas::geqrfBatched(handle, m, n, input_ptr_array_data, lda, tau_ptr_array_data, &info, batch_size);
-
-  // info only indicates wrong arguments to geqrfBatched call
-  // info is a host variable, we can check it without device synchronization
-  TORCH_INTERNAL_ASSERT(info == 0);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    at::cuda::blas::geqrfBatched(handle, m, n, &input_ptr_array_data[mini_idx], lda, &tau_ptr_array_data[mini_idx], &info, cur_batch_size);
+    TORCH_INTERNAL_ASSERT(info == 0);
+  }
 }
 
 void geqrf_batched_cublas(const Tensor& input, const Tensor& tau) {
@@ -118,7 +119,13 @@ static void apply_lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots
   Tensor a_ptr_array = get_device_pointers<scalar_t>(A);
   auto a_ptr_array_data = reinterpret_cast<scalar_t**>(a_ptr_array.data_ptr());
 
-  at::cuda::blas::getrfBatched(n, a_ptr_array_data, lda, pivots_data, infos_data, batch_size);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    auto pivots_cur = pivots_data ? &pivots_data[mini_idx * n] : nullptr;
+    auto infos_cur = &infos_data[mini_idx];
+    at::cuda::blas::getrfBatched(n, &a_ptr_array_data[mini_idx], lda, pivots_cur, infos_cur, cur_batch_size);
+  }
 }
 
 void lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots, const Tensor& infos, bool get_pivots) {
@@ -146,9 +153,16 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   auto b_ptr_array_data = reinterpret_cast<scalar_t**>(b_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  at::cuda::blas::getrsBatched(handle, trans, m, nrhs, const_cast<scalar_t**>(lu_ptr_array_data),
-    lda, const_cast<int*>(pivots_data), b_ptr_array_data, lda, &info, batch_size);
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    auto pivots_cur = const_cast<int*>(&pivots_data[mini_idx * m]);
+    auto lu_ptr_cur = const_cast<scalar_t**>(&lu_ptr_array_data[mini_idx]);
+    auto b_ptr_cur = &b_ptr_array_data[mini_idx];
+    at::cuda::blas::getrsBatched(handle, trans, m, nrhs, lu_ptr_cur,
+      lda, pivots_cur, b_ptr_cur, lda, &info, cur_batch_size);
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
+  }
 }
 
 void lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
@@ -214,7 +228,11 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
   auto handle = at::cuda::getCurrentCUDABlasHandle();
-  at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, A_ptr_array_data, lda, B_ptr_array_data, ldb, batch_size);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, &A_ptr_array_data[mini_idx], lda, &B_ptr_array_data[mini_idx], ldb, cur_batch_size);
+  }
 }
 
 void triangular_solve_batched_cublas(const Tensor& A, const Tensor& B, bool left, bool upper, TransposeType transpose, bool unitriangular) {
@@ -279,16 +297,18 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
   int info;
 
-  at::cuda::blas::gelsBatched<scalar_t>(
-    handle, trans, m, n, nrhs,
-    A_ptr_array_data, lda,
-    B_ptr_array_data, ldb,
-    &info,
-    infos_data,
-    batch_size);
-
-  // negative info indicates that an argument to gelsBatched call is invalid
-  TORCH_INTERNAL_ASSERT(info == 0);
+  constexpr int batch_limit = 65535;
+  for (int mini_idx = 0; mini_idx < batch_size; mini_idx += batch_limit) {
+    int cur_batch_size = std::min<int>(batch_size - mini_idx, batch_limit);
+    at::cuda::blas::gelsBatched<scalar_t>(
+      handle, trans, m, n, nrhs,
+      &A_ptr_array_data[mini_idx], lda,
+      &B_ptr_array_data[mini_idx], ldb,
+      &info,
+      &infos_data[mini_idx],
+      cur_batch_size);
+    TORCH_INTERNAL_ASSERT(info == 0);
+  }
 }
 
 // This is a type dispatching helper function for 'apply_gels_batched'

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4836,6 +4836,13 @@ class TestLinalg(TestCase):
             for A, B, left, upper, uni in gen_inputs(shape, dtype, device, well_conditioned=True):
                 self._test_linalg_solve_triangular(A, B, upper, left, uni)
 
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_linalg_inv_large_batch(self, device, dtype):
+        a = torch.eye(3, device=device, dtype=dtype).repeat(65536, 1, 1)
+        res = torch.linalg.inv(a)
+        self.assertEqual(res.sum().item(), 3.0 * 65536)
+
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-2, torch.complex64: 1e-2,
                         torch.float64: 1e-8, torch.complex128: 1e-8})


### PR DESCRIPTION
Fixes : #192508

### Root Cause
For batched small matrices (such as 3x3), functions like `torch.linalg.inv`, `torch.linalg.solve`, `torch.linalg.qr`, `torch.linalg.cholesky`, and `torch.linalg.lstsq` dispatch to GPU batched routines (`apply_lu_factor_batched_cublas`, `apply_lu_solve_batched_cublas`, `apply_geqrf_batched`, `apply_triangular_solve_batched`, `apply_gels_batched`, `apply_cholesky_cusolver_potrfBatched`, and `apply_cholesky_cusolver_potrsBatched`).

These wrapper functions previously passed `batch_size` directly to the underlying cuBLAS/hipBLAS/hipSOLVER API calls. In CUDA and HIP runtimes, 2D/3D grid dimensions (`gridDim.y`/`gridDim.z`) are hardware-limited to 65,535. When `batch_size > 65535` , passing `batch_size` directly caused the HIP kernel launcher on ROCm (Windows gfx1201) to exceed grid limits, throwing `hipErrorInvalidConfiguration` (`CUDA error: invalid configuration argument`).

### What Changed
Chunked `batch_size` into mini batches of at most 65,535 (`batch_limit`) across GPU batched linear algebra functions:

1. **`aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp`**:
   - `apply_lu_factor_batched_cublas`: Chunked `getrfBatched` loop for batch sizes exceeding 65,535.
   - `apply_lu_solve_batched_cublas`: Chunked `getrsBatched` loop for batch sizes exceeding 65,535.
   - `apply_geqrf_batched`: Chunked `geqrfBatched` loop for batch sizes exceeding 65,535.
   - `apply_triangular_solve_batched`: Chunked `trsmBatched` loop for batch sizes exceeding 65,535.
   - `apply_gels_batched`: Chunked `gelsBatched` loop for batch sizes exceeding 65,535.

2. **`aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp`**:
   - `apply_cholesky_cusolver_potrfBatched`: Chunked `potrfBatched` loop for batch sizes exceeding 65,535.
   - `apply_cholesky_cusolver_potrsBatched`: Chunked `potrsBatched` loop for batch sizes exceeding 65,535.

3. **`test/test_linalg.py`**:
   - Added `test_linalg_inv_large_batch` unit test verifying matrix inversion for batch size 65,536 (`batch_size > 65535`).


### Test Plan
Tested with Python unit test verifying large batch matrix inversion (`batch_size = 65536`):

```python
import torch
a = torch.eye(3, device='cuda:0').repeat(65536, 1, 1)
out = torch.linalg.inv(a)
assert out.sum().item() == 3.0 * 65536


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang