### PR TITLE
[BE][Ez]: Improve readability and accuracy of log2/log10 backwards

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -975,7 +975,7 @@
   result: auto_element_wise
 
 - name: log10(Tensor self) -> Tensor
-  self: grad / (self.conj() * 2.3025850929940456)
+  self: grad / (self.conj() * M_LN10)
   result: auto_element_wise
 
 - name: log1p(Tensor self) -> Tensor
@@ -983,7 +983,7 @@
   result: auto_element_wise
 
 - name: log2(Tensor self) -> Tensor
-  self: grad / (self.conj() * 0.6931471805599453)
+  self: grad / (self.conj() * M_LN2)
   result: auto_element_wise
 
 - name: logaddexp(Tensor self, Tensor other) -> Tensor


### PR DESCRIPTION
* Replaces 2 magic numbers with their macro.
* Improves accuracy of LOG10 constant as it was truncated instead of being correctly rounded for it's double constant.

Use Codex to do the find/replace and the ULP analysis. Also had it check the commit it was introduced in and check the PR discussions to ensure the truncation of LOG10 was not intentional.