### PR TITLE
✴️ iz2: Add PhiloxStatelessRNG.cpp to build_variables.bzl (sync with internal)

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1495,6 +1495,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/Normalization.cpp",
     "aten/src/ATen/native/Onehot.cpp",
     "aten/src/ATen/native/PackedSequence.cpp",
+    "aten/src/ATen/native/PhiloxStatelessRNG.cpp",
     "aten/src/ATen/native/PixelShuffle.cpp",
     "aten/src/ATen/native/PointwiseOps.cpp",
     "aten/src/ATen/native/Pooling.cpp",


### PR DESCRIPTION
✴️ iz2: (opened by Ivan's agent on his behalf)

#177692 ("CPU support for stateless RNG APIs") added `aten/src/ATen/native/PhiloxStatelessRNG.cpp` but did not register it in `build_variables.bzl`. When that PR was imported internally, the entry was added to the internal copy of `build_variables.bzl` before it landed. The two copies of the file have been out of sync since.

This adds the same single line to the OSS copy, so `build_variables.bzl` matches on both sides.

The entry goes into `aten_native_source_non_codegen_list`, in sorted position between `PackedSequence.cpp` and `PixelShuffle.cpp`.

### Build impact

No effect on the default CMake build. `aten/src/ATen/CMakeLists.txt` has an if/else on `BUILD_LITE_INTERPRETER`: the `append_filelist("aten_native_source_non_codegen_list" ...)` call is only in the `ON` branch, while the default `OFF` branch composes `all_cpu_cpp` from `file(GLOB native_cpp "native/*.cpp")`, which already picks this file up. The two branches are mutually exclusive, so there is no double-add.

The change does add the file to the source list used by the `BUILD_LITE_INTERPRETER=ON` branch and by the buck path (`aten_native_source_list` → `buckbuild.bzl`, `pt_template_srcs.bzl`), where it is currently absent. That is a real change in source composition for those configurations rather than pure metadata, so it is worth calling out — though it is the composition the file's own `native_functions.yaml` CPU dispatch entries imply. The equivalent internal buck build already compiles this file from a list containing this exact line.

### Verification

- `build_variables.bzl` on this branch is byte-identical to the internal copy as of internal master `63074c69e3aa` (both 79151 bytes, matching md5). Before this change the OSS copy was 79100 bytes and the only difference between the two files was this one line, in one direction — there were no OSS-only lines.
- `lintrunner` is clean.

Byte-identity is stated against that named internal snapshot; it is not a claim about future drift.
