### PR TITLE
Fix mkstemp file descriptor leak in FileStore rendezvous (#191394)

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,19 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch("torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore")
+    def test_create_backend_closes_mkstemp_fd(
+        self, filestore_mock, mkstemp_mock, os_close_mock
+    ) -> None:
+        expected_fd = 42
+        expected_path = "/tmp/dummy_rendezvous_path"
+        mkstemp_mock.return_value = (expected_fd, expected_path)
+        
+        self._params_filestore.endpoint = ""
+        create_backend(self._params_filestore)
+
+        os_close_mock.assert_called_once_with(expected_fd)
+        filestore_mock.assert_called_once_with(expected_path)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
Closes #191394

### What does this PR do?
Fixes a file descriptor leak in `_create_file_store()` where `tempfile.mkstemp()` was called without closing the returned file descriptor.

- Added `os.close(fd)` immediately after `mkstemp()`
- Added regression test `test_create_backend_closes_mkstemp_fd` to `c10d_rendezvous_backend_test.py` as requested in the issue.