### PR TITLE
Fix torch.all/any with uint8 out= truncating float input on CPU

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1666,8 +1666,16 @@ static inline TensorIterator get_allany_iter(
     // casting, so it can take the same fast path.
     return meta::make_reduction(self, result, dims, keepdim, self.scalar_type());
   }
-  return meta::make_reduction_from_out_ty(
-      self, result, dims, keepdim, result.scalar_type());
+  // On CPU we must reduce in kBool so the cast from self applies a nonzero
+  // test, not a truncating cast (e.g. a float 0.5 cast to uint8 is 0, silently
+  // making a truthy value falsy). Keep result's dtype only when self is already
+  // Byte/Bool, where the cast is exact and the byte fast path in
+  // and_kernel_impl/or_kernel_impl applies.
+  const ScalarType in_dtype =
+      (self.scalar_type() == at::kByte || self.scalar_type() == at::kBool)
+      ? result.scalar_type()
+      : at::kBool;
+  return meta::make_reduction(self, result, dims, keepdim, in_dtype);
 }
 
 template <int identity, typename Stub>

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1181,6 +1181,19 @@ class TestReductions(TestCase):
         c = a.to(torch.bool).all(dim=0)
         self.assertEqual(torch.ne(b, c).sum(), 0)
 
+    def test_all_any_uint8_out_float_input(self, device):
+        # Issue #117215: with a uint8 out=, a float input must be nonzero-tested,
+        # not truncated to uint8 first (0.5 -> uint8 0 would wrongly become falsy).
+        for op in (torch.all, torch.any):
+            for contig in (True, False):
+                x = torch.full((4, 3), 0.5, device=device)
+                if not contig:
+                    x = x.t()
+                expected = op(x.to(torch.bool), dim=0).to(torch.uint8)
+                out = torch.empty(expected.shape, dtype=torch.uint8, device=device)
+                op(x, dim=0, out=out)
+                self.assertEqual(out, expected)
+
     @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfXPU(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)


### PR DESCRIPTION
Fixes #117215

## Summary

On CPU, `torch.all` / `torch.any` with a `uint8` `out=` returned wrong results for inputs that are neither bool nor uint8. `get_allany_iter` (aten/src/ATen/native/ReduceOps.cpp) built the CPU reduction with `in_dtype = out.dtype`, so `self` was cast to the out dtype before the reduction ran. When `out` is `uint8`, a float input is truncated (`0.5` becomes `0`), silently turning a truthy value falsy:

```python
torch.all(torch.full((4, 3), 0.5), dim=0, out=torch.empty(3, dtype=torch.uint8))
# returns [0, 0, 0], should be [1, 1, 1]
```

`any` had the same bug. A bool `out=`, no `out=`, and the CUDA/MPS paths were already correct (they reduce in bool, or do not cast the input).

The fix reduces in `kBool` (a nonzero test, not a truncating cast) unless `self` is already `Byte` or `Bool`, where the cast is exact and the existing byte fast path in `and_kernel_impl` / `or_kernel_impl` is kept. This also corrects non-byte integer inputs, e.g. an `int` value `256` that previously truncated to `uint8` `0`.

I left `make_reduction_from_out_ty` untouched. It is shared by `sum` / `prod` / `mean`, where casting the input to the out dtype is the intended behavior; the narrower change in `get_allany_iter` avoids touching those. The reduce kernels are correct and unchanged. An earlier partial fix (#117827) addressed only the uint8-input case and left this input-truncation case open.

## Test Plan

Issue repro, before and after the fix:

```python
import torch
a = torch.randn((73, 11, 3, 17))
out = torch.randint(0, 255, (11, 3, 17), dtype=torch.uint8)
torch.all(a, dim=0, out=out)
print((out != a.to(torch.bool).all(dim=0)).sum().item())
# before: 561   after: 0
```

New regression test, CPU and CUDA:

```
python test/test_reductions.py -k all_any_uint8_out_float_input -v
```

No regression in existing all/any coverage:

```
python test/test_reductions.py -k test_all_any -v
# 30 passed (all/any, empty, with_dim, vs_numpy across dtypes)
```

## BC-breaking?

No. It only corrects a wrong result.

---

_This change was prepared with the help of an AI coding assistant and reviewed by me before submission._
