### PR TITLE
[symm_mem] Route multicast setup through the PG when PG rendezvous is…

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -381,16 +381,23 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
             ag_entries = [
                 e for e in entries if e["profiling_name"] == "nccl:_all_gather_base"
             ]
-            # On NVLink-fabric hardware both the RendezvousRequest and handle
-            # exchange go through pg_all_gather → 2 allgathers. On hardware
-            # without NVLink fabric only the RendezvousRequest uses
-            # pg_all_gather (handle exchange falls back to ipc_channel) → 1.
-            self.assertIn(
-                len(ag_entries),
-                [1, 2],
-                lambda msg: f"{msg}\nexpected 1 or 2 NCCL _all_gather_base from rendezvous, "
-                f"got {len(ag_entries)}: {[e['profiling_name'] for e in entries]}",
+            bc_entries = [e for e in entries if e["profiling_name"] == "nccl:broadcast"]
+            has_mc = symm_mem_hdl.multicast_ptr != 0
+            # Exchanges routed through the PG: the RendezvousRequest allgather
+            # (always), the handle exchange allgather (NVLink-fabric hardware
+            # only; elsewhere handles go through ipc_channel), and, when
+            # multicast is set up, a success-flag allgather plus a multicast
+            # handle broadcast (fabric only).
+            lo, hi = (2, 3) if has_mc else (1, 2)
+            self.assertTrue(
+                lo <= len(ag_entries) <= hi,
+                f"expected {lo} to {hi} NCCL _all_gather_base from rendezvous "
+                f"(multicast={has_mc}), got {len(ag_entries)}: "
+                f"{[e['profiling_name'] for e in entries]}",
             )
+            self.assertLessEqual(len(bc_entries), 1)
+            if bc_entries:
+                self.assertTrue(has_mc)
 
             symm_mem_hdl.barrier()
             for peer in range(self.world_size):

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -592,12 +592,14 @@ static void init_multicast_for_block(
     const c10::intrusive_ptr<Block>& block,
     std::conditional_t<!use_fabric_handle, IpcChannel&, int&> ipc_channel,
     const std::vector<int>& pids,
-    const c10::intrusive_ptr<c10d::Store>& store,
+    const c10::intrusive_ptr<c10d::ProcessGroup>& group,
+    bool use_pg,
     int rank,
     int world_size) {
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
     defined(CUDART_SUPPORTS_MULTICAST)
   auto driver_api = c10::cuda::DriverAPI::get();
+  auto store = group->getStore();
   auto handleType = use_fabric_handle
       ? CU_MEM_HANDLE_TYPE_FABRIC
       : CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
@@ -637,6 +639,8 @@ static void init_multicast_for_block(
   McHandleType recv_handle;
   if constexpr (!use_fabric_handle) {
     recv_handle = ipc_channel.broadcast_fds(rank, 0, pids, mc_exported_handle);
+  } else if (use_pg) {
+    recv_handle = pg_broadcast(group, block->device_idx, 0, mc_exported_handle);
   } else {
     // TODO implement storeExchange.broadcast
     auto gathered_handles = storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
@@ -692,9 +696,14 @@ static void init_multicast_for_block(
 check_all:
   // Whether all ranks have succeeded
   bool all_succeed = true;
-  auto rank_successes = storeExchange.all_gather(store, rank, world_size, success_end);
+  // uint8_t rather than bool: std::vector<bool> is not memcpy-able, which
+  // pg_all_gather requires.
+  auto success_flag = static_cast<uint8_t>(success_end);
+  auto rank_successes = use_pg
+      ? pg_all_gather(group, block->device_idx, success_flag)
+      : storeExchange.all_gather(store, rank, world_size, success_flag);
   for (int r = 0; r < world_size; ++r) {
-    all_succeed &= rank_successes[r];
+    all_succeed &= (rank_successes[r] != 0);
   }
   if (imported_mc_handle != 0) {
     // Rank 0 may only drop the reference cuMulticastCreate gave it once every
@@ -869,7 +878,11 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       close(imported_handles[r]);
     }
   }
-  storeExchange.barrier(store, rank, world_size);
+  if (use_pg) {
+    pg_barrier(group, block->device_idx);
+  } else {
+    storeExchange.barrier(store, rank, world_size);
+  }
   if constexpr (!use_fabric_handle) {
     close(block_handle);
   }
@@ -879,7 +892,7 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
   bool group_has_multicast_support = check_group_multicast_support(reqs);
   if (!allow_overlapping_devices() && group_has_multicast_support) {
     init_multicast_for_block<use_fabric_handle>(
-        mc_handle, mc_addr, block, ipc_channel, pids, store, rank, world_size);
+        mc_handle, mc_addr, block, ipc_channel, pids, group, use_pg, rank, world_size);
   }
 
   std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -31,6 +31,28 @@ bool allow_overlapping_devices() {
       true;
 }
 
+namespace {
+
+// Every PG exchange during rendezvous stages its payload on `device_idx`: the
+// group may only have a CUDA backend, so a CPU tensor would dispatch to a
+// backend that isn't there. The H2D/D2H copies are negligible at the sizes
+// exchanged (a few hundred bytes per rank).
+at::Tensor stage_bytes_to_device(
+    const void* data,
+    size_t nbytes,
+    int device_idx) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  void* mutable_data = const_cast<void*>(data);
+  return at::from_blob(
+             mutable_data,
+             {static_cast<int64_t>(nbytes)},
+             at::TensorOptions().dtype(at::kByte))
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+      .to(c10::Device(c10::DeviceType::CUDA, device_idx));
+}
+
+} // namespace
+
 at::Tensor pg_all_gather_bytes(
     const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
     const void* data,
@@ -43,26 +65,59 @@ at::Tensor pg_all_gather_bytes(
 
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   c10::cuda::CUDAGuard guard(device_idx);
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-  auto device = c10::Device(c10::DeviceType::CUDA, device_idx);
 
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  void* mutable_data = const_cast<void*>(data);
-  at::Tensor in_buf = at::from_blob(
-                          mutable_data,
-                          {static_cast<int64_t>(nbytes)},
-                          at::TensorOptions().dtype(at::kByte))
-                          .to(device);
-
+  at::Tensor in_buf = stage_bytes_to_device(data, nbytes, device_idx);
   at::Tensor out_buf = at::empty(
       {static_cast<int64_t>(total_bytes)},
-      at::TensorOptions().dtype(at::kByte).device(device));
+      at::TensorOptions().dtype(at::kByte).device(in_buf.device()));
 
   c10d::AllgatherOptions ag_opts;
   ag_opts.asyncOp = false;
   pg->all_gather_single(out_buf, in_buf, ag_opts);
 
   return out_buf.cpu();
+}
+
+at::Tensor pg_broadcast_bytes(
+    const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
+    const void* data,
+    size_t nbytes,
+    int device_idx,
+    int root) {
+  TORCH_CHECK(pg != nullptr, "pg_broadcast_bytes: null ProcessGroup");
+
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+  c10::cuda::CUDAGuard guard(device_idx);
+
+  std::vector<at::Tensor> bufs{stage_bytes_to_device(data, nbytes, device_idx)};
+
+  c10d::BroadcastOptions bc_opts;
+  bc_opts.rootRank = root;
+  bc_opts.asyncOp = false;
+  pg->broadcast(bufs, bc_opts);
+
+  return bufs[0].cpu();
+}
+
+void pg_barrier(
+    const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
+    int device_idx) {
+  TORCH_CHECK(pg != nullptr, "pg_barrier: null ProcessGroup");
+
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+  c10::cuda::CUDAGuard guard(device_idx);
+
+  c10d::BarrierOptions bar_opts;
+  // ProcessGroup::barrier stages its own dummy tensor, so pinning the device
+  // here is what keeps it on the CUDA backend, same as the exchanges above.
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+  bar_opts.device = c10::Device(c10::DeviceType::CUDA, device_idx);
+  bar_opts.device_ids = {static_cast<int64_t>(device_idx)};
+  bar_opts.asyncOp = false;
+  auto work = pg->barrier(bar_opts);
+  if (work != nullptr) {
+    work->wait();
+  }
 }
 
 // Query environment variable to get the backend used for CUDA Symmetric Memory.

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -22,14 +22,28 @@ std::string getSymmMemBackendCUDA();
 
 // All-gather a fixed-size byte payload through the given ProcessGroup.
 // Uses ProcessGroup::all_gather_single (NCCL allgather for a NCCL-backed PG).
-// The payload is staged through a uint8 CUDA tensor on `device_idx`; the H2D
-// and D2H copies are negligible at the sizes exchanged during rendezvous (a
-// few hundred bytes per rank). Returns a contiguous CPU tensor of
-// world_size * nbytes uint8 elements.
+// The payload is staged through a uint8 tensor on `device_idx`. Returns a
+// contiguous CPU tensor of world_size * nbytes uint8 elements.
 at::Tensor pg_all_gather_bytes(
     const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
     const void* data,
     size_t nbytes,
+    int device_idx);
+
+// Broadcast a fixed-size byte payload from rank `root` through the given
+// ProcessGroup. Same staging scheme as `pg_all_gather_bytes`. Returns a
+// contiguous CPU tensor of `nbytes` uint8 elements.
+at::Tensor pg_broadcast_bytes(
+    const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
+    const void* data,
+    size_t nbytes,
+    int device_idx,
+    int root);
+
+// Blocking barrier over the given ProcessGroup, pinned to `device_idx` so the
+// backend does not have to guess which device to barrier on.
+void pg_barrier(
+    const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
     int device_idx);
 
 // Templated wrapper around `pg_all_gather_bytes` matching the shape of
@@ -54,6 +68,29 @@ std::vector<T> pg_all_gather(
       flat.numel());
   std::vector<T> out(world_size);
   std::memcpy(out.data(), flat.data_ptr(), expected);
+  return out;
+}
+
+// Templated wrapper around `pg_broadcast_bytes`. On non-source ranks `val` is
+// ignored and only used to size the payload.
+template <typename T>
+T pg_broadcast(
+    const c10::intrusive_ptr<c10d::ProcessGroup>& pg,
+    int device_idx,
+    int root,
+    const T& val) {
+  static_assert(
+      std::is_trivially_copyable_v<T>,
+      "pg_broadcast requires a trivially copyable type");
+  at::Tensor flat = pg_broadcast_bytes(pg, &val, sizeof(T), device_idx, root);
+  TORCH_CHECK(
+      static_cast<size_t>(flat.numel()) == sizeof(T),
+      "pg_broadcast: expected ",
+      sizeof(T),
+      " bytes but got ",
+      flat.numel());
+  T out{};
+  std::memcpy(&out, flat.data_ptr(), sizeof(T));
   return out;
 }
 


### PR DESCRIPTION
… enabled

`use_pg_for_symm_mem_rendezvous` moved the RendezvousRequest and block handle exchanges off the TCPStore, since the store gets overloaded during rendezvous at large rank counts, but multicast setup was left behind: the multicast handle exchange, the per-rank success flag, and the barrier after peer handles are imported hit the store. This routes tthem through the process group when the option is set. The multicast handle uses a real broadcast (`pg_broadcast`) rather than the store path's allgather-and-keep-element-0. The POSIX-fd path is unchanged, exchanging the multicast fd over `ipc_channel` as before.

The barrier moves too as for large jobs the aggregate request rate from all groups is problematic rather than any single exchange; The success flag is carried as `uint8_t` because `pg_all_gather` memcpys into its result vector and `std::vector<bool>` packs bits, leaving no usable `data()` to copy into.
`test_rendezvous_via_pg_allgather` asserted an exact allgather count, so it now derives the expected range from whether the handle got a multicast pointer.

Test Plan:

On 2x GB200 (NVLink fabric handles, multicast supported):

```
python test/distributed/test_symmetric_memory.py -v
```

134 tests, 1 pre-existing failure (`LoweringTest.test_custom_op_symm_mem_realization`, an `alloc_id` size mismatch that also reproduces without this change and passes in isolation). The NCCL flight recorder around a PG rendezvous confirms nothing is left on the store, and `multimem_all_gather_out` over the resulting pointer confirms the PG-exchanged multicast handle works:

```
nccl ops: ['nccl:_all_gather_base',    # RendezvousRequest
           'nccl:_all_gather_base',    # block handles
           'nccl:all_reduce_barrier',  # post-import barrier
           'nccl:broadcast',           # multicast handle
           'nccl:_all_gather_base']    # multicast success flag
```

This PR was authored with the assistance of an AI coding agent (Claude Code).