### PR TITLE
[TEST] Refactor test/package/test_model.py with hw_classification

### DIFF
--- a/test/package/test_model.py
+++ b/test/package/test_model.py
@@ -6,7 +6,12 @@ from unittest import skipIf
 
 import torch
 from torch.package import PackageExporter, PackageImporter, sys_importer
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+)
 
 
 try:
@@ -31,6 +36,8 @@ except ImportError:
 @skipIfNoTorchVision
 class ModelTest(PackageTestCase):
     """End-to-end tests packaging an entire model."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIf(
         IS_FBCODE or IS_SANDCASTLE,


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = GENERIC to ModelTest — 3 package/serialization tests (all CPU-only, no device references)

## Test Plan

```
python test/package/test_model.py -v
Ran 3 tests in 0.807s — OK (skipped=3)

python test/package/test_model.py -v --hw-classification GENERIC
HW classification mode active (['GENERIC']): total=3, passed=3, unclassified=0, mismatched=0
Ran 3 tests in 0.817s — OK (skipped=3)
```