### PR TITLE
[TEST] Refactor test_autoload.py with hw_classification

### DIFF
--- a/test/test_autoload.py
+++ b/test/test_autoload.py
@@ -2,10 +2,16 @@
 
 import os
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestDeviceBackendAutoload(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_autoload(self):
         switch = os.getenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
 


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add hw_classification = GENERIC to TestDeviceBackendAutoload — 1 env-var-only test, no device references

## Test Plan

```
python test/test_autoload.py -v
Ran 1 test in 1.140s — OK

python test/test_autoload.py -v --hw-classification GENERIC
HW classification mode active (['GENERIC']): total=1, passed=1, unclassified=0, mismatched=0
Ran 1 test in 1.198s — OK
```