### PR TITLE
fix(inductor): guard memory_tracker calls when both memory caps are None

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1080,26 +1080,46 @@ class TestOverlapPreservingBucketing(InductorTestCase):
     def test_no_memory_tracking_preserves_in_flight_limit(self):
         """Both memory-increase caps may be disabled without breaking scheduling."""
         from torch._inductor.fx_passes.overlap_scheduling import (
+            OverlapScheduler,
             schedule_overlap_bucketing,
         )
 
         def func(a, b):
             group_name = "0"
             group_size = 1
+            independent_mm = torch.mm(a, b)
             ag = torch.ops._c10d_functional.all_gather_into_tensor(
                 a, group_size, group_name
             )
-            mm_result = torch.mm(a, b)
             ag_out = torch.ops._c10d_functional.wait_tensor(ag)
-            return (mm_result + ag_out).sum()
+            mm_result = torch.mm(ag_out, b)
+            return independent_mm.sum() + mm_result.sum()
 
         with FakeTensorMode():
             a = torch.randn(16, 16, device=self.device)
             b = torch.randn(16, 16, device=self.device)
             gm = make_fx(func)(a, b)
 
+        scheduler = OverlapScheduler(
+            gm,
+            max_in_flight_gb=1e-9,
+            max_compute_pre_fetch=200,
+            collective_bucketing=False,
+            insert_overlap_deps=False,
+            compute_overlap_multipler=1.0,
+            max_coll_distance=200,
+            collective_estimator="analytical",
+            compute_estimator="analytical",
+            max_memory_increase_gb=None,
+            max_memory_increase_ratio=None,
+            enable_fusion_regions=False,
+        )
+        collective = next(iter(scheduler.collective_info))
+        assert scheduler._prefetch_would_exceed_memory_budget(collective)
+
         schedule_overlap_bucketing(
             gm,
+            max_in_flight_gb=1e-9,
             max_memory_increase_gb=None,
             max_memory_increase_ratio=None,
             collective_estimator="analytical",

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1076,6 +1076,37 @@ class TestOverlapPreservingBucketing(InductorTestCase):
         # Should not error in deterministic mode (would have errored before fix)
         schedule_overlap_bucketing(gm)
 
+    @torch._inductor.config.patch(deterministic=True)
+    def test_no_memory_tracking_preserves_in_flight_limit(self):
+        """Both memory-increase caps may be disabled without breaking scheduling."""
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        def func(a, b):
+            group_name = "0"
+            group_size = 1
+            ag = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, group_size, group_name
+            )
+            mm_result = torch.mm(a, b)
+            ag_out = torch.ops._c10d_functional.wait_tensor(ag)
+            return (mm_result + ag_out).sum()
+
+        with FakeTensorMode():
+            a = torch.randn(16, 16, device=self.device)
+            b = torch.randn(16, 16, device=self.device)
+            gm = make_fx(func)(a, b)
+
+        schedule_overlap_bucketing(
+            gm,
+            max_memory_increase_gb=None,
+            max_memory_increase_ratio=None,
+            collective_estimator="analytical",
+            compute_estimator="analytical",
+            pre_bucketing_fsdp_collectives=False,
+        )
+
     def test_assume_bucketed_latency_exceeds_exposed_time(self):
         """
         When assume_bucketing_reduces_latency is True and two same-type

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1115,7 +1115,7 @@ class TestOverlapPreservingBucketing(InductorTestCase):
             enable_fusion_regions=False,
         )
         collective = next(iter(scheduler.collective_info))
-        assert scheduler._prefetch_would_exceed_memory_budget(collective)
+        self.assertTrue(scheduler._prefetch_would_exceed_memory_budget(collective))
 
         schedule_overlap_bucketing(
             gm,

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1650,6 +1650,48 @@ class TestOverlapSchedulingFixes(InductorTestCase):
         result = scheduler.run()
         result.graph.lint()
 
+    @torch._inductor.config.patch(deterministic=True)
+    def test_no_memory_caps_no_attribute_error(self):
+        """
+        Test that both memory caps set to None don't error during overlap
+        scheduling.
+
+        Before the fix, the scheduler crashed with AttributeError because
+        memory_tracker is None when both max_memory_increase_gb and
+        max_memory_increase_ratio are None, while the code still dereferenced
+        it. The independent max_in_flight_gb limit must also remain active in
+        this configuration.
+        """
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        def func(a, b):
+            group_name = "0"
+            group_size = 1
+
+            ag = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, group_size, group_name
+            )
+
+            # Compute with gemm
+            mm_result = torch.mm(a, b)
+            pointwise = mm_result + 1.0
+
+            ag_out = torch.ops._c10d_functional.wait_tensor(ag)
+
+            return (pointwise + ag_out).sum()
+
+        with FakeTensorMode():
+            a = torch.randn(16, 16, device=self.device)
+            b = torch.randn(16, 16, device=self.device)
+            gm = make_fx(func)(a, b)
+
+        # Should not error (would have errored before fix)
+        schedule_overlap_bucketing(
+            gm, max_memory_increase_gb=None, max_memory_increase_ratio=None
+        )
+
     def test_no_cycle_with_fusion_regions_and_bucketing(self):
         """Test that fusion regions + bucketing doesn't create cycles."""
 

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -524,11 +524,11 @@ class OverlapScheduler:
             self.allowed_peak_memory_bytes = self.original_peak_memory + (
                 memory_increase_bytes or 0
             )
-            self.memory_tracker = MemoryTracker(self.graph)
+            self.memory_tracker: MemoryTracker | None = MemoryTracker(self.graph)
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
-            self.memory_tracker = None  # type: ignore[assignment]
+            self.memory_tracker = None
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [
             0 for _ in range(len(self.compute_nodes))
@@ -629,11 +629,6 @@ class OverlapScheduler:
         Check if prefetching this collective would exceed memory budget at ANY compute node
         between now and when it's used.
         """
-        # No memory caps configured (both None): memory tracking is disabled,
-        # so a prefetch can never be rejected on memory grounds.
-        if self.memory_tracker is None:
-            return False
-
         info = self.collective_info[start_node]
         size = info.size_bytes
 
@@ -643,9 +638,10 @@ class OverlapScheduler:
         if domination_index == sys.maxsize:
             return False
 
-        # check current mem
+        # check current mem (only meaningful when memory tracking is enabled)
         if (
-            self.memory_tracker.current_memory_bytes + size
+            self.memory_tracker is not None
+            and self.memory_tracker.current_memory_bytes + size
             > self.allowed_peak_memory_bytes
         ):
             return True
@@ -659,10 +655,18 @@ class OverlapScheduler:
             ]
 
             # Check 1: Would cumulative prefetch exceed in-flight limit?
+            # This limit is independent of memory tracking (max_in_flight_gb) and
+            # must stay active even when both memory caps are None.
             if (cumulative_prefetch + size) > self.max_in_flight_bytes:
                 return True
 
-            # Check 2: Would total memory (baseline + cumulative prefetch) exceed budget?
+            # Check 2: Would total memory (baseline + cumulative prefetch) exceed
+            # budget? Requires memory tracking: original_mem_before_compute_index
+            # is only populated when tracking is enabled, so this check must be
+            # skipped (not short-circuited to False) when it is disabled.
+            if self.memory_tracker is None:
+                continue
+
             baseline_mem = self.original_mem_before_compute_index[compute_idx]
             projected = baseline_mem + cumulative_prefetch + size
 
@@ -1145,12 +1149,9 @@ class OverlapScheduler:
         self._scheduled_bits |= self.node_ancestors.node_bit(node)
         if self.memory_tracker is not None:
             self.memory_tracker.schedule_node(node)
-
-        current_memory_bytes = (
-            self.memory_tracker.get_current_memory_bytes()
-            if self.memory_tracker is not None
-            else 0
-        )
+            current_memory_bytes = self.memory_tracker.current_memory_bytes
+        else:
+            current_memory_bytes = 0
         log.debug(
             "Scheduled node %s: current_memory=%d bytes, total_scheduled=%d",
             node.name,

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -629,6 +629,11 @@ class OverlapScheduler:
         Check if prefetching this collective would exceed memory budget at ANY compute node
         between now and when it's used.
         """
+        # No memory caps configured (both None): memory tracking is disabled,
+        # so a prefetch can never be rejected on memory grounds.
+        if self.memory_tracker is None:
+            return False
+
         info = self.collective_info[start_node]
         size = info.size_bytes
 
@@ -932,7 +937,8 @@ class OverlapScheduler:
                 # Defer exposed waits until hidden or over memory budget
                 info = self.collective_info[self.wait_to_start[node]]
                 over_budget = (
-                    self.memory_tracker.current_memory_bytes
+                    self.memory_tracker is not None
+                    and self.memory_tracker.current_memory_bytes
                     > self.allowed_peak_memory_bytes
                 )
                 should_schedule = not info.is_exposed or over_budget
@@ -1137,12 +1143,18 @@ class OverlapScheduler:
             raise AssertionError(f"node {node} has unscheduled input nodes")
         self.scheduled.add(node)
         self._scheduled_bits |= self.node_ancestors.node_bit(node)
-        self.memory_tracker.schedule_node(node)
+        if self.memory_tracker is not None:
+            self.memory_tracker.schedule_node(node)
 
+        current_memory_bytes = (
+            self.memory_tracker.get_current_memory_bytes()
+            if self.memory_tracker is not None
+            else 0
+        )
         log.debug(
             "Scheduled node %s: current_memory=%d bytes, total_scheduled=%d",
             node.name,
-            self.memory_tracker.get_current_memory_bytes(),
+            current_memory_bytes,
             len(self.scheduled),
         )
 
@@ -1613,7 +1625,10 @@ class OverlapScheduler:
             potentially_hidden_collectives
         )
         counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
-        counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
+        rescheduled_peak_memory = (
+            self.memory_tracker.peak_memory if self.memory_tracker is not None else 0
+        )
+        counters["inductor"]["rescheduled_mem"] = rescheduled_peak_memory
 
         log.info(
             "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
@@ -1624,7 +1639,7 @@ class OverlapScheduler:
             len(bad_exposed),
             len(potentially_hidden_collectives),
             self.original_peak_memory,
-            self.memory_tracker.peak_memory,
+            rescheduled_peak_memory,
             total_exposed,
             hideable_exposed_ms,
             total_potential_exposed,


### PR DESCRIPTION
## Summary

Closes #192618.

`schedule_overlap_bucketing` with both memory caps `None` (the documented "no limit" configuration) sets `memory_tracker = None`, but several scheduling and end-of-run paths dereference it and raise `AttributeError` on the first scheduled node. This change guards all `memory_tracker` uses: when tracking is disabled, scheduling skips memory tracking, prefetch is never rejected on memory grounds, and counters/logs report 0. Configured-cap behavior is unchanged.

## Checklist

- [ ] I have run `spin fixlint` and all lint checks pass (not run locally)
- [ ] I have added or updated tests (the guard covers all 8 `memory_tracker` reference sites; no new test file was reported)
- [x] I have updated documentation (not applicable to this internal error-handling fix)
- [x] I have included benchmark results (not applicable; no performance-sensitive behavior was changed)

## BC-breaking?

No. Existing behavior with memory caps configured is unchanged; the no-limit configuration no longer raises an `AttributeError`.

## Validation

- `python3 -m py_compile` passes.
- No line exceeds 88 characters.
- All 8 `memory_tracker` reference sites in `overlap_scheduling.py` are covered.
- The `make_fx` reproduction could not be executed locally because this checkout has no built PyTorch.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
