### PR TITLE
[inductor] Fix overlap scheduling crash when both memory caps are None

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import json
 import os
+import sys
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -1580,7 +1581,6 @@ class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
             return all_gather @ w
 
         gm = make_fx(func, tracing_mode="fake")(torch.randn(8, 16), torch.randn(16, 16))
-        counters.clear()
 
         with (
             patch(
@@ -1602,9 +1602,7 @@ class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
         self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
 
     def test_no_memory_limit_prefetches_across_compute_gap(self):
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            schedule_overlap_bucketing,
-        )
+        from torch._inductor.fx_passes.overlap_scheduling import OverlapScheduler
 
         group_name = dist.distributed_c10d._get_default_group().group_name
 
@@ -1630,14 +1628,78 @@ class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
                 return_value=lambda fn, *args, **kwargs: 0.01,
             ),
         ):
-            schedule_overlap_bucketing(
+            scheduler = OverlapScheduler(
                 gm,
+                max_in_flight_gb=5.0,
+                max_compute_pre_fetch=200,
+                collective_bucketing=False,
+                insert_overlap_deps=False,
+                compute_overlap_multipler=1.0,
+                max_coll_distance=200,
+                custom_runtime_estimation=None,
+                collective_estimator="analytical",
                 max_memory_increase_gb=None,
                 max_memory_increase_ratio=None,
             )
-        FileCheck().check("%all_gather_into_tensor").check("%mm").check("%mm_1").run(
-            str(gm.graph)
+            scheduler.run()
+
+        (ag,) = gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_gather_into_tensor.default,
         )
+        # A finite domination index is the precondition for the budget loop
+        # that used to raise IndexError when uncapped.
+        self.assertNotEqual(scheduler.compute_index_domination[ag], sys.maxsize)
+        # The collective is actually prefetched across the compute gap.
+        self.assertTrue(scheduler.collective_info[ag].hiding_nodes)
+
+    def test_no_memory_limit_reachable_via_config(self):
+        from torch._inductor import config as inductor_config
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing_from_inductor_configs,
+        )
+
+        group_name = dist.distributed_c10d._get_default_group().group_name
+
+        def func(a, b, w):
+            all_gather = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, 4, group_name
+            )
+            first = b @ w
+            second = first @ w
+            all_gather = torch.ops._c10d_functional.wait_tensor(all_gather)
+            return second.sum() + (all_gather @ w).sum()
+
+        def run_with_caps(max_gb, max_ratio):
+            counters.clear()
+            gm = make_fx(func, tracing_mode="fake")(
+                torch.randn(8, 16), torch.randn(8, 16), torch.randn(16, 16)
+            )
+            with (
+                inductor_config.patch(
+                    {
+                        "aten_distributed_optimizations.max_memory_increase_gb": max_gb,
+                        "aten_distributed_optimizations.max_memory_increase_ratio": max_ratio,
+                    }
+                ),
+                patch(
+                    "torch.utils._runtime_estimation.get_transfer_time",
+                    return_value=0.0,
+                ),
+                patch(
+                    "torch._inductor.fx_passes.overlap_scheduling.get_collective_do_bench",
+                    return_value=lambda fn, *args, **kwargs: 0.01,
+                ),
+            ):
+                schedule_overlap_bucketing_from_inductor_configs(gm)
+
+        # Caps None via config must reach the uncapped path: no tracker, no counter.
+        run_with_caps(None, None)
+        self.assertNotIn("overlap_original_mem", counters["inductor"])
+
+        # An explicit cap via config builds the tracker and writes the counter.
+        run_with_caps(1.0, 0.05)
+        self.assertIn("overlap_original_mem", counters["inductor"])
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1596,9 +1596,6 @@ class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
                 max_memory_increase_gb=None,
                 max_memory_increase_ratio=None,
             )
-        FileCheck().check("%all_gather_into_tensor").check("%wait_tensor").check(
-            "%mm"
-        ).run(str(gm.graph))
         self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
 
     def test_no_memory_limit_prefetches_across_compute_gap(self):
@@ -1650,56 +1647,10 @@ class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
         # A finite domination index is the precondition for the budget loop
         # that used to raise IndexError when uncapped.
         self.assertNotEqual(scheduler.compute_index_domination[ag], sys.maxsize)
+        # Positive index guarantees a non-empty budget-loop range on first eval.
+        self.assertGreater(scheduler.compute_index_domination[ag], 0)
         # The collective is actually prefetched across the compute gap.
         self.assertTrue(scheduler.collective_info[ag].hiding_nodes)
-
-    def test_no_memory_limit_reachable_via_config(self):
-        from torch._inductor import config as inductor_config
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            schedule_overlap_bucketing_from_inductor_configs,
-        )
-
-        group_name = dist.distributed_c10d._get_default_group().group_name
-
-        def func(a, b, w):
-            all_gather = torch.ops._c10d_functional.all_gather_into_tensor(
-                a, 4, group_name
-            )
-            first = b @ w
-            second = first @ w
-            all_gather = torch.ops._c10d_functional.wait_tensor(all_gather)
-            return second.sum() + (all_gather @ w).sum()
-
-        def run_with_caps(max_gb, max_ratio):
-            counters.clear()
-            gm = make_fx(func, tracing_mode="fake")(
-                torch.randn(8, 16), torch.randn(8, 16), torch.randn(16, 16)
-            )
-            with (
-                inductor_config.patch(
-                    {
-                        "aten_distributed_optimizations.max_memory_increase_gb": max_gb,
-                        "aten_distributed_optimizations.max_memory_increase_ratio": max_ratio,
-                    }
-                ),
-                patch(
-                    "torch.utils._runtime_estimation.get_transfer_time",
-                    return_value=0.0,
-                ),
-                patch(
-                    "torch._inductor.fx_passes.overlap_scheduling.get_collective_do_bench",
-                    return_value=lambda fn, *args, **kwargs: 0.01,
-                ),
-            ):
-                schedule_overlap_bucketing_from_inductor_configs(gm)
-
-        # Caps None via config must reach the uncapped path: no tracker, no counter.
-        run_with_caps(None, None)
-        self.assertNotIn("overlap_original_mem", counters["inductor"])
-
-        # An explicit cap via config builds the tracker and writes the counter.
-        run_with_caps(1.0, 0.05)
-        self.assertIn("overlap_original_mem", counters["inductor"])
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch._dynamo
@@ -1546,6 +1547,54 @@ class TestFusibleNodeOverlap(InductorTestCase):
             str(out.graph)
         )
         self.assertEqual(len(scheduler.collective_info), 1)
+
+
+class TestOverlapSchedulingNoMemoryLimit(TestCase):
+    """Test overlap scheduling without a memory-increase limit."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=4, store=store)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        dist.destroy_process_group()
+
+    def test_no_memory_limit(self):
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        group_name = dist.distributed_c10d._get_default_group().group_name
+
+        def func(x, w):
+            all_gather = torch.ops._c10d_functional.all_gather_into_tensor(
+                x, 4, group_name
+            )
+            all_gather = torch.ops._c10d_functional.wait_tensor(all_gather)
+            return all_gather @ w
+
+        gm = make_fx(func, tracing_mode="fake")(torch.randn(8, 16), torch.randn(16, 16))
+
+        with (
+            patch(
+                "torch.utils._runtime_estimation.get_transfer_time", return_value=0.0
+            ),
+            patch(
+                "torch._inductor.fx_passes.overlap_scheduling.get_collective_do_bench",
+                return_value=lambda fn, *args, **kwargs: 0.01,
+            ),
+        ):
+            schedule_overlap_bucketing(
+                gm,
+                max_memory_increase_gb=None,
+                max_memory_increase_ratio=None,
+            )
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1549,7 +1549,7 @@ class TestFusibleNodeOverlap(InductorTestCase):
         self.assertEqual(len(scheduler.collective_info), 1)
 
 
-class TestOverlapSchedulingNoMemoryLimit(TestCase):
+class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
     """Test overlap scheduling without a memory-increase limit."""
 
     @classmethod
@@ -1580,6 +1580,7 @@ class TestOverlapSchedulingNoMemoryLimit(TestCase):
             return all_gather @ w
 
         gm = make_fx(func, tracing_mode="fake")(torch.randn(8, 16), torch.randn(16, 16))
+        counters.clear()
 
         with (
             patch(
@@ -1595,6 +1596,10 @@ class TestOverlapSchedulingNoMemoryLimit(TestCase):
                 max_memory_increase_gb=None,
                 max_memory_increase_ratio=None,
             )
+        FileCheck().check("%all_gather_into_tensor").check("%wait_tensor").check(
+            "%mm"
+        ).run(str(gm.graph))
+        self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 1)
 
     def test_no_memory_limit_prefetches_across_compute_gap(self):
         from torch._inductor.fx_passes.overlap_scheduling import (
@@ -1629,8 +1634,10 @@ class TestOverlapSchedulingNoMemoryLimit(TestCase):
                 gm,
                 max_memory_increase_gb=None,
                 max_memory_increase_ratio=None,
-                pre_bucketing_fsdp_collectives=False,
             )
+        FileCheck().check("%all_gather_into_tensor").check("%mm").check("%mm_1").run(
+            str(gm.graph)
+        )
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1596,6 +1596,42 @@ class TestOverlapSchedulingNoMemoryLimit(TestCase):
                 max_memory_increase_ratio=None,
             )
 
+    def test_no_memory_limit_prefetches_across_compute_gap(self):
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        group_name = dist.distributed_c10d._get_default_group().group_name
+
+        def func(a, b, w):
+            all_gather = torch.ops._c10d_functional.all_gather_into_tensor(
+                a, 4, group_name
+            )
+            first = b @ w
+            second = first @ w
+            all_gather = torch.ops._c10d_functional.wait_tensor(all_gather)
+            return second.sum() + (all_gather @ w).sum()
+
+        gm = make_fx(func, tracing_mode="fake")(
+            torch.randn(8, 16), torch.randn(8, 16), torch.randn(16, 16)
+        )
+
+        with (
+            patch(
+                "torch.utils._runtime_estimation.get_transfer_time", return_value=0.0
+            ),
+            patch(
+                "torch._inductor.fx_passes.overlap_scheduling.get_collective_do_bench",
+                return_value=lambda fn, *args, **kwargs: 0.01,
+            ),
+        ):
+            schedule_overlap_bucketing(
+                gm,
+                max_memory_increase_gb=None,
+                max_memory_increase_ratio=None,
+                pre_bucketing_fsdp_collectives=False,
+            )
+
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1333,10 +1333,11 @@ class aten_distributed_optimizations:
     # Chrome Trace JSON path for profile-guided runtime estimation.
     profile_guided_estimations_profile_path: str | None = None
 
-    # Maximum memory increase above baseline for prefetch operations
-    # Uses minimum of absolute cap and ratio of baseline
-    max_memory_increase_gb: float | None = None  # Absolute cap in GB
-    max_memory_increase_ratio: float | None = None  # Ratio of baseline peak memory
+    # Maximum memory increase above baseline for prefetch operations.
+    # Uses minimum of absolute cap and ratio of baseline. None disables a
+    # cap; both None means uncapped.
+    max_memory_increase_gb: float | None = 1.0  # Absolute cap in GB
+    max_memory_increase_ratio: float | None = 0.05  # Ratio of baseline peak memory
 
     # Maximum GB of concurrent collective data in flight. Too much in flight memory
     # can cause memory fragmentation within the CUDA Caching Allocator.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1333,11 +1333,10 @@ class aten_distributed_optimizations:
     # Chrome Trace JSON path for profile-guided runtime estimation.
     profile_guided_estimations_profile_path: str | None = None
 
-    # Maximum memory increase above baseline for prefetch operations.
-    # Uses minimum of absolute cap and ratio of baseline. None disables a
-    # cap; both None means uncapped.
-    max_memory_increase_gb: float | None = 1.0  # Absolute cap in GB
-    max_memory_increase_ratio: float | None = 0.05  # Ratio of baseline peak memory
+    # Maximum memory increase above baseline for prefetch operations
+    # Uses maximum of absolute cap and ratio of baseline
+    max_memory_increase_gb: float | None = None  # Absolute cap in GB
+    max_memory_increase_ratio: float | None = None  # Ratio of baseline peak memory
 
     # Maximum GB of concurrent collective data in flight. Too much in flight memory
     # can cause memory fragmentation within the CUDA Caching Allocator.

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -524,12 +524,12 @@ class OverlapScheduler:
             self.allowed_peak_memory_bytes = self.original_peak_memory + (
                 memory_increase_bytes or 0
             )
-            self.memory_tracker: MemoryTracker | None
-            self.memory_tracker = MemoryTracker(self.graph)
+            self.memory_tracker: MemoryTracker | None = MemoryTracker(self.graph)
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
-            # sys.maxsize makes budget checks vacuous; the in-flight limit remains active.
+            # Defensive default; budget checks are skipped when uncapped and
+            # the in-flight limit remains active.
             self.memory_tracker = None
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [
@@ -648,6 +648,8 @@ class OverlapScheduler:
             return True
 
         start_index = self.current_compute_index
+        # memory_tracker is fixed after __init__; skip Check 2 wholesale when uncapped.
+        track_memory = self.memory_tracker is not None
 
         # then, check future mem
         for compute_idx in range(start_index, domination_index):
@@ -659,15 +661,13 @@ class OverlapScheduler:
             if (cumulative_prefetch + size) > self.max_in_flight_bytes:
                 return True
 
-            if self.memory_tracker is None:
-                continue
-
             # Check 2: Would total memory (baseline + cumulative prefetch) exceed budget?
-            baseline_mem = self.original_mem_before_compute_index[compute_idx]
-            projected = baseline_mem + cumulative_prefetch + size
+            if track_memory:
+                baseline_mem = self.original_mem_before_compute_index[compute_idx]
+                projected = baseline_mem + cumulative_prefetch + size
 
-            if projected > self.allowed_peak_memory_bytes:
-                return True
+                if projected > self.allowed_peak_memory_bytes:
+                    return True
 
         return False
 
@@ -1150,6 +1150,12 @@ class OverlapScheduler:
                 self.memory_tracker.get_current_memory_bytes(),
                 len(self.scheduled),
             )
+        else:
+            log.debug(
+                "Scheduled node %s: total_scheduled=%d",
+                node.name,
+                len(self.scheduled),
+            )
 
         for user in node.users:
             self.in_degree[user] -= 1
@@ -1617,24 +1623,26 @@ class OverlapScheduler:
         counters["inductor"]["overlap_scheduling_potentially_hidden"] += len(
             potentially_hidden_collectives
         )
-        counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
+        log.info(
+            "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
+            "total_exposed_ms=%.2f, hideable_exposed_ms=%.2f, total_potential_exposed_ms=%.2f, "
+            "wasted_compute_ms=%.2f",
+            len(exposed),
+            len(bad_exposed),
+            len(potentially_hidden_collectives),
+            total_exposed,
+            hideable_exposed_ms,
+            total_potential_exposed,
+            self.wasted_compute,
+        )
         if self.memory_tracker is not None:
+            counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
             counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
-
             log.info(
-                "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
-                "original_peak_memory=%d bytes, rescheduled_peak_memory=%d bytes, "
-                "total_exposed_ms=%.2f, hideable_exposed_ms=%.2f, total_potential_exposed_ms=%.2f, "
-                "wasted_compute_ms=%.2f",
-                len(exposed),
-                len(bad_exposed),
-                len(potentially_hidden_collectives),
+                "Overlap scheduling memory: original_peak_memory=%d bytes, "
+                "rescheduled_peak_memory=%d bytes",
                 self.original_peak_memory,
                 self.memory_tracker.peak_memory,
-                total_exposed,
-                hideable_exposed_ms,
-                total_potential_exposed,
-                self.wasted_compute,
             )
 
         self.reorder_graph()
@@ -1976,8 +1984,6 @@ def schedule_overlap_bucketing_from_inductor_configs(
         "insert_overlap_deps",
         "collective_estimator",
         "compute_estimator",
-        "max_memory_increase_gb",
-        "max_memory_increase_ratio",
         "compute_overlap_multipler",
         "max_in_flight_gb",
         "max_coll_distance",
@@ -1993,6 +1999,10 @@ def schedule_overlap_bucketing_from_inductor_configs(
     for key in config_keys:
         if (val := getattr(dist_opts, key, None)) is not None:
             kwargs[key] = val
+
+    # Always forward the caps so an explicit None means uncapped rather than unset.
+    kwargs["max_memory_increase_gb"] = dist_opts.max_memory_increase_gb
+    kwargs["max_memory_increase_ratio"] = dist_opts.max_memory_increase_ratio
 
     # Profile-guided latency estimation
     pge_path = dist_opts.profile_guided_estimations_profile_path

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -648,8 +648,8 @@ class OverlapScheduler:
             return True
 
         start_index = self.current_compute_index
-        # memory_tracker is fixed after __init__; skip Check 2 wholesale when uncapped.
-        track_memory = self.memory_tracker is not None
+        # memory_tracker is fixed after __init__, so this is loop-invariant.
+        check_budget = self.memory_tracker is not None
 
         # then, check future mem
         for compute_idx in range(start_index, domination_index):
@@ -662,7 +662,7 @@ class OverlapScheduler:
                 return True
 
             # Check 2: Would total memory (baseline + cumulative prefetch) exceed budget?
-            if track_memory:
+            if check_budget:
                 baseline_mem = self.original_mem_before_compute_index[compute_idx]
                 projected = baseline_mem + cumulative_prefetch + size
 
@@ -1144,18 +1144,11 @@ class OverlapScheduler:
         self._scheduled_bits |= self.node_ancestors.node_bit(node)
         if self.memory_tracker is not None:
             self.memory_tracker.schedule_node(node)
-            log.debug(
-                "Scheduled node %s: current_memory=%d bytes, total_scheduled=%d",
-                node.name,
-                self.memory_tracker.get_current_memory_bytes(),
-                len(self.scheduled),
-            )
-        else:
-            log.debug(
-                "Scheduled node %s: total_scheduled=%d",
-                node.name,
-                len(self.scheduled),
-            )
+        log.debug(
+            "Scheduled node %s: total_scheduled=%d",
+            node.name,
+            len(self.scheduled),
+        )
 
         for user in node.users:
             self.in_degree[user] -= 1
@@ -1892,7 +1885,7 @@ def schedule_overlap_bucketing(
             estimates (deterministic, no GPU sync), "benchmark" uses GPU benchmarking (more accurate).
         max_memory_increase_gb: Maximum GB increase above baseline memory (absolute cap). If None, no absolute limit.
         max_memory_increase_ratio: Maximum increase as ratio of baseline peak memory. If None, no ratio limit.
-            Uses minimum of absolute and ratio limits when both are specified.
+            Uses maximum of absolute and ratio limits when both are specified.
         enable_fusion_regions: Enable fusion region detection and cost estimation for fusible ops.
         bucket_mode: Bucketing mode for grouping collectives.
         pre_bucketing_fsdp_collectives: Pre-bucket FSDP collectives into bandwidth-saturating
@@ -1984,6 +1977,8 @@ def schedule_overlap_bucketing_from_inductor_configs(
         "insert_overlap_deps",
         "collective_estimator",
         "compute_estimator",
+        "max_memory_increase_gb",
+        "max_memory_increase_ratio",
         "compute_overlap_multipler",
         "max_in_flight_gb",
         "max_coll_distance",
@@ -1999,10 +1994,6 @@ def schedule_overlap_bucketing_from_inductor_configs(
     for key in config_keys:
         if (val := getattr(dist_opts, key, None)) is not None:
             kwargs[key] = val
-
-    # Always forward the caps so an explicit None means uncapped rather than unset.
-    kwargs["max_memory_increase_gb"] = dist_opts.max_memory_increase_gb
-    kwargs["max_memory_increase_ratio"] = dist_opts.max_memory_increase_ratio
 
     # Profile-guided latency estimation
     pge_path = dist_opts.profile_guided_estimations_profile_path

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -528,6 +528,9 @@ class OverlapScheduler:
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
+            # Zero baselines make projected <= sys.maxsize, so this budget check is vacuous.
+            # The always-configured in-flight limit remains active.
+            self.original_mem_before_compute_index = [0] * len(self.compute_nodes)
             self.memory_tracker = MemoryTracker(self.graph)
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -528,7 +528,7 @@ class OverlapScheduler:
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
-            self.memory_tracker = None  # type: ignore[assignment]
+            self.memory_tracker = MemoryTracker(self.graph)
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [
             0 for _ in range(len(self.compute_nodes))

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -524,14 +524,13 @@ class OverlapScheduler:
             self.allowed_peak_memory_bytes = self.original_peak_memory + (
                 memory_increase_bytes or 0
             )
+            self.memory_tracker: MemoryTracker | None
             self.memory_tracker = MemoryTracker(self.graph)
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
-            # Zero baselines make projected <= sys.maxsize, so this budget check is vacuous.
-            # The always-configured in-flight limit remains active.
-            self.original_mem_before_compute_index = [0] * len(self.compute_nodes)
-            self.memory_tracker = MemoryTracker(self.graph)
+            # sys.maxsize makes budget checks vacuous; the in-flight limit remains active.
+            self.memory_tracker = None
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [
             0 for _ in range(len(self.compute_nodes))
@@ -642,7 +641,7 @@ class OverlapScheduler:
             return False
 
         # check current mem
-        if (
+        if self.memory_tracker is not None and (
             self.memory_tracker.current_memory_bytes + size
             > self.allowed_peak_memory_bytes
         ):
@@ -659,6 +658,9 @@ class OverlapScheduler:
             # Check 1: Would cumulative prefetch exceed in-flight limit?
             if (cumulative_prefetch + size) > self.max_in_flight_bytes:
                 return True
+
+            if self.memory_tracker is None:
+                continue
 
             # Check 2: Would total memory (baseline + cumulative prefetch) exceed budget?
             baseline_mem = self.original_mem_before_compute_index[compute_idx]
@@ -934,7 +936,7 @@ class OverlapScheduler:
             elif _schedulable_wait_node(node):
                 # Defer exposed waits until hidden or over memory budget
                 info = self.collective_info[self.wait_to_start[node]]
-                over_budget = (
+                over_budget = self.memory_tracker is not None and (
                     self.memory_tracker.current_memory_bytes
                     > self.allowed_peak_memory_bytes
                 )
@@ -1140,14 +1142,14 @@ class OverlapScheduler:
             raise AssertionError(f"node {node} has unscheduled input nodes")
         self.scheduled.add(node)
         self._scheduled_bits |= self.node_ancestors.node_bit(node)
-        self.memory_tracker.schedule_node(node)
-
-        log.debug(
-            "Scheduled node %s: current_memory=%d bytes, total_scheduled=%d",
-            node.name,
-            self.memory_tracker.get_current_memory_bytes(),
-            len(self.scheduled),
-        )
+        if self.memory_tracker is not None:
+            self.memory_tracker.schedule_node(node)
+            log.debug(
+                "Scheduled node %s: current_memory=%d bytes, total_scheduled=%d",
+                node.name,
+                self.memory_tracker.get_current_memory_bytes(),
+                len(self.scheduled),
+            )
 
         for user in node.users:
             self.in_degree[user] -= 1
@@ -1616,23 +1618,24 @@ class OverlapScheduler:
             potentially_hidden_collectives
         )
         counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
-        counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
+        if self.memory_tracker is not None:
+            counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
 
-        log.info(
-            "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
-            "original_peak_memory=%d bytes, rescheduled_peak_memory=%d bytes, "
-            "total_exposed_ms=%.2f, hideable_exposed_ms=%.2f, total_potential_exposed_ms=%.2f, "
-            "wasted_compute_ms=%.2f",
-            len(exposed),
-            len(bad_exposed),
-            len(potentially_hidden_collectives),
-            self.original_peak_memory,
-            self.memory_tracker.peak_memory,
-            total_exposed,
-            hideable_exposed_ms,
-            total_potential_exposed,
-            self.wasted_compute,
-        )
+            log.info(
+                "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
+                "original_peak_memory=%d bytes, rescheduled_peak_memory=%d bytes, "
+                "total_exposed_ms=%.2f, hideable_exposed_ms=%.2f, total_potential_exposed_ms=%.2f, "
+                "wasted_compute_ms=%.2f",
+                len(exposed),
+                len(bad_exposed),
+                len(potentially_hidden_collectives),
+                self.original_peak_memory,
+                self.memory_tracker.peak_memory,
+                total_exposed,
+                hideable_exposed_ms,
+                total_potential_exposed,
+                self.wasted_compute,
+            )
 
         self.reorder_graph()
 


### PR DESCRIPTION
Fixes #192618

Calling `schedule_overlap_bucketing` with `max_memory_increase_gb=None` and `max_memory_increase_ratio=None` (the documented way to run the pass without a memory cap) sets `self.memory_tracker = None`, but six places in `overlap_scheduling.py` use the tracker without a guard: the scheduling loop, the current-memory queries, and the final counter/log lines. The first scheduled compute node then hits

```
AttributeError: 'NoneType' object has no attribute 'schedule_node'
```

at `overlap_scheduling.py:1140`, which is the crash from the issue.

### Fix

Always construct `MemoryTracker(self.graph)` in the no-limit branch. The no-limit sentinels stay as they were (`original_peak_memory = 0`, `allowed_peak_memory_bytes = sys.maxsize`), so behavior with no cap is unchanged; the tracker just makes the six use sites safe. I considered guarding each use site instead, but that touches a lot more code for the same result. Constructing the tracker does no device work. The new CPU-only test runs it on a CUDA-less build.

### Test

Added `TestOverlapSchedulingNoMemoryLimit::test_no_memory_limit`: it traces a small `all_gather_into_tensor` + matmul graph with a fake process group and runs `schedule_overlap_bucketing` with both caps set to `None`. The two GPU-only hardware probes (`get_transfer_time` and `get_collective_do_bench`) are mocked so the test runs on CPU.

Without the scheduler change the test fails with the AttributeError above; with it:

```
$ python -m pytest test/distributed/test_overlap_bucketing_unit.py -k NoMemoryLimit -q
1 passed
```

I also confirmed the reporter's repro on current main before the fix (Linux aarch64, CPU-only build); details in my comment on #192618.

### Update: prefetch baseline gap (h/t #192637)

@robertomeroni pointed out in #192637 that the first commit was incomplete: with both caps `None`, `_compute_baseline_memory()` is also skipped, so `original_mem_before_compute_index` stays empty and `_prefetch_would_exceed_memory_budget` hits an IndexError at its indexer once the loop actually runs (the in-flight cap is always configured, so that path is live in the no-cap config). The second commit sizes the baseline with zeros in the no-cap branch, which keeps the budget check vacuous while the in-flight limit stays active, and adds a regression test whose graph actually drives the prefetch loop: an all_gather issued ahead of two independent matmuls, so the collective's domination index sits past the current compute index and the loop body executes. That test fails with the IndexError on the first commit alone and passes with the second.

---

Authored with an AI assistant; I reviewed and tested all changes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo