### PR TITLE
[TEST] Add hw_classification to test_extension_utils.py and test_autoload.py

### DIFF
--- a/test/test_autoload.py
+++ b/test/test_autoload.py
@@ -2,10 +2,16 @@
 
 import os
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestDeviceBackendAutoload(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_autoload(self):
         switch = os.getenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
 

--- a/test/test_extension_utils.py
+++ b/test/test_extension_utils.py
@@ -2,7 +2,12 @@
 import sys
 
 import torch
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 class DummyPrivateUse1Module:
@@ -32,6 +37,8 @@ class DummyPrivateUse1Module:
 
 
 class TestExtensionUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         # Clean up
         backend_name = torch._C._get_privateuse1_backend_name()


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

**test/test_extension_utils.py:**
- Add `hw_classification = HardwareClassification.GENERIC` to `TestExtensionUtils` — tests PrivateUse1 backend registration utilities, no device execution

**test/test_autoload.py:**
- Add `hw_classification = HardwareClassification.GENERIC` to `TestDeviceBackendAutoload` — tests environment-variable-driven autoload logic, CPU-only

Closes #192626

## Test Plan

```
python test/test_extension_utils.py -v
python test/test_autoload.py -v
```

cc @parsshar-RH