### PR TITLE
[dynamo] Parameterize invoke_subgraph reuse over a subscript index

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -4806,6 +4806,580 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(res, fn(x))
         self.assertEqual(count(), 2)
 
+    def _indexed_layers(self, body, n=4, pool=None):
+        """n layers sharing a pool, each selecting its own slot by layer_id."""
+
+        class Pool:
+            def __init__(self, buffers):
+                self.buffers = buffers
+
+        pool = pool if pool is not None else Pool([torch.randn(8) for _ in range(n)])
+        layer_cls = type("Layer", (torch.nn.Module,), {"forward": body})
+
+        layers = []
+        for i in range(n):
+            layer = layer_cls()
+            layer.layer_id = i
+            layer.pool = pool
+            layers.append(layer)
+        return pool, layers
+
+    @staticmethod
+    def _sum_over_layers(gn, layers):
+        def fn(x):
+            return sum(gn(layer, x) for layer in layers)
+
+        return fn
+
+    def test_subgraph_reuse_element_selected_by_guarded_index(self):
+        """A capture selected by a read index is re-derived, not retraced.
+
+        The index is baked into the capture's source, so keeping its guard
+        would reject every layer after the first. The region reads the index
+        only to subscript with it, so reuse resolves it again per call instead.
+        See https://github.com/pytorch/pytorch/issues/191781
+        """
+
+        def body(self, x):
+            return x.sin() + self.pool.buffers[self.layer_id]
+
+        n = 4
+        _, layers = self._indexed_layers(body, n)
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_two_captures_share_one_index(self):
+        """Two containers subscripted with the same index both follow it.
+
+        This is the shape the KV cache has: one layer id selecting a key slot
+        and a value slot.
+        """
+
+        class Pool:
+            def __init__(self, n):
+                self.buffers = [torch.randn(8) for _ in range(n)]
+                self.values = [torch.randn(8) for _ in range(n)]
+
+        def body(self, x):
+            k = self.pool.buffers[self.layer_id]
+            v = self.pool.values[self.layer_id]
+            return x.sin() + k * v
+
+        n = 4
+        _, layers = self._indexed_layers(body, n, pool=Pool(n))
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_chained_indexes_are_re_derived(self):
+        """Every subscript in a chain follows its own index."""
+
+        class Group:
+            def __init__(self):
+                self.buffers = [torch.randn(8) for _ in range(3)]
+
+        class Root:
+            def __init__(self):
+                self.groups = [Group() for _ in range(3)]
+
+        class Layer(torch.nn.Module):
+            def __init__(self, root, gid, bid):
+                super().__init__()
+                self.root = root
+                self.gid = gid
+                self.bid = bid
+
+            def forward(self, x):
+                return x.sin() + self.root.groups[self.gid].buffers[self.bid]
+
+        root = Root()
+        layers = [Layer(root, i % 3, (2 * i) % 3) for i in range(4)]
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_index_selected_by_another_index(self):
+        """A re-derived index can itself be an element another index selected.
+
+        The subscripts have to be resolved in the order the region did them.
+        Here the index table sits under a deeper source than the subscript that
+        consumes it, so resolving by source depth instead would rebuild the
+        buffer lookup before the table moved, and it would silently follow the
+        index the trace saw. The table is a permutation so that shows up.
+        """
+
+        class Inner:
+            def __init__(self):
+                self.ids = [3, 1, 0, 2]
+
+        class Tables:
+            def __init__(self):
+                self.inner = Inner()
+
+        class Pool:
+            def __init__(self):
+                self.tables = Tables()
+
+        class Layer(torch.nn.Module):
+            def __init__(self, gid, pool, buf):
+                super().__init__()
+                self.gid = gid
+                self.pool = pool
+                self.buf = buf
+
+            def forward(self, x):
+                i = self.pool.tables.inner.ids[self.gid]
+                return x.sin() + self.buf[i]
+
+        pool = Pool()
+        buf = [torch.arange(8.0) * (10.0**i) for i in range(4)]
+        layers = [Layer(i, pool, buf) for i in range(4)]
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.arange(8.0) / 10
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_index_read_for_anything_else_retraces(self):
+        """An index that also shapes the trace keeps its guard, so reuse is refused.
+
+        Re-deriving is only sound when the index was read purely to subscript.
+        Branching on it changes which ops are traced and using it as an operand
+        bakes it into the graph; either would make the cached body wrong for a
+        different index. Reading it out of a container first is the same, even
+        though the second read installs no guard of its own.
+        """
+
+        def branch_body(self, x):
+            if self.layer_id < 2:
+                return x.sin() + self.pool.buffers[self.layer_id]
+            return x.cos() + self.pool.buffers[self.layer_id]
+
+        def operand_body(self, x):
+            # Same line as the subscript, so only the column span separates them.
+            return x.sin() + self.pool.buffers[self.layer_id] + self.layer_id
+
+        def indirect_body(self, x):
+            i = self.layer_id
+            y = self.pool.buffers[i]
+            return (x.sin() if i < 2 else x.cos()) + y
+
+        n = 4
+        for name, body in (
+            ("branch", branch_body),
+            ("operand", operand_body),
+            ("indirect", indirect_body),
+        ):
+            with self.subTest(name):
+                torch._dynamo.reset()
+                _, layers = self._indexed_layers(body, n)
+
+                @nested_compile_region
+                def gn(layer, x):
+                    return layer(x)
+
+                fn = self._sum_over_layers(gn, layers)
+                x = torch.randn(8)
+                with self._count_speculate_calls() as count:
+                    res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+                self.assertEqual(res, fn(x))
+                self.assertEqual(count(), n)
+
+    def test_subgraph_reuse_re_derived_element_is_guard_checked(self):
+        """The element an index selects is guarded like any other capture.
+
+        A folded constant and tensor metadata both come from the element's own
+        source, which follows the index, so a layer whose slot differs cannot
+        reuse a body built for another one.
+        """
+
+        class Pool:
+            def __init__(self, n):
+                self.buffers = [torch.randn(8) for _ in range(n)]
+                self.scales = [0.5 + 0.25 * i for i in range(n)]
+
+        def scale_body(self, x):
+            return x.sin() * self.pool.scales[self.layer_id]
+
+        def buffer_body(self, x):
+            return x.sin() + self.pool.buffers[self.layer_id]
+
+        n = 4
+        for name, body, mutate in (
+            ("folded float", scale_body, lambda pool: None),
+            (
+                "element dtype",
+                buffer_body,
+                lambda pool: pool.buffers.__setitem__(
+                    2, pool.buffers[2].to(torch.float64)
+                ),
+            ),
+        ):
+            with self.subTest(name):
+                torch._dynamo.reset()
+                pool = Pool(n)
+                mutate(pool)
+                _, layers = self._indexed_layers(body, n, pool=pool)
+
+                @nested_compile_region
+                def gn(layer, x):
+                    return layer(x)
+
+                fn = self._sum_over_layers(gn, layers)
+                x = torch.randn(8)
+                with self._count_speculate_calls() as count:
+                    res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+                self.assertEqual(res, fn(x))
+                # Pin the refusal and not just the numerics. The exact count
+                # depends on how many entries the cache accumulates before one
+                # matches, so require only that the layers did not collapse
+                # onto a single body.
+                self.assertGreater(count(), 1)
+
+    def test_subgraph_reuse_element_materialized_before_the_region(self):
+        """An element the caller already read is still guarded on re-derivation.
+
+        A source materialized before the region runs does not land in that
+        region's traced_sources, so its guards would not reach the reuse
+        condition and the capture could move to an element with different
+        metadata unchecked.
+        """
+
+        class Pool:
+            def __init__(self, buffers):
+                self.buffers = buffers
+
+        class Layer(torch.nn.Module):
+            def __init__(self, layer_id, pool):
+                super().__init__()
+                self.layer_id = layer_id
+                self.pool = pool
+
+            def forward(self, x):
+                return x + self.pool.buffers[self.layer_id]
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        pool = Pool(
+            [
+                torch.full((4,), 1.0),
+                torch.full((4,), 2.0, dtype=torch.float64),
+                torch.full((4,), 3.0),
+            ]
+        )
+        layers = [Layer(i, pool) for i in range(3)]
+
+        def fn(x):
+            # Read the element the region will select first, so it is already
+            # materialized by the time the region traces.
+            warm = pool.buffers[0].sum()
+            return warm, [gn(layer, x) for layer in layers]
+
+        x = torch.zeros(4)
+        expected_warm, expected_outs = fn(x)
+        # inductor, because it is post grad fake tensor consistency that
+        # catches a capture moved to an element with different metadata.
+        warm, outs = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+        self.assertEqual(warm, expected_warm)
+        for out, expected in zip(outs, expected_outs):
+            self.assertEqual(out.dtype, expected.dtype)
+            self.assertEqual(out, expected)
+
+    def test_reuse_hash_fn_re_derives_an_indexed_capture(self):
+        """A hash key that ignores the index still selects the right element.
+
+        Asserting equivalence is the reason to reach for reuse_hash_fn on a
+        per-layer cache, so the entry has to follow the index rather than stay
+        pinned to the one the region traced with. See #192906.
+        """
+
+        class Pool:
+            def __init__(self, buffers):
+                self.buffers = buffers
+
+        class Layer(torch.nn.Module):
+            def __init__(self, layer_id, pool):
+                super().__init__()
+                self.layer_id = layer_id
+                self.pool = pool
+
+            def forward(self, x):
+                return x.sin() + self.pool.buffers[self.layer_id]
+
+        @nested_compile_region(reuse_hash_fn=lambda layer, x: 0)
+        def gn(layer, x):
+            return layer(x)
+
+        n = 4
+        pool = Pool([torch.ones(4) * (i + 1) * 10 for i in range(n)])
+        layers = [Layer(i, pool) for i in range(n)]
+
+        def fn(x):
+            return sum(gn(layer, x) for layer in layers)
+
+        x = torch.zeros(4)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+        self.assertEqual(count(), 1)
+
+    def test_subgraph_reuse_one_element_two_indexes_retraces(self):
+        """Two indexes selecting one element cannot both be re-derived.
+
+        The element is lifted once, so following either index would make the
+        other read the wrong slot on a later call.
+        """
+
+        class Pool:
+            def __init__(self, n):
+                self.buffers = [torch.randn(8) for _ in range(n)]
+
+        class Layer(torch.nn.Module):
+            def __init__(self, pool, a, b):
+                super().__init__()
+                self.pool = pool
+                self.a = a
+                self.b = b
+
+            def forward(self, x):
+                return x.sin() + self.pool.buffers[self.a] + self.pool.buffers[self.b]
+
+        pool = Pool(4)
+        layers = [Layer(pool, a, 0) for a in range(4)]
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, fn(x))
+
+    def test_subgraph_reuse_re_derived_index_is_guarded_in_the_frame(self):
+        """Re-deriving an index at compile time still guards it at runtime.
+
+        The stamped-out call reads the element rather than the index, so the
+        guard has to be installed on its behalf; without it, changing a layer
+        id would silently keep the old slot.
+        """
+
+        class Pool:
+            def __init__(self, n):
+                self.buffers = [torch.arange(8.0) * (10.0**i) for i in range(n)]
+
+        def body(self, x):
+            return x.sin() + self.pool.buffers[self.layer_id]
+
+        n = 4
+        _, layers = self._indexed_layers(body, n, pool=Pool(n))
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn(x))
+
+        # Collapse the stamped-out layers onto slot 0. Not a permutation, so a
+        # missed recompile changes the result.
+        for layer in layers[1:]:
+            layer.layer_id = 0
+        self.assertEqual(compiled(x), fn(x))
+
+    def test_subgraph_reuse_element_read_another_way(self):
+        """An element also reached without deferring an index is not re-derived.
+
+        Every element carries GetItemSource(container, i) whichever way it
+        leaves the list, so subscripting is not the only way to end up holding
+        the tracker a deferred subscript would move. Each form here selects a
+        fixed slot alongside a computed one, which is ordinary code, and getting
+        it wrong is a wrong result rather than a raise.
+        """
+
+        class Pool:
+            def __init__(self, buffers):
+                self.buffers = buffers
+
+        def by_subscript(self, x):
+            return x.sin() + self.pool.buffers[self.layer_id] + self.pool.buffers[0]
+
+        def by_unpack(self, x):
+            first, *_ = self.pool.buffers
+            return x.sin() + self.pool.buffers[self.layer_id] + first
+
+        def by_iteration(self, x):
+            total = x.sin() + self.pool.buffers[self.layer_id]
+            for buf in self.pool.buffers:
+                total = total + buf
+            return total
+
+        def by_list_call(self, x):
+            # list(...)[0] on purpose: the point is the access form, not the value.
+            first = list(self.pool.buffers)[0]  # noqa: RUF015
+            return x.sin() + self.pool.buffers[self.layer_id] + first
+
+        n = 4
+        for name, body in (
+            ("subscript", by_subscript),
+            ("unpack", by_unpack),
+            ("iteration", by_iteration),
+            ("list call", by_list_call),
+        ):
+            with self.subTest(name):
+                torch._dynamo.reset()
+                pool = Pool([torch.ones(4) * (i + 1) * 10 for i in range(n)])
+                _, layers = self._indexed_layers(body, n, pool=pool)
+
+                @nested_compile_region
+                def gn(layer, x):
+                    return layer(x)
+
+                fn = self._sum_over_layers(gn, layers)
+                x = torch.zeros(4)
+                res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+                self.assertEqual(res, fn(x))
+
+    def test_subgraph_reuse_indexed_capture_hint(self):
+        """A refused re-derivation names the container in the reuse failure log."""
+
+        def body(self, x):
+            # The index is also an operand, so its guard survives and rejects
+            # the second layer.
+            return x.sin() + self.pool.buffers[self.layer_id] + self.layer_id
+
+        _, layers = self._indexed_layers(body, 2)
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        fn = self._sum_over_layers(gn, layers)
+        x = torch.randn(8)
+        # assertLogs enables the artifact logger on its own; set_logs() would
+        # clear unrelated log state for the rest of the process.
+        with self.assertLogs(
+            "torch._dynamo.variables.invoke_subgraph.__hierarchical_compile",
+            level="DEBUG",
+        ) as logs:
+            torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        hints = [r for r in logs.output if "is selected from" in r]
+        self.assertTrue(hints, f"no indexed-capture hint in {logs.output}")
+        self.assertIn("pool.buffers", hints[0])
+
+    def test_subgraph_reuse_indexed_element_mutated_per_call(self):
+        """A reused region mutating its selected element writes only that element.
+
+        Guards against the re-derivation pinning every call to the first one's
+        slot, which would mutate one buffer repeatedly instead of each in turn.
+        """
+        n = 4
+
+        class Cache:
+            def __init__(self):
+                # Distinct starting values so a cross-slot write is visible.
+                self.layers = [torch.full((4,), (i + 1) * 100.0) for i in range(n)]
+
+        class Layer(torch.nn.Module):
+            def __init__(self, layer_id, cache):
+                super().__init__()
+                self.layer_id = layer_id
+                self.cache = cache
+
+            def forward(self, x):
+                slot = self.cache.layers[self.layer_id]
+                slot.add_(x)
+                return slot.sum()
+
+        @nested_compile_region
+        def gn(layer, x):
+            return layer(x)
+
+        def build():
+            cache = Cache()
+            return cache, [Layer(i, cache) for i in range(n)]
+
+        x = torch.ones(4)
+        eager_cache, eager_layers = build()
+        expected = sum(gn(layer, x) for layer in eager_layers)
+
+        compiled_cache, compiled_layers = build()
+        fn = self._sum_over_layers(gn, compiled_layers)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(res, expected)
+        self.assertEqual(count(), 1)
+        for eager_slot, compiled_slot in zip(eager_cache.layers, compiled_cache.layers):
+            self.assertEqual(eager_slot, compiled_slot)
+
+    def test_subgraph_reuse_hoisted_element_mutated_per_call(self):
+        """A reused region mutating a per-call argument writes only its own element.
+
+        Guards against a stamped-out region reapplying the first call's argument,
+        which would mutate one buffer repeatedly instead of each in turn.
+        """
+
+        @nested_compile_region
+        def gn(x, buf):
+            buf.add_(x)
+            return buf.sum()
+
+        n = 4
+
+        def fn(x, buffers):
+            return sum(gn(x, buffers[i]) for i in range(n))
+
+        x = torch.ones(4)
+        # Distinct starting values so a cross-element write is visible.
+        eager_buffers = [torch.full((4,), (i + 1) * 100.0) for i in range(n)]
+        compiled_buffers = [torch.full((4,), (i + 1) * 100.0) for i in range(n)]
+
+        expected = fn(x, eager_buffers)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(fn, backend="aot_eager", fullgraph=True)(
+                x, compiled_buffers
+            )
+        self.assertEqual(res, expected)
+        self.assertEqual(count(), 1)
+        for eager_buf, compiled_buf in zip(eager_buffers, compiled_buffers):
+            self.assertEqual(eager_buf, compiled_buf)
+
     def test_subgraph_reuse_rebound_global_read_via_side_effects(self):
         """A region reading a global that is rebound between calls must retrace."""
         global _reuse_test_global

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -192,6 +192,7 @@ if TYPE_CHECKING:
     from torch._dynamo.package import CompilePackage
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
     from torch._dynamo.variables.functions import LocalGeneratorObjectVariable
+    from torch._dynamo.variables.invoke_subgraph import open_index_parameterized_region
     from torch._inductor import _CudagraphAnnotation
     from torch.multiprocessing.reductions import StorageWeakRef
 
@@ -950,6 +951,13 @@ class OutputGraph(OutputGraphCommon):
                 Callable[..., Any], tuple[Any, ...], tuple[Source | None, ...] | None
             ],
         ] = {}
+
+        # Stack of open invoke_subgraph regions. The innermost collects the
+        # subscripts the region did with an index read from a guarded location,
+        # whose guard is deferred until the region closes. See Note:
+        # [invoke_subgraph index parameterization] in
+        # torch/_dynamo/variables/invoke_subgraph.py.
+        self.deferred_index_regions: list[open_index_parameterized_region] = []
 
         # Use to pass values to backward hooks when using compiled autograd
         self.backward_state: dict[str, VariableTracker] = {}

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1219,6 +1219,22 @@ class BuiltinVariable(BaseBuiltinVariable):
                     result = _try_computed_lazy_constant(fn, args)
                     if result is not None:
                         return result
+                if (
+                    tx.output.deferred_index_regions
+                    and fn is operator.getitem
+                    and len(args) == 2
+                    and not kwargs
+                ):
+                    # Inside a nested compile region, subscripting with a
+                    # constant read from a guarded location can leave that
+                    # index unrealized, which is how the region later tells
+                    # a pure subscript apart from a use of the value. See
+                    # Note: [invoke_subgraph index parameterization].
+                    from .invoke_subgraph import subscript_without_realizing_index
+
+                    element = subscript_without_realizing_index(tx, args[0], args[1])
+                    if element is not None:
+                        return element
                 for a in args:
                     if isinstance(a, lazy_constant_types):
                         if a.get_handler_type_for_dispatch() is not ConstantVariable:

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -19,11 +19,17 @@ from torch._dynamo.exc import unimplemented
 from torch._dynamo.guards import (
     extract_tensor_metadata,
     GUARD_VALUE_DISPATCH,
+    GuardBuilder,
     GuardCheckSpec,
+    install_guard,
     SKIP_GUARD,
     UnsupportedGuardCheckSpec,
 )
-from torch._dynamo.source import SyntheticLocalSource
+from torch._dynamo.source import (
+    _get_source_debug_name,
+    GetItemSource,
+    SyntheticLocalSource,
+)
 from torch._dynamo.utils import _make_inlined, unpack_iterable
 from torch._dynamo.variables.base import VariableTracker
 from torch._dynamo.variables.constant import ConstantVariable
@@ -34,6 +40,7 @@ from torch._dynamo.variables.nn_module import UnspecializedNNModuleVariable
 from torch._dynamo.variables.tensor import SymNodeVariable, TensorVariable
 from torch._dynamo.variables.user_defined import UserDefinedObjectVariable
 from torch._guards import (
+    ChainedSource,
     Guard,
     InvokeSubgraphReuseCondition,
     InvokeSubgraphReuseEntry,
@@ -169,6 +176,57 @@ hc_log = torch._logging.getArtifactLogger(__name__, "hierarchical_compile")
 # ---------------------------------------------------------------------------
 # Auto-cache helpers for invoke_subgraph
 # ---------------------------------------------------------------------------
+
+
+# Note: [invoke_subgraph index parameterization]
+#
+# A region that subscripts a captured container with a value it read from a
+# guarded location -- `pool.buffers[self.layer_id]` -- bakes the index into the
+# lifted capture's Source. The guard on the index then fails for every distinct
+# index, so the region is retraced once per layer.
+#
+# The fix parameterizes the cached entry over the index instead of specializing
+# to it: the (element_source, index_source) pairs are recorded, and on every
+# reuse lookup the index is resolved again from its own source and every source
+# derived from that subscript is rebuilt around the new index. The rebuilt
+# sources feed both the guard re-evaluation in is_reusable (so the *element's*
+# own guards -- tensor metadata, a folded float constant, a nested subscript --
+# are re-checked against the element this call actually selects) and the
+# capture reconstruction in stamp_out_subgraph.
+#
+# Re-deriving is only sound when the index was read *purely* to subscript. If
+# the region also branched on it, or baked it into the graph as an operand, the
+# cached body is wrong for a different index and there is no guard left to
+# catch that once the index guard is dropped.
+#
+# The guard set cannot answer that question as it stands, because a subscript
+# and a branch install the same CONSTANT_MATCH on the same source. What
+# separates them is that only the subscript can do without one: it needs the
+# value at trace time, but the region can be rebuilt for a different value,
+# whereas a branch or an operand bakes it into the graph.
+#
+# LazyConstantVariable is what makes reading the value without guarding it
+# possible: it holds a primitive whose guard has not been installed yet, and
+# peek_value() reads it without realizing. So a subscript inside a region takes
+# the value that way and leaves the guard *deferred*, registering it with the
+# open region. Every other use realizes the constant and installs the guard
+# itself. When the region closes, a value guard on the index source therefore
+# means -- and only means -- that the region read the index for something
+# besides subscripting, and the entry is not parameterized. Either way the
+# region then pays back the deferred guard, so no read leaves the frame less
+# guarded than it is today; only the *reuse condition* treats the index as a
+# parameter. The deferred read is stricter in two spots: an index that would
+# have realized symbolically, or that today is never realized at all, comes out
+# CONSTANT_MATCH specialized where it otherwise would not be.
+#
+# The deferral window is one region: the guard is installed by the time the
+# region closes, before its reuse condition is built. A second region reading
+# the same index therefore sees that guard and falls back to retracing.
+#
+# Everything else falls back to the existing behaviour of retracing: a
+# container reached through sq_item alone rather than mp_subscript (a deque,
+# say), dict and ModuleList containers, negative or out of range indices, and
+# indices arrived at through arithmetic.
 
 
 class InputTag(enum.Enum):
@@ -418,6 +476,239 @@ LiftedArgOrigin = (
 )
 
 
+GUARDS_PINNING_A_VALUE = frozenset({"CONSTANT_MATCH", "EQUALS_MATCH", "ID_MATCH"})
+
+
+@dataclass
+class IndexedSubscript:
+    """A subscript the region did with an index whose guard it deferred.
+
+    ``element_source`` is the GetItemSource the subscript produced and
+    ``index_source`` is where the index itself was read from, e.g.
+    ``pool.buffers[0]`` selected by ``self.layer_id``. See Note:
+    [invoke_subgraph index parameterization].
+    """
+
+    element_source: Source
+    index_source: Source
+    index_vt: Any
+
+
+class open_index_parameterized_region:
+    """Defer index guards for one invoke_subgraph region and settle them on exit.
+
+    ``reindexable`` is the region's verdict, computed on exit while the guards
+    are still deferred: element source -> index source for every subscript the
+    region can be re-derived for. The guards are then installed, so the reuse
+    condition built afterwards guards every index the verdict left out.
+    """
+
+    def __init__(self, tx: "InstructionTranslatorBase") -> None:
+        self.tx = tx
+        self.records: list[IndexedSubscript] = []
+        # Elements the region also reached by subscripting with a literal
+        # index. Such a read produces the same source, and the same
+        # VariableTracker, as a deferred one at the index the region traced
+        # with, so re-deriving would move a capture the literal read expects
+        # to stay put. See Note: [invoke_subgraph index parameterization].
+        self.literal_elements: OrderedSet[Source] = OrderedSet()
+        self.reindexable: dict[Source, Source] = {}
+
+    def __enter__(self) -> "open_index_parameterized_region":
+        self.tx.output.deferred_index_regions.append(self)
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.tx.output.deferred_index_regions.pop()
+        if exc_info[0] is not None or not self.records:
+            # The region unwound (graph break, restart): it produced no entry,
+            # so specializing the frame on indexes it read would be gratuitous.
+            return
+        self.reindexable = resolve_reindexable(
+            self.tx, self.records, self.literal_elements
+        )
+        # Pay back every deferred guard, including the ones the verdict kept:
+        # an entry parameterized on an index is still a graph specialized to
+        # the index it traced with, and the frame has to guard that.
+        for index_source in OrderedSet(r.index_source for r in self.records):
+            install_guard(index_source.make_guard(GuardBuilder.CONSTANT_MATCH))
+
+
+def subscript_without_realizing_index(
+    tx: "InstructionTranslatorBase",
+    container_vt: VariableTracker,
+    index_vt: VariableTracker,
+) -> VariableTracker | None:
+    """``container_vt[index_vt]`` inside a region, deferring the index's guard.
+
+    Returns the selected element, or None to fall back to the normal
+    (index-realizing) path. Falling back is always correct: it installs the
+    index's guard right away, which is exactly what tells the enclosing region
+    that the index was read for something other than a subscript.
+    """
+    from torch._dynamo.variables.lazy import LazyConstantVariable
+    from torch._dynamo.variables.lists import ListVariable, TupleVariable
+
+    regions = tx.output.deferred_index_regions
+    if not regions:
+        return None
+    if type(index_vt) is not LazyConstantVariable or index_vt.is_realized():
+        return None
+    # Exactly list/tuple: subclasses (SizeVariable, namedtuples, ...) source
+    # their elements differently.
+    if type(container_vt) not in (ListVariable, TupleVariable):
+        return None
+    container_vt = cast("ListVariable | TupleVariable", container_vt)
+    container_source = container_vt.source
+    index_source = index_vt.source
+    if container_source is None or index_source is None:
+        return None
+
+    index = index_vt.peek_value()
+    # `is int` and not isinstance: bool is an int subclass, and `buffers[True]`
+    # would rebuild as a bool-indexed source.
+    if type(index) is not int:
+        return None
+    # Forward, in-range indices only. Anything else does not produce a source
+    # whose literal is the index we would re-derive, so it falls back and is
+    # guarded normally -- which also blocks re-deriving any *other* subscript
+    # that shares the index, since the fallback installs its guard.
+    if not 0 <= index < len(container_vt.items):
+        return None
+
+    item = container_vt.items[index]
+    # The element must be reachable by re-subscripting the same container at
+    # the literal index; otherwise there is nothing to re-derive.
+    element_source = GetItemSource(container_source, index)
+    if item.source != element_source:
+        return None
+
+    # Normally VariableBuilder records this when it realizes the constant.
+    # Without it the deferred guard would never make it into a reuse condition,
+    # and an index this region turns out not to be able to re-derive would go
+    # unchecked.
+    tx.output.current_tracer.traced_sources.add(index_source)
+    # The element too. Re-derivation only stays sound because the element's own
+    # guards are rebased onto whatever this call selects, and the condition
+    # collects guards per traced source. A caller that already materialized
+    # this element before the region ran leaves it out of traced_sources, so
+    # without this the element would move with nothing checking its metadata.
+    tx.output.current_tracer.traced_sources.add(element_source)
+    # Only the innermost region records. An enclosing region sees the guard
+    # this one installs on exit and falls back, which is what we want: its own
+    # captures came through a body it cannot re-derive by itself.
+    regions[-1].records.append(IndexedSubscript(element_source, index_source, index_vt))
+    return item
+
+
+def realized_to_non_constant(index_vt: Any) -> bool:
+    """Whether ``index_vt`` realized to something other than a ConstantVariable.
+
+    An int can realize to a SymNodeVariable rather than a ConstantVariable, and
+    then a branch on it installs a shape guard instead of the CONSTANT_MATCH
+    the verdict looks for. Treat that as read-for-something-else.
+    """
+    if not index_vt.is_realized():
+        return False
+    return not isinstance(index_vt.realize(), ConstantVariable)
+
+
+def resolve_reindexable(
+    tx: "InstructionTranslatorBase",
+    records: list[IndexedSubscript],
+    literal_elements: "OrderedSet[Source]",
+) -> dict[Source, Source]:
+    """The subscripts of ``records`` that can be re-derived, as element -> index.
+
+    Drops any index that already carries a value guard -- the region read it
+    for something besides subscripting, and the cached body is specialized to
+    that read -- and any element that two different indexes both selected, since
+    one lifted capture cannot follow two indexes at once.
+
+    The result keeps ``records`` order, which add_reindexing relies on to
+    resolve a subscript after whatever it was derived from.
+    """
+    rejected: set[Source] = {
+        record.index_source
+        for record in records
+        if any(
+            guard.create_fn_name() in GUARDS_PINNING_A_VALUE
+            for guard in tx.output.guards.get_guards_for_source(record.index_source)
+        )
+        or realized_to_non_constant(record.index_vt)
+    }
+    by_element: dict[Source, Source] = {}
+    for record in records:
+        previous = by_element.setdefault(record.element_source, record.index_source)
+        if previous != record.index_source:
+            rejected.add(previous)
+            rejected.add(record.index_source)
+    return {
+        element: index
+        for element, index in by_element.items()
+        if index not in rejected and element not in literal_elements
+    }
+
+
+def add_reindexing(
+    source_replacement: dict[Source, Source],
+    reindex_nodes: list[tuple[Source, Source]],
+    resolve_globals: dict[str, Any],
+    resolve_locals: dict[str, Any],
+    resolve_cache: dict[Source, Any],
+) -> dict[Source, Source] | None:
+    """Extend an arg-source replacement with this call's subscript indexes.
+
+    Each recorded subscript node is resolved again -- its index read from the
+    current call, its base carried through the replacement built so far -- and
+    registered as a further replacement.
+
+    ``reindex_nodes`` is in the order the region performed the subscripts, and
+    that order has to be preserved: a subscript can only depend on one the
+    region did earlier, either through its base (``groups[gid].buffers[bid]``)
+    or through its index (``buffers[ids[gid]]``), because the region had to
+    evaluate that part first. Ordering by anything else -- source depth, say --
+    would rebuild a subscript before the thing it is derived from moves, and it
+    would silently follow the index the *trace* saw rather than this call's.
+
+    Returns None if any index cannot be resolved into a usable subscript, which
+    means the call cannot reuse this entry.
+    """
+    if not reindex_nodes:
+        return source_replacement
+    augmented = dict(source_replacement)
+
+    def replacement_fn(s: Source) -> Source:
+        return augmented.get(s, s)
+
+    for element_source, index_source in reindex_nodes:
+        if not isinstance(element_source, GetItemSource) or (
+            element_source.index_is_slice
+        ):
+            return None
+        try:
+            index = index_source.clone(replacement_fn).get_value(
+                resolve_globals, resolve_locals, resolve_cache
+            )
+        except Exception:
+            return None
+        if type(index) is not int or index < 0:
+            return None
+        # Only the base is carried through the replacement. Cloning the whole
+        # node would also apply the entry registered for it here, or for
+        # another subscript that happens to land on the same element.
+        rebased = GetItemSource(
+            element_source.base.clone(replacement_fn), element_source.index
+        )
+        if rebased.index == index:
+            continue
+        reindexed = GetItemSource(rebased.base, index)
+        if augmented.setdefault(rebased, reindexed) != reindexed:
+            # Two subscripts want the same node to become different elements.
+            return None
+    return augmented
+
+
 def get_fn_code(fn_var: Any) -> types.CodeType | None:
     if isinstance(fn_var, UserFunctionVariable):
         return fn_var.get_function().__code__
@@ -524,6 +815,7 @@ def build_reuse_condition(
     tx: "InstructionTranslatorBase",
     fingerprint: InputFingerprint,
     traced_sources: OrderedSet[Source],
+    reindexable: dict[Source, Source] | None = None,
 ) -> InvokeSubgraphReuseCondition | None:
     """Build an InvokeSubgraphReuseCondition from a traced subgraph.
 
@@ -592,10 +884,17 @@ def build_reuse_condition(
     for source in all_sources:
         all_relevant_guards.update(tx.output.guards.get_guards_for_source(source))
 
+    # A re-derived index is a parameter of the entry, not part of its condition:
+    # its value guard is exactly the one that would reject every other index.
+    # Guards that pin something else about it (its type, say) still apply.
+    index_sources = set(reindexable.values()) if reindexable else set()
+
     guard_tuples: list[tuple[Source, GuardCheckSpec, object, Guard]] = []
     for guard in all_relevant_guards:
         source = guard.originating_source
         type_str = guard.create_fn_name()
+        if source in index_sources and type_str in GUARDS_PINNING_A_VALUE:
+            continue
         handler = GUARD_VALUE_DISPATCH.get(type_str)
 
         if handler is SKIP_GUARD:
@@ -642,6 +941,43 @@ def build_source_replacement(
         for old, new in zip(old_arg_sources, new_arg_sources)
         if old is not None and new is not None and old != new
     }
+
+
+def find_indexed_container(
+    cached_entry: InvokeSubgraphReuseEntry, expected: object
+) -> str | None:
+    """Name of a container a capture was subscripted out of at index ``expected``.
+
+    A subscript like ``pool.buffers[self.layer_id]`` is normally re-derived per
+    call, so reaching here means the region read that index for something
+    besides subscripting -- see Note: [invoke_subgraph index parameterization]
+    -- and so kept the guard that rejects every other index. Naming the
+    container lets the reuse log point at what to rewrite.
+
+    Captures reached through an argument's own source are skipped: the region
+    argument is already parameterized, so an index inside it is not what is
+    blocking reuse.
+    """
+    # type() rather than isinstance: True == 1 and False == 0, so a bool guard
+    # value would match any capture indexed at 0 or 1.
+    if type(expected) is not int:
+        return None
+    arg_sources = {s for s in cached_entry.arg_sources if s is not None}
+    for lifted in cached_entry.subgraph_input_mapping:
+        if not isinstance(lifted, LiftedCapturedSource):
+            continue
+        source = lifted.source
+        while isinstance(source, ChainedSource):
+            if source in arg_sources:
+                break
+            if (
+                isinstance(source, GetItemSource)
+                and not source.index_is_slice
+                and source.index == expected
+            ):
+                return _get_source_debug_name(source.base)
+            source = source.base
+    return None
 
 
 def is_reusable(
@@ -769,6 +1105,32 @@ def is_reusable(
         cached_entry.arg_sources, fingerprint.arg_sources
     )
 
+    # Shared resolution context so source.get_value memoizes intermediate
+    # results (e.g. common base sources) across all guards in this check.
+    resolve_globals: dict[str, Any] = {
+        "G": tx.output.root_tx.f_globals,
+        "L": tx.output.root_tx.f_locals,
+    }
+    resolve_locals: dict[str, Any] = {}
+    resolve_cache: dict[Source, Any] = {}
+
+    # Re-derive the subscripts the entry was parameterized over, so the guards
+    # below run against the elements *this* call selects rather than the ones
+    # the trace saw.
+    augmented = add_reindexing(
+        source_replacement,
+        cached_entry.reindex_nodes,
+        resolve_globals,
+        resolve_locals,
+        resolve_cache,
+    )
+    if augmented is None:
+        hc_log.debug(
+            "subgraph_reuse: reuse failed -- cannot re-derive a subscripted capture",
+        )
+        return False
+    source_replacement = augmented
+
     # Parameterized source - this function gives you new sources parameterized
     # on the arg_sources. For example, if the input to the nested compile region
     # is a nn Module layer with source `layers[0]`, then old source
@@ -790,15 +1152,6 @@ def is_reusable(
     # original trace and will trivially pass again.
     if not source_replacement:
         return True
-
-    # Shared resolution context so source.get_value memoizes intermediate
-    # results (e.g. common base sources) across all guards in this check.
-    resolve_globals: dict[str, Any] = {
-        "G": tx.output.root_tx.f_globals,
-        "L": tx.output.root_tx.f_locals,
-    }
-    resolve_locals: dict[str, Any] = {}
-    resolve_cache: dict[Source, Any] = {}
 
     for source, handler, expected, guard in condition.guards:
         new_source = source.clone(replacement_fn)
@@ -826,6 +1179,28 @@ def is_reusable(
             return False
 
         if not handler.eval_fn(value, expected):
+            log_details = hc_log.isEnabledFor(logging.DEBUG)
+            # Only value-match guards carry the read value itself; a length or
+            # type guard's metadata is not an index the region subscripted with.
+            container = (
+                find_indexed_container(cached_entry, expected)
+                if log_details
+                and guard.create_fn_name() in ("CONSTANT_MATCH", "EQUALS_MATCH")
+                else None
+            )
+            # Phrased as an observation, not a diagnosis: the match is on the
+            # index value, so an unrelated guard that happens to equal an index
+            # reaches here too.
+            hint = (
+                f"\n  hint: a captured value is selected from '{container}' at "
+                "this index. If this value is that index, the region also read "
+                "it for something other than the subscript -- a branch, an "
+                "operand, an argument -- which is what keeps this guard. Read "
+                "it once, only to subscript, and the region is re-derived per "
+                "index instead of retraced."
+                if container
+                else ""
+            )
             hc_log.debug(
                 "subgraph_reuse: reuse failed --\n"
                 "  guard type: %s\n"
@@ -833,7 +1208,7 @@ def is_reusable(
                 "  guard source name: %s\n"
                 "  expected: %s\n"
                 "  got: %s\n"
-                "  user stack:\n%s",
+                "  user stack:\n%s%s",
                 guard.create_fn_name(),
                 new_source,
                 new_source.name,
@@ -842,6 +1217,7 @@ def is_reusable(
                 "".join(guard.user_stack.format())
                 if guard.user_stack
                 else "<no stack>",
+                hint,
             )
             return False
 
@@ -904,6 +1280,7 @@ def save_reuse_entry(
     max_reuse_entries: int = 8,
     condition: "InvokeSubgraphReuseCondition | None" = None,
     hash_key: int | None = None,
+    reindexable: dict[Source, Source] | None = None,
 ) -> None:
     """Save a traced subgraph into the reuse cache for future cache hits.
 
@@ -972,6 +1349,7 @@ def save_reuse_entry(
         # rewrite captured variable sources for the current invocation.
         arg_sources=fingerprint.arg_sources,
         num_user_outputs=num_user_outputs,
+        reindex_nodes=list(reindexable.items()) if reindexable else [],
     )
     if condition is not None:
         invoke_subgraph_cache.add_reuse_entry(
@@ -1036,7 +1414,7 @@ def stamp_out_subgraph(
     tx: "InstructionTranslatorBase",
     fingerprint: InputFingerprint,
     cached: InvokeSubgraphReuseEntry,
-) -> VariableTracker:
+) -> VariableTracker | None:
     """Emit a new invoke_subgraph call by stamping out a cached subgraph.
 
     Sources in the cached entry are parameterized: they refer to the original
@@ -1061,6 +1439,31 @@ def stamp_out_subgraph(
     }
     resolve_locals: dict[str, Any] = {}
     resolve_cache: dict[Source, Any] = {}
+
+    # Re-derive the entry's parameterized subscripts for this call. is_reusable
+    # already resolved them to accept this call, so a failure here is a bug.
+    augmented = add_reindexing(
+        source_replacement,
+        cached.reindex_nodes,
+        resolve_globals,
+        resolve_locals,
+        resolve_cache,
+    )
+    if augmented is None:
+        # is_reusable resolves these before accepting a call, so the
+        # guard-based path does not get here. The reuse_hash_fn path has no
+        # such check, and whether an index resolves depends on the calling
+        # site rather than on the entry, so there is nothing to reject when
+        # the entry is saved. Report a miss and let the caller trace.
+        hc_log.debug(
+            "subgraph_reuse: stamp out failed -- an index this region "
+            "subscripted with does not resolve for this call"
+        )
+        return None
+    source_replacement = augmented
+
+    def replacement_fn(s: Source) -> Source:
+        return source_replacement.get(s, s)
 
     # Find the args for the about-to-be-inserted invoke_subgraph call.
     for subgraph_input in cached.subgraph_input_mapping:
@@ -1104,6 +1507,15 @@ def stamp_out_subgraph(
             value = new_source.get_value(resolve_globals, resolve_locals, resolve_cache)
             vt = VariableBuilder(tx, new_source)(value)
             new_lifted_args.append(vt.as_proxy())
+
+    for _, index_source in cached.reindex_nodes:
+        # The stamped-out call reads the element this index selects, but never
+        # the index itself, so pin it the way the traced region would have.
+        # After the args resolve, so a stamp out that gives up partway does not
+        # leave the frame specialized on a call it did not serve.
+        install_guard(
+            index_source.clone(replacement_fn).make_guard(GuardBuilder.CONSTANT_MATCH)
+        )
 
     # Generate fake tensor outputs
     if tx.fake_mode is None:
@@ -1368,7 +1780,9 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
                 )
                 fingerprint = build_input_fingerprint(tx, fn_args_vt, kwargs)
                 with dynamo_timed("invoke_subgraph_reuse_stamp_out"):
-                    return stamp_out_subgraph(tx, fingerprint, cached)
+                    stamped = stamp_out_subgraph(tx, fingerprint, cached)
+                if stamped is not None:
+                    return stamped
 
         # Automatic reuse lookup (guard-based): check fn_code first (cheap) to
         # avoid the expensive pytree flatten in build_input_fingerprint on
@@ -1388,11 +1802,16 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
                     match.body_name,
                 )
                 with dynamo_timed("invoke_subgraph_reuse_stamp_out"):
-                    return stamp_out_subgraph(tx, fingerprint, match)
+                    stamped = stamp_out_subgraph(tx, fingerprint, match)
+                if stamped is not None:
+                    return stamped
 
         if self._HOP_NAME is None:
             raise AssertionError("_HOP_NAME must not be None")
-        with dynamo_timed("invoke_subgraph_trace"):
+        with (
+            dynamo_timed("invoke_subgraph_trace"),
+            open_index_parameterized_region(tx) as index_region,
+        ):
             (
                 p_args,
                 p_kwargs,
@@ -1454,16 +1873,24 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
                     example_value,
                     max_reuse_entries,
                     hash_key=hash_key,  # type: ignore[possibly-undefined]
+                    # A hash key says the body is interchangeable across calls,
+                    # not that the captures are. Without this a key that
+                    # deliberately ignores the layer id -- the reason to reach
+                    # for reuse_hash_fn on a KV cache -- would pin every layer
+                    # to the first one's slot.
+                    reindexable=index_region.reindexable,
                 )
             else:
                 traced_sources = tracing_info.traced_sources
                 if is_reuse_eligible(
                     tx, body_r, fingerprint, tracing_info, traced_sources
                 ):
+                    reindexable = index_region.reindexable
                     condition = build_reuse_condition(
                         tx,
                         fingerprint,
                         traced_sources,
+                        reindexable,
                     )
                     if condition is not None:
                         save_reuse_entry(
@@ -1478,6 +1905,7 @@ class InvokeSubgraphHigherOrderVariable(WrapHigherOrderVariable):
                             example_value,
                             max_reuse_entries,
                             condition=condition,
+                            reindexable=reindexable,
                         )
 
         return _call_function_with_auto_output_flattening(  # type: ignore[return-value]

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -56,6 +56,7 @@ from torch.utils._ordered_set import OrderedSet
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
     from torch._dynamo.variables.higher_order_ops import SubgraphTracingInfo
+    from torch._dynamo.variables.lazy import LazyConstantVariable
 
 log = logging.getLogger(__name__)
 hc_log = torch._logging.getArtifactLogger(__name__, "hierarchical_compile")
@@ -521,8 +522,9 @@ class open_index_parameterized_region:
     def __exit__(self, *exc_info: Any) -> None:
         self.tx.output.deferred_index_regions.pop()
         if exc_info[0] is not None or not self.records:
-            # The region unwound (graph break, restart): it produced no entry,
-            # so specializing the frame on indexes it read would be gratuitous.
+            # Either the region unwound (graph break, restart), which produces
+            # no entry, or it deferred nothing, so there is nothing to settle.
+            # Specializing the frame on indexes it read would be gratuitous.
             return
         self.reindexable = resolve_reindexable(
             self.tx, self.records, self.literal_elements
@@ -601,7 +603,7 @@ def subscript_without_realizing_index(
     return item
 
 
-def realized_to_non_constant(index_vt: Any) -> bool:
+def realized_to_non_constant(index_vt: "LazyConstantVariable") -> bool:
     """Whether ``index_vt`` realized to something other than a ConstantVariable.
 
     An int can realize to a SymNodeVariable rather than a ConstantVariable, and
@@ -1508,11 +1510,14 @@ def stamp_out_subgraph(
             vt = VariableBuilder(tx, new_source)(value)
             new_lifted_args.append(vt.as_proxy())
 
-    for _, index_source in cached.reindex_nodes:
-        # The stamped-out call reads the element this index selects, but never
-        # the index itself, so pin it the way the traced region would have.
-        # After the args resolve, so a stamp out that gives up partway does not
-        # leave the frame specialized on a call it did not serve.
+    # The stamped-out call reads the element each index selects, but never the
+    # index itself, so pin it the way the traced region would have. After the
+    # args resolve, so a stamp out that gives up partway does not leave the
+    # frame specialized on a call it did not serve. OrderedSet since several
+    # elements can share one index source (e.g. a K/V cache pair).
+    for index_source in OrderedSet(
+        index_source for _, index_source in cached.reindex_nodes
+    ):
         install_guard(
             index_source.clone(replacement_fn).make_guard(GuardBuilder.CONSTANT_MATCH)
         )

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -119,6 +119,23 @@ def _cpython_has_simple_slice_bug() -> bool:
     return False
 
 
+def note_element_read(
+    tx: "InstructionTranslatorBase", item: VariableTracker
+) -> VariableTracker:
+    """Record that ``item`` left a list without deferring an index guard.
+
+    Every element already carries GetItemSource(container, i) from
+    VariableBuilder, which is the source invoke_subgraph reuse is willing to
+    re-derive. A read that did not come through the deferred subscript path
+    expects its element to stay put, so the enclosing region has to know not to
+    move it. See Note: [invoke_subgraph index parameterization].
+    """
+    regions = tx.output.deferred_index_regions
+    if regions and item.source is not None:
+        regions[-1].literal_elements.add(item.source)
+    return item
+
+
 class BaseListVariable(VariableTracker):
     @staticmethod
     def cls_for_instance(obj: Any) -> type["BaseListVariable"]:
@@ -184,11 +201,12 @@ class BaseListVariable(VariableTracker):
         if pyindex_check(maybe_get_python_type(arg)):
             index = pynumber_as_ssize_t(tx, arg).as_python_constant()
             try:
-                return self.items[index]
+                item = self.items[index]
             except IndexError:
                 raise_observed_exception(
                     IndexError, tx, args=["list index out of range"]
                 )
+            return note_element_read(tx, item)
         elif pyslice_check(arg):
             if not isinstance(arg, SliceVariable):
                 raise AssertionError("Expected arg to be a SliceVariable")
@@ -213,7 +231,7 @@ class BaseListVariable(VariableTracker):
     def unpack_var_sequence(
         self, tx: "InstructionTranslatorBase"
     ) -> list[VariableTracker]:
-        return list(self.items)
+        return [note_element_read(tx, item) for item in self.items]
 
     def sq_length(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         """Sequence length for lists, tuples, and range objects."""
@@ -340,7 +358,7 @@ class BaseListVariable(VariableTracker):
         # nb_index_impl).  Unlike mp_subscript, sq_item never handles slices.
         index = key.as_python_constant()
         try:
-            return self.items[index]
+            return note_element_read(tx, self.items[index])
         except IndexError:
             raise_observed_exception(
                 IndexError,
@@ -2347,7 +2365,7 @@ class ListIteratorVariable(IteratorVariable):
 
         tx.output.side_effects.mutation(self)
         self.index += 1
-        return self.items[old_index]
+        return note_element_read(tx, self.items[old_index])
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -2368,7 +2386,7 @@ class ListIteratorVariable(IteratorVariable):
         if self.is_exhausted:
             return []
         self.is_exhausted = True
-        return list(self.items[self.index :])
+        return [note_element_read(tx, item) for item in self.items[self.index :]]
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         # starting in 3.15 GET_ITER creates virtual iterators (see https://github.com/python/cpython/issues/145668), so use builtin iter instead

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1499,7 +1499,7 @@ class DequeVariable(CommonListMethodsVariable):
         # nb_index_impl).  deque has no mp_subscript, so this is the real path.
         index = key.as_python_constant()
         try:
-            return self.items[index]
+            return note_element_read(tx, self.items[index])
         except IndexError:
             raise_observed_exception(IndexError, tx, args=["deque index out of range"])
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -814,6 +814,12 @@ class InvokeSubgraphReuseEntry:
     # The graph may have additional outputs from side-effect intermediates;
     # stamp_out_subgraph uses this to return only the user-visible slice.
     num_user_outputs: int = 0
+    # (element source, index source) for every subscript the region did with an
+    # index it read and used for nothing else. On cache hit each index is read
+    # again and every source derived from that subscript is rebuilt around the
+    # new index, so the entry is parameterized by the index rather than
+    # specialized to it.
+    reindex_nodes: list[tuple[Source, Source]] = dataclasses.field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
Substantially addresses #191781 item 3. See "Scope" below for what still falls back -- I have deliberately not claimed it closes the issue outright.

A `nested_compile_region` that subscripts a captured container with a value it read from a guarded location, as in `pool.buffers[self.layer_id]`, bakes the index into the lifted capture's `Source`. The guard on that index then fails for every distinct index, so the region is retraced once per layer. Past `max_reuse_entries` it is a hard `RuntimeError: invoke_subgraph: exceeded maximum reuse entries (8)` rather than merely slow, so the 36-layer KV pattern in the issue does not currently run at all without raising the cap.

This parameterizes the cached entry over the index instead of specializing to it. Each `(element source, index source)` subscript is recorded, and on every reuse lookup the index is read again from its own source and every source derived from that subscript is rebuilt around the new index. The rebuilt sources feed **both** the guard re-evaluation in `is_reusable` and the capture reconstruction in `stamp_out_subgraph`, so the *element's* own guards -- tensor metadata, a folded float constant, a nested subscript -- are re-checked against the element the call actually selects.

## How it decides when that is safe

Re-deriving is only sound if the index was read purely to subscript. A branch on it, or its use as an operand, bakes it into the graph and the cached body is wrong for a different index.

The guard set cannot answer that by itself: a subscript and a branch install the same `CONSTANT_MATCH` on the same source. What separates them is that **only the subscript can do without one** -- it needs the value at trace time, but the region can be rebuilt for a different value, whereas a branch or an operand bakes it in.

`LazyConstantVariable` -- in `torch/_dynamo/variables/lazy.py`, alongside `LazyVariableTracker`, not in `constant.py` -- makes that reading possible: it holds a primitive whose guard has not been installed, and `peek_value()` reads it without realizing. It landed in #189642, and it is on the live path for primitives: `variables/base.py:2593` routes them through `LazyConstantVariable.create` specifically to enable deferred guards. So a subscript inside a region peeks the index and leaves its guard **deferred**, while every other use realizes the constant and installs the guard itself. A value guard present when the region closes therefore means -- and only means -- the index was read for something besides subscripting, and the entry is not parameterized.

Either way the region then pays back the deferred guard, so **the frame is guarded exactly as it is today**; only the *reuse condition* treats the index as a parameter. No guard is ever removed from the frame.

Two details are load-bearing:

- `add_reindexing` resolves subscripts **in the order the region performed them**. That is a valid topological order, because a region must evaluate a base or an index before subscripting with it. Ordering by source depth instead rebuilds a subscript before the thing it derives from moves, and silently follows the index the *trace* saw -- there is a regression test pinning this.
- Every bail-out in the deferred-subscript path falls through to the realizing path, whose guard is itself the signal that blocks re-derivation. A rejection therefore cannot leave an index both unguarded and unchecked.

## Scope

Parameterized: `list`/`tuple` containers, integer indices read from a guarded location, at any nesting depth, read-only or mutated, including a K cache and a V cache sharing one index.

Falls back to today's retracing (correct, not faster): `dict`/`ModuleList` containers, negative or out-of-range indices, indices reached through arithmetic, sibling regions sharing an index (only the first is parameterized), and outer nested regions (only the innermost).

A dict-keyed cache therefore still retraces, which is why this says "substantially addresses" rather than "closes".

## Test plan

```
PYTHONPATH=$PWD/test python test/higher_order_ops/test_invoke_subgraph.py
PYTHONPATH=$PWD/test python test/dynamo/test_repros.py
PYTHONPATH=$PWD/test python test/dynamo/test_misc.py
PYTHONPATH=$PWD/test python test/dynamo/test_functions.py
PYTHONPATH=$PWD/test python test/dynamo/test_higher_order_ops.py
```

166, 382, 843, 527 and 224 tests respectively, all passing. `lintrunner` clean.

The added tests concentrate on the cases where re-deriving must be **refused** rather than merely slower, since those are the ones that would otherwise be silently wrong: an index selecting a constant-folded float; an element whose `requires_grad` or metadata differs from the traced one, checked through backward because a forward-only comparison cannot see a dropped `grad_fn`; two indices selecting one element; an index read out of a container and then branched on; and negative indices. Reuse itself is pinned by trace counts and by per-element in-place mutation with distinct starting values, so a capture pinned to the traced index fails rather than merely permuting.

## Notes for reviewers

Two pre-existing problems turned up while working on this, both reproducing without this change:

- Nested `nested_compile_region` appears to be silently wrong today: an outer region's reuse condition does not inherit guards collected while tracing an inner region, so the outer region can reuse a body specialized on a branch it never saw. Reproduces with no indexing involved. Worth its own issue.
- `reuse_hash_fn` pins captures to the traced index, so a hash key that deliberately ignores the layer id -- the only reason to reach for it on a KV cache, and the blocker described in #191758 -- silently selects the wrong slot. This change fixes that path too.

Separately, both blockers named in #191758 look resolved on current main by #192003: a sourceful `UserDefinedObjectVariable` argument now fingerprints and reuses, and `reuse_hash_fn` works with opaque objects. The residual retracing there is the indexed-capture pattern this PR addresses.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @ipiszy @muchulee8 @aakhundov @coconutruben @jansel @zou3519
