### PR TITLE
Fix torch.special.ndtr flushing lower-tail float64 values to zero

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -712,7 +712,7 @@ namespace {
 
 inline Tensor calc_ndtr(const Tensor& self) {
   auto x_sqrt_2 = self * M_SQRT1_2;
-  return (1 + at::erf(x_sqrt_2)) * 0.5;
+  return 0.5 * at::erfc(-x_sqrt_2);
 }
 
 } // namespace

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1541,6 +1541,34 @@ class TestUnaryUfuncs(TestCase):
         t = torch.tensor([min, max, eps, tiny], dtype=dtype, device=device)
         check_equal(t)
 
+    @dtypes(torch.float64)
+    def test_special_ndtr_lower_tail(self, device, dtype):
+        x = torch.tensor(
+            [-9.0, -10.0, -12.0, -15.0, -20.0, -30.0],
+            dtype=dtype,
+            device=device,
+        )
+        expected = torch.tensor(
+            [
+                1.1285884059538405e-19,
+                7.619853024160525e-24,
+                1.776482112077679e-33,
+                3.670966199312751e-51,
+                2.7536241186062337e-89,
+                4.906713927148187e-198,
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        actual = torch.special.ndtr(x)
+        self.assertFalse(bool((actual == 0).all()))
+        self.assertEqual(actual, expected, atol=0, rtol=1e-13)
+
+        sanity_x = torch.tensor([0.0, 9.0], dtype=dtype, device=device)
+        sanity_actual = torch.special.ndtr(sanity_x)
+        self.assertEqual(sanity_actual[0], 0.5, atol=0, rtol=0)
+        self.assertEqual(sanity_actual[1], 1.0, atol=0, rtol=1e-15)
+
     @dtypes(torch.float32, torch.float64)
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     def test_special_log_ndtr_vs_scipy(self, device, dtype):

--- a/torch/_refs/special/__init__.py
+++ b/torch/_refs/special/__init__.py
@@ -192,7 +192,7 @@ def ndtr(a: TensorLikeType) -> TensorLikeType:
     # Note: M_SQRT1_2 is the value of 1 / sqrt(2)
     M_SQRT1_2 = 0.707106781186547524400844362104849039
     a_sqrt_2 = a * M_SQRT1_2
-    return (1 + torch.erf(a_sqrt_2)) * 0.5
+    return 0.5 * torch.erfc(-a_sqrt_2)
 
 
 @register_decomposition(aten.special_ndtri)


### PR DESCRIPTION
Fixes #192295

`torch.special.ndtr` computed the normal CDF as `(1 + erf(x/sqrt(2))) * 0.5` (`calc_ndtr` in `aten/src/ATen/native/UnaryOps.cpp`). For x below about -8.3, `erf(x/sqrt(2))` is within 2^-53 of -1 and rounds to exactly -1.0 in float64, so the addition cancels to a hard zero even though the true CDF values are representable down to about x = -37. The Python reference in `torch/_refs/special/__init__.py` had the same formula.

### Fix

Both sites now compute `0.5 * erfc(-x/sqrt(2))`, which is what `scipy.special.ndtr` uses. The lower tail stays representable, and the upper tail keeps the same rounding quality as before (erfc approaches 2 there and the multiply by 0.5 is exact). `erfc` has the same dtype and device coverage as `erf`, so the composite stays device generic.

Gradients are unaffected: `special_ndtr` is CompositeImplicitAutograd, and the chain rules of the two formulations reduce to the same `exp(-x^2/2)/sqrt(2*pi)`.

### Test

`test_special_ndtr_lower_tail` in `test/test_unary_ufuncs.py` checks the issue's six inputs against 60-digit mpmath references at `rtol=1e-13` (the rebuilt kernel's worst case is 3.3e-14, at x=-30), plus x=0 and x=9 sanity values. On the previous formulation all six values are exactly 0.0, so the test fails before this change.

One note on references: three of the expected values quoted in the issue body carry up to ~9e-5 relative error against a fresh 60-digit mpmath computation (largest at x=-9). The test uses the re-derived values; the diagnosis is the same against either set, since 0.0 is wrong regardless.

```
python -m pytest test/test_unary_ufuncs.py -k ndtr   # 517 passed, 4 skipped (scipy not installed locally)
python -m pytest test/test_ops.py -k ndtr            # 174 passed, 50 skipped (CPU-only box)
```

Also spot-checked: x=0 returns exactly 0.5, +inf/-inf return 1.0/0.0, NaN propagates, integer promotion is unchanged, and `torch.compile` (inductor, CPU) matches eager.

Tested on Linux aarch64, CPU build; CUDA goes through the same composite via the dispatched `erfc`, so CI should confirm parity there.

`torch.distributions.Normal.cdf` has the same `1 + erf` pattern and the same latent tail problem. I left it out of scope for this issue and can follow up separately.

---

Authored with an AI assistant; I reviewed and tested all changes.


cc @mruberry @kshitij12345