### PR TITLE
Support integral dtypes in unfold on CPU and CUDA

### DIFF
--- a/aten/src/ATen/native/Im2Col.cpp
+++ b/aten/src/ATen/native/Im2Col.cpp
@@ -94,7 +94,7 @@ void im2col_out_cpu_template(
 
   output.resize_({batch_size, n_output_plane, output_length});
 
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND3(kBFloat16, kHalf, kBool,
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBFloat16, kHalf, kBool,
       input.scalar_type(), "im2col_out_cpu", [&] {
         Tensor input_n;
         Tensor output_n;

--- a/aten/src/ATen/native/cuda/Im2Col.cu
+++ b/aten/src/ATen/native/cuda/Im2Col.cu
@@ -103,7 +103,7 @@ static void im2col_out_cuda_template(
   output.resize_({batch_size, n_output_plane, output_length});
 
   // Launch kernel
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND3(kHalf, kBFloat16, kBool,
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool,
       input.scalar_type(), "im2col_out_cuda", [&] {
     Tensor input_n;
     Tensor output_n;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -49,7 +49,7 @@ from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_
     dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, \
     skipCUDAIf, skipCUDAIfRocm, skipMPSIf, skipMPS, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
-    skipMeta, get_all_device_types
+    skipMeta, get_all_device_types, onlyOn
 from torch.testing._internal.common_modules import module_inputs_torch_nn_LinearCrossEntropyLoss
 
 from hypothesis import given
@@ -9158,6 +9158,29 @@ class TestNNDeviceType(NNTestCase):
         t = torch.randn((10,))
         with self.assertRaisesRegex(RuntimeError, 'Expected all tensors to be on the same device'):
             F.mse_loss(i, t)
+
+    @onlyOn(["cpu", "cuda"])
+    @dtypes(*integral_types())
+    def test_unfold_integral(self, device, dtype):
+        info = torch.iinfo(dtype)
+        values = [info.min, info.max, 2, 3, 4, 5, 6, 7, 8]
+        x = torch.tensor(values, device=device, dtype=dtype).reshape(1, 1, 3, 3)
+        expected = torch.tensor(
+            [[
+                [values[0], values[1], values[3], values[4]],
+                [values[1], values[2], values[4], values[5]],
+                [values[3], values[4], values[6], values[7]],
+                [values[4], values[5], values[7], values[8]],
+            ]],
+            device=device,
+            dtype=dtype,
+        )
+
+        self.assertEqual(F.unfold(x, kernel_size=2), expected)
+        self.assertEqual(nn.Unfold(kernel_size=2)(x), expected)
+        self.assertEqual(
+            F.unfold(x.squeeze(0), kernel_size=2), expected.squeeze(0)
+        )
 
     @onlyNativeDeviceTypes
     def test_Unfold_empty(self, device):


### PR DESCRIPTION
# Fixing an Issue

Before submitting, please review:
- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy

---

## Issue

Fixes #44989

## Summary

I reviewed the implementation line by line and authorized submission after reviewing the baseline, build, lint, and CPU/CUDA test evidence. I understand the change and take responsibility for it.

> **AI assistance disclosure:** AI tools assisted with the implementation and this draft description. The contributor reviewed and approved both.
>
> This extends the CPU and CUDA `im2col` dispatch to the legacy integral dtypes supported by `integral_types()`. It enables integral inputs for `F.unfold` and `nn.Unfold`, and adds exact-value coverage for `uint8`, `int8`, `int16`, `int32`, and `int64`, including batched and unbatched inputs. A CUDA-enabled editable build completed successfully; the focused test ran 10 CPU/CUDA cases, and related `unfold` tests and targeted lint passed.

## Checklist

- [ ] Passes lint (`spin fixlint`); targeted `CLANGFORMAT`, `RUFF`, and `CODESPELL` passed
- [x] Added/updated tests
- [x] Updated documentation (not applicable; public signatures and documented behavior are unchanged)
- [x] Included benchmark results (not applicable; this only extends dtype dispatch coverage)

## BC-breaking?

No.
