### PR TITLE
[Testcase Refactoring] Make APoT linear tests device-agnostic

### DIFF
--- a/test/quantization/core/experimental/test_linear.py
+++ b/test/quantization/core/experimental/test_linear.py
@@ -3,63 +3,80 @@
 import torch
 from torch.ao.quantization.experimental.linear import LinearAPoT
 from torch.nn.modules.linear import Linear
-import unittest
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
-class TestNonUniformObserver(unittest.TestCase):
+
+class TestNonUniformObserver(TestCase):
     """
         Test linear_APoT_fn by comparing to uniform linear
         for 2d tensors with size (4,4) and k=1
     """
-    def test_linear_APoT_k1(self):
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_linear_APoT_k1(self, device):
         # weight: fp tensor
-        weight = 1000 * torch.rand(4, 4)
+        weight = 1000 * torch.rand(4, 4, device=device)
 
         # activation: fp32 tensor with ~ integer values
-        activation = torch.randint(low=0, high=255, size=(4, 4), dtype=torch.float)
+        activation = torch.randint(
+            low=0, high=255, size=(4, 4), dtype=torch.float, device=device
+        )
 
         # calculate result from calling linear forward method
         apot_linear = LinearAPoT(weight, 8, 1)
         apot_linear_result = apot_linear(activation)
 
         # calculate expected results
-        fp_linear = Linear(4, 4, bias=False)
+        fp_linear = Linear(4, 4, bias=False, device=device)
 
         # set weight for fp linear
-        apot_quantized_weight_float = apot_linear.weight.type(torch.FloatTensor)
+        apot_quantized_weight_float = apot_linear.weight.to(dtype=torch.float)
         fp_linear_weight = torch.nn.parameter.Parameter(data=apot_quantized_weight_float)
         fp_linear.weight = fp_linear_weight
 
         fp_linear_result = fp_linear(activation).data
 
-        self.assertTrue(torch.equal(apot_linear_result, fp_linear_result))
+        self.assertEqual(apot_linear_result, fp_linear_result, rtol=0, atol=0)
 
     """
         Test linear_APoT_fn by comparing to uniform linear
         for 2d tensors with size (5,3), (3, 5) and k=2
     """
-    def test_linear_APoT_k2(self):
+    def test_linear_APoT_k2(self, device):
         # weight: fp tensor
-        weight = 1000 * torch.rand(5, 3)
+        weight = 1000 * torch.rand(5, 3, device=device)
 
         # activation: fp32 tensor with ~ integer values
         # note: transpose of activation matrix will have dimension (3, 5)
-        activation = torch.randint(low=0, high=255, size=(5, 3), dtype=torch.float)
+        activation = torch.randint(
+            low=0, high=255, size=(5, 3), dtype=torch.float, device=device
+        )
 
         # calculate result from calling linear forward method
         apot_linear = LinearAPoT(weight, 8, 2)
         apot_linear_result = apot_linear(activation)
 
         # calculate expected results
-        fp_linear = Linear(4, 4, bias=False)
+        fp_linear = Linear(4, 4, bias=False, device=device)
 
         # set weight for fp linear
-        apot_quantized_weight_float = apot_linear.weight.type(torch.FloatTensor)
+        apot_quantized_weight_float = apot_linear.weight.to(dtype=torch.float)
         fp_linear_weight = torch.nn.parameter.Parameter(data=apot_quantized_weight_float)
         fp_linear.weight = fp_linear_weight
 
         fp_linear_result = fp_linear(activation).data
 
-        self.assertTrue(torch.equal(apot_linear_result, fp_linear_result))
+        self.assertEqual(apot_linear_result, fp_linear_result, rtol=0, atol=0)
 
-if __name__ == '__main__':
-    unittest.main()
+
+instantiate_device_type_tests(TestNonUniformObserver, globals())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -6,6 +6,8 @@ using APoT nonuniform quantization methods.
 
 import math
 
+import torch
+
 
 r"""Converts floating point input into APoT number
     based on quantization levels
@@ -32,6 +34,25 @@ def float_to_apot(x, levels, indices, alpha):
             best_idx = idx
 
     return best_idx
+
+
+def float_to_apot_device(
+    tensor: torch.Tensor,
+    levels: torch.Tensor,
+    indices: torch.Tensor,
+    alpha: torch.Tensor,
+) -> torch.Tensor:
+    r"""Converts a floating point tensor into APoT numbers on its device."""
+    alpha = alpha.reshape(())
+    level_deltas = torch.abs(tensor.unsqueeze(-1) - levels)
+    nearest_level_indices = indices[level_deltas.argmin(dim=-1)]
+    nearest_level_indices = torch.where(
+        torch.isnan(tensor),
+        torch.zeros_like(nearest_level_indices),
+        nearest_level_indices,
+    )
+    quantized = torch.where(tensor < -alpha, -alpha, nearest_level_indices)
+    return torch.where(tensor > alpha, alpha, quantized)
 
 
 r"""Converts floating point input into

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -123,7 +123,9 @@ class LinearAPoT(WeightedQuantizedModule):
         rows2 = decomposed_weight.shape[0]
         cols2 = decomposed_weight.shape[1]
 
-        result = torch.zeros(rows1, cols2)
+        result = torch.zeros(
+            rows1, cols2, dtype=torch.float32, device=activation.device
+        )
 
         # compute matrix multiplication with bitshifts
         for i in range(rows1):
@@ -138,7 +140,7 @@ class LinearAPoT(WeightedQuantizedModule):
 
         return result
 
-    def forward(self, activation: torch.Tensor) -> torch.FloatTensor:
+    def forward(self, activation: torch.Tensor) -> torch.Tensor:
         r"""
         Multiply APoT quantized weight and uniformly quantized activation (dtype: quint8)
         with bitshifting instead of matrix multiplication.
@@ -160,12 +162,10 @@ class LinearAPoT(WeightedQuantizedModule):
         for row in range(weight_rows):
             for col in range(weight_cols):
                 decomposed_weight[row][col] = self.decompose_APoT(
-                    bin(self.weight_transposed[row][col])
+                    bin(int(self.weight_transposed[row][col]))
                 )
 
-        result = self.matmul(decomposed_weight, activation).type(torch.FloatTensor)
-
-        return result
+        return self.matmul(decomposed_weight, activation)
 
     @classmethod
     def from_reference(  # type: ignore[override]

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -99,9 +99,7 @@ class APoTObserver(ObserverBase):
         # if signed, add element at index 0 for each tensor
         # else, add element at index 1 for each tensor
         # gamma defined to ensure alpha is at max of range
-        p_sum = torch.zeros(
-            (), dtype=torch.get_default_dtype(), device=alpha.device
-        )
+        p_sum = torch.zeros((), dtype=torch.get_default_dtype(), device=alpha.device)
         for tens in p_all:
             if signed:
                 p_sum += tens[0]
@@ -125,9 +123,7 @@ class APoTObserver(ObserverBase):
                 row_sum += ele
             quantization_levels_list.append(row_sum)
 
-        quantization_levels = gamma.reshape(()) * torch.stack(
-            quantization_levels_list
-        )
+        quantization_levels = gamma.reshape(()) * torch.stack(quantization_levels_list)
         quantization_levels, level_indices = quantization_levels.sort()
 
         return (alpha, gamma, quantization_levels, level_indices)

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -73,15 +73,19 @@ class APoTObserver(ObserverBase):
 
         # create levels
         for i in range(self.n):
-            p_curr = torch.tensor([0])
+            p_curr = torch.zeros(
+                1, dtype=torch.get_default_dtype(), device=alpha.device
+            )
 
             for j in range((2**self.k - 2) + 1):
                 curr_ele = 2 ** (-(i + j * self.n))
-                p_append = torch.tensor([curr_ele])
+                p_append = torch.tensor(
+                    [curr_ele], dtype=torch.get_default_dtype(), device=alpha.device
+                )
                 p_curr = torch.cat((p_curr, p_append))
                 # introduce signed numbers
                 if signed:
-                    p_curr = torch.cat((p_curr, torch.tensor([-curr_ele])))
+                    p_curr = torch.cat((p_curr, -p_append))
 
             if signed:
                 # sort tensor in reverse order before adding to list if signed
@@ -95,12 +99,14 @@ class APoTObserver(ObserverBase):
         # if signed, add element at index 0 for each tensor
         # else, add element at index 1 for each tensor
         # gamma defined to ensure alpha is at max of range
-        p_sum = 0.0
+        p_sum = torch.zeros(
+            (), dtype=torch.get_default_dtype(), device=alpha.device
+        )
         for tens in p_all:
             if signed:
-                p_sum += float(tens[0])
+                p_sum += tens[0]
             else:
-                p_sum += float(tens[1])
+                p_sum += tens[1]
 
         # assign gamma
         gamma = alpha / p_sum
@@ -112,16 +118,16 @@ class APoTObserver(ObserverBase):
 
         # calculate sum of each row
         for row in cartesian_product:
-            sum = 0.0
+            row_sum = torch.zeros(
+                (), dtype=torch.get_default_dtype(), device=alpha.device
+            )
             for ele in row:
-                sum += ele
-            quantization_levels_list.append(sum)
+                row_sum += ele
+            quantization_levels_list.append(row_sum)
 
-        quantization_levels_gamma = [
-            float(gamma) * ele for ele in quantization_levels_list
-        ]
-        quantization_levels = torch.tensor(quantization_levels_gamma)
-        level_indices = torch.tensor([])
+        quantization_levels = gamma.reshape(()) * torch.stack(
+            quantization_levels_list
+        )
         quantization_levels, level_indices = quantization_levels.sort()
 
         return (alpha, gamma, quantization_levels, level_indices)

--- a/torch/ao/quantization/experimental/quantizer.py
+++ b/torch/ao/quantization/experimental/quantizer.py
@@ -5,6 +5,7 @@ import torch
 from torch import Tensor
 from torch.ao.quantization.experimental.apot_utils import (
     apot_to_float,
+    float_to_apot_device,
     quant_dequant_util,
 )
 
@@ -23,11 +24,13 @@ class APoTQuantizer:
         gamma: torch.Tensor,
         quantization_levels: torch.Tensor,
         level_indices: torch.Tensor,
+        device: torch.device | None = None,
     ) -> None:
-        self.alpha = alpha
-        self.gamma = gamma
-        self.quantization_levels = quantization_levels
-        self.level_indices = level_indices
+        device = alpha.device if device is None else device
+        self.alpha = alpha.to(device=device)
+        self.gamma = gamma.to(device=device)
+        self.quantization_levels = quantization_levels.to(device=device)
+        self.level_indices = level_indices.to(device=device)
 
     r""" Quantizes fp Tensor to integer APoT representation.
     Conversion is based on the qparams from a specified APoT non-uniform observer.
@@ -40,25 +43,12 @@ class APoTQuantizer:
 
     def quantize(self, tensor2quantize: Tensor):
         tensor2quantize = tensor2quantize.detach()
-        quantization_levels = self.quantization_levels.to(
-            device=tensor2quantize.device
+        quantized = float_to_apot_device(
+            tensor2quantize,
+            self.quantization_levels,
+            self.level_indices,
+            self.alpha,
         )
-        level_indices = self.level_indices.to(device=tensor2quantize.device)
-        alpha = self.alpha.to(device=tensor2quantize.device).reshape(())
-
-        level_deltas = torch.abs(
-            tensor2quantize.unsqueeze(-1) - quantization_levels
-        )
-        nearest_level_indices = level_indices[level_deltas.argmin(dim=-1)]
-        nearest_level_indices = torch.where(
-            torch.isnan(tensor2quantize),
-            torch.zeros_like(nearest_level_indices),
-            nearest_level_indices,
-        )
-        quantized = torch.where(
-            tensor2quantize < -alpha, -alpha, nearest_level_indices
-        )
-        quantized = torch.where(tensor2quantize > alpha, alpha, quantized)
 
         tensor2quantize.data.copy_(quantized)
 
@@ -140,6 +130,7 @@ def quantize_APoT(
         gamma=gamma,
         quantization_levels=quantization_levels,
         level_indices=level_indices,
+        device=tensor2quantize.device,
     )
     result = quantizer.quantize(tensor2quantize)
     return result

--- a/torch/ao/quantization/experimental/quantizer.py
+++ b/torch/ao/quantization/experimental/quantizer.py
@@ -5,7 +5,6 @@ import torch
 from torch import Tensor
 from torch.ao.quantization.experimental.apot_utils import (
     apot_to_float,
-    float_to_apot,
     quant_dequant_util,
 )
 
@@ -40,23 +39,35 @@ class APoTQuantizer:
     """
 
     def quantize(self, tensor2quantize: Tensor):
-        result = torch.tensor([])
-
-        # map float_to_apot over tensor2quantize elements
-        tensor2quantize = tensor2quantize.detach().apply_(
-            lambda x: float_to_apot(
-                x, self.quantization_levels, self.level_indices, self.alpha
-            )
+        tensor2quantize = tensor2quantize.detach()
+        quantization_levels = self.quantization_levels.to(
+            device=tensor2quantize.device
         )
+        level_indices = self.level_indices.to(device=tensor2quantize.device)
+        alpha = self.alpha.to(device=tensor2quantize.device).reshape(())
+
+        level_deltas = torch.abs(
+            tensor2quantize.unsqueeze(-1) - quantization_levels
+        )
+        nearest_level_indices = level_indices[level_deltas.argmin(dim=-1)]
+        nearest_level_indices = torch.where(
+            torch.isnan(tensor2quantize),
+            torch.zeros_like(nearest_level_indices),
+            nearest_level_indices,
+        )
+        quantized = torch.where(
+            tensor2quantize < -alpha, -alpha, nearest_level_indices
+        )
+        quantized = torch.where(tensor2quantize > alpha, alpha, quantized)
+
+        tensor2quantize.data.copy_(quantized)
 
         # convert to APoT int representation for dtype
         tensor2quantize = tensor2quantize.int()
 
         from torch.ao.quantization.experimental.APoT_tensor import TensorAPoT
 
-        result = TensorAPoT(self, tensor2quantize)  # type: ignore[assignment]
-
-        return result
+        return TensorAPoT(self, tensor2quantize)
 
     r""" Dequantizes integer Tensor to floating point (fp) representation
     based on the calculated quantization levels from a specified APoT non-uniform observer.


### PR DESCRIPTION
## Background

The experimental APoT linear tests and their shared implementation path rely on CPU-default tensor creation, `torch.FloatTensor`, and the CPU-only `Tensor.apply_()` API. These assumptions prevent registered accelerator backends, including PrivateUse1 devices, from reusing the tests through PyTorch's standard device-type test infrastructure.

This change makes the existing APoT linear tests device-agnostic without adding or removing source test methods, changing their inputs, or relaxing their numerical assertions. This work is part of the test case refactoring initiative tracked in #185590.

## Changes

- Convert `TestNonUniformObserver` to PyTorch's common `TestCase` and classify it with `HardwareClassification.ACCELERATOR`.
- Instantiate the two existing APoT linear tests with `instantiate_device_type_tests` and use the framework-provided `device` for tensors and `Linear` modules.
- Keep `LinearAPoT` outputs on the activation device and remove the CPU-specific `torch.FloatTensor` conversion.
- Create APoT observer levels and quantization parameters on the observed tensor's device.
- Replace the CPU-only `Tensor.apply_()` quantization path with vectorized device-side tensor operations.
- Preserve clipping behavior, NaN handling, first-minimum selection, detached in-place input mutation, and the legacy autograd version-counter behavior.
- Preserve the original test inputs, expected values, test method names, and strict `rtol=0, atol=0` comparison semantics.

## Test Plan

### CPU

Target test:

```bash
PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu python test/quantization/core/experimental/test_linear.py -v
```

- `test_linear_APoT_k1_cpu` — passed
- `test_linear_APoT_k2_cpu` — passed
- Result: `Ran 2 tests ... OK`

Related APoT regression tests:

```bash
python test/quantization/core/experimental/test_nonuniform_observer.py -v
```

- Result: `Ran 6 tests ... OK`

```bash
python test/quantization/core/experimental/test_quantized_tensor.py -v
```

- Result: `Ran 1 test ... OK`

Additional semantic verification:

- Verified that APoT quantization still mutates the input storage while preserving the legacy autograd version-counter behavior (`0 -> 0`).

### CUDA

- Not run locally because no CUDA-capable GPU is available.
- CUDA validation will be provided by the upstream CI.

## Risk Assessment

- No source test methods are added, removed, or renamed; device-type instantiation only generates the corresponding device variants.
- The original inputs, expected values, and strict comparison semantics remain unchanged.
- The changes are limited to the experimental APoT linear test and the shared APoT implementation path required for device-agnostic execution.
- CUDA was not validated locally and therefore remains dependent on upstream CI coverage.