### PR TITLE
[inductor] Fix overlap scheduling crash and empty memory baseline when both caps are None

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 import torch._dynamo
@@ -26,6 +27,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    subtest,
     TestCase,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
@@ -1894,6 +1896,158 @@ class TestForeachGroupsUnit(InductorTestCase):
             ag_ins, 2, torch.float32, out_dtype_ints, 0, None
         )
         self.assertTrue(torch.allclose(result_with, result_without))
+
+
+_NO_MEMORY_CAPS = {
+    "max_memory_increase_gb": None,
+    "max_memory_increase_ratio": None,
+}
+
+
+@unittest.skipIf(not dist.is_available(), "requires distributed")
+@instantiate_parametrized_tests
+class TestOverlapSchedulingNoMemoryLimit(InductorTestCase):
+    """
+    Both memory caps set to None is the documented "no limit" configuration, so
+    it must schedule as if the budget were unbounded rather than raise.
+
+    Deliberately not gated on an accelerator (like TestBitsetAncestors): a fake
+    process group plus a patched DRAM bandwidth keeps this on CPU, so it runs
+    everywhere rather than skipping.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=4, store=store)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        dist.destroy_process_group()
+
+    def _make_gm(self):
+        group_name = dist.distributed_c10d._get_default_group().group_name
+
+        def func(a, b):
+            # mm can hide the collective; mm_1 is blocked by it, so the prefetch
+            # memory-budget check runs over a real compute index.
+            mm = torch.mm(a, b)
+            ag = torch.ops._c10d_functional.all_gather_into_tensor(b, 4, group_name)
+            ag_out = torch.ops._c10d_functional.wait_tensor(ag)
+            mm_1 = torch.mm(ag_out, ag_out.t())
+            return mm.sum() + mm_1.sum()
+
+        return make_fx(func, tracing_mode="fake")(
+            torch.randn(64, 256), torch.randn(256, 256)
+        )
+
+    def _schedule(self, **caps):
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            schedule_overlap_bucketing,
+        )
+
+        def custom_runtime(node: fx.Node, override_size: int | None) -> float | None:
+            # Pin every estimate so the hiding decision is independent of the
+            # host's roofline numbers.
+            if "all_gather" in str(node.target):
+                return 1.0
+            if node.target is torch.ops.aten.mm.default:
+                return 10.0
+            return 0.0
+
+        counters.clear()
+        gm = self._make_gm()
+        with mock.patch(
+            "torch.utils._runtime_estimation.get_gpu_dram_gbps", return_value=1_000
+        ):
+            schedule_overlap_bucketing(
+                gm,
+                custom_runtime_estimation=custom_runtime,
+                compute_estimator="analytical",
+                # Pre-bucketing sizes its buckets from the detected interconnect,
+                # so leaving it on would make the assertions host-dependent.
+                pre_bucketing_fsdp_collectives=False,
+                **caps,
+            )
+        return [n.name for n in gm.graph.nodes]
+
+    @parametrize(
+        "caps,expect_overlap",
+        [
+            # Only both_none takes the no-memory-tracking branch; the rest are
+            # controls pinning that each cap combination still decides as it did.
+            subtest(({}, True), name="defaults"),
+            # Ratio-only: the budget is baseline * 0.05, and these graphs trace CPU
+            # tensors, which MemoryTracker's default device_filter excludes. So the
+            # baseline is 0, the budget is 0, and every prefetch is refused.
+            subtest(({"max_memory_increase_gb": None}, False), name="gb_none"),
+            subtest(({"max_memory_increase_ratio": None}, True), name="ratio_none"),
+            subtest((_NO_MEMORY_CAPS, True), name="both_none"),
+        ],
+    )
+    def test_memory_caps_schedule(self, caps, expect_overlap):
+        node_names = self._schedule(**caps)
+        ag = node_names.index("all_gather_into_tensor")
+        # Overlapped means the collective is hoisted above the mm that hides it.
+        self.assertEqual(ag < node_names.index("mm"), expect_overlap)
+        self.assertLess(ag, node_names.index("wait_tensor"))
+        exposed = 0 if expect_overlap else 1
+        self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], exposed)
+
+    def test_both_none_matches_unbounded_budget(self):
+        """
+        Both caps None must behave like an explicitly enormous budget, not merely
+        avoid crashing: the collective is still prefetched ahead of the compute
+        that hides it, so nothing is left exposed.
+        """
+        both_none = self._schedule(**_NO_MEMORY_CAPS)
+        self.assertEqual(counters["inductor"]["overlap_scheduling_exposed"], 0)
+        self.assertEqual(
+            counters["inductor"]["overlap_scheduling_potentially_hidden"], 1
+        )
+        self.assertLess(
+            both_none.index("all_gather_into_tensor"), both_none.index("mm")
+        )
+
+        huge_budget = self._schedule(
+            max_memory_increase_gb=1e6, max_memory_increase_ratio=None
+        )
+        self.assertEqual(both_none, huge_budget)
+
+    def test_no_memory_limit_tracker_is_inert(self):
+        from torch._inductor.fx_passes.memory_estimator import (
+            MemoryTracker,
+            NoOpMemoryTracker,
+        )
+
+        tracker = NoOpMemoryTracker()
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        # A node the tracker never saw: the real MemoryTracker raises KeyError
+        # here, which is why schedule_node is overridden rather than inherited.
+        foreign = graph.call_function(torch.ops.aten.mm.default, (x, x))
+        tracker.schedule_node(foreign)
+        tracker.schedule_node(foreign)  # no "scheduled twice" bookkeeping
+        self.assertEqual(tracker.current_memory_bytes, 0)
+        self.assertEqual(tracker.get_current_memory_bytes(), 0)
+        self.assertEqual(tracker.peak_memory, 0)
+        # Its zeros must be distinguishable from a measured zero, or the memory
+        # counters get reported as if they had been measured.
+        self.assertFalse(tracker.tracks_memory)
+        self.assertTrue(MemoryTracker(graph).tracks_memory)
+
+    def test_both_none_omits_memory_counters(self):
+        """Inert tracker means no memory counters, rather than a fabricated 0."""
+        self._schedule(**_NO_MEMORY_CAPS)
+        self.assertNotIn("rescheduled_mem", counters["inductor"])
+        self.assertNotIn("overlap_original_mem", counters["inductor"])
+
+        self._schedule(max_memory_increase_gb=1e6)
+        self.assertIn("rescheduled_mem", counters["inductor"])
 
 
 class TestNodeRuntimeEstimationUnit(InductorTestCase):

--- a/torch/_inductor/fx_passes/memory_estimator.py
+++ b/torch/_inductor/fx_passes/memory_estimator.py
@@ -345,6 +345,8 @@ class MemoryTracker:
         self.nodes = list(graph.nodes)
         self.device_filter = device_filter or (lambda device: device.type != "cpu")
         self.scheduled: OrderedSet[fx.Node] = OrderedSet()
+        # False in NoOpMemoryTracker, whose zeros are not measurements.
+        self.tracks_memory = True
 
         # Memory tracking using GraphAliasTracker
         self.alias_tracker = GraphAliasTracker(self.nodes)
@@ -452,3 +454,27 @@ class MemoryTracker:
             len(storages_to_free),
             self.current_memory_bytes // (1024 * 1024),
         )
+
+
+class NoOpMemoryTracker(MemoryTracker):
+    """
+    MemoryTracker that always reports zero memory and does no bookkeeping.
+
+    Building a real tracker walks every storage in the graph, which is pure
+    overhead for a caller that set no memory budget. Using this instead lets
+    such a caller keep an always-present tracker rather than ``None``.
+
+    Only ``tracks_memory``, ``current_memory_bytes``, ``get_current_memory_bytes``,
+    ``peak_memory`` and ``schedule_node`` are meaningful; the inherited
+    per-node accounting has no state to work from. ``tracks_memory`` is False so
+    callers can tell the zeros apart from a measured zero. Overriding
+    ``schedule_node`` also drops the parent's scheduled-twice assertion, which is
+    safe because ``OverlapScheduler._schedule`` makes that check itself.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(fx.Graph())
+        self.tracks_memory = False
+
+    def schedule_node(self, node: fx.Node) -> None:
+        pass

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -23,7 +23,7 @@ from torch._inductor.fx_passes.bucketing import (
     get_full_bucket_key,
     is_wait_tensor,
 )
-from torch._inductor.fx_passes.memory_estimator import MemoryTracker
+from torch._inductor.fx_passes.memory_estimator import MemoryTracker, NoOpMemoryTracker
 from torch._inductor.fx_passes.utils import BitsetAncestors
 from torch._logging import trace_structured
 from torch.fx.experimental.symbolic_shapes import optimization_hint
@@ -528,7 +528,12 @@ class OverlapScheduler:
         else:
             self.original_peak_memory = 0
             self.allowed_peak_memory_bytes = sys.maxsize
-            self.memory_tracker = None  # type: ignore[assignment]
+            self.memory_tracker = NoOpMemoryTracker()
+            # _compute_baseline_memory() did not run, so fill the per-compute-index
+            # baseline that _prefetch_would_exceed_memory_budget indexes. Zero
+            # baselines keep its budget check vacuous against sys.maxsize while
+            # its in-flight check still applies.
+            self.original_mem_before_compute_index = [0] * len(self.compute_nodes)
 
         self.cumulative_prefetch_mem_by_compute_index: list[int] = [
             0 for _ in range(len(self.compute_nodes))
@@ -1612,19 +1617,25 @@ class OverlapScheduler:
         counters["inductor"]["overlap_scheduling_potentially_hidden"] += len(
             potentially_hidden_collectives
         )
-        counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
-        counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
+        # With no cap the tracker is inert, so a 0 here would read as a measured
+        # peak rather than an absent measurement.
+        tracked = self.memory_tracker.tracks_memory
+        if tracked:
+            counters["inductor"]["overlap_original_mem"] = self.original_peak_memory
+            counters["inductor"]["rescheduled_mem"] = self.memory_tracker.peak_memory
 
+        orig_mem = self.original_peak_memory if tracked else "n/a"
+        resched_mem = self.memory_tracker.peak_memory if tracked else "n/a"
         log.info(
             "Overlap scheduling results: exposed=%d, bad_exposed=%d, potentially_hidden=%d, "
-            "original_peak_memory=%d bytes, rescheduled_peak_memory=%d bytes, "
+            "original_peak_memory=%s bytes, rescheduled_peak_memory=%s bytes, "
             "total_exposed_ms=%.2f, hideable_exposed_ms=%.2f, total_potential_exposed_ms=%.2f, "
             "wasted_compute_ms=%.2f",
             len(exposed),
             len(bad_exposed),
             len(potentially_hidden_collectives),
-            self.original_peak_memory,
-            self.memory_tracker.peak_memory,
+            orig_mem,
+            resched_mem,
             total_exposed,
             hideable_exposed_ms,
             total_potential_exposed,


### PR DESCRIPTION
## Issue

Fixes #192618

## Summary

With neither memory cap set, `OverlapScheduler.__init__` leaves `memory_tracker = None` (dereferenced
at six sites) and skips `_compute_baseline_memory()`, leaving `original_mem_before_compute_index` empty
while `_prefetch_would_exceed_memory_budget` indexes it. Fixing only the tracker turns the
`AttributeError` into an `IndexError`, so this installs a no-op tracker and sizes the baseline list.
Only reachable via the documented kwargs, not `torch.compile`.

**Overlaps #192627 / #192628**, both opened ~5h earlier; as of their current revisions all three fix
both defects, so the difference is design, not coverage. They make `memory_tracker` `Optional` and guard
each dereference; this keeps it non-`None`, leaving the scheduling path unconditional. Happy to close in
favour of one, or to switch to the `Optional` shape. Two details here worth keeping either way: the inert
tracker sets `tracks_memory = False`, so `overlap_original_mem` / `rescheduled_mem` are omitted rather
than reported as a measured 0; and the tests assert node order and exposed-collective count, not just
absence of an exception.

## Test Plan

```
python test/distributed/test_overlap_bucketing_unit.py -k NoMemoryLimit -v
# before: FAILED (errors=4)   after: Ran 7 tests ... OK
python test/distributed/test_overlap_bucketing_unit.py
# Ran 52 tests ... OK (skipped=35); unmodified main: 45 tests, same 35 skips
```

`test_both_none_matches_unbounded_budget` pins semantics rather than non-crashing: both-`None` must
schedule identically to an explicitly enormous finite cap. Tests are ungated, since the repro needs no
accelerator; the GPU-gated suites skip here, so device coverage is upstream CI's.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Only the configuration that previously raised changes behaviour; other cap combinations give
byte-identical node ordering.

---
AI assistance was used in developing this change (Opus 5): investigation, validation, additional testing, description