### PR TITLE
Fix unpack_dual returning a None tangent under torch.func.functionalize

### DIFF
--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -16,6 +16,7 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_to_copy.h>
+#include <ATen/ops/_unpack_dual.h>
 #include <ATen/ops/lift.h>
 #include <ATen/ops/lift_fresh.h>
 #include <ATen/ops/lift_fresh_copy.h>
@@ -309,6 +310,27 @@ static at::Tensor _to_copy_functionalize(
   return at::functionalization::impl::to_functional_tensor(out);
 }
 
+static std::tuple<at::Tensor, at::Tensor> _unpack_dual_functionalize(
+    const at::Tensor& dual,
+    int64_t level) {
+  if (!at::functionalization::impl::isFunctionalTensor(dual)) {
+    at::AutoDispatchSkipFunctionalize guard;
+    return at::_unpack_dual(dual, level);
+  }
+
+  at::functionalization::impl::sync(dual);
+  auto dual_ = at::functionalization::impl::from_functional_tensor(dual);
+  auto primal = dual._fw_primal(level);
+  auto tangent = dual_._fw_grad(level);
+  if (tangent.defined()) {
+    // The tangent is wrapped as a fresh non-view functional tensor: mutations
+    // to it are not written back through the dual, consistent with
+    // functionalization's value semantics. Eager returns the tangent itself.
+    tangent = at::functionalization::impl::to_functional_tensor(tangent);
+  }
+  return {primal, tangent};
+}
+
 
 // Why is _unsafe_view special-cased here?
 // Basically just to satisfy autograd's debug asserts.
@@ -418,6 +440,7 @@ TORCH_LIBRARY_IMPL(aten, Functionalize, m) {
   m.impl("lift_fresh", TORCH_FN(lift_fresh_functionalize));
   m.impl("lift_fresh_copy", TORCH_FN(lift_fresh_functionalize_copy));
   m.impl("_to_copy", TORCH_FN(_to_copy_functionalize));
+  m.impl("_unpack_dual", TORCH_FN(_unpack_dual_functionalize));
   m.impl("_unsafe_view", TORCH_FN(_unsafe_view_functionalize));
   // The overloads of set_() that take in a storage should never
   // appear with torch.compile, because dynamo graph breaks

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5040,6 +5040,53 @@ def forward(self, x_1, indices_1) -> torch.Tensor:
         self.assertEqual(out1, out2)
         self.assertEqual(inpt1, inpt2)
 
+    def test_functionalize_unpack_dual(self, device):
+        x = torch.tensor([1.0, 2.0], device=device)
+        tangent = torch.tensor([3.0, 4.0], device=device)
+
+        def f(dual):
+            output = dual + dual
+            inspected_tangent = fwAD.unpack_dual(dual).tangent
+            return output, inspected_tangent + 1
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            expected_output, expected_tangent = f(dual)
+            actual_output, actual_tangent = torch.func.functionalize(f)(dual)
+            expected_primal, expected_propagated_tangent = fwAD.unpack_dual(
+                expected_output
+            )
+            actual_primal, actual_propagated_tangent = fwAD.unpack_dual(actual_output)
+
+        self.assertEqual(actual_primal, expected_primal)
+        self.assertEqual(actual_propagated_tangent, expected_propagated_tangent)
+        self.assertEqual(actual_tangent, expected_tangent)
+
+    def test_functionalize_unpack_dual_without_tangent(self, device):
+        x = torch.tensor([1.0, 2.0], device=device)
+
+        with fwAD.dual_level():
+            tangent = torch.func.functionalize(
+                lambda tensor: fwAD.unpack_dual(tensor).tangent
+            )(x)
+
+        self.assertIsNone(tangent)
+
+    def test_functionalize_unpack_dual_without_views(self, device):
+        x = torch.tensor([1.0, 2.0], device=device)
+        tangent = torch.tensor([3.0, 4.0], device=device)
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "Trying to use forward AD with aten::_fw_primal_copy that does not support it",
+            ):
+                torch.func.functionalize(
+                    lambda tensor: fwAD.unpack_dual(tensor).tangent,
+                    remove="mutations_and_views",
+                )(dual)
+
     @unittest.skipIf(IS_FBCODE, "fails in fbcode")
     def test_vmap_functionalize_jvp(self, device):
         def f(x: torch.Tensor) -> torch.Tensor:

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -1120,6 +1120,9 @@ def gen_functionalization_registration(
         # See Note [Functionalization <> torch.Tensor constructor]
         if str(g.view.func.name) == "lift_fresh":
             return []
+        # _unpack_dual has mixed view/non-view outputs and a hand-written kernel.
+        if str(g.view.func.name) == "_unpack_dual":
+            return []
         view_str = []
         view_str.append(emit_registration_helper(g.view))
         if g.view_inplace is not None:


### PR DESCRIPTION
Fixes #192629

Inside `torch.func.functionalize` (default `remove='mutations'`), `torch.autograd.forward_ad.unpack_dual` reported `tangent=None` for tensors that are duals, silently. Ordinary ops kept propagating tangents correctly; only inspecting the dual structure failed, which silently breaks any code that branches on the tangent, such as custom `autograd.Function`s wrapping fused primal-and-tangent kernels.

### Root cause

`_unpack_dual` is CompositeImplicitAutograd, so the functionalization codegen registers it as a bare passthrough to `at::native::_unpack_dual` (no unwrap step; contrast `_fw_primal` and `_make_dual`, which get generated unwrap kernels). The composite calls `tensor._fw_grad(level)`, and `TensorImpl::_fw_grad` is not a dispatched op: it reads autograd metadata directly off the tensor it is given. Under functionalize that is the `FunctionalTensorWrapper`, whose fresh `TensorImpl` has no forward grad, so the tangent comes back undefined. The tangent on the wrapped inner tensor is intact the whole time; nothing ever unwraps to reach it.

### Fix

A hand-written `Functionalize`-key kernel for `aten::_unpack_dual` in `FunctionalizeFallbackKernel.cpp`, next to the file's other exceptional kernels. It syncs and unwraps the functional tensor, delegates the primal half to the existing `_fw_primal` functionalization path (keeping its view bookkeeping), reads the tangent from the unwrapped tensor, and returns it wrapped as a functional tensor. Non-functional inputs take the old path unchanged. The codegen passthrough is suppressed in `gen_functionalization_type.py`, mirroring the existing `lift_fresh` special case.

Gradcheck on behavior surfaces: eager is untouched, `remove='mutations_and_views'` still raises its existing `NotImplementedError` (unchanged), and a non-dual input still yields `tangent=None`.

### Notes

- The returned tangent is a fresh non-view functional tensor: mutating it is not written back through the dual. That matches functionalization's value semantics; eager returns the tangent itself. Noted in a code comment.
- With this fix, the issue's full fused-kernel example now reaches the pre-existing `NYI: Functionalize rule for custom_function_call` instead of silently producing a wrong JVP. Loud beats silent, but full end-to-end support for `autograd.Function` under plain `functionalize` is separate work.

### Test

Three tests in `test/functorch/test_eager_transforms.py` (`TestFunctionalize`): the regression (tangent visible under functionalize and its value correct, including a tangent propagated through ops), the undefined-tangent case, and the `mutations_and_views` guard. The regression test fails before this change (`TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`).

```
pytest test/functorch/test_eager_transforms.py -k functionalize_unpack_dual   # 3 passed
python repro from the issue                                                    # functionalize: True (was False)
pytest test/test_functionalization.py -q                                       # 109 passed, 12 xfailed
python test/test_autograd.py TestAutogradForwardMode                           # 29 passed
pytest test/functorch/test_eager_transforms.py -k "functionalize or jvp"       # 67 passed
```

Tested on Linux aarch64, CPU build. The kernel has no device-specific branches; the delegated `_fw_primal` path already carries the XLA/Lazy handling.

---

Authored with an AI assistant; I reviewed and tested all changes.


cc @bdhirsh @ezyang @Chillee @samdow @kshitij12345