### PR TITLE
[Testcase Refactoring] Decouple and classify tests by hardware

### DIFF
--- a/test/distributed/test_inductor_compile_collectives.py
+++ b/test/distributed/test_inductor_compile_collectives.py
@@ -15,7 +15,11 @@ from torch._inductor._functionalize_collectives import (
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph_module import _share_torchbind_and_process_group_on_deepcopy
 from torch.fx.passes.regional_inductor import regional_inductor
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 if not dist.is_available():
@@ -34,6 +38,8 @@ def _make_fx_with_allreduce():
 
 
 class TestInductorCompileCollectives(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def setUp(self):
         super().setUp()
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")

--- a/test/functorch/test_ac_knapsack.py
+++ b/test/functorch/test_ac_knapsack.py
@@ -10,7 +10,11 @@ from torch._functorch._activation_checkpointing.knapsack_evaluator import (
     KnapsackEvaluator,
 )
 from torch.fx.graph import Graph
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestGraphInfoProvider(TestCase):
@@ -18,6 +22,8 @@ class TestGraphInfoProvider(TestCase):
     Test class for GraphInfoProvider.
     The test class sets up a small graph example and tests the methods validating the graph building logic.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self) -> None:
         super().setUp()
@@ -192,6 +198,8 @@ class TestKnapsackEvaluator(TestCase):
     The test class sets up a small graph example and tests the methods validating the knapsack evaluation logic.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self.graph_nodes_in_order = [
@@ -331,6 +339,8 @@ class TestKnapsackEvaluator(TestCase):
 
 
 class TestActivationCheckpointingKnapsack(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def setUp(self):
         super().setUp()
         # (memory, runtime, max_memory, expected_runtime, expected_saved, expected_recomputable)

--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -8,10 +8,16 @@ from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
 from torch.fx import Graph, Node
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestAcLogging(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self.graph: MagicMock = MagicMock(spec=Graph)

--- a/test/functorch/test_codegen_backward_epilogue.py
+++ b/test/functorch/test_codegen_backward_epilogue.py
@@ -19,7 +19,11 @@ from contextlib import contextmanager
 
 import torch
 import torch._functorch.config
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -27,6 +31,8 @@ trace_log = logging.getLogger("torch.__trace")
 
 
 class TestCodegenBackwardEpilogue(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @contextmanager
     def _capture_codegen_source(self, artifact_name):
         """Capture codegen artifacts from the structured trace log."""

--- a/test/functorch/test_codegen_backward_prologue.py
+++ b/test/functorch/test_codegen_backward_prologue.py
@@ -18,11 +18,17 @@ from common_utils import capture_codegen_source
 
 import torch
 import torch._functorch.config
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
 class TestCodegenBackwardPrologue(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_saved_subclass_tensors_unwrapped(self):
         """
         When subclass tensors are saved for backward, the prologue should

--- a/test/functorch/test_codegen_debug_assert.py
+++ b/test/functorch/test_codegen_debug_assert.py
@@ -19,13 +19,19 @@ from contextlib import contextmanager
 
 import torch
 import torch._functorch.config
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 trace_log = logging.getLogger("torch.__trace")
 
 
 class TestCodegenDebugAssert(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @contextmanager
     def _capture_codegen_source(self, artifact_name):
         """Capture codegen artifacts from the structured trace log."""

--- a/test/functorch/test_codegen_dedup.py
+++ b/test/functorch/test_codegen_dedup.py
@@ -20,7 +20,11 @@ from contextlib import contextmanager
 import torch
 import torch._functorch.config
 from torch._functorch.aot_autograd import aot_function
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 trace_log = logging.getLogger("torch.__trace")
@@ -31,6 +35,8 @@ def _nop_compiler(gm, example_inputs):  # type: ignore[no-untyped-def]
 
 
 class TestCodegenDedup(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @contextmanager
     def _capture_codegen_source(self, artifact_name):
         """Capture codegen artifacts from the structured trace log."""

--- a/test/functorch/test_codegen_mutation_epilogue.py
+++ b/test/functorch/test_codegen_mutation_epilogue.py
@@ -25,13 +25,20 @@ import torch
 import torch._functorch.config
 from functorch.compile import nop
 from torch._functorch.aot_autograd import aot_function
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 trace_log = logging.getLogger("torch.__trace")
 
 
 class TestCodegenMutationEpilogue(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @contextmanager
     def _capture_codegen_source(self, artifact_name):
         """Capture codegen artifacts from the structured trace log."""

--- a/test/functorch/test_codegen_output_alias.py
+++ b/test/functorch/test_codegen_output_alias.py
@@ -22,13 +22,20 @@ import torch
 import torch._functorch.config
 from functorch.compile import nop
 from torch._functorch.aot_autograd import aot_function
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 trace_log = logging.getLogger("torch.__trace")
 
 
 class TestCodegenOutputAlias(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()

--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -20,10 +20,17 @@ from common_utils import capture_codegen_source
 import torch
 import torch._dynamo
 import torch._functorch.config as functorch_config
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 class TestCodegenRuntimeWrapper(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()

--- a/test/functorch/test_control_flow_cuda_initialization.py
+++ b/test/functorch/test_control_flow_cuda_initialization.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_CUDA_GRAPH_CONDITIONAL_NODES,
     TestCase,
@@ -14,6 +15,8 @@ from torch.testing._internal.common_utils import (
     "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
 )
 class TestControlFlowInCUDAGraphInitialization(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # Duplicated from test_cuda_primary_ctx.py
     CTX_ALREADY_CREATED_ERR_MSG = (
         "Tests defined in TestControlFlowInCUDAGraphInitialization must be run in a process "

--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -641,9 +641,9 @@ class TestLeafFunctionEscapedGradients(TestCase):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFxAndCompile(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     """Tests for @leaf_function when mixing torch.compile and make_fx."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_not_called_during_compilation(self):
         """The real leaf_fn body runs only at runtime, not during compilation."""
@@ -2509,9 +2509,9 @@ instantiate_parametrized_tests(TestLeafFunctionDynamo)
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionRegisterHook(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     """Tests for @leaf_function's register_multi_grad_hook API."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_hook_fires_on_backward(self):
         hook_grads = []

--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -18,6 +18,7 @@ from torch._dynamo.testing import normalize_gm
 from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -36,6 +37,8 @@ def extract_graph(fx_g, _, graph_cell):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFx(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _has_invoke_leaf_function_node(self, gm):
         for node in gm.graph.nodes:
             if node.op == "call_function" and node.target is invoke_leaf_function:
@@ -292,6 +295,8 @@ class f(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionAotFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_simple(self):
         @leaf_function
         def my_fn(x, y):
@@ -499,6 +504,8 @@ class GraphModule(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionEscapedGradients(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_escaped_gradient_multiple_closures(self):
         weight1 = torch.randn(3, 3, requires_grad=True)
         weight2 = torch.randn(3, 3, requires_grad=True)
@@ -634,6 +641,8 @@ class TestLeafFunctionEscapedGradients(TestCase):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFxAndCompile(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for @leaf_function when mixing torch.compile and make_fx."""
 
     def test_not_called_during_compilation(self):
@@ -840,6 +849,8 @@ class outer(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionDynamo(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -2498,6 +2509,8 @@ instantiate_parametrized_tests(TestLeafFunctionDynamo)
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionRegisterHook(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for @leaf_function's register_multi_grad_hook API."""
 
     def test_hook_fires_on_backward(self):
@@ -2757,6 +2770,8 @@ class TestLeafFunctionRegisterHook(TestCase):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionGradDtype(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_pair(self, size, dtype, grad_dtype):
         torch.manual_seed(42)
         x_ref = torch.randn(size, dtype=dtype, requires_grad=True)

--- a/test/functorch/test_logging.py
+++ b/test/functorch/test_logging.py
@@ -4,11 +4,13 @@ import logging
 import torch
 from torch._functorch.aot_autograd import aot_function
 from torch._functorch.compilers import nop
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
 class TestAOTLogging(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @make_logging_test(aot=logging.DEBUG)
     def test_logging(self, records):
         def f(x):

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -2,7 +2,6 @@
 
 import inspect
 import random
-import unittest
 from collections.abc import Callable
 
 import torch
@@ -12,10 +11,12 @@ from functorch import make_fx
 from functorch.compile import memory_efficient_fusion
 from torch._functorch.compile_utils import fx_graph_cse
 from torch.nn import functional as F
-from torch.testing._internal.common_utils import run_tests, TestCase
-
-
-HAS_CUDA = torch.cuda.is_available()
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def _num_args(fn: Callable):
@@ -96,9 +97,8 @@ def hard_mish(x):
 # evo_norm_inp = [(128, 2048, 8, 8)]
 
 
-def run_and_compare_activation(self, fn, inps):
+def run_and_compare_activation(self, fn, inps, device):
     with torch.jit.fuser("fuser1"):
-        device = "cuda"
         dtype = torch.float
         if isinstance(fn, nn.Module):
             fn = fn.to(device=device, dtype=dtype)
@@ -124,24 +124,25 @@ def run_and_compare_activation(self, fn, inps):
             self.assertEqual(ref_arg.grad, res_arg.grad)
 
 
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
 class TestMemoryEfficientOpAuthoring(TestCase):
-    def test_gelu_bias(self):
-        run_and_compare_activation(self, gelu_bias, [(1024,), (1024,)])
+    hw_classification = HardwareClassification.CUDA
 
-    def test_mish(self):
-        run_and_compare_activation(self, mish, [(1024,)])
+    def test_gelu_bias(self, device):
+        run_and_compare_activation(self, gelu_bias, [(1024,), (1024,)], device)
 
-    def test_swish(self):
-        run_and_compare_activation(self, swish, [(1024,)])
+    def test_mish(self, device):
+        run_and_compare_activation(self, mish, [(1024,)], device)
 
-    def test_hard_sigmoid(self):
-        run_and_compare_activation(self, hard_sigmoid, [(1024,)])
+    def test_swish(self, device):
+        run_and_compare_activation(self, swish, [(1024,)], device)
 
-    def test_hard_swish(self):
-        run_and_compare_activation(self, hard_swish, [(1024,)])
+    def test_hard_sigmoid(self, device):
+        run_and_compare_activation(self, hard_sigmoid, [(1024,)], device)
 
-    def test_layer_norm(self):
+    def test_hard_swish(self, device):
+        run_and_compare_activation(self, hard_swish, [(1024,)], device)
+
+    def test_layer_norm(self, device):
         def layer_norm(x, weight, bias):
             dim = -1
             eps = 1e-5
@@ -155,9 +156,9 @@ class TestMemoryEfficientOpAuthoring(TestCase):
         bs = 10
         ln_size = 16
         layer_norm_inps = [(bs, ln_size), (ln_size,), (ln_size,)]
-        run_and_compare_activation(self, layer_norm, layer_norm_inps)
+        run_and_compare_activation(self, layer_norm, layer_norm_inps, device)
 
-    def test_rmsnorm(self):
+    def test_rmsnorm(self, device):
         class T5LayerNorm(nn.Module):
             def __init__(self, hidden_size, eps=1e-6):
                 """
@@ -185,7 +186,7 @@ class TestMemoryEfficientOpAuthoring(TestCase):
         hidden = 1024
         t5_norm = T5LayerNorm(hidden)
         t5_norm_inputs = [(bs, seq, hidden)]
-        run_and_compare_activation(self, t5_norm, t5_norm_inputs)
+        run_and_compare_activation(self, t5_norm, t5_norm_inputs, device)
 
     # TODO - Assertion failure
     # def test_hard_mish(self):
@@ -241,6 +242,8 @@ def check(f, t, delta, check_val=True, graph_input=False):
 
 
 class NoChangeTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_nochange(self):
         def f(x):
             a = x + 1
@@ -339,6 +342,8 @@ class NoChangeTestCase(TestCase):
 
 
 class ReduceTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_immutable_list_type(self):
         def f(x):
             a = x.sum(dim=1)
@@ -473,6 +478,8 @@ class ReduceTestCase(TestCase):
 
 
 class RandomOpTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_random(self):
         def f(x):
             vals = [x]
@@ -489,6 +496,11 @@ class RandomOpTestCase(TestCase):
 
         for _ in range(30):
             check(fx_g, t, -1, graph_input=True)
+
+
+instantiate_device_type_tests(
+    TestMemoryEfficientOpAuthoring, globals(), only_for=("cuda",)
+)
 
 
 if __name__ == "__main__":

--- a/test/functorch/test_minifier.py
+++ b/test/functorch/test_minifier.py
@@ -8,10 +8,16 @@ from functorch import make_fx
 from functorch.compile import minifier
 from torch._functorch.compile_utils import get_outputs, get_placeholders
 from torch._functorch.fx_minifier import dump_state
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestMinifier(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_has_mul_minifier(self):
         def failing_f(x, y):
             y = y / 3

--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -12,7 +12,11 @@ from torch._functorch._aot_autograd.schemas import PlainTensorMeta
 from torch._functorch._aot_autograd.subclass_codegen import (
     _codegen_subclass_wrapper_source,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -35,6 +39,8 @@ class _TestSubclassMeta:
 
 
 class TestSubclassCodegen(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _two_tensor_meta(self) -> _TestSubclassMeta:
         return _TestSubclassMeta(
             flat_tensor_start_idx=0,

--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -411,6 +411,13 @@ class TestInlineAsmElementwiseInputValidation(TestCase):
                 dtype=torch.float32,
             )
 
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestInlineAsmElementwiseCUDAContract(TestCase):
+    """Tests for CUDA-specific API contracts."""
+
+    hw_classification = HardwareClassification.CUDA
+
     def test_error_cpu_tensor(self):
         x = torch.randn(100, dtype=torch.float32)
         with self.assertRaises(RuntimeError):

--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -14,7 +14,9 @@ from dataclasses import dataclass
 import torch
 from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch.testing._internal.common_cuda import evaluate_gfx_arch_within, SM70OrLater
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     MI200_ARCH,
     MI300_ARCH,
@@ -22,7 +24,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     skipIfRocm,
-    TEST_CUDA,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
@@ -46,7 +47,7 @@ TEST_CASES = [
     # Basic float32 operations
     AsmTestCase(
         "identity_f32",
-        lambda: (torch.randn(100, device="cuda", dtype=torch.float32),),
+        lambda device: (torch.randn(100, device=device, dtype=torch.float32),),
         "v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
         "=v, v" if torch.version.hip else "=f,f",
         torch.float32,
@@ -54,9 +55,9 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "add_f32",
-        lambda: (
-            torch.randn(100, device="cuda", dtype=torch.float32),
-            torch.randn(100, device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.randn(100, device=device, dtype=torch.float32),
+            torch.randn(100, device=device, dtype=torch.float32),
         ),
         "v_add_f32 $0, $1, $2" if torch.version.hip else "add.f32 $0, $1, $2;",
         "=v, v, v" if torch.version.hip else "=f,f,f",
@@ -65,9 +66,9 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "mul_f32",
-        lambda: (
-            torch.randn(100, device="cuda", dtype=torch.float32),
-            torch.randn(100, device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.randn(100, device=device, dtype=torch.float32),
+            torch.randn(100, device=device, dtype=torch.float32),
         ),
         "v_mul_f32 $0, $1, $2" if torch.version.hip else "mul.f32 $0, $1, $2;",
         "=v, v, v" if torch.version.hip else "=f,f,f",
@@ -76,10 +77,10 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "fma_f32",
-        lambda: (
-            torch.randn(100, device="cuda", dtype=torch.float32),
-            torch.randn(100, device="cuda", dtype=torch.float32),
-            torch.randn(100, device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.randn(100, device=device, dtype=torch.float32),
+            torch.randn(100, device=device, dtype=torch.float32),
+            torch.randn(100, device=device, dtype=torch.float32),
         ),
         "v_fma_f32 $0, $1, $2, $3"
         if torch.version.hip
@@ -91,7 +92,7 @@ TEST_CASES = [
     # Multi-line inline asm. PTX uses curly braces; AMDGCN uses newlines.
     AsmTestCase(
         "double_multiline",
-        lambda: (torch.randn(100, device="cuda", dtype=torch.float32),),
+        lambda device: (torch.randn(100, device=device, dtype=torch.float32),),
         (
             """
             v_mov_b32 $0, $1
@@ -107,7 +108,7 @@ TEST_CASES = [
     # bf16/fp16 upcasting (compile-only: Jiterator can't handle dtype mismatch)
     AsmTestCase(
         "bf16_upcast",
-        lambda: (torch.randn(100, device="cuda", dtype=torch.bfloat16),),
+        lambda device: (torch.randn(100, device=device, dtype=torch.bfloat16),),
         "v_add_f32 $0, $1, $1" if torch.version.hip else "add.f32 $0, $1, $1;",
         "=v, v" if torch.version.hip else "=f,f",
         torch.float32,
@@ -117,7 +118,7 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "fp16_upcast",
-        lambda: (torch.randn(100, device="cuda", dtype=torch.float16),),
+        lambda device: (torch.randn(100, device=device, dtype=torch.float16),),
         "v_add_f32 $0, $1, $1" if torch.version.hip else "add.f32 $0, $1, $1;",
         "=v, v" if torch.version.hip else "=f,f",
         torch.float32,
@@ -127,9 +128,9 @@ TEST_CASES = [
     # Integer operations
     AsmTestCase(
         "bitwise_and",
-        lambda: (
-            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
-            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+        lambda device: (
+            torch.randint(0, 2**16, (100,), device=device, dtype=torch.int32),
+            torch.randint(0, 2**16, (100,), device=device, dtype=torch.int32),
         ),
         "v_and_b32 $0, $1, $2" if torch.version.hip else "and.b32 $0, $1, $2;",
         "=v, v, v" if torch.version.hip else "=r,r,r",
@@ -138,9 +139,9 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "bitwise_or",
-        lambda: (
-            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
-            torch.randint(0, 2**16, (100,), device="cuda", dtype=torch.int32),
+        lambda device: (
+            torch.randint(0, 2**16, (100,), device=device, dtype=torch.int32),
+            torch.randint(0, 2**16, (100,), device=device, dtype=torch.int32),
         ),
         "v_or_b32 $0, $1, $2" if torch.version.hip else "or.b32 $0, $1, $2;",
         "=v, v, v" if torch.version.hip else "=r,r,r",
@@ -152,8 +153,8 @@ TEST_CASES = [
     # shift-and-mask sequence in a single instruction.
     AsmTestCase(
         "exponent_extract",
-        lambda: (
-            torch.tensor([1.0, 2.0, 0.5, 16.0], device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.tensor([1.0, 2.0, 0.5, 16.0], device=device, dtype=torch.float32),
         ),
         (
             "v_bfe_u32 $0, $1, 23, 8"
@@ -171,7 +172,9 @@ TEST_CASES = [
     # and extract the lower 16 bits via v_bfe_u32.
     AsmTestCase(
         "truncate_to_uint16",
-        lambda: (torch.randint(0, 256, (100,), device="cuda", dtype=torch.int32),),
+        lambda device: (
+            torch.randint(0, 256, (100,), device=device, dtype=torch.int32),
+        ),
         "v_bfe_u32 $0, $1, 0, 16" if torch.version.hip else "cvt.u16.u32 $0, $1;",
         "=v, v" if torch.version.hip else "=h,r",
         torch.uint16,
@@ -181,9 +184,9 @@ TEST_CASES = [
     # Broadcasting
     AsmTestCase(
         "broadcast_add",
-        lambda: (
-            torch.randn(4, 1, device="cuda", dtype=torch.float32),
-            torch.randn(1, 8, device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.randn(4, 1, device=device, dtype=torch.float32),
+            torch.randn(1, 8, device=device, dtype=torch.float32),
         ),
         "v_add_f32 $0, $1, $2" if torch.version.hip else "add.f32 $0, $1, $2;",
         "=v, v, v" if torch.version.hip else "=f,f,f",
@@ -193,7 +196,7 @@ TEST_CASES = [
     # Non-contiguous
     AsmTestCase(
         "noncontiguous",
-        lambda: (torch.randn(8, 16, device="cuda", dtype=torch.float32).t(),),
+        lambda device: (torch.randn(8, 16, device=device, dtype=torch.float32).t(),),
         "v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
         "=v, v" if torch.version.hip else "=f,f",
         torch.float32,
@@ -205,9 +208,9 @@ TEST_CASES = [
     # format.  PTX "h" constraints tell Triton to downcast before the asm.
     AsmTestCase(
         "add_fp16_native",
-        lambda: (
-            torch.randn(100, device="cuda", dtype=torch.float16),
-            torch.randn(100, device="cuda", dtype=torch.float16),
+        lambda device: (
+            torch.randn(100, device=device, dtype=torch.float16),
+            torch.randn(100, device=device, dtype=torch.float16),
         ),
         (
             "v_add_f32 $0, $1, $2\nv_cvt_f16_f32 $0, $0"
@@ -224,9 +227,9 @@ TEST_CASES = [
     # bf16 slot) are used by Triton.
     AsmTestCase(
         "add_bf16_native",
-        lambda: (
-            torch.randn(100, device="cuda", dtype=torch.bfloat16),
-            torch.randn(100, device="cuda", dtype=torch.bfloat16),
+        lambda device: (
+            torch.randn(100, device=device, dtype=torch.bfloat16),
+            torch.randn(100, device=device, dtype=torch.bfloat16),
         ),
         (
             "v_add_f32 $0, $1, $2\nv_cvt_pk_bf16_f32 $0, $0, $0"
@@ -242,7 +245,7 @@ TEST_CASES = [
     # pack=2: each asm invocation processes 2 elements (compile-only)
     AsmTestCase(
         "identity_pack2",
-        lambda: (torch.randn(128, device="cuda", dtype=torch.float32),),
+        lambda device: (torch.randn(128, device=device, dtype=torch.float32),),
         (
             """
             v_mov_b32 $0, $2
@@ -259,9 +262,9 @@ TEST_CASES = [
     ),
     AsmTestCase(
         "add_pack2",
-        lambda: (
-            torch.randn(128, device="cuda", dtype=torch.float32),
-            torch.randn(128, device="cuda", dtype=torch.float32),
+        lambda device: (
+            torch.randn(128, device=device, dtype=torch.float32),
+            torch.randn(128, device=device, dtype=torch.float32),
         ),
         (
             """
@@ -281,16 +284,17 @@ TEST_CASES = [
 TEST_CASE_NAMES = [tc.name for tc in TEST_CASES]
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA not available")
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
 @instantiate_parametrized_tests
-class TestInlineAsmElementwise(TestCase):
+class TestInlineAsmElementwiseCUDA(TestCase):
     """Parametrized tests for inline_asm_elementwise."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @parametrize(
         "case_idx", list(range(len(TEST_CASES))), name_fn=lambda i: TEST_CASE_NAMES[i]
     )
-    def test_eager_vs_compiled_bitwise(self, case_idx):
+    def test_eager_vs_compiled_bitwise(self, device, case_idx):
         """Verify eager and compiled produce bitwise identical results."""
         tc = TEST_CASES[case_idx]
         if not torch.version.hip and torch.cuda.get_device_capability() < (
@@ -313,7 +317,7 @@ class TestInlineAsmElementwise(TestCase):
         ):
             self.skipTest("Requires gfx950+")
 
-        inputs = tc.input_gen_fn()
+        inputs = tc.input_gen_fn(device)
 
         def fn(*args):
             return inline_asm_elementwise(
@@ -348,7 +352,7 @@ class TestInlineAsmElementwise(TestCase):
     @parametrize(
         "case_idx", list(range(len(TEST_CASES))), name_fn=lambda i: TEST_CASE_NAMES[i]
     )
-    def test_correctness(self, case_idx):
+    def test_correctness(self, device, case_idx):
         """Verify result matches reference function."""
         tc = TEST_CASES[case_idx]
         if not torch.version.hip and torch.cuda.get_device_capability() < (
@@ -371,7 +375,7 @@ class TestInlineAsmElementwise(TestCase):
         ):
             self.skipTest("Requires gfx950+")
 
-        inputs = tc.input_gen_fn()
+        inputs = tc.input_gen_fn(device)
 
         def fn(*args):
             return inline_asm_elementwise(
@@ -394,9 +398,10 @@ class TestInlineAsmElementwise(TestCase):
         self.assertEqual(result.float(), expected.float(), atol=1e-5, rtol=1e-5)
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA not available")
-class TestInlineAsmElementwiseErrors(TestCase):
-    """Tests for error handling."""
+class TestInlineAsmElementwiseErrorsGENERIC(TestCase):
+    """Device-independent tests for error handling."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_error_no_inputs(self):
         with self.assertRaises(ValueError):
@@ -408,9 +413,15 @@ class TestInlineAsmElementwiseErrors(TestCase):
                 dtype=torch.float32,
             )
 
-    def test_error_constraint_mismatch(self):
-        x = torch.randn(100, device="cuda", dtype=torch.float32)
-        y = torch.randn(100, device="cuda", dtype=torch.float32)
+
+class TestInlineAsmElementwiseErrorsCUDA(TestCase):
+    """CUDA-specific tests for error handling."""
+
+    hw_classification = HardwareClassification.CUDA
+
+    def test_error_constraint_mismatch(self, device):
+        x = torch.randn(100, device=device, dtype=torch.float32)
+        y = torch.randn(100, device=device, dtype=torch.float32)
         with self.assertRaises(ValueError):
             inline_asm_elementwise(
                 x,
@@ -422,9 +433,9 @@ class TestInlineAsmElementwiseErrors(TestCase):
                 dtype=torch.float32,
             )
 
-    def test_error_mixed_dtypes(self):
-        x = torch.randn(100, device="cuda", dtype=torch.float32)
-        y = torch.randint(0, 10, (100,), device="cuda", dtype=torch.int32)
+    def test_error_mixed_dtypes(self, device):
+        x = torch.randn(100, device=device, dtype=torch.float32)
+        y = torch.randint(0, 10, (100,), device=device, dtype=torch.int32)
         with self.assertRaises(ValueError):
             inline_asm_elementwise(
                 x,
@@ -436,7 +447,7 @@ class TestInlineAsmElementwiseErrors(TestCase):
                 dtype=torch.float32,
             )
 
-    def test_error_cpu_tensor(self):
+    def test_error_cpu_tensor(self, device):
         x = torch.randn(100, dtype=torch.float32)
         with self.assertRaises(RuntimeError):
             inline_asm_elementwise(
@@ -447,13 +458,14 @@ class TestInlineAsmElementwiseErrors(TestCase):
             )
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA not available")
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
-class TestInlineAsmElementwiseEdgeCases(TestCase):
+class TestInlineAsmElementwiseEdgeCasesCUDA(TestCase):
     """Tests for edge cases."""
 
-    def test_empty_tensor(self):
-        x = torch.empty(0, device="cuda", dtype=torch.float32)
+    hw_classification = HardwareClassification.CUDA
+
+    def test_empty_tensor(self, device):
+        x = torch.empty(0, device=device, dtype=torch.float32)
         result = inline_asm_elementwise(
             x,
             asm_str="v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
@@ -462,8 +474,8 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         )
         self.assertEqual(result.shape, torch.Size([0]))
 
-    def test_scalar_tensor(self):
-        x = torch.tensor(3.14, device="cuda", dtype=torch.float32)
+    def test_scalar_tensor(self, device):
+        x = torch.tensor(3.14, device=device, dtype=torch.float32)
         result = inline_asm_elementwise(
             x,
             asm_str="v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
@@ -473,8 +485,8 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         self.assertEqual(result.shape, torch.Size([]))
         self.assertEqual(result, x)
 
-    def test_4d_tensor(self):
-        x = torch.randn(2, 3, 4, 5, device="cuda", dtype=torch.float32)
+    def test_4d_tensor(self, device):
+        x = torch.randn(2, 3, 4, 5, device=device, dtype=torch.float32)
         result = inline_asm_elementwise(
             x,
             asm_str="v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
@@ -485,7 +497,7 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         self.assertEqual(result, x)
 
     @xfailIfNoAcceleratorTriton
-    def test_composition_with_pytorch_ops(self):
+    def test_composition_with_pytorch_ops(self, device):
         def fn(x, y):
             z = x * 2
             w = inline_asm_elementwise(
@@ -499,8 +511,8 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
             )
             return w + 1.0
 
-        x = torch.randn(100, device="cuda", dtype=torch.float32)
-        y = torch.randn(100, device="cuda", dtype=torch.float32)
+        x = torch.randn(100, device=device, dtype=torch.float32)
+        y = torch.randn(100, device=device, dtype=torch.float32)
 
         eager_result = fn(x, y)
         compiled_fn = torch.compile(fn, backend="inductor")
@@ -509,14 +521,14 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         self.assertEqual(eager_result, compiled_result)
         self.assertEqual(eager_result, x * 2 + y + 1.0)
 
-    def test_output_strides_mixed_inputs(self):
+    def test_output_strides_mixed_inputs(self, device):
         """Verify fake mode output strides match eager (TensorIterator) strides."""
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         # Two inputs with different strides: one contiguous, one transposed.
         # This exercises TensorIterator's slow path for stride computation.
-        x = torch.randn(8, 16, device="cuda", dtype=torch.float32)
-        y = torch.randn(16, 8, device="cuda", dtype=torch.float32).t()
+        x = torch.randn(8, 16, device=device, dtype=torch.float32)
+        y = torch.randn(16, 8, device=device, dtype=torch.float32).t()
 
         eager_result = inline_asm_elementwise(
             x,
@@ -570,7 +582,7 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         self.assertEqual(nested, x + x)
 
     @xfailIfNoAcceleratorTriton
-    def test_dynamic_shapes(self):
+    def test_dynamic_shapes(self, device):
         def fn(x, y):
             return inline_asm_elementwise(
                 x,
@@ -585,20 +597,21 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         compiled_fn = torch.compile(fn, backend="inductor", dynamic=True)
 
         for size in [50, 100, 200]:
-            x = torch.randn(size, device="cuda", dtype=torch.float32)
-            y = torch.randn(size, device="cuda", dtype=torch.float32)
+            x = torch.randn(size, device=device, dtype=torch.float32)
+            y = torch.randn(size, device=device, dtype=torch.float32)
             eager_result = fn(x, y)
             compiled_result = compiled_fn(x, y)
             self.assertEqual(eager_result, compiled_result)
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA not available")
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
 @xfailIfNoAcceleratorTriton
-class TestInlineAsmPackPadding(TestCase):
+class TestInlineAsmPackPaddingCUDA(TestCase):
     """Test that pack padding works when block size < pack."""
 
-    def test_pack2_xblock1_padding(self):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_pack2_xblock1_padding(self, device):
         """Force XBLOCK=1 with pack=2 so padding is needed."""
         from torch._inductor.choices import InductorChoices
         from torch._inductor.codegen.triton import FixedTritonConfig
@@ -628,7 +641,7 @@ class TestInlineAsmPackPadding(TestCase):
                 pack=2,
             )
 
-        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        x = torch.randn(128, device=device, dtype=torch.float32)
         with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock1()):
             torch._dynamo.reset()
             result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
@@ -637,7 +650,7 @@ class TestInlineAsmPackPadding(TestCase):
         # Verify padding helpers are emitted in the generated code
         FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
 
-    def test_pack4_xblock1_padding(self):
+    def test_pack4_xblock1_padding(self, device):
         """Force XBLOCK=1 with pack=4 so padding is needed."""
         from torch._inductor.choices import InductorChoices
         from torch._inductor.codegen.triton import FixedTritonConfig
@@ -673,7 +686,7 @@ class TestInlineAsmPackPadding(TestCase):
                 pack=4,
             )
 
-        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        x = torch.randn(128, device=device, dtype=torch.float32)
         with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock1()):
             torch._dynamo.reset()
             result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
@@ -681,7 +694,7 @@ class TestInlineAsmPackPadding(TestCase):
         self.assertEqual(result, x)
         FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
 
-    def test_pack4_xblock2_partial_padding(self):
+    def test_pack4_xblock2_partial_padding(self, device):
         """XBLOCK=2 < pack=4, so 1 round of padding is needed (not 2)."""
         from torch._inductor.choices import InductorChoices
         from torch._inductor.codegen.triton import FixedTritonConfig
@@ -717,7 +730,7 @@ class TestInlineAsmPackPadding(TestCase):
                 pack=4,
             )
 
-        x = torch.randn(128, device="cuda", dtype=torch.float32)
+        x = torch.randn(128, device=device, dtype=torch.float32)
         with torch._inductor.virtualized.V.set_choices_handler(ForceXBlock2()):
             torch._dynamo.reset()
             result, (code,) = run_and_get_code(torch.compile(fn, backend="inductor"), x)
@@ -725,7 +738,7 @@ class TestInlineAsmPackPadding(TestCase):
         self.assertEqual(result, x)
         FileCheck().check("inline_asm_pack").check("inline_asm_unpack").run(code)
 
-    def test_pack2_xblock1_yblock1_padding(self):
+    def test_pack2_xblock1_yblock1_padding(self, device):
         """Force XBLOCK=1, YBLOCK=1 with pack=2 on a 2D-tiled kernel."""
         from torch._inductor.choices import InductorChoices
         from torch._inductor.codegen.triton import FixedTritonConfig
@@ -756,9 +769,9 @@ class TestInlineAsmPackPadding(TestCase):
                 pack=2,
             )
 
-        x = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+        x = torch.randn(8, 16, device=device, dtype=torch.float32)
         # Transposed input triggers 2D tiling (different stride patterns)
-        y = torch.randn(16, 8, device="cuda", dtype=torch.float32).T
+        y = torch.randn(16, 8, device=device, dtype=torch.float32).T
         with torch._inductor.virtualized.V.set_choices_handler(ForceXY1()):
             torch._dynamo.reset()
             result, (code,) = run_and_get_code(
@@ -769,6 +782,20 @@ class TestInlineAsmPackPadding(TestCase):
         FileCheck().check("YBLOCK").check("inline_asm_pack").check(
             "inline_asm_unpack"
         ).run(code)
+
+
+instantiate_device_type_tests(
+    TestInlineAsmElementwiseCUDA, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestInlineAsmElementwiseErrorsCUDA, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestInlineAsmElementwiseEdgeCasesCUDA, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestInlineAsmPackPaddingCUDA, globals(), only_for=("cuda",)
+)
 
 
 if __name__ == "__main__":

--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -17,7 +17,6 @@ from torch.testing._internal.common_cuda import evaluate_gfx_arch_within, SM70Or
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     MI200_ARCH,
     MI300_ARCH,
     NAVI_ARCH,
@@ -285,8 +284,7 @@ TEST_CASE_NAMES = [tc.name for tc in TEST_CASES]
 
 
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
-@instantiate_parametrized_tests
-class TestInlineAsmElementwiseCUDA(TestCase):
+class TestInlineAsmElementwise(TestCase):
     """Parametrized tests for inline_asm_elementwise."""
 
     hw_classification = HardwareClassification.CUDA
@@ -398,7 +396,7 @@ class TestInlineAsmElementwiseCUDA(TestCase):
         self.assertEqual(result.float(), expected.float(), atol=1e-5, rtol=1e-5)
 
 
-class TestInlineAsmElementwiseErrorsGENERIC(TestCase):
+class TestInlineAsmElementwiseInputValidation(TestCase):
     """Device-independent tests for error handling."""
 
     hw_classification = HardwareClassification.GENERIC
@@ -413,8 +411,18 @@ class TestInlineAsmElementwiseErrorsGENERIC(TestCase):
                 dtype=torch.float32,
             )
 
+    def test_error_cpu_tensor(self):
+        x = torch.randn(100, dtype=torch.float32)
+        with self.assertRaises(RuntimeError):
+            inline_asm_elementwise(
+                x,
+                asm_str="v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
+                constraints="=v,v" if torch.version.hip else "=f,f",
+                dtype=torch.float32,
+            )
 
-class TestInlineAsmElementwiseErrorsCUDA(TestCase):
+
+class TestInlineAsmElementwiseErrors(TestCase):
     """CUDA-specific tests for error handling."""
 
     hw_classification = HardwareClassification.CUDA
@@ -447,19 +455,9 @@ class TestInlineAsmElementwiseErrorsCUDA(TestCase):
                 dtype=torch.float32,
             )
 
-    def test_error_cpu_tensor(self, device):
-        x = torch.randn(100, dtype=torch.float32)
-        with self.assertRaises(RuntimeError):
-            inline_asm_elementwise(
-                x,
-                asm_str="v_mov_b32 $0, $1" if torch.version.hip else "mov.f32 $0, $1;",
-                constraints="=v,v" if torch.version.hip else "=f,f",
-                dtype=torch.float32,
-            )
-
 
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
-class TestInlineAsmElementwiseEdgeCasesCUDA(TestCase):
+class TestInlineAsmElementwiseEdgeCases(TestCase):
     """Tests for edge cases."""
 
     hw_classification = HardwareClassification.CUDA
@@ -606,7 +604,7 @@ class TestInlineAsmElementwiseEdgeCasesCUDA(TestCase):
 
 @unittest.skipIf(not SM70OrLater, "Requires SM70+")
 @xfailIfNoAcceleratorTriton
-class TestInlineAsmPackPaddingCUDA(TestCase):
+class TestInlineAsmPackPadding(TestCase):
     """Test that pack padding works when block size < pack."""
 
     hw_classification = HardwareClassification.CUDA
@@ -784,18 +782,14 @@ class TestInlineAsmPackPaddingCUDA(TestCase):
         ).run(code)
 
 
+instantiate_device_type_tests(TestInlineAsmElementwise, globals(), only_for=("cuda",))
 instantiate_device_type_tests(
-    TestInlineAsmElementwiseCUDA, globals(), only_for=("cuda",)
+    TestInlineAsmElementwiseErrors, globals(), only_for=("cuda",)
 )
 instantiate_device_type_tests(
-    TestInlineAsmElementwiseErrorsCUDA, globals(), only_for=("cuda",)
+    TestInlineAsmElementwiseEdgeCases, globals(), only_for=("cuda",)
 )
-instantiate_device_type_tests(
-    TestInlineAsmElementwiseEdgeCasesCUDA, globals(), only_for=("cuda",)
-)
-instantiate_device_type_tests(
-    TestInlineAsmPackPaddingCUDA, globals(), only_for=("cuda",)
-)
+instantiate_device_type_tests(TestInlineAsmPackPadding, globals(), only_for=("cuda",))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_cpu_backend.py
+++ b/test/inductor/test_triton_cpu_backend.py
@@ -3,6 +3,7 @@ import unittest
 
 from torch._inductor import config
 from torch._inductor.test_case import run_tests
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import HAS_CPU, TRITON_HAS_CPU
 
 
@@ -36,7 +37,7 @@ if HAS_CPU and TRITON_HAS_CPU:
         }
     )
     class SweepInputsCpuTritonTest(test_torchinductor.SweepInputsCpuTest):
-        pass
+        hw_classification = HardwareClassification.CPU
 
     @config.patch(
         {
@@ -46,6 +47,8 @@ if HAS_CPU and TRITON_HAS_CPU:
         }
     )
     class CpuTritonTests(test_torchinductor.TestCase):
+        hw_classification = HardwareClassification.CPU
+
         common = test_torchinductor.check_model
         device = "cpu"
 

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -39,6 +39,7 @@ from torch.ops import aten
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -50,7 +51,7 @@ from torch.utils import _triton as triton_utils
 from torch.utils._sympy.functions import Identity
 
 
-class TestUtilsGENERIC(TestCase):
+class TestUtils(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def test_python_subprocess_env_prioritizes_loaded_torch(self):
@@ -341,17 +342,19 @@ class TestUtilsGENERIC(TestCase):
             self.assertEqual(flops, expected)
 
 
-class TestUtilsCUDA(TestCase):
-    hw_classification = HardwareClassification.CUDA
+class TestDeviceTflops(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @xfailIfNoAcceleratorTriton
+    @onlyAccelerator
     @dtypes(torch.float16, torch.bfloat16, torch.float32)
-    def test_get_device_tflops(self, dtype):
-        ret = get_device_tflops(dtype)
+    def test_get_device_tflops(self, device, dtype):
+        with torch.device(device):
+            ret = get_device_tflops(dtype)
         self.assertTrue(type(ret) is float)
 
 
-instantiate_device_type_tests(TestUtilsCUDA, globals(), only_for=("cuda",))
+instantiate_device_type_tests(TestDeviceTflops, globals(), allow_xpu=True)
 
 
 class TestLoadTemplate(TestCase):
@@ -417,10 +420,10 @@ class TestRuntimeEstimation(TestCase):
         self.assertAlmostEqual(result_ns, expected_ns)
 
 
-class TestFP4SupportCUDA(TestCase):
+class TestFP4Support(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
 
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.GENERIC
 
     @unittest.skipIf(
         importlib.util.find_spec("cutlass_api") is None,
@@ -440,16 +443,20 @@ class TestFP4SupportCUDA(TestCase):
         result_fp32 = cutlass_api.utils.cutlass_type_from_torch_type(torch.float32)
         self.assertEqual(result_fp32, cutlass.Float32)
 
-    def test_rand_strided_fp4_cuda(self):
+
+class TestRandStridedFP4(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_rand_strided_fp4(self, device):
         from torch._dynamo.testing import rand_strided
 
-        t = rand_strided((16, 32), (32, 1), dtype=torch.float4_e2m1fn_x2, device="cuda")
+        t = rand_strided((16, 32), (32, 1), dtype=torch.float4_e2m1fn_x2, device=device)
         self.assertEqual(t.dtype, torch.float4_e2m1fn_x2)
         self.assertEqual(t.shape, (16, 32))
         self.assertTrue(t.is_cuda)
 
 
-instantiate_device_type_tests(TestFP4SupportCUDA, globals(), only_for=("cuda",))
+instantiate_device_type_tests(TestRandStridedFP4, globals(), only_for=("cuda",))
 
 
 class TestFP4SupportCPU(TestCase):

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -39,7 +39,6 @@ from torch.ops import aten
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
-    onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -343,18 +342,17 @@ class TestUtils(TestCase):
 
 
 class TestDeviceTflops(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CUDA
 
     @xfailIfNoAcceleratorTriton
-    @onlyAccelerator
     @dtypes(torch.float16, torch.bfloat16, torch.float32)
     def test_get_device_tflops(self, device, dtype):
-        with torch.device(device):
+        with torch.cuda.device(device):
             ret = get_device_tflops(dtype)
         self.assertTrue(type(ret) is float)
 
 
-instantiate_device_type_tests(TestDeviceTflops, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestDeviceTflops, globals(), only_for=("cuda",))
 
 
 class TestLoadTemplate(TestCase):
@@ -423,11 +421,12 @@ class TestRuntimeEstimation(TestCase):
 class TestFP4Support(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
 
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(
-        importlib.util.find_spec("cutlass_api") is None,
-        "requires cutlass_api",
+        not torch.cuda.is_available()
+        or importlib.util.find_spec("cutlass_api") is None,
+        "requires CUDA and cutlass_api",
     )
     def test_ensure_fp4_dtype_registered(self):
         """_ensure_fp4_dtype_registered should patch cutlass_api for FP4."""

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TestCase,
     xfailIfNoAcceleratorTriton,
@@ -49,7 +50,9 @@ from torch.utils import _triton as triton_utils
 from torch.utils._sympy.functions import Identity
 
 
-class TestUtils(TestCase):
+class TestUtilsGENERIC(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_python_subprocess_env_prioritizes_loaded_torch(self):
         torch_package_root = os.path.dirname(
             os.path.dirname(os.path.abspath(torch.__file__))
@@ -337,18 +340,23 @@ class TestUtils(TestCase):
             )
             self.assertEqual(flops, expected)
 
+
+class TestUtilsCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @xfailIfNoAcceleratorTriton
-    @unittest.skipIf(not torch.cuda.is_available(), "skip if no device")
     @dtypes(torch.float16, torch.bfloat16, torch.float32)
     def test_get_device_tflops(self, dtype):
         ret = get_device_tflops(dtype)
         self.assertTrue(type(ret) is float)
 
 
-instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestUtilsCUDA, globals(), only_for=("cuda",))
 
 
 class TestLoadTemplate(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_load_template_uses_utf8(self):
         # load_template must decode templates as UTF-8 regardless of the ambient
         # locale. On a host whose default encoding is ascii, reading a template
@@ -381,6 +389,8 @@ class TestLoadTemplate(TestCase):
 
 
 class TestRuntimeEstimation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_compute_time_units(self):
         """TFLOPS-to-FLOPS/s conversion must use 1e12, not 1e15."""
         from unittest.mock import patch
@@ -407,13 +417,14 @@ class TestRuntimeEstimation(TestCase):
         self.assertAlmostEqual(result_ns, expected_ns)
 
 
-class TestFP4Support(TestCase):
+class TestFP4SupportCUDA(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
 
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or importlib.util.find_spec("cutlass_api") is None,
-        "requires CUDA and cutlass_api",
+        importlib.util.find_spec("cutlass_api") is None,
+        "requires cutlass_api",
     )
     def test_ensure_fp4_dtype_registered(self):
         """_ensure_fp4_dtype_registered should patch cutlass_api for FP4."""
@@ -429,16 +440,6 @@ class TestFP4Support(TestCase):
         result_fp32 = cutlass_api.utils.cutlass_type_from_torch_type(torch.float32)
         self.assertEqual(result_fp32, cutlass.Float32)
 
-    def test_rand_strided_fp4(self):
-        """rand_strided should produce valid FP4 tensors."""
-        from torch._dynamo.testing import rand_strided
-
-        t = rand_strided((4, 8), (8, 1), dtype=torch.float4_e2m1fn_x2, device="cpu")
-        self.assertEqual(t.dtype, torch.float4_e2m1fn_x2)
-        self.assertEqual(t.shape, (4, 8))
-        self.assertEqual(t.stride(), (8, 1))
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_rand_strided_fp4_cuda(self):
         from torch._dynamo.testing import rand_strided
 
@@ -448,8 +449,26 @@ class TestFP4Support(TestCase):
         self.assertTrue(t.is_cuda)
 
 
+instantiate_device_type_tests(TestFP4SupportCUDA, globals(), only_for=("cuda",))
+
+
+class TestFP4SupportCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
+    def test_rand_strided_fp4(self):
+        """rand_strided should produce valid FP4 tensors."""
+        from torch._dynamo.testing import rand_strided
+
+        t = rand_strided((4, 8), (8, 1), dtype=torch.float4_e2m1fn_x2, device="cpu")
+        self.assertEqual(t.dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(t.shape, (4, 8))
+        self.assertEqual(t.stride(), (8, 1))
+
+
 class TestTritonTypeMapping(TestCase):
     """Tests for acc_type() dtype conversions."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_acc_type(self):
         from torch._inductor.kernel.mm_common import acc_type
@@ -469,6 +488,8 @@ class TestTritonTypeMapping(TestCase):
 
 
 class TestFakeTensorUpdater(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @staticmethod
     def _get_faketensormode(
         graph: torch.fx.GraphModule,

--- a/test/inductor/test_xpu_basic.py
+++ b/test/inductor/test_xpu_basic.py
@@ -4,6 +4,8 @@ import os
 import sys
 
 import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 importlib.import_module("filelock")
@@ -23,6 +25,8 @@ from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inducto
 
 
 class XpuBasicTests(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     common = check_model_gpu
     device = "xpu"
 
@@ -49,6 +53,11 @@ class XpuBasicTests(TestCase):
             return a / b
 
         self.common(fn, (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16)))
+
+
+instantiate_device_type_tests(
+    XpuBasicTests, globals(), only_for=("xpu",), allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_xpu_basic.py
+++ b/test/inductor/test_xpu_basic.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import torch
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
 
 
@@ -53,11 +52,6 @@ class XpuBasicTests(TestCase):
             return a / b
 
         self.common(fn, (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16)))
-
-
-instantiate_device_type_tests(
-    XpuBasicTests, globals(), only_for=("xpu",), allow_xpu=True
-)
 
 
 if __name__ == "__main__":

--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -6,11 +6,17 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.utils import _triton as triton_utils
 
 
 class TestTritonUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_triton_backend_load_failure(self, exc, env):
         driver_mod = importlib.import_module("triton.runtime.driver")
         fake_driver = SimpleNamespace(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2108,8 +2108,7 @@ def xfailIfNoAcceleratorTriton(test_func):
             try:
                 return test_func(*args, **kwargs)
             except ImportError as e:
-                # This except block required only for TestUtilsCPU::test_get_device_tflops_cpu
-                # test_get_device_tflops imports triton directly in its body — even for CPU
+                # A CPU test may still import Triton directly despite using a CPU fallback.
                 if "triton" in str(e).lower():
                     import pytest
                     pytest.xfail(f"Triton not available (device={spec!r}): {e}")


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple 18 Python test files from implicit hardware assumptions by splitting test classes and adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Separate generic, CPU, CUDA, and XPU test contracts where needed.
> - Add corresponding `HardwareClassification` labels.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile <modified test files>
> lintrunner -a <modified test files>
> git diff --check
> ```
>
> CI:
>
> - Run the modified test files through their existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.
>
> @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo