### PR TITLE
[TEST] Add hw_classification to test_matmul_cuda.py

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_device_type import (
 )
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_JETSON,
     IS_WINDOWS,
     MI200_ARCH,
@@ -121,6 +122,8 @@ def sm_carveout(value: int | None):
 
 
 class TestMatmulCuda(InductorTestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         # Snapshot fp32_precision (not allow_tf32) so the round-trip is exact:
@@ -1448,6 +1451,8 @@ class TestMatmulCuda(InductorTestCase):
 @unittest.skipIf(IS_WINDOWS, "Windows doesn't support CUTLASS extensions")
 @unittest.skipIf(not _IS_SM8X, "mixed dtypes linear only supported on SM 8.x")
 class TestMixedDtypesLinearCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @dtypes(torch.float16, torch.bfloat16)
     def test_mixed_dtypes_linear(self, dtype: torch.dtype, device: str = "cuda"):
         def run_test(


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.CUDA` to `TestMatmulCuda` — 28 cuBLAS/cuBLASLt/grouped GEMM tests
- Add `hw_classification = HardwareClassification.CUDA` to `TestMixedDtypesLinearCuda` — 1 CUTLASS mixed-dtype test

## Test Plan

```
python test/test_matmul_cuda.py -v --hw-classification CUDA
Ran 1792 tests in 83.165s
OK (skipped=206)
HW classification mode active (['CUDA']): total=1792, passed=1792, unclassified=0, mismatched=0
```