### PR TITLE
[inductor] Make align_random_eager dropout RNG work on XPU

### DIFF
--- a/torch/_inductor/fx_passes/replace_random.py
+++ b/torch/_inductor/fx_passes/replace_random.py
@@ -14,6 +14,7 @@ from ..pattern_matcher import (
     PatternMatcherPass,
     register_graph_pattern,
 )
+from ..utils import eager_rng_align_supported, get_eager_rng_offset
 from ..virtualized import V
 
 
@@ -38,22 +39,10 @@ def _shape_to_offset(shape, device: torch.device):
     elif isinstance(device, str):
         device = torch.device(device)
 
-    if device.type != "cuda":
+    if not eager_rng_align_supported(device):
         return 0
 
-    block_size = 256
-    unroll = 4
-    curand4_engine_calls = 4
-
-    device_property = torch.cuda.get_device_properties(device)
-
-    blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
-    max_grid = device_property.multi_processor_count * blocks_per_sm
-    grid_size = (nelem + block_size - 1) // block_size
-    grid_size = -torch.sym_min(-grid_size, -1)
-    grid_size = torch.sym_min(grid_size, max_grid)
-
-    return ((nelem - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+    return get_eager_rng_offset(device, nelem)
 
 
 def replace_random_passes(gm: torch.fx.GraphModule):
@@ -214,7 +203,11 @@ def replace_random(
     device = get_device(device)
     replacement_fn = replacement
 
-    if mode == "rand" and config.align_random_eager and device.type == "cuda":
+    if (
+        mode == "rand"
+        and config.align_random_eager
+        and eager_rng_align_supported(device)
+    ):
         # Only enable when align_random_eager is on.
         def replacement_align(size):
             offset = _shape_to_offset(size, device)

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -101,16 +101,21 @@ randint = make_prim(
 
 def _reserve_rng_state(device: torch.device, used_offset):
     """
-    Reserve `used_offset` 32-bit Philox samples on the given CUDA device and
+    Reserve `used_offset` 32-bit Philox samples on the given device and
     return (seed, base), where base is in Philox-4x32 units.
 
     This mirrors how Inductor accounts for Philox consumption so compiled
     dropout kernels can reconstruct eager RNG state.
     """
     dev = device if isinstance(device, torch.device) else torch.device(device)
+
+    if dev.type == "xpu":
+        return _reserve_rng_state_xpu(dev, used_offset)
+
     if dev.type != "cuda":
-        # Only CUDA devices have Philox-based CUDAGenerator. For non-CUDA
-        # devices this prim should be dead code and never actually run.
+        # Only CUDA/XPU devices have a Philox-based generator Inductor can
+        # align with. For other devices this prim should be dead code and
+        # never actually run.
         return 0, 0
 
     dev_index = _get_device_index(dev, optional=True)
@@ -130,6 +135,33 @@ def _reserve_rng_state(device: torch.device, used_offset):
     else:
         base = torch.div(off_t + intra_t, 4, rounding_mode="floor")
     return seed_t, base
+
+
+def _reserve_rng_state_xpu(dev: torch.device, used_offset):
+    """
+    XPU equivalent of the CUDA reservation above.
+
+    inductor_reserve_rng_state() is implemented only for CUDA/ROCm (see
+    torch/csrc/inductor/inductor_ops_gpu.cpp), so the reservation is done
+    through the generator's public offset API instead. Unlike the C++ op this
+    read-modify-write is not atomic and is not XPU-graph aware, so concurrent
+    RNG consumers or graph capture are not supported yet.
+    """
+    dev_index = dev.index
+    if dev_index is None:
+        dev_index = torch.xpu.current_device()
+
+    gen = torch.xpu.default_generators[dev_index]
+    seed = gen.initial_seed()
+    offset = gen.get_offset()
+    # set_offset() requires a multiple of 4, matching XPUGeneratorState::increase.
+    gen.set_offset(offset + ((used_offset + 3) // 4) * 4)
+
+    opts = {"device": dev, "dtype": torch.int64}
+    return (
+        torch.tensor([seed], **opts),  # type: ignore[arg-type]
+        torch.tensor([offset // 4], **opts),  # type: ignore[arg-type]
+    )
 
 
 def _rand_eager_offset_impl(offset, device: torch.device) -> Tensor:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -88,6 +88,9 @@ from .utils import (
     ceildiv,
     convert_symint_to_expr,
     decode_device,
+    eager_rng_align_supported,
+    get_eager_rng_threads_per_round,
+    get_eager_rng_vec_width,
     is_dynamic,
     is_gpu,
     is_nvidia_sm100_or_later,
@@ -3127,24 +3130,11 @@ def inductor_lookup_seed(seeds, index):
     )
 
 
-def get_threads_per_round(device: torch.device):
+def get_threads_per_round(device: torch.device, nelem: int):
     if not isinstance(device, torch.device):
         device = torch.device(device)
 
-    if device.type == "cuda":
-        idx = device.index
-        if idx is None:
-            idx = torch.cuda.current_device()
-
-        prop = torch.cuda.get_device_properties(idx)
-        threads_per_round = (
-            prop.multi_processor_count * prop.max_threads_per_multi_processor
-        )
-    else:
-        _CPU_GRAIN_SIZE = 32768
-        threads_per_round = _CPU_GRAIN_SIZE
-
-    return threads_per_round
+    return get_eager_rng_threads_per_round(device, nelem)
 
 
 @register_lowering(inductor_prims.random, type_promotion_kind=None)
@@ -3168,15 +3158,12 @@ def inductor_random(
     ).make_indexer()
     seed_loader = seed.make_loader()
 
-    if config.align_random_eager and device.type == "cuda":
-        threads_per_round = get_threads_per_round(device)
-
-        def _vec_from_dtype(dt: torch.dtype) -> int:
-            if dt in (torch.float16, torch.bfloat16):
-                return 8
-            return 4
-
-        vec = _vec_from_dtype(align_dtype)
+    if config.align_random_eager and eager_rng_align_supported(device):
+        nelem = 1
+        for s in size:
+            nelem *= s
+        threads_per_round = get_threads_per_round(device, nelem)
+        vec = get_eager_rng_vec_width(device, align_dtype)
 
         def inner_fn(index):
             rng_seed = seed_loader([0])

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3062,6 +3062,90 @@ def get_gpu_shared_memory() -> int:
     return driver.active.utils.get_device_properties(0).get("max_shared_mem", 0)
 
 
+# Philox generates 128 bits (4 x uint32) per counter increment, and the eager
+# dropout kernels consume exactly one such quad per unrolled iteration.
+PHILOX_ENGINE_CALLS = 4
+PHILOX_UNROLL = 4
+
+# Fallback hardware threads per EU for XPU. This is not exposed through
+# torch.xpu.get_device_properties(), while the eager launch policy
+# (syclMaxWorkItemsPerTile in torch-xpu-ops) needs it. All currently supported
+# Intel GPU architectures use 8.
+_XPU_HW_THREADS_PER_EU = 8
+
+# Grain size used by the CPU eager RNG.
+_CPU_GRAIN_SIZE = 32768
+
+
+def eager_rng_align_supported(device: torch.device) -> bool:
+    return device.type in ("cuda", "xpu")
+
+
+def get_eager_rng_vec_width(device: torch.device, dtype: torch.dtype) -> int:
+    """Elements handled per thread by the eager dropout kernel.
+
+    CUDA widens to 8 for 16-bit dtypes, while the XPU kernel static_asserts
+    VecSize <= 4 (see torch-xpu-ops src/ATen/native/xpu/sycl/Dropout.cpp), so
+    it stays at 4 for every dtype.
+    """
+    if device.type == "cuda" and dtype in (torch.float16, torch.bfloat16):
+        return 8
+    return PHILOX_ENGINE_CALLS
+
+
+def _eager_rng_launch_geometry(device: torch.device) -> tuple[int, int]:
+    if device.type == "cuda":
+        idx = device.index
+        if idx is None:
+            idx = torch.cuda.current_device()
+        prop = torch.cuda.get_device_properties(idx)
+        # aten/src/ATen/native/cuda/Dropout.cu uses a fixed 256-thread block.
+        threads_per_group = 256
+        max_groups = prop.multi_processor_count * (
+            prop.max_threads_per_multi_processor // threads_per_group
+        )
+        return threads_per_group, max_groups
+
+    if device.type == "xpu":
+        idx = device.index
+        if idx is None:
+            idx = torch.xpu.current_device()
+        prop = torch.xpu.get_device_properties(idx)
+        sub_group_size = max(prop.sub_group_sizes)
+        eu_per_subslice = prop.gpu_eu_count // prop.gpu_subslice_count
+        # syclMaxWorkItemsPerSubSlice() in torch-xpu-ops src/comm/DeviceProperties.h
+        threads_per_group = sub_group_size * eu_per_subslice
+        # syclMaxWorkItemsPerTile() / threads_per_group
+        max_work_items = prop.gpu_eu_count * sub_group_size * _XPU_HW_THREADS_PER_EU
+        return threads_per_group, max_work_items // threads_per_group
+
+    return _CPU_GRAIN_SIZE, 1
+
+
+def get_eager_rng_threads_per_round(device: torch.device, nelem: int) -> int:
+    """Number of threads the eager RNG kernel launches for ``nelem`` elements.
+
+    This mirrors calc_execution_policy()/the Dropout.cu grid computation: the
+    grid is clamped to what the device can hold resident, so the value is
+    shape dependent. Both the offset accounting and the generated kernel must
+    use the same number or the compiled stream desynchronizes from eager.
+    """
+    threads_per_group, max_groups = _eager_rng_launch_geometry(device)
+    num_groups = (nelem + threads_per_group - 1) // threads_per_group
+    # sym_min/sym_max keep this guard-free when nelem is a symbolic shape.
+    num_groups = torch.sym_max(torch.sym_min(num_groups, max_groups), 1)
+    return threads_per_group * num_groups
+
+
+def get_eager_rng_offset(device: torch.device, nelem: int) -> int:
+    if nelem == 0:
+        return 0
+    threads_per_round = get_eager_rng_threads_per_round(device, nelem)
+    return (
+        (nelem - 1) // (threads_per_round * PHILOX_UNROLL) + 1
+    ) * PHILOX_ENGINE_CALLS
+
+
 def get_max_numwarps() -> int:
     if torch.cuda.is_available():
         device = torch.device("cuda", torch.cuda.current_device())


### PR DESCRIPTION
## Summary

`config.align_random_eager` makes compiled dropout reproduce the eager Philox stream, so that eager and `torch.compile` produce identical dropout masks under the same seed. It was implemented for CUDA only — every decision point tested `device.type == "cuda"` — so on XPU the lowering silently fell back to the unaligned `ops.rand` path and the compiled mask agreed with eager only at chance level:

```
AssertionError: 0.5005362033843994 not less than or equal to 0.0001
Dropout mask mismatch ratio too high: 0.50053620
```

XPU eager dropout already uses the same Philox contract as CUDA (seed + global-thread-id subsequence + generator offset, `UNROLL=4`, one `rand_uniform4` per unrolled iteration), so the compiled path can be made to match exactly. Two details genuinely differ and are now modelled per backend:

* **Launch geometry** — CUDA derives the grid from a fixed 256-thread block and SM occupancy; XPU derives it from SYCL sub-slice/tile limits (`calc_execution_policy` / `syclMaxWorkItemsPerSubSlice` in torch-xpu-ops). XPU eager is deliberately left untouched, since changing its launch policy would alter RNG consumption for existing eager users.
* **Vector width** — CUDA widens to 8 elements/thread for 16-bit dtypes, while the XPU kernel `static_assert`s `VecSize <= 4`, so XPU stays at 4 for every dtype.

Launch geometry, vector width and Philox offset accounting move into shared helpers in `_inductor/utils.py`, consumed by both `_shape_to_offset()` (offset reservation) and `inductor_random()` (kernel codegen). Deriving both from one helper is what keeps them in sync — previously each carried its own copy of the formula.

### Also fixes a latent CUDA bug

`get_threads_per_round()` returned the grid cap unconditionally, while eager clamps `grid = min(ceil(nelem / block), cap)`. The two therefore disagreed for any tensor too small to saturate the device, meaning `align_random_eager` only actually held for saturating shapes. The helper now takes `nelem` and applies the same clamp as eager; `sym_min`/`sym_max` keep it guard-free under dynamic shapes.

### Known follow-ups (documented in code)

`inductor_reserve_rng_state` is a CUDA/ROCm-only C++ op (`torch/csrc/inductor/inductor_ops_gpu.cpp` casts to `CUDAGeneratorImpl`), so XPU reserves its offset through the generator's public offset API. Two gaps are left as follow-ups:

1. That read-modify-write is **not atomic** (the C++ op holds the generator mutex) and is **not XPU-graph aware**.
2. `_XPU_HW_THREADS_PER_EU` is a fallback because `gpu_hw_threads_per_eu` is not exposed to Python. It is correct for all currently supported Intel GPUs, but the XPU execution policy should ideally be exposed from C++ instead.

Fixes https://github.com/intel/torch-xpu-ops/issues/4882

## Test plan

Run on an Intel Data Center GPU Max 1550:

```bash
python -m pytest -sv test/inductor/test_dropout_align_random_eager.py
```

Note this test class is currently gated to CUDA (`HAS_CUDA_AND_TRITON`); the runs below were done with the class gating relaxed to `HAS_GPU_AND_TRITON` locally so the XPU path is actually exercised. Enabling that upstream is left to a separate change.

* `test_dropout_mask_parity_and_rng_offset_cuda` — **failed before** (`0.5005362`), **passes after**.
* The other three parity tests in the class sharing this root cause also pass, including `test_large_seed` (seeds above 2\*\*32) and the multi-dropout test that exercises horizontal offset fusion.
* Eager/compiled masks are **bit-identical (0.000000 mismatch)** across `{(8,8), (1024,), (4096,), (256,256), (1536,3072), (2048,2048)} x {float32, float16, bfloat16}` — covering both unsaturated shapes (which the previous cap-only `threads_per_round` got wrong) and saturated ones.
* Default `align_random_eager=False` path confirmed unchanged.

Separately validated the index mapping by reconstructing the eager XPU dropout mask in pure Python from only `(seed, offset)` plus the launch policy, using the same Philox mapping as `triton_helpers.rand_eager_kernel`. It matched eager exactly, and the predicted generator offset delta matched the measured delta for every shape tested:

| nelem | measured Δoffset | predicted |
|---|---|---|
| 1 .. 524288 | 4 | 4 |
| 1048576 | 8 | 8 |
| 4718592 | 36 | 36 |
| 8388608 | 64 | 64 |

CUDA numerics are unverified locally (no CUDA device available) — CI coverage is needed for the shape-aware `threads_per_round` change on CUDA.

This PR was authored with the assistance of an AI coding agent.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo