### PR TITLE
Fix out-of-bounds read in weight_norm_cuda for empty tensors

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -57,6 +57,12 @@ std::tuple<Tensor,Tensor> weight_norm_cpu(
   const auto dtype = (g.scalar_type() == at::ScalarType::BFloat16 || g.scalar_type() == at::ScalarType::Half) ?
       at::ScalarType::Float : g.scalar_type();
   auto norm = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(dtype));
+
+  if (v.numel() == 0) {
+    norm.zero_();
+    return std::tuple<Tensor, Tensor>{std::move(w), std::move(norm)};
+  }
+
   weight_norm_stub(kCPU, w, norm, v, g, dim);
 
   return std::tuple<Tensor, Tensor>{std::move(w), std::move(norm)};
@@ -74,6 +80,12 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cpu(
 
   auto grad_v = at::empty_like(saved_v, at::MemoryFormat::Contiguous);
   auto grad_g = at::empty_like(saved_g, at::MemoryFormat::Contiguous);
+
+  if (saved_v.numel() == 0) {
+    grad_g.zero_();
+    return std::tuple<Tensor, Tensor>{std::move(grad_v), std::move(grad_g)};
+  }
+
   weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
 
   return std::tuple<Tensor, Tensor>{std::move(grad_v), std::move(grad_g)};

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -353,6 +353,10 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
   // current device is?  I believe so, because Type::* functions are DeviceGuard()ed.
   auto norms = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(AccType));
 
+  if (v.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{w, norms};
+  }
+
   const int ndims = v.dim();
 
   if(dim == 0)
@@ -441,6 +445,10 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cuda
 
   auto grad_v = at::empty_like(saved_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto grad_g = at::empty_like(saved_g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  if (saved_v.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+  }
 
   const int ndims = saved_v.dim();
 

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -354,6 +354,7 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
   auto norms = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(AccType));
 
   if (v.numel() == 0) {
+    norms.zero_();
     return std::tuple<Tensor, Tensor>{w, norms};
   }
 
@@ -447,6 +448,7 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cuda
   auto grad_g = at::empty_like(saved_g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
   if (saved_v.numel() == 0) {
+    grad_g.zero_();
     return std::tuple<Tensor, Tensor>{grad_v, grad_g};
   }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1817,6 +1817,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+    def test_weight_norm_empty_tensor(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/191848
+        # weight_norm_cuda was launching kernels on empty tensors, causing an
+        # out-of-bounds memory read. Verify that it handles empty tensors safely.
+        for device in ["cpu"] + (["cuda"] if torch.cuda.is_available() else []):
+            v = torch.empty_strided(
+                (5, 4, 16, 0), (64, 16, 1, 1), dtype=torch.float32, device=device
+            )
+            g = torch.empty_strided(
+                (0, 1, 16, 3), (48, 48, 3, 1), dtype=torch.float32, device=device
+            )
+            w, norms = torch._weight_norm(v, g, 0)
+            self.assertEqual(w.shape, v.shape)
+            self.assertEqual(norms.shape, g.shape)
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1817,21 +1817,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
-    def test_weight_norm_empty_tensor(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/191848
-        # weight_norm_cuda was launching kernels on empty tensors, causing an
-        # out-of-bounds memory read. Verify that it handles empty tensors safely.
-        for device in ["cpu"] + (["cuda"] if torch.cuda.is_available() else []):
-            v = torch.empty_strided(
-                (5, 4, 16, 0), (64, 16, 1, 1), dtype=torch.float32, device=device
-            )
-            g = torch.empty_strided(
-                (0, 1, 16, 3), (48, 48, 3, 1), dtype=torch.float32, device=device
-            )
-            w, norms = torch._weight_norm(v, g, 0)
-            self.assertEqual(w.shape, v.shape)
-            self.assertEqual(norms.shape, g.shape)
-
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))
@@ -7383,6 +7368,38 @@ def _buildEquivalentAffineTransforms3d(device, input_size, output_size, angle_ra
 
 
 class TestNNDeviceType(NNTestCase):
+
+    def test_weight_norm_empty_tensor(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/191848
+        def run_test(v_shape, g_shape, dim):
+            v = torch.empty(v_shape, dtype=torch.float32, device=device, requires_grad=True)
+            g = torch.empty(g_shape, dtype=torch.float32, device=device, requires_grad=True)
+            
+            # Forward pass
+            w, norms = torch._weight_norm(v, g, dim)
+            self.assertEqual(w.shape, v.shape)
+            self.assertEqual(norms.shape, g.shape)
+            
+            # Assert values are zero-filled
+            if norms.numel() > 0:
+                self.assertEqual(norms, torch.zeros_like(norms))
+            
+            # Backward pass
+            grad_w = torch.ones_like(w)
+            w.backward(grad_w)
+            
+            # Assert grad is zero-filled
+            if g.grad is not None and g.grad.numel() > 0:
+                self.assertEqual(g.grad, torch.zeros_like(g.grad))
+
+        # 1. Legitimately-shaped empty case (dim=0)
+        run_test((5, 0), (5, 1), 0)
+        
+        # 2. Legitimately-shaped empty case (dim=-1)
+        run_test((0, 5), (1, 5), 1)
+
+        # 3. Crash reproducer (both 0-element)
+        run_test((5, 4, 16, 0), (0, 1, 16, 3), 0)
 
     def test_grid_sample_backward_error_checking(self, device):
         input = torch.empty(1, 1, 2, 2, device=device)


### PR DESCRIPTION
Fixes #191848

**Summary**
`weight_norm_cuda` (forward and backward) was launching CUDA kernels even when the input tensor `v` has 0 elements (e.g., shape `(5, 4, 16, 0)`). Because the outer dimension is non-zero (5 blocks are launched), each block tries to read from `g[row]` — but `g` has 0 elements, causing an illegal out-of-bounds memory read.

**Reproduction**
```python
import torch
gpu = torch.device('cuda')
v = torch.empty_strided((5, 4, 16, 0), (64, 16, 1, 1), dtype=torch.float32, device=gpu)
g = torch.empty_strided((0, 1, 16, 3), (48, 48, 3, 1), dtype=torch.float32, device=gpu)
torch._weight_norm(v, g, 0)
torch.cuda.synchronize()  # crashes here
```

