### PR TITLE
[inductor][NVGEMM] Remove dots from parametrized test names (#192646)

### DIFF
--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -26,6 +26,7 @@ from torch._inductor.utils import (
     run_and_get_code,
 )
 from torch.testing._internal.common_utils import (
+    dtype_name,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -1268,7 +1269,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             ((((N,), torch.float32),), True),
         ),
         name_fn=lambda case: "_and_".join(
-            f"{'x'.join(map(str, shape))}_{dtype}" for shape, dtype in case[0]
+            f"{'x'.join(map(str, shape))}_{dtype_name(dtype)}" for shape, dtype in case[0]
         ),
     )
     def test_scaled_mm_broadcast_epilogue_fusion(self, case):


### PR DESCRIPTION
Summary:

The `name_fn` for `test_scaled_mm_broadcast_epilogue_fusion` interpolated a bare
`torch.dtype`, and `str(torch.bfloat16)` is `"torch.bfloat16"`. That put a literal
`.` into the generated method names, e.g.
`test_scaled_mm_broadcast_epilogue_fusion_1x512_torch.bfloat16`.

Root cause: `setattr` happily accepts a non-identifier name, so these tests list
fine and `buck run` works. `buck test` does not. The TPX unittest adapter lists
tests as `module.Class.method` and re-resolves them through CPython's
`loadTestsFromName`, which does `name.split('.')` and walks with `getattr`.
Listing joins on `.` and running splits on `.`, so the round trip is lossy
whenever a method name contains one. Resolution dies one component short with

  type object 'TestNVUniversalGemmEpilogueFusion' has no attribute
  'test_scaled_mm_broadcast_epilogue_fusion_1x512_torch'

and `unittest_test_loader.py` turns that into `sys.exit(1)`. Because names are
loaded via `sorted(test_names)`, the alphabetically first dotted name aborts the
load before any test runs, so every test in the target gets reported as FAILED.
That is why 6 misnamed tests produced 23 open TestX issues. The harness renders
the abort as the unhelpful "Test appears to have passed but the binary exited
with a non-zero exit code."

The fix uses `dtype_name()` from `torch.testing._internal.common_utils`. That is
the same helper `parametrize`'s default namer already applies to dtypes -
supplying a custom `name_fn` is exactly what bypasses that sanitization. Test IDs
change accordingly, e.g. `..._1x512_torch.bfloat16` becomes `..._1x512_bfloat16`.

These tests have never passed: they have failed at load time since they were
introduced, and TestX reports zero passing runs for them. Renaming makes the
target loadable again, but it does not by itself establish that the 17 collateral
`grouped_reduce` tests are green, because they have never actually executed.

This diff was authored with the assistance of an AI coding agent.

___

Test Plan:
Lint is clean:

```
arc lint fbcode/caffe2/test/inductor/test_nv_universal_gemm.py
```

Verified the six generated names are now valid Python identifiers with no
collisions:

```
test_scaled_mm_broadcast_epilogue_fusion_512x512_bfloat16
test_scaled_mm_broadcast_epilogue_fusion_512_bfloat16
test_scaled_mm_broadcast_epilogue_fusion_1x512_bfloat16
test_scaled_mm_broadcast_epilogue_fusion_512x1_bfloat16
test_scaled_mm_broadcast_epilogue_fusion_512_bfloat16_and_512x1_bfloat16
test_scaled_mm_broadcast_epilogue_fusion_512_float32
```

Differential Revision: D115356757


