### PR TITLE
topk: restrict CuTeDSL override to SM100 and newer (#192647) (#192647) (#192647)

### DIFF
--- a/test/python_native/test_topk_cutedsl_eligibility.py
+++ b/test/python_native/test_topk_cutedsl_eligibility.py
@@ -1,0 +1,43 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+from unittest import mock
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestCuTeDSLTopKEligibility(TestCase):
+    def test_pre_sm100_devices_are_ineligible(self) -> None:
+        from torch._native.ops.topk import cutedsl_impl
+
+        x = mock.Mock(
+            is_cuda=True,
+            dtype=torch.float32,
+            device=torch.device("cuda:0"),
+            shape=(256, 256),
+            ndim=2,
+        )
+        with (
+            mock.patch.object(cutedsl_impl, "any_cow", return_value=False),
+            mock.patch.object(cutedsl_impl, "last_dim_row_major_ok", return_value=True),
+            mock.patch.object(cutedsl_impl, "_min_rows_for_full_wave", return_value=1),
+            mock.patch.object(torch.cuda, "get_device_capability") as get_capability,
+        ):
+            for capability, expected in (
+                ((8, 0), False),
+                ((9, 0), False),
+                ((10, 0), True),
+            ):
+                with self.subTest(capability=capability):
+                    cutedsl_impl._sm100_or_above.cache_clear()
+                    get_capability.reset_mock()
+                    get_capability.return_value = capability
+                    for _ in range(2):
+                        self.assertEqual(
+                            cutedsl_impl._eligible(x, 32, -1, True, True), expected
+                        )
+                    get_capability.assert_called_once_with(0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_native/ops/topk/cutedsl_impl.py
+++ b/torch/_native/ops/topk/cutedsl_impl.py
@@ -19,7 +19,7 @@ Two kernels, picked by (K, N) - see ``cutedsl_kernels.py``:
         Faster (~5-10%); indices may differ across runs on threshold ties.
 
 Common eligibility (see ``_cond``):
-  - fp32 input, CUDA, not COW
+  - fp32 input, CUDA on SM100 or newer, not COW
   - ``largest=True``, ``sorted=True``
   - reducing over the last axis, ``self`` contiguous (2D flatten is a view)
   - row count at least one full wave of SMs (perf gate)
@@ -92,6 +92,12 @@ def _kernel_for(k: int, n: int) -> str | None:
 
 
 @functools.cache
+def _sm100_or_above(device: int) -> bool:
+    major, _ = torch.cuda.get_device_capability(device)
+    return major >= 10
+
+
+@functools.cache
 def _min_rows_for_full_wave(device_idx: int) -> int:
     """Row threshold below which the one-CTA-per-row kernel underutilises
     the GPU. A full wave is SM-count CTAs; below that, aten's multi-CTA
@@ -103,6 +109,8 @@ def _eligible(
     self: torch.Tensor, k: int, dim: int, largest: bool, sorted_: bool
 ) -> bool:
     if not self.is_cuda or self.dtype != torch.float32:
+        return False
+    if not _sm100_or_above(self.device.index or 0):
         return False
     if any_cow(self):
         return False


### PR DESCRIPTION
Summary:
The CuTeDSL `topk` thresholds were tuned on B200, but `_eligible()` admitted older CUDA architectures where `aten` is faster.

# This diff:

- Require compute capability major 10 or newer before selecting the CuTeDSL override.
- Keep A100 and Hopper on `aten::topk`; preserve the optimized path on B200 and newer GPUs.
- Pin the dispatch boundary with a CPU-only SM80/SM90/SM100 eligibility test.


Test Plan:
**Validation**

- `test/python_native/test_topk_cutedsl_eligibility.py`: 2 passed under the internal Python test runner, covering SM80 and SM90 fallback plus SM100 eligibility.
- `test/test_sort_and_select.py -k topk`: 31 passed under the internal Python test runner.
- GitHub CI will run OSS public-bindings and lintrunner coverage.
- Tested internal flows and runtime reduced 6.5x on A100

Pulled By:
Trolann

Trolann

Reviewed By: ezrakhuzadi

Differential Revision: D115327835
