### PR TITLE
Reject generated test names containing '.' at instantiation time

### DIFF
--- a/test/functorch/test_vmap_registrations.py
+++ b/test/functorch/test_vmap_registrations.py
@@ -210,7 +210,7 @@ def dispatch_registrations(
     subtests = [
         subtest(
             reg,
-            name=f"[{reg}]",
+            name=f"[{reg}]".replace(".", "_"),
             decorators=([unittest.expectedFailure] if reg in xfails else []),
         )
         for reg in registrations

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -4781,7 +4781,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             ("floor", 448.0, float("inf"), 247),
             ("floor", 2.0**-122, 64.0, 255),
         ),
-        name_fn=lambda case: f"{case[0]}_max{case[1]:g}_code{case[3]}",
+        name_fn=lambda c: f"{c[0]}_max{c[1]:g}_code{c[3]}".replace(".", "_"),
     )
     def test_mm_tuple_aux_mx_scale_rounding(self, case):
         rounding, max_value, value, expected_code = case

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -26,6 +26,7 @@ from torch._inductor.utils import (
     run_and_get_code,
 )
 from torch.testing._internal.common_utils import (
+    dtype_name,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -1268,7 +1269,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             ((((N,), torch.float32),), True),
         ),
         name_fn=lambda case: "_and_".join(
-            f"{'x'.join(map(str, shape))}_{dtype}" for shape, dtype in case[0]
+            f"{'x'.join(map(str, sh))}_{dtype_name(dt)}" for sh, dt in case[0]
         ),
     )
     def test_scaled_mm_broadcast_epilogue_fusion(self, case):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1977,6 +1977,26 @@ class TestTestParametrization(TestCase):
         test_names = _get_test_names_for_test_class(TestParametrized)
         self.assertEqual(expected_test_names, test_names)
 
+    def test_name_fn_with_dot_raises(self):
+        # Dots in test names break unittest.TestLoader.loadTestsFromName, so
+        # instantiation should fail loudly rather than produce an unloadable test.
+        class TestParametrized(TestCase):
+            @parametrize("dtype", [torch.bfloat16], name_fn=str)
+            def test_bad_name(self, dtype):
+                pass
+
+        with self.assertRaisesRegex(RuntimeError, 'contains a "." character'):
+            instantiate_parametrized_tests(TestParametrized)
+
+    def test_subtest_name_with_dot_raises(self):
+        class TestParametrized(TestCase):
+            @parametrize("x", [subtest(1, name="a.b")])
+            def test_bad_name(self, x):
+                pass
+
+        with self.assertRaisesRegex(RuntimeError, 'contains a "." character'):
+            instantiate_parametrized_tests(TestParametrized)
+
     def test_reparametrize(self):
 
         def include_is_even_arg(test_name, param_kwargs):
@@ -2157,6 +2177,18 @@ class TestTestParametrizationDeviceType(TestCase):
         ]
         test_names = _get_test_names_for_test_class(device_cls)
         self.assertEqual(expected_test_names, test_names)
+
+    def test_name_fn_with_dot_raises(self, device):
+        device = self.device_type
+
+        class TestParametrized(TestCase):
+            @parametrize("dtype", [torch.bfloat16], name_fn=str)
+            def test_bad_name(self, device, dtype):
+                pass
+
+        locals_dict = dict(locals())
+        with self.assertRaisesRegex(RuntimeError, 'contains a "." character'):
+            instantiate_device_type_tests(TestParametrized, locals_dict, only_for=device)
 
     def test_empty_param_names(self, device):
         # If no param names are passed, ensure things still work without parametrization.

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -171,7 +171,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(PASS_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=PASS_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=PASS_DIR))[0],
     )
     def test_success(self, path) -> None:
         output_mypy = self.get_mypy_output()
@@ -183,7 +183,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(FAIL_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=FAIL_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=FAIL_DIR))[0],
     )
     def test_fail(self, path):
         __tracebackhide__ = True
@@ -224,7 +224,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(REVEAL_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=REVEAL_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=REVEAL_DIR))[0],
     )
     def test_reveal(self, path):
         __tracebackhide__ = True

--- a/test/torch_np/test_dtype.py
+++ b/test/torch_np/test_dtype.py
@@ -26,7 +26,7 @@ np_dtype_params = [
     subtest(("bool", "bool"), name="bool"),
     subtest(
         ("bool", numpy.dtype("bool")),
-        name="numpy.dtype('bool')",
+        name="numpy_dtype('bool')",
         decorators=[xfail],  # reason="XXX: np.dtype() objects not supported"),
     ),
 ]
@@ -36,10 +36,10 @@ for name in dtype_names:
     np_dtype_params.append(subtest((name, name), name=repr(name)))
 
     np_dtype_params.append(
-        subtest((name, getattr(numpy, name)), name=f"numpy.{name}", decorators=[xfail])
+        subtest((name, getattr(numpy, name)), name=f"numpy_{name}", decorators=[xfail])
     )  # numpy namespaced dtypes not supported
     np_dtype_params.append(
-        subtest((name, numpy.dtype(name)), name=f"numpy.{name!r}", decorators=[xfail])
+        subtest((name, numpy.dtype(name)), name=f"numpy_{name!r}", decorators=[xfail])
     )
 
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -55,6 +55,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_UBSAN,
     TEST_XPU,
     TestCase,
+    validate_test_name,
 )
 
 
@@ -717,6 +718,7 @@ class DeviceTypeTestBase(TestCase):
             test_name = (
                 f"{name}{test_suffix}{device_suffix}{_dtype_test_suffix(dtype_kwarg)}"
             )
+            validate_test_name(test_name)
 
             instantiate_test_helper(
                 cls=cls,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -693,6 +693,24 @@ def compose_parametrize_fns(old_parametrize_fn, new_parametrize_fn):
     return composite_fn
 
 
+def validate_test_name(name):
+    """
+    Validates a generated test name at instantiation time. In particular, test names must
+    not contain '.': unittest.TestLoader.loadTestsFromName resolves dotted names by
+    splitting on '.' and walking with getattr, so a dotted test name is discoverable in a
+    full-suite run but breaks any attempt to load the test by name (e.g.
+    `python test_foo.py TestClass.test_name`).
+    """
+    if '.' in name:
+        raise RuntimeError(
+            f'Test name "{name}" is invalid: it contains a "." character, which breaks '
+            'loading the test by name (unittest.TestLoader.loadTestsFromName splits on '
+            '"."). This name likely comes from a custom name_fn or an explicit subtest '
+            'name that interpolates a value whose string form contains a dot (e.g. '
+            'str(torch.bfloat16) == "torch.bfloat16" or a float). Use dtype_name() for '
+            'dtypes, or sanitize the generated name (e.g. .replace(".", "_")).')
+
+
 def instantiate_parametrized_tests(generic_cls):
     """
     Instantiates tests that have been decorated with a parametrize_fn. This is generally performed by a
@@ -732,6 +750,7 @@ def instantiate_parametrized_tests(generic_cls):
         for (test, test_suffix, param_kwargs, decorator_fn) in class_attr.parametrize_fn(
                 class_attr, generic_cls=generic_cls, device_cls=None):
             full_name = f'{test.__name__}_{test_suffix}'
+            validate_test_name(full_name)
 
             # Apply decorators based on full param kwargs.
             for decorator in decorator_fn(param_kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192648

A parametrized test with a custom name_fn that interpolates a value whose
str() contains a dot (e.g. str(torch.bfloat16) == "torch.bfloat16")
produces a test method name with a literal dot. setattr accepts any
string, so the class builds fine and the test runs in a full-suite
sweep, but any name-based selection breaks:
unittest.TestLoader.loadTestsFromName resolves names by splitting on '.'
and walking with getattr, so the walk dies one component short
("has no attribute 'test_foo_torch'"). Such names look fine locally and
only explode when something loads the test by name (python test_foo.py
TestClass.test_name, unittest -k, or per-test CI runners), which
silently broke an entire test target for days.

The fix adds validate_test_name(), called at both instantiation choke
points (instantiate_parametrized_tests in common_utils.py and the
device-type instantiate_test loop in common_device_type.py), raising a
RuntimeError at class construction that names the bad generated name and
the remedy (dtype_name() or sanitizing the name_fn).

A survey of all 396 test files using the instantiation helpers
(501,596 generated names) found 670 dotted names in 5 files, all fixed
here: test_nv_universal_gemm.py (str(dtype) -> dtype_name),
test_vmap_registrations.py ("aten::op.overload" subtest names),
torch_np/test_dtype.py ("numpy.<name>" subtest names), test_typing.py
(names ending in ".py"), test_flex_gemm.py (a float repr). The CI
disabled-tests and slow-tests lists reference none of the renamed
tests. isidentifier() was considered as the predicate but rejected:
~3,600 existing names contain ':', '[', ']', '-', etc., which getattr
resolves fine; only '.' actually breaks name-based loading.

Test Plan:

New regression tests verify a dotted name_fn or subtest name raises at
class construction on both the generic and device-type paths:

```
python test/test_testing.py -k dot_raises
```

Re-ran the affected suites and verified by-name loading now works:

```
python test/functorch/test_vmap_registrations.py
python test/torch_np/test_dtype.py
python test/test_typing.py
python test/test_testing.py TestTestParametrization
python test/test_testing.py -k TestTestParametrizationDeviceType
python test/inductor/test_nv_universal_gemm.py TestNVUniversalGemmEpilogueFusion.test_scaled_mm_broadcast_epilogue_fusion_1x512_bfloat16
```

Re-ran the full 501k-name survey with validation enabled: zero dotted
names remain and no new module import errors.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo