### PR TITLE
Handle empty inputs consistently in native MHA fast paths

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -349,7 +349,17 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
     if (query.is_nested()) {
       return std::make_tuple(Tensor(), Tensor());
     }
-    return std::make_tuple(at::empty_like(query), Tensor());
+    Tensor attention_weights;
+    if (need_weights) {
+      attention_weights = average_attn_weights
+          ? at::empty(
+                {query.size(0), query.size(1), query.size(1)}, query.options())
+          : at::empty(
+                {query.size(0), num_head, query.size(1), query.size(1)},
+                query.options());
+    }
+    return std::make_tuple(
+        at::empty_like(query), std::move(attention_weights));
   }
 
 #ifndef NDEBUG

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -788,7 +788,8 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
 
 #endif
   const auto dim_per_head = D / num_head;
-  if ((query.is_same(key) && key.is_same(value)) && !need_weights) {
+  if (!need_weights && query.numel() != 0 && query.is_same(key) &&
+      key.is_same(value)) {
 
     // We have not done linear projection yet but the input for SDP
     // Is expected to be 4 dimensional. We "cheaply" create view tensors
@@ -836,7 +837,17 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
     if (query.is_nested()) {
       return std::make_tuple(Tensor(), Tensor());
     }
-    return std::make_tuple(at::empty_like(query), Tensor());
+    Tensor attention_weights;
+    if (need_weights) {
+      attention_weights = average_attn_weights
+          ? at::empty(
+                {query.size(0), query.size(1), query.size(1)}, query.options())
+          : at::empty(
+                {query.size(0), num_head, query.size(1), query.size(1)},
+                query.options());
+    }
+    return std::make_tuple(
+        at::empty_like(query), std::move(attention_weights));
   }
 
 #ifndef NDEBUG

--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -739,6 +739,54 @@ class TestMultiheadAttentionNN(NNTestCase):
 class TestMultiheadAttentionNNDeviceType(NNTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @torch.no_grad()
+    @onlyOn(["cpu", "cuda"])
+    @unittest.skipIf(
+        TEST_WITH_CROSSREF,
+        "CrossRef turns on TorchFunctionMode, and so disables fastpath.",
+    )
+    def test_multihead_attn_fast_path_empty_input(self, device):
+        mha = nn.MultiheadAttention(
+            embed_dim=4, num_heads=2, batch_first=True, device=device
+        ).eval()
+        previous_fastpath = torch.backends.mha.get_fastpath_enabled()
+
+        try:
+            for batch_size, seq_len in ((0, 3), (2, 0)):
+                query = torch.empty(batch_size, seq_len, 4, device=device)
+                for average_attn_weights in (True, False):
+                    torch.backends.mha.set_fastpath_enabled(False)
+                    expected = mha(
+                        query,
+                        query,
+                        query,
+                        need_weights=True,
+                        average_attn_weights=average_attn_weights,
+                    )
+
+                    torch.backends.mha.set_fastpath_enabled(True)
+                    actual = mha(
+                        query,
+                        query,
+                        query,
+                        need_weights=True,
+                        average_attn_weights=average_attn_weights,
+                    )
+
+                    self.assertIsNotNone(actual[1])
+                    self.assertEqual(actual, expected)
+
+                torch.backends.mha.set_fastpath_enabled(False)
+                expected = mha(query, query, query, need_weights=False)
+
+                torch.backends.mha.set_fastpath_enabled(True)
+                actual = mha(query, query, query, need_weights=False)
+
+                self.assertIsNone(actual[1])
+                self.assertEqual(actual, expected)
+        finally:
+            torch.backends.mha.set_fastpath_enabled(previous_fastpath)
+
     def test_multihead_self_attn_two_masks_fast_path(self, device):
         """
         Multihead self-attention should give the same result on the fast path (BetterTransformer) as on the slow path


### PR DESCRIPTION
Hey! I noticed two empty-input discrepancies in the `nn.MultiheadAttention` fast path.

When either the batch or sequence dimension is empty, the native CPU/CUDA path returns `None` for attention weights even with `need_weights=True`, while the slow path returns correctly shaped empty weights. Separately, with `need_weights=False`, a zero-batch CUDA input reaches an optimized reshape before the existing empty-input handling and raises an ambiguous `-1` reshape error.

This makes the CUDA no-weights optimization skip empty inputs so the existing empty return handles them, and returns the expected averaged or per-head empty weight tensor when weights are requested. The regression test covers empty batches and empty sequences, both `need_weights` modes, averaged and per-head weights, and CPU/CUDA.

Checks:
- reproduced on PyTorch 2.13.0 on CPU and A100 CUDA
- reproduced on `2.14.0.dev20260809+cu130` on A100 CUDA
- CPU and CUDA translation units compile locally against the August 9 nightly headers
- focused empty-input cases pass on CPU and CUDA

I was also looking at this with [TorchLean](https://github.com/lean-dojo/TorchLean), and I can add a small Lean formalization of the shape contract if that would be useful :)