### PR TITLE
[CD][CUDA13.4][Triton] Bundle cu13.4 ptxas in nightly wheels for (PyTorch wheel self-contained) Rubin support

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -150,12 +150,12 @@ def cuda_build_env(cuda_version: str, arch: str) -> dict[str, str]:
         # Pre-built MAGMA tarballs are x86-only.
         env["USE_MAGMA"] = "0"
     # Bundle the CUDA 13.4 ptxas binary into nightly wheels so that users on
-    # Rubin (sm_107a) hardware can use torch.compile without needing to
+    # Rubin (sm_107) hardware can use torch.compile without needing to
     # install the CUDA 13.4 toolkit separately. Triton's default ptxas only
     # goes up to CUDA 13.3 and will fail with "Value 'sm_107a' is not defined".
     # torch/_inductor/runtime/compile_tasks.py picks up torch/bin/ptxas via
     # _set_triton_ptxas_path() automatically.
-    if cuda_version == "13.4" and not _is_release_build():
+    if cuda_version == "13.4":
         env.setdefault("BUILD_BUNDLE_PTXAS", "1")
     return env
 

--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -149,6 +149,14 @@ def cuda_build_env(cuda_version: str, arch: str) -> dict[str, str]:
     if arch == "aarch64":
         # Pre-built MAGMA tarballs are x86-only.
         env["USE_MAGMA"] = "0"
+    # Bundle the CUDA 13.4 ptxas binary into nightly wheels so that users on
+    # Rubin (sm_107a) hardware can use torch.compile without needing to
+    # install the CUDA 13.4 toolkit separately. Triton's default ptxas only
+    # goes up to CUDA 13.3 and will fail with "Value 'sm_107a' is not defined".
+    # torch/_inductor/runtime/compile_tasks.py picks up torch/bin/ptxas via
+    # _set_triton_ptxas_path() automatically.
+    if cuda_version == "13.4" and not _is_release_build():
+        env.setdefault("BUILD_BUNDLE_PTXAS", "1")
     return env
 
 

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -44,7 +44,7 @@ def _reload_python_module(
 def _set_triton_ptxas_path() -> None:
     if os.environ.get("TRITON_PTXAS_PATH") is not None:
         return
-    ptxas = Path(__file__).absolute().parents[1] / "bin" / "ptxas"
+    ptxas = Path(__file__).absolute().parents[2] / "bin" / "ptxas"
     if not ptxas.exists():
         return
     if ptxas.is_file() and os.access(ptxas, os.X_OK):


### PR DESCRIPTION
###Starting Human Note
This does not remove the need to set TRITON_PTXAS_BLACKWELL_PATH when using torch.compile. It just provides a ptxas binary with PyTorch cu13.4 in case CTK 13.4 is not setup yet. (Which may not be a common case.)  

Downloaded the PR artifacts: 
/usr/local/lib/python3.12/dist-packages/torch/bin# ./ptxas  --version                                                          
ptxas: NVIDIA (R) Ptx optimizing assembler                                                                                                                   
Copyright (c) 2005-2026 NVIDIA Corporation                                                                                                                   
Built on Sun_Jul_12_11:25:10_PDT_2026                                                                                                                        
Cuda compilation tools, release 13.4, V13.4.46                                                                                                               
Build cuda_13.4.r13.4/compiler.38501229_0   

/usr/local/lib/python3.12/dist-packages/torch/bin# export TRITON_PTXAS_BLACKWELL_PATH=/usr/local/lib/python3.12/dist-packages/t
orch/bin/ptxas                    (note again: including up to ptxas, PATH should really be PATH_AND_PTXAS)

 python3 torch_compile_basic.py                                 
/usr/local/lib/python3.12/dist-packages/torch/_subclasses/functional_tensor.py:368: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Trigger
ed internally at /__w/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  cpu = _conversion_method_template(device=torch.device("cpu"))               
tensor([[-8.4444e-01,  1.1035e-01,  1.4258e+00,  4.3796e-02,  5.3046e-01,
          1.7954e+00, -7.0635e-01,  7.9206e-01, -2.7616e-01,  1.4288e+00],
        [ 2.0817e-01,  2.1699e-02,  1.8267e+00,  1.2682e+00,  9.9973e-01,
         -1.1154e+00,  8.2375e-02,  5.5137e-01, -7.0376e-01,  8.1187e-01],
        [-4.2836e-01,  2.4952e-01,  3.0094e-01,  7.5320e-01,  9.3198e-01,
         -1.0289e+00,  2.8035e-01,  1.3297e+00, -4.5067e-04,  5.6013e-02],
        [ 1.5539e+00,  3.5165e-01,  1.1706e+00,  1.5033e+00,  1.0630e+00,
          1.4707e+00,  1.1254e+00,  1.6382e-01,  1.4310e-01, -6.2383e-01],
        [ 1.0903e+00,  1.6882e+00,  1.4076e+00, -7.1308e-02,  1.8261e+00,
         -4.2610e-01,  6.2521e-01,  7.8017e-01,  1.4354e+00, -5.2705e-01],
        [ 8.6222e-01,  7.1433e-02, -2.6829e-01,  9.0819e-01,  1.1282e+00,
         -3.3412e-01,  1.3024e+00, -5.1658e-03, -9.3174e-04,  4.2042e-03],
        [ 6.6848e-02,  5.5066e-01,  1.9624e+00,  5.8537e-01,  9.3327e-01,
          4.1252e-01,  7.3457e-01, -1.0550e-01, -4.7113e-01,  2.7920e-01],
        [ 1.2007e-02,  8.3944e-01, -2.8724e-01,  3.7443e-01,  1.8069e+00,
          7.1231e-01,  1.6827e+00,  8.1056e-01, -1.1663e+00,  1.8521e+00],
        [-4.7621e-02,  9.5032e-01,  1.3626e+00,  1.0745e+00,  1.8179e-01,
          1.3318e+00,  6.0024e-01,  2.5125e-01,  6.5333e-01,  5.9489e-01],
        [-4.8965e-01,  1.0883e+00,  1.4518e+00, -2.1555e-02,  5.8692e-01,
          1.9796e+00, -4.6379e-01, -8.6318e-01, -3.4632e-01,  1.0793e+00]],
       device='cuda:0')

No longer encounters "  ptxas-blackwell fatal: Value 'sm_107a' is not defined for option 'gpu-name'"
### Ending Human Note

## Background

> AI-generated summary (reviewed by Wei Wang):

```
Triton's release/3.8.x ships a CUDA 13.3 ptxas binary. That binary does
not recognize sm_107a (Rubin), so users downloading the cu13.4 nightly
wheel and running torch.compile on Rubin hardware hit:

  ptxas-blackwell fatal: Value 'sm_107a' is not defined for option 'gpu-name'

Triton is evaluating a fix in triton-lang/triton#11038 but it has not
landed yet.

There are two user scenarios:

1. User has CUDA 13.4 DP toolkit installed -- the system ptxas already
   handles sm_107a; no extra setup is needed.
2. User does not have CUDA 13.4 DP installed -- torch.compile fails with
   the error above.

This PR addresses scenario 2 by bundling the CUDA 13.4 DP ptxas binary
into cu13.4 nightly wheels. The existing _set_triton_ptxas_path() in
torch/_inductor/runtime/compile_tasks.py automatically sets
TRITON_PTXAS_PATH to torch/bin/ptxas on startup, so users get Rubin
support with no extra configuration.

## Changes

build_env_setup.py already handles both x86 and aarch64 CUDA builds
through the same cuda_build_env() path, so a single condition
(cuda_version == "13.4" and not release build) enables
BUILD_BUNDLE_PTXAS=1 for both architectures.

The path fix in compile_tasks.py is a bug fix: parents[1] resolved to
torch/_inductor/bin/ptxas (nonexistent); parents[2] is the correct
torch/bin/ptxas where CMake installs the bundled binary.

Note: this only covers the torch.compile path through
_set_triton_ptxas_path(). Use cases that bypass that function will not
automatically pick up the bundled ptxas.

See similar issues in the past #163801
See also: triton-lang/triton#11038, #163988

## Test Plan

Build a cu13.4 nightly wheel and confirm ptxas is bundled:

  unzip -l torch-*.whl | grep bin/ptxas

On a Rubin machine without the CUDA 13.4 toolkit installed, verify
torch.compile works end-to-end after installing the wheel.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

cc @ptrblck @eqy @tinglvv @malfet @atalman @warrendeng @njriasan