### PR TITLE
Make ConstantLR with total_iters <= 0 a no-op instead of a permanent scaling

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -449,6 +449,25 @@ class TestLRScheduler(TestCase):
         scheduler = ConstantLR(self.opt, factor=1.0 / 2, total_iters=5)
         self._test(scheduler, targets, epochs)
 
+    def test_constantlr_zero_total_iters(self):
+        # total_iters=0 asks for the factor to apply over no iterations at all,
+        # which is how _get_closed_form_lr already reads it, so the lr is the
+        # base lr from the very first epoch.
+        # lr = 0.05 for every epoch
+        epochs = 10
+        single_targets = [0.05] * epochs
+        targets = [single_targets, [x * epochs for x in single_targets]]
+        scheduler = ConstantLR(self.opt, factor=1.0 / 2, total_iters=0)
+        self._test(scheduler, targets, epochs)
+
+    def test_constantlr_negative_total_iters(self):
+        # Same reasoning as total_iters=0: the milestone is already behind us.
+        epochs = 10
+        single_targets = [0.05] * epochs
+        targets = [single_targets, [x * epochs for x in single_targets]]
+        scheduler = ConstantLR(self.opt, factor=1.0 / 2, total_iters=-1)
+        self._test(scheduler, targets, epochs)
+
     def test_linearlr(self):
         # lr = 0.025     if epoch == 0
         # lr = 0.03125   if epoch == 1

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -844,6 +844,13 @@ class ConstantLR(LRScheduler):
         """
         _warn_get_lr_called_within_step(self)
 
+        if self.total_iters <= 0:
+            # The milestone is already behind us at epoch 0, so the factor applies
+            # over no iterations at all. Without this the scaling branch below runs
+            # at epoch 0 and the restoring branch is then unreachable, which pins
+            # the lr at factor * base_lr for the whole run.
+            return _param_groups_val_list(self.optimizer, "lr")
+
         if self.last_epoch == 0:
             return [group["lr"] * self.factor for group in self.optimizer.param_groups]
 


### PR DESCRIPTION
`ConstantLR.get_lr` scales by `factor` at epoch 0 and undoes it once `last_epoch` reaches `total_iters`:

```python
if self.last_epoch == 0:
    return [group["lr"] * self.factor for group in self.optimizer.param_groups]
if self.last_epoch != self.total_iters:
    return _param_groups_val_list(self.optimizer, "lr")
return [group["lr"] * (1.0 / self.factor) for group in self.optimizer.param_groups]
```

With `total_iters <= 0` the restoring branch is unreachable: epoch 0 is consumed by the first branch, and every later epoch takes the `last_epoch != total_iters` path. The lr stays at `factor * base_lr` for the whole run, with no warning.

`_get_closed_form_lr` reads the same config the other way, as `base_lr` from the first epoch, since `last_epoch >= total_iters` is already true at epoch 0. So the two forms disagree, and only for `total_iters <= 0`:

```
                     recursive get_lr                closed form
total_iters= 0   [0.005, 0.005, 0.005, ...]    [0.05, 0.05, 0.05, ...]
total_iters=-1   [0.005, 0.005, 0.005, ...]    [0.05, 0.05, 0.05, ...]
total_iters= 1   [0.005, 0.05,  0.05,  ...]    [0.005, 0.05,  0.05, ...]
total_iters= 2   [0.005, 0.005, 0.05,  ...]    [0.005, 0.005, 0.05, ...]
```

Sweeping factor in {0.1, 0.5, 1/3} and total_iters in {-2, -1, 0, 1, 2, 3, 5, 8}, 9 of the 24 combinations disagree and every one of them has `total_iters <= 0`. That localises it to the degenerate value rather than to a general get_lr / closed-form mismatch.

`total_iters=0` is the natural way to write "warmup disabled" in config-driven code, and `__init__` validates `factor` but places no constraint on `total_iters`, so the value is accepted and then trains at `factor * base_lr` for the entire run. For a typical `factor=0.1` that is a learning rate 10x smaller than asked for, silently.

## Fix

Return early when the milestone is already behind us. Positive `total_iters` is untouched, and the result now matches `_get_closed_form_lr` for every value: 0 of 24 combinations disagree after the change.

## Test

Two cases added next to `test_constantlr` in `test/optim/test_lrscheduler.py`, using the same `_test` helper and the same style, one for `total_iters=0` and one for `total_iters=-1`. Both fail before this change (all 10 epochs wrong, 0.025 where 0.05 is expected) and pass after, while `test_constantlr` itself is unaffected.

Run locally on CPU by patching the installed `torch/optim/lr_scheduler.py`, exercising the real `ConstantLR` through a replica of the test class's `setUp` and `_test`, then restoring the file and confirming it was byte-identical to the original by SHA-256.

## Two notes

This is deliberately not a `ValueError` on non-positive `total_iters`, which would be the other way to close it. That would be BC-breaking for anyone already writing `total_iters=0` to disable warmup, and it would also reject a config that `_get_closed_form_lr` already handles sensibly. Happy to switch if you would rather have validation. It is separate from #189374, which validates `total_iters` for `LinearLR` and `PolynomialLR` but only touches `ConstantLR`'s `factor`, and from #187814 / #185006, which are about `factor=0`.

Second, and worth flagging separately: the obvious home for a regression test here is `_test_against_closed_form`, and I did not use it because it does not currently test anything. Its first line is `self.setUp()`, which replaces `self.opt` after the test method has already constructed both schedulers on the previous optimizer, so both loops read an optimizer that neither scheduler is attached to. A scheduler whose `get_lr` returns `123.456` and whose `_get_closed_form_lr` returns `-999.0` passes it. That affects every `test_closed_form_*` test. I can open a separate issue or PR for it if useful; it is not folded in here because fixing it needs the call sites to give each scheduler its own optimizer.
