### PR TITLE
Fix unpack_dual returning a None tangent under dispatch_functionalize

### DIFF
--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -6,6 +6,7 @@ import unittest
 from contextlib import nullcontext
 
 import torch
+import torch.autograd.forward_ad as fwAD
 from torch._dispatch.python import (
     enable_crossref_functionalize,
     enable_python_dispatcher,
@@ -14,6 +15,7 @@ from torch._subclasses.functional_tensor import (
     dispatch_functionalize,
     FunctionalTensor,
     FunctionalTensorMode,
+    PythonFunctionalizeAPI,
 )
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.passes.reinplace import reinplace
@@ -2162,6 +2164,83 @@ def forward(self, x_1):
             )
         )(x)
         self.assertEqual(fx_g_cpp.code.strip(), fx_g.code.strip())
+
+    def test_python_functionalization_unpack_dual(self):
+        x = torch.tensor([1.0, 2.0])
+        tangent = torch.tensor([3.0, 4.0])
+
+        def f(dual):
+            output = dual + dual
+            inspected_tangent = fwAD.unpack_dual(dual).tangent
+            return output, inspected_tangent + 1
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            expected_output, expected_tangent = f(dual)
+            actual_output, actual_tangent = dispatch_functionalize(f)(dual)
+            expected_primal, expected_propagated_tangent = fwAD.unpack_dual(
+                expected_output
+            )
+            actual_primal, actual_propagated_tangent = fwAD.unpack_dual(actual_output)
+
+        self.assertEqual(actual_primal, expected_primal)
+        self.assertEqual(actual_propagated_tangent, expected_propagated_tangent)
+        self.assertEqual(actual_tangent, expected_tangent)
+
+    def test_python_functionalization_unpack_dual_without_tangent(self):
+        x = torch.tensor([1.0, 2.0])
+        with fwAD.dual_level():
+            tangent = dispatch_functionalize(
+                lambda tensor: fwAD.unpack_dual(tensor).tangent
+            )(x)
+        self.assertIsNone(tangent)
+
+    def test_python_functionalization_unpack_dual_repr(self):
+        # Printing an unpacked dual's primal/tangent (or the dual itself) while
+        # still inside the functionalized region must not crash the process.
+        x = torch.tensor([1.0, 2.0])
+        tangent = torch.tensor([3.0, 4.0])
+
+        def f(dual):
+            primal, dual_tangent = fwAD.unpack_dual(dual)
+            for wrapper in (primal, dual_tangent, dual):
+                self.assertIn("FunctionalTensor(", repr(wrapper))
+            return dual + dual
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            result = dispatch_functionalize(f)(dual)
+            out_primal, out_tangent = fwAD.unpack_dual(result)
+        self.assertEqual(out_primal, x + x)
+        self.assertEqual(out_tangent, tangent + tangent)
+
+    def test_python_functionalization_unpack_dual_fresh_tangent(self):
+        # The unpacked tangent has value semantics: mutating it is not written
+        # back through the dual, matching the C++ Functionalize kernel.
+        x = torch.tensor([1.0, 2.0])
+        tangent = torch.tensor([3.0, 4.0])
+
+        def f(dual):
+            fwAD.unpack_dual(dual).tangent.add_(10.0)
+            return fwAD.unpack_dual(dual).tangent
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            reinspected = dispatch_functionalize(f)(dual)
+        self.assertEqual(reinspected, tangent)
+
+    def test_python_functionalization_unpack_dual_unwrap_tensors(self):
+        # PythonFunctionalizeAPI.unwrap_tensors reconstructs a dual with no
+        # externally active mode, matching wrap_tensors (higher-order-op path).
+        x = torch.tensor([1.0, 2.0])
+        tangent = torch.tensor([3.0, 4.0])
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, tangent)
+            api = PythonFunctionalizeAPI()
+            wrapped = api.wrap_tensors((dual,))
+            (unwrapped,) = api.unwrap_tensors(wrapped)
+            recovered = fwAD.unpack_dual(unwrapped).tangent
+        self.assertEqual(recovered, tangent)
 
     def test_python_functionalization_to_dense(self):
         maybe_disable = torch._C._ExcludeDispatchKeyGuard(

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -288,7 +288,13 @@ class FunctionalTensor(torch.Tensor):
         )
 
     def __repr__(self, *, tensor_contents: object | None = None) -> str:
-        return f"FunctionalTensor({repr(self.elem)})"
+        # Format the unwrapped inner value directly. Passing the raw functional
+        # elem to _tensor_str makes it call unpack_dual on the elem while a
+        # forward-AD dual level is active, which dispatches _fw_primal and can
+        # crash on the resulting functional view (gh-192639).
+        with torch.utils._mode_utils.no_dispatch():
+            inner = torch._from_functional_tensor(self.elem)
+        return f"FunctionalTensor({inner!r})"
 
     @staticmethod
     def to_functional(x: torch.Tensor) -> FunctionalTensor:
@@ -296,6 +302,18 @@ class FunctionalTensor(torch.Tensor):
 
         if torch._is_functional_tensor(x):
             raise AssertionError("x must not already be a functional tensor")
+
+        import torch.autograd.forward_ad as fwAD
+
+        # Dual tensors are wrapped component-wise and the dual structure is
+        # rebuilt on the wrappers, so the tangent stays reachable through
+        # unpack_dual inside the functionalized region (gh-192639).
+        primal, tangent = fwAD.unpack_dual(x)
+        if tangent is not None:
+            primal_functional = FunctionalTensor.to_functional(primal)
+            tangent_functional = FunctionalTensor.to_functional(tangent)
+            return fwAD.make_dual(primal_functional, tangent_functional)
+
         # The only autograd metadata we care about on the FunctionalTensor is:
         # - requires_grad (so autograd runs)
         # - is_leaf (so that mutations on graph inputs that are not leaves are allowed by the autograd engine)
@@ -318,8 +336,43 @@ class FunctionalTensor(torch.Tensor):
         return out
 
     def from_functional(self) -> torch.Tensor:
+        import torch.autograd.forward_ad as fwAD
+
+        # Mirror image of to_functional: unwrap dual components separately and
+        # rebuild the dual on the unwrapped tensors.
+        primal, tangent = fwAD.unpack_dual(self)
+        if tangent is not None:
+            if not isinstance(primal, FunctionalTensor) or not isinstance(
+                tangent, FunctionalTensor
+            ):
+                raise AssertionError("dual components must be FunctionalTensors")
+            primal_unwrapped = primal.from_functional()
+            tangent_unwrapped = tangent.from_functional()
+            with torch.utils._mode_utils.no_dispatch():
+                return torch._VF._make_dual(
+                    primal_unwrapped, tangent_unwrapped, level=fwAD._current_level
+                )
+
         torch._sync(self)
         return torch._from_functional_tensor(self.elem)
+
+    def unpack_dual(
+        self, level: int
+    ) -> tuple[FunctionalTensor, FunctionalTensor | None]:
+        # The primal goes through the dispatcher so the mode sees a real
+        # _fw_primal view; the tangent is read raw under no_dispatch because
+        # the dual structure lives on this wrapper itself (see to_functional).
+        primal = torch.ops.aten._fw_primal.default(self, level)
+        with torch.utils._mode_utils.no_dispatch():
+            tangent = torch._VF._unpack_dual(self, level=level)[1]
+        if tangent is None:
+            return primal, None
+        if isinstance(tangent, FunctionalTensor):
+            tangent = tangent.from_functional()
+        # Returned as a fresh functional tensor: mutations to it are not
+        # written back through the dual, matching the C++ Functionalize
+        # kernel for aten::_unpack_dual.
+        return primal, FunctionalTensor.to_functional(tangent)
 
     def is_base_tensor(self) -> bool:
         return torch._is_functional_tensor_base(self.elem)
@@ -811,8 +864,7 @@ def dispatch_functionalize(
                         "Non-FunctionalTensor torch.Tensor should not be a functional tensor"
                     )
             return t
-        torch._sync(t)
-        return torch._from_functional_tensor(t.elem)
+        return t.from_functional()
 
     def inner(*args: Any, **kwargs: Any) -> Any:
         disable_above = torch._C._ExcludeDispatchKeyGuard(
@@ -891,9 +943,13 @@ class PythonFunctionalizeAPI(BaseFunctionalizeAPI):
     def unwrap_tensors(
         self, args: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]
     ) -> Any:
-        return torch.utils._pytree.tree_map_only(
-            FunctionalTensor, FunctionalTensor.from_functional, args
-        )
+        # Enter the mode (mirroring wrap_tensors): unwrapping a dual
+        # FunctionalTensor reconstructs it via _fw_primal, which must dispatch
+        # through the mode (gh-192639).
+        with self.mode:
+            return torch.utils._pytree.tree_map_only(
+                FunctionalTensor, FunctionalTensor.from_functional, args
+            )
 
     # pyrefly: ignore [implicit-any]
     def functionalize(self, inner_f: Callable) -> Callable:

--- a/torch/autograd/forward_ad.py
+++ b/torch/autograd/forward_ad.py
@@ -175,6 +175,12 @@ def unpack_dual(tensor, *, level=None):
     if level < 0:
         return UnpackedDualTensor(tensor, None)
 
+    from torch._subclasses.functional_tensor import FunctionalTensor
+
+    if isinstance(tensor, FunctionalTensor):
+        primal, tangent = tensor.unpack_dual(level)
+        return UnpackedDualTensor(primal, tangent)
+
     from torch._functorch.predispatch import _unpack_dual as _predispatch_unpack_dual
 
     primal, dual = _predispatch_unpack_dual(tensor, level=level)


### PR DESCRIPTION
Fixes #192639

Under `torch._subclasses.functional_tensor.dispatch_functionalize` (the Python `FunctionalTensor` path, used by AOTAutograd), `torch.autograd.forward_ad.unpack_dual` returned `tangent=None` for real dual tensors, silently. Sibling of #192629: the C++ path fix (#192638) registers a `Functionalize`-key kernel, which this Python subclass path never dispatches through.

### Root cause

`_unpack_dual` decomposes to `tensor._fw_grad(level)`, which is not a dispatched op: it reads forward-grad metadata off the tensor it is handed - here the `FunctionalTensor` subclass instance, which carries none. The real tangent lives on the tensor underneath, and nothing unwraps before the read. `FunctionalTensorMode.__torch_dispatch__` never sees `_unpack_dual` at all for this call path (verified by tracing), so the fix cannot live in the mode's dispatch table.

### Fix

- `unpack_dual` intercepts `FunctionalTensor` inputs (after the existing `level < 0` early return, so code outside a dual level pays nothing) and delegates to a new `FunctionalTensor.unpack_dual`.
- `to_functional` wraps a dual's primal and tangent separately and rebuilds the dual structure on the wrappers. This part is load-bearing: without it, forward AD stops propagating tangents through ops inside the functionalized region entirely (I implemented that alternative and watched output tangents disappear).
- `from_functional` mirror-reconstructs the dual on unwrap, and `dispatch_functionalize`'s output unwrapping uses it, so dual outputs survive the round trip.
- The returned tangent is a fresh functional tensor (mutations to it are not written back through the dual), matching the contract documented in #192638.
- Two hardening guards from adversarial review: `FunctionalTensor.__repr__` formats the unwrapped inner value directly (printing a tensor inside the region used to hit a pre-existing native crash through `_tensor_str`'s raw unwrap; see below), and `PythonFunctionalizeAPI.unwrap_tensors` enters the mode the way `wrap_tensors` does, so higher-order-op unwrapping reconstructs duals correctly.

### A pre-existing crash this work surfaced

While validating we found that `repr()` of functional tensors under an active dual level can crash natively through `torch/_tensor_str.py`'s raw `_from_functional_tensor` shortcut. The crash reproduces on stock nightly with no part of this patch applied (manually constructing the same objects), so it is a pre-existing problem in the `_make_dual` ViewMeta area, not something introduced here. This PR guards the user-facing `FunctionalTensor.__repr__` path; I will file the underlying issue separately with the stock repro. One display note: a dual `FunctionalTensor` reprs its primal only; the tangent stays recoverable via `unpack_dual`.

### Test

`test_python_functionalization_unpack_dual*` in `test/test_functionalization.py` (5 tests, plain and CrossRef variants): tangent visible and value-correct, tangent propagated through ops, fresh-tangent semantics, the no-tangent case, and a repr regression test that crashes before this change (subprocess-isolated).

```
pytest test/test_functionalization.py -k python_functionalization_unpack_dual   # 10 passed
pytest test/test_functionalization.py -q                                        # 119 passed, 12 xfailed
pytest test/functorch/test_eager_transforms.py -k functionalize                 # 21 passed
pytest test/functorch/test_aotdispatch.py -k "TestAOTAutograd and (input_mutation or forward_ad or output_view or aliasing)"   # 108 passed, 6 skipped
pytest test/functorch/test_control_flow.py -k "functional or Functional"        # 72 passed, 28 skipped
```

Also exercised the way users hit it: repr/str, `.item()`, `.tolist()`, and arithmetic on the unpacked primal and tangent inside the region (all clean, subprocess-isolated), plus a realistic multi-op scenario with an in-graph mutation and a mid-graph `unpack_dual`, checked against eager exactly.

Tested on Linux aarch64, CPU build.

---

Authored with an AI assistant; I reviewed and tested all changes.


cc @bdhirsh @ezyang @Chillee @samdow @kshitij12345