### PR TITLE
Remove custom bitset implementation in c10/utils/Bitset.h

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -1,7 +1,9 @@
 #include <ATen/core/dispatch/DispatchKeyExtractor.h>
 #include <c10/util/irange.h>
 
+#include <algorithm>
 #include <sstream>
+#include <string>
 
 namespace c10 {
 
@@ -55,15 +57,10 @@ void DispatchKeyExtractor::setOperatorHasFallthroughForKey(DispatchKey k, bool h
 }
 
 std::string DispatchKeyExtractor::dumpState() const {
+  std::string bits = dispatch_arg_indices_reverse_.to_string();
+  std::reverse(bits.begin(), bits.end());
   std::ostringstream oss;
-  for (const auto i : c10::irange(c10::utils::bitset::NUM_BITS())) {
-    if (dispatch_arg_indices_reverse_.get(i)) {
-      oss << '1';
-    } else {
-      oss << '0';
-    }
-  }
-  oss << ' ' << nonFallthroughKeys_ << '\n';
+  oss << bits << ' ' << nonFallthroughKeys_ << '\n';
   return std::move(oss).str();
 }
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -136,11 +136,11 @@ struct TORCH_API DispatchKeyExtractor final {
   }
 
   void registerSchema(const FunctionSchema& schema) {
-    TORCH_INTERNAL_ASSERT(dispatch_arg_indices_reverse_.is_entirely_unset());
+    TORCH_INTERNAL_ASSERT(dispatch_arg_indices_reverse_.none());
     dispatch_arg_indices_reverse_ = makeBitsetForDispatchArgs(schema);
   }
   void deregisterSchema() {
-    dispatch_arg_indices_reverse_ = c10::utils::bitset();
+    dispatch_arg_indices_reverse_.reset();
   }
 
   C10_ALWAYS_INLINE DispatchKeySet getDispatchKeySetFromRawDispatchKeySet(
@@ -162,30 +162,31 @@ struct TORCH_API DispatchKeyExtractor final {
 
   DispatchKeySet getDispatchKeySetBoxed(const torch::jit::Stack* stack) const {
     DispatchKeySet ks;
-    dispatch_arg_indices_reverse_.for_each_set_bit([&](size_t
-                                                           reverse_arg_index) {
-      const auto& ivalue = torch::jit::peek(*stack, 0, reverse_arg_index + 1);
-      if (C10_LIKELY(ivalue.isTensor())) {
-        // NB: Take care not to introduce a refcount bump (there's
-        // no safe toTensorRef method, alas)
-        ks = ks | ivalue.unsafeToTensorImpl()->key_set();
-      } else if (C10_UNLIKELY(ivalue.isTensorList())) {
-        // NB: use toListRef as it doesn't induce refcount bumps
-        // (toTensorListRef is not a thing)
-        for (const auto& nv : ivalue.toListRef()) {
-          auto* tensor = nv.unsafeToTensorImpl();
-          ks = ks | tensor->key_set();
-        }
-      }
-      // Tensor?[] translates to a c10::List<IValue> so we need to peek inside
-      else if (C10_UNLIKELY(ivalue.isList())) {
-        for (const auto& elt : ivalue.toListRef()) {
-          if (elt.isTensor()) {
-            ks = ks | elt.toTensor().key_set();
+    c10::utils::for_each_set_bit(
+        dispatch_arg_indices_reverse_, [&](size_t reverse_arg_index) {
+          const auto& ivalue =
+              torch::jit::peek(*stack, 0, reverse_arg_index + 1);
+          if (C10_LIKELY(ivalue.isTensor())) {
+            // NB: Take care not to introduce a refcount bump (there's
+            // no safe toTensorRef method, alas)
+            ks = ks | ivalue.unsafeToTensorImpl()->key_set();
+          } else if (C10_UNLIKELY(ivalue.isTensorList())) {
+            // NB: use toListRef as it doesn't induce refcount bumps
+            // (toTensorListRef is not a thing)
+            for (const auto& nv : ivalue.toListRef()) {
+              auto* tensor = nv.unsafeToTensorImpl();
+              ks = ks | tensor->key_set();
+            }
           }
-        }
-      }
-    });
+          // Tensor?[] translates to c10::List<IValue> so we need to peek inside
+          else if (C10_UNLIKELY(ivalue.isList())) {
+            for (const auto& elt : ivalue.toListRef()) {
+              if (elt.isTensor()) {
+                ks = ks | elt.toTensor().key_set();
+              }
+            }
+          }
+        });
     return getDispatchKeySetFromRawDispatchKeySet(ks);
   }
 
@@ -232,13 +233,13 @@ struct TORCH_API DispatchKeyExtractor final {
   }
   static c10::utils::bitset makeBitsetForDispatchArgs(
       const FunctionSchema& schema) {
+    c10::utils::bitset dispatch_arg_indices_reverse;
     TORCH_CHECK(
-        schema.arguments().size() <= c10::utils::bitset::NUM_BITS(),
+        schema.arguments().size() <= dispatch_arg_indices_reverse.size(),
         "The function schema has ",
         schema.arguments().size(),
         " arguments but this PyTorch build only supports ",
-        c10::utils::bitset::NUM_BITS());
-    c10::utils::bitset dispatch_arg_indices_reverse;
+        dispatch_arg_indices_reverse.size());
     for (const auto index : c10::irange(schema.arguments().size())) {
       if (isDispatchType(*schema.arguments()[index].type())) {
         dispatch_arg_indices_reverse.set(schema.arguments().size() - 1 - index);

--- a/c10/test/util/Bitset_test.cpp
+++ b/c10/test/util/Bitset_test.cpp
@@ -4,45 +4,46 @@
 #include <c10/util/irange.h>
 
 using c10::utils::bitset;
+using c10::utils::for_each_set_bit;
 
 TEST(BitsetTest, givenEmptyBitset_whenGettingBit_thenIsZero) {
   bitset b;
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  for (size_t i = 0; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
 TEST(BitsetTest, givenEmptyBitset_whenUnsettingBit_thenIsZero) {
   bitset b;
-  b.unset(4);
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  b.reset(4);
+  for (size_t i = 0; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
 TEST(BitsetTest, givenEmptyBitset_whenSettingAndUnsettingBit_thenIsZero) {
   bitset b;
   b.set(4);
-  b.unset(4);
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  b.reset(4);
+  for (size_t i = 0; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
 TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenIsSet) {
   bitset b;
   b.set(6);
-  EXPECT_TRUE(b.get(6));
+  EXPECT_TRUE(b.test(6));
 }
 
 TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenOthersStayUnset) {
   bitset b;
   b.set(6);
   for (const auto i : c10::irange(6)) {
-    EXPECT_FALSE(b.get(i));
+    EXPECT_FALSE(b.test(i));
   }
-  for (size_t i = 7; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  for (size_t i = 7; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
@@ -50,7 +51,7 @@ TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenIsSet) {
   bitset b;
   b.set(6);
   b.set(30);
-  EXPECT_TRUE(b.get(30));
+  EXPECT_TRUE(b.test(30));
 }
 
 TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenOthersStayAtOldValue) {
@@ -58,13 +59,13 @@ TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenOthersStayAtOldValue) {
   b.set(6);
   b.set(30);
   for (const auto i : c10::irange(6)) {
-    EXPECT_FALSE(b.get(i));
+    EXPECT_FALSE(b.test(i));
   }
   for (const auto i : c10::irange(7, 30)) {
-    EXPECT_FALSE(b.get(i));
+    EXPECT_FALSE(b.test(i));
   }
-  for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  for (size_t i = 31; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
@@ -72,8 +73,8 @@ TEST(BitsetTest, givenNonemptyBitset_whenUnsettingBit_thenIsUnset) {
   bitset b;
   b.set(6);
   b.set(30);
-  b.unset(6);
-  EXPECT_FALSE(b.get(6));
+  b.reset(6);
+  EXPECT_FALSE(b.test(6));
 }
 
 TEST(
@@ -82,13 +83,13 @@ TEST(
   bitset b;
   b.set(6);
   b.set(30);
-  b.unset(6);
+  b.reset(6);
   for (const auto i : c10::irange(30)) {
-    EXPECT_FALSE(b.get(i));
+    EXPECT_FALSE(b.test(i));
   }
-  EXPECT_TRUE(b.get(30));
-  for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
-    EXPECT_FALSE(b.get(i));
+  EXPECT_TRUE(b.test(30));
+  for (size_t i = 31; i < b.size(); ++i) {
+    EXPECT_FALSE(b.test(i));
   }
 }
 
@@ -110,7 +111,7 @@ struct IndexCallbackMock final {
 TEST(BitsetTest, givenEmptyBitset_whenCallingForEachBit_thenDoesntCall) {
   IndexCallbackMock callback;
   bitset b;
-  b.for_each_set_bit(callback);
+  for_each_set_bit(b, callback);
   callback.expect_was_called_for_indices({});
 }
 
@@ -120,7 +121,7 @@ TEST(
   IndexCallbackMock callback;
   bitset b;
   b.set(5);
-  b.for_each_set_bit(callback);
+  for_each_set_bit(b, callback);
   callback.expect_was_called_for_indices({5});
 }
 
@@ -135,8 +136,8 @@ TEST(
   b.set(32);
   b.set(50);
   b.set(0);
-  b.unset(25);
+  b.reset(25);
   b.set(10);
-  b.for_each_set_bit(callback);
+  for_each_set_bit(b, callback);
   callback.expect_was_called_for_indices({0, 2, 5, 10, 32, 50});
 }

--- a/c10/util/Bitset.h
+++ b/c10/util/Bitset.h
@@ -1,118 +1,19 @@
 #pragma once
 
+#include <bit>
+#include <bitset>
 #include <cstddef>
-#if defined(_MSC_VER)
-#include <intrin.h>
-#endif
 
 namespace c10::utils {
 
-/**
- * This is a simple bitset class with sizeof(long long int) bits.
- * You can set bits, unset bits, query bits by index,
- * and query for the first set bit.
- * Before using this class, please also take a look at std::bitset,
- * which has more functionality and is more generic. It is probably
- * a better fit for your use case. The sole reason for c10::utils::bitset
- * to exist is that std::bitset misses a find_first_set() method.
- */
-struct bitset final {
- private:
-#if defined(_MSC_VER)
-  // MSVCs _BitScanForward64 expects int64_t
-  using bitset_type = int64_t;
-#else
-  // POSIX ffsll expects long long int
-  using bitset_type = long long int;
-#endif
- public:
-  [[nodiscard]] static constexpr size_t NUM_BITS() {
-    return 8 * sizeof(bitset_type);
+using bitset = std::bitset<64>;
+
+template <class Func>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+void for_each_set_bit(bitset b, Func&& func) {
+  for (auto val = b.to_ullong(); val; val = val & (val - 1)) {
+    func(static_cast<size_t>(std::countr_zero(val)));
   }
-
-  constexpr bitset() noexcept = default;
-  constexpr bitset(const bitset&) noexcept = default;
-  constexpr bitset(bitset&&) noexcept = default;
-  // there is an issue for gcc 5.3.0 when define default function as constexpr
-  // see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68754.
-  bitset& operator=(const bitset&) noexcept = default;
-  bitset& operator=(bitset&&) noexcept = default;
-  ~bitset() = default;
-
-  constexpr void set(size_t index) noexcept {
-    bitset_ |= (static_cast<long long int>(1) << index);
-  }
-
-  constexpr void unset(size_t index) noexcept {
-    bitset_ &= ~(static_cast<long long int>(1) << index);
-  }
-
-  [[nodiscard]] constexpr bool get(size_t index) const noexcept {
-    return bitset_ & (static_cast<long long int>(1) << index);
-  }
-
-  [[nodiscard]] constexpr bool is_entirely_unset() const noexcept {
-    return 0 == bitset_;
-  }
-
-  // Call the given functor with the index of each bit that is set
-  template <class Func>
-  // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-  void for_each_set_bit(Func&& func) const {
-    bitset cur = *this;
-    size_t index = cur.find_first_set();
-    while (0 != index) {
-      // -1 because find_first_set() is not one-indexed.
-      index -= 1;
-      func(index);
-      cur.unset(index);
-      index = cur.find_first_set();
-    }
-  }
-
- private:
-  // Return the index of the first set bit. The returned index is one-indexed
-  // (i.e. if the very first bit is set, this function returns '1'), and a
-  // return of '0' means that there was no bit set.
-  size_t find_first_set() const {
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    unsigned long result;
-    bool has_bits_set = (0 != _BitScanForward64(&result, bitset_));
-    if (!has_bits_set) {
-      return 0;
-    }
-    return result + 1;
-#elif defined(_MSC_VER) && defined(_M_IX86)
-    unsigned long result;
-    if (static_cast<uint32_t>(bitset_) != 0) {
-      bool has_bits_set =
-          (0 != _BitScanForward(&result, static_cast<uint32_t>(bitset_)));
-      if (!has_bits_set) {
-        return 0;
-      }
-      return result + 1;
-    } else {
-      bool has_bits_set =
-          (0 != _BitScanForward(&result, static_cast<uint32_t>(bitset_ >> 32)));
-      if (!has_bits_set) {
-        return 32;
-      }
-      return result + 33;
-    }
-#else
-    return __builtin_ffsll(bitset_);
-#endif
-  }
-
-  [[nodiscard]] friend bool operator==(bitset lhs, bitset rhs) noexcept {
-    return lhs.bitset_ == rhs.bitset_;
-  }
-
-  bitset_type bitset_{0};
-};
-
-[[nodiscard]] inline bool operator!=(bitset lhs, bitset rhs) noexcept {
-  return !(lhs == rhs);
 }
 
 } // namespace c10::utils

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -262,8 +262,8 @@ static c10::DispatchKeySet pyobject_dispatch_compute_keyset(
     PyObject* const* args,
     Py_ssize_t nargs) {
   uint64_t key_set = 0;
-  extractor.dispatchArgIndicesReverse().for_each_set_bit(
-      [&](size_t reverse_arg_index) {
+  c10::utils::for_each_set_bit(
+      extractor.dispatchArgIndicesReverse(), [&](size_t reverse_arg_index) {
         pyobject_dispatch_collect_keys(
             args[nargs - 1 - static_cast<Py_ssize_t>(reverse_arg_index)],
             key_set);


### PR DESCRIPTION
The only new functionality provided by this class is `for_each_set_bit`. This can be implemented in an efficient and platform independent manner using `std::countr_zero` provided by C++20's <bit> header.

Related-to: #176662