### PR TITLE
Improve unexpected keyword argument errors for overloaded functions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7730,6 +7730,23 @@ class TestTorch(TestCase):
         # doesn't accept floating point variables
         self.assertRaises(TypeError, lambda: torch.cumsum(torch.ones(5, 5), torch.tensor(0.)))
 
+    def test_python_arg_parser_unexpected_keyword(self):
+        x = torch.ones(3, 3)
+        self.assertEqual(
+            torch.mean(x, dim=(0, 1), keepdim=True), torch.ones(1, 1)
+        )
+
+        with self.assertRaises(TypeError) as cm:
+            torch.mean(x, dims=(0, 1), keepdim=True)
+        self.assertEqual(
+            str(cm.exception), "mean() got an unexpected keyword argument 'dims'"
+        )
+
+        with self.assertRaises(TypeError) as cm:
+            torch.mean(x, dim="bad", keepdim=True)
+        self.assertIn("received an invalid combination of arguments", str(cm.exception))
+        self.assertNotIn("unexpected keyword argument", str(cm.exception))
+
     def test_parsing_double(self):
         # accepts floating point and integer arguments
         x = torch.randn(2, 3)

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1883,6 +1883,35 @@ void PythonArgParser::print_error(
     PyObject* args,
     PyObject* kwargs,
     PyObject* parsed_args[]) { // NOLINT
+  if (kwargs) {
+    PyObject* key = nullptr;
+    PyObject* value = nullptr;
+    Py_ssize_t pos = 0;
+
+    // Note that this dict traversal is NoGil safe as the kwargs dict is only
+    // accessible within this thread.
+    while (PyDict_Next(kwargs, &pos, &key, &value)) {
+      if (!THPUtils_checkString(key)) {
+        TORCH_CHECK_TYPE(false, "keywords must be strings");
+      }
+
+      bool found = false;
+      for (auto& signature : signatures_) {
+        if (find_param(signature, key) >= 0) {
+          found = true;
+          break;
+        }
+      }
+
+      TORCH_CHECK_TYPE(
+          found,
+          fmt::format(
+              "{}() got an unexpected keyword argument '{}'",
+              function_name,
+              THPUtils_unpackString(key)));
+    }
+  }
+
   size_t num_args =
       (args ? PyTuple_GET_SIZE(args) : 0) + (kwargs ? PyDict_Size(kwargs) : 0);
   std::vector<unsigned> plausible_idxs;


### PR DESCRIPTION
## Issue

Fixes #87031

## Summary

Improve the error message for unexpected keyword arguments in `PythonArgParser`.

When argument parsing fails, `PythonArgParser::print_error` now checks whether the keyword is accepted by any overload. If not, it reports an unexpected keyword argument `TypeError`. Keywords that are valid for another overload keep the existing type/overload error behavior.

Added regression tests for `dims`, as well as coverage for valid `dim`/`keepdim` keywords and recognized keywords with invalid types.

## Test Plan

* `BUILD_TEST=0 MAX_JOBS=8 .venv/bin/python -m pip install -e . -v --no-build-isolation`
* `.venv/bin/python test/test_torch.py TestTorch.test_python_arg_parser_unexpected_keyword TestTorch.test_parsing_int64 TestTorch.test_parsing_double TestTorch.test_parsing_intlist`

  * `Ran 4 tests`
  * `OK`
* `spin fixlint`
* `spin lint`

  * passed except `CLANGTIDY` and `CLANGTIDY_EXECUTORCH_COMPATIBILITY`
* `git diff --check`

The clang-tidy checks were skipped because the downloaded macOS binary did not match the SHA256 pinned in the lint configuration.

## Checklist

* [ ] Passes lint (`spin fixlint`)
* [x] Added/updated tests
* [ ] Updated documentation (not applicable)
* [ ] Included benchmark results (not applicable)

## BC-breaking?

No

cc @malfet @albanD