### PR TITLE
[TEST] Add `hw_classification` to `test_logging.py`

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -15,10 +15,16 @@ from pathlib import Path
 import torch
 import torch._logging._internal as log_internal
 from torch._logging._internal import _init_logs, trace_log, trace_structured
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class LoggingTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_backend_autoload_registers_torch_logs_before_env_parse(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             package_dir = os.path.join(tmpdir, "torch_issue173759_backend")


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `LoggingTest`. All 9 tests exercise `torch._logging` infrastructure (trace handlers, structured logging, fork behavior, log initialization). Pure Python, no accelerator dependency.

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590).

## Test Plan

```
python test/test_logging.py -v
Ran 9 tests in 4.7s — OK
```
Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508