### PR TITLE
[XPU] Enable fast path for nn.MultiHeadAttention

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -993,7 +993,9 @@ class TestMultiheadAttentionNNDeviceType(NNTestCase):
         mha(query, key, key)
 
 
-instantiate_device_type_tests(TestMultiheadAttentionNNDeviceType, globals())
+instantiate_device_type_tests(
+    TestMultiheadAttentionNNDeviceType, globals(), allow_xpu=True
+)
 instantiate_parametrized_tests(TestMultiheadAttentionNN)
 
 if __name__ == "__main__":

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1059,6 +1059,7 @@ def _check_arg_device(x: torch.Tensor | None) -> bool:
         return x.device.type in [
             "cpu",
             "cuda",
+            "xpu",
             torch.utils.backend_registration._privateuse1_backend_name,
         ]
     return True
@@ -1413,7 +1414,7 @@ class MultiheadAttention(Module):
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
                     "some Tensor argument's device is neither one of "
-                    f"cpu, cuda or {torch.utils.backend_registration._privateuse1_backend_name}"
+                    f"cpu, cuda, xpu or {torch.utils.backend_registration._privateuse1_backend_name}"
                 )
             elif torch.is_grad_enabled() and any(
                 _arg_requires_grad(x) for x in tensor_args


### PR DESCRIPTION
Fixes #192670.

This fix adds `"xpu"` to the list of devices for which fast path is allowed. Without this addition, the XPU kernel of `aten::_native_multi_head_attention` is unreachable from `nn.MultiHeadAttention`. This brings `nn.MultiHeadAttention` in line with `nn.TransformerEncoderLayer`, which has its own device list that does include `"xpu"`.

The fix also enables the XPU test in `test_multihead_self_attn_two_masks_fast_path_mock` by instantiating `TestMultiheadAttentionNNDeviceType` with `allow_xpu=True`. It seems this was intended by #165405 but without the flag the test never ran on XPU. The instantiation with the flag is broader, but is in line with the referenced #114850 from #165405.

Test plan:

With the `allow_xpu=True` instantiation of `TestMultiheadAttentionNNDeviceType`:

```
python test/nn/test_multihead_attention.py -v
```