### PR TITLE
[ROCm] Remove obsolete ROCm 7.14 test skips

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -42,7 +42,6 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
-    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
@@ -739,7 +738,6 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)

--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -28,7 +28,6 @@ from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import (
     DistributedTestBase,
     skip_if_lt_x_gpu,
-    skip_if_rocm_ver_atleast_multiprocess,
     sm_is_or_higher_than,
 )
 from torch.testing._internal.common_fsdp import get_devtype
@@ -198,7 +197,6 @@ class ReplicateTest(MultiProcessInductorTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @torch._inductor.config.patch(
         reorder_for_locality=False, reorder_for_peak_memory=False
     )
@@ -235,7 +233,6 @@ class ReplicateTest(MultiProcessInductorTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_compile_fp16(self):
         def setup(model, compiled_replicate_model, compiled_ddp_model) -> None:
             model.register_comm_hook(None, ddp_default_hooks.fp16_compress_hook)

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -56,10 +56,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_distributed import (
-    skip_if_lt_x_gpu,
-    skip_if_rocm_ver_atleast_multiprocess,
-)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -684,7 +681,6 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_cp_flex_attention_causal_mask(self) -> None:
         seq_length_list = [256 * self.world_size, 2048]
         load_balance_type_list = [
@@ -752,7 +748,6 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_cp_flex_attention_document_mask(self) -> None:
         random.seed(10)
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     IS_WINDOWS,
     parametrize,
-    skipIfRocmVersionAtLeast,
     skipIfXpu,
     slowTest,
 )
@@ -523,8 +522,6 @@ class TestGpuWrapper(InductorTestCase):
         self.assertEqual(actual, expected)
         self.assertIn("needs_vec_isa=False", code)
 
-    # The vec-ISA probe child cannot resolve ROCm SDK libraries in CI.
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_cuda_cpp_wrapper_keeps_vec_isa_for_host_vectorized_code(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     serialTest,
     skipIfRocmArch,
-    skipIfRocmVersionAtLeast,
     TEST_CUDA_MEM_LEAK_CHECK,
     TEST_WITH_ASAN,
 )
@@ -199,14 +198,6 @@ if HAS_CPU:
                 self.assertEqual(actual[1], expected[1])
 
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
-
-    if hasattr(DynamicShapesCpuTests, "test_tmp_not_defined_issue3_dynamic_shapes_cpu"):
-        # The vec-ISA probe child cannot resolve ROCm SDK libraries in CI.
-        DynamicShapesCpuTests.test_tmp_not_defined_issue3_dynamic_shapes_cpu = (
-            skipIfRocmVersionAtLeast([7, 14])(
-                DynamicShapesCpuTests.test_tmp_not_defined_issue3_dynamic_shapes_cpu
-            )
-        )
 
 
 if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7261,7 +7261,6 @@ print(value, end="")
         finally:
             random.setstate(state)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_nvml_get_handler(self):
         if not torch.version.hip:
@@ -7269,12 +7268,10 @@ print(value, end="")
         else:
             self.assertTrue(torch.cuda._get_amdsmi_handler() is not None)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_temperature(self):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_device_memory_used(self):
         """
@@ -7308,17 +7305,14 @@ print(value, end="")
             # test the order of magnitude
             self.assertTrue(num_bytes // 32 <= mem_bytes <= num_bytes * 32)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_power_draw(self):
         self.assertTrue(torch.cuda.power_draw() >= 0)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")
     def test_raw_amdsmi_device_count(self):

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_utils import (
     load_tests,
     run_tests,
     skipIfRocm,
-    skipIfRocmVersionAtLeast,
     slowTest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
@@ -647,8 +646,6 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
     def test_fd_pool(self):
         self._test_pool(repeat=TEST_REPEATS)
 
-    # torch_shm_manager cannot resolve librocprofiler-sdk.so.1 in CI child processes.
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(
         TEST_WITH_ASAN,
         "seems to hang with ASAN, see https://github.com/pytorch/pytorch/issues/5326",
@@ -660,17 +657,14 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
             repeat = 1 if IS_MACOS else TEST_REPEATS
             self._test_sharing(repeat=repeat)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_preserve_sharing(self):
         with fs_sharing():
             self._test_preserve_sharing(repeat=TEST_REPEATS)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_pool(self):
         with fs_sharing():
             self._test_pool(repeat=TEST_REPEATS)
 
-    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not HAS_SHM_FILES, "don't not how to check if shm files exist")
     def test_fs(self):
         def queue_put():
@@ -1082,8 +1076,6 @@ if __name__ == "__main__":
     def test_is_shared(self):
         self._test_is_shared()
 
-    # torch_shm_manager cannot resolve librocprofiler-sdk.so.1 in CI child processes.
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_is_shared(self):
         with fs_sharing():
             self._test_is_shared()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -41,7 +41,6 @@ from torch.testing._internal.common_optimizers import (
     TensorTracker,
 )
 from torch.testing._internal.common_utils import (
-    getRocmVersion,
     markDynamoStrictTest,
     parametrize,
     run_tests,
@@ -453,19 +452,6 @@ class TestOptimRenewed(TestCase):
     )
     def test_rosenbrock_sparse(self, device, dtype, optim_info, with_lrsched):
         optim_cls = optim_info.optim_cls
-
-        if (
-            TEST_WITH_ROCM
-            and getRocmVersion() >= (7, 14)
-            and optim_cls.__name__ == "SGD"
-            and not with_lrsched
-            and torch.device(device).type == "cuda"
-            and dtype == torch.float64
-        ):
-            self.skipTest(
-                "order/state-dependent sparse SGD step timeout on ROCm 7.14+ "
-                "(with_lrsched=False, SGD, cuda, float64)"
-            )
 
         # Skip differentiable testing for now, see https://github.com/pytorch/pytorch/issues/116490
         # Fused impls do not support sparse gradients

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
     skipIfCrossRef, TEST_WITH_CROSSREF, skipIfTorchDynamo, set_default_dtype,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
-    skipIfRocm, skipIfRocmVersionAtLeast, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
+    skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
     wrapDeterministicFlagAPITest, DeterministicGuard, CudaSyncGuard,
     bytes_to_scalar, parametrize, noncontiguous_like,
     AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, xfailIfTorchDynamo,
@@ -8757,7 +8757,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         torch.__config__.show()
 
     @unittest.skipIf(IS_FBCODE, "CXX_FLAGS is only for OSS build.")
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_cxx_flags(self):
         torch.__config__._cxx_flags()
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -34,7 +34,6 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
-    skipIfRocmVersionAtLeast,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
 )
@@ -782,8 +781,6 @@ class TestAssert(TestCase):
 
 @unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
-    # The standalone binary cannot resolve librocprofiler-sdk.so.1 in CI.
-    @skipIfRocmVersionAtLeast([7, 14])
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
## Summary  
Remove 21 temporary ROCm 7.14 test skips added by #188593.  ROCm trunk now uses ROCm 7.14. These failures no longer reproduce.  

## Child loader fixes  
#188429 fixed the ROCm wheel environment and library search paths. Child processes can now load the required ROCm libraries.  
Remove the skips for:  
- `test/test_multiprocessing.py::TestMultiprocessing::test_fs_sharing`
- `test/test_multiprocessing.py::TestMultiprocessing::test_fs_preserve_sharing
- `test/test_multiprocessing.py::TestMultiprocessing::test_fs_pool` 
- `test/test_multiprocessing.py::TestMultiprocessing::test_fs`
- `test/test_multiprocessing.py::TestMultiprocessing::test_fs_is_shared`
- `test/test_utils.py::TestStandaloneCPPJIT::test_load_standalone`
- `test/inductor/test_gpu_cpp_wrapper.py::TestGpuWrapper::test_cuda_cpp_wrapper_keeps_vec_isa_for_host_vectorized_code`
- `test/inductor/test_torchinductor_dynamic_shapes.py::DynamicShapesCpuTests::test_tmp_not_defined_issue3_dynamic_shapes_cpu`  

## Other obsolete skips  
The following tests no longer fail with ROCm 7.14:  

- `test/test_optim.py::TestOptimRenewed::test_rosenbrock_sparse[SGD,cuda,float64,with_lrsched=False]`
- `test/test_cuda.py::TestCudaAllocator::test_nvml_get_handler`
- `test/test_cuda.py::TestCudaAllocator::test_temperature`
- `test/test_cuda.py::TestCudaAllocator::test_device_memory_used`
- `test/test_cuda.py::TestCudaAllocator::test_power_draw`
- `test/test_cuda.py::TestCudaAllocator::test_clock_speed` 
- `test/test_cuda.py::TestCudaAllocator::test_raw_amdsmi_device_count`
- `test/distributed/_composable/fsdp/test_fully_shard_training.py::TestFullyShard1DTrainingCore::test_post_optim_event`
- `test/distributed/_composable/test_replicate_with_compiler.py::ReplicateTest::test_compile_gpu`
- `test/distributed/_composable/test_replicate_with_compiler.py::ReplicateTest::test_compile_fp16`
- `test/distributed/tensor/test_attention.py::CPFlexAttentionTest::test_cp_flex_attention_causal_mask`
- `test/distributed/tensor/test_attention.py::CPFlexAttentionTest::test_cp_flex_attention_document_mask`
- `test/test_torch.py::TestTorch::test_cxx_flags`
## ROCm/CUDA CI evidence

The PR head (`6d80a47`) was tested in run [31399645566](https://github.com/pytorch/pytorch/actions/runs/31399645566). CI verified 20 of the 21 re-enabled tests; the remaining dynamic-shapes CPU test was not scheduled in the available TD shards.

- Multiprocessing (`test_fs_sharing`, `test_fs_preserve_sharing`, `test_fs_pool`, `test_fs`, `test_fs_is_shared`) passed on CUDA 13.0 default shard 3/14: `test_multiprocessing 1/1 was successful` ([job 93495192855, lines 6970-6971](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93495192855#step:10:6970)).
- `test_load_standalone` passed on CUDA 13.0 default shard 2/14: `test_utils 1/1 was successful` ([job 93495192828, line 6966](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93495192828#step:10:6966)).
- `test_cuda_cpp_wrapper_keeps_vec_isa_for_host_vectorized_code` passed on CUDA 13.0 default shard 10/14: `inductor/test_gpu_cpp_wrapper 2/2 was successful` ([job 93495192873, line 7404](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93495192873#step:10:7404)); the shard list includes the test ([line 7894](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93495192873#step:10:7894)).
- `test_tmp_not_defined_issue3_dynamic_shapes_cpu`: not found in the downloaded CUDA/ROCm TD shard lists for this run. The inductor CPU run [31399645147](https://github.com/pytorch/pytorch/actions/runs/31399645147) explicitly excludes `inductor/test_torchinductor_dynamic_shapes`; this test needs separate validation.
- `test_rosenbrock_sparse[SGD,cuda,float64,with_lrsched=False]` passed on ROCm default shard 7/8: `test_optim 1/2 was successful` ([job 93498959456, lines 9052-9053](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93498959456#step:10:9052)).
- The six CUDA allocator/AMD SMI tests (`test_nvml_get_handler`, `test_temperature`, `test_device_memory_used`, `test_power_draw`, `test_clock_speed`, `test_raw_amdsmi_device_count`) passed on ROCm default shard 1/8: `test_cuda 1/1 was successful` ([job 93498959446, lines 9442-9443](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93498959446#step:10:9442)).
- `test_post_optim_event` passed on ROCm distributed shard 1/3: `distributed/_composable/fsdp/test_fully_shard_training 1/1 was successful` ([job 93498959453, line 9041](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93498959453#step:10:9041)).
- `test_compile_gpu` and `test_compile_fp16` passed on ROCm distributed shard 2/3: `distributed/_composable/test_replicate_with_compiler 1/1 was successful` ([job 93498959538, line 9060](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93498959538#step:10:9060)).
- `test_cp_flex_attention_causal_mask` and `test_cp_flex_attention_document_mask` passed on CUDA 13.2 distributed shard 3/3: `distributed/tensor/test_attention 1/1 was successful` ([job 93495192213, lines 6919-6920](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93495192213#step:10:6919)).
- `test_cxx_flags` passed on the ROCm inductor shard: `test_torch 1/3 was successful` ([job 93498959536, line 8650](https://github.com/pytorch/pytorch/actions/runs/31399645566/job/93498959536#step:10:8650)).

Individual `PASSED` lines are in the pytest artifacts referenced by these module-level success lines.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben