### PR TITLE
Fix FakeTensor output strides for native_batch_norm on CPU

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -741,6 +741,40 @@ class FakeTensorTest(TestCase):
             check(torch.randn(2, 3, 4).transpose(1, 2), training)
             # channels_last inputs must keep their layout, not be made contiguous.
             check(torch.randn(2, 3, 8, 8).to(memory_format=torch.channels_last), training)
+            # A size-1 dim leaves its stride unconstrained, so the kernel's
+            # freshly allocated strides can differ from the input's even though
+            # the input already counts as contiguous.
+            check(torch.randn(2, 4).as_strided((2, 1, 4), (4, 999, 1)), training)
+            check(torch.randn(2, 1, 8, 8).to(memory_format=torch.channels_last), training)
+
+    def test_native_batch_norm_backward_cpu_strides(self):
+        # batch_norm_backward_cpu allocates grad_input with
+        # empty_like(input, input.suggest_memory_format()).
+        # https://github.com/pytorch/pytorch/issues/192668
+        def check(x, train):
+            c = x.size(1)
+            args = (
+                torch.randn_like(x),
+                x,
+                torch.ones(c),
+                # eval mode reads the running stats, so they must be provided
+                torch.zeros(c),
+                torch.ones(c),
+                torch.zeros(c),
+                torch.ones(c),
+                train,
+                1e-5,
+                [True, True, True],
+            )
+            eager_out = torch.ops.aten.native_batch_norm_backward.default(*args)[0]
+            with FakeTensorMode(allow_non_fake_inputs=True):
+                fake_out = torch.ops.aten.native_batch_norm_backward.default(*args)[0]
+            self.assertEqual(fake_out.stride(), eager_out.stride())
+
+        for train in (True, False):
+            check(torch.randn(2, 3, 4).transpose(1, 2), train)
+            check(torch.randn(2, 3, 8, 8).to(memory_format=torch.channels_last), train)
+            check(torch.randn(2, 4).as_strided((2, 1, 4), (4, 999, 1)), train)
 
     def test_private_convolution_symint(self):
         shape_env = ShapeEnv()

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -736,25 +736,34 @@ class FakeTensorTest(TestCase):
                 fake_out = torch.ops.aten.native_batch_norm.default(*make_args())[0]
             self.assertEqual(fake_out.stride(), eager_out.stride())
 
+        cl, cl3d = torch.channels_last, torch.channels_last_3d
         for training in (True, False):
-            # A noncontiguous input gets a contiguous output from the kernel.
+            # Noncontiguous inputs get a contiguous output from the kernel.
             check(torch.randn(2, 3, 4).transpose(1, 2), training)
-            # channels_last inputs must keep their layout, not be made contiguous.
-            check(torch.randn(2, 3, 8, 8).to(memory_format=torch.channels_last), training)
+            check(torch.randn(2, 4, 3), training)
+            check(torch.randn(8, 8, 4, 2).permute(3, 2, 0, 1), training)
+            check(torch.randn(4, 5, 6, 7).transpose(0, 2), training)
+            # Contiguous and channels_last inputs keep their layout.
+            check(torch.randn(2, 3, 8, 8), training)
+            check(torch.randn(2, 3, 8, 8).to(memory_format=cl), training)
+            check(torch.randn(2, 3, 4, 5, 5).to(memory_format=cl3d), training)
             # A size-1 dim leaves its stride unconstrained, so the kernel's
             # freshly allocated strides can differ from the input's even though
             # the input already counts as contiguous.
             check(torch.randn(2, 4).as_strided((2, 1, 4), (4, 999, 1)), training)
-            check(torch.randn(2, 1, 8, 8).to(memory_format=torch.channels_last), training)
+            check(torch.randn(2, 1, 8, 8).to(memory_format=cl), training)
+            check(torch.randn(2, 3, 1, 1).to(memory_format=cl), training)
+            check(torch.randn(1, 3, 8, 8).to(memory_format=cl), training)
 
     def test_native_batch_norm_backward_cpu_strides(self):
-        # batch_norm_backward_cpu allocates grad_input with
-        # empty_like(input, input.suggest_memory_format()).
+        # batch_norm_backward_cpu allocates grad_input rather than inheriting
+        # the input's strides, and picks the format differently depending on
+        # whether input and grad_out agree on layout.
         # https://github.com/pytorch/pytorch/issues/192668
-        def check(x, train):
+        def check(x, train, grad_out=None):
             c = x.size(1)
             args = (
-                torch.randn_like(x),
+                torch.randn_like(x) if grad_out is None else grad_out,
                 x,
                 torch.ones(c),
                 # eval mode reads the running stats, so they must be provided
@@ -771,10 +780,25 @@ class FakeTensorTest(TestCase):
                 fake_out = torch.ops.aten.native_batch_norm_backward.default(*args)[0]
             self.assertEqual(fake_out.stride(), eager_out.stride())
 
+        cl, cl3d = torch.channels_last, torch.channels_last_3d
         for train in (True, False):
             check(torch.randn(2, 3, 4).transpose(1, 2), train)
-            check(torch.randn(2, 3, 8, 8).to(memory_format=torch.channels_last), train)
+            check(torch.randn(8, 8, 4, 2).permute(3, 2, 0, 1), train)
+            check(torch.randn(2, 3, 8, 8), train)
+            check(torch.randn(2, 3, 8, 8).to(memory_format=cl), train)
+            check(torch.randn(2, 3, 4, 5, 5).to(memory_format=cl3d), train)
             check(torch.randn(2, 4).as_strided((2, 1, 4), (4, 999, 1)), train)
+            # A size-1 channel or spatial dim makes channels_last and contiguous
+            # indistinguishable, and the kernel resolves the tie differently in
+            # its contiguous fast path.
+            check(torch.randn(2, 1, 8, 8).to(memory_format=cl), train)
+            check(torch.randn(2, 3, 1, 1).to(memory_format=cl), train)
+            # The fast path also requires input and grad_out to agree on layout.
+            check(
+                torch.randn(2, 3, 8, 8).to(memory_format=cl),
+                train,
+                grad_out=torch.randn(2, 3, 8, 8),
+            )
 
     def test_private_convolution_symint(self):
         shape_env = ShapeEnv()

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -713,6 +713,35 @@ class FakeTensorTest(TestCase):
         eager_out = model.forward(x, w, b)
         self.assertEqual(fake_out.stride(), eager_out.stride())
 
+    def test_native_batch_norm_cpu_strides(self):
+        # batch_norm_cpu chooses the output memory format explicitly instead of
+        # inheriting the input's strides, so FakeTensor has to match it.
+        # https://github.com/pytorch/pytorch/issues/192668
+        def check(x, training):
+            def make_args():
+                c = x.size(1)
+                return (
+                    x,
+                    torch.ones(c),
+                    torch.zeros(c),
+                    torch.zeros(c),
+                    torch.ones(c),
+                    training,
+                    0.1,
+                    1e-5,
+                )
+
+            eager_out = torch.ops.aten.native_batch_norm.default(*make_args())[0]
+            with FakeTensorMode(allow_non_fake_inputs=True):
+                fake_out = torch.ops.aten.native_batch_norm.default(*make_args())[0]
+            self.assertEqual(fake_out.stride(), eager_out.stride())
+
+        for training in (True, False):
+            # A noncontiguous input gets a contiguous output from the kernel.
+            check(torch.randn(2, 3, 4).transpose(1, 2), training)
+            # channels_last inputs must keep their layout, not be made contiguous.
+            check(torch.randn(2, 3, 8, 8).to(memory_format=torch.channels_last), training)
+
     def test_private_convolution_symint(self):
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2076,20 +2076,28 @@ def _fused_rms_norm_backward(
 
 def _is_contiguous_in_any_format(t: Tensor) -> bool:
     # Mirrors is_contiguous_in_any_format in
-    # aten/src/ATen/native/Normalization.cpp
+    # aten/src/ATen/native/Normalization.cpp. The `_or_false` variants keep this
+    # usable under unbacked symbolic shapes, where a plain is_contiguous() would
+    # raise a data-dependent error.
     return (
-        t.is_contiguous()
-        or t.is_contiguous(memory_format=torch.channels_last)
-        or t.is_contiguous(memory_format=torch.channels_last_3d)
+        utils.is_contiguous_or_false(t)
+        or utils.is_contiguous_for_memory_format_or_false(
+            t, memory_format=torch.channels_last
+        )
+        or utils.is_contiguous_for_memory_format_or_false(
+            t, memory_format=torch.channels_last_3d
+        )
     )
 
 
 def _suggest_memory_format_contig(t: Tensor) -> torch.memory_format:
     # Mirrors suggest_memory_format_contig in
     # aten/src/ATen/native/Normalization.cpp
-    if t.is_contiguous():
+    if utils.is_contiguous_or_false(t):
         return torch.contiguous_format
-    elif t.is_contiguous(memory_format=torch.channels_last_3d):
+    elif utils.is_contiguous_for_memory_format_or_false(
+        t, memory_format=torch.channels_last_3d
+    ):
         return torch.channels_last_3d
     else:
         return torch.channels_last
@@ -2109,14 +2117,22 @@ def _batch_norm_cpu_output_memory_format(
     # running_mean/running_var are copied below.
     all_contiguous = (
         _is_contiguous_in_any_format(input)
-        and (weight is None or weight.is_contiguous())
-        and (bias is None or bias.is_contiguous())
-        and (running_mean is None or running_mean.is_contiguous())
-        and (running_var is None or running_var.is_contiguous())
+        and (weight is None or utils.is_contiguous_or_false(weight))
+        and (bias is None or utils.is_contiguous_or_false(bias))
+        and (running_mean is None or utils.is_contiguous_or_false(running_mean))
+        and (running_var is None or utils.is_contiguous_or_false(running_var))
     )
     if all_contiguous:
         return _suggest_memory_format_contig(input)
     return utils.suggest_memory_format(input)
+
+
+def _to_memory_format_strides(t: Tensor, memory_format: torch.memory_format) -> Tensor:
+    # empty_like() always builds fresh strides for the requested memory format,
+    # while contiguous()/to() are no-ops whenever the tensor already qualifies.
+    # Those differ when a size-1 dimension leaves its stride unconstrained, so
+    # go through empty_like to match what the eager kernels allocate.
+    return torch.empty_like(t, memory_format=memory_format).copy_(t)
 
 
 def native_batch_norm_helper(
@@ -2205,10 +2221,8 @@ def native_batch_norm_helper(
     if input.device.type == "cpu":
         save_mean = save_mean.to(dtype=input.dtype)
         save_rstd = save_rstd.to(dtype=input.dtype)
-    if output_memory_format is not None and not output.is_contiguous(
-        memory_format=output_memory_format
-    ):
-        output = output.contiguous(memory_format=output_memory_format)
+    if output_memory_format is not None:
+        output = _to_memory_format_strides(output, output_memory_format)
     return (
         output.to(dtype=input.dtype),
         save_mean,
@@ -2746,6 +2760,17 @@ def native_batch_norm_backward(
         grad_input = ((grad_out_cast - proj) - grad_mean) * grad_scale
     else:
         grad_input = grad_out_cast * grad_scale
+
+    if input.device.type == "cpu":
+        # batch_norm_backward_cpu allocates grad_input as
+        # empty_like(input, input.suggest_memory_format()) rather than
+        # inheriting the input's strides. CUDA is left alone here: it picks
+        # between several kernels based on runtime properties (channels-last
+        # layout, 32-bit indexability), so its strides cannot be reproduced
+        # statically.
+        grad_input = _to_memory_format_strides(
+            grad_input, utils.suggest_memory_format(input)
+        )
 
     if output_mask[1]:
         grad_weight = dot_p * invstd

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2127,16 +2127,6 @@ def _batch_norm_cpu_output_memory_format(
     return utils.suggest_memory_format(input)
 
 
-def _to_memory_format_strides(t: Tensor, memory_format: torch.memory_format) -> Tensor:
-    # The eager kernels allocate with empty_like, which always builds fresh
-    # strides for the requested memory format, whereas contiguous() is a no-op
-    # whenever the tensor already qualifies. Those differ when a size-1
-    # dimension leaves its stride unconstrained. copy=True forces the restride
-    # while staying functional: an empty_like().copy_() would put a copy_ on an
-    # intermediate into the graph and trip assert_functional_graph.
-    return t.to(memory_format=memory_format, copy=True)
-
-
 def native_batch_norm_helper(
     input: Tensor,
     weight: Tensor | None,
@@ -2224,9 +2214,19 @@ def native_batch_norm_helper(
         save_mean = save_mean.to(dtype=input.dtype)
         save_rstd = save_rstd.to(dtype=input.dtype)
     if output_memory_format is not None:
-        output = _to_memory_format_strides(output, output_memory_format)
+        # copy=True forces the restride: to() alone leaves the strides untouched
+        # whenever the tensor already qualifies for the format, which differs
+        # from the empty_like() the kernel allocates with when a size-1
+        # dimension leaves its stride unconstrained. Folding it into the dtype
+        # cast keeps this to a single copy, and staying out-of-place avoids
+        # putting a copy_ on an intermediate into the graph.
+        output = output.to(
+            dtype=input.dtype, memory_format=output_memory_format, copy=True
+        )
+    else:
+        output = output.to(dtype=input.dtype)
     return (
-        output.to(dtype=input.dtype),
+        output,
         save_mean,
         save_rstd,
         new_running_mean,
@@ -2764,15 +2764,28 @@ def native_batch_norm_backward(
         grad_input = grad_out_cast * grad_scale
 
     if input.device.type == "cpu":
-        # batch_norm_backward_cpu allocates grad_input as
-        # empty_like(input, input.suggest_memory_format()) rather than
-        # inheriting the input's strides. CUDA is left alone here: it picks
-        # between several kernels based on runtime properties (channels-last
-        # layout, 32-bit indexability), so its strides cannot be reproduced
-        # statically.
-        grad_input = _to_memory_format_strides(
-            grad_input, utils.suggest_memory_format(input)
+        # batch_norm_backward_cpu allocates grad_input rather than inheriting
+        # the input's strides. It takes a contiguous fast path that requires
+        # input and grad_out to agree on layout, and picks the output format
+        # differently in each case. CUDA is left alone: it dispatches between
+        # several kernels based on runtime properties (channels-last layout,
+        # 32-bit indexability), so its strides cannot be reproduced statically.
+        all_contiguous = (
+            _is_contiguous_in_any_format(input)
+            and _is_contiguous_in_any_format(grad_out)
+            and utils.suggest_memory_format(input)
+            == utils.suggest_memory_format(grad_out)
         )
+        grad_input_memory_format = (
+            _suggest_memory_format_contig(input)
+            if all_contiguous
+            else utils.suggest_memory_format(input)
+        )
+        grad_input = grad_input.to(
+            dtype=input_dtype, memory_format=grad_input_memory_format, copy=True
+        )
+    else:
+        grad_input = grad_input.to(input_dtype)
 
     if output_mask[1]:
         grad_weight = dot_p * invstd
@@ -2785,7 +2798,7 @@ def native_batch_norm_backward(
         grad_bias = None  # "None" doesn't work with vjp, should use zeros for vjp
 
     return (
-        grad_input.to(input_dtype),
+        grad_input,
         _maybe_cast(grad_weight, weight_dtype),
         _maybe_cast(grad_bias, weight_dtype),
     )

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2128,11 +2128,13 @@ def _batch_norm_cpu_output_memory_format(
 
 
 def _to_memory_format_strides(t: Tensor, memory_format: torch.memory_format) -> Tensor:
-    # empty_like() always builds fresh strides for the requested memory format,
-    # while contiguous()/to() are no-ops whenever the tensor already qualifies.
-    # Those differ when a size-1 dimension leaves its stride unconstrained, so
-    # go through empty_like to match what the eager kernels allocate.
-    return torch.empty_like(t, memory_format=memory_format).copy_(t)
+    # The eager kernels allocate with empty_like, which always builds fresh
+    # strides for the requested memory format, whereas contiguous() is a no-op
+    # whenever the tensor already qualifies. Those differ when a size-1
+    # dimension leaves its stride unconstrained. copy=True forces the restride
+    # while staying functional: an empty_like().copy_() would put a copy_ on an
+    # intermediate into the graph and trip assert_functional_graph.
+    return t.to(memory_format=memory_format, copy=True)
 
 
 def native_batch_norm_helper(

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2074,6 +2074,51 @@ def _fused_rms_norm_backward(
     )
 
 
+def _is_contiguous_in_any_format(t: Tensor) -> bool:
+    # Mirrors is_contiguous_in_any_format in
+    # aten/src/ATen/native/Normalization.cpp
+    return (
+        t.is_contiguous()
+        or t.is_contiguous(memory_format=torch.channels_last)
+        or t.is_contiguous(memory_format=torch.channels_last_3d)
+    )
+
+
+def _suggest_memory_format_contig(t: Tensor) -> torch.memory_format:
+    # Mirrors suggest_memory_format_contig in
+    # aten/src/ATen/native/Normalization.cpp
+    if t.is_contiguous():
+        return torch.contiguous_format
+    elif t.is_contiguous(memory_format=torch.channels_last_3d):
+        return torch.channels_last_3d
+    else:
+        return torch.channels_last
+
+
+def _batch_norm_cpu_output_memory_format(
+    input: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    running_mean: Tensor | None,
+    running_var: Tensor | None,
+) -> torch.memory_format:
+    # batch_norm_cpu picks the output memory format explicitly rather than
+    # inheriting the input's strides, so this decomposition has to do the same
+    # to report the strides the CPU kernel actually produces. Must be computed
+    # from the original arguments, before weight/bias are reshaped and
+    # running_mean/running_var are copied below.
+    all_contiguous = (
+        _is_contiguous_in_any_format(input)
+        and (weight is None or weight.is_contiguous())
+        and (bias is None or bias.is_contiguous())
+        and (running_mean is None or running_mean.is_contiguous())
+        and (running_var is None or running_var.is_contiguous())
+    )
+    if all_contiguous:
+        return _suggest_memory_format_contig(input)
+    return utils.suggest_memory_format(input)
+
+
 def native_batch_norm_helper(
     input: Tensor,
     weight: Tensor | None,
@@ -2085,6 +2130,16 @@ def native_batch_norm_helper(
     eps: float,
     functional: bool,
 ) -> tuple[Tensor, Tensor, Tensor, Tensor | None, Tensor | None]:
+    # batch_norm_cuda uses at::empty_like(self) (MemoryFormat::Preserve), which
+    # already matches the strides the elementwise ops below produce, so only the
+    # CPU output layout needs to be forced.
+    output_memory_format = (
+        _batch_norm_cpu_output_memory_format(
+            input, weight, bias, running_mean, running_var
+        )
+        if input.device.type == "cpu"
+        else None
+    )
     reduction_dims = [0] + list(range(2, input.dim()))
     computation_dtype = utils.get_computation_dtype(input.dtype)
     new_running_mean = running_mean
@@ -2150,6 +2205,10 @@ def native_batch_norm_helper(
     if input.device.type == "cpu":
         save_mean = save_mean.to(dtype=input.dtype)
         save_rstd = save_rstd.to(dtype=input.dtype)
+    if output_memory_format is not None and not output.is_contiguous(
+        memory_format=output_memory_format
+    ):
+        output = output.contiguous(memory_format=output_memory_format)
     return (
         output.to(dtype=input.dtype),
         save_mean,


### PR DESCRIPTION
Fixes #192668

`batch_norm_cpu` chooses its output memory format explicitly rather than inheriting the input's strides, but the decomposition used for meta/fake tensors builds the output from elementwise ops, which inherit the input's strides. This breaks `torch.compile` and `torch.export` on noncontiguous CPU inputs.

The fix mirrors the kernel's `all_contiguous` check and applies the resulting memory format. It is computed from the original arguments, before `weight`/`bias` are reshaped and `running_mean`/`running_var` are copied.

**CPU only, deliberately:** `batch_norm_cuda` uses `at::empty_like(self)` (`MemoryFormat::Preserve`), which already matches what the elementwise ops produce — applying this unconditionally would regress CUDA.

Also covers `_native_batch_norm_legit` and `_native_batch_norm_legit_no_training`, which share the same helper.

**Known remaining gap:** MPS has the same class of mismatch but allocates via `suggest_memory_format(channels_last_strides_exact_match=true)`, so it needs different handling and is left out of scope here.

Added a regression test in `test/test_fake_tensor.py` covering noncontiguous inputs (train and eval) and confirming channels_last inputs keep their layout. Verified it fails without the fix and passes with it.

cc @eellison @aorenste @liangel-02