### PR TITLE
[refs] Fix nll_loss on empty inputs

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2658,6 +2658,7 @@ class TestRefsOpsInfo(TestCase):
         "_refs.nn.functional.l1_loss",
         "_refs.nn.functional.smooth_l1_loss",
         "_refs.nn.functional.log_softmax",
+        "_refs.nn.functional.nll_loss",
         "_refs.nn.functional.poisson_nll_loss",
         "_refs.nn.functional.softmax",
         "_refs.nn.functional.softmin",
@@ -2749,6 +2750,23 @@ class TestRefsOpsInfo(TestCase):
                 torch._decomp.decomposition_table.values(),
                 lambda msg: f"{msg}\nDid not find {op} in torch._decomp.decomposition_table.values()",
             )
+
+    def test_nll_loss_empty_input_autograd(self, device):
+        for shape in ((0, 3), (0, 3, 5, 7), (2, 3, 0, 7)):
+            target = torch.empty(
+                (shape[0], *shape[2:]),
+                device=device,
+                dtype=torch.long,
+            )
+            for reduction in ("none", "mean", "sum"):
+                input = torch.empty(shape, device=device, requires_grad=True)
+                result = torch._refs.nn.functional.nll_loss(
+                    input, target, reduction=reduction
+                )
+
+                self.assertTrue(result.requires_grad)
+                result.sum().backward()
+                self.assertEqual(input.grad, torch.empty_like(input))
 
 
 fake_skips = (

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -809,8 +809,7 @@ def _nll_loss_nd(
         return torch.sum(loss) / torch.sum(current_weight)
 
 
-@register_decomposition(aten.nll_loss)
-@out_wrapper()
+# CompositeImplicitAutograd - don't register decomp
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("input",),
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
@@ -838,20 +837,6 @@ def nll_loss(
     if size_average is not None or reduce is not None:
         reduction = _get_string_reduction_arg(size_average=size_average, reduce=reduce)
 
-    # The expected behavior when the target and input have zero elements:
-    #   reduction = 'none' --- tensor([])
-    #   reduction = 'sum'  --- tensor(0.)
-    #   reduction = 'mean' --- tensor(nan)
-    # Mean reduction on empty tensors produces NaN. See the discussion in
-    # https://github.com/pytorch/pytorch/pull/64572#issuecomment-926504162
-    if input.numel() == 0 and target.numel() == 0:
-        if reduction == "none":
-            return torch.zeros_like(target)
-        elif reduction == "sum":
-            return torch.empty_like(target)
-        else:
-            return torch.full_like(target, float("nan"))
-
     # The _nll_loss_nd helper function handles the most common cases.
     # ndim == 1 (Single Example)
     #   => Batch Size: 1, Input: (C), Target: ()
@@ -877,9 +862,10 @@ def nll_loss(
     batch_size = input.shape[0]
     num_classes = input.shape[1]
     out_size = [batch_size] + list(target.shape[1:])
+    flattened_size = math.prod(target.shape[1:])
 
-    input = torch.reshape(input, [batch_size, num_classes, -1])
-    target = torch.reshape(target, [batch_size, -1])
+    input = torch.reshape(input, [batch_size, num_classes, flattened_size])
+    target = torch.reshape(target, [batch_size, flattened_size])
     if reduction != "none":
         return _nll_loss_nd(input, target, weight, reduction, ignore_index)
     else:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8997,6 +8997,31 @@ def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_input(shape), args=(target,), kwargs={'ignore_index': -1})
 
 
+def reference_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
+    yield from sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs)
+
+    make_input = partial(
+        make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    for shape, reduction in product(
+        ((0, 3), (0, 3, 5, 7), (2, 3, 0, 7)),
+        ("none", "mean", "sum"),
+    ):
+        target = torch.empty(
+            (shape[0], *shape[2:]),
+            device=device,
+            dtype=torch.long,
+        )
+        yield SampleInput(
+            make_input(shape),
+            args=(target,),
+            kwargs={"reduction": reduction},
+        )
+
+
 def sample_inputs_binary_cross_entropy_with_logits(
     op_info, device, dtype, requires_grad, **kwargs
 ):
@@ -22517,6 +22542,7 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
         ),
         supports_out=False,
         sample_inputs_func=sample_inputs_nll_loss,
+        reference_inputs_func=reference_inputs_nll_loss,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         assert_jit_shape_analysis=True,
@@ -24740,9 +24766,6 @@ python_ref_db = [
     PythonRefInfo(
         "_refs.nn.functional.nll_loss",
         torch_opinfo_name="nn.functional.nll_loss",
-        # The corresponding PyTorch op doesn't support out.  But the ref is
-        # registered as a decomp and ATen has an out variant.
-        supports_out=True,
         # For simpler indexing, we flatten target indices, then reshape the result tensor.
         # This creates inconsistent view state with reference impl.
         validate_view_consistency=False,


### PR DESCRIPTION
I noticed the `nll_loss` reference handled empty inputs differently from eager PyTorch, including returning incorrect outputs and detaching them from autograd.

This removes the empty-input shortcut, fixes higher-dimensional empty shapes, and removes the invalid `aten.nll_loss` decomposition registration described in #106375.

Added forward and backward regression tests. I can also share a corresponding TorchLean formalization if useful.