### PR TITLE
[refs] Fix nll_loss ignore_index handling

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2715,6 +2715,22 @@ class TestRefsOpsInfo(TestCase):
                 lambda msg: f"{msg}\nDid not find {op} in torch._decomp.decomposition_table.values()",
             )
 
+    def test_nll_loss_ignore_index_nonfinite(self, device):
+        input = torch.tensor(
+            [[float("nan"), float("inf"), float("-inf")], [1.0, 2.0, 3.0]],
+            device=device,
+        )
+        target = torch.tensor([-100, 1], device=device)
+
+        for reduction in ("none", "mean", "sum"):
+            expected = torch.nn.functional.nll_loss(
+                input, target, ignore_index=-100, reduction=reduction
+            )
+            actual = torch._refs.nn.functional.nll_loss(
+                input, target, ignore_index=-100, reduction=reduction
+            )
+            self.assertEqual(actual, expected)
+
 
 fake_skips = (
     "aminmax",  # failing input

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -751,6 +751,7 @@ def _nll_loss_nd(
 
     flat_target = torch.flatten(target)
     ignore_classes_mask = torch.eq(flat_target, ignore_index)
+    safe_target = torch.where(ignore_classes_mask, 0, flat_target)
 
     # TODO: Enable data-dependent checks with debug mode
     # TODO: This check does not work with FakeTensor inputs; See Issue #85834
@@ -772,7 +773,7 @@ def _nll_loss_nd(
     class_weight = (
         torch.scalar_tensor(1, dtype=input.dtype, device=input.device)
         if weight is None
-        else weight[flat_target]
+        else weight[safe_target]
     )
     current_weight = torch.where(
         ignore_classes_mask,
@@ -783,11 +784,11 @@ def _nll_loss_nd(
     if input.ndim == 1:
         # implicit batch size = 1
         # input (1 batch size, C classes)
-        loss = -input[target] * current_weight
+        loss = -input[safe_target] * current_weight
     elif input.ndim == 2:
         # input (N batch size, C classes)
         batch_size = input.shape[0]
-        loss = -input[torch.arange(batch_size), target] * current_weight
+        loss = -input[torch.arange(batch_size), safe_target] * current_weight
     else:
         # 3D case (N batch size, C classes, K dimensions)
         # input (N batch size, C classes, K)
@@ -797,7 +798,8 @@ def _nll_loss_nd(
         indices = torch.arange(numel)
         bdx = indices // extent
         kdx = indices % extent
-        loss = -input[bdx, flat_target, kdx] * current_weight
+        loss = -input[bdx, safe_target, kdx] * current_weight
+    loss = torch.where(ignore_classes_mask, 0, loss)
     loss = torch.reshape(loss, target.shape)
 
     if reduction == "none":

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9088,6 +9088,11 @@ def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
                 t.fill_(0)
             yield make_input(s), t, dict(ignore_index=num_classes // 2, reduction=reduction)
             yield make_input(s), t, dict(ignore_index=num_classes // 2, reduction=reduction, weight=make_weight())
+            if not (reduction == "mean" and len(s) == 1):
+                t = make_target(s)
+                t.reshape(-1)[0] = -100
+                yield make_input(s), t, dict(ignore_index=-100, reduction=reduction)
+                yield make_input(s), t, dict(ignore_index=-100, reduction=reduction, weight=make_weight())
             # Test ignoring all the targets
             # If "mean", nll returns NaN, so it's not differentiable at those points
             if reduction != "mean":
@@ -9102,6 +9107,9 @@ def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
     # Noncontiguous target
     target = torch.randint(num_classes, (2 * shape[0],), device=device)[::2]
     yield SampleInput(make_input(shape), args=(target,))
+
+    target = torch.tensor([num_classes, 2], device=device, dtype=torch.long)
+    yield SampleInput(make_input(shape), args=(target,), kwargs={'ignore_index': num_classes})
 
 
 def sample_inputs_binary_cross_entropy_with_logits(


### PR DESCRIPTION
Hey! I noticed the Python `nll_loss` reference indexes targets before applying `ignore_index`, so out-of-range sentinels like the default `-100` raise instead of being ignored.

This uses a safe class only for indexing, then masks the loss afterward so non-finite values in ignored rows cannot leak into the result. I also added OpInfo coverage for negative and positive out-of-range sentinels, plus a focused non-finite regression test.