### PR TITLE
[Testcase Refactoring] Classify Dynamo support tests by hardware

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -14,6 +14,7 @@ from torch._dynamo.exc import Unsupported
 from torch._dynamo.trace_rules import is_callable_allowed
 from torch._dynamo.utils import counters
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
@@ -29,6 +30,8 @@ def my_custom_function(x):
 
 
 class DecoratorTests(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_disallow_in_graph(self):
         cnts = torch._dynamo.testing.CompileCounter()
 
@@ -1445,8 +1448,8 @@ class DecoratorTests(PytreeRegisteringTestCase):
         if compile_outer:
 
             class Foo:
-                @compile_decorator
                 @staticmethod
+                @compile_decorator
                 def bar(x):
                     return x.sin()
 
@@ -1473,8 +1476,8 @@ class DecoratorTests(PytreeRegisteringTestCase):
         cnt = torch._dynamo.testing.CompileCounter()
 
         class Foo:
-            @torch.compile(backend=cnt)
             @staticmethod
+            @torch.compile(backend=cnt)
             def bar(x):
                 return x.sin()
 

--- a/test/dynamo/test_deque_reconstruct.py
+++ b/test/dynamo/test_deque_reconstruct.py
@@ -5,9 +5,12 @@ import contextlib
 
 import torch
 import torch._inductor.test_case
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestDequeReconstruct(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     UNSET = object()
 
     @contextlib.contextmanager

--- a/test/dynamo/test_deviceguard.py
+++ b/test/dynamo/test_deviceguard.py
@@ -53,7 +53,7 @@ class TestDeviceGuardWithInterface(torch._dynamo.test_case.TestCase):
     Unit tests for the DeviceGuard class using a real DeviceInterface.
     """
 
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def test_device_guard_no_index(self, device):
         device_interface = get_interface_for_device(torch.device(device).type)

--- a/test/dynamo/test_deviceguard.py
+++ b/test/dynamo/test_deviceguard.py
@@ -6,12 +6,15 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.device_interface import DeviceGuard, get_interface_for_device
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestDeviceGuard(torch._dynamo.test_case.TestCase):
     """
     Unit tests for the DeviceGuard class using a mock DeviceInterface.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -49,6 +52,8 @@ class TestDeviceGuardWithInterface(torch._dynamo.test_case.TestCase):
     """
     Unit tests for the DeviceGuard class using a real DeviceInterface.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_device_guard_no_index(self, device):
         device_interface = get_interface_for_device(torch.device(device).type)


### PR DESCRIPTION
## Summary
Classifies decorator, deque reconstruction, and device guard Dynamo tests with hardware metadata.

## Changes
- Add HardwareClassification coverage for decorator tests.
- Add HardwareClassification coverage for deque reconstruction tests.
- Add HardwareClassification coverage for device guard tests.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_decorators.py test/dynamo/test_deque_reconstruct.py test/dynamo/test_deviceguard.py
python -m py_compile test/dynamo/test_decorators.py test/dynamo/test_deque_reconstruct.py test/dynamo/test_deviceguard.py
git diff --check -- test/dynamo/test_decorators.py test/dynamo/test_deque_reconstruct.py test/dynamo/test_deviceguard.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98