### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to 6 dynamo test files

### DIFF
--- a/test/dynamo/test_skip_guard_eval_unsafe.py
+++ b/test/dynamo/test_skip_guard_eval_unsafe.py
@@ -3,6 +3,7 @@
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 def my_custom_function(x):
@@ -10,6 +11,8 @@ def my_custom_function(x):
 
 
 class RunDiffGuardTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_bool_recompile(self):
         def fn(x, y, c):
             if c:

--- a/test/dynamo/test_sources.py
+++ b/test/dynamo/test_sources.py
@@ -10,6 +10,7 @@ from torch._dynamo.source import (
     is_from_local_source,
     LocalSource,
 )
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class CausalLMOutputWithPast:
@@ -17,6 +18,8 @@ class CausalLMOutputWithPast:
 
 
 class SourceTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_is_local(self):
         x_src = LocalSource("x")
         y_src = GlobalSource("y")

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -8,6 +8,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import unsupported
 from torch._dynamo.utils import ifdynstaticdefault
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 globalmod = torch.nn.ReLU()
@@ -19,6 +20,8 @@ def indirectly_unsupported(a, b):
 
 
 class SubGraphTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _common(self, fn, frame_count, op_count):
         torch._dynamo.reset()
         v1 = torch.ones(10)

--- a/test/dynamo/test_torchrec.py
+++ b/test/dynamo/test_torchrec.py
@@ -8,7 +8,7 @@ import torch._dynamo.test_case
 from torch import nn
 from torch._dynamo.test_case import TestCase
 from torch._dynamo.testing import CompileCounter
-from torch.testing._internal.common_utils import NoTest
+from torch.testing._internal.common_utils import HardwareClassification, NoTest
 
 
 try:
@@ -67,6 +67,8 @@ if not HAS_TORCHREC:
 
 @unittest.skipIf(not HAS_TORCHREC, "these tests require torchrec")
 class TorchRecTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_pooled(self):
         tables = [
             (nn.EmbeddingBag(2000, 8), ["a0", "b0"]),

--- a/test/dynamo/test_tp_hash.py
+++ b/test/dynamo/test_tp_hash.py
@@ -6,9 +6,12 @@ import sys
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TpHashTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_hash_equals(self, value):
         """Assert Dynamo's hash(value) matches eager Python's hash(value)."""
         expected = hash(value)

--- a/test/dynamo/test_tp_slots.py
+++ b/test/dynamo/test_tp_slots.py
@@ -20,10 +20,13 @@ from torch._C._dynamo import (
     PyTypeSlots,
 )
 from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestTypeSlots(TestCase):
     """Test suite for type slot detection."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _get_slot_info(self, obj_type):
         """Helper to get and unpack slot information."""


### PR DESCRIPTION
## Summary

This PR classifies 6 `test/dynamo` test classes as device-generic (`HardwareClassification.GENERIC`) so that CI runners can route tests by hardware capability.

## Changes

Added hw_classification = HardwareClassification.GENERIC and the corresponding import to:
  - `RunDiffGuardTests` in `test_skip_guard_eval_unsafe.py`
  - `SourceTests` in `test_sources.py`
  - `SubGraphTests` in `test_subgraphs.py`
  - `TorchRecTests` in `test_torchrec.py`
  - `TpHashTests` in `test_tp_hash.py`
  - `TestTypeSlots` in `test_tp_slots.py`

## Test plan

`python test/dynamo/test_skip_guard_eval_unsafe.py --hw-classification GENERIC -v`
`python test/dynamo/test_sources.py --hw-classification GENERIC -v`
`python test/dynamo/test_subgraphs.py --hw-classification GENERIC -v`
`python test/dynamo/test_torchrec.py --hw-classification GENERIC -v`
`python test/dynamo/test_tp_hash.py --hw-classification GENERIC -v`
`python test/dynamo/test_tp_slots.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590