### PR TITLE
[Testcase Refactoring] Classify device guard tests by hardware

### DIFF
--- a/test/dynamo/test_deviceguard.py
+++ b/test/dynamo/test_deviceguard.py
@@ -6,12 +6,15 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.device_interface import DeviceGuard, get_interface_for_device
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestDeviceGuard(torch._dynamo.test_case.TestCase):
     """
     Unit tests for the DeviceGuard class using a mock DeviceInterface.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -49,6 +52,8 @@ class TestDeviceGuardWithInterface(torch._dynamo.test_case.TestCase):
     """
     Unit tests for the DeviceGuard class using a real DeviceInterface.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_device_guard_no_index(self, device):
         device_interface = get_interface_for_device(torch.device(device).type)


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo device guard tests.

## Changes
- Import HardwareClassification for the test file.
- Mark generic device guard tests as HardwareClassification.GENERIC.
- Mark device-interface coverage as HardwareClassification.ACCELERATOR.

## Test plan
```bash
npu-run-suite npu ./test_deviceguard.py
ok
```

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98