### PR TITLE
[Testcase Refactoring] Classify deque reconstruct tests by hardware

### DIFF
--- a/test/dynamo/test_deque_reconstruct.py
+++ b/test/dynamo/test_deque_reconstruct.py
@@ -5,9 +5,12 @@ import contextlib
 
 import torch
 import torch._inductor.test_case
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestDequeReconstruct(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     UNSET = object()
 
     @contextlib.contextmanager


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo deque reconstruction tests.

## Changes
- Import HardwareClassification for the test file.
- Mark the deque reconstruction test class as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_deque_reconstruct.py
git diff --check -- test/dynamo/test_deque_reconstruct.py
 npu-run-suite npu ./test_deque_reconstruct.py

ok
```

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98