### PR TITLE
[Testcase Refactoring] Generalize requires_world_size to be hardware-agnostic

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -339,7 +339,11 @@ def requires_world_size(n: int):
     """
     Decorator to request a specific world size for a test. The test harness can
     read this attribute to set the number of ranks to spawn. If there are fewer
-    than `n` CUDA devices available, the test should be skipped by the harness.
+    than ``n`` accelerators available, the test is skipped.
+
+    NOTE: The skip logic is hardware-agnostic and works for any accelerator
+    supported by ``torch.accelerator`` (e.g. CUDA, XPU, HPU, and
+    PrivateUse1-based backends).
 
     Usage:
         @require_world_size(3)
@@ -349,9 +353,12 @@ def requires_world_size(n: int):
 
     def decorator(func):
         func._required_world_size = n
-        available = torch.cuda.device_count()
+        acc = torch.accelerator.current_accelerator(check_available=True)
+        available = (
+            torch.get_device_module(acc.type).device_count() if acc is not None else 0
+        )
         return unittest.skipUnless(
-            available >= n, f"requires {n} GPUs, found {available}"
+            available >= n, f"requires {n} accelerators, found {available}"
         )(func)
 
     return decorator


### PR DESCRIPTION
`requires_world_size` is the world-size gate that capability-gated FSDP test migrations (e.g. #192208 and the `test_fsdp_*` series) are migrating **to** from `skip_if_lt_x_gpu`. It hardcodes `torch.cuda.device_count()`, so on any non-CUDA accelerator (XPU/HPU/PrivateUse1) every `@requires_world_size(n)` test is skipped even when devices are present.

Generalizes the skip to `torch.accelerator.current_accelerator(check_available=True)` + `torch.get_device_module(acc.type).device_count()`, mirroring `skip_if_lt_x_gpu`'s generalization in #187650. Without this, #187650 alone does not unblock the migrated tests because they call `requires_world_size`, not `skip_if_lt_x_gpu`; #187650 generalized the old function while the migrations target the new one.

Sibling to #187650. Independent of the capability foundation PRs #190846/#191919/#192043 (this changes `common_distributed.requires_world_size`, they change `common_device_type.py`).

## Test plan
Validated on Ascend 910B (PrivateUse1, `torch.accelerator.device_count()=4`): `@requires_world_size(2)` tests run instead of being skipped ("requires 2 accelerators, found 4"); the 6 capability-gated `test_fsdp_*` files pass on 4-card NPU (56 tests, 0 failures). Container-side shims of the foundation PRs (#190846/#191919) were applied only to provide the Capability/requires_capabilities imports (not yet on main); this change is independent of those.
