### PR TITLE
[Testcase Refactoring] Migrate test_fsdp_fine_tune to capability gating

### DIFF
--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -15,17 +15,18 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_distributed import requires_world_size
+from torch.testing._internal.common_fsdp import FSDPTestContinuous
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
-    TEST_CUDA,
     TEST_WITH_DEV_DBG_ASAN,
 )
-
-
-device_type = torch.device(get_devtype())
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -61,14 +62,41 @@ class ModelUnusedInput(nn.Module):
         return torch.concat([x, y, z, learnable_input])
 
 
-class TestFSDPFineTune(FSDPTestContinuous):
-    """Tests fine-tuning cases where some parameters are frozen."""
+class FineTuneTestBase(FSDPTestContinuous):
+    """Device-agnostic base.
 
-    NUM_LINEARS = 6
+    FSDPTestContinuous inherits the module-level ``DEVICE_TYPE`` /
+    ``DEVICE_COUNT`` / ``DISTRIBUTED_BACKEND`` globals from ``common_fsdp``,
+    which only recognize cuda/hpu/xpu. Override the device-resolution hooks so
+    the test runs on any accelerator (incl. out-of-tree PrivateUse1 backends)
+    once instantiated via ``instantiate_device_type_tests``. Mirrors the
+    ``DTensorPPTestBase`` pattern in PR #192051: the intermediate base holds
+    ``backend_str`` so the device-specific generated class inherits it rather
+    than ports it (a ported classmethod cannot see the variant's device_type).
+    """
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def _resolved_device_type(cls) -> str:
+        dt = cls.device_type
+        if dt == "privateuse1":
+            dt = torch._C._get_privateuse1_backend_name()
+        return dt
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return dist.get_default_backend_for_device(cls._resolved_device_type())
 
     @property
     def world_size(self) -> int:
-        return min(_get_device_module(self.device_type).device_count(), 2)
+        return min(2, _get_device_module(self.device_type).device_count())
+
+
+class TestFSDPFineTune(FineTuneTestBase):
+    """Tests fine-tuning cases where some parameters are frozen."""
+
+    NUM_LINEARS = 6
 
     def _init_seq_module(self, device) -> nn.Module:
         torch.manual_seed(42)
@@ -88,7 +116,11 @@ class TestFSDPFineTune(FSDPTestContinuous):
                 for param in seq[i * 2].parameters(recurse=True):
                     param.requires_grad = requires_grad
 
-    @skip_if_lt_x_gpu(2)
+    @requires_world_size(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     def test_backward_reshard_hooks(self, device):
         """
         Tests that the post-backward reshard happens even for flat parameters
@@ -117,6 +149,7 @@ class TestFSDPFineTune(FSDPTestContinuous):
         inp_requires_grad: bool,
         unfreeze_params: bool,
     ):
+        device_type = torch.device(self._resolved_device_type())
         seq = self._init_seq_module(device_type)
         policy = ModuleWrapPolicy({nn.Linear})
         fsdp_kwargs = {"device_id": device_type}
@@ -213,8 +246,12 @@ class TestFSDPFineTune(FSDPTestContinuous):
 
         return TestModule()
 
-    @skip_if_lt_x_gpu(2)
-    def test_hooks_multi_traversal(self):
+    @requires_world_size(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_hooks_multi_traversal(self, device):
         """
         Tests that the hooks do reshard / unshard correctly in the case of same
         parameters being used multiple times during forward pass.
@@ -240,6 +277,7 @@ class TestFSDPFineTune(FSDPTestContinuous):
         inp_requires_grad: bool,
         forward_prefetch: bool,
     ):
+        device_type = torch.device(self._resolved_device_type())
         seq = self._init_multi_traversal_module(device_type.type)
         policy = ModuleWrapPolicy({nn.Linear})
         fsdp_kwargs = {"device_id": device_type}
@@ -269,8 +307,12 @@ class TestFSDPFineTune(FSDPTestContinuous):
             torch.testing.assert_close(losses[0], losses[1])
             losses.clear()
 
-    @skip_if_lt_x_gpu(2)
-    def test_parity_with_ddp(self):
+    @requires_world_size(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_parity_with_ddp(self, device):
         """
         Tests parity with DDP when mixing flat parameters that require and do
         not require gradients.
@@ -292,6 +334,7 @@ class TestFSDPFineTune(FSDPTestContinuous):
         sharding_strategy: ShardingStrategy,
         use_orig_params: bool,
     ):
+        device_type = torch.device(self._resolved_device_type())
         seq = self._init_seq_module(device_type)
         policy = ModuleWrapPolicy({nn.Linear})
         fsdp_kwargs = {"device_id": device_type}
@@ -315,13 +358,17 @@ class TestFSDPFineTune(FSDPTestContinuous):
                 loss.backward()
                 optim.step()
                 optim.zero_grad()
-            if TEST_CUDA:
+            if self._resolved_device_type() == "cuda":
                 torch.testing.assert_close(losses[0], losses[1])
             else:
                 torch.testing.assert_close(losses[0], losses[1], atol=1e-03, rtol=1e-03)
             losses.clear()
 
-    @skip_if_lt_x_gpu(2)
+    @requires_world_size(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     def test_parity_with_non_frozen_fsdp(self, device):
         """
         For frozen modules with unused input, reshard could happen without unshard
@@ -362,6 +409,7 @@ class TestFSDPFineTune(FSDPTestContinuous):
         mixed_precision: MixedPrecision,
         backward_prefetch: BackwardPrefetch,
     ):
+        device_type = torch.device(self._resolved_device_type())
         torch.manual_seed(42)
         model = ModelUnusedInput(freeze=True).to(device_type)
         torch.manual_seed(42)
@@ -404,9 +452,8 @@ class TestFSDPFineTune(FSDPTestContinuous):
                     self.assertEqual(param, ref_param)
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestFSDPFineTune, globals(), only_for=devices, allow_xpu=True
+    TestFSDPFineTune, globals(), except_for="cpu", allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_device_type import (
     requires_capabilities,
 )
 from torch.testing._internal.common_distributed import requires_world_size
-from torch.testing._internal.common_fsdp import FSDPTestContinuous
+from torch.testing._internal.common_fsdp import DISTRIBUTED_BACKEND, FSDPTestContinuous
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -87,7 +87,14 @@ class FineTuneTestBase(FSDPTestContinuous):
 
     @classmethod
     def backend_str(cls) -> str:
-        return dist.get_default_backend_for_device(cls._resolved_device_type())
+        try:
+            return dist.get_default_backend_for_device(cls._resolved_device_type())
+        except ValueError:
+            # Devices without a registered default backend (e.g. ``hpu`` unless
+            # the vendor extension registers ``hccl`` via ``register_backend``):
+            # fall back to the historical ``common_fsdp`` ``DISTRIBUTED_BACKEND``
+            # ("hccl" on HPU), preserving the pre-refactor behavior.
+            return DISTRIBUTED_BACKEND
 
     @property
     def world_size(self) -> int:
@@ -129,7 +136,6 @@ class TestFSDPFineTune(FineTuneTestBase):
         """
         self.run_subtests(
             {
-                "device_id": [device],
                 "sharding_strategy": [
                     ShardingStrategy.FULL_SHARD,
                     ShardingStrategy.SHARD_GRAD_OP,
@@ -144,7 +150,6 @@ class TestFSDPFineTune(FineTuneTestBase):
 
     def _test_backward_reshard_hooks(
         self,
-        device_id,
         sharding_strategy: ShardingStrategy,
         use_orig_params: bool,
         inp_requires_grad: bool,
@@ -378,7 +383,6 @@ class TestFSDPFineTune(FineTuneTestBase):
         """
         self.run_subtests(
             {
-                "device_id": [device],
                 "sharding_strategy": [
                     ShardingStrategy.FULL_SHARD,
                     ShardingStrategy.SHARD_GRAD_OP,
@@ -403,7 +407,6 @@ class TestFSDPFineTune(FineTuneTestBase):
 
     def _test_parity_with_non_frozen_fsdp(
         self,
-        device_id,
         sharding_strategy: ShardingStrategy,
         use_orig_params: bool,
         offload_params: bool,

--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -28,6 +28,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
 )
 
+
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)


### PR DESCRIPTION
Migrates `test/distributed/fsdp/test_fsdp_fine_tune.py` to capability gating: drops module-level `device_type` globals; introduces an intermediate test base `FineTuneTestBase` with `_resolved_device_type()` / `backend_str` / `world_size`; gates tests with `@requires_world_size(2)` + `@requires_capabilities(...)` instead of `@skip_if_lt_x_gpu`.

## Test plan
`python test/distributed/fsdp/test_fsdp_fine_tune.py` -> Ran 4 tests, OK (validated on a 4-card accelerator host; the accelerator run is reproducible with non-CUDA runtime prerequisites #187650 + #192694, which are NOT merge dependencies).

## Dependencies
Merge-blocking: #191919 (provides `Capability.distributed.{backend,fsdp,dtensor}` + `requires_capabilities` + runtime gate; not on main yet). Note: #190846 is a competing capability design whose `Capability.lib`/`Capability.dtype` namespace this file does not use — if that design lands instead, the `Capability.distributed.*` references here must be adapted.
