### PR TITLE
[Testcase Refactoring] Classify config tests by hardware

### DIFF
--- a/test/dynamo/test_config.py
+++ b/test/dynamo/test_config.py
@@ -8,12 +8,15 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.utils import disable_cache_limit
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 # NB: do NOT include this test class in test_dynamic_shapes.py
 
 
 class ConfigTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_config_module(self, name: str):
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo config tests.

## Changes
- Import HardwareClassification for the test file.
- Mark the config test class as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_config.py
git diff --check -- test/dynamo/test_config.py
npu-run-suite npu  ./test_config.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98