### PR TITLE
[Testcase Refactoring] Classify comptime tests by hardware

### DIFF
--- a/test/dynamo/test_comptime.py
+++ b/test/dynamo/test_comptime.py
@@ -10,6 +10,7 @@ from io import StringIO
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.comptime import comptime
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 # Because we don't support free variables in comptime at the moment,
@@ -21,6 +22,8 @@ SELF = None
 
 
 class ComptimeTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_print_single(self):
         global FILE
         FILE = StringIO()


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo comptime tests.

## Changes
- Import HardwareClassification for the test file.
- Mark the comptime test class as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_comptime.py
git diff --check -- test/dynamo/test_comptime.py
npu-run-suite npu  ./test_comptime.py
```
ok
### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98