### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to test_verify_correctness.py, test_aot_autograd.py and test_sympy_utils.py

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -33,7 +33,10 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import compare_equal_outs_and_grads
+from torch.testing._internal.common_utils import (
+    compare_equal_outs_and_grads,
+    HardwareClassification,
+)
 from torch.utils._sympy.symbol import make_symbol, SymT
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -59,6 +62,8 @@ lib.impl("maybe_dupe_op", maybe_dupe_op, "Meta")
 
 
 class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):
@@ -1912,6 +1917,8 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
 
 class AotAutogradFallbackTestsDevice(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     @patch.object(torch._dynamo.config, "capture_dynamic_output_shape_ops", True)

--- a/test/dynamo/test_verify_correctness.py
+++ b/test/dynamo/test_verify_correctness.py
@@ -7,6 +7,7 @@ import torch._dynamo.config as config
 import torch._dynamo.test_case
 from torch._dynamo.testing import same
 from torch.fx._lazy_graph_module import _force_skip_lazy_graph_module
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class Seq(torch.nn.Module):
@@ -60,6 +61,8 @@ def transform(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 @config.patch("verify_correctness", True)
 class TestVerifyCorrectness(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_example_inputs(self):
         def fn(a, bc, d):
             b, c = bc

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -14,6 +14,7 @@ import torch.fx as fx
 from sympy.core.relational import is_ge, is_gt, is_le, is_lt
 from torch.testing._internal.common_device_type import skipIf
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -163,6 +164,8 @@ def generate_range(vals):
 
 
 class TestNumbers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_int_infinity(self):
         self.assertIsInstance(int_oo, IntInfinity)
         self.assertIsInstance(-int_oo, NegativeIntInfinity)
@@ -231,6 +234,8 @@ class TestNumbers(TestCase):
 
 
 class TestCppPrinter(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_min_max_preserve_float_expressions(self):
         s0 = sympy.Symbol("s0")
         expr = TorchSymMin(
@@ -263,6 +268,8 @@ class TestCppPrinter(TestCase):
 
 
 class TestValueRanges(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize("fn", UNARY_OPS)
     @parametrize("dtype", ("int", "float"))
     def test_unary_ref(self, fn, dtype):
@@ -620,6 +627,8 @@ class TestValueRanges(TestCase):
 
 
 class TestSympyInterp(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS
     )
@@ -841,6 +850,8 @@ def parametrize_relational_types(*types):
 
 
 class TestSympySolve(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_integer_symbols(self) -> list[sympy.Symbol]:
         return sympy.symbols("a b c", integer=True)
 
@@ -1101,6 +1112,8 @@ class TestSympySolve(TestCase):
 
 
 class TestSympyFunctions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_shift_edges(self):
         x = sympy.Symbol("x", integer=True)
         self.assertEqual(LShift(x, 0), x)
@@ -1148,6 +1161,8 @@ class TestSympyFunctions(TestCase):
 
 
 class TestSingletonInt(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         j1 = SingletonInt(1, coeff=1)
         j1_copy = SingletonInt(1, coeff=1)
@@ -1231,6 +1246,8 @@ class TestSingletonInt(TestCase):
         self.assertEqual(j1.free_symbols, set())
 
 class TestIdentity(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_expand_identity(self):
         """
         Test removing an identity via expansion.
@@ -1263,6 +1280,8 @@ class TestIdentity(TestCase):
         self.assertRaises(TypeError, float, tup_I)
 
 class TestTypedExpr(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_typed_expr(self):
         I = Identity(1)
         typed_I = TypedExpr(I, torch.int32)
@@ -1271,6 +1290,8 @@ class TestTypedExpr(TestCase):
 
 class TestCCodePrinting(TestCase):
     """Test _ccode methods on sympy function classes."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_floor_to_int_ccode(self):
         from torch.utils._sympy.functions import FloorToInt


### PR DESCRIPTION
## Summary

This PR classifies 3 test files as device-unrelated by adding `hw_classification = HardwareClassification.GENERIC`, enabling the PyTorch test infrasturcture to correctly identify these tests as hardware-agnostic.

## Changes

- test/dynamo/test_aot_autograd.py:
   - Added `hw_classification = HardwareClassification.GENERIC` to `AotAutogradFallbackTests`
   - Added `hw_classification = HardwareClassification.ACCELERATOR` to `AotAutogradFallbackTestsDevice `(`instantiate_device_type_tests` already exists)
   - Imported `HardwareClassification` from `torch.testing._internal.common_utils`
- test/dynamo/test_verify_correctness.py:
   - Added `hw_classification = HardwareClassification.GENERIC` to `TestVerifyCorrectness`
   - Imported `HardwareClassification` from `torch.testing._internal.common_utils`
- test/test_sympy_utils.py:
   - Added `hw_classification = HardwareClassification.GENERIC` to 10 test classes: `TestNumbers`, `TestCppPrinter`, `TestValueRanges`, `TestSympyInterp`, `TestSympySolve`, `TestSympyFunctions`, `TestSingletonInt`, `TestIdentity`, `TestTypedExpr`, `TestCCodePrinting`
   - Imported `HardwareClassification` from `torch.testing._internal.common_utils`

## Test plan

`python test/dynamo/test_aot_autograd.py --hw-classification GENERIC -v`
`python test/dynamo/test_aot_autograd.py --hw-classification ACCELERATOR -v`
`python test/dynamo/test_verify_correctness.py --hw-classification GENERIC -v`
`python test/test_sympy_utils.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

- Classifying `AotAutogradFallbackTests` silently propagates into `test/dynamo/test_dynamic_shapes.py`. The other test classes in `test/dynamo/test_dynamic_shapes.py`, except for `AotAutogradFallbackTests`, have been assigned to respective owners for modification and are not going to be fixed in this PR.
- This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98