### PR TITLE
[Testcase Refactoring] Decouple test_codecache.py from CUDA-specific

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -602,6 +602,608 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
             "torch.randperm(1 << 12, dtype=torch.float32).log()"
         )
 
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @config.patch({"compile_threads": 1})
+    @functorch_config.patch({"enable_autograd_cache": False})
+    def test_local_cache_stats(self):
+        from torch._inductor.remote_cache import cache_stats
+
+        cache_stats._stats.clear()
+
+        def fn(x, y):
+            return x * 2 + y
+
+        compiled_fn = torch.compile(fn)
+        a = torch.rand(25)
+        b = torch.rand(25)
+        compiled_fn(a, b)
+
+        stats = cache_stats._stats.get("LocalFxGraphCache")
+        self.assertIsNotNone(stats)
+        self.assertEqual(stats.miss, 1)
+        self.assertEqual(stats.put, 1)
+        self.assertEqual(stats.hit, 0)
+
+        self.reset()
+        compiled_fn(a, b)
+
+        self.assertEqual(stats.hit, 1)
+        cache_stats._stats.clear()
+
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": False})
+    def test_default_dtype_affects_factory_cache_key(self):
+        old_dtype = torch.get_default_dtype()
+        FxGraphCache.clear()
+
+        def fn():
+            return (
+                torch.ones(2),
+                torch.zeros(2),
+                torch.tensor([1.0, 2.0]),
+                torch.arange(2.0),
+                torch.empty(2),
+            )
+
+        compiled_fn = torch.compile(fn, backend="inductor")
+
+        try:
+            torch.set_default_dtype(torch.float32)
+            first = compiled_fn()
+            self.assertEqual([x.dtype for x in first], [torch.float32] * 5)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            torch.set_default_dtype(torch.float64)
+            expected = fn()
+            actual = compiled_fn()
+            self.assertEqual([x.dtype for x in actual], [x.dtype for x in expected])
+            self.assertEqual([x.dtype for x in actual], [torch.float64] * 5)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+        finally:
+            torch.set_default_dtype(old_dtype)
+            FxGraphCache.clear()
+
+    @config.patch(
+        {
+            "fx_graph_cache": True,
+            "fx_graph_remote_cache": False,
+        }
+    )
+    def test_cache_hot_load_repeat(self):
+        def fn(x, y):
+            return x @ y.sin()
+
+        compiled_fn = torch.compile(fn, dynamic=False)
+
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+
+        a2 = torch.randn(4, 8)
+        b2 = torch.randn(8, 4)
+
+        with fresh_cache():
+            eager_result = fn(a, b)
+            compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+        self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        self.reset()
+
+        with fresh_cache():
+            torch.compiler.load_cache_artifacts(artifact_bytes)
+            eager_result = fn(a, b)
+            compiled_result = compiled_fn(a, b)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+
+        self.reset()
+
+        with fresh_cache():
+            eager_result = fn(a2, b2)
+            compiled_result = compiled_fn(a2, b2)
+            self.assertEqual(eager_result, compiled_result)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        self.assertTrue(torch.compiler._cache.CacheArtifactManager.need_serialize())
+
+    @torch._dynamo.config.patch(automatic_dynamic_local_pgo=True)
+    @torch._functorch.config.patch({"enable_autograd_cache": False})
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    def test_cache_hot_load_pgo(self):
+        """
+        Verify that we can populate and hot load functions from the cache with pgo.
+        """
+
+        backend = torch._dynamo.testing.CompileCounterWithBackend("inductor")
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def f(x):
+            return x * 2
+
+        # Record artifacts
+        with torch.compiler.config.patch(job_id=self.id()), fresh_cache():
+            f(torch.randn(2, 3))
+            f(torch.randn(2, 4))
+            self.assertEqual(backend.frame_count, 2)
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+
+        self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        self.assertEqual(len(cache_info.inductor_artifacts), 2)
+        self.assertEqual(len(cache_info.autotune_artifacts), 0)
+        self.assertEqual(len(cache_info.aot_autograd_artifacts), 0)
+        self.assertEqual(len(cache_info.pgo_artifacts), 2)
+
+        self.reset()
+        backend.clear()
+
+        # Clean triton kernels
+        shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
+
+        # Hot load and hit
+        with torch.compiler.config.patch({"job_id": self.id()}), fresh_cache():
+            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
+
+            self.assertEqual(len(cache_info.inductor_artifacts), 2)
+            self.assertEqual(len(cache_info.autotune_artifacts), 0)
+            self.assertEqual(len(cache_info.aot_autograd_artifacts), 0)
+            self.assertEqual(len(cache_info.pgo_artifacts), 2)
+
+            f(torch.randn(2, 5))
+            f(torch.randn(2, 6))
+            self.assertEqual(backend.frame_count, 1)
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+    @torch._dynamo.config.patch(automatic_dynamic_local_pgo=True)
+    @torch._functorch.config.patch({"enable_autograd_cache": False})
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    def test_cache_hot_load_pgo_swap_file_names(self):
+        """
+        Verify that we can populate and hot load functions from the cache with pgo
+        with file name swapping
+        """
+
+        backend = torch._dynamo.testing.CompileCounterWithBackend("inductor")
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def f(x):
+            return x * 2
+
+        # Record artifacts
+        with mock.patch(
+            "torch._utils_internal.get_mast_job_name_version", return_value=("foo", 5)
+        ):
+            with fresh_cache():
+                f(torch.randn(2, 3))
+                f(torch.randn(2, 4))
+                self.assertEqual(backend.frame_count, 2)
+
+            artifacts = torch.compiler.save_cache_artifacts()
+
+            self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        self.assertEqual(len(cache_info.pgo_artifacts), 2)
+
+        self.reset()
+        backend.clear()
+
+        # Clean triton kernels
+        shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
+
+        # Hot load and hit
+        with (
+            mock.patch(
+                "torch._utils_internal.get_mast_job_name_version",
+                return_value=("bar", 10),
+            ),
+            fresh_cache(),
+        ):
+            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
+
+            self.assertEqual(len(cache_info.pgo_artifacts), 2)
+
+            f(torch.randn(2, 5))
+            f(torch.randn(2, 6))
+            self.assertEqual(backend.frame_count, 1)
+
+    def test_cache_hot_load_empty(self):
+        self.assertIsNone(torch.compiler.save_cache_artifacts())
+
+    def test_cache_hot_load_generic(self):
+        class CacheStub:
+            def __init__(self):
+                self.cache = {}
+
+            def lookup(self, key):
+                content = self.cache.get(key)
+                if content is None:
+                    return None
+
+                CacheArtifactManager.record_artifact(
+                    ArbitraryCacheArtifact.type(), key, content
+                )
+                return content
+
+            def save(self, key, content):
+                self.cache[key] = content
+                CacheArtifactManager.record_artifact(
+                    ArbitraryCacheArtifact.type(), key, content
+                )
+
+            def clear(self):
+                self.cache.clear()
+
+        cache_stub = CacheStub()
+
+        @CacheArtifactFactory.register
+        class ArbitraryCacheArtifact(CacheArtifact):
+            @override
+            def populate_cache(self) -> None:
+                cache_stub.cache[self.key] = self.content.decode()
+
+            @override
+            @staticmethod
+            def type() -> str:
+                return "test"
+
+            @override
+            @staticmethod
+            def encode(content: str) -> bytes:
+                return content.encode()
+
+        test_cache = {"1": "foo", "2": "bar", "foo": "bar"}
+
+        for k, v in test_cache.items():
+            cache_stub.save(k, v)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        artifact_bytes, cache_info = artifacts
+
+        self.assertEqual(len(cache_info.test_artifacts), 3)
+
+        cache_stub.clear()
+        CacheArtifactManager.clear()
+
+        cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
+        self.assertEqual(len(cache_info.test_artifacts), 3)
+        self.assertEqual(cache_stub.cache, test_cache)
+
+        CacheArtifactManager.clear()
+        cache_stub.lookup("foo")
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        _, cache_info = artifacts
+        self.assertEqual(len(cache_info.test_artifacts), 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @parametrize("variant", ("v1", "v2"))
+    def test_auto_functionalized_caching(self, variant):
+        if variant == "v1":
+            patch = torch._inductor.config.patch(enable_auto_functionalized_v2=False)
+        else:
+            if variant != "v2":
+                raise AssertionError(f"Expected 'v2', got {variant!r}")
+            patch = torch._inductor.config.patch(enable_auto_functionalized_v2=True)
+
+        @torch.library.custom_op("mylib::sin_inplace", mutates_args=["x"])
+        def sin_inplace(x: torch.Tensor) -> None:
+            x.sin_()
+
+        @torch.library.custom_op("mylib::cos_inplace", mutates_args=["x"])
+        def cos_inplace(x: torch.Tensor) -> None:
+            x.cos_()
+
+        @torch.compile(fullgraph=True)
+        def fn(x, op):
+            y = torch.empty_like(x)
+            op(y)
+            return y
+
+        x = torch.randn(3)
+
+        with patch:
+            # A first call should miss in the cache.
+            fn(x, sin_inplace)
+            self.reset()
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
+
+            # A second call should hit. (First reset so in-memory guards
+            # don't prevent compilation).
+            self.reset()
+            fn(x, sin_inplace)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+            # A third call with different operator should have a cache miss
+            self.reset()
+            fn(x, cos_inplace)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_generated_kernel_count(self):
+        """
+        Test that we bump the generated_kernel_count metric on a cache hit.
+        """
+        torch._logging.set_logs(inductor_metrics=True)
+
+        def fn(x, y):
+            return (x * y + y,)
+
+        a = torch.rand(5, 5)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(fn)
+
+        metrics.reset()
+        self.assertEqual(metrics.generated_kernel_count, 0)
+
+        # Verify the "miss" case.
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
+        # Verify the "hit" case
+        self.reset()
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+        self.assertEqual(metrics.generated_kernel_count, 2)
+        torch._logging.set_logs()
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_inductor_counters(self):
+        """
+        Test that we bump the inductor counters on a cache hit.
+        """
+
+        def fn(a, b):
+            return torch.mm(a, b)
+
+        a = torch.rand(8, 32, device="cpu")
+        b = torch.rand(32, 8, device="cpu")
+
+        compiled_fn = torch.compile(fn)
+
+        # Verify the "miss" case.
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        # Verify the "hit" case.
+        self.reset()
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_clear(self):
+        """
+        Test clearing the cache.
+        """
+
+        def fn(x, y):
+            return (x * y,)
+
+        a = torch.rand(5, 5)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(fn)
+
+        # A first call should miss in the cache.
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        # A second call should hit.
+        counters.clear()
+        self.reset()
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        # Clear the cache; now we should miss.
+        counters.clear()
+        self.reset()
+        torch._inductor.codecache.FxGraphCache.clear()
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_with_nt(self):
+        def gen_nt(r):
+            values = torch.randn(r, 16)
+            offsets = torch.tensor([0, 2, 3, 6, 13, r])
+            return torch.nested.nested_tensor_from_jagged(values, offsets)
+
+        def fn(nt):
+            if nt.values().size(0) % 16 == 0:
+                return nt.sin()
+            return nt.cos()
+
+        inp1 = gen_nt(19)
+        inp2 = gen_nt(20)
+
+        counters.clear()
+        torch.compile(fn)(inp1)
+        torch.compile(fn)(inp2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.reset()
+        counters.clear()
+        torch.compile(fn)(inp1)
+        torch.compile(fn)(inp2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_with_symint_non_arg_guard(self):
+        def fn(x, ref_id):
+            self_id = 22
+            if self_id == ref_id:
+                x = torch.mul(x, 1.0)
+            else:
+                x = torch.mul(x, 0)
+            return x
+
+        x = torch.ones(2)
+
+        counters.clear()
+        torch.compile(fn, fullgraph=True, dynamic=True)(x, 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.reset()
+        counters.clear()
+        torch.compile(fn, fullgraph=True, dynamic=True)(x, 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_guard(self):
+        def f(x, val):
+            if val > 5:
+                return x.sin()
+            else:
+                return x.cos()
+
+        x = torch.ones(2)
+        a = torch.compile(f, dynamic=True)(x, 6)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.reset()
+        counters.clear()
+        b = torch.compile(f, dynamic=True)(x, 4)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.assertNotEqual(a, b)
+
+    @config.patch({"fx_graph_cache": True})
+    def test_cache_guard_overspec(self):
+        b = torch.tensor([0, 2, 4, 6, 8])
+
+        @torch.compile
+        class MyModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.isin(x, b)
+
+        model = MyModel()
+
+        counters.clear()
+
+        for i in range(1, 5):
+            model(torch.arange(i))
+
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.reset()
+        counters.clear()
+
+        for i in range(1, 5):
+            model(torch.arange(i))
+
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 2)
+
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    def test_cache_guard_sqrt_no_recompilation(self):
+        """
+        Verify that guards containing OpaqueUnaryFn_sqrt (math.sqrt)
+        do not cause spurious recompilations when loaded from cache.
+
+        Previously, the guard printer emitted math.sqrt(...) for
+        OpaqueUnaryFn_sqrt, which when re-evaluated with SymInt inputs during
+        cache hit would force concretization/specialization of the symbol,
+        creating guards like `sym_float(size) == <concrete_value>` that didn't
+        exist in the original program. This caused a cache miss + recompilation
+        for every unique input size.
+
+        The fix emits torch._sym_sqrt(...) which propagates symbolically
+        without forcing specialization.
+
+        See https://github.com/pytorch/pytorch/issues/152435
+        """
+        import math
+
+        def func(x):
+            y = math.ceil((x.numel() // 5) / (math.ceil(math.sqrt(x.numel())))) > 64
+            if y:
+                return x * 5, y
+            else:
+                return x * 10, y
+
+        compiled_fn = torch.compile(func, dynamic=True)
+
+        # Warm up the cache with one size
+        compiled_fn(torch.rand(1000000))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+
+        # Simulate a new process loading from cache
+        self.reset()
+        counters.clear()
+
+        compiled_fn2 = torch.compile(func, dynamic=True)
+        # First call should hit the cache
+        compiled_fn2(torch.rand(2000000))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+
+        # Subsequent calls with different sizes should NOT recompile.
+        # Before the fix, each new size would create a spurious guard
+        # `sym_float(size) == <value>` causing a recompilation.
+        for size in [3000000, 5000000, 6000000, 7000000]:
+            compiled_fn2(torch.rand(size))
+
+        # All subsequent calls should reuse the already-loaded compiled graph
+        # without any additional cache misses or dynamo recompilations.
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+
+
+class TestFxGraphCacheDevice(TestFxGraphCacheBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipMPS
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
@@ -809,70 +1411,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
                         if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
                         else 0,
                     )
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    @config.patch({"compile_threads": 1})
-    @functorch_config.patch({"enable_autograd_cache": False})
-    def test_local_cache_stats(self):
-        from torch._inductor.remote_cache import cache_stats
-
-        cache_stats._stats.clear()
-
-        def fn(x, y):
-            return x * 2 + y
-
-        compiled_fn = torch.compile(fn)
-        a = torch.rand(25)
-        b = torch.rand(25)
-        compiled_fn(a, b)
-
-        stats = cache_stats._stats.get("LocalFxGraphCache")
-        self.assertIsNotNone(stats)
-        self.assertEqual(stats.miss, 1)
-        self.assertEqual(stats.put, 1)
-        self.assertEqual(stats.hit, 0)
-
-        self.reset()
-        compiled_fn(a, b)
-
-        self.assertEqual(stats.hit, 1)
-        cache_stats._stats.clear()
-
-    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
-    @functorch_config.patch({"enable_autograd_cache": False})
-    def test_default_dtype_affects_factory_cache_key(self):
-        old_dtype = torch.get_default_dtype()
-        FxGraphCache.clear()
-
-        def fn():
-            return (
-                torch.ones(2),
-                torch.zeros(2),
-                torch.tensor([1.0, 2.0]),
-                torch.arange(2.0),
-                torch.empty(2),
-            )
-
-        compiled_fn = torch.compile(fn, backend="inductor")
-
-        try:
-            torch.set_default_dtype(torch.float32)
-            first = compiled_fn()
-            self.assertEqual([x.dtype for x in first], [torch.float32] * 5)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-            torch.set_default_dtype(torch.float64)
-            expected = fn()
-            actual = compiled_fn()
-            self.assertEqual([x.dtype for x in actual], [x.dtype for x in expected])
-            self.assertEqual([x.dtype for x in actual], [torch.float64] * 5)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-        finally:
-            torch.set_default_dtype(old_dtype)
-            FxGraphCache.clear()
 
     @skipMPS
     @requires_triton()
@@ -1185,243 +1723,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 1)
-
-    @config.patch(
-        {
-            "fx_graph_cache": True,
-            "fx_graph_remote_cache": False,
-        }
-    )
-    def test_cache_hot_load_repeat(self):
-        def fn(x, y):
-            return x @ y.sin()
-
-        compiled_fn = torch.compile(fn, dynamic=False)
-
-        a = torch.randn(4, 4)
-        b = torch.randn(4, 4)
-
-        a2 = torch.randn(4, 8)
-        b2 = torch.randn(8, 4)
-
-        with fresh_cache():
-            eager_result = fn(a, b)
-            compiled_result = compiled_fn(a, b)
-            self.assertEqual(eager_result, compiled_result)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        artifacts = torch.compiler.save_cache_artifacts()
-
-        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
-        self.assertIsNotNone(artifacts)
-
-        artifact_bytes, cache_info = artifacts
-
-        self.reset()
-
-        with fresh_cache():
-            torch.compiler.load_cache_artifacts(artifact_bytes)
-            eager_result = fn(a, b)
-            compiled_result = compiled_fn(a, b)
-            self.assertEqual(eager_result, compiled_result)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
-
-        self.reset()
-
-        with fresh_cache():
-            eager_result = fn(a2, b2)
-            compiled_result = compiled_fn(a2, b2)
-            self.assertEqual(eager_result, compiled_result)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-        self.assertTrue(torch.compiler._cache.CacheArtifactManager.need_serialize())
-
-    @torch._dynamo.config.patch(automatic_dynamic_local_pgo=True)
-    @torch._functorch.config.patch({"enable_autograd_cache": False})
-    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
-    def test_cache_hot_load_pgo(self):
-        """
-        Verify that we can populate and hot load functions from the cache with pgo.
-        """
-
-        backend = torch._dynamo.testing.CompileCounterWithBackend("inductor")
-
-        @torch.compile(backend=backend, fullgraph=True)
-        def f(x):
-            return x * 2
-
-        # Record artifacts
-        with torch.compiler.config.patch(job_id=self.id()), fresh_cache():
-            f(torch.randn(2, 3))
-            f(torch.randn(2, 4))
-            self.assertEqual(backend.frame_count, 2)
-
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
-
-        artifacts = torch.compiler.save_cache_artifacts()
-
-        self.assertIsNotNone(artifacts)
-
-        artifact_bytes, cache_info = artifacts
-
-        self.assertEqual(len(cache_info.inductor_artifacts), 2)
-        self.assertEqual(len(cache_info.autotune_artifacts), 0)
-        self.assertEqual(len(cache_info.aot_autograd_artifacts), 0)
-        self.assertEqual(len(cache_info.pgo_artifacts), 2)
-
-        self.reset()
-        backend.clear()
-
-        # Clean triton kernels
-        shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
-
-        # Hot load and hit
-        with torch.compiler.config.patch({"job_id": self.id()}), fresh_cache():
-            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
-
-            self.assertEqual(len(cache_info.inductor_artifacts), 2)
-            self.assertEqual(len(cache_info.autotune_artifacts), 0)
-            self.assertEqual(len(cache_info.aot_autograd_artifacts), 0)
-            self.assertEqual(len(cache_info.pgo_artifacts), 2)
-
-            f(torch.randn(2, 5))
-            f(torch.randn(2, 6))
-            self.assertEqual(backend.frame_count, 1)
-
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
-
-    @torch._dynamo.config.patch(automatic_dynamic_local_pgo=True)
-    @torch._functorch.config.patch({"enable_autograd_cache": False})
-    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
-    def test_cache_hot_load_pgo_swap_file_names(self):
-        """
-        Verify that we can populate and hot load functions from the cache with pgo
-        with file name swapping
-        """
-
-        backend = torch._dynamo.testing.CompileCounterWithBackend("inductor")
-
-        @torch.compile(backend=backend, fullgraph=True)
-        def f(x):
-            return x * 2
-
-        # Record artifacts
-        with mock.patch(
-            "torch._utils_internal.get_mast_job_name_version", return_value=("foo", 5)
-        ):
-            with fresh_cache():
-                f(torch.randn(2, 3))
-                f(torch.randn(2, 4))
-                self.assertEqual(backend.frame_count, 2)
-
-            artifacts = torch.compiler.save_cache_artifacts()
-
-            self.assertIsNotNone(artifacts)
-
-        artifact_bytes, cache_info = artifacts
-
-        self.assertEqual(len(cache_info.pgo_artifacts), 2)
-
-        self.reset()
-        backend.clear()
-
-        # Clean triton kernels
-        shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
-
-        # Hot load and hit
-        with (
-            mock.patch(
-                "torch._utils_internal.get_mast_job_name_version",
-                return_value=("bar", 10),
-            ),
-            fresh_cache(),
-        ):
-            cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
-
-            self.assertEqual(len(cache_info.pgo_artifacts), 2)
-
-            f(torch.randn(2, 5))
-            f(torch.randn(2, 6))
-            self.assertEqual(backend.frame_count, 1)
-
-    def test_cache_hot_load_empty(self):
-        self.assertIsNone(torch.compiler.save_cache_artifacts())
-
-    def test_cache_hot_load_generic(self):
-        class CacheStub:
-            def __init__(self):
-                self.cache = {}
-
-            def lookup(self, key):
-                content = self.cache.get(key)
-                if content is None:
-                    return None
-
-                CacheArtifactManager.record_artifact(
-                    ArbitraryCacheArtifact.type(), key, content
-                )
-                return content
-
-            def save(self, key, content):
-                self.cache[key] = content
-                CacheArtifactManager.record_artifact(
-                    ArbitraryCacheArtifact.type(), key, content
-                )
-
-            def clear(self):
-                self.cache.clear()
-
-        cache_stub = CacheStub()
-
-        @CacheArtifactFactory.register
-        class ArbitraryCacheArtifact(CacheArtifact):
-            @override
-            def populate_cache(self) -> None:
-                cache_stub.cache[self.key] = self.content.decode()
-
-            @override
-            @staticmethod
-            def type() -> str:
-                return "test"
-
-            @override
-            @staticmethod
-            def encode(content: str) -> bytes:
-                return content.encode()
-
-        test_cache = {"1": "foo", "2": "bar", "foo": "bar"}
-
-        for k, v in test_cache.items():
-            cache_stub.save(k, v)
-
-        artifacts = torch.compiler.save_cache_artifacts()
-        self.assertIsNotNone(artifacts)
-        artifact_bytes, cache_info = artifacts
-
-        self.assertEqual(len(cache_info.test_artifacts), 3)
-
-        cache_stub.clear()
-        CacheArtifactManager.clear()
-
-        cache_info = torch.compiler.load_cache_artifacts(artifact_bytes)
-        self.assertEqual(len(cache_info.test_artifacts), 3)
-        self.assertEqual(cache_stub.cache, test_cache)
-
-        CacheArtifactManager.clear()
-        cache_stub.lookup("foo")
-        artifacts = torch.compiler.save_cache_artifacts()
-        self.assertIsNotNone(artifacts)
-        _, cache_info = artifacts
-        self.assertEqual(len(cache_info.test_artifacts), 1)
 
     @skipMPS
     @requires_triton()
@@ -1740,56 +2041,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
         # A differently-aligned input must NOT trigger a recompile.
         self.assertEqual(fn(unaligned), compiled_fn(unaligned))
         self.assertEqual(backend.frame_count, 1)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    @parametrize("variant", ("v1", "v2"))
-    def test_auto_functionalized_caching(self, variant):
-        if variant == "v1":
-            patch = torch._inductor.config.patch(enable_auto_functionalized_v2=False)
-        else:
-            if variant != "v2":
-                raise AssertionError(f"Expected 'v2', got {variant!r}")
-            patch = torch._inductor.config.patch(enable_auto_functionalized_v2=True)
-
-        @torch.library.custom_op("mylib::sin_inplace", mutates_args=["x"])
-        def sin_inplace(x: torch.Tensor) -> None:
-            x.sin_()
-
-        @torch.library.custom_op("mylib::cos_inplace", mutates_args=["x"])
-        def cos_inplace(x: torch.Tensor) -> None:
-            x.cos_()
-
-        @torch.compile(fullgraph=True)
-        def fn(x, op):
-            y = torch.empty_like(x)
-            op(y)
-            return y
-
-        x = torch.randn(3)
-
-        with patch:
-            # A first call should miss in the cache.
-            fn(x, sin_inplace)
-            self.reset()
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
-
-            # A second call should hit. (First reset so in-memory guards
-            # don't prevent compilation).
-            self.reset()
-            fn(x, sin_inplace)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
-
-            # A third call with different operator should have a cache miss
-            self.reset()
-            fn(x, cos_inplace)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
     @skipCPUIf(True, "only gpu")
     @skipMPS
@@ -2149,171 +2400,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
 
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_generated_kernel_count(self):
-        """
-        Test that we bump the generated_kernel_count metric on a cache hit.
-        """
-        torch._logging.set_logs(inductor_metrics=True)
-
-        def fn(x, y):
-            return (x * y + y,)
-
-        a = torch.rand(5, 5)
-        b = torch.rand(5, 5)
-
-        compiled_fn = torch.compile(fn)
-
-        metrics.reset()
-        self.assertEqual(metrics.generated_kernel_count, 0)
-
-        # Verify the "miss" case.
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-        self.assertEqual(metrics.generated_kernel_count, 1)
-
-        # Verify the "hit" case
-        self.reset()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-        self.assertEqual(metrics.generated_kernel_count, 2)
-        torch._logging.set_logs()
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_inductor_counters(self):
-        """
-        Test that we bump the inductor counters on a cache hit.
-        """
-
-        def fn(a, b):
-            return torch.mm(a, b)
-
-        a = torch.rand(8, 32, device="cpu")
-        b = torch.rand(32, 8, device="cpu")
-
-        compiled_fn = torch.compile(fn)
-
-        # Verify the "miss" case.
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        # Verify the "hit" case.
-        self.reset()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_clear(self):
-        """
-        Test clearing the cache.
-        """
-
-        def fn(x, y):
-            return (x * y,)
-
-        a = torch.rand(5, 5)
-        b = torch.rand(5, 5)
-
-        compiled_fn = torch.compile(fn)
-
-        # A first call should miss in the cache.
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        # A second call should hit.
-        counters.clear()
-        self.reset()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-        # Clear the cache; now we should miss.
-        counters.clear()
-        self.reset()
-        torch._inductor.codecache.FxGraphCache.clear()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_with_nt(self):
-        def gen_nt(r):
-            values = torch.randn(r, 16)
-            offsets = torch.tensor([0, 2, 3, 6, 13, r])
-            return torch.nested.nested_tensor_from_jagged(values, offsets)
-
-        def fn(nt):
-            if nt.values().size(0) % 16 == 0:
-                return nt.sin()
-            return nt.cos()
-
-        inp1 = gen_nt(19)
-        inp2 = gen_nt(20)
-
-        counters.clear()
-        torch.compile(fn)(inp1)
-        torch.compile(fn)(inp2)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        self.reset()
-        counters.clear()
-        torch.compile(fn)(inp1)
-        torch.compile(fn)(inp2)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_with_symint_non_arg_guard(self):
-        def fn(x, ref_id):
-            self_id = 22
-            if self_id == ref_id:
-                x = torch.mul(x, 1.0)
-            else:
-                x = torch.mul(x, 0)
-            return x
-
-        x = torch.ones(2)
-
-        counters.clear()
-        torch.compile(fn, fullgraph=True, dynamic=True)(x, 2)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        self.reset()
-        counters.clear()
-        torch.compile(fn, fullgraph=True, dynamic=True)(x, 2)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_guard(self):
-        def f(x, val):
-            if val > 5:
-                return x.sin()
-            else:
-                return x.cos()
-
-        x = torch.ones(2)
-        a = torch.compile(f, dynamic=True)(x, 6)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        self.reset()
-        counters.clear()
-        b = torch.compile(f, dynamic=True)(x, 4)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        self.assertNotEqual(a, b)
-
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
     @skipCPUIf(True, "only gpu")
     @skipMPS
@@ -2339,88 +2425,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
 
         self.assertEqual(counters["inductor"]["async_compile_cache_miss"], 1)
         self.assertEqual(counters["inductor"]["async_compile_cache_hit"], 1)
-
-    @config.patch({"fx_graph_cache": True})
-    def test_cache_guard_overspec(self):
-        b = torch.tensor([0, 2, 4, 6, 8])
-
-        @torch.compile
-        class MyModel(torch.nn.Module):
-            def forward(self, x):
-                return torch.isin(x, b)
-
-        model = MyModel()
-
-        counters.clear()
-
-        for i in range(1, 5):
-            model(torch.arange(i))
-
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-        self.reset()
-        counters.clear()
-
-        for i in range(1, 5):
-            model(torch.arange(i))
-
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 2)
-
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_guard_sqrt_no_recompilation(self):
-        """
-        Verify that guards containing OpaqueUnaryFn_sqrt (math.sqrt)
-        do not cause spurious recompilations when loaded from cache.
-
-        Previously, the guard printer emitted math.sqrt(...) for
-        OpaqueUnaryFn_sqrt, which when re-evaluated with SymInt inputs during
-        cache hit would force concretization/specialization of the symbol,
-        creating guards like `sym_float(size) == <concrete_value>` that didn't
-        exist in the original program. This caused a cache miss + recompilation
-        for every unique input size.
-
-        The fix emits torch._sym_sqrt(...) which propagates symbolically
-        without forcing specialization.
-
-        See https://github.com/pytorch/pytorch/issues/152435
-        """
-        import math
-
-        def func(x):
-            y = math.ceil((x.numel() // 5) / (math.ceil(math.sqrt(x.numel())))) > 64
-            if y:
-                return x * 5, y
-            else:
-                return x * 10, y
-
-        compiled_fn = torch.compile(func, dynamic=True)
-
-        # Warm up the cache with one size
-        compiled_fn(torch.rand(1000000))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-
-        # Simulate a new process loading from cache
-        self.reset()
-        counters.clear()
-
-        compiled_fn2 = torch.compile(func, dynamic=True)
-        # First call should hit the cache
-        compiled_fn2(torch.rand(2000000))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
-
-        # Subsequent calls with different sizes should NOT recompile.
-        # Before the fix, each new size would create a spurious guard
-        # `sym_float(size) == <value>` causing a recompilation.
-        for size in [3000000, 5000000, 6000000, 7000000]:
-            compiled_fn2(torch.rand(size))
-
-        # All subsequent calls should reuse the already-loaded compiled graph
-        # without any additional cache misses or dynamo recompilations.
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
 
     # For machines with mkldnn_fp16 support, weight_pack in mkldnn_fusion.py causes
     # the creation of a mkldnn format tensor which the current implementation does
@@ -2487,10 +2491,6 @@ class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
         )
 
 
-class TestFxGraphCacheDevice(TestFxGraphCacheBase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-
 class TestStandaloneCompileBase(TestCase):
     def setUp(self):
         super().setUp()
@@ -2534,72 +2534,6 @@ class TestStandaloneCompileBase(TestCase):
 @instantiate_parametrized_tests
 class TestStandaloneCompileGeneric(TestStandaloneCompileBase):
     hw_classification = HardwareClassification.GENERIC
-
-    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    @functorch_config.patch({"enable_autograd_cache": True})
-    @parametrize("format", ("binary", "unpacked"))
-    @parametrize("dynamic", (False, True))
-    @parametrize("graph_partition", (False, True))
-    @parametrize("is_aot", (False, True))
-    def test_basic(
-        self,
-        device: str,
-        format: str,
-        dynamic: bool,
-        graph_partition: bool,
-        is_aot: bool,
-    ) -> None:
-        # AOT mode does not support unpacked format
-        if is_aot and format == "unpacked":
-            raise unittest.SkipTest("AOT mode does not support unpacked format")
-
-        mod = torch.nn.Linear(1, 3, device=device)
-        x = torch.randn(4, 1, device=device)
-        if dynamic:
-            torch._dynamo.mark_dynamic(x, 0)
-
-        def f(x):
-            with torch.no_grad():
-                return mod(x), x.sin()
-
-        eager_out = f(x)
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            config.patch(graph_partition=graph_partition),
-        ):
-            path = (
-                temp_dir
-                if format == "unpacked"
-                else os.path.join(temp_dir, "compiled_artifact.bin")
-            )
-            with fresh_cache():
-                gm, args, kwargs = self.capture(f)(x)
-                if kwargs:
-                    raise AssertionError
-
-                compiled_artifact = torch._inductor.standalone_compile(
-                    gm, args, aot=is_aot
-                )
-                compiled_artifact.save(path=path, format=format)
-
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-            with fresh_cache():
-                loaded = torch._inductor.CompiledArtifact.load(path=path, format=format)
-                if dynamic:
-                    concrete_args = [
-                        4 if isinstance(a, torch.SymInt) else a for a in args
-                    ]
-                else:
-                    concrete_args = args
-                compiled_out = loaded(*concrete_args)
-                self.assertEqual(eager_out, compiled_out)
-
-            if not is_aot:
-                self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -2757,65 +2691,6 @@ class TestStandaloneCompileGeneric(TestStandaloneCompileBase):
                     mod.weight.grad, torch.ones_like(eager_out).t().matmul(x)
                 )
                 self.assertEqual(mod.bias.grad, torch.full_like(mod.bias, x.shape[0]))
-
-    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
-    @config.patch({"fx_graph_cache": True})
-    @config.patch({"fx_graph_remote_cache": False})
-    @functorch_config.patch({"enable_autograd_cache": True})
-    def test_modify_unpacked_file(self, device: str) -> None:
-        x = torch.ones(4, device=device)
-
-        def f(x):
-            with torch.no_grad():
-                return 2 * x, x.sin()
-
-        eager_out = f(x)
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with fresh_cache():
-                gm, args, kwargs = self.capture(f)(x)
-                if kwargs:
-                    raise AssertionError
-
-                compiled_artifact = torch._inductor.standalone_compile(gm, args)
-                compiled_out = compiled_artifact(*args)
-                self.assertEqual(eager_out, compiled_out)
-
-                compiled_artifact.save(path=temp_dir, format="unpacked")
-
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-
-            with fresh_cache():
-                # Now modify the output file and expect to see the changes
-                for subdir in os.listdir(temp_dir):
-                    if subdir in ["aotautograd", "fxgraph"]:
-                        continue
-                    subdir_path = os.path.join(temp_dir, subdir)
-                    for file in os.listdir(subdir_path):
-                        file_path = os.path.join(subdir_path, file)
-                        if not os.path.isfile(file_path):
-                            raise AssertionError
-                        with open(file_path) as f:
-                            file_contents = f.read()
-                        if device != "cpu":
-                            file_contents = file_contents.replace(
-                                "2.0, tl.float32", "8.0, tl.float32"
-                            )
-                        else:
-                            file_contents = file_contents.replace(
-                                "auto tmp1 = static_cast<float>(2.0);",
-                                "auto tmp1 = static_cast<float>(8.0);",
-                            )
-                        with open(file_path, "w") as f:
-                            f.write(file_contents)
-
-                loaded = torch._inductor.CompiledArtifact.load(
-                    path=temp_dir, format="unpacked"
-                )
-                compiled_out = loaded(*args)
-                self.assertEqual(4 * eager_out[0], compiled_out[0])
-
-            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
     @unittest.skipIf(IS_FBCODE, "torch import error")
     @config.patch({"fx_graph_cache": True})
@@ -3346,6 +3221,131 @@ if not torch.allclose(eager_result, compiled_result, atol=0.1, rtol=0.01):
 class TestStandaloneCompileDevice(TestStandaloneCompileBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": True})
+    @parametrize("format", ("binary", "unpacked"))
+    @parametrize("dynamic", (False, True))
+    @parametrize("graph_partition", (False, True))
+    @parametrize("is_aot", (False, True))
+    def test_basic(
+        self,
+        device: str,
+        format: str,
+        dynamic: bool,
+        graph_partition: bool,
+        is_aot: bool,
+    ) -> None:
+        # AOT mode does not support unpacked format
+        if is_aot and format == "unpacked":
+            raise unittest.SkipTest("AOT mode does not support unpacked format")
+
+        mod = torch.nn.Linear(1, 3, device=device)
+        x = torch.randn(4, 1, device=device)
+        if dynamic:
+            torch._dynamo.mark_dynamic(x, 0)
+
+        def f(x):
+            with torch.no_grad():
+                return mod(x), x.sin()
+
+        eager_out = f(x)
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            config.patch(graph_partition=graph_partition),
+        ):
+            path = (
+                temp_dir
+                if format == "unpacked"
+                else os.path.join(temp_dir, "compiled_artifact.bin")
+            )
+            with fresh_cache():
+                gm, args, kwargs = self.capture(f)(x)
+                if kwargs:
+                    raise AssertionError
+
+                compiled_artifact = torch._inductor.standalone_compile(
+                    gm, args, aot=is_aot
+                )
+                compiled_artifact.save(path=path, format=format)
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            with fresh_cache():
+                loaded = torch._inductor.CompiledArtifact.load(path=path, format=format)
+                if dynamic:
+                    concrete_args = [
+                        4 if isinstance(a, torch.SymInt) else a for a in args
+                    ]
+                else:
+                    concrete_args = args
+                compiled_out = loaded(*concrete_args)
+                self.assertEqual(eager_out, compiled_out)
+
+            if not is_aot:
+                self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_modify_unpacked_file(self, device: str) -> None:
+        x = torch.ones(4, device=device)
+
+        def f(x):
+            with torch.no_grad():
+                return 2 * x, x.sin()
+
+        eager_out = f(x)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with fresh_cache():
+                gm, args, kwargs = self.capture(f)(x)
+                if kwargs:
+                    raise AssertionError
+
+                compiled_artifact = torch._inductor.standalone_compile(gm, args)
+                compiled_out = compiled_artifact(*args)
+                self.assertEqual(eager_out, compiled_out)
+
+                compiled_artifact.save(path=temp_dir, format="unpacked")
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            with fresh_cache():
+                # Now modify the output file and expect to see the changes
+                for subdir in os.listdir(temp_dir):
+                    if subdir in ["aotautograd", "fxgraph"]:
+                        continue
+                    subdir_path = os.path.join(temp_dir, subdir)
+                    for file in os.listdir(subdir_path):
+                        file_path = os.path.join(subdir_path, file)
+                        if not os.path.isfile(file_path):
+                            raise AssertionError
+                        with open(file_path) as f:
+                            file_contents = f.read()
+                        if device != "cpu":
+                            file_contents = file_contents.replace(
+                                "2.0, tl.float32", "8.0, tl.float32"
+                            )
+                        else:
+                            file_contents = file_contents.replace(
+                                "auto tmp1 = static_cast<float>(2.0);",
+                                "auto tmp1 = static_cast<float>(8.0);",
+                            )
+                        with open(file_path, "w") as f:
+                            f.write(file_contents)
+
+                loaded = torch._inductor.CompiledArtifact.load(
+                    path=temp_dir, format="unpacked"
+                )
+                compiled_out = loaded(*args)
+                self.assertEqual(4 * eager_out[0], compiled_out[0])
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
 
 class _TestCustomPartitionerFn(CustomPartitionerFn):
     def __init__(self):
@@ -3462,91 +3462,6 @@ class TestFxGraphCacheHashingGeneric(TestFxGraphCacheHashingBase):
                 torch.set_num_threads(2)
                 key_2 = self._fx_graph_cache_key(gm, [])
                 self.assertNotEqual(key_1, key_2)
-        finally:
-            torch.set_num_threads(orig_num_threads)
-
-    def test_cpu_thread_count_ignored_for_explicit_non_cpu_factory(self, device):
-        gm = self._no_input_factory_graph(device=device)
-        orig_num_threads = torch.get_num_threads()
-
-        try:
-            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
-                torch.set_num_threads(1)
-                key_1 = self._fx_graph_cache_key(gm, [])
-                torch.set_num_threads(2)
-                key_2 = self._fx_graph_cache_key(gm, [])
-                self.assertEqual(key_1, key_2)
-        finally:
-            torch.set_num_threads(orig_num_threads)
-
-    def test_cpu_thread_count_ignores_non_device_string_on_factory(self, device):
-        graph = torch.fx.Graph()
-        result = graph.call_function(
-            torch.empty,
-            ((4,),),
-            {
-                "dtype": torch.float32,
-                "device": torch.device(device),
-                "debug_device": "cpu",
-            },
-        )
-        graph.output(result)
-        gm = torch.fx.GraphModule({}, graph)
-
-        orig_num_threads = torch.get_num_threads()
-        try:
-            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
-                torch.set_num_threads(1)
-                key_1 = self._fx_graph_cache_key(gm, [])
-                torch.set_num_threads(2)
-                key_2 = self._fx_graph_cache_key(gm, [])
-                self.assertEqual(key_1, key_2)
-        finally:
-            torch.set_num_threads(orig_num_threads)
-
-    def test_cpu_thread_count_ignored_for_cuda_like_factory(self, device):
-        graph = torch.fx.Graph()
-        x = graph.placeholder("x")
-        result = graph.call_function(torch.empty_like, (x,), {})
-        graph.output(result)
-        gm = torch.fx.GraphModule({}, graph)
-
-        with torch._subclasses.FakeTensorMode():
-            example_input = torch.empty(4, device=device)
-
-        orig_num_threads = torch.get_num_threads()
-        try:
-            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
-                torch.set_num_threads(1)
-                key_1 = self._fx_graph_cache_key(gm, [example_input])
-                torch.set_num_threads(2)
-                key_2 = self._fx_graph_cache_key(gm, [example_input])
-                self.assertEqual(key_1, key_2)
-        finally:
-            torch.set_num_threads(orig_num_threads)
-
-    def test_cpu_thread_count_ignored_for_cuda_metadata_device_constructor(
-        self, device
-    ):
-        graph = torch.fx.Graph()
-        x = graph.placeholder("x")
-        result = graph.call_function(torch.as_tensor, (x,), {})
-        graph.output(result)
-        gm = torch.fx.GraphModule({}, graph)
-
-        with torch._subclasses.FakeTensorMode():
-            example_input = torch.empty(4, device=device)
-        x.meta["val"] = example_input
-        result.meta["example_value"] = example_input
-
-        orig_num_threads = torch.get_num_threads()
-        try:
-            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
-                torch.set_num_threads(1)
-                key_1 = self._fx_graph_cache_key(gm, [example_input])
-                torch.set_num_threads(2)
-                key_2 = self._fx_graph_cache_key(gm, [example_input])
-                self.assertEqual(key_1, key_2)
         finally:
             torch.set_num_threads(orig_num_threads)
 
@@ -4653,6 +4568,91 @@ class TestFxGraphCacheHashingGeneric(TestFxGraphCacheHashingBase):
 class TestFxGraphCacheHashingDevice(TestFxGraphCacheHashingBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    def test_cpu_thread_count_ignored_for_explicit_non_cpu_factory(self, device):
+        gm = self._no_input_factory_graph(device=device)
+        orig_num_threads = torch.get_num_threads()
+
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
+    def test_cpu_thread_count_ignores_non_device_string_on_factory(self, device):
+        graph = torch.fx.Graph()
+        result = graph.call_function(
+            torch.empty,
+            ((4,),),
+            {
+                "dtype": torch.float32,
+                "device": torch.device(device),
+                "debug_device": "cpu",
+            },
+        )
+        graph.output(result)
+        gm = torch.fx.GraphModule({}, graph)
+
+        orig_num_threads = torch.get_num_threads()
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
+    def test_cpu_thread_count_ignored_for_cuda_like_factory(self, device):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        result = graph.call_function(torch.empty_like, (x,), {})
+        graph.output(result)
+        gm = torch.fx.GraphModule({}, graph)
+
+        with torch._subclasses.FakeTensorMode():
+            example_input = torch.empty(4, device=device)
+
+        orig_num_threads = torch.get_num_threads()
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [example_input])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [example_input])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
+    def test_cpu_thread_count_ignored_for_cuda_metadata_device_constructor(
+        self, device
+    ):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        result = graph.call_function(torch.as_tensor, (x,), {})
+        graph.output(result)
+        gm = torch.fx.GraphModule({}, graph)
+
+        with torch._subclasses.FakeTensorMode():
+            example_input = torch.empty(4, device=device)
+        x.meta["val"] = example_input
+        result.meta["example_value"] = example_input
+
+        orig_num_threads = torch.get_num_threads()
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [example_input])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [example_input])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
 
 class TestCudaCompileCommand(TestCase):
     hw_classification = HardwareClassification.CUDA
@@ -4885,6 +4885,10 @@ class TestAutotuneCacheGeneric(TestAutotuneCacheBase):
         self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
         self.assertIsNone(graph._compile_context)
 
+
+class TestAutotuneCacheDevice(TestAutotuneCacheBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @requires_triton()
     @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @skipXPU
@@ -5096,10 +5100,6 @@ class TestAutotuneCacheGeneric(TestAutotuneCacheBase):
                 self.assertEqual(get_autotune_stats(), Stats(2, 0, 2))
 
                 self.assertEqual(res1, res2)
-
-
-class TestAutotuneCacheDevice(TestAutotuneCacheBase):
-    hw_classification = HardwareClassification.ACCELERATOR
 
 
 class TestRemoteAOTAutogradCache(TestCase):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -72,32 +72,31 @@ from torch.compiler._cache import (
     CacheInfo,
 )
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
-from torch.testing._internal.common_cuda import (
-    SM80OrLater,
-    TEST_MULTIGPU,
-    with_tf32_off,
+from torch.testing._internal.common_cuda import SM80OrLater, with_tf32_off
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    largeTensorTest,
+    skipCPUIf,
+    skipCUDAIf,
+    skipIf,
+    skipMPS,
+    skipXPU,
 )
-from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_FBCODE,
     IS_SANDCASTLE,
     parametrize,
+    TEST_ACCELERATOR,
+    TEST_PRIVATEUSE1,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU,
     HAS_MULTIGPU,
     HAS_TRITON,
-    HAS_XPU_AND_TRITON,
     patch_inductor_backend,
-    requires_gpu,
     requires_triton,
-)
-from torch.testing._internal.triton_utils import (
-    requires_cuda_and_triton,
-    requires_gpu_and_triton,
 )
 from torch.testing._internal.two_tensor import TwoTensor
 
@@ -117,10 +116,13 @@ torch._dynamo.config.fake_tensor_cache_enabled = True
 torch._dynamo.config.fake_tensor_cache_crosscheck_enabled = True
 
 
+TEST_MULTIGPU = TEST_ACCELERATOR and torch.accelerator.device_count() >= 2
 STATIC_LAUNCHER_DEVICES = ("cuda", "xpu")
 
 
 class TestCacheKeyStrategy(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _compact_sha256(self, data: bytes) -> str:
         return (
             base64.b32encode(hashlib.sha256(data).digest())[:51].decode("utf-8").lower()
@@ -246,6 +248,8 @@ class TestCacheKeyStrategy(TestCase):
 
 
 class TestTorchKeyCache(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_prefetch(self):
         import threading
 
@@ -346,6 +350,8 @@ _custom_empty.__name__ = "empty"
 
 
 class TestPyCodeCache(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_linemaps_empty(self):
         src = """import torch"""
         (key, path) = PyCodeCache.write(src, "")
@@ -505,10 +511,7 @@ class TestPyCodeCache(TestCase):
         self.assertIn("Py_NewRef(Py_None)", generated_source)
 
 
-@instantiate_parametrized_tests
-class TestFxGraphCache(TestCase):
-    device_type = GPU_TYPE
-
+class TestFxGraphCacheBase(TestCase):
     def setUp(self):
         super().setUp()
         counters.clear()
@@ -530,6 +533,11 @@ class TestFxGraphCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
+
+
+@instantiate_parametrized_tests
+class TestFxGraphCacheGeneric(TestFxGraphCacheBase):
+    hw_classification = HardwareClassification.GENERIC
 
     def _check_cpu_thread_count_cache_key_no_input(self, return_expr):
         script = textwrap.dedent(
@@ -594,11 +602,11 @@ class TestFxGraphCache(TestCase):
             "torch.randperm(1 << 12, dtype=torch.float32).log()"
         )
 
+    @skipMPS
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"compile_threads": 1})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("dynamic", (False, True))
     @parametrize("bundle_triton", (False, True))
@@ -610,17 +618,15 @@ class TestFxGraphCache(TestCase):
         """
         Verify that we can populate and load functions from the cache.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
         ):
             raise unittest.SkipTest("requires SM80 or later")
         if use_static_triton_launcher and not (
-            device in STATIC_LAUNCHER_DEVICES and bundle_triton
+            (device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1) and bundle_triton
         ):
             raise unittest.SkipTest(
                 "Static triton launcher requires cuda/xpu and triton bundling"
@@ -691,7 +697,9 @@ class TestFxGraphCache(TestCase):
                 if use_static_triton_launcher:
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_save_static_autotuner"],
-                        grad_multiplier if device in STATIC_LAUNCHER_DEVICES else 0,
+                        grad_multiplier
+                        if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
+                        else 0,
                     )
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_load_static_autotuner"], 0
@@ -739,11 +747,15 @@ class TestFxGraphCache(TestCase):
                 if use_static_triton_launcher:
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_save_static_autotuner"],
-                        grad_multiplier if device in STATIC_LAUNCHER_DEVICES else 0,
+                        grad_multiplier
+                        if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
+                        else 0,
                     )
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_load_static_autotuner"],
-                        grad_multiplier if device in STATIC_LAUNCHER_DEVICES else 0,
+                        grad_multiplier
+                        if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
+                        else 0,
                     )
 
             self.reset()
@@ -787,11 +799,15 @@ class TestFxGraphCache(TestCase):
                 if use_static_triton_launcher:
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_save_static_autotuner"],
-                        grad_multiplier * 2 if device in STATIC_LAUNCHER_DEVICES else 0,
+                        grad_multiplier * 2
+                        if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
+                        else 0,
                     )
                     self.assertEqual(
                         counters["inductor"]["triton_bundler_load_static_autotuner"],
-                        grad_multiplier if device in STATIC_LAUNCHER_DEVICES else 0,
+                        grad_multiplier
+                        if device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1
+                        else 0,
                     )
 
     @config.patch({"fx_graph_cache": True})
@@ -858,9 +874,9 @@ class TestFxGraphCache(TestCase):
             torch.set_default_dtype(old_dtype)
             FxGraphCache.clear()
 
+    @skipMPS
     @requires_triton()
     @config.patch({"fx_graph_remote_cache": True})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("dynamic", (False, True))
     @parametrize("bundle_triton", (False, True))
@@ -873,17 +889,15 @@ class TestFxGraphCache(TestCase):
     ):
         from unittest.mock import patch
 
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
         ):
             raise unittest.SkipTest("requires SM80 or later")
         if use_static_triton_launcher and not (
-            device in STATIC_LAUNCHER_DEVICES and bundle_triton
+            (device in STATIC_LAUNCHER_DEVICES or TEST_PRIVATEUSE1) and bundle_triton
         ):
             raise unittest.SkipTest(
                 "Static cuda launcher requires cuda and triton bundling"
@@ -929,6 +943,7 @@ class TestFxGraphCache(TestCase):
         for k in global_stats.fx_graph.cache:
             self.assertRegex(k, r"pt2:fx-graph-v1::[0-9a-z]{52}:c[0-9]+")
 
+    @skipMPS
     @requires_triton()
     @config.patch(
         {
@@ -937,7 +952,6 @@ class TestFxGraphCache(TestCase):
             "autotune_local_cache": True,
         }
     )
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("dynamic", (False, True))
     @torch._functorch.config.patch({"enable_autograd_cache": False})
@@ -945,10 +959,8 @@ class TestFxGraphCache(TestCase):
         """
         Verify that we can populate and hot load functions from the cache.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
@@ -979,7 +991,7 @@ class TestFxGraphCache(TestCase):
 
         artifact_bytes, cache_info = artifacts
 
-        autotune_expect = 1 if device == GPU_TYPE else 0
+        autotune_expect = 0 if device == "cpu" else 1
 
         self.assertEqual(len(cache_info.inductor_artifacts), 1)
         self.assertEqual(len(cache_info.autotune_artifacts), autotune_expect)
@@ -1021,6 +1033,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
+    @skipMPS
     @requires_triton()
     @config.patch(
         {
@@ -1035,17 +1048,14 @@ class TestFxGraphCache(TestCase):
         }
     )
     @parametrize("dynamic", (False, True))
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     def test_cache_hot_load_caching_precompile(self, device, dtype, dynamic):
         """
         Verify that we can populate and hot load functions from the cache.
         """
 
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
@@ -1078,7 +1088,7 @@ class TestFxGraphCache(TestCase):
 
         artifact_bytes, cache_info = artifacts
 
-        autotune_expect = 2 if device == GPU_TYPE else 0
+        autotune_expect = 0 if device == "cpu" else 2
         self.assertEqual(len(cache_info.inductor_artifacts), 2)
         self.assertEqual(len(cache_info.autotune_artifacts), autotune_expect)
         self.assertEqual(len(cache_info.aot_autograd_artifacts), 1)
@@ -1129,7 +1139,10 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_miss"], 2)
             self.assertEqual(counters["dynamo_cache"]["dynamo_cache_hit"], 1)
 
-    @requires_cuda_and_triton
+    @skipCPUIf(True, "only gpu")
+    @skipMPS
+    @skipXPU
+    @requires_triton()
     @config.patch(
         {
             "fx_graph_cache": True,
@@ -1141,15 +1154,15 @@ class TestFxGraphCache(TestCase):
             "caching_precompile": True,
         }
     )
-    def test_cache_hot_load_caching_precompile_autocast(self):
+    def test_cache_hot_load_caching_precompile_autocast(self, device):
         def fn(x):
             return x + 1 * x
 
-        x = torch.randn(3, 2, device="cuda")
+        x = torch.randn(3, 2, device=device)
 
         with fresh_cache():
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=torch.device(device).type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1167,7 +1180,7 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(len(cache_info.precompile_artifacts), 1)
 
             compiled_fn = torch.compile(fn)
-            with torch.amp.autocast(device_type="cuda"):
+            with torch.amp.autocast(device_type=torch.device(device).type):
                 eager_result = fn(x)
                 compiled_result = compiled_fn(x)
             self.assertEqual(eager_result, compiled_result)
@@ -1410,18 +1423,16 @@ class TestFxGraphCache(TestCase):
         _, cache_info = artifacts
         self.assertEqual(len(cache_info.test_artifacts), 1)
 
+    @skipMPS
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.float64))
     @parametrize("dynamic", (False, True))
     def test_cache_load_model(self, device, dtype, dynamic):
         """
         Verify that we can populate and load models from the cache.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
 
         def fn(mod, x):
             mod.zero_grad()
@@ -1450,20 +1461,20 @@ class TestFxGraphCache(TestCase):
         # And the results should be the same.
         self.assertEqual(grads1, grads2)
 
-    @largeTensorTest("64GB", device=GPU_TYPE, inductor=True)
+    @skipCPUIf(True, "only gpu")
+    @skipMPS
+    @requires_triton()
+    @largeTensorTest("64GB", inductor=True)
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    @parametrize("device", (GPU_TYPE,))
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_cache_load_with_guards_int32_bounds(self, device, dtype):
         """
         Test caching the same graph, but under conditions that introduce guards
         for tensor sizes < int32.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
@@ -1505,19 +1516,18 @@ class TestFxGraphCache(TestCase):
 
             self.assertEqual(res1, res2)
 
+    @skipMPS
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     def test_cache_load_with_guards_static_bounds(self, device, dtype):
         """
         Test caching the same graph, but under conditions that introduce guards
         for static bounds.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
         if (
-            device == "cuda"
+            "cuda" in device
             and torch.version.hip is None
             and dtype == torch.bfloat16
             and not SM80OrLater
@@ -1554,12 +1564,14 @@ class TestFxGraphCache(TestCase):
 
             self.assertEqual(res1, res2)
 
+    @skipMPS
+    @skipXPU
     @config.patch("fx_graph_cache", True)
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
-    def test_no_arguments_tensor_device_guards(self):
+    @requires_triton()
+    def test_no_arguments_tensor_device_guards(self, device):
         """
         Usually, when there are example inputs, the device index of the inputs
         is sufficient to make sure we don't cache hit with the results from different
@@ -1570,26 +1582,29 @@ class TestFxGraphCache(TestCase):
 
         @torch.compile
         def f():
-            y = torch.randn(3, device="cuda")
+            y = torch.randn(3, device=device)
             return (y,)
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        device = torch.device(device).type
+        with torch.accelerator.device_index(0):
+            torch.accelerator.set_device_index(0)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:0"))
+            self.assertEqual(result[0].device, torch.device(f"{device}:0"))
         self.reset()
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        with torch.accelerator.device_index(1):
+            torch.accelerator.set_device_index(1)
             result = f()
-            self.assertEqual(result[0].device, torch.device("cuda:1"))
+            self.assertEqual(result[0].device, torch.device(f"{device}:1"))
 
+    @skipMPS
+    @skipXPU
     @config.patch("fx_graph_cache", True)
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @config.patch("fx_graph_remote_cache", False)
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
-    @requires_cuda_and_triton
-    def test_tensor_device_guards_cpu_tensor(self):
+    @requires_triton()
+    def test_tensor_device_guards_cpu_tensor(self, device):
         """
         CPU tensor arguments should still cache hit
         """
@@ -1598,29 +1613,28 @@ class TestFxGraphCache(TestCase):
         def f(x):
             return x.sin()
 
-        with torch.cuda._DeviceGuard(0):
-            torch.cuda.set_device(0)
+        with torch.accelerator.device_index(0):
+            torch.accelerator.set_device_index(0)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
         self.reset()
         # Should not cache hit with device guard
-        with torch.cuda._DeviceGuard(1):
-            torch.cuda.set_device(1)
+        with torch.accelerator.device_index(1):
+            torch.accelerator.set_device_index(1)
             result = f(torch.randn(3, device="cpu"))
             self.assertEqual(result.device, torch.device("cpu"))
 
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
+    @skipMPS
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     def test_constant_handling(self, device):
         """
         Test that different constants are recognized correctly.
         """
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
 
         def fn1(x):
             return x + torch.tensor(list(range(12)), device=device)
@@ -1643,10 +1657,11 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    def test_cache_hit_aligned_and_unaligned_inputs(self):
+    def test_cache_hit_aligned_and_unaligned_inputs(self, device):
         """
         A function compiled with an aligned GPU input should share a cache
         entry with the same function called with an unaligned GPU input.
@@ -1660,7 +1675,6 @@ class TestFxGraphCache(TestCase):
         aligned). The cached graph therefore services both alignments --
         whichever variant compiled first realigns the other at runtime.
         """
-        device = GPU_TYPE
 
         def fn(x):
             return torch.nn.functional.relu(x) * 2
@@ -1695,10 +1709,11 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 2)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    def test_aligned_unaligned_inputs_no_recompile(self):
+    def test_aligned_unaligned_inputs_no_recompile(self, device):
         """
         Alignment is deliberately not guarded (storage_offset guards cause
         recompiles), so calling a compiled function in-process with an aligned
@@ -1706,7 +1721,6 @@ class TestFxGraphCache(TestCase):
         without recompiling. The unaligned input is realigned at runtime via
         copy_if_misaligned.
         """
-        device = GPU_TYPE
 
         def fn(x):
             return torch.nn.functional.relu(x) * 2
@@ -1777,11 +1791,13 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
-    @requires_gpu_and_triton
+    @skipCPUIf(True, "only gpu")
+    @skipMPS
+    @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @with_tf32_off
-    def test_flex_attention_caching(self):
+    def test_flex_attention_caching(self, device):
         from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 
         block_mask = create_block_mask(
@@ -1800,7 +1816,7 @@ class TestFxGraphCache(TestCase):
         def fn2(q, k, v):
             return flex_attention(q, k, v, score_mod=score_mod2, block_mask=block_mask)
 
-        a, b, c = (torch.randn(1, 4, 512, 64).to(GPU_TYPE) for _ in range(3))
+        a, b, c = (torch.randn(1, 4, 512, 64).to(device) for _ in range(3))
         compiled_fn = torch.compile(fn)
         compiled_fn2 = torch.compile(fn2)
 
@@ -1827,12 +1843,12 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
         self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @parametrize("bundle_triton", (False, True))
-    def test_higher_order_op_bypass(self, bundle_triton):
+    def test_higher_order_op_bypass(self, device, bundle_triton):
         """
         Verify that we bypass the cache when we have a higher order ops
         and that bundler start/end works with a cache bypass.
@@ -1852,18 +1868,18 @@ class TestFxGraphCache(TestCase):
         ):
             compiled_fn = torch.compile(fn, dynamic=True, fullgraph=True)
 
-            x = torch.randn(4, 4, device=GPU_TYPE)
+            x = torch.randn(4, 4, device=device)
             compiled_fn(x)
 
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
             self.assertGreater(counters["inductor"]["fxgraph_cache_bypass"], 0)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
-    def test_graphsafe_rng_cache_hit(self):
+    def test_graphsafe_rng_cache_hit(self, device):
         """graphsafe_run_with_rng_state must not bypass FxGraphCache.
 
         Activation checkpointing with preserve_rng_state=True inserts
@@ -1880,9 +1896,9 @@ class TestFxGraphCache(TestCase):
                 return F.scaled_dot_product_attention(q, k, v, dropout_p=0.1)
 
         inner = SDPADrop()
-        q = torch.randn(2, 4, 16, 16, device=GPU_TYPE, requires_grad=True)
-        k = torch.randn(2, 4, 16, 16, device=GPU_TYPE)
-        v = torch.randn(2, 4, 16, 16, device=GPU_TYPE)
+        q = torch.randn(2, 4, 16, 16, device=device, requires_grad=True)
+        k = torch.randn(2, 4, 16, 16, device=device)
+        v = torch.randn(2, 4, 16, 16, device=device)
 
         def model(q, k, v):
             return checkpoint(
@@ -1923,12 +1939,12 @@ class TestFxGraphCache(TestCase):
         out3 = torch.compile(model, fullgraph=True)(q, k, v).sum()
         self.assertFalse(torch.allclose(out1, out3))
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @parametrize("bundle_triton", (False, True))
-    def test_triton_higher_order_op(self, bundle_triton):
+    def test_triton_higher_order_op(self, device, bundle_triton):
         """
         Verify that we can cache user defined triton kernel higher order op
         """
@@ -1953,8 +1969,8 @@ class TestFxGraphCache(TestCase):
             compiled_fn = torch.compile(fn, fullgraph=True)
             compiled_fn2 = torch.compile(fn2, fullgraph=True)
 
-            x = torch.randn(4, device=GPU_TYPE)
-            y = torch.randn(4, device=GPU_TYPE)
+            x = torch.randn(4, device=device)
+            y = torch.randn(4, device=device)
 
             compiled_fn(x, y)
 
@@ -1990,12 +2006,12 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @parametrize("bundle_triton", (False, True))
-    def test_triton_higher_order_op_different_configs(self, bundle_triton):
+    def test_triton_higher_order_op_different_configs(self, device, bundle_triton):
         """
         Verify that user defined triton kernel with
         different configs are cached separately.
@@ -2037,8 +2053,8 @@ class TestFxGraphCache(TestCase):
             compiled_fn = torch.compile(fn, fullgraph=True)
             compiled_fn2 = torch.compile(fn2, fullgraph=True)
 
-            x = torch.randn(4, device=GPU_TYPE)
-            y = torch.randn(4, device=GPU_TYPE)
+            x = torch.randn(4, device=device)
+            y = torch.randn(4, device=device)
 
             compiled_fn(x, y)
 
@@ -2074,14 +2090,14 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
 
-    @requires_gpu()
+    @skipCPUIf(True, "only gpu")
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"compile_threads": 1})
     @parametrize("bundle_triton", (False, True))
     @parametrize("use_static_triton_launcher", (False, True))
-    def test_triton_op(self, bundle_triton, use_static_triton_launcher):
+    def test_triton_op(self, device, bundle_triton, use_static_triton_launcher):
         if use_static_triton_launcher and TEST_WITH_ROCM:
             raise unittest.SkipTest("Static cuda launcher doesn't work with ROCM")
 
@@ -2110,8 +2126,8 @@ class TestFxGraphCache(TestCase):
         ):
             compiled_fn = torch.compile(f, fullgraph=True)
 
-            x = torch.randn(4, device=GPU_TYPE)
-            y = torch.randn(4, device=GPU_TYPE)
+            x = torch.randn(4, device=device)
+            y = torch.randn(4, device=device)
 
             compiled_fn(x, y)
 
@@ -2299,9 +2315,12 @@ class TestFxGraphCache(TestCase):
         self.assertNotEqual(a, b)
 
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
-    @requires_cuda_and_triton
+    @skipCPUIf(True, "only gpu")
+    @skipMPS
+    @skipXPU
+    @requires_triton()
     @unittest.expectedFailure  # TODO: pass in optimize_mem at runtime
-    def test_async_compile_cache(self):
+    def test_async_compile_cache(self, device):
         class SimpleFunction(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x):
@@ -2311,7 +2330,7 @@ class TestFxGraphCache(TestCase):
             def backward(ctx, grad_output):
                 return grad_output * 2
 
-        x = torch.rand([10], requires_grad=True, device="cuda")
+        x = torch.rand([10], requires_grad=True, device=device)
         counters.clear()
 
         sf = SimpleFunction
@@ -2403,25 +2422,21 @@ class TestFxGraphCache(TestCase):
         # without any additional cache misses or dynamo recompilations.
         self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
 
+    # For machines with mkldnn_fp16 support, weight_pack in mkldnn_fusion.py causes
+    # the creation of a mkldnn format tensor which the current implementation does
+    # not support.
+    @skipCPUIf(
+        torch.backends.mkldnn.is_available()
+        and torch.ops.mkldnn._is_mkldnn_fp16_supported(),
+        "mkldnn tensors unsupported",
+    )
+    @skipMPS
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"freezing": True})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("inlinable", (True, False))
     def test_freezing(self, device, inlinable):
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
-
-        # For machines with mkldnn_fp16 support, weight_pack in mkldnn_fusion.py causes
-        # the creation of a mkldnn format tensor which the current implementation does
-        # not support.
-        if (
-            device == "cpu"
-            and torch.backends.mkldnn.is_available()
-            and torch.ops.mkldnn._is_mkldnn_fp16_supported()
-        ):
-            raise unittest.SkipTest("mkldnn tensors unsupported")
-
         # The shape of the frozen constant determines if it will be inlined.
         shape = (4,) if inlinable else (8, 8)
 
@@ -2472,8 +2487,11 @@ class TestFxGraphCache(TestCase):
         )
 
 
-@instantiate_parametrized_tests
-class TestStandaloneCompile(TestCase):
+class TestFxGraphCacheDevice(TestFxGraphCacheBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+
+class TestStandaloneCompileBase(TestCase):
     def setUp(self):
         super().setUp()
         counters.clear()
@@ -2512,10 +2530,15 @@ class TestStandaloneCompile(TestCase):
 
         return inner
 
+
+@instantiate_parametrized_tests
+class TestStandaloneCompileGeneric(TestStandaloneCompileBase):
+    hw_classification = HardwareClassification.GENERIC
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @functorch_config.patch({"enable_autograd_cache": True})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("format", ("binary", "unpacked"))
     @parametrize("dynamic", (False, True))
     @parametrize("graph_partition", (False, True))
@@ -2528,9 +2551,6 @@ class TestStandaloneCompile(TestCase):
         graph_partition: bool,
         is_aot: bool,
     ) -> None:
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
-
         # AOT mode does not support unpacked format
         if is_aot and format == "unpacked":
             raise unittest.SkipTest("AOT mode does not support unpacked format")
@@ -2738,14 +2758,11 @@ class TestStandaloneCompile(TestCase):
                 )
                 self.assertEqual(mod.bias.grad, torch.full_like(mod.bias, x.shape[0]))
 
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @functorch_config.patch({"enable_autograd_cache": True})
-    @parametrize("device", (GPU_TYPE, "cpu"))
     def test_modify_unpacked_file(self, device: str) -> None:
-        if device == GPU_TYPE and not HAS_GPU:
-            raise unittest.SkipTest(f"requires {GPU_TYPE}")
-
         x = torch.ones(4, device=device)
 
         def f(x):
@@ -2780,13 +2797,11 @@ class TestStandaloneCompile(TestCase):
                             raise AssertionError
                         with open(file_path) as f:
                             file_contents = f.read()
-                        if device == GPU_TYPE:
+                        if device != "cpu":
                             file_contents = file_contents.replace(
                                 "2.0, tl.float32", "8.0, tl.float32"
                             )
                         else:
-                            if device != "cpu":
-                                raise AssertionError(f"Expected 'cpu', got {device!r}")
                             file_contents = file_contents.replace(
                                 "auto tmp1 = static_cast<float>(2.0);",
                                 "auto tmp1 = static_cast<float>(8.0);",
@@ -3328,6 +3343,10 @@ if not torch.allclose(eager_result, compiled_result, atol=0.1, rtol=0.01):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
 
+class TestStandaloneCompileDevice(TestStandaloneCompileBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+
 class _TestCustomPartitionerFn(CustomPartitionerFn):
     def __init__(self):
         self._uuid = None
@@ -3341,7 +3360,7 @@ class _TestCustomPartitionerFn(CustomPartitionerFn):
         return self._uuid
 
 
-class TestFxGraphCacheHashing(TestCase):
+class TestFxGraphCacheHashingBase(TestCase):
     def _fx_graph_cache_key(self, gm, example_inputs):
         details = FxGraphHashDetails(gm, example_inputs, cast(Any, {}), [])
         return FxGraphCachePickler(gm).get_key(details)
@@ -3354,6 +3373,10 @@ class TestFxGraphCacheHashing(TestCase):
         result = graph.call_function(torch.empty, ((4,),), kwargs)
         graph.output(result)
         return torch.fx.GraphModule({}, graph)
+
+
+class TestFxGraphCacheHashingGeneric(TestFxGraphCacheHashingBase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_cpu_thread_count_affects_cache_key(self):
         def fn(x):
@@ -3442,8 +3465,8 @@ class TestFxGraphCacheHashing(TestCase):
         finally:
             torch.set_num_threads(orig_num_threads)
 
-    def test_cpu_thread_count_ignored_for_explicit_non_cpu_factory(self):
-        gm = self._no_input_factory_graph(device="cuda")
+    def test_cpu_thread_count_ignored_for_explicit_non_cpu_factory(self, device):
+        gm = self._no_input_factory_graph(device=device)
         orig_num_threads = torch.get_num_threads()
 
         try:
@@ -3456,14 +3479,14 @@ class TestFxGraphCacheHashing(TestCase):
         finally:
             torch.set_num_threads(orig_num_threads)
 
-    def test_cpu_thread_count_ignores_non_device_string_on_factory(self):
+    def test_cpu_thread_count_ignores_non_device_string_on_factory(self, device):
         graph = torch.fx.Graph()
         result = graph.call_function(
             torch.empty,
             ((4,),),
             {
                 "dtype": torch.float32,
-                "device": torch.device("cuda"),
+                "device": torch.device(device),
                 "debug_device": "cpu",
             },
         )
@@ -3481,7 +3504,7 @@ class TestFxGraphCacheHashing(TestCase):
         finally:
             torch.set_num_threads(orig_num_threads)
 
-    def test_cpu_thread_count_ignored_for_cuda_like_factory(self):
+    def test_cpu_thread_count_ignored_for_cuda_like_factory(self, device):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         result = graph.call_function(torch.empty_like, (x,), {})
@@ -3489,7 +3512,7 @@ class TestFxGraphCacheHashing(TestCase):
         gm = torch.fx.GraphModule({}, graph)
 
         with torch._subclasses.FakeTensorMode():
-            example_input = torch.empty(4, device="cuda")
+            example_input = torch.empty(4, device=device)
 
         orig_num_threads = torch.get_num_threads()
         try:
@@ -3502,7 +3525,9 @@ class TestFxGraphCacheHashing(TestCase):
         finally:
             torch.set_num_threads(orig_num_threads)
 
-    def test_cpu_thread_count_ignored_for_cuda_metadata_device_constructor(self):
+    def test_cpu_thread_count_ignored_for_cuda_metadata_device_constructor(
+        self, device
+    ):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         result = graph.call_function(torch.as_tensor, (x,), {})
@@ -3510,7 +3535,7 @@ class TestFxGraphCacheHashing(TestCase):
         gm = torch.fx.GraphModule({}, graph)
 
         with torch._subclasses.FakeTensorMode():
-            example_input = torch.empty(4, device="cuda")
+            example_input = torch.empty(4, device=device)
         x.meta["val"] = example_input
         result.meta["example_value"] = example_input
 
@@ -3854,13 +3879,14 @@ class TestFxGraphCacheHashing(TestCase):
             )
 
             if HAS_MULTIGPU:
+                device = getattr(torch.accelerator.current_accelerator(), "type", None)
                 self.assertEqual(
-                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
-                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{device}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{device}:1")),
                 )
                 self.assertNotEqual(
-                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:0")),
-                    pickler.dumps(torch.randn(3, device=f"{GPU_TYPE}:1")),
+                    pickler.dumps(torch.randn(3, device=f"{device}:0")),
+                    pickler.dumps(torch.randn(3, device=f"{device}:1")),
                 )
 
     def test_hash_kwargs(self):
@@ -4624,9 +4650,15 @@ class TestFxGraphCacheHashing(TestCase):
             pickler.dumps(TotallyOpaque())
 
 
+class TestFxGraphCacheHashingDevice(TestFxGraphCacheHashingBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+
 class TestCudaCompileCommand(TestCase):
-    @requires_cuda_and_triton
-    def test_cuda_compile_command(self):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_triton()
+    def test_cuda_compile_command(self, device):
         cmd_no_extra_args: str = cuda_compile_command(
             ["abc.cu", "def.cu"], "output", "so"
         )
@@ -4665,10 +4697,7 @@ class TestCudaCompileCommand(TestCase):
                 raise AssertionError(cmd_parts)
 
 
-@instantiate_parametrized_tests
-class TestAutotuneCache(TestCase):
-    device_type = GPU_TYPE
-
+class TestAutotuneCacheBase(TestCase):
     def setUp(self):
         super().setUp()
         counters.clear()
@@ -4683,6 +4712,10 @@ class TestAutotuneCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
+
+
+class TestAutotuneCacheGeneric(TestAutotuneCacheBase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_remote_only_autotune_records_cache_artifacts(self):
         from torch._inductor.runtime.autotune_cache import AutotuneCache
@@ -4852,8 +4885,9 @@ class TestAutotuneCache(TestCase):
         self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
         self.assertIsNone(graph._compile_context)
 
-    @requires_cuda_and_triton
-    @unittest.skipIf(not SM80OrLater, "Requires SM80+")
+    @requires_triton()
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
+    @skipXPU
     @config.patch({"use_static_triton_launcher": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -4864,7 +4898,7 @@ class TestAutotuneCache(TestCase):
     @config.patch(
         {"compile_threads": 1}
     )  # Worker processes do not register PatchCaches() properly
-    def test_autotune_cache_warm_start(self):
+    def test_autotune_cache_warm_start(self, device):
         class Model(torch.nn.Module):
             def forward(self, x, y, a, b):
                 return x + y, a + b
@@ -4872,10 +4906,10 @@ class TestAutotuneCache(TestCase):
         def f(x, y, a, b):
             return Model()(x, y, a, b)
 
-        x = torch.randn(100, 100).cuda()
-        y = torch.randn(100, 100).cuda()
-        a = torch.randn(1000, 100).cuda()
-        b = torch.randn(1000, 100).cuda()
+        x = torch.randn(100, 100, device=device)
+        y = torch.randn(100, 100, device=device)
+        a = torch.randn(1000, 100, device=device)
+        b = torch.randn(1000, 100, device=device)
         f_compiled = torch.compile(f, fullgraph=True)
 
         with PatchCaches():
@@ -4900,8 +4934,8 @@ class TestAutotuneCache(TestCase):
         for k in global_stats.triton.cache:
             self.assertRegex(k, r"triton:[0-9a-f]{64}::[0-9a-f]{64}:c[0-9]+")
 
-    @requires_gpu_and_triton
-    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
+    @requires_triton()
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"autotune_local_cache": False})
@@ -4911,7 +4945,7 @@ class TestAutotuneCache(TestCase):
     @config.patch(
         {"compile_threads": 1}
     )  # Worker processes do not register PatchCaches() properly
-    def test_autotune_cache(self):
+    def test_autotune_cache(self, device):
         class Model(torch.nn.Module):
             def forward(self, x, y, a, b):
                 return x + y, a + b
@@ -4919,10 +4953,10 @@ class TestAutotuneCache(TestCase):
         def f(x, y, a, b):
             return Model()(x, y, a, b)
 
-        x = torch.randn(100, 100).to(GPU_TYPE)
-        y = torch.randn(100, 100).to(GPU_TYPE)
-        a = torch.randn(1000, 100).to(GPU_TYPE)
-        b = torch.randn(1000, 100).to(GPU_TYPE)
+        x = torch.randn(100, 100).to(device)
+        y = torch.randn(100, 100).to(device)
+        a = torch.randn(1000, 100).to(device)
+        b = torch.randn(1000, 100).to(device)
         f_compiled = torch.compile(f, fullgraph=True)
 
         with PatchCaches():
@@ -4941,8 +4975,8 @@ class TestAutotuneCache(TestCase):
         for k in global_stats.triton.cache:
             self.assertRegex(k, r"triton:[0-9a-f]{64}::[0-9a-f]{64}:c[0-9]+")
 
-    @requires_gpu_and_triton
-    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
+    @requires_triton()
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"autotune_local_cache": True})
@@ -4950,7 +4984,7 @@ class TestAutotuneCache(TestCase):
     @config.patch({"bundled_autotune_remote_cache": True})
     @config.patch({"compile_threads": 1})
     @config.patch({"max_autotune": True})
-    def test_bundled_autotune_remote_cache(self):
+    def test_bundled_autotune_remote_cache(self, device):
         class Model(torch.nn.Module):
             def forward(self, a, b, c, d, e, f):
                 return a + b, c + d, e + f
@@ -4960,12 +4994,12 @@ class TestAutotuneCache(TestCase):
 
         f_compiled = torch.compile(f, fullgraph=True)
 
-        a = torch.randn(101, 100).to(GPU_TYPE)
-        b = torch.randn(101, 100).to(GPU_TYPE)
-        c = torch.randn(102, 100).to(GPU_TYPE)
-        d = torch.randn(102, 100).to(GPU_TYPE)
-        e = torch.randn(103, 100).to(GPU_TYPE)
-        f = torch.randn(103, 100).to(GPU_TYPE)
+        a = torch.randn(101, 100).to(device)
+        b = torch.randn(101, 100).to(device)
+        c = torch.randn(102, 100).to(device)
+        d = torch.randn(102, 100).to(device)
+        e = torch.randn(103, 100).to(device)
+        f = torch.randn(103, 100).to(device)
 
         with PatchCaches():
             f_compiled(a, b, c, d, e, f)
@@ -5002,8 +5036,7 @@ class TestAutotuneCache(TestCase):
             self.assertRegex(k, r"triton:[0-9a-f]{64}::[0-9a-f]{64}:c[0-9]+")
 
     @requires_triton()
-    @requires_gpu_and_triton
-    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
     @config.patch({"fx_graph_remote_cache": False})
     @config.patch({"bundled_autotune_remote_cache": False})
@@ -5012,7 +5045,7 @@ class TestAutotuneCache(TestCase):
         {"compile_threads": 1}
     )  # Worker processes do not register PatchCaches() properly
     @parametrize("remote_cache", (True, False))
-    def test_modified_autotune_cache(self, remote_cache):
+    def test_modified_autotune_cache(self, device, remote_cache):
         """
         If a developer changes the way the autotune cache is handled,
         there's a chance it'll break the cache. This happened with
@@ -5031,8 +5064,8 @@ class TestAutotuneCache(TestCase):
         def fn(x, y):
             return (x + y).relu()
 
-        x = torch.randn(100, 100).to(GPU_TYPE)
-        y = torch.randn(100, 100).to(GPU_TYPE)
+        x = torch.randn(100, 100).to(device)
+        y = torch.randn(100, 100).to(device)
 
         with config.patch(
             {
@@ -5065,20 +5098,26 @@ class TestAutotuneCache(TestCase):
                 self.assertEqual(res1, res2)
 
 
+class TestAutotuneCacheDevice(TestAutotuneCacheBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+
 class TestRemoteAOTAutogradCache(TestCase):
-    @requires_gpu()
-    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_triton()
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
     @config.patch({"fx_graph_remote_cache": True})
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @torch._functorch.config.patch({"enable_remote_autograd_cache": True})
-    def test_autograd_remote_cache(self):
+    def test_autograd_remote_cache(self, device):
         def f(a, b):
             return a + b
 
         f_compiled = torch.compile(f)
-        a = torch.randn(101, 100, device=GPU_TYPE, requires_grad=False)
-        b = torch.randn(101, 100, device=GPU_TYPE, requires_grad=False)
+        a = torch.randn(101, 100, device=device, requires_grad=False)
+        b = torch.randn(101, 100, device=device, requires_grad=False)
         with PatchCaches():
             f_compiled(a, b)
 
@@ -5105,13 +5144,13 @@ class TestRemoteAOTAutogradCache(TestCase):
         for k in global_stats.fx_graph.cache:
             self.assertRegex(k, r"pt2:fx-graph-v1::[0-9a-z]{52}:c[0-9]+")
 
-    @requires_gpu_and_triton
-    @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
+    @requires_triton()
+    @skipCUDAIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
     @config.patch({"fx_graph_remote_cache": True})
     @torch._functorch.config.patch({"enable_autograd_cache": False})
     @torch._functorch.config.patch({"enable_remote_autograd_cache": True})
-    def test_autograd_remote_lazy_backward(self):
+    def test_autograd_remote_lazy_backward(self, device):
         """
         Lazily compile the backward, and lazily save to cache
         """
@@ -5155,7 +5194,9 @@ class TestRemoteAOTAutogradCache(TestCase):
             self.assertEqual(b.grad, b2.grad)
 
 
-class TestUtils(TestCase):
+class TestUtilsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @config.patch({"fx_graph_remote_cache": False})
     def test_fresh_cache(self):
         def fn(x, y):
@@ -5178,20 +5219,24 @@ class TestUtils(TestCase):
         self.assertEqual(res1, res2)
         self.assertNotEqual(cache_dir1, cache_dir2)
 
+
+class TestUtilsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # This combination of settings exposed a bug where we cleared the
     # PyCodeCache disk artifacts while they were still needed:
-    @requires_gpu_and_triton
+    @requires_triton()
     @config.patch(
         {
             "coordinate_descent_tuning": True,
             "force_disable_caches": True,
         }
     )
-    def test_force_disable_coordinate_descent(self):
+    def test_force_disable_coordinate_descent(self, device):
         def fn():
-            inp = torch.randn(32, 50, 768, device=GPU_TYPE)
-            weight = torch.randn(768, 768, device=GPU_TYPE)
-            layer = torch.nn.LayerNorm(768, device=GPU_TYPE)
+            inp = torch.randn(32, 50, 768, device=device)
+            weight = torch.randn(768, 768, device=device)
+            layer = torch.nn.LayerNorm(768, device=device)
             return layer(inp @ weight)
 
         torch.compile(fn)()
@@ -5211,7 +5256,9 @@ class TestVecISACheckBuild(TestCase):
     # CppTorchOptions construction is brittle to host compiler probes
     # when handed an off-arch VecISA like VecAVX2 on aarch64/macOS-arm64).
 
-    def test_probe_load_returns_false_on_timeout(self):
+    hw_classification = HardwareClassification.CPU
+
+    def test_probe_load_returns_false_on_timeout(self, device):
         from torch._inductor import cpu_vec_isa
 
         calls: list[Any] = []
@@ -5240,7 +5287,7 @@ class TestVecISACheckBuild(TestCase):
             msg=lambda msg: f"{msg}\nexpected timeout warning, got: {[str(w.message) for w in caught]}",
         )
 
-    def test_probe_load_returns_false_on_called_process_error(self):
+    def test_probe_load_returns_false_on_called_process_error(self, device):
         from torch._inductor import cpu_vec_isa
 
         def fake_run(*args, **kwargs):
@@ -5259,7 +5306,7 @@ class TestVecISACheckBuild(TestCase):
 
         self.assertFalse(result)
 
-    def test_build_probe_env_prepends_torch_lib_dir_to_loader_path(self):
+    def test_build_probe_env_prepends_torch_lib_dir_to_loader_path(self, device):
         from torch._inductor import cpu_vec_isa
 
         env = cpu_vec_isa.VecISA._build_probe_env()
@@ -5273,7 +5320,7 @@ class TestVecISACheckBuild(TestCase):
         )
 
     @unittest.skipUnless(sys.platform == "linux", "Linux loader semantics")
-    def test_avx_py_load_falls_back_to_import_torch(self):
+    def test_avx_py_load_falls_back_to_import_torch(self, device):
         # Wheels whose native deps only resolve once `import torch` has run
         # (e.g. ROCm wheels with DT_NEEDED refs on sonames that exist only as
         # already-loaded renamed bundles, see #189194) fail the cold dlopen,
@@ -5326,6 +5373,8 @@ class TestVecISACheckBuild(TestCase):
 
 
 class TestCompilationEventLogging(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def reset(self):
         DynamoCache.clear()
         PrecompileContext.clear()
@@ -5524,6 +5573,8 @@ class TestAutotuneCacheExtraOptions(TestCase):
     extra_options is correctly preserved when saving and loading from cache.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     @requires_triton()
     def test_load_cached_autotuning_preserves_extra_options_with_coordesc(self):
         """
@@ -5705,6 +5756,25 @@ class TestAutotuneCacheExtraOptions(TestCase):
         saved_data = mock_local_backend.put.call_args[0][1]
         self.assertNotIn("extra_options", saved_data)
 
+
+instantiate_device_type_tests(
+    TestFxGraphCacheDevice, globals(), allow_xpu=True, allow_mps=True
+)
+instantiate_device_type_tests(TestStandaloneCompileDevice, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestFxGraphCacheHashingDevice, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(TestCudaCompileCommand, globals(), only_for="cuda")
+instantiate_device_type_tests(
+    TestAutotuneCacheDevice, globals(), allow_xpu=True, except_for="cpu"
+)
+instantiate_device_type_tests(
+    TestRemoteAOTAutogradCache, globals(), allow_xpu=True, except_for="cpu"
+)
+instantiate_device_type_tests(
+    TestUtilsDevice, globals(), allow_xpu=True, except_for="cpu"
+)
+instantiate_device_type_tests(TestVecISACheckBuild, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests, hardware classify and instantiate device-specific test classes.

## Changes
- Uses `torch.accelerator.is_available()` to detect the available accelerator type.
- Replace hardcoded `device="cuda"` and `.cuda()` with device parameter.
- Replace hardcoded CUDA references with device-agnostic `torch.accelerator` APIs or equivalents.
- Add `privateuseone` to accelerator test cases just with `cuda`.
- Add `skipPRIVATEUSE1` to skip `CUDA-specific` test cases.
- Split tests class into generic class and device-specific class.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `HardwareClassification.GENERIC|ACCELERATOR|CPU|CUDA|XXX` to tests class.

## Motivation
`torch.cuda` and `torch.xpu` only recognizes CUDA and XPU. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_codecache.py --hw-classification GENERIC ACCELERATOR CUDA CPU`
- Verified test cases correctly on CPU, GPU, XPU and MPS.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo