### PR TITLE
[Testcase Refactoring] Label test_fsdp_freezing_weights ACCELERATOR and switch to device-type instantiation

### DIFF
--- a/test/distributed/fsdp/test_fsdp_freezing_weights.py
+++ b/test/distributed/fsdp/test_fsdp_freezing_weights.py
@@ -10,10 +10,14 @@ import torch.optim as optim
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.nn.parallel import DistributedDataParallel
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_full_params
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -30,8 +34,6 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 class Model(nn.Module):
@@ -118,6 +120,8 @@ class FreezingMethod(str, Enum):
 
 
 class TestFreezingWeights(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _create_model(
         self,
         with_fsdp,
@@ -144,8 +148,10 @@ class TestFreezingWeights(FSDPTest):
         with_fsdp,
         disable_autograd,
         forward_prefetch,
+        device,
     ):
         torch.manual_seed(0)
+        device_type = torch.device(device).type
         batch = torch.randn(size=(2, 3, 224, 224)).to(device_type)
 
         fsdp_kwargs = {
@@ -199,6 +205,7 @@ class TestFreezingWeights(FSDPTest):
         return list(model.parameters())
 
     @skip_if_lt_x_gpu(2)
+    @onlyAccelerator
     @parametrize("with_nested_trunk", [True, False])
     @parametrize(
         "freezing_method", [FreezingMethod.RequiresGrad, FreezingMethod.GradToNone]
@@ -208,6 +215,7 @@ class TestFreezingWeights(FSDPTest):
     @parametrize("forward_prefetch", [True, False])
     def test_freezing_weights(
         self,
+        device,
         with_nested_trunk,
         freezing_method,
         freeze_after_wrap_fsdp,
@@ -222,6 +230,7 @@ class TestFreezingWeights(FSDPTest):
             with_fsdp=False,
             disable_autograd=disable_autograd,
             forward_prefetch=False,  # does not apply to DDP
+            device=device,
         )
 
         # FSDP
@@ -232,6 +241,7 @@ class TestFreezingWeights(FSDPTest):
             with_fsdp=True,
             disable_autograd=disable_autograd,
             forward_prefetch=forward_prefetch,
+            device=device,
         )
 
         self.assertEqual(
@@ -246,7 +256,7 @@ class TestFreezingWeights(FSDPTest):
                 self.assertEqual(ddp_param.requires_grad, fsdp_param.requires_grad)
 
 
-instantiate_parametrized_tests(TestFreezingWeights)
+instantiate_device_type_tests(TestFreezingWeights, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Label `TestFreezingWeights` as `ACCELERATOR`, switch it from `@instantiate_parametrized_tests` to `instantiate_device_type_tests` (no `except_for`), skip the CPU variant explicitly with `@onlyAccelerator`, and migrate the test call chain from the module-level `device_type` constant to the injected `device` parameter using the type-only form for tensor creation and model placement.

## Changes

- **`test/distributed/fsdp/test_fsdp_freezing_weights.py`**:
  - Add `hw_classification = HardwareClassification.ACCELERATOR` and import `HardwareClassification`.
  - Switch from `@instantiate_parametrized_tests` to `instantiate_device_type_tests(TestFreezingWeights, globals(), allow_xpu=True)` so the class is instantiated as a device-type test, generating per-accelerator variants (including PrivateUse1 out-of-tree backends). No `except_for`: on machines without an accelerator the only generatable variant is CPU, and excluding it would silently drop the class from collection (0 tests collected, exit code 0); with the bare call the CPU variant is collected and skipped explicitly by the existing device-count guards (review feedback).
  - Decorate `test_freezing_weights` with `@onlyAccelerator` (variant-level: raises `SkipTest` when `self.device_type` is cpu/meta). Without it, on machines with >= 2 accelerators `@skip_if_lt_x_gpu(2)` (a global device-count check) would let the CPU variant through, and the test would fail deterministically in the DDP branch — `DistributedDataParallel` with a CPU module and non-empty `device_ids=[self.rank]` raises `ValueError` unconditionally.
  - Migrate `test_freezing_weights` and `_dist_train` from the module-level `device_type = acc.type if (acc := ...) else "cpu"` constant to the injected `device` parameter. Delete the module-level `device_type` constant.
  - In `_dist_train`, derive `device_type = torch.device(device).type` (type-only, index stripped) and use it for `batch.to`, `model.to`, and `target.to`. The pre-existing `device_id=self.rank` / `device_ids=[self.rank]` (int rank) are kept unchanged from main.

## Motivation

`TestFreezingWeights` runs FSDP/DDP device-tensor paths guarded by `@skip_if_lt_x_gpu(2)` and is not CPU-runnable, so `ACCELERATOR` is the correct classification; the original `@instantiate_parametrized_tests` did not generate per-device variants, a classification/mechanism mismatch. The bare `instantiate_device_type_tests` call keeps the class collectable on machines without an accelerator (the CPU variant is reported as skipped rather than the class disappearing from collection), while `@onlyAccelerator` keeps the CPU variant from actually running on accelerator machines where the global `@skip_if_lt_x_gpu(2)` check would let it through. The `device` parameter migration is required because `instantiate_device_type_tests` generates per-device variants whose `cls.device_type` differs, and a module-level constant cannot follow. The type-only form (`torch.device(device).type`) is required for tensor creation and model placement because the injected `device` is an indexed string (e.g. `"cuda:0"`); passing it bare forces all ranks onto device 0 and produces numerical mismatches from the FSDP auto-move path, while the type-only form lets each rank use its current device.

## Test Plan

- Verified end-to-end on an 8-device accelerator backend (with the `common_fsdp.py` accelerator branch from #187650 applied):

```bash
python test/distributed/fsdp/test_fsdp_freezing_weights.py
```

- Result: `Ran 64 tests ... OK (skipped=32)` — 32 parametrized combinations x cpu/accelerator variants; the 32 CPU variants are skipped by `@onlyAccelerator`, the 32 accelerator variants pass.
- `lintrunner` reports no lint issues.

## Notes

- `skip_if_lt_x_gpu` device decoupling (letting that helper recognize out-of-tree accelerators) is tracked by pytorch/pytorch#187650 — an independent framework-level change to `common_distributed.py`, orthogonal to this PR. This PR keeps `@skip_if_lt_x_gpu(2)` unchanged.
- For FSDP tests using the `FSDPTest` base class to truly run on an out-of-tree accelerator (rather than falling back to a CPU/gloo path), the `common_fsdp.py` device/backend selection also needs the accelerator branch that #187650 adds. That is a framework-level change tracked by #187650, separate from this PR.
- This is part of the test case refactoring initiative tracked in #185590.
