### PR TITLE
[Testcase Refactoring] Migrate test_max_autotune to instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -117,6 +117,7 @@ from torch.testing._internal.inductor_utils import (
     get_func_call,
     get_kernel_launch,
     HAS_CUDA_AND_TRITON,
+    IS_BIG_GPU,
 )
 
 
@@ -254,7 +255,6 @@ class TestMaxAutotune(TestCase):
                     "max_autotune should include all pointwise configs from max_autotune_pointwise",
                 )
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -337,7 +337,6 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     def test_use_triton_tma_template_rejects_descriptor_shapes_exceeding_int32(
         self, device
     ):
@@ -415,7 +414,7 @@ class TestMaxAutotune(TestCase):
                 guard_or_false.assert_called_once_with(condition)
                 statically_known_true.assert_not_called()
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -466,7 +465,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -521,7 +520,6 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -666,7 +664,6 @@ class TestMaxAutotune(TestCase):
         for size in ws_sizes:
             self.assertEqual(size, expected_bytes)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -735,7 +732,6 @@ class TestMaxAutotune(TestCase):
             check_str = "triton.language.make_tensor_descriptor"
         FileCheck().check("triton_tem_fused_mm").check(check_str).run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -769,7 +765,6 @@ class TestMaxAutotune(TestCase):
         # given the config flags above, we should have no choices left.
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -845,7 +840,6 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -958,7 +952,6 @@ class TestMaxAutotune(TestCase):
 
             self.assertEqual((100,), extern_bias_shape)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -1045,7 +1038,6 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -1589,7 +1581,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
@@ -1609,7 +1601,7 @@ class TestMaxAutotune(TestCase):
         act = f(x1, y1, x2, y2)
         torch.testing.assert_close(act, ref, atol=1e-1, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="",
@@ -1624,7 +1616,7 @@ class TestMaxAutotune(TestCase):
             torch.compile(lambda a, b: a.matmul(b))(a, b)
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.triton.native_matmul, "Only test when template is being called"
     )
@@ -1650,7 +1642,7 @@ class TestMaxAutotune(TestCase):
                 torch.compile(lambda a, b: a.matmul(b))(a, b)
             self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(force_shape_pad=True, max_autotune=True)
     def test_linear_and_cel(self, device):
         """
@@ -1732,7 +1724,7 @@ class TestMaxAutotune(TestCase):
                     rtol=1e-4,
                 )
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1799,7 +1791,7 @@ class TestMaxAutotune(TestCase):
                     code[1]
                 )
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -2050,7 +2042,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_mm").run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
+    @unittest.skipIf(not IS_BIG_GPU, "Requires big GPU with triton")
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
@@ -2164,7 +2156,6 @@ class TestMaxAutotune(TestCase):
             FileCheck().check("triton_tem_fused_bmm").run(code[0])
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     def test_triton_template_generated_code_cache_key(self, device):
         generate_and_load_args = len(
             inspect.signature(
@@ -2182,7 +2173,7 @@ class TestMaxAutotune(TestCase):
         self.assertEqual(generate_and_load_args - 1, make_key_args)
         self.assertEqual(generate_and_load_args, 21)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @fresh_cache()
     @config.patch(
         {
@@ -2211,7 +2202,7 @@ class TestMaxAutotune(TestCase):
             ):
                 torch.compile(func_test1, dynamic=False)(a, b, a, b)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -2403,7 +2394,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 0)
             self.assertEqual(misses(), 7)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -2440,7 +2431,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -2559,7 +2550,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(aliased, torch.bmm(x, x), atol=0.1, rtol=0.05)
             self.assertEqual(distinct, torch.bmm(a, b), atol=0.1, rtol=0.05)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @fresh_cache()
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -2609,7 +2600,7 @@ class TestMaxAutotune(TestCase):
                     self.assertTrue(decompose_count > 0)
                     self.assertTrue(decompose_count <= num_decompose_k_splits)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul takes different tuning configs",
@@ -2675,7 +2666,7 @@ class TestMaxAutotune(TestCase):
             out, code = run_and_get_code(compiled_f, a, b)
             torch.testing.assert_close(out, mm(a, b), atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("op", ("mm", "addmm", "bmm", "baddbmm", "mm_plus_mm"))
     @parametrize("max_autotune", (False, True))
     @config.patch(
@@ -2850,7 +2841,7 @@ class TestMaxAutotune(TestCase):
             _, code_out = run_and_get_code(c_f, *args)
             FileCheck().check(output_code_padding_check).run(code_out[0])
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("k", (15, 16))
     @parametrize("dynamic", (False, True))
     def test_even_k(self, device, k: int, dynamic: bool):
@@ -2922,7 +2913,7 @@ class TestMaxAutotune(TestCase):
             # should force fallback to extern_kernels.bmm
             FileCheck().check_not("triton_tem").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("always_freeze", [True, False])
     def test_mm_layout_freezing_behavior(self, device, always_freeze):
         """Test that mm layout freezing behavior depends on always_freeze_layout.
@@ -3125,7 +3116,7 @@ class TestMaxAutotune(TestCase):
             _, code = run_and_get_code(compiled_fn, a, b, c, idx0, idx1, value)
             FileCheck().check("triton_tem_fused").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/182093")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
@@ -3225,7 +3216,7 @@ class TestMaxAutotune(TestCase):
         else:
             self.assertEqual(out, out_unfused)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
     def test_triton_gemm_no_epilogue_no_truncation_casts(
@@ -3741,6 +3732,7 @@ class TestMaxAutotuneCuda(TestCase):
             torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
 
 
+@unittest.skipIf(not IS_BIG_GPU, "Requires big GPU for shared memory pruning")
 class TestTemplateConfigPruning(TestCase):
     """Test class for pruning logic in GEMM autotuning."""
 
@@ -3911,7 +3903,7 @@ class TestTemplateConfigPruning(TestCase):
             shared_memory_checker_opts,
         )
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @skipIfXpu(msg="Missing device_properties shared_memory_per_block on xpu.")
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("mat1_transposed", (False, True))
@@ -4121,7 +4113,7 @@ class TestMaxAutotunePrecompile(TestCase):
         fn_c = torch.compile(mode="max-autotune-no-cudagraphs")(fn)
         self.assertEqual(counters["inductor"]["select_algorithm_precompile"], 0)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(autotune_local_cache=False, autotune_remote_cache=False)
     @unittest.skipIf(config.triton.native_matmul, "native matmul has counter 0")
     def test_precompilations(self, device):
@@ -4323,7 +4315,7 @@ class TestMaxAutotuneSubproc(TestCase):
             ),
         )
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     def test_triton_template_with_epilogues_and_dynamic_shape(self, device):
         def fn(
             x: torch.Tensor, w: torch.Tensor, bias: torch.Tensor, mul: torch.Tensor
@@ -4378,7 +4370,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
         super().tearDown()
         PatchCaches.tearDown()
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     @config.patch(
         {"compile_threads": 1, "prologue_fusion": False}
@@ -4517,7 +4509,6 @@ class TestTuningProcessPool(TestCase):
             expected_dir,
         )
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_cache_env_resets(self, device):
         with mock.patch.dict(os.environ, {}, clear=False):
@@ -4543,7 +4534,6 @@ class TestTuningProcessPool(TestCase):
             finally:
                 tuning_pool.shutdown()
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_cache_env_clears_codecache(self, device):
         with (
@@ -4624,7 +4614,6 @@ class TestTuningProcessPool(TestCase):
             finally:
                 autotune_pool._shutdown()
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_crash(self, device):
         tuning_pool = TuningProcessPool()
@@ -4648,7 +4637,6 @@ class TestTuningProcessPool(TestCase):
 
         tuning_pool.shutdown()
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_timeout(self, device):
         tuning_pool = TuningProcessPool()
@@ -4673,7 +4661,6 @@ class TestTuningProcessPool(TestCase):
 
         tuning_pool.shutdown()
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": True})
     def test_tuning_pool_multiple_devices(self, device):
         # Adapt the test to the available devices (and whether the backend-specific
@@ -4972,7 +4959,7 @@ class TestPrologueFusion(TestCase):
         # should not be done in low precision, two kernels
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -4990,7 +4977,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("sizes", ((64, 128, 256), (64, 64, 64), (64, 120, 64)))
     @parametrize("use_async_compile", (True, False))
     @unittest.skipIf(
@@ -5118,7 +5105,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, out_eager, atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     def test_storage_offset_prologue(self, device):
         def foo(a):
             q = a[:64, :]
@@ -5130,7 +5117,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(inp), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=1)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
@@ -5182,7 +5169,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -5214,7 +5201,7 @@ class TestPrologueFusion(TestCase):
                 f = FileCheck().check("k_idx").check("a =").check_not("tl.where")
             f.check("tl.dot").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("benchmark_fusion", (True, False))
     @parametrize("use_async_compile", (True, False))
@@ -5244,7 +5231,7 @@ class TestPrologueFusion(TestCase):
                     code[0], num_kernels=2, num_allocs=None, num_deallocs=None
                 )
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @config.patch(allow_buffer_reuse=False)
     @unittest.skipIf(
@@ -5267,7 +5254,7 @@ class TestPrologueFusion(TestCase):
         # not sure why disabling buffer reuse doesn't stop
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @skipIfXpu
     @config.patch(
         {
@@ -5350,7 +5337,7 @@ class TestPrologueFusion(TestCase):
             "to_copy_add_div_mm_mul_relu_sub_tanh_1"
         ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(shape_padding=True)
     @config.patch(force_shape_pad=True)
     @parametrize("sizes", ((250, 245, 128), (250, 256, 128), (256, 128, 62)))
@@ -5543,7 +5530,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         finally:
             mm_heuristic.mm_configs = original_mm_configs
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support in Triton")
     @skipIfXpu(msg="Bad tma config can be covered by XPU TMA")
     @unittest.skipIf(
@@ -5649,7 +5635,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 tma_heuristic.mm_configs = original_tma_mm_configs
                 mm_heuristic.mm_configs = original_mm_mm_configs
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179695")
     @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
@@ -5724,7 +5709,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
@@ -5781,7 +5765,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused_add_mul"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179694")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176115")
     @requires_capabilities(Capability.lib.triton)
@@ -5848,7 +5831,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176114")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176113")
     @requires_capabilities(Capability.lib.triton)
@@ -5915,7 +5897,6 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @requires_capabilities(Capability.lib.triton)
     @parametrize("use_async_compile", (True, False))
     def test_epilogue_prologue_fusion_cache_preserved(
@@ -6142,7 +6123,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         cache_entries_after_second = len(AsyncAutotuner.choice_hash_to_future)
         self.assertEqual(cache_entries_after_second, 0)
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(max_autotune_gemm=True)
     def test_triton_error_precompilation_and_autotuning(self, device):
         """

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -5985,10 +5985,10 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
     def setUp(self):
         super().setUp()
         AutotuneProcessPool._shutdown_for_inactivity = False
-        test_name = self._testMethodName
-        for skip_test_name in self.SKIP_TESTS:
-            if skip_test_name in test_name or TEST_XPU or config.cpp_wrapper:
-                self.skipTest(self.SKIP_TESTS[skip_test_name])
+        if TEST_XPU or config.cpp_wrapper:
+            self.skipTest(
+                "Async pipelined autotuning not supported on XPU or with cpp_wrapper"
+            )
 
     def tearDown(self):
         super().tearDown()
@@ -6171,11 +6171,14 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
             test_aten_chosen()
 
 
-# Copy parent test methods into child __dict__ (must be before instantiate calls)
+# Copy parent test methods into child __dict__ (must be before instantiate calls).
+# Methods listed in SKIP_TESTS are excluded; they are incompatible with async pipelining.
+_async_pipelined_skip = frozenset(TestMaxAutotuneAsyncPipelined.SKIP_TESTS)
 for _base in (TestMaxAutotune, TestEpilogueFusionStaticAnalysis):
     for _name, _fn in _base.__dict__.items():
         if (
             _name.startswith("test")
+            and _name not in _async_pipelined_skip
             and _name not in TestMaxAutotuneAsyncPipelined.__dict__
         ):
             setattr(TestMaxAutotuneAsyncPipelined, _name, _fn)

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -117,6 +117,7 @@ from torch.testing._internal.inductor_utils import (
     get_func_call,
     get_kernel_launch,
     HAS_CUDA_AND_TRITON,
+    HAS_TRITON,
     IS_BIG_GPU,
 )
 
@@ -166,12 +167,24 @@ class FailChoiceCaller(ChoiceCaller):
         raise RuntimeError("This choice caller will always throw")
 
 
-@unittest.mock.patch(
-    "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
-)
-@config.patch(enable_caching_generated_triton_templates=True)
 class TestMaxAutotune(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        self._config_ctx = config.patch(enable_caching_generated_triton_templates=True)
+        self._config_ctx.__enter__()
+        self._test_cache_patcher = unittest.mock.patch(
+            "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
+        )
+        self._test_cache_patcher.start()
+
+    def tearDown(self):
+        if hasattr(self, "_test_cache_patcher"):
+            self._test_cache_patcher.stop()
+        if hasattr(self, "_config_ctx"):
+            self._config_ctx.__exit__(None, None, None)
+        super().tearDown()
 
     def _make_matrices(self, M, K, N, *batch_dims, dtype, device, requires_grad):
         make_matrix = functools.partial(
@@ -184,7 +197,7 @@ class TestMaxAutotune(TestCase):
         b = make_matrix(K, N, *batch_dims, reduction_dim=-2)
         return a, b
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_max_autotune_mm_plus_mm_zero_size_input(
@@ -414,7 +427,7 @@ class TestMaxAutotune(TestCase):
                 guard_or_false.assert_called_once_with(condition)
                 statically_known_true.assert_not_called()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -465,7 +478,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -879,7 +892,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_zero_size_input(self, device, dynamic: bool):
         """
@@ -896,7 +909,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @fresh_cache()
     def test_addmm_1d_bias_no_reinterpret_tensor(self, device):
         """
@@ -1110,7 +1123,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm_zero_size_input(self, device, dynamic):
         """
@@ -1126,7 +1139,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(addmm, dynamic=dynamic)(x, a, b)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm_unrealized_view_bias(self, device, dynamic):
         """
@@ -1143,7 +1156,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(fn, dynamic=dynamic)(x, a, b)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_autotune_conv1x1(self, device, search_space):
         # Assuming input has 3 channels and we want to produce 16 channels as output
@@ -1203,7 +1216,7 @@ class TestMaxAutotune(TestCase):
         )
         torch._export.aot_compile(fn, args=inputs)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_cat_addmm(self, device):
         def fn(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):
             return torch.cat(
@@ -1229,7 +1242,7 @@ class TestMaxAutotune(TestCase):
             actual = torch.compile(fn)(*args)
             torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         benchmark_kernel=True,
         fallback_random=True,
@@ -1263,7 +1276,7 @@ class TestMaxAutotune(TestCase):
             print(f"ref\n{ref}\nact\n{act}")
         torch.testing.assert_close(ref, act, atol=1e-1, rtol=1e-1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         max_autotune_gemm=True,
     )
@@ -1281,7 +1294,7 @@ class TestMaxAutotune(TestCase):
         ref = f(x, y)
         self.assertTrue(torch.allclose(act, ref, atol=4 * 1e-3, rtol=4 * 1e-3))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179777")
     @config.patch(max_autotune=True)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
@@ -1309,7 +1322,7 @@ class TestMaxAutotune(TestCase):
             act = opt_f(x, weight)
             self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(max_autotune_gemm_backends="TRITON")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_baddmm(self, device, search_space):
@@ -1339,7 +1352,7 @@ class TestMaxAutotune(TestCase):
             if not config.triton.native_matmul:
                 FileCheck().check("triton_tem_fused_baddbmm").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(max_autotune=True)
     def test_conv1x1_with_free_symbols(self, device):
         """
@@ -1410,7 +1423,7 @@ class TestMaxAutotune(TestCase):
         f_c = torch.compile(mode="max-autotune-no-cudagraphs")(f)
         self.assertEqual(f_c(*inps), f(*inps), atol=0.03, rtol=0.25)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch("trace.enabled", True)
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     @config.patch("triton.native_matmul", False)
@@ -1477,7 +1490,7 @@ class TestMaxAutotune(TestCase):
     def test_cat_max_autotune_triton(self, device):
         self._test_cat_max_autotune_impl(device, using_triton_mm=True)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_conv_cat(self, device, search_space):
         class ToyModel(torch.nn.Module):
@@ -1504,7 +1517,7 @@ class TestMaxAutotune(TestCase):
                 if not TEST_WITH_ROCM:
                     FileCheck().check("def triton_poi_fused_add_cat_").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_conv3d(self, device, search_space):
         fn = torch.nn.functional.conv3d
@@ -1518,7 +1531,7 @@ class TestMaxAutotune(TestCase):
             actual = torch.compile(fn)(image, filt)
             torch.testing.assert_close(actual, expected, atol=6e-5, rtol=0.001)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         max_autotune=True, max_autotune_conv_backends="", layout_optimization=False
     )
@@ -1533,7 +1546,7 @@ class TestMaxAutotune(TestCase):
 
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_non_contiguous_input_mm(self, device):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.
@@ -1550,7 +1563,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_non_contiguous_input_addmm(self, device):
         b = torch.randn((768), dtype=torch.bfloat16, device=device)
         x = rand_strided((50257, 2048), (1, 50304), dtype=torch.bfloat16, device=device)
@@ -1564,7 +1577,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_non_contiguous_input_bmm(self, device):
         x = rand_strided(
             (1, 50257, 2048), (0, 1, 50304), dtype=torch.bfloat16, device=device
@@ -1581,7 +1594,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
@@ -1601,7 +1614,7 @@ class TestMaxAutotune(TestCase):
         act = f(x1, y1, x2, y2)
         torch.testing.assert_close(act, ref, atol=1e-1, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="",
@@ -1616,7 +1629,7 @@ class TestMaxAutotune(TestCase):
             torch.compile(lambda a, b: a.matmul(b))(a, b)
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.triton.native_matmul, "Only test when template is being called"
     )
@@ -1642,7 +1655,7 @@ class TestMaxAutotune(TestCase):
                 torch.compile(lambda a, b: a.matmul(b))(a, b)
             self.assertIn("NoValidChoicesError", str(context.exception))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(force_shape_pad=True, max_autotune=True)
     def test_linear_and_cel(self, device):
         """
@@ -1724,7 +1737,7 @@ class TestMaxAutotune(TestCase):
                     rtol=1e-4,
                 )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1791,7 +1804,7 @@ class TestMaxAutotune(TestCase):
                     code[1]
                 )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1843,7 +1856,7 @@ class TestMaxAutotune(TestCase):
                     f" empty_strided_{torch.device(device).type}((256, 1096), (1096, 1), torch.bfloat16)"
                 ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -1887,7 +1900,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_mm").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -1932,7 +1945,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_addmm").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_contiguous_transform_non_contiguous_second_matrix(
@@ -2000,7 +2013,7 @@ class TestMaxAutotune(TestCase):
             out2, expected2_fp64.to(torch.float32), atol=1e-2, rtol=1e-2
         )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @config.patch(
         max_autotune=True,
@@ -2120,7 +2133,7 @@ class TestMaxAutotune(TestCase):
                 self.assertEqual(len(configs), 1)
                 self.assertEqual(configs[0], expected_config)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
     def test_bmm_out_dtype(self, device):
         def f(a, b):
@@ -2138,7 +2151,7 @@ class TestMaxAutotune(TestCase):
             FileCheck().check("extern_kernels.bmm_dtype").run(code[0])
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
     def test_triton_bmm_out_dtype(self, device):
         def f(a, b, out_dtype=torch.float32):
@@ -2173,7 +2186,7 @@ class TestMaxAutotune(TestCase):
         self.assertEqual(generate_and_load_args - 1, make_key_args)
         self.assertEqual(generate_and_load_args, 21)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @fresh_cache()
     @config.patch(
         {
@@ -2202,7 +2215,7 @@ class TestMaxAutotune(TestCase):
             ):
                 torch.compile(func_test1, dynamic=False)(a, b, a, b)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -2394,7 +2407,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 0)
             self.assertEqual(misses(), 7)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -2431,7 +2444,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -2473,7 +2486,6 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     def test_generated_code_cache_key_input_aliasing(self, device):
         """make_key must distinguish aliased inputs, e.g. mm(x, x), from
         distinct inputs with identical layouts, and stay name-insensitive."""
@@ -2512,7 +2524,7 @@ class TestMaxAutotune(TestCase):
         self.assertEqual(key(a, b), key(b, a))
         self.assertIn("'input_aliasing': (0, 1)", key(a, b))
 
-    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "test_configs.max_mm_configs": 4,
@@ -2550,7 +2562,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(aliased, torch.bmm(x, x), atol=0.1, rtol=0.05)
             self.assertEqual(distinct, torch.bmm(a, b), atol=0.1, rtol=0.05)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @fresh_cache()
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -2600,7 +2612,7 @@ class TestMaxAutotune(TestCase):
                     self.assertTrue(decompose_count > 0)
                     self.assertTrue(decompose_count <= num_decompose_k_splits)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul takes different tuning configs",
@@ -2646,7 +2658,7 @@ class TestMaxAutotune(TestCase):
                 if "benchmark_gpu" in counter:
                     self.assertEqual(counters["inductor"][counter], 2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -2666,7 +2678,7 @@ class TestMaxAutotune(TestCase):
             out, code = run_and_get_code(compiled_f, a, b)
             torch.testing.assert_close(out, mm(a, b), atol=1e-2, rtol=1e-2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("op", ("mm", "addmm", "bmm", "baddbmm", "mm_plus_mm"))
     @parametrize("max_autotune", (False, True))
     @config.patch(
@@ -2741,7 +2753,7 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "ATEN,TRITON"}
     )
@@ -2780,7 +2792,7 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns(clear_defaults=False)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}
     )
@@ -2841,7 +2853,7 @@ class TestMaxAutotune(TestCase):
             _, code_out = run_and_get_code(c_f, *args)
             FileCheck().check(output_code_padding_check).run(code_out[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("k", (15, 16))
     @parametrize("dynamic", (False, True))
     def test_even_k(self, device, k: int, dynamic: bool):
@@ -2861,7 +2873,7 @@ class TestMaxAutotune(TestCase):
         self.assertObjectIn(k, (15, 16))
         self.assertEqual("'EVEN_K': True" in cache_key, k == 16 and not dynamic)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -2913,7 +2925,7 @@ class TestMaxAutotune(TestCase):
             # should force fallback to extern_kernels.bmm
             FileCheck().check_not("triton_tem").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("always_freeze", [True, False])
     def test_mm_layout_freezing_behavior(self, device, always_freeze):
         """Test that mm layout freezing behavior depends on always_freeze_layout.
@@ -2981,7 +2993,7 @@ class TestMaxAutotune(TestCase):
 
         self.assertTrue(flexible_layout_called)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -3033,7 +3045,7 @@ class TestMaxAutotune(TestCase):
 
             FileCheck().check("triton_tem_fused").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune": True,
@@ -3063,7 +3075,7 @@ class TestMaxAutotune(TestCase):
 
         run_and_get_code(compiled_fn, *args)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @fresh_cache()
     @config.patch(
         {
@@ -3116,7 +3128,7 @@ class TestMaxAutotune(TestCase):
             _, code = run_and_get_code(compiled_fn, a, b, c, idx0, idx1, value)
             FileCheck().check("triton_tem_fused").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/182093")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
@@ -3216,7 +3228,7 @@ class TestMaxAutotune(TestCase):
         else:
             self.assertEqual(out, out_unfused)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
     def test_triton_gemm_no_epilogue_no_truncation_casts(
@@ -3270,13 +3282,25 @@ class TestMaxAutotune(TestCase):
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
 
 
-@unittest.mock.patch(
-    "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
-)
-@config.patch(enable_caching_generated_triton_templates=True)
 class TestMaxAutotuneCuda(TestCase):
     hw_classification = HardwareClassification.CUDA
     """CUDA-specific max-autotune tests that require CUDA-only APIs."""
+
+    def setUp(self):
+        super().setUp()
+        self._config_ctx = config.patch(enable_caching_generated_triton_templates=True)
+        self._config_ctx.__enter__()
+        self._test_cache_patcher = unittest.mock.patch(
+            "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
+        )
+        self._test_cache_patcher.start()
+
+    def tearDown(self):
+        if hasattr(self, "_test_cache_patcher"):
+            self._test_cache_patcher.stop()
+        if hasattr(self, "_config_ctx"):
+            self._config_ctx.__exit__(None, None, None)
+        super().tearDown()
 
     def _make_matrices(self, M, K, N, *batch_dims, dtype, device, requires_grad):
         make_matrix = functools.partial(
@@ -3835,7 +3859,7 @@ class TestTemplateConfigPruning(TestCase):
             return bias_1d, mat1, mat2
         return mat1, mat2
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_max_autotune_prune_choices(self, device):
         def mm(x, y):
             return x @ y
@@ -3903,7 +3927,7 @@ class TestTemplateConfigPruning(TestCase):
             shared_memory_checker_opts,
         )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @skipIfXpu(msg="Missing device_properties shared_memory_per_block on xpu.")
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("mat1_transposed", (False, True))
@@ -4094,7 +4118,7 @@ class TestMaxAutotunePrecompile(TestCase):
         finally:
             V.set_debug_handler(old_debug_handler)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_filled_cache_precompile(self, device):
         def fn(a, b, c):
             a = (a @ b) @ c
@@ -4113,7 +4137,7 @@ class TestMaxAutotunePrecompile(TestCase):
         fn_c = torch.compile(mode="max-autotune-no-cudagraphs")(fn)
         self.assertEqual(counters["inductor"]["select_algorithm_precompile"], 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(autotune_local_cache=False, autotune_remote_cache=False)
     @unittest.skipIf(config.triton.native_matmul, "native matmul has counter 0")
     def test_precompilations(self, device):
@@ -4219,7 +4243,7 @@ class TestMaxAutotuneSubproc(TestCase):
             child.join()
             self.assertNotEqual(0, child.exitcode)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("autotune_multi_device", (True, False))
     def test_max_autotune_mm_plus_mm(
@@ -4248,7 +4272,7 @@ class TestMaxAutotuneSubproc(TestCase):
         ):
             torch.compile(mm_plus_mm)(a, b, c, d)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm(self, device, dynamic: bool):
         """
@@ -4265,7 +4289,7 @@ class TestMaxAutotuneSubproc(TestCase):
         with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_max_autotune_profiler_benchmarker_smoke(self, device):
         """
         Smoke test that a simple max-autotune matmul runs with profiler
@@ -4315,7 +4339,7 @@ class TestMaxAutotuneSubproc(TestCase):
             ),
         )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_triton_template_with_epilogues_and_dynamic_shape(self, device):
         def fn(
             x: torch.Tensor, w: torch.Tensor, bias: torch.Tensor, mul: torch.Tensor
@@ -4370,7 +4394,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
         super().tearDown()
         PatchCaches.tearDown()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("dynamic", (False, True))
     @config.patch(
         {"compile_threads": 1, "prologue_fusion": False}
@@ -4777,7 +4801,7 @@ class TestTuningProcessPool(TestCase):
         # Verify they were cleared
         self.assertEqual(len(cache.feedback_saver_fns), 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_feedback_saver_integration(self, device):
         """Test that feedback savers are actually called during autotuning."""
         # Clear any existing feedback savers
@@ -4879,7 +4903,7 @@ class TestPrologueFusion(TestCase):
                 "del", num_deallocs, exactly=True
             ).run(code_str)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     def test_upcast(self, device, sizes):
         M, K, N = sizes
@@ -4900,7 +4924,7 @@ class TestPrologueFusion(TestCase):
             # upcast preserves zero mask
             FileCheck().check("a =").check_not("tl.where").check("tl.dot").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skip("Triton bug in compilation")
     def test_gather_fusion(self, device):
         M, K, N = (64, 128, 256)
@@ -4925,7 +4949,7 @@ class TestPrologueFusion(TestCase):
             .run(code[0])
         )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_capabilities(Capability.dtype.fp8)
     @config.patch({"triton.native_matmul": False})
     def test_low_precision(self, device):
@@ -4959,7 +4983,7 @@ class TestPrologueFusion(TestCase):
         # should not be done in low precision, two kernels
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -4977,7 +5001,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("sizes", ((64, 128, 256), (64, 64, 64), (64, 120, 64)))
     @parametrize("use_async_compile", (True, False))
     @unittest.skipIf(
@@ -5005,7 +5029,7 @@ class TestPrologueFusion(TestCase):
             "tl.full([1], 1.1, tl.float32)", 3, exactly=True
         ).check("tl.store").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/152221")
     @config.patch(
         {
@@ -5061,7 +5085,7 @@ class TestPrologueFusion(TestCase):
             ).run(code[0])
             self.assertEqual(out, resolve_pending(x), atol=0.05, rtol=0.05)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(
         {
             "max_autotune_gemm_backends": "Triton",
@@ -5085,7 +5109,7 @@ class TestPrologueFusion(TestCase):
         ).run(code[0])
         self.assertEqual(out, test_multiple_fusions(x), atol=0.05, rtol=0.05)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
     def test_multiple_inputs(self, device, sizes, use_async_compile: bool):
@@ -5105,7 +5129,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, out_eager, atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_storage_offset_prologue(self, device):
         def foo(a):
             q = a[:64, :]
@@ -5117,7 +5141,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(inp), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
@@ -5141,7 +5165,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("K", (63, 64))
     def test_broadcast_x(self, device, K):
         def foo(x, y):
@@ -5154,7 +5178,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_broadcast_y(self, device):
         def foo(x, y):
             return x @ y
@@ -5169,7 +5193,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -5201,7 +5225,7 @@ class TestPrologueFusion(TestCase):
                 f = FileCheck().check("k_idx").check("a =").check_not("tl.where")
             f.check("tl.dot").run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("benchmark_fusion", (True, False))
     @parametrize("use_async_compile", (True, False))
@@ -5231,7 +5255,7 @@ class TestPrologueFusion(TestCase):
                     code[0], num_kernels=2, num_allocs=None, num_deallocs=None
                 )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @config.patch(allow_buffer_reuse=False)
     @unittest.skipIf(
@@ -5254,7 +5278,7 @@ class TestPrologueFusion(TestCase):
         # not sure why disabling buffer reuse doesn't stop
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @skipIfXpu
     @config.patch(
         {
@@ -5337,7 +5361,7 @@ class TestPrologueFusion(TestCase):
             "to_copy_add_div_mm_mul_relu_sub_tanh_1"
         ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(shape_padding=True)
     @config.patch(force_shape_pad=True)
     @parametrize("sizes", ((250, 245, 128), (250, 256, 128), (256, 128, 62)))
@@ -5636,7 +5660,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 mm_heuristic.mm_configs = original_mm_mm_configs
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179695")
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5709,7 +5733,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5767,7 +5791,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179694")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176115")
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5833,7 +5857,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176114")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176113")
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5897,7 +5921,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @parametrize("use_async_compile", (True, False))
     def test_epilogue_prologue_fusion_cache_preserved(
         self, device, use_async_compile: bool
@@ -5997,7 +6021,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         # Clear the AsyncAutotuner cache to prevent test pollution
         AsyncAutotuner.choice_hash_to_future.clear()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(max_autotune_gemm=True)
     def test_async_autotuner_cache_same_inputs(self, device):
         M, K, N = 128, 64, 256
@@ -6075,7 +6099,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         self.assertIsNone(pool_instance._timer)
         self.assertTrue(AutotuneProcessPool._shutdown_for_inactivity)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @patch(
         "torch._inductor.autotune_process.AUTOTUNE_POOL_INACTIVITY_TIMEOUT",
         2,
@@ -6123,7 +6147,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         cache_entries_after_second = len(AsyncAutotuner.choice_hash_to_future)
         self.assertEqual(cache_entries_after_second, 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @config.patch(max_autotune_gemm=True)
     def test_triton_error_precompilation_and_autotuning(self, device):
         """
@@ -6233,4 +6257,7 @@ instantiate_device_type_tests(
 
 
 if __name__ == "__main__":
-    run_tests()
+    from torch.utils._triton import has_triton
+
+    if has_triton():
+        run_tests()

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -594,150 +594,6 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
-    def test_max_autotune_persistent_tma_workspace_reuse(self, device):
-        """
-        Test that make_kernel_render creates unique workspace names.
-
-        This test patches get_tma_workspace_arg to return the same WorkspaceArg
-        instance, simulating the bug condition where templates share workspace_arg.
-        The fix in make_kernel_render should create a new WorkspaceArg with a
-        unique name for each kernel, preventing self-assignment bugs like
-        'workspace_X = workspace_X; del workspace_X'.
-        """
-        from torch._inductor.codegen.common import WorkspaceZeroMode
-
-        def three_same_shape_matmuls(a, b, c, d, e, f):
-            x = torch.mm(a, b)
-            y = torch.mm(c, d)
-            z = torch.mm(e, f)
-            return x, y, z
-
-        M, K, N = 4608, 2048, 7040
-
-        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
-        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
-
-        mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
-        mm_heuristic = CUDAMMTemplateConfigHeuristic()
-
-        original_tma_configs = mm_tma_heuristic.mm_configs
-        original_mm_configs = mm_heuristic.mm_configs
-
-        # Create a single WorkspaceArg to be returned by all calls
-        shared_workspace_arg = WorkspaceArg(
-            count=1024,
-            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
-            device=torch.device(device),
-            outer_name="shared_workspace",
-        )
-
-        def mock_get_tma_workspace_arg(*args, **kwargs):
-            return shared_workspace_arg
-
-        try:
-            # Force only TMA template by clearing non-TMA configs
-            mm_heuristic.mm_configs = []
-
-            # Use a single TMA config to ensure deterministic behavior
-            mm_tma_heuristic.mm_configs = [GemmConfig(128, 128, 64, 4, 8, group_m=8)]
-
-            with (
-                config.patch(
-                    {
-                        "max_autotune_gemm": True,
-                        "max_autotune_gemm_backends": "TRITON",
-                        "triton.enable_persistent_tma_matmul": True,
-                    }
-                ),
-                fresh_cache(),
-                patch(
-                    "torch._inductor.heuristics.template.triton.get_tma_workspace_arg",
-                    mock_get_tma_workspace_arg,
-                ),
-            ):
-                torch._dynamo.reset()
-                compiled_fn = torch.compile(
-                    three_same_shape_matmuls, mode="max-autotune-no-cudagraphs"
-                )
-
-                _, _ = run_and_get_code(compiled_fn, a, b, a, b, a, b)
-
-        finally:
-            mm_tma_heuristic.mm_configs = original_tma_configs
-            mm_heuristic.mm_configs = original_mm_configs
-
-    @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
-    )
-    def test_workspace_size_bytes_accounts_for_dtype(self, device):
-        """workspace_size passed to benchmark request must be in bytes, not elements."""
-        import sympy
-
-        from torch._inductor.codegen.common import WorkspaceZeroMode
-        from torch._inductor.utils import get_dtype_size
-
-        count = 1024
-        dtype = torch.float32
-        expected_bytes = count * get_dtype_size(dtype)
-
-        fake_ws = WorkspaceArg(
-            count=sympy.Integer(count),
-            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
-            device=torch.device(device),
-            outer_name="test_ws",
-            dtype=dtype,
-        )
-
-        captured_sizes = []
-        orig_init = TritonBenchmarkRequest.__init__
-
-        def spy_init(self, *args, **kwargs):
-            captured_sizes.append(kwargs.get("workspace_size"))
-            orig_init(self, *args, **kwargs)
-
-        M, K, N = 64, 64, 64
-        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
-        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
-
-        mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
-        mm_heuristic = CUDAMMTemplateConfigHeuristic()
-        original_tma_configs = mm_tma_heuristic.mm_configs
-        original_mm_configs = mm_heuristic.mm_configs
-
-        try:
-            mm_heuristic.mm_configs = []
-            mm_tma_heuristic.mm_configs = [GemmConfig(128, 128, 64, 4, 8, group_m=8)]
-
-            with (
-                config.patch(
-                    {
-                        "max_autotune_gemm": True,
-                        "max_autotune_gemm_backends": "TRITON",
-                        "triton.enable_persistent_tma_matmul": True,
-                    }
-                ),
-                fresh_cache(),
-                patch(
-                    "torch._inductor.heuristics.template.triton.get_tma_workspace_arg",
-                    return_value=fake_ws,
-                ),
-                patch.object(TritonBenchmarkRequest, "__init__", spy_init),
-            ):
-                torch._dynamo.reset()
-                torch.compile(torch.mm, mode="max-autotune-no-cudagraphs")(a, b)
-
-        finally:
-            mm_tma_heuristic.mm_configs = original_tma_configs
-            mm_heuristic.mm_configs = original_mm_configs
-
-        ws_sizes = [s for s in captured_sizes if s is not None]
-        self.assertTrue(len(ws_sizes) > 0, "No workspace benchmark requests created")
-        for size in ws_sizes:
-            self.assertEqual(size, expected_bytes)
-
-    @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
-    )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(),
         "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
@@ -3426,6 +3282,154 @@ class TestMaxAutotuneCuda(TestCase):
         return a, b
 
     @fresh_cache()
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    def test_max_autotune_persistent_tma_workspace_reuse(self, device):
+        """
+        Test that make_kernel_render creates unique workspace names.
+
+        This test patches get_tma_workspace_arg to return the same WorkspaceArg
+        instance, simulating the bug condition where templates share workspace_arg.
+        The fix in make_kernel_render should create a new WorkspaceArg with a
+        unique name for each kernel, preventing self-assignment bugs like
+        'workspace_X = workspace_X; del workspace_X'.
+        """
+        from torch._inductor.codegen.common import WorkspaceZeroMode
+
+        def three_same_shape_matmuls(a, b, c, d, e, f):
+            x = torch.mm(a, b)
+            y = torch.mm(c, d)
+            z = torch.mm(e, f)
+            return x, y, z
+
+        M, K, N = 4608, 2048, 7040
+
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
+
+        mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
+        mm_heuristic = CUDAMMTemplateConfigHeuristic()
+
+        original_tma_configs = mm_tma_heuristic.mm_configs
+        original_mm_configs = mm_heuristic.mm_configs
+
+        # Create a single WorkspaceArg to be returned by all calls
+        shared_workspace_arg = WorkspaceArg(
+            count=1024,
+            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
+            device=torch.device(device),
+            outer_name="shared_workspace",
+        )
+
+        def mock_get_tma_workspace_arg(*args, **kwargs):
+            return shared_workspace_arg
+
+        try:
+            # Force only TMA template by clearing non-TMA configs
+            mm_heuristic.mm_configs = []
+
+            # Use a single TMA config to ensure deterministic behavior
+            mm_tma_heuristic.mm_configs = [GemmConfig(128, 128, 64, 4, 8, group_m=8)]
+
+            with (
+                config.patch(
+                    {
+                        "max_autotune_gemm": True,
+                        "max_autotune_gemm_backends": "TRITON",
+                        "triton.enable_persistent_tma_matmul": True,
+                    }
+                ),
+                fresh_cache(),
+                patch(
+                    "torch._inductor.heuristics.template.triton.get_tma_workspace_arg",
+                    mock_get_tma_workspace_arg,
+                ),
+            ):
+                torch._dynamo.reset()
+                compiled_fn = torch.compile(
+                    three_same_shape_matmuls, mode="max-autotune-no-cudagraphs"
+                )
+
+                _, _ = run_and_get_code(compiled_fn, a, b, a, b, a, b)
+
+        finally:
+            mm_tma_heuristic.mm_configs = original_tma_configs
+            mm_heuristic.mm_configs = original_mm_configs
+
+    @fresh_cache()
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    def test_workspace_size_bytes_accounts_for_dtype(self, device):
+        """workspace_size passed to benchmark request must be in bytes, not elements."""
+        import sympy
+
+        from torch._inductor.codegen.common import WorkspaceZeroMode
+        from torch._inductor.utils import get_dtype_size
+
+        count = 1024
+        dtype = torch.float32
+        expected_bytes = count * get_dtype_size(dtype)
+
+        fake_ws = WorkspaceArg(
+            count=sympy.Integer(count),
+            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
+            device=torch.device(device),
+            outer_name="test_ws",
+            dtype=dtype,
+        )
+
+        captured_sizes = []
+        orig_init = TritonBenchmarkRequest.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured_sizes.append(kwargs.get("workspace_size"))
+            orig_init(self, *args, **kwargs)
+
+        M, K, N = 64, 64, 64
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
+
+        mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
+        mm_heuristic = CUDAMMTemplateConfigHeuristic()
+        original_tma_configs = mm_tma_heuristic.mm_configs
+        original_mm_configs = mm_heuristic.mm_configs
+
+        try:
+            mm_heuristic.mm_configs = []
+            mm_tma_heuristic.mm_configs = [GemmConfig(128, 128, 64, 4, 8, group_m=8)]
+
+            with (
+                config.patch(
+                    {
+                        "max_autotune_gemm": True,
+                        "max_autotune_gemm_backends": "TRITON",
+                        "triton.enable_persistent_tma_matmul": True,
+                    }
+                ),
+                fresh_cache(),
+                patch(
+                    "torch._inductor.heuristics.template.triton.get_tma_workspace_arg",
+                    return_value=fake_ws,
+                ),
+                patch.object(TritonBenchmarkRequest, "__init__", spy_init),
+            ):
+                torch._dynamo.reset()
+                torch.compile(torch.mm, mode="max-autotune-no-cudagraphs")(a, b)
+
+        finally:
+            mm_tma_heuristic.mm_configs = original_tma_configs
+            mm_heuristic.mm_configs = original_mm_configs
+
+        ws_sizes = [s for s in captured_sizes if s is not None]
+        self.assertTrue(len(ws_sizes) > 0, "No workspace benchmark requests created")
+        for size in ws_sizes:
+            self.assertEqual(size, expected_bytes)
+
+    @fresh_cache()
     @skipIfXpu(msg="XPU doesn't support sm carveout")
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support sm carveout")
     @unittest.skipIf(IS_WINDOWS, "Windows doesn't support persistent TMA")
@@ -3934,7 +3938,7 @@ class TestMaxAutotuneCuda(TestCase):
 class TestTemplateConfigPruning(TestCase):
     """Test class for pruning logic in GEMM autotuning."""
 
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CUDA
 
     @classmethod
     def setUpClass(cls):
@@ -5731,9 +5735,12 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         return f
 
     @contextlib.contextmanager
-    def _setup_mm_heuristic(self, use_async_compile: bool):
+    def _setup_mm_heuristic(self, use_async_compile: bool, device):
         """Setup MM heuristic with single GemmConfig and handle cleanup."""
-        mm_heuristic = CUDAMMTemplateConfigHeuristic()
+        if torch.device(device).type == "xpu":
+            mm_heuristic = XPUMMTemplateConfigHeuristic()
+        else:
+            mm_heuristic = CUDAMMTemplateConfigHeuristic()
         original_mm_configs = mm_heuristic.mm_configs
         gemm_config = GemmConfig(64, 64, 32, 2, 4, group_m=8)
         mm_heuristic.mm_configs = [gemm_config]
@@ -5903,7 +5910,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         f = self._get_mm_with_epilogue_fn()
         a, b = self._get_mm_inputs(device)
 
-        with self._setup_mm_heuristic(use_async_compile):
+        with self._setup_mm_heuristic(use_async_compile, device):
             with self.get_common_patches(
                 use_async_compile,
                 False,
@@ -5961,7 +5968,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         else:
             triton_time = unfused_time - estimated_fused + 0.01
 
-        with self._setup_mm_heuristic(use_async_compile):
+        with self._setup_mm_heuristic(use_async_compile, device):
             with self.get_common_patches(
                 use_async_compile,
                 False,
@@ -6026,7 +6033,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         f = self._get_mm_with_epilogue_fn()
         a, b = self._get_mm_inputs(device)
 
-        with self._setup_mm_heuristic(use_async_compile):
+        with self._setup_mm_heuristic(use_async_compile, device):
             with self.get_common_patches(
                 use_async_compile,
                 False,
@@ -6092,7 +6099,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         f = self._get_mm_with_epilogue_fn()
         a, b = self._get_mm_inputs(device)
 
-        with self._setup_mm_heuristic(use_async_compile):
+        with self._setup_mm_heuristic(use_async_compile, device):
             with self.get_common_patches(
                 use_async_compile,
                 False,
@@ -6140,7 +6147,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         def always_allow_prologue(*args):
             return True
 
-        with self._setup_mm_heuristic(use_async_compile):
+        with self._setup_mm_heuristic(use_async_compile, device):
             with self.get_common_patches(
                 use_async_compile,
                 False,
@@ -6412,12 +6419,7 @@ instantiate_device_type_tests(
     TestMaxAutotune, globals(), except_for="cpu", allow_xpu=True
 )
 instantiate_device_type_tests(TestMaxAutotuneCuda, globals(), only_for="cuda")
-instantiate_device_type_tests(
-    TestTemplateConfigPruning,
-    globals(),
-    except_for="cpu",
-    allow_xpu=True,
-)
+instantiate_device_type_tests(TestTemplateConfigPruning, globals(), only_for="cuda")
 instantiate_device_type_tests(
     TestMaxAutotunePrecompile,
     globals(),

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -427,6 +427,64 @@ class TestMaxAutotune(TestCase):
                 guard_or_false.assert_called_once_with(condition)
                 statically_known_true.assert_not_called()
 
+    def test_tma_descriptor_max_offset_fits_in_int32(self, device):
+        from torch._inductor.utils import _tma_descriptor_max_offset_fits_in_int32
+
+        # G=128, N=16384, K=5120: reported to overflow when selecting the TMA
+        # grouped-mm path -- (G - 1) * (N * K) exceeds int32 even though G, N,
+        # and K each individually fit.
+        mat = mock.Mock()
+        mat.get_size.return_value = [128, 16384, 5120]
+        mat.get_stride.return_value = [16384 * 5120, 5120, 1]
+        self.assertFalse(_tma_descriptor_max_offset_fits_in_int32(mat))
+
+        mat.get_size.return_value = [16, 16384, 5120]
+        mat.get_stride.return_value = [16384 * 5120, 5120, 1]
+        self.assertTrue(_tma_descriptor_max_offset_fits_in_int32(mat))
+
+    def test_tma_descriptor_max_offset_fits_in_int32_uses_expected_guarding(
+        self, device
+    ):
+        from torch._inductor.utils import _tma_descriptor_max_offset_fits_in_int32
+
+        gm = make_fx(lambda: torch.zeros(2, 3))()
+        graph = GraphLowering(gm)
+        size0 = sympy.Symbol("s0", integer=True, nonnegative=True)
+        stride0 = sympy.Symbol("st0", integer=True, nonnegative=True)
+        mat = mock.Mock()
+        mat.get_size.return_value = [size0]
+        mat.get_stride.return_value = [stride0]
+        condition = sympy.Le((size0 - 1) * stride0, torch.iinfo(torch.int32).max)
+
+        with V.set_graph_handler(graph):
+            with (
+                mock.patch.object(
+                    V.graph.sizevars, "statically_known_true", return_value=True
+                ) as statically_known_true,
+                mock.patch.object(
+                    V.graph.sizevars, "guard_or_false", return_value=True
+                ) as guard_or_false,
+            ):
+                self.assertTrue(
+                    _tma_descriptor_max_offset_fits_in_int32(mat, add_guards=False)
+                )
+                statically_known_true.assert_called_once_with(condition)
+                guard_or_false.assert_not_called()
+
+            with (
+                mock.patch.object(
+                    V.graph.sizevars, "statically_known_true", return_value=True
+                ) as statically_known_true,
+                mock.patch.object(
+                    V.graph.sizevars, "guard_or_false", return_value=True
+                ) as guard_or_false,
+            ):
+                self.assertTrue(
+                    _tma_descriptor_max_offset_fits_in_int32(mat, add_guards=True)
+                )
+                guard_or_false.assert_called_once_with(condition)
+                statically_known_true.assert_not_called()
+
     @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
@@ -1855,6 +1913,60 @@ class TestMaxAutotune(TestCase):
                 ).check(
                     f" empty_strided_{torch.device(device).type}((256, 1096), (1096, 1), torch.bfloat16)"
                 ).run(code[0])
+
+    @unittest.skipIf(
+        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
+    )
+    @unittest.skipIf(
+        config.triton.native_matmul,
+        "ignore decompose_k when native matmul codegen",
+    )
+    @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
+    def test_decompose_k_shape_keeps_mm_template_when_exhaustive(
+        self, device, search_space
+    ):
+        """On a shape where decompose_k applies even at threshold_multiple=2, tuned_mm
+        drops the plain mm template to save autotuning time -- except under EXHAUSTIVE,
+        where the user asked for every choice."""
+        a, b = self._make_matrices(
+            M=32,
+            K=32768,
+            N=64,
+            dtype=torch.bfloat16,
+            device=device,
+            requires_grad=False,
+        )
+
+        names: list[str] = []
+
+        def record(choices):
+            names.extend(c.name for c in choices)
+            return choices
+
+        torch._dynamo.reset()
+        add_preprocessing_fn(record)
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "ATEN,TRITON",
+                    "max_autotune_gemm_search_space": search_space,
+                    # keeps the exhaustive space from dominating test runtime
+                    "test_configs.max_mm_configs": 1,
+                    **_DECOMPOSE_K_PATCH_ROCM,
+                }
+            ):
+                torch.compile(lambda x, y: x @ y)(a, b)
+        finally:
+            clear_preprocessing_fns(clear_defaults=False)
+
+        # the shape must actually be in decompose_k territory, else the test is vacuous
+        self.assertTrue(any(n.startswith("decompose_k") for n in names), names)
+        plain_mm = [n for n in names if n.startswith("triton_mm")]
+        if search_space == "EXHAUSTIVE":
+            self.assertTrue(plain_mm, f"mm_template dropped under EXHAUSTIVE: {names}")
+        else:
+            self.assertFalse(plain_mm, f"mm_template should be skipped: {names}")
 
     @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(not torch.version.hip, "ROCM only")
@@ -3466,6 +3578,68 @@ class TestMaxAutotuneCuda(TestCase):
     @fresh_cache()
     @skipIfXpu
     @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @largeTensorTest("6 GB")
+    def test_max_autotune_grouped_mm_large_input_tensor_int64_indexing(self, device):
+        def grouped_mm(a, b, offs):
+            return torch._grouped_mm(a, b.transpose(-2, -1), offs=offs)
+
+        # G*N*K == 2**31: smallest size triggering int64 INDEX_DTYPE while
+        # max_offset (== numel - 1) still fits int32, so TMA stays enabled.
+        G, M, N, K = 8, 128, 16384, 16384
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(G, N, K, device=device, dtype=torch.bfloat16)
+        offs = torch.arange(M // G, M + 1, M // G, device=device, dtype=torch.int32)
+
+        self.assertEqual(b.numel(), 2**31)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_grouped_mm",
+            }
+        ):
+            result = torch.compile(grouped_mm)(a, b, offs)
+
+        torch.testing.assert_close(result, grouped_mm(a, b, offs), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @largeTensorTest("6 GB")
+    def test_max_autotune_grouped_mm_large_input_tensor_tma_disabled(self, device):
+        # Grouped mm whose TMA descriptor max offset exceeds int32_max;
+        # USE_TMA_LOAD must be disabled and the non-TMA fallback still correct.
+        def grouped_mm(a, b, offs):
+            return torch._grouped_mm(a, b.transpose(-2, -1), offs=offs)
+
+        G, M, N, K = 8, 128, 16384, 16512
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(G, N, K, device=device, dtype=torch.bfloat16)
+        offs = torch.arange(M // G, M + 1, M // G, device=device, dtype=torch.int32)
+
+        self.assertGreater(b.numel(), 2**31)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_grouped_mm",
+            }
+        ):
+            result = torch.compile(grouped_mm)(a, b, offs)
+
+        torch.testing.assert_close(result, grouped_mm(a, b, offs), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
     @largeTensorTest("6 GB")
     def test_max_autotune_mm_large_storage_offset_i64_indexing(self, device):
         """
@@ -4166,6 +4340,24 @@ class TestMaxAutotuneSubproc(TestCase):
             name=name,
             layout=FixedLayout(torch.device(device), dtype=torch.float32, size=shape),
         )
+
+    def test_async_autotuner_skips_unscheduled_choices(self, device):
+        inputs_key = "inputs"
+        scheduled_choice = mock.Mock(hash_key=lambda: "scheduled")
+        unscheduled_choice = mock.Mock(hash_key=lambda: "unscheduled")
+        future = mock.Mock()
+        future.result.return_value = 1.0
+        with mock.patch.object(
+            AsyncAutotuner,
+            "choice_hash_to_future",
+            {"scheduled" + inputs_key: future},
+        ):
+            self.assertEqual(
+                {scheduled_choice: 1.0},
+                AsyncAutotuner.get_results(
+                    [scheduled_choice, unscheduled_choice], inputs_key
+                ),
+            )
 
     @skipIfXpu(msg="XPU not support multiprocessing tensor reduction")
     def test_benchmark_choice_in_subproc(self, device):
@@ -5987,6 +6179,15 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         "test_autotune_device_guard": "Flaky on trunk",
         "test_template_bad_epilogue_fusion": "Benchmarking path is different",
         "test_persistent_tma_epilogue_fusion_store_cache": "Epilogue fusion disabled in async pipelining",
+        # grouped_mm's input_gen_fns forces return_multi_template=False, so
+        # do_autotuning() takes its pipelined-only branch and returns None
+        # instead of timings, crashing min(timings, ...). Pre-existing bug, not
+        # test-specific -- hits any input_gen_fns op under
+        # pipeline_max_autotune_gemm=True.
+        "test_max_autotune_grouped_mm_large_input_tensor_int64_indexing": "grouped_mm's input_gen_fns forces return_multi_template=False, "
+        "which do_autotuning's pipelined branch does not handle",
+        "test_max_autotune_grouped_mm_large_input_tensor_tma_disabled": "grouped_mm's input_gen_fns forces return_multi_template=False, "
+        "which do_autotuning's pipelined branch does not handle",
     }
 
     @classmethod

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -75,10 +75,15 @@ from torch._inductor.select_algorithm import (
     TritonTemplate,
     TritonTemplateCaller,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
-from torch.testing._internal.common_device_type import largeTensorTest
+from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    largeTensorTest,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_WINDOWS,
     parametrize,
     random_matrix_with_scaled_reduction_dim,
@@ -111,10 +116,7 @@ from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import (
     get_func_call,
     get_kernel_launch,
-    GPU_TYPE,
-    HAS_CPU,
     HAS_CUDA_AND_TRITON,
-    HAS_GPU,
 )
 
 
@@ -167,8 +169,9 @@ class FailChoiceCaller(ChoiceCaller):
     "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
 )
 @config.patch(enable_caching_generated_triton_templates=True)
-@instantiate_parametrized_tests
 class TestMaxAutotune(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _make_matrices(self, M, K, N, *batch_dims, dtype, device, requires_grad):
         make_matrix = functools.partial(
             random_matrix_with_scaled_reduction_dim,
@@ -182,7 +185,9 @@ class TestMaxAutotune(TestCase):
 
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_max_autotune_mm_plus_mm_zero_size_input(self, dynamic, search_space):
+    def test_max_autotune_mm_plus_mm_zero_size_input(
+        self, device, dynamic, search_space
+    ):
         """
         Make sure autotuning mm_plus_mm with zero-size input works without crashes.
         """
@@ -191,17 +196,17 @@ class TestMaxAutotune(TestCase):
         def mm_plus_mm(a, b, c, d):
             return a @ b + c @ d
 
-        a = torch.randn(m, k).to(GPU_TYPE)
-        b = torch.randn(k, n).to(GPU_TYPE)
-        c = torch.randn(m, k).to(GPU_TYPE)
-        d = torch.randn(k, n).to(GPU_TYPE)
+        a = torch.randn(m, k).to(device)
+        b = torch.randn(k, n).to(device)
+        c = torch.randn(m, k).to(device)
+        d = torch.randn(k, n).to(device)
 
         with config.patch(
             {"max_autotune": True, "max_autotune_gemm_search_space": search_space}
         ):
             torch.compile(mm_plus_mm, dynamic=dynamic)(a, b, c, d)
 
-    def test_max_autotune_includes_max_autotune_pointwise_configs(self):
+    def test_max_autotune_includes_max_autotune_pointwise_configs(self, device):
         """
         Verify that `max_autotune` includes all pointwise configs from
         `max_autotune_pointwise` for 1D, 2D, and 3D pointwise kernels.
@@ -262,6 +267,7 @@ class TestMaxAutotune(TestCase):
     @parametrize("tma_store", (False, True))
     def test_max_autotune_regular_mm_persistent_tma(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -285,12 +291,12 @@ class TestMaxAutotune(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
 
         with config.patch(
@@ -329,7 +335,9 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    def test_use_triton_tma_template_rejects_descriptor_shapes_exceeding_int32(self):
+    def test_use_triton_tma_template_rejects_descriptor_shapes_exceeding_int32(
+        self, device
+    ):
         from torch._inductor.utils import use_triton_tma_template
 
         int32_max = torch.iinfo(torch.int32).max
@@ -359,7 +367,7 @@ class TestMaxAutotune(TestCase):
                 use_triton_tma_template(mat1, mat2, output_layout=output_layout)
             )
 
-    def test_descriptor_shape_fits_in_int32_uses_expected_guarding(self):
+    def test_descriptor_shape_fits_in_int32_uses_expected_guarding(self, device):
         from torch._inductor.utils import _descriptor_shape_fits_in_int32
 
         gm = make_fx(lambda: torch.zeros(2, 3))()
@@ -404,68 +412,13 @@ class TestMaxAutotune(TestCase):
                 guard_or_false.assert_called_once_with(condition)
                 statically_known_true.assert_not_called()
 
-    def test_tma_descriptor_max_offset_fits_in_int32(self):
-        from torch._inductor.utils import _tma_descriptor_max_offset_fits_in_int32
-
-        # G=128, N=16384, K=5120: reported to overflow when selecting
-        # the TMA grouped-mm path -- (G - 1) * (N * K) exceeds int32
-        # even though G, N, and K each individually fit.
-        mat = mock.Mock()
-        mat.get_size.return_value = [128, 16384, 5120]
-        mat.get_stride.return_value = [16384 * 5120, 5120, 1]
-        self.assertFalse(_tma_descriptor_max_offset_fits_in_int32(mat))
-
-        mat.get_size.return_value = [16, 16384, 5120]
-        mat.get_stride.return_value = [16384 * 5120, 5120, 1]
-        self.assertTrue(_tma_descriptor_max_offset_fits_in_int32(mat))
-
-    def test_tma_descriptor_max_offset_fits_in_int32_uses_expected_guarding(self):
-        from torch._inductor.utils import _tma_descriptor_max_offset_fits_in_int32
-
-        gm = make_fx(lambda: torch.zeros(2, 3))()
-        graph = GraphLowering(gm)
-        size0 = sympy.Symbol("s0", integer=True, nonnegative=True)
-        stride0 = sympy.Symbol("st0", integer=True, nonnegative=True)
-        mat = mock.Mock()
-        mat.get_size.return_value = [size0]
-        mat.get_stride.return_value = [stride0]
-        condition = sympy.Le((size0 - 1) * stride0, torch.iinfo(torch.int32).max)
-
-        with V.set_graph_handler(graph):
-            with (
-                mock.patch.object(
-                    V.graph.sizevars, "statically_known_true", return_value=True
-                ) as statically_known_true,
-                mock.patch.object(
-                    V.graph.sizevars, "guard_or_false", return_value=True
-                ) as guard_or_false,
-            ):
-                self.assertTrue(
-                    _tma_descriptor_max_offset_fits_in_int32(mat, add_guards=False)
-                )
-                statically_known_true.assert_called_once_with(condition)
-                guard_or_false.assert_not_called()
-
-            with (
-                mock.patch.object(
-                    V.graph.sizevars, "statically_known_true", return_value=True
-                ) as statically_known_true,
-                mock.patch.object(
-                    V.graph.sizevars, "guard_or_false", return_value=True
-                ) as guard_or_false,
-            ):
-                self.assertTrue(
-                    _tma_descriptor_max_offset_fits_in_int32(mat, add_guards=True)
-                )
-                guard_or_false.assert_called_once_with(condition)
-                statically_known_true.assert_not_called()
-
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_persistent(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -485,12 +438,12 @@ class TestMaxAutotune(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
 
         with config.patch(
@@ -515,6 +468,7 @@ class TestMaxAutotune(TestCase):
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_addmm_persistent(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -535,14 +489,14 @@ class TestMaxAutotune(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
-        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+        x = torch.randn(N).to(torch.float16).to(device)
 
         with config.patch(
             {
@@ -565,7 +519,7 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
-    def test_max_autotune_persistent_tma_workspace_reuse(self):
+    def test_max_autotune_persistent_tma_workspace_reuse(self, device):
         """
         Test that make_kernel_render creates unique workspace names.
 
@@ -585,8 +539,8 @@ class TestMaxAutotune(TestCase):
 
         M, K, N = 4608, 2048, 7040
 
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
 
         mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
         mm_heuristic = CUDAMMTemplateConfigHeuristic()
@@ -598,7 +552,7 @@ class TestMaxAutotune(TestCase):
         shared_workspace_arg = WorkspaceArg(
             count=1024,
             zero_mode=WorkspaceZeroMode.UNINITIALIZED,
-            device=torch.device(GPU_TYPE),
+            device=torch.device(device),
             outer_name="shared_workspace",
         )
 
@@ -640,7 +594,7 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
-    def test_workspace_size_bytes_accounts_for_dtype(self):
+    def test_workspace_size_bytes_accounts_for_dtype(self, device):
         """workspace_size passed to benchmark request must be in bytes, not elements."""
         import sympy
 
@@ -654,7 +608,7 @@ class TestMaxAutotune(TestCase):
         fake_ws = WorkspaceArg(
             count=sympy.Integer(count),
             zero_mode=WorkspaceZeroMode.UNINITIALIZED,
-            device=torch.device(GPU_TYPE),
+            device=torch.device(device),
             outer_name="test_ws",
             dtype=dtype,
         )
@@ -667,8 +621,8 @@ class TestMaxAutotune(TestCase):
             orig_init(self, *args, **kwargs)
 
         M, K, N = 64, 64, 64
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b = torch.randn(K, N, device=device, dtype=torch.bfloat16)
 
         mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
         mm_heuristic = CUDAMMTemplateConfigHeuristic()
@@ -719,6 +673,7 @@ class TestMaxAutotune(TestCase):
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_persistent_tma_strided(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -744,16 +699,16 @@ class TestMaxAutotune(TestCase):
         a_stride = (
             (next_multiple_16(M), 1) if a_transposed else (next_multiple_16(K), 1)
         )
-        a = torch.empty_strided(a_shape, a_stride, dtype=torch.float16).to(GPU_TYPE)
+        a = torch.empty_strided(a_shape, a_stride, dtype=torch.float16).to(device)
         a[:] = torch.randn(a_shape, dtype=torch.float16)
-        a = a.to(GPU_TYPE)
+        a = a.to(device)
         b_shape = (N, K) if b_transposed else (K, N)
         b_stride = (
             (next_multiple_16(K), 1) if a_transposed else (next_multiple_16(N), 1)
         )
         b = torch.empty_strided(b_shape, b_stride, dtype=torch.float16)
         b[:] = torch.randn(b_shape, dtype=torch.float16)
-        b = b.to(GPU_TYPE)
+        b = b.to(device)
         with config.patch(
             {
                 "max_autotune": True,
@@ -778,13 +733,15 @@ class TestMaxAutotune(TestCase):
     )
     @skipIfXpu(msg="Covered by XPU TMA")
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_regular_mm_persistent_tma_illegal_alignment(self, dynamic):
+    def test_max_autotune_regular_mm_persistent_tma_illegal_alignment(
+        self, device, dynamic
+    ):
         def mm(a, b):
             return torch.mm(a, b)
 
         M, N, K = 21, 31, 11
-        a = torch.randn(M, K).to(torch.float16).to(GPU_TYPE)
-        b = torch.randn(K, N).to(torch.float16).to(GPU_TYPE)
+        a = torch.randn(M, K).to(torch.float16).to(device)
+        b = torch.randn(K, N).to(torch.float16).to(device)
 
         with (
             self.assertRaises(BackendCompilerFailed) as context,
@@ -809,19 +766,19 @@ class TestMaxAutotune(TestCase):
     )
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_persistent_tma_illegal_output_alignment(
-        self, dynamic
+        self, device, dynamic
     ):
         def mm(a, b, out):
             torch.mm(a, b, out=out)
             return out
 
         M, N, K = 21, 31, 32
-        a = torch.empty_strided((M, K), (K, 1), dtype=torch.float16, device=GPU_TYPE)
+        a = torch.empty_strided((M, K), (K, 1), dtype=torch.float16, device=device)
         a[:] = torch.randn((M, K), dtype=torch.float16)
-        b = torch.empty_strided((K, N), (1, K), dtype=torch.float16, device=GPU_TYPE)
+        b = torch.empty_strided((K, N), (1, K), dtype=torch.float16, device=device)
         b[:] = torch.randn((K, N), dtype=torch.float16)
         # allocate an output with a stride not divisible by 16, so it can't satisfy TMA alignment checks.
-        out = torch.empty_strided((M, N), (N, 1), dtype=torch.float16, device=GPU_TYPE)
+        out = torch.empty_strided((M, N), (N, 1), dtype=torch.float16, device=device)
 
         with (
             self.assertRaises(BackendCompilerFailed) as context,
@@ -844,13 +801,13 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
-    def test_max_autotune_regular_mm_tma_dynamic_outer_dim(self):
+    def test_max_autotune_regular_mm_tma_dynamic_outer_dim(self, device):
         def mm(a, b):
             return torch.mm(a, b)
 
         M, N, K = 21, 31, 11
-        a = torch.randn(M, K).to(torch.float16).to(GPU_TYPE)
-        b = torch.randn(K, N).to(torch.float16).to(GPU_TYPE)
+        a = torch.randn(M, K).to(torch.float16).to(device)
+        b = torch.randn(K, N).to(torch.float16).to(device)
 
         # TMA requires 16-byte alignment: here we repeat the dims
         # by the factor of 8, as float16 is 2-byte. All dims are
@@ -886,7 +843,7 @@ class TestMaxAutotune(TestCase):
         has_datacenter_blackwell_tma_device(),
         "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
     )
-    def test_persistent_tma_epilogue_fusion_store_cache(self):
+    def test_persistent_tma_epilogue_fusion_store_cache(self, device):
         # Regression test: when epilogue fusion runs with TMA store, the
         # store_cache must be updated so that a subsequent epilogue load from
         # the same buffer hits the cache. Otherwise remove_kernel_local_buffers
@@ -899,8 +856,8 @@ class TestMaxAutotune(TestCase):
             return mm.relu()
 
         M, N, K = 21, 31, 11
-        a = torch.randn(M, K, dtype=torch.float16, device=GPU_TYPE)
-        b = torch.randn(K, N, dtype=torch.float16, device=GPU_TYPE)
+        a = torch.randn(M, K, dtype=torch.float16, device=device)
+        b = torch.randn(K, N, dtype=torch.float16, device=device)
 
         with config.patch(
             {
@@ -919,7 +876,7 @@ class TestMaxAutotune(TestCase):
         torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_regular_mm_zero_size_input(self, dynamic: bool):
+    def test_max_autotune_regular_mm_zero_size_input(self, device, dynamic: bool):
         """
         Make sure autotuning mm with zero-size input works without crashes.
         """
@@ -928,14 +885,14 @@ class TestMaxAutotune(TestCase):
             a = torch.sin(a)
             return a @ b
 
-        a = torch.randn(0, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        a = torch.randn(0, 10).to(device)
+        b = torch.randn(10, 100).to(device)
 
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
     @fresh_cache()
-    def test_addmm_1d_bias_no_reinterpret_tensor(self):
+    def test_addmm_1d_bias_no_reinterpret_tensor(self, device):
         """
         Verify that aten addmm with 1D bias does not wrap bias in reinterpret_tensor.
         This ensures cublasLt uses its optimized bias epilogue (requires dim==1).
@@ -944,9 +901,9 @@ class TestMaxAutotune(TestCase):
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
 
-        x = torch.randn(100).to(GPU_TYPE)
-        a = torch.randn(100, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        x = torch.randn(100).to(device)
+        a = torch.randn(100, 10).to(device)
+        b = torch.randn(10, 100).to(device)
 
         extern_bias_shape = None
         original_bmreq_init = ExternKernelBenchmarkRequest.__init__
@@ -1003,6 +960,7 @@ class TestMaxAutotune(TestCase):
     @parametrize("tma_store", (False, True))
     def test_max_autotune_addmm_persistent_tma(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -1027,14 +985,14 @@ class TestMaxAutotune(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
-        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+        x = torch.randn(N).to(torch.float16).to(device)
 
         with config.patch(
             {
@@ -1079,14 +1037,14 @@ class TestMaxAutotune(TestCase):
     )
     @skipIfXpu(msg="Covered by XPU TMA")
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_addmm_persistent_tma_illegal_alignment(self, dynamic):
+    def test_max_autotune_addmm_persistent_tma_illegal_alignment(self, device, dynamic):
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
 
         M, N, K = 21, 31, 11
-        a = torch.randn(M, K).to(torch.float16).to(GPU_TYPE)
-        b = torch.randn(K, N).to(torch.float16).to(GPU_TYPE)
-        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+        a = torch.randn(M, K).to(torch.float16).to(device)
+        b = torch.randn(K, N).to(torch.float16).to(device)
+        x = torch.randn(N).to(torch.float16).to(device)
 
         with (
             self.assertRaises(BackendCompilerFailed) as context,
@@ -1109,14 +1067,14 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
-    def test_max_autotune_addmm_tma_dynamic_outer_dim(self):
+    def test_max_autotune_addmm_tma_dynamic_outer_dim(self, device):
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
 
         M, N, K = 21, 31, 11
-        a = torch.randn(M, K).to(torch.float16).to(GPU_TYPE)
-        b = torch.randn(K, N).to(torch.float16).to(GPU_TYPE)
-        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+        a = torch.randn(M, K).to(torch.float16).to(device)
+        b = torch.randn(K, N).to(torch.float16).to(device)
+        x = torch.randn(N).to(torch.float16).to(device)
 
         # TMA requires 16-byte alignment: here we repeat the dims
         # by the factor of 8, as float16 is 2-byte. All dims are
@@ -1146,114 +1104,8 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
-    @fresh_cache()
-    @skipIfXpu(msg="XPU doesn't support sm carveout")
-    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support sm carveout")
-    @unittest.skipIf(IS_WINDOWS, "Windows doesn't support persistent TMA")
-    @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
-    )
-    @unittest.skipIf(
-        has_datacenter_blackwell_tma_device(), "B200 doesn't support sm carveout"
-    )
-    @parametrize("carveout", (None, 0, 27))
-    @parametrize("op", ("mm", "scaled_mm"))
-    def test_honor_sm_carveout_with_triton_tma(self, carveout, op: str):
-        def mm_func(a, b):
-            return torch.mm(a, b)
-
-        def scaled_mm(
-            a,
-            b,
-            scale_a,
-            scale_b,
-        ):
-            return torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.bfloat16)
-
-        # Create large matrices to ensure we use all possible sms
-        size = 2560
-        a = torch.randn(size, size, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = (
-            torch.randn(size, size, device=GPU_TYPE, dtype=torch.bfloat16)
-            .transpose(0, 1)
-            .contiguous()
-            .transpose(0, 1)
-        )
-        scale_a = torch.tensor(1, dtype=torch.float32, device=GPU_TYPE)
-        scale_b = torch.tensor(1, dtype=torch.float32, device=GPU_TYPE)
-
-        args = (
-            (a.to(torch.float8_e4m3fn), b.to(torch.float8_e4m3fn), scale_a, scale_b)
-            if op == "scaled_mm"
-            else (a, b)
-        )
-        func = scaled_mm if op == "scaled_mm" else mm_func
-
-        # Set the specified carveout value
-        torch._C._set_sm_carveout_experimental(carveout)
-        if carveout is None:
-            self.assertIsNone(torch._C._get_sm_carveout_experimental())
-        else:
-            self.assertEqual(torch._C._get_sm_carveout_experimental(), carveout)
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "triton.enable_persistent_tma_matmul": True,
-                "triton.native_matmul": False,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": "tma",
-            }
-        ):
-            compiled_mm = torch.compile(func, mode="max-autotune-no-cudagraphs")
-            compiled_mm(*args)  # Warm-up compilation
-
-            with tempfile.NamedTemporaryFile() as f:
-                with torch.profiler.profile(
-                    activities=[torch.profiler.ProfilerActivity.CUDA]
-                ) as prof:
-                    # Run with the specified carveout
-                    compiled_mm(*args)
-
-                # Export trace and analyze results
-                prof.export_chrome_trace(f.name)
-
-                # Extract grid sizes from the trace events for TMA kernels
-                kernel_name = "triton_tem_fused"
-                with open(f.name) as file:
-                    kernel_events = [
-                        {
-                            "grid": evt.get("args", {}).get("grid", []),
-                            "grid_size": math.prod(evt.get("args", {}).get("grid", [])),
-                        }
-                        for evt in json.load(file)["traceEvents"]
-                        if evt.get("cat", "") == "kernel"
-                        and kernel_name in evt.get("name", "").lower()
-                    ]
-
-                # We should have exactly 1 kernel event for this run
-                self.assertEqual(
-                    len(kernel_events),
-                    1,
-                    lambda msg: f"{msg}\nExpected exactly 1 kernel event, but got {len(kernel_events)}",
-                )
-
-                # Check that grid size matches expected values based on carveout
-                expected_grid_size = None
-                max_grid_size = torch.cuda.get_device_properties(
-                    "cuda"
-                ).multi_processor_count
-                careveout = 0 if carveout is None else carveout
-                expected_grid_size = max_grid_size - careveout
-
-                self.assertEqual(
-                    kernel_events[0]["grid_size"],
-                    expected_grid_size,
-                    lambda msg: f"{msg}\nGrid size {kernel_events[0]['grid_size']} doesn't match {expected_grid_size} for carveout={carveout}",
-                )
-
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_addmm_zero_size_input(self, dynamic):
+    def test_max_autotune_addmm_zero_size_input(self, device, dynamic):
         """
         Make sure autotuning addmm with zero-size input works without crashes.
         """
@@ -1261,14 +1113,14 @@ class TestMaxAutotune(TestCase):
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
 
-        x = torch.randn(100).to(GPU_TYPE)
-        a = torch.randn(0, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        x = torch.randn(100).to(device)
+        a = torch.randn(0, 10).to(device)
+        b = torch.randn(10, 100).to(device)
         with config.patch({"max_autotune": True}):
             torch.compile(addmm, dynamic=dynamic)(x, a, b)
 
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_addmm_unrealized_view_bias(self, dynamic):
+    def test_max_autotune_addmm_unrealized_view_bias(self, device, dynamic):
         """
         Make sure autotuning addmm with an unrealized view-class bias
         (here a PermuteView over a fused Pointwise) works without crashes.
@@ -1277,19 +1129,19 @@ class TestMaxAutotune(TestCase):
         def fn(x, a, b):
             return torch.addmm((x * 2.0).transpose(0, 1), a, b)
 
-        x = torch.randn(8, 8).to(GPU_TYPE)
-        a = torch.randn(8, 16).to(GPU_TYPE)
-        b = torch.randn(16, 8).to(GPU_TYPE)
+        x = torch.randn(8, 8).to(device)
+        a = torch.randn(8, 16).to(device)
+        b = torch.randn(16, 8).to(device)
         with config.patch({"max_autotune": True}):
             torch.compile(fn, dynamic=dynamic)(x, a, b)
 
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_autotune_conv1x1(self, search_space):
+    def test_autotune_conv1x1(self, device, search_space):
         # Assuming input has 3 channels and we want to produce 16 channels as output
         conv1x1 = (
             torch.nn.Conv2d(in_channels=3, out_channels=16, kernel_size=1)
             .to(memory_format=torch.channels_last)
-            .to(GPU_TYPE)
+            .to(device)
         )
 
         # Example input tensor: batch size = 4, channels = 3, height = 32, width = 32
@@ -1297,7 +1149,7 @@ class TestMaxAutotune(TestCase):
         input_tensor = (
             torch.randn(4, 3, 32, 32)
             .contiguous(memory_format=torch.channels_last)
-            .to(GPU_TYPE)
+            .to(device)
         )
 
         with config.patch(
@@ -1321,7 +1173,7 @@ class TestMaxAutotune(TestCase):
 
     @fresh_cache()
     @config.patch(max_autotune=True, max_fusion_size=2)
-    def test_jit_fusion_matches_aot_fusion(self):
+    def test_jit_fusion_matches_aot_fusion(self, device):
         # In this example, AOTInductor's JIT-compile will fuse(buf1, buf2) due
         # to proximity, we want to make sure AOT-compile pass does the same.
         # AOT could do fuse(buf2, buf4) instead if buf3 was pushed to the end
@@ -1337,12 +1189,12 @@ class TestMaxAutotune(TestCase):
             return buf0, buf1, buf2, buf3, buf4
 
         inputs = (
-            torch.rand([256, 256], device=GPU_TYPE),
-            torch.tensor(3, device=GPU_TYPE),
+            torch.rand([256, 256], device=device),
+            torch.tensor(3, device=device),
         )
         torch._export.aot_compile(fn, args=inputs)
 
-    def test_cat_addmm(self):
+    def test_cat_addmm(self, device):
         def fn(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):
             return torch.cat(
                 [
@@ -1353,9 +1205,9 @@ class TestMaxAutotune(TestCase):
             )
 
         args = [
-            torch.randn(4, 4, device=GPU_TYPE),
-            torch.randn(4, 4, device=GPU_TYPE),
-            torch.randn(4, 4, device=GPU_TYPE),
+            torch.randn(4, 4, device=device),
+            torch.randn(4, 4, device=device),
+            torch.randn(4, 4, device=device),
         ]
         with config.patch(
             {
@@ -1372,8 +1224,10 @@ class TestMaxAutotune(TestCase):
         fallback_random=True,
         max_autotune_gemm=True,
     )
-    @parametrize("device", ("cpu", GPU_TYPE))
-    def test_matmul_dropout(self, device):
+    @parametrize("matmul_device", ("cpu", "accelerator"))
+    def test_matmul_dropout(self, device, matmul_device):
+        device = "cpu" if matmul_device == "cpu" else device
+
         def fwd(a, b):
             x = a @ b
             x = torch.nn.functional.dropout(x, 0.1)
@@ -1401,13 +1255,11 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune_gemm=True,
     )
-    @unittest.skipIf(
-        getattr(torch, GPU_TYPE).device_count() < 2,
-        "Need at least 2 devices for this test",
-    )
-    def test_autotune_device_guard(self):
-        x = torch.randn(1024, 1024, device=f"{GPU_TYPE}:1")
-        y = torch.randn(1024, 1024, device=f"{GPU_TYPE}:1")
+    def test_autotune_device_guard(self, device):
+        if getattr(torch, torch.device(device).type).device_count() < 2:
+            self.skipTest("Need at least 2 devices for this test")
+        x = torch.randn(1024, 1024, device=f"{torch.device(device).type}:1")
+        y = torch.randn(1024, 1024, device=f"{torch.device(device).type}:1")
 
         def f(x, y):
             return x @ y
@@ -1421,9 +1273,9 @@ class TestMaxAutotune(TestCase):
     @config.patch(max_autotune=True)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     @parametrize("kernel_size", (1, 3))
-    def test_empty_conv_input(self, search_space, kernel_size):
-        x = torch.randn(0, 256, 14, 14, device=GPU_TYPE)
-        weight = torch.randn(256, 256, kernel_size, kernel_size, device=GPU_TYPE)
+    def test_empty_conv_input(self, device, search_space, kernel_size):
+        x = torch.randn(0, 256, 14, 14, device=device)
+        weight = torch.randn(256, 256, kernel_size, kernel_size, device=device)
 
         def f(x, weight):
             return torch.convolution(
@@ -1446,7 +1298,7 @@ class TestMaxAutotune(TestCase):
 
     @config.patch(max_autotune_gemm_backends="TRITON")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_baddmm(self, search_space):
+    def test_baddmm(self, device, search_space):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1461,9 +1313,9 @@ class TestMaxAutotune(TestCase):
                 return torch.ops.aten.baddbmm.default(self.bias, x, self.weight)
 
         x = torch.randn(
-            64, 2048, 64, dtype=torch.float16, requires_grad=False, device=GPU_TYPE
+            64, 2048, 64, dtype=torch.float16, requires_grad=False, device=device
         )
-        mod = M().to(GPU_TYPE)
+        mod = M().to(device)
 
         with config.patch({"max_autotune_gemm_search_space": search_space}):
             m_c = torch.compile(mode="max-autotune")(mod)
@@ -1474,13 +1326,13 @@ class TestMaxAutotune(TestCase):
                 FileCheck().check("triton_tem_fused_baddbmm").run(code[0])
 
     @config.patch(max_autotune=True)
-    def test_conv1x1_with_free_symbols(self):
+    def test_conv1x1_with_free_symbols(self, device):
         """
         Make sure there is no exception due to free symbols.
         """
         conv = nn.Conv2d(
             3, 64, kernel_size=(1, 1), stride=(1, 1), padding=(0, 0), bias=False
-        ).to(device=GPU_TYPE)
+        ).to(device=device)
 
         @torch.compile
         def f(x, y, z):
@@ -1491,14 +1343,14 @@ class TestMaxAutotune(TestCase):
             return x
 
         x = torch.randn(4, 3, 224, 224).to(
-            memory_format=torch.channels_last, device=GPU_TYPE
+            memory_format=torch.channels_last, device=device
         )
         for _ in range(2):
-            y = torch.randint(0, 10, (224,)).to(device=GPU_TYPE)
-            z = torch.randint(0, 10, (224,)).to(device=GPU_TYPE)
+            y = torch.randint(0, 10, (224,)).to(device=device)
+            z = torch.randint(0, 10, (224,)).to(device=device)
             f(x, y, z)
 
-    def _test_cat_max_autotune_impl(self, using_triton_mm):
+    def _test_cat_max_autotune_impl(self, device, using_triton_mm):
         def f(x, y):
             y = torch.cos(y)
             x = torch.mm(x, x)
@@ -1506,8 +1358,8 @@ class TestMaxAutotune(TestCase):
 
         f_c = torch.compile(mode="max-autotune-no-cudagraphs")(f)
         inps = [
-            torch.randn(32, 32, device=GPU_TYPE),
-            torch.randn(32, 32, device=GPU_TYPE),
+            torch.randn(32, 32, device=device),
+            torch.randn(32, 32, device=device),
         ]
         _, code = run_and_get_code(f_c, inps[0], inps[1])
         self.assertEqual(f_c(*inps), f(*inps), atol=0.03, rtol=0.25)
@@ -1546,7 +1398,7 @@ class TestMaxAutotune(TestCase):
     @config.patch("trace.enabled", True)
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     @config.patch("triton.native_matmul", False)
-    def test_mutation_rename(self):
+    def test_mutation_rename(self, device):
         torch._logging.set_logs(ir_post_fusion=True)
 
         def f(x, y, z, other):
@@ -1554,10 +1406,10 @@ class TestMaxAutotune(TestCase):
             diag = torch.diagonal(mul)
             diag.copy_(other)
             x = torch.mm(mul, z)
-            y = torch.diagonal(x).add_(torch.tensor(1, device=GPU_TYPE))
+            y = torch.diagonal(x).add_(torch.tensor(1, device=device))
             return y
 
-        t = functools.partial(torch.randn, device=GPU_TYPE)
+        t = functools.partial(torch.randn, device=device)
         inps = (t(3, 3), t(3, 3), t(3, 3), t(3))
         fn = torch.compile(f, mode="max-autotune-no-cudagraphs")
 
@@ -1597,8 +1449,8 @@ class TestMaxAutotune(TestCase):
         torch._logging.set_logs()
 
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
-    def test_cat_max_autotune_extern(self):
-        self._test_cat_max_autotune_impl(using_triton_mm=False)
+    def test_cat_max_autotune_extern(self, device):
+        self._test_cat_max_autotune_impl(device, using_triton_mm=False)
 
     @config.patch(
         {
@@ -1606,11 +1458,11 @@ class TestMaxAutotune(TestCase):
             "benchmark_epilogue_fusion": False,
         }
     )
-    def test_cat_max_autotune_triton(self):
-        self._test_cat_max_autotune_impl(using_triton_mm=True)
+    def test_cat_max_autotune_triton(self, device):
+        self._test_cat_max_autotune_impl(device, using_triton_mm=True)
 
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_conv_cat(self, search_space):
+    def test_conv_cat(self, device, search_space):
         class ToyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1624,8 +1476,8 @@ class TestMaxAutotune(TestCase):
 
         with config.patch({"max_autotune_gemm_search_space": search_space}):
             with torch.no_grad():
-                m = ToyModel().to(device=GPU_TYPE)
-                input_tensor = torch.randn(32, 3, 64, 64).to(device=GPU_TYPE)
+                m = ToyModel().to(device=device)
+                input_tensor = torch.randn(32, 3, 64, 64).to(device=device)
 
                 # convolution is not currently plannable
                 m = torch.compile(m, mode="max-autotune-no-cudagraphs")
@@ -1636,7 +1488,7 @@ class TestMaxAutotune(TestCase):
                     FileCheck().check("def triton_poi_fused_add_cat_").run(code[0])
 
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_conv3d(self, search_space):
+    def test_conv3d(self, device, search_space):
         fn = torch.nn.functional.conv3d
         image = torch.randn([1, 3, 8, 16, 32])
         filt = torch.randn([3, 3, 7, 7, 7])
@@ -1651,26 +1503,24 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True, max_autotune_conv_backends="", layout_optimization=False
     )
-    def test_conv_backend(self):
+    def test_conv_backend(self, device):
         m = torch.nn.Sequential(
             torch.nn.Conv2d(3, 3, 1, 1),
-        ).to(GPU_TYPE)
-        inp = torch.randn([2, 3, 16, 16]).to(GPU_TYPE)
+        ).to(device)
+        inp = torch.randn([2, 3, 16, 16]).to(device)
 
         with self.assertRaises(BackendCompilerFailed) as context:
             torch.compile(m)(inp)
 
         self.assertIn("NoValidChoicesError", str(context.exception))
 
-    def test_non_contiguous_input_mm(self):
+    def test_non_contiguous_input_mm(self, device):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.
         Check https://github.com/pytorch/pytorch/issues/125437 for more details.
         """
-        x = rand_strided(
-            (50257, 2048), (1, 50304), dtype=torch.bfloat16, device=GPU_TYPE
-        )
-        y = rand_strided((2048, 768), (768, 1), dtype=torch.bfloat16, device=GPU_TYPE)
+        x = rand_strided((50257, 2048), (1, 50304), dtype=torch.bfloat16, device=device)
+        y = rand_strided((2048, 768), (768, 1), dtype=torch.bfloat16, device=device)
 
         @torch.compile(mode="max-autotune")
         def f(x, y):
@@ -1680,12 +1530,10 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    def test_non_contiguous_input_addmm(self):
-        b = torch.randn((768), dtype=torch.bfloat16, device=GPU_TYPE)
-        x = rand_strided(
-            (50257, 2048), (1, 50304), dtype=torch.bfloat16, device=GPU_TYPE
-        )
-        y = rand_strided((2048, 768), (768, 1), dtype=torch.bfloat16, device=GPU_TYPE)
+    def test_non_contiguous_input_addmm(self, device):
+        b = torch.randn((768), dtype=torch.bfloat16, device=device)
+        x = rand_strided((50257, 2048), (1, 50304), dtype=torch.bfloat16, device=device)
+        y = rand_strided((2048, 768), (768, 1), dtype=torch.bfloat16, device=device)
 
         @torch.compile(mode="max-autotune")
         def f(x, y):
@@ -1695,12 +1543,12 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    def test_non_contiguous_input_bmm(self):
+    def test_non_contiguous_input_bmm(self, device):
         x = rand_strided(
-            (1, 50257, 2048), (0, 1, 50304), dtype=torch.bfloat16, device=GPU_TYPE
+            (1, 50257, 2048), (0, 1, 50304), dtype=torch.bfloat16, device=device
         )
         y = rand_strided(
-            (1, 2048, 768), (0, 768, 1), dtype=torch.bfloat16, device=GPU_TYPE
+            (1, 2048, 768), (0, 768, 1), dtype=torch.bfloat16, device=device
         )
 
         @torch.compile(mode="max-autotune")
@@ -1715,12 +1563,12 @@ class TestMaxAutotune(TestCase):
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
     )
-    def test_non_contiguous_input_mm_plus_mm(self):
-        x1 = rand_strided((50257, 2048), (1, 50304), device=GPU_TYPE)
-        y1 = rand_strided((2048, 768), (768, 1), device=GPU_TYPE)
+    def test_non_contiguous_input_mm_plus_mm(self, device):
+        x1 = rand_strided((50257, 2048), (1, 50304), device=device)
+        y1 = rand_strided((2048, 768), (768, 1), device=device)
 
-        x2 = rand_strided((50257, 2048), (1, 50304), device=GPU_TYPE)
-        y2 = rand_strided((2048, 768), (768, 1), device=GPU_TYPE)
+        x2 = rand_strided((50257, 2048), (1, 50304), device=device)
+        y2 = rand_strided((2048, 768), (768, 1), device=device)
 
         @torch.compile(mode="max-autotune")
         def f(x1, y1, x2, y2):
@@ -1737,9 +1585,9 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         config.triton.native_matmul, "native matmul generates when size >=2"
     )
-    def test_no_valid_choices(self):
-        a = torch.zeros([2, 2], device=GPU_TYPE)
-        b = torch.zeros([2, 2], device=GPU_TYPE)
+    def test_no_valid_choices(self, device):
+        a = torch.zeros([2, 2], device=device)
+        b = torch.zeros([2, 2], device=device)
         with self.assertRaises(BackendCompilerFailed) as context:
             torch.compile(lambda a, b: a.matmul(b))(a, b)
         self.assertIn("NoValidChoicesError", str(context.exception))
@@ -1752,15 +1600,15 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_inf_timing(self, multi_template):
+    def test_inf_timing(self, device, multi_template):
         lookup = AlgorithmSelectorCache.lookup
 
         def mock_lookup(self, *args, **kwargs):
             timings = lookup(self, *args, **kwargs)
             return {choice: float("inf") for choice in timings}
 
-        a = torch.zeros([16, 16], device=GPU_TYPE)
-        b = torch.zeros([16, 16], device=GPU_TYPE)
+        a = torch.zeros([16, 16], device=device)
+        b = torch.zeros([16, 16], device=device)
         with (
             patch.object(AlgorithmSelectorCache, "lookup", mock_lookup),
             config.patch(benchmark_epilogue_fusion=multi_template),
@@ -1770,7 +1618,7 @@ class TestMaxAutotune(TestCase):
             self.assertIn("NoValidChoicesError", str(context.exception))
 
     @config.patch(force_shape_pad=True, max_autotune=True)
-    def test_linear_and_cel(self):
+    def test_linear_and_cel(self, device):
         """
         Similate a GPU without enough SMs. Make sure max-autotune still
         works even when the MultiTritonTemplate encapsulates just extern
@@ -1782,7 +1630,7 @@ class TestMaxAutotune(TestCase):
 
         B, T, C, V = 32, 1024, 768, 50257
 
-        linear = nn.Linear(C, V).bfloat16().to(device=GPU_TYPE)
+        linear = nn.Linear(C, V).bfloat16().to(device=device)
         ce = torch.nn.CrossEntropyLoss()
 
         def f(x, y):
@@ -1794,9 +1642,9 @@ class TestMaxAutotune(TestCase):
             loss.backward()
             return loss
 
-        x = torch.randn(B * T, C, requires_grad=True).to(GPU_TYPE).bfloat16()
+        x = torch.randn(B * T, C, requires_grad=True).to(device).bfloat16()
         x.retain_grad()
-        y = torch.randint(0, V, (B * T,)).to(GPU_TYPE)
+        y = torch.randint(0, V, (B * T,)).to(device)
 
         import torch._inductor.utils as inductor_utils
 
@@ -1824,7 +1672,7 @@ class TestMaxAutotune(TestCase):
         comprehensive_padding=False,
         shape_padding=False,
     )
-    def test_max_autotune_decompose_k(self, sizes, dtype, dynamic):
+    def test_max_autotune_decompose_k(self, device, sizes, dtype, dynamic):
         # UT specific change to force testing decompose K feature on ROCm until
         # enabled by default, same strategy as #169948
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
@@ -1848,7 +1696,7 @@ class TestMaxAutotune(TestCase):
                 K,
                 N,
                 dtype=dtype,
-                device=GPU_TYPE,
+                device=device,
                 requires_grad=True,
             )
 
@@ -1867,7 +1715,9 @@ class TestMaxAutotune(TestCase):
 
                         self.assertTrue(
                             divisor_found,
-                            lambda msg: f"{msg}\nCould not find a split in {divisors} in {kernel}",
+                            lambda msg: (
+                                f"{msg}\nCould not find a split in {divisors} in {kernel}"
+                            ),
                         )
 
             compiled_func = torch.compile(lambda a, b: a @ b, dynamic=dynamic)
@@ -1938,63 +1788,11 @@ class TestMaxAutotune(TestCase):
         config.triton.native_matmul,
         "ignore decompose_k when native matmul codegen",
     )
-    @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    def test_decompose_k_shape_keeps_mm_template_when_exhaustive(self, search_space):
-        """On a shape where decompose_k applies even at threshold_multiple=2, tuned_mm
-        drops the plain mm template to save autotuning time -- except under EXHAUSTIVE,
-        where the user asked for every choice."""
-        a, b = self._make_matrices(
-            M=32,
-            K=32768,
-            N=64,
-            dtype=torch.bfloat16,
-            device=GPU_TYPE,
-            requires_grad=False,
-        )
-
-        names: list[str] = []
-
-        def record(choices):
-            names.extend(c.name for c in choices)
-            return choices
-
-        torch._dynamo.reset()
-        add_preprocessing_fn(record)
-        try:
-            with config.patch(
-                {
-                    "max_autotune": True,
-                    "max_autotune_gemm_backends": "ATEN,TRITON",
-                    "max_autotune_gemm_search_space": search_space,
-                    # keeps the exhaustive space from dominating test runtime
-                    "test_configs.max_mm_configs": 1,
-                    **_DECOMPOSE_K_PATCH_ROCM,
-                }
-            ):
-                torch.compile(lambda x, y: x @ y)(a, b)
-        finally:
-            clear_preprocessing_fns(clear_defaults=False)
-
-        # the shape must actually be in decompose_k territory, else the test is vacuous
-        self.assertTrue(any(n.startswith("decompose_k") for n in names), names)
-        plain_mm = [n for n in names if n.startswith("triton_mm")]
-        if search_space == "EXHAUSTIVE":
-            self.assertTrue(plain_mm, f"mm_template dropped under EXHAUSTIVE: {names}")
-        else:
-            self.assertFalse(plain_mm, f"mm_template should be skipped: {names}")
-
-    @unittest.skipIf(
-        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
-    )
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "ignore decompose_k when native matmul codegen",
-    )
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_max_autotune_decompose_k_dynamic_input(self):
+    def test_max_autotune_decompose_k_dynamic_input(self, device):
         # UT specific change to force testing decompose K feature on ROCm until
         # enabled by default, same strategy as #169948
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
@@ -2008,7 +1806,7 @@ class TestMaxAutotune(TestCase):
                 K=32768,
                 N=64,
                 dtype=torch.bfloat16,
-                device=GPU_TYPE,
+                device=device,
                 requires_grad=True,
             )
 
@@ -2019,8 +1817,8 @@ class TestMaxAutotune(TestCase):
             with mock.patch(
                 "torch._inductor.kernel.mm.use_decompose_k_choice"
             ) as decomp_mock:
-                decomp_mock.side_effect = (
-                    lambda *args, **kwargs: kwargs.get("threshold_multiple", 1) == 1
+                decomp_mock.side_effect = lambda *args, **kwargs: (
+                    kwargs.get("threshold_multiple", 1) == 1
                 )
 
                 out, code = run_and_get_code(compiled_func, a, b)
@@ -2047,7 +1845,7 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_max_autotune_decompose_k_dynamic_input_bwd(self):
+    def test_max_autotune_decompose_k_dynamic_input_bwd(self, device):
         # UT specific change to force testing decompose K feature on ROCm until
         # enabled by default, same strategy as #169948
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
@@ -2062,7 +1860,7 @@ class TestMaxAutotune(TestCase):
                 K=64,
                 N=32768,
                 dtype=torch.bfloat16,
-                device=GPU_TYPE,
+                device=device,
                 requires_grad=True,
             )
 
@@ -2075,8 +1873,8 @@ class TestMaxAutotune(TestCase):
             with mock.patch(
                 "torch._inductor.kernel.mm.use_decompose_k_choice"
             ) as decomp_mock:
-                decomp_mock.side_effect = (
-                    lambda *args, **kwargs: kwargs.get("threshold_multiple", 1) == 1
+                decomp_mock.side_effect = lambda *args, **kwargs: (
+                    kwargs.get("threshold_multiple", 1) == 1
                 )
 
                 def fwd_bwd():
@@ -2113,7 +1911,7 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_max_autotune_decompose_k_output_stride(self):
+    def test_max_autotune_decompose_k_output_stride(self, device):
         # UT specific change to force testing decompose K feature on ROCm until
         # enabled by default, same strategy as #169948
         with config.patch(_DECOMPOSE_K_PATCH_ROCM):
@@ -2122,15 +1920,15 @@ class TestMaxAutotune(TestCase):
                 a = a.transpose(0, 1)
                 return a @ b
 
-            a = torch.randn((32768, 256), device=GPU_TYPE, dtype=torch.bfloat16)
-            b = torch.randn((32768, 1152), device=GPU_TYPE, dtype=torch.bfloat16)
+            a = torch.randn((32768, 256), device=device, dtype=torch.bfloat16)
+            b = torch.randn((32768, 1152), device=device, dtype=torch.bfloat16)
 
             b = b[:, :1096]
 
             # Force only decomposeK choice
             with (
                 override_template_heuristics(
-                    device_type=GPU_TYPE,
+                    device_type=torch.device(device).type,
                     template_op_pairs=[
                         (torch._inductor.kernel.mm.mm_template.name, "mm")
                     ],
@@ -2150,7 +1948,7 @@ class TestMaxAutotune(TestCase):
                 FileCheck().check_not("extern_kernels.bmm_dtype").check(
                     "decompose_k"
                 ).check(
-                    f" empty_strided_{GPU_TYPE}((256, 1096), (1096, 1), torch.bfloat16)"
+                    f" empty_strided_{torch.device(device).type}((256, 1096), (1096, 1), torch.bfloat16)"
                 ).run(code[0])
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
@@ -2159,7 +1957,7 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True,
     )
-    def test_max_autotune_contiguous_transform_mm(self, sizes, dtype):
+    def test_max_autotune_contiguous_transform_mm(self, device, sizes, dtype):
         """
         Test the contiguous subgraph transform with A * transpose(B) pattern.
         This transform makes the second matrix contiguous before the matmul.
@@ -2169,8 +1967,8 @@ class TestMaxAutotune(TestCase):
         def mm_transpose(a, b):
             return a @ b.transpose(0, 1)
 
-        a = torch.randn(M, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
-        b = torch.randn(N, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
+        a = torch.randn(M, K, dtype=dtype, device=device, requires_grad=True)
+        b = torch.randn(N, K, dtype=dtype, device=device, requires_grad=True)
 
         # Compute fp64 baseline
         a_fp64 = a.to(torch.float64)
@@ -2202,7 +2000,7 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         max_autotune=True,
     )
-    def test_max_autotune_contiguous_transform_addmm(self, sizes, dtype):
+    def test_max_autotune_contiguous_transform_addmm(self, device, sizes, dtype):
         """
         Test the contiguous subgraph transform for addmm with non-contiguous second matrix.
         """
@@ -2211,9 +2009,9 @@ class TestMaxAutotune(TestCase):
         def addmm_transpose(inp, a, b):
             return torch.addmm(inp, a, b.transpose(0, 1))
 
-        inp = torch.randn(M, N, dtype=dtype, device=GPU_TYPE, requires_grad=True)
-        a = torch.randn(M, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
-        b = torch.randn(N, K, dtype=dtype, device=GPU_TYPE, requires_grad=True)
+        inp = torch.randn(M, N, dtype=dtype, device=device, requires_grad=True)
+        a = torch.randn(M, K, dtype=dtype, device=device, requires_grad=True)
+        b = torch.randn(N, K, dtype=dtype, device=device, requires_grad=True)
 
         # Compute fp64 baseline
         inp_fp64 = inp.to(torch.float64)
@@ -2243,7 +2041,7 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_contiguous_transform_non_contiguous_second_matrix(
-        self, dynamic
+        self, device, dynamic
     ):
         """
         Test that contiguous transform is only applied when the second matrix is non-contiguous.
@@ -2253,10 +2051,10 @@ class TestMaxAutotune(TestCase):
         def mm(a, b):
             return a @ b
 
-        a = torch.randn(M, K, dtype=torch.float32, device=GPU_TYPE)
-        b_contiguous = torch.randn(K, N, dtype=torch.float32, device=GPU_TYPE)
+        a = torch.randn(M, K, dtype=torch.float32, device=device)
+        b_contiguous = torch.randn(K, N, dtype=torch.float32, device=device)
         b_non_contiguous = torch.randn(
-            N, K, dtype=torch.float32, device=GPU_TYPE
+            N, K, dtype=torch.float32, device=device
         ).transpose(0, 1)
 
         # Compute fp64 baselines without max_autotune (since fp64 doesn't work with max_autotune=True)
@@ -2312,7 +2110,7 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_max_autotune_contiguous_transform_with_epilogue(self):
+    def test_max_autotune_contiguous_transform_with_epilogue(self, device):
         """
         Test contiguous transform with epilogue operations like relu.
         """
@@ -2321,8 +2119,8 @@ class TestMaxAutotune(TestCase):
         def mm_transpose_relu(a, b):
             return (a @ b.transpose(0, 1)).relu()
 
-        a = torch.randn(M, K, dtype=torch.float32, device=GPU_TYPE)
-        b = torch.randn(N, K, dtype=torch.float32, device=GPU_TYPE)
+        a = torch.randn(M, K, dtype=torch.float32, device=device)
+        b = torch.randn(N, K, dtype=torch.float32, device=device)
 
         # Compute fp64 baseline
         a_fp64 = a.to(torch.float64)
@@ -2352,7 +2150,7 @@ class TestMaxAutotune(TestCase):
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
     )
-    def test_override_template_heuristics_with_custom_class(self):
+    def test_override_template_heuristics_with_custom_class(self, device):
         """
         Test that override_template_heuristics works with a custom heuristic class.
         Verifies that get_template_heuristic returns an instance of our custom class
@@ -2368,7 +2166,7 @@ class TestMaxAutotune(TestCase):
 
         # Get the base heuristic class that would normally be used for mm_template
         base_heuristic_class = get_registered_heuristic_class(
-            template_uid, GPU_TYPE, "mm"
+            template_uid, torch.device(device).type, "mm"
         )
         self.assertIsNotNone(base_heuristic_class)
 
@@ -2382,7 +2180,7 @@ class TestMaxAutotune(TestCase):
             mat1 = Buffer(
                 name="mat1",
                 layout=FixedLayout(
-                    torch.device(GPU_TYPE),
+                    torch.device(device),
                     dtype=torch.float32,
                     size=(64, 64),
                 ),
@@ -2390,7 +2188,7 @@ class TestMaxAutotune(TestCase):
             mat2 = Buffer(
                 name="mat2",
                 layout=FixedLayout(
-                    torch.device(GPU_TYPE),
+                    torch.device(device),
                     dtype=torch.float32,
                     size=(64, 64),
                 ),
@@ -2409,12 +2207,14 @@ class TestMaxAutotune(TestCase):
                     yield expected_config
 
             with override_template_heuristics(
-                device_type=GPU_TYPE,
+                device_type=torch.device(device).type,
                 template_op_pairs=[(template_uid, "mm")],
                 override_heuristic_class=CustomMMHeuristic,
             ):
                 # Get the heuristic and verify it's our custom class
-                heuristic = get_template_heuristic(template_uid, GPU_TYPE, "mm")
+                heuristic = get_template_heuristic(
+                    template_uid, torch.device(device).type, "mm"
+                )
                 self.assertIsInstance(heuristic, CustomMMHeuristic)
                 self.assertIsInstance(heuristic, base_heuristic_class)
 
@@ -2424,12 +2224,12 @@ class TestMaxAutotune(TestCase):
                 self.assertEqual(configs[0], expected_config)
 
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
-    def test_bmm_out_dtype(self):
+    def test_bmm_out_dtype(self, device):
         def f(a, b):
             return torch.bmm(a, b, out_dtype=torch.float32)
 
-        a = torch.randn(2, 3, 4, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2, 4, 5, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2, 3, 4, device=device, dtype=torch.float16)
+        b = torch.randn(2, 4, 5, device=device, dtype=torch.float16)
         expected = torch.bmm(a.float(), b.float())
         with config.patch(
             max_autotune=False,
@@ -2441,12 +2241,12 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
-    def test_triton_bmm_out_dtype(self):
+    def test_triton_bmm_out_dtype(self, device):
         def f(a, b, out_dtype=torch.float32):
             return torch.bmm(a, b, out_dtype=out_dtype)
 
-        a = torch.randn(2, 3, 4, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2, 4, 5, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2, 3, 4, device=device, dtype=torch.float16)
+        b = torch.randn(2, 4, 5, device=device, dtype=torch.float16)
         expected = torch.bmm(a.float(), b.float())
         with config.patch(
             max_autotune=True,
@@ -2457,7 +2257,7 @@ class TestMaxAutotune(TestCase):
             FileCheck().check("triton_tem_fused_bmm").run(code[0])
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
-    def test_triton_template_generated_code_cache_key(self):
+    def test_triton_template_generated_code_cache_key(self, device):
         generate_and_load_args = len(
             inspect.signature(
                 torch._inductor.select_algorithm.TritonTemplate.generate_and_load
@@ -2483,14 +2283,14 @@ class TestMaxAutotune(TestCase):
         }
     )
     @unittest.skipIf(config.triton.native_matmul, "only test on template-based matmul")
-    def test_triton_template_generated_code_cache_strategy(self):
+    def test_triton_template_generated_code_cache_strategy(self, device):
         def func_test1(x, y, z, m):
             a = torch.matmul(x, y)
             b = torch.matmul(z, m)
             return a, b
 
-        a = torch.rand(10, 22, device=GPU_TYPE)
-        b = torch.rand(22, 30, device=GPU_TYPE)
+        a = torch.rand(10, 22, device=device)
+        b = torch.rand(22, 30, device=device)
         # Test that the testing strategy works by overriding input_dependent_preserved_state and simulate a cache hit.
         with unittest.mock.patch(
             "torch._inductor.select_algorithm.TritonTemplateKernel.input_dependent_preserved_state",
@@ -2510,7 +2310,7 @@ class TestMaxAutotune(TestCase):
         }
     )
     @unittest.skipIf(config.triton.native_matmul, "only test on template-based matmul")
-    def test_triton_template_generated_code_caching(self):
+    def test_triton_template_generated_code_caching(self, device):
         def reset_counters():
             torch._dynamo.utils.counters.clear()
 
@@ -2539,8 +2339,8 @@ class TestMaxAutotune(TestCase):
             b = torch.matmul(z, m)
             return a, b
 
-        a = torch.rand(10, 22, device=GPU_TYPE)
-        b = torch.rand(22, 30, device=GPU_TYPE)
+        a = torch.rand(10, 22, device=device)
+        b = torch.rand(22, 30, device=device)
 
         # Valid cache hit.
         with fresh_cache():
@@ -2567,7 +2367,7 @@ class TestMaxAutotune(TestCase):
                         'BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':False},
                         'hint_override':None,'triton_meta':None}"""
 
-                expected = expected.replace("cuda", GPU_TYPE)
+                expected = expected.replace("cuda", torch.device(device).type)
                 self.assertExpectedInline(
                     remove_white_space(cache_key),
                     remove_white_space(expected),
@@ -2580,11 +2380,11 @@ class TestMaxAutotune(TestCase):
 
         # Test symbolic shapes with different symbols. Will cache miss due to different symbols in inputs.
         with fresh_cache():
-            a = torch.rand(10, 22, device=GPU_TYPE)
-            b = torch.rand(22, 30, device=GPU_TYPE)
+            a = torch.rand(10, 22, device=device)
+            b = torch.rand(22, 30, device=device)
 
-            c = torch.rand(9, 21, device=GPU_TYPE)
-            d = torch.rand(21, 30, device=GPU_TYPE)
+            c = torch.rand(9, 21, device=device)
+            d = torch.rand(21, 30, device=device)
             reset_counters()
             compiled_results = torch.compile(func_test1, dynamic=True)(a, b, c, d)
             eager_results = func_test1(a, b, c, d)
@@ -2608,7 +2408,7 @@ class TestMaxAutotune(TestCase):
                     'tma_load_for_template_epilogue':False,'transpose_discontiguous_tensor_descriptors_override':None,
                     'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,
                     'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':False},'hint_override':None,'triton_meta':None}"""
-                expected = expected.replace("cuda", GPU_TYPE)
+                expected = expected.replace("cuda", torch.device(device).type)
                 self.assertExpectedInline(
                     remove_white_space(cache_key),
                     remove_white_space(expected),
@@ -2651,7 +2451,7 @@ class TestMaxAutotune(TestCase):
 
         with fresh_cache():
             reset_counters()
-            input = torch.rand(10, 10, device=GPU_TYPE)
+            input = torch.rand(10, 10, device=device)
 
             compile_results = torch.compile(test_func2, dynamic=False)(input)
             eager_results = test_func2(input)
@@ -2662,7 +2462,7 @@ class TestMaxAutotune(TestCase):
 
         with fresh_cache():
             reset_counters()
-            input = torch.rand(10, 10, device=GPU_TYPE)
+            input = torch.rand(10, 10, device=device)
 
             compile_results = torch.compile(test_func2, dynamic=True)(input)
             eager_results = test_func2(input)
@@ -2680,11 +2480,11 @@ class TestMaxAutotune(TestCase):
             return a, b
 
         with fresh_cache():
-            a = torch.rand(10, 22, device=GPU_TYPE)
-            b = torch.rand(22, 30, device=GPU_TYPE)
-            c = torch.rand(10, 11, device=GPU_TYPE)
-            d = torch.rand(8, 30, device=GPU_TYPE)
-            e = torch.rand(3, 30, device=GPU_TYPE)
+            a = torch.rand(10, 22, device=device)
+            b = torch.rand(22, 30, device=device)
+            c = torch.rand(10, 11, device=device)
+            d = torch.rand(8, 30, device=device)
+            e = torch.rand(3, 30, device=device)
 
             compile_results = torch.compile(test_func3, dynamic=True)(a, b, c, d, e)
             eager_results = test_func3(a, b, c, d, e)
@@ -2701,14 +2501,14 @@ class TestMaxAutotune(TestCase):
         }
     )
     @unittest.skipIf(config.triton.native_matmul, "only test on template-based matmul")
-    def test_triton_template_generated_code_caching_bmm(self):
+    def test_triton_template_generated_code_caching_bmm(self, device):
         def func_test1(x, y, z, m):
             a = torch.bmm(x, y)
             b = torch.bmm(z, m)
             return a, b
 
-        a = torch.rand(10, 10, 22, device=GPU_TYPE)
-        b = torch.rand(10, 22, 30, device=GPU_TYPE)
+        a = torch.rand(10, 10, 22, device=device)
+        b = torch.rand(10, 22, 30, device=device)
 
         def hits():
             return torch._dynamo.utils.counters["inductor"][
@@ -2737,7 +2537,7 @@ class TestMaxAutotune(TestCase):
         }
     )
     @unittest.skipIf(config.triton.native_matmul, "only test on template-based matmul")
-    def test_triton_template_generated_code_caching_mm_plus_mm(self):
+    def test_triton_template_generated_code_caching_mm_plus_mm(self, device):
         def func_test1(x, y, z, m):
             a = torch.mm(x, y)
             b = torch.mm(z, m)
@@ -2748,8 +2548,8 @@ class TestMaxAutotune(TestCase):
             sum2 = c + d
             return sum1, sum2
 
-        a = torch.rand(10, 40, device=GPU_TYPE)
-        b = torch.rand(40, 30, device=GPU_TYPE)
+        a = torch.rand(10, 40, device=device)
+        b = torch.rand(40, 30, device=device)
 
         def hits():
             return torch._dynamo.utils.counters["inductor"][
@@ -2862,14 +2662,14 @@ class TestMaxAutotune(TestCase):
     @parametrize("num_decompose_k_splits", (0, 5, 20))
     @parametrize("decompose_k_threshold", (8, 16))
     def test_max_autotune_decompose_k_envvars(
-        self, num_decompose_k_splits, decompose_k_threshold
+        self, device, num_decompose_k_splits, decompose_k_threshold
     ):
         shapes = [(32, 32, 32768), (32, 32, 256)]
         for M, N, K in shapes:
             get_k_splits.cache_clear()
             use_decompose_k_choice.cache_clear()
-            a = torch.randn(M, K, dtype=torch.float16, device=GPU_TYPE)
-            b = torch.randn(K, N, dtype=torch.float16, device=GPU_TYPE)
+            a = torch.randn(M, K, dtype=torch.float16, device=device)
+            b = torch.randn(K, N, dtype=torch.float16, device=device)
 
             with config.patch(
                 {
@@ -2900,14 +2700,14 @@ class TestMaxAutotune(TestCase):
         "native matmul takes different tuning configs",
     )
     @config.patch(max_autotune=True, max_autotune_gemm_search_space="EXHAUSTIVE")
-    def test_max_autotune_exhaustive(self):
+    def test_max_autotune_exhaustive(self, device):
         def f(a, b):
             return a @ b
 
         M, N, K = (1024, 1024, 1024)
 
-        a = torch.randn(M, K, dtype=torch.float16, device=GPU_TYPE, requires_grad=True)
-        b = torch.randn(K, N, dtype=torch.float16, device=GPU_TYPE, requires_grad=True)
+        a = torch.randn(M, K, dtype=torch.float16, device=device, requires_grad=True)
+        b = torch.randn(K, N, dtype=torch.float16, device=device, requires_grad=True)
 
         with mock.patch(
             "torch._inductor.heuristics.registry.get_template_heuristic"
@@ -2915,7 +2715,7 @@ class TestMaxAutotune(TestCase):
             # Create heuristic instance and modify it before setting as mock return value
             # On ROCm, use ROCmMMTemplateConfigHeuristic; on XPU use XPUMMTemplateConfigHeuristic;
             # otherwise use CUDAMMTemplateConfigHeuristic
-            if GPU_TYPE == "xpu":
+            if torch.device(device).type == "xpu":
                 config_heuristics = XPUMMTemplateConfigHeuristic()
             elif torch.version.hip:
                 config_heuristics = ROCmMMTemplateConfigHeuristic()
@@ -2946,14 +2746,14 @@ class TestMaxAutotune(TestCase):
             "max_autotune_gemm_backends": "TRITON",
         }
     )
-    def test_mm_k_1(self):
+    def test_mm_k_1(self, device):
         def mm(x, y):
             return x @ y
 
         for i in range(90, 100):
             torch._dynamo.reset()
-            a = torch.randn((i, 1), device=GPU_TYPE, dtype=torch.float32)
-            b = torch.randn((1, i), device=GPU_TYPE, dtype=torch.float32)
+            a = torch.randn((i, 1), device=device, dtype=torch.float32)
+            b = torch.randn((1, i), device=device, dtype=torch.float32)
             compiled_f = torch.compile(mm)
 
             out, code = run_and_get_code(compiled_f, a, b)
@@ -2968,12 +2768,12 @@ class TestMaxAutotune(TestCase):
             "triton.native_matmul": False,
         }
     )
-    def test_autotune_gemm_choice_validation(self, op, max_autotune):
+    def test_autotune_gemm_choice_validation(self, device, op, max_autotune):
         def generate_inputs_and_func(op_name):
             # Base config with just x and w
             base_inputs = [
-                torch.randn(128, 256, device=GPU_TYPE),
-                torch.randn(256, 128, device=GPU_TYPE),
+                torch.randn(128, 256, device=device),
+                torch.randn(256, 128, device=device),
             ]
             func = torch.mm
             if op_name == "mm":
@@ -2981,24 +2781,24 @@ class TestMaxAutotune(TestCase):
                 pass
             elif op_name == "addmm":
                 # Add bias for addmm
-                base_inputs = [torch.randn(128, device=GPU_TYPE)] + base_inputs
+                base_inputs = [torch.randn(128, device=device)] + base_inputs
                 func = torch.addmm
             elif op_name in ["bmm", "baddbmm"]:
                 # Override for batch dimensions
-                base_inputs[0] = torch.randn(4, 128, 256, device=GPU_TYPE)
-                base_inputs[1] = torch.randn(4, 256, 128, device=GPU_TYPE)
+                base_inputs[0] = torch.randn(4, 128, 256, device=device)
+                base_inputs[1] = torch.randn(4, 256, 128, device=device)
                 func = torch.bmm
                 if op_name == "baddbmm":
                     # Add batch bias
                     base_inputs = [
-                        torch.torch.randn(4, 128, 128, device=GPU_TYPE)
+                        torch.torch.randn(4, 128, 128, device=device)
                     ] + base_inputs
                     func = torch.baddbmm
             elif op_name == "mm_plus_mm":
                 # Add second matrix pair
                 base_inputs += [
-                    torch.randn(128, 256, device=GPU_TYPE),
-                    torch.randn(256, 128, device=GPU_TYPE),
+                    torch.randn(128, 256, device=device),
+                    torch.randn(256, 128, device=device),
                 ]
 
                 def mmpmm(x, w, x2, w2):
@@ -3037,7 +2837,7 @@ class TestMaxAutotune(TestCase):
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "ATEN,TRITON"}
     )
     @parametrize("max_autotune_enabled", (True, False))
-    def test_autotune_layout_optimization(self, max_autotune_enabled):
+    def test_autotune_layout_optimization(self, device, max_autotune_enabled):
         """Test that layouts are flexible when every choice is ExternKernelChoice"""
 
         # we use a proxy here of bias_addmm and max-autotune because this enables us to see
@@ -3052,16 +2852,18 @@ class TestMaxAutotune(TestCase):
                     self.assertIsInstance(
                         choice.layout,
                         expected_layout,
-                        lambda msg: f"{msg}\nExpected {expected_layout.__name__} with max_autotune={max_autotune_enabled}",
+                        lambda msg: (
+                            f"{msg}\nExpected {expected_layout.__name__} with max_autotune={max_autotune_enabled}"
+                        ),
                     )
             return choices
 
         add_preprocessing_fn(layout_checker)
 
         try:
-            bias = torch.randn(64, device=GPU_TYPE)
-            x = torch.randn(32, 128, device=GPU_TYPE)
-            w = torch.randn(128, 64, device=GPU_TYPE)
+            bias = torch.randn(64, device=device)
+            x = torch.randn(32, 128, device=device)
+            w = torch.randn(128, 64, device=device)
 
             with config.patch({"max_autotune": max_autotune_enabled}):
                 compiled_fn = torch.compile(lambda b, x, w: torch.addmm(b, x, w))
@@ -3072,7 +2874,7 @@ class TestMaxAutotune(TestCase):
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}
     )
-    def test_fixed_layout_at_lowering(self):
+    def test_fixed_layout_at_lowering(self, device):
         """
         Test that max-autotune with addmm/bmm/mm_plus_mm correctly handles
         padding and maintains correct output strides. Specifically, when matrix
@@ -3104,16 +2906,16 @@ class TestMaxAutotune(TestCase):
             b2_dtype = b2.to(torch.bfloat16)
             return (a1_t @ b1_dtype + a2_t @ b2_dtype).to(torch.float32)
 
-        a = torch.randn((4608, 512), device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn((4608, 1490), device=GPU_TYPE)
-        bias = torch.randn(1490, device=GPU_TYPE)
+        a = torch.randn((4608, 512), device=device, dtype=torch.bfloat16)
+        b = torch.randn((4608, 1490), device=device)
+        bias = torch.randn(1490, device=device)
 
-        a_bmm = torch.randn((512, 4608, 8), device=GPU_TYPE, dtype=torch.bfloat16)
-        b_bmm = torch.randn((8, 4608, 1490), device=GPU_TYPE)
+        a_bmm = torch.randn((512, 4608, 8), device=device, dtype=torch.bfloat16)
+        b_bmm = torch.randn((8, 4608, 1490), device=device)
 
         # Test mm_plus_mm
-        a2 = torch.randn((4608, 512), device=GPU_TYPE, dtype=torch.bfloat16)
-        b2 = torch.randn((4608, 1490), device=GPU_TYPE)
+        a2 = torch.randn((4608, 512), device=device, dtype=torch.bfloat16)
+        b2 = torch.randn((4608, 1490), device=device)
 
         # 1490 padded to 1536, check in template code
         output_code_padding_check = "stride_bk = 1536"
@@ -3131,10 +2933,10 @@ class TestMaxAutotune(TestCase):
 
     @parametrize("k", (15, 16))
     @parametrize("dynamic", (False, True))
-    def test_even_k(self, k: int, dynamic: bool):
+    def test_even_k(self, device, k: int, dynamic: bool):
         M, N = 21, 31
-        a = torch.randn((M, k), dtype=torch.float16, device=GPU_TYPE)
-        b = torch.randn((k, N), dtype=torch.float16, device=GPU_TYPE)
+        a = torch.randn((M, k), dtype=torch.float16, device=device)
+        b = torch.randn((k, N), dtype=torch.float16, device=device)
 
         if dynamic:
             torch._dynamo.mark_dynamic(a, 1)
@@ -3156,7 +2958,7 @@ class TestMaxAutotune(TestCase):
         }
     )
     @parametrize("epilogue", (True, False))
-    def test_deferred_layout_constraint_cat_fusion(self, epilogue):
+    def test_deferred_layout_constraint_cat_fusion(self, device, epilogue):
         def mm_with_cat(a, b1, b2, d):
             catted_b = torch.cat([b1, b2], dim=1)
             catted_b_add = catted_b + 1.0
@@ -3179,9 +2981,9 @@ class TestMaxAutotune(TestCase):
         k1, k2 = 256, 256
         n = 1490  # Would normally trigger padding (1490 -> 1536)
 
-        a = torch.randn(batch, m, k1 + k2, device=GPU_TYPE)
-        b1 = torch.randn(batch, k1, n, device=GPU_TYPE)
-        b2 = torch.randn(batch, k2, n, device=GPU_TYPE)
+        a = torch.randn(batch, m, k1 + k2, device=device)
+        b1 = torch.randn(batch, k1, n, device=device)
+        b2 = torch.randn(batch, k2, n, device=device)
         d = torch.cat([b1, b2], dim=1).to(torch.bfloat16)
 
         with (
@@ -3200,7 +3002,7 @@ class TestMaxAutotune(TestCase):
             FileCheck().check_not("triton_tem").run(code[0])
 
     @parametrize("always_freeze", [True, False])
-    def test_mm_layout_freezing_behavior(self, always_freeze):
+    def test_mm_layout_freezing_behavior(self, device, always_freeze):
         """Test that mm layout freezing behavior depends on always_freeze_layout.
 
         When always_freeze_layout=True, FlexibleLayout should be frozen to FixedLayout.
@@ -3238,8 +3040,8 @@ class TestMaxAutotune(TestCase):
             return torch.mm(x, y)
 
         M, K, N = 256, 128, 256
-        x = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
-        y = torch.randn(K, N, device=GPU_TYPE, dtype=torch.float16)
+        x = torch.randn(M, K, device=device, dtype=torch.float16)
+        y = torch.randn(K, N, device=device, dtype=torch.float16)
 
         # Save original value to restore later
         original_always_freeze = mm_template.always_freeze_layout
@@ -3272,21 +3074,21 @@ class TestMaxAutotune(TestCase):
             "test_configs.max_mm_configs": 1,
         }
     )
-    def test_deffered_layout_constraint_reintepret(self):
+    def test_deffered_layout_constraint_reintepret(self, device):
         batch, m, k, n = 4608, 40, 112, 1119
 
         # Shape: batch x m x k (contiguous)
-        a = torch.randn(batch, m, k, dtype=torch.bfloat16, device=GPU_TYPE)
+        a = torch.randn(batch, m, k, dtype=torch.bfloat16, device=device)
 
         padded_batch_stride = k * n + 48
         b = torch.empty_strided(
             size=(batch, k, n),
             stride=(padded_batch_stride, 1, k),
             dtype=torch.bfloat16,
-            device=GPU_TYPE,
+            device=device,
         )
         b.copy_(torch.randn_like(b))
-        c = torch.randn(batch, k, m, dtype=torch.bfloat16, device=GPU_TYPE)
+        c = torch.randn(batch, k, m, dtype=torch.bfloat16, device=device)
 
         def fn(a, b, c):
             # Apply a pointwise op to b to make it FlexibleLayout in Inductor
@@ -3322,7 +3124,7 @@ class TestMaxAutotune(TestCase):
             "max_autotune": True,
         }
     )
-    def test_deffered_layout_constraint_mm_cat_mm(self):
+    def test_deffered_layout_constraint_mm_cat_mm(self, device):
         def mm_cat_mm(t1, t2, t3, t4):
             add = t2 + 1
             matmul1 = torch.matmul(t1, add)
@@ -3335,10 +3137,10 @@ class TestMaxAutotune(TestCase):
         K = 144
         N = 160
         P = 96
-        t1 = torch.randn(B, M, K, device=GPU_TYPE, dtype=torch.float16)
-        t2 = torch.randn(B, K, N, device=GPU_TYPE, dtype=torch.float16)
-        t3 = torch.randn(B, P, N, device=GPU_TYPE, dtype=torch.float16)
-        t4 = torch.randn(B, M, K, device=GPU_TYPE, dtype=torch.float16)
+        t1 = torch.randn(B, M, K, device=device, dtype=torch.float16)
+        t2 = torch.randn(B, K, N, device=device, dtype=torch.float16)
+        t3 = torch.randn(B, P, N, device=device, dtype=torch.float16)
+        t4 = torch.randn(B, M, K, device=device, dtype=torch.float16)
 
         args = (t1, t2, t3, t4)
 
@@ -3347,256 +3149,28 @@ class TestMaxAutotune(TestCase):
         run_and_get_code(compiled_fn, *args)
 
     @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @unittest.skipIf(
-        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
-    )
-    @largeTensorTest("10 GB", device=GPU_TYPE)
-    def test_max_autotune_mm_large_input_tensor_int64_indexing(self):
-        """
-        Test mm with input tensor exceeding 2^31 elements.
-        Regression test for https://github.com/pytorch/pytorch/issues/171389
-        When input tensor storage exceeds 2^31 elements, tl.arange() must be
-        cast to INDEX_DTYPE (int64) to avoid integer overflow in pointer arithmetic.
-        """
-
-        def mm(a, b):
-            return torch.mm(a, b)
-
-        M, K, N = 1280, 65536, 65536
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.float16)
-
-        self.assertTrue(
-            b.numel() > 2**31 - 1,
-            lambda msg: f"{msg}\nTest requires tensor with >2^31 elements, got {b.numel()}",
-        )
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
-            }
-        ):
-            result = torch.compile(mm)(a, b)
-
-        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @unittest.skipIf(
-        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
-    )
-    @largeTensorTest("6 GB", device=GPU_TYPE)
-    def test_max_autotune_grouped_mm_large_input_tensor_int64_indexing(self):
-        def grouped_mm(a, b, offs):
-            return torch._grouped_mm(a, b.transpose(-2, -1), offs=offs)
-
-        # G*N*K == 2**31: smallest size triggering int64 INDEX_DTYPE
-        # while max_offset (== numel - 1) still fits int32, so TMA
-        # stays enabled.
-        G, M, N, K = 8, 128, 16384, 16384
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(G, N, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        offs = torch.arange(M // G, M + 1, M // G, device=GPU_TYPE, dtype=torch.int32)
-
-        self.assertEqual(b.numel(), 2**31)
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": r"^triton_grouped_mm",
-            }
-        ):
-            result = torch.compile(grouped_mm)(a, b, offs)
-
-        torch.testing.assert_close(result, grouped_mm(a, b, offs), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @unittest.skipIf(
-        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
-    )
-    @largeTensorTest("6 GB", device=GPU_TYPE)
-    def test_max_autotune_grouped_mm_large_input_tensor_tma_disabled(self):
-        # Grouped mm whose TMA descriptor max offset exceeds
-        # int32_max; USE_TMA_LOAD must be disabled and the non-TMA
-        # fallback still correct.
-        def grouped_mm(a, b, offs):
-            return torch._grouped_mm(a, b.transpose(-2, -1), offs=offs)
-
-        G, M, N, K = 8, 128, 16384, 16512
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(G, N, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        offs = torch.arange(M // G, M + 1, M // G, device=GPU_TYPE, dtype=torch.int32)
-
-        self.assertGreater(b.numel(), 2**31)
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": r"^triton_grouped_mm",
-            }
-        ):
-            result = torch.compile(grouped_mm)(a, b, offs)
-
-        torch.testing.assert_close(result, grouped_mm(a, b, offs), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @largeTensorTest("6 GB", device=GPU_TYPE)
-    def test_max_autotune_mm_large_storage_offset_i64_indexing(self):
-        """
-        Test mm with input having dynamic storage offset exceeding i32 range.
-        When a dynamic-shaped input is a slice with offset proportional to
-        the dynamic dim (e.g., offset=70000*s6), the ks parameter in the
-        triton template signature must use i64 to avoid overflow in pointer
-        arithmetic like `A = arg_A + 70000*ks0`.
-        """
-
-        def mm(x, w):
-            batch = x.shape[0] // 8
-            a = x[7 * batch :]
-            return torch.mm(a, w)
-
-        K, N = 10000, 32
-        batch = 32768
-        x = torch.randn(8 * batch, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        w = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
-
-        expected_offset = 7 * batch * K
-        self.assertTrue(
-            expected_offset > 2**31 - 1,
-            lambda msg: f"{msg}\nTest requires offset > i32_max, got {expected_offset}",
-        )
-
-        torch._dynamo.mark_dynamic(x, 0)
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
-            }
-        ):
-            result = torch.compile(mm)(x, w)
-
-        a = x[7 * batch :]
-        torch.testing.assert_close(result, torch.mm(a, w), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @unittest.skipIf(
-        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
-    )
-    @largeTensorTest("10 GB", device=GPU_TYPE)
-    def test_max_autotune_mm_large_output_tensor_int32_overflow(self):
-        """
-        Test mm with output tensor exceeding 2^32 elements.
-        Regression test for https://github.com/pytorch/pytorch/issues/171389
-        When M * N >= 2^32, the early exit check `if M * N == 0` can overflow
-        to 0 in int32 arithmetic, causing the kernel to return immediately
-        with all-zero output.
-        """
-
-        def mm(a, b):
-            return torch.mm(a, b)
-
-        M, K, N = 65536, 32, 65536
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.float16)
-
-        self.assertTrue(
-            M * N >= 2**32,
-            lambda msg: f"{msg}\nTest requires M*N >= 2^32 for overflow, got {M * N}",
-        )
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
-            }
-        ):
-            result = torch.compile(mm)(a, b)
-
-        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
-    @skipIfXpu
-    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
-    @unittest.skipIf(
-        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
-    )
-    @unittest.skipIf(
-        has_datacenter_blackwell_tma_device(),
-        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
-    )
-    @largeTensorTest("10 GB", device=GPU_TYPE)
-    def test_max_autotune_mm_persistent_tma_large_input_tensor_int64_indexing(self):
-        """
-        Test persistent TMA mm with input tensor exceeding 2^31 elements.
-        Regression test for https://github.com/pytorch/pytorch/issues/171389.
-        Triton TMA descriptors require 32-bit block offsets even when the
-        surrounding kernel uses int64 indexing.
-        """
-
-        def mm(a, b):
-            return torch.mm(a, b)
-
-        M, K, N = 1280, 65536, 65536
-        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(K, N, device=GPU_TYPE, dtype=torch.float16)
-
-        self.assertTrue(
-            b.numel() > 2**31 - 1,
-            lambda msg: f"{msg}\nTest requires tensor with >2^31 elements, got {b.numel()}",
-        )
-
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "triton.enable_persistent_tma_matmul": "1",
-                "triton.native_matmul": False,
-                "test_configs.autotune_choice_name_regex": "mm_persistent_tma",
-            }
-        ):
-            result = torch.compile(mm)(a, b)
-
-        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
-
-    @fresh_cache()
     @config.patch(
         {
             "max_autotune": True,
             "test_configs.max_mm_configs": 1,
         }
     )
-    def test_deferred_layout_constraint_reinterpret_3d(self):
+    def test_deferred_layout_constraint_reinterpret_3d(self, device):
         batch, m, k, n = 32, 40, 1053, 40
         batch_stride = 42176
 
-        a = torch.randn(batch, m, k, dtype=torch.bfloat16, device=GPU_TYPE)
+        a = torch.randn(batch, m, k, dtype=torch.bfloat16, device=device)
         b = torch.empty_strided(
             size=(batch, k * n),
             stride=(batch_stride, 1),
             dtype=torch.bfloat16,
-            device=GPU_TYPE,
+            device=device,
         )
         b.copy_(torch.randn_like(b))
-        c = torch.randn(batch, n, m, dtype=torch.bfloat16, device=GPU_TYPE)
-        idx0 = torch.tensor([0], device=GPU_TYPE)
-        idx1 = torch.tensor([0], device=GPU_TYPE)
-        value = torch.zeros(1, dtype=torch.bfloat16, device=GPU_TYPE)
+        c = torch.randn(batch, n, m, dtype=torch.bfloat16, device=device)
+        idx0 = torch.tensor([0], device=device)
+        idx1 = torch.tensor([0], device=device)
+        value = torch.zeros(1, dtype=torch.bfloat16, device=device)
 
         def fn(a, b, c, idx0, idx1, value):
             # Mirror the 2D regression first: a simple pointwise op gives us a
@@ -3629,7 +3203,9 @@ class TestMaxAutotune(TestCase):
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/182093")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
-    def test_triton_gemm_epilogue_fusion_truncates_accumulator(self, dtype, use_addmm):
+    def test_triton_gemm_epilogue_fusion_truncates_accumulator(
+        self, device, dtype, use_addmm
+    ):
         """
         Verify that Triton GEMM epilogue fusion properly truncates the fp32
         accumulator to the output dtype before performing epilogue operations.
@@ -3653,8 +3229,8 @@ class TestMaxAutotune(TestCase):
             def fn(x):
                 return (x @ x).relu() - 1.0
 
-        x = torch.randn(128, 128, dtype=dtype, device=GPU_TYPE)
-        bias = torch.randn(128, dtype=dtype, device=GPU_TYPE) if use_addmm else None
+        x = torch.randn(128, 128, dtype=dtype, device=device)
+        bias = torch.randn(128, dtype=dtype, device=device) if use_addmm else None
 
         with config.patch(
             {
@@ -3718,14 +3294,16 @@ class TestMaxAutotune(TestCase):
                 out_unfused, code_unfused = run_and_get_code(torch.compile(fn), x)
 
         FileCheck().check_not(kernel_name).run(code_unfused[0])
-        if GPU_TYPE == "xpu" and dtype == torch.float16:
+        if torch.device(device).type == "xpu" and dtype == torch.float16:
             torch.testing.assert_close(out, out_unfused, atol=5e-4, rtol=5e-4)
         else:
             self.assertEqual(out, out_unfused)
 
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
-    def test_triton_gemm_no_epilogue_no_truncation_casts(self, dtype, use_addmm):
+    def test_triton_gemm_no_epilogue_no_truncation_casts(
+        self, device, dtype, use_addmm
+    ):
         """
         Verify that Triton GEMM without epilogue fusion does not have
         truncation casts in the epilogue.
@@ -3743,8 +3321,8 @@ class TestMaxAutotune(TestCase):
             def fn(x):
                 return x @ x
 
-        x = torch.randn(128, 128, dtype=dtype, device=GPU_TYPE)
-        bias = torch.randn(128, dtype=dtype, device=GPU_TYPE) if use_addmm else None
+        x = torch.randn(128, 128, dtype=dtype, device=device)
+        bias = torch.randn(128, dtype=dtype, device=device) if use_addmm else None
 
         with config.patch(
             {
@@ -3774,9 +3352,299 @@ class TestMaxAutotune(TestCase):
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
 
 
-@instantiate_parametrized_tests
+@unittest.mock.patch(
+    "torch._inductor.select_algorithm.TritonTemplate.test_cache", new=True
+)
+@config.patch(enable_caching_generated_triton_templates=True)
+class TestMaxAutotuneCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+    """CUDA-specific max-autotune tests that require CUDA-only APIs."""
+
+    @fresh_cache()
+    @skipIfXpu(msg="XPU doesn't support sm carveout")
+    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support sm carveout")
+    @unittest.skipIf(IS_WINDOWS, "Windows doesn't support persistent TMA")
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(), "B200 doesn't support sm carveout"
+    )
+    @parametrize("carveout", (None, 0, 27))
+    @parametrize("op", ("mm", "scaled_mm"))
+    def test_honor_sm_carveout_with_triton_tma(self, device, carveout, op: str):
+        def mm_func(a, b):
+            return torch.mm(a, b)
+
+        def scaled_mm(
+            a,
+            b,
+            scale_a,
+            scale_b,
+        ):
+            return torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.bfloat16)
+
+        # Create large matrices to ensure we use all possible sms
+        size = 2560
+        a = torch.randn(size, size, device=device, dtype=torch.bfloat16)
+        b = (
+            torch.randn(size, size, device=device, dtype=torch.bfloat16)
+            .transpose(0, 1)
+            .contiguous()
+            .transpose(0, 1)
+        )
+        scale_a = torch.tensor(1, dtype=torch.float32, device=device)
+        scale_b = torch.tensor(1, dtype=torch.float32, device=device)
+
+        args = (
+            (a.to(torch.float8_e4m3fn), b.to(torch.float8_e4m3fn), scale_a, scale_b)
+            if op == "scaled_mm"
+            else (a, b)
+        )
+        func = scaled_mm if op == "scaled_mm" else mm_func
+
+        # Set the specified carveout value
+        torch._C._set_sm_carveout_experimental(carveout)
+        if carveout is None:
+            self.assertIsNone(torch._C._get_sm_carveout_experimental())
+        else:
+            self.assertEqual(torch._C._get_sm_carveout_experimental(), carveout)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "triton.enable_persistent_tma_matmul": True,
+                "triton.native_matmul": False,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": "tma",
+            }
+        ):
+            compiled_mm = torch.compile(func, mode="max-autotune-no-cudagraphs")
+            compiled_mm(*args)  # Warm-up compilation
+
+            with tempfile.NamedTemporaryFile() as f:
+                with torch.profiler.profile(
+                    activities=[torch.profiler.ProfilerActivity.CUDA]
+                ) as prof:
+                    # Run with the specified carveout
+                    compiled_mm(*args)
+
+                # Export trace and analyze results
+                prof.export_chrome_trace(f.name)
+
+                # Extract grid sizes from the trace events for TMA kernels
+                kernel_name = "triton_tem_fused"
+                with open(f.name) as file:
+                    kernel_events = [
+                        {
+                            "grid": evt.get("args", {}).get("grid", []),
+                            "grid_size": math.prod(evt.get("args", {}).get("grid", [])),
+                        }
+                        for evt in json.load(file)["traceEvents"]
+                        if evt.get("cat", "") == "kernel"
+                        and kernel_name in evt.get("name", "").lower()
+                    ]
+
+                # We should have exactly 1 kernel event for this run
+                self.assertEqual(
+                    len(kernel_events),
+                    1,
+                    lambda msg: (
+                        f"{msg}\nExpected exactly 1 kernel event, but got {len(kernel_events)}"
+                    ),
+                )
+
+                # Check that grid size matches expected values based on carveout
+                expected_grid_size = None
+                max_grid_size = torch.cuda.get_device_properties(
+                    "cuda"
+                ).multi_processor_count
+                careveout = 0 if carveout is None else carveout
+                expected_grid_size = max_grid_size - careveout
+
+                self.assertEqual(
+                    kernel_events[0]["grid_size"],
+                    expected_grid_size,
+                    lambda msg: (
+                        f"{msg}\nGrid size {kernel_events[0]['grid_size']} doesn't match {expected_grid_size} for carveout={carveout}"
+                    ),
+                )
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @largeTensorTest("10 GB")
+    def test_max_autotune_mm_large_input_tensor_int64_indexing(self, device):
+        """
+        Test mm with input tensor exceeding 2^31 elements.
+        Regression test for https://github.com/pytorch/pytorch/issues/171389
+        When input tensor storage exceeds 2^31 elements, tl.arange() must be
+        cast to INDEX_DTYPE (int64) to avoid integer overflow in pointer arithmetic.
+        """
+
+        def mm(a, b):
+            return torch.mm(a, b)
+
+        M, K, N = 1280, 65536, 65536
+        a = torch.randn(M, K, device=device, dtype=torch.float16)
+        b = torch.randn(K, N, device=device, dtype=torch.float16)
+
+        self.assertTrue(
+            b.numel() > 2**31 - 1,
+            lambda msg: (
+                f"{msg}\nTest requires tensor with >2^31 elements, got {b.numel()}"
+            ),
+        )
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
+            }
+        ):
+            result = torch.compile(mm)(a, b)
+
+        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @largeTensorTest("6 GB")
+    def test_max_autotune_mm_large_storage_offset_i64_indexing(self, device):
+        """
+        Test mm with input having dynamic storage offset exceeding i32 range.
+        When a dynamic-shaped input is a slice with offset proportional to
+        the dynamic dim (e.g., offset=70000*s6), the ks parameter in the
+        triton template signature must use i64 to avoid overflow in pointer
+        arithmetic like `A = arg_A + 70000*ks0`.
+        """
+
+        def mm(x, w):
+            batch = x.shape[0] // 8
+            a = x[7 * batch :]
+            return torch.mm(a, w)
+
+        K, N = 10000, 32
+        batch = 32768
+        x = torch.randn(8 * batch, K, device=device, dtype=torch.bfloat16)
+        w = torch.randn(K, N, device=device, dtype=torch.bfloat16)
+
+        expected_offset = 7 * batch * K
+        self.assertTrue(
+            expected_offset > 2**31 - 1,
+            lambda msg: f"{msg}\nTest requires offset > i32_max, got {expected_offset}",
+        )
+
+        torch._dynamo.mark_dynamic(x, 0)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
+            }
+        ):
+            result = torch.compile(mm)(x, w)
+
+        a = x[7 * batch :]
+        torch.testing.assert_close(result, torch.mm(a, w), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @largeTensorTest("10 GB")
+    def test_max_autotune_mm_large_output_tensor_int32_overflow(self, device):
+        """
+        Test mm with output tensor exceeding 2^32 elements.
+        Regression test for https://github.com/pytorch/pytorch/issues/171389
+        When M * N >= 2^32, the early exit check `if M * N == 0` can overflow
+        to 0 in int32 arithmetic, causing the kernel to return immediately
+        with all-zero output.
+        """
+
+        def mm(a, b):
+            return torch.mm(a, b)
+
+        M, K, N = 65536, 32, 65536
+        a = torch.randn(M, K, device=device, dtype=torch.float16)
+        b = torch.randn(K, N, device=device, dtype=torch.float16)
+
+        self.assertTrue(
+            M * N >= 2**32,
+            lambda msg: f"{msg}\nTest requires M*N >= 2^32 for overflow, got {M * N}",
+        )
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "test_configs.autotune_choice_name_regex": r"^triton_mm_",
+            }
+        ):
+            result = torch.compile(mm)(a, b)
+
+        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
+
+    @fresh_cache()
+    @skipIfXpu
+    @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
+    @unittest.skipIf(
+        not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
+    )
+    @largeTensorTest("10 GB")
+    def test_max_autotune_mm_persistent_tma_large_input_tensor_int64_indexing(
+        self, device
+    ):
+        """
+        Test persistent TMA mm with input tensor exceeding 2^31 elements.
+        Regression test for https://github.com/pytorch/pytorch/issues/171389.
+        Triton TMA descriptors require 32-bit block offsets even when the
+        surrounding kernel uses int64 indexing.
+        """
+
+        def mm(a, b):
+            return torch.mm(a, b)
+
+        M, K, N = 1280, 65536, 65536
+        a = torch.randn(M, K, device=device, dtype=torch.float16)
+        b = torch.randn(K, N, device=device, dtype=torch.float16)
+
+        self.assertTrue(
+            b.numel() > 2**31 - 1,
+            lambda msg: (
+                f"{msg}\nTest requires tensor with >2^31 elements, got {b.numel()}"
+            ),
+        )
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "triton.enable_persistent_tma_matmul": "1",
+                "triton.native_matmul": False,
+                "test_configs.autotune_choice_name_regex": "mm_persistent_tma",
+            }
+        ):
+            result = torch.compile(mm)(a, b)
+
+        torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
+
+
 class TestTemplateConfigPruning(TestCase):
     """Test class for pruning logic in GEMM autotuning."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @classmethod
     def setUpClass(cls):
@@ -3851,6 +3719,7 @@ class TestTemplateConfigPruning(TestCase):
 
     def create_test_tensors(
         self,
+        device,
         M,
         N,
         K,
@@ -3860,28 +3729,28 @@ class TestTemplateConfigPruning(TestCase):
         mat2_transposed=False,
     ):
         if mat1_transposed:
-            mat1 = torch.randn(K, M, dtype=dtype, device=GPU_TYPE).t()
+            mat1 = torch.randn(K, M, dtype=dtype, device=device).t()
         else:
-            mat1 = torch.randn(M, K, dtype=dtype, device=GPU_TYPE)
+            mat1 = torch.randn(M, K, dtype=dtype, device=device)
 
         if mat2_transposed:
-            mat2 = torch.randn(N, K, dtype=dtype, device=GPU_TYPE).t()
+            mat2 = torch.randn(N, K, dtype=dtype, device=device).t()
         else:
-            mat2 = torch.randn(K, N, dtype=dtype, device=GPU_TYPE)
+            mat2 = torch.randn(K, N, dtype=dtype, device=device)
 
         if include_bias:
-            bias_1d = torch.randn(N, dtype=dtype, device=GPU_TYPE)
+            bias_1d = torch.randn(N, dtype=dtype, device=device)
             return bias_1d, mat1, mat2
         return mat1, mat2
 
-    def test_max_autotune_prune_choices(self):
+    def test_max_autotune_prune_choices(self, device):
         def mm(x, y):
             return x @ y
 
         M, K, N = (3, 3, 3)
 
-        x = torch.rand([M, K], device=GPU_TYPE, dtype=torch.float32)
-        y = torch.rand([K, N], device=GPU_TYPE, dtype=torch.float32)
+        x = torch.rand([M, K], device=device, dtype=torch.float32)
+        y = torch.rand([K, N], device=device, dtype=torch.float32)
 
         compiled_f = torch.compile(mm, mode="max-autotune")
         compiled_f(x, y)
@@ -3897,6 +3766,7 @@ class TestTemplateConfigPruning(TestCase):
     @parametrize("use_tma", (False, True))
     def test_shared_memory_pruning_addmm(
         self,
+        device,
         dtype: torch.dtype,
         mat1_transposed: bool,
         mat2_transposed: bool,
@@ -3912,6 +3782,7 @@ class TestTemplateConfigPruning(TestCase):
 
         M, K, N = 512, 512, 512
         bias_1d, mat1, mat2 = self.create_test_tensors(
+            device,
             M,
             N,
             K,
@@ -3946,6 +3817,7 @@ class TestTemplateConfigPruning(TestCase):
     @parametrize("use_tma", (False, True))
     def test_shared_memory_pruning_mm(
         self,
+        device,
         dtype: torch.dtype,
         mat1_transposed: bool,
         mat2_transposed: bool,
@@ -3959,6 +3831,7 @@ class TestTemplateConfigPruning(TestCase):
 
         M, K, N = 512, 512, 512
         mat1, mat2 = self.create_test_tensors(
+            device,
             M,
             N,
             K,
@@ -4039,18 +3912,24 @@ class TestTemplateConfigPruning(TestCase):
             if triton_compilation_fails:
                 self.assertTrue(
                     exceeds,
-                    lambda msg: f"{msg}\nConfig {c} failed to compile due to shared memory, "
-                    "but the checker predicted it would NOT exceed shared memory limits.",
+                    lambda msg: (
+                        f"{msg}\nConfig {c} failed to compile due to shared memory, "
+                        "but the checker predicted it would NOT exceed shared memory limits."
+                    ),
                 )
             else:
                 self.assertTrue(
                     captured_smem <= smem_estimation,
-                    lambda msg: f"{msg}\nEstimated maximum smem should exceed actual smem used for config {c}",
+                    lambda msg: (
+                        f"{msg}\nEstimated maximum smem should exceed actual smem used for config {c}"
+                    ),
                 )
 
 
 class TestMaxAutotunePrecompile(TestCase):
-    def test_precompilation_threads(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_precompilation_threads(self, device):
         import threading
         from typing import Any
         from unittest.mock import Mock
@@ -4121,14 +4000,14 @@ class TestMaxAutotunePrecompile(TestCase):
         finally:
             V.set_debug_handler(old_debug_handler)
 
-    def test_filled_cache_precompile(self):
+    def test_filled_cache_precompile(self, device):
         def fn(a, b, c):
             a = (a @ b) @ c
             a, b, c = (t.to(torch.float16) for t in [a, b, c])
             return (a @ b) @ c
 
         fn_c = torch.compile(mode="max-autotune-no-cudagraphs")(fn)
-        inputs = [torch.rand([256, 256], device=GPU_TYPE) for _ in range(3)]
+        inputs = [torch.rand([256, 256], device=device) for _ in range(3)]
         from torch._dynamo.utils import counters
 
         self.assertEqual(fn(*inputs), fn_c(*inputs), atol=1e-2, rtol=1e-2)
@@ -4141,7 +4020,7 @@ class TestMaxAutotunePrecompile(TestCase):
 
     @config.patch(autotune_local_cache=False, autotune_remote_cache=False)
     @unittest.skipIf(config.triton.native_matmul, "native matmul has counter 0")
-    def test_precompilations(self):
+    def test_precompilations(self, device):
         def fn(a, b, c):
             a = (a @ b) @ c
             a, b, c = (t.to(torch.float16) for t in [a, b, c])
@@ -4150,7 +4029,7 @@ class TestMaxAutotunePrecompile(TestCase):
         fn_c = torch.compile(mode="max-autotune-no-cudagraphs")(fn)
         # Scale down so float16 doesn't overflow: rand [0,1) -> (a@b)@c has elements in [0, 256^2).
         # float16 max ~65504, so we keep values in a safe range (e.g. scale by 1/256).
-        inputs = [torch.rand([256, 256], device=GPU_TYPE) / 256.0 for _ in range(3)]
+        inputs = [torch.rand([256, 256], device=device) / 256.0 for _ in range(3)]
 
         torch.testing.assert_close(fn_c(*inputs), fn(*inputs), atol=1e-2, rtol=1e-2)
 
@@ -4159,36 +4038,17 @@ class TestMaxAutotunePrecompile(TestCase):
         self.assertEqual(counters["inductor"]["select_algorithm_precompile"], 2)
 
 
-@instantiate_parametrized_tests
 class TestMaxAutotuneSubproc(TestCase):
-    def _create_buffer(self, name, shape):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _create_buffer(self, device, name, shape):
         return Buffer(
             name=name,
-            layout=FixedLayout(
-                torch.device(f"{GPU_TYPE}:0"), dtype=torch.float32, size=shape
-            ),
+            layout=FixedLayout(torch.device(device), dtype=torch.float32, size=shape),
         )
 
-    def test_async_autotuner_skips_unscheduled_choices(self):
-        inputs_key = "inputs"
-        scheduled_choice = mock.Mock(hash_key=lambda: "scheduled")
-        unscheduled_choice = mock.Mock(hash_key=lambda: "unscheduled")
-        future = mock.Mock()
-        future.result.return_value = 1.0
-        with mock.patch.object(
-            AsyncAutotuner,
-            "choice_hash_to_future",
-            {"scheduled" + inputs_key: future},
-        ):
-            self.assertEqual(
-                {scheduled_choice: 1.0},
-                AsyncAutotuner.get_results(
-                    [scheduled_choice, unscheduled_choice], inputs_key
-                ),
-            )
-
     @skipIfXpu(msg="XPU not support multiprocessing tensor reduction")
-    def test_benchmark_choice_in_subproc(self):
+    def test_benchmark_choice_in_subproc(self, device):
         gm = make_fx(
             lambda: torch.zeros(2, 3)
         )()  # a dummy graph to construct the GraphLowering
@@ -4196,12 +4056,12 @@ class TestMaxAutotuneSubproc(TestCase):
 
         # the graph handler is needed to create benchmark example value below
         with V.set_graph_handler(graph):
-            buf1 = self._create_buffer("mat1", (2, 3))
-            buf2 = self._create_buffer("mat2", (3, 2))
-            buf3 = self._create_buffer("mat3", (2, 3))
-            buf4 = self._create_buffer("mat4", (3, 2))
+            buf1 = self._create_buffer(device, "mat1", (2, 3))
+            buf2 = self._create_buffer(device, "mat2", (3, 2))
+            buf3 = self._create_buffer(device, "mat3", (2, 3))
+            buf4 = self._create_buffer(device, "mat4", (3, 2))
 
-            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (2, 2))
+            layout = FixedLayout(torch.device(device), torch.float32, (2, 2))
 
             mat1 = AlgorithmSelectorCache.benchmark_example_value(buf1)
             mat2 = AlgorithmSelectorCache.benchmark_example_value(buf2)
@@ -4227,7 +4087,7 @@ class TestMaxAutotuneSubproc(TestCase):
             print(f"timings is {timings}, out {out}, expected_out {expected_out}")
 
     @skipIfXpu(msg="XPU not support multiprocessing tensor reduction")
-    def test_benchmark_choice_fail_in_subproc(self):
+    def test_benchmark_choice_fail_in_subproc(self, device):
         gm = make_fx(
             lambda: torch.zeros(2, 3)
         )()  # a dummy graph to construct the GraphLowering
@@ -4235,12 +4095,12 @@ class TestMaxAutotuneSubproc(TestCase):
 
         # the graph handler is needed to create benchmark example value below
         with V.set_graph_handler(graph):
-            buf1 = self._create_buffer("mat1", (2, 3))
-            buf2 = self._create_buffer("mat2", (3, 2))
-            buf3 = self._create_buffer("mat3", (2, 3))
-            buf4 = self._create_buffer("mat4", (3, 2))
+            buf1 = self._create_buffer(device, "mat1", (2, 3))
+            buf2 = self._create_buffer(device, "mat2", (3, 2))
+            buf3 = self._create_buffer(device, "mat3", (2, 3))
+            buf4 = self._create_buffer(device, "mat4", (3, 2))
 
-            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (2, 2))
+            layout = FixedLayout(torch.device(device), torch.float32, (2, 2))
 
             mat1 = AlgorithmSelectorCache.benchmark_example_value(buf1)
             mat2 = AlgorithmSelectorCache.benchmark_example_value(buf2)
@@ -4265,7 +4125,9 @@ class TestMaxAutotuneSubproc(TestCase):
 
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("autotune_multi_device", (True, False))
-    def test_max_autotune_mm_plus_mm(self, autotune_in_subproc, autotune_multi_device):
+    def test_max_autotune_mm_plus_mm(
+        self, device, autotune_in_subproc, autotune_multi_device
+    ):
         """
         This crash previously due to a triton issue: https://github.com/triton-lang/triton/issues/1298 .
         With autotuning in subprocess, we don't crash anymore.
@@ -4275,10 +4137,10 @@ class TestMaxAutotuneSubproc(TestCase):
         def mm_plus_mm(a, b, c, d):
             return a @ b + c @ d
 
-        a = torch.randn(m, k).to(GPU_TYPE)
-        b = torch.randn(k, n).to(GPU_TYPE)
-        c = torch.randn(m, k).to(GPU_TYPE)
-        d = torch.randn(k, n).to(GPU_TYPE)
+        a = torch.randn(m, k).to(device)
+        b = torch.randn(k, n).to(device)
+        c = torch.randn(m, k).to(device)
+        d = torch.randn(k, n).to(device)
 
         with config.patch(
             {
@@ -4290,7 +4152,7 @@ class TestMaxAutotuneSubproc(TestCase):
             torch.compile(mm_plus_mm)(a, b, c, d)
 
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_regular_mm(self, dynamic: bool):
+    def test_max_autotune_regular_mm(self, device, dynamic: bool):
         """
         Make sure autotuning mm in sub processes work without crashes.
         """
@@ -4299,13 +4161,13 @@ class TestMaxAutotuneSubproc(TestCase):
             a = torch.sin(a)
             return a @ b
 
-        a = torch.randn(100, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        a = torch.randn(100, 10).to(device)
+        b = torch.randn(10, 100).to(device)
 
         with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
-    def test_max_autotune_profiler_benchmarker_smoke(self):
+    def test_max_autotune_profiler_benchmarker_smoke(self, device):
         """
         Smoke test that a simple max-autotune matmul runs with profiler
         benchmarker selection enabled through config patching, and records
@@ -4315,8 +4177,8 @@ class TestMaxAutotuneSubproc(TestCase):
         def mm(a, b):
             return a @ b
 
-        a = torch.randn(64, 32).to(GPU_TYPE)
-        b = torch.randn(32, 64).to(GPU_TYPE)
+        a = torch.randn(64, 32).to(device)
+        b = torch.randn(32, 64).to(device)
 
         import torch._inductor.runtime.benchmarking as inductor_benchmarking
 
@@ -4342,17 +4204,21 @@ class TestMaxAutotuneSubproc(TestCase):
         self.assertGreater(
             len(finite_timings_ms),
             0,
-            lambda msg: f"{msg}\nExpected finite autotune benchmark timings, got {benchmark_timings_ms}",
+            lambda msg: (
+                f"{msg}\nExpected finite autotune benchmark timings, got {benchmark_timings_ms}"
+            ),
         )
         self.assertGreater(
             min(finite_timings_ms),
             0.0,
-            lambda msg: f"{msg}\nExpected autotune benchmark timing > 0, got {finite_timings_ms}",
+            lambda msg: (
+                f"{msg}\nExpected autotune benchmark timing > 0, got {finite_timings_ms}"
+            ),
         )
 
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     @parametrize("dynamic", (False, True))
-    def test_max_autotune_addmm(self, search_space, dynamic=False):
+    def test_max_autotune_addmm(self, device, search_space, dynamic=False):
         """
         Make sure autotuning addmm in sub processes work without crashes.
         """
@@ -4362,9 +4228,9 @@ class TestMaxAutotuneSubproc(TestCase):
         def addmm(x, a, b):
             return torch.addmm(x, a, b)
 
-        x = torch.randn(100).to(GPU_TYPE)
-        a = torch.randn(100, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        x = torch.randn(100).to(device)
+        a = torch.randn(100, 10).to(device)
+        b = torch.randn(10, 100).to(device)
         with config.patch(
             {
                 "max_autotune": True,
@@ -4376,7 +4242,7 @@ class TestMaxAutotuneSubproc(TestCase):
             Y = addmm(x, a, b)
             torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
 
-    def test_triton_template_with_epilogues_and_dynamic_shape(self):
+    def test_triton_template_with_epilogues_and_dynamic_shape(self, device):
         def fn(
             x: torch.Tensor, w: torch.Tensor, bias: torch.Tensor, mul: torch.Tensor
         ) -> torch.Tensor:
@@ -4392,8 +4258,8 @@ class TestMaxAutotuneSubproc(TestCase):
         M1 = 8
         K = 4
         N = 3
-        w = torch.rand(N, K).to(GPU_TYPE).half()
-        b = torch.rand(N).to(GPU_TYPE).half()
+        w = torch.rand(N, K).to(device).half()
+        b = torch.rand(N).to(device).half()
 
         with config.patch(
             {
@@ -4406,21 +4272,22 @@ class TestMaxAutotuneSubproc(TestCase):
                 fn, fullgraph=True, dynamic=True, mode="max-autotune-no-cudagraphs"
             )
 
-            x0 = torch.rand(K, M0).to(GPU_TYPE).half()
-            mul0 = torch.rand(M0, N).to(GPU_TYPE).half()
+            x0 = torch.rand(K, M0).to(device).half()
+            mul0 = torch.rand(M0, N).to(device).half()
             y0 = compiled_fn(x0, w, b, mul0)
             y0_expected = fn(x0, w, b, mul0)
             torch.testing.assert_close(y0, y0_expected)
 
-            x1 = torch.rand(K, M1).to(GPU_TYPE).half()
-            mul1 = torch.rand(M1, N).to(GPU_TYPE).half()
+            x1 = torch.rand(K, M1).to(device).half()
+            mul1 = torch.rand(M1, N).to(device).half()
             y1 = compiled_fn(x1, w, b, mul1)
             y1_expected = fn(x1, w, b, mul1)
             torch.testing.assert_close(y1, y1_expected)
 
 
-@instantiate_parametrized_tests
 class TestMaxAutotuneRemoteCache(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         PatchCaches.setUp()
@@ -4433,13 +4300,13 @@ class TestMaxAutotuneRemoteCache(TestCase):
     @config.patch(
         {"compile_threads": 1, "prologue_fusion": False}
     )  # Worker processes do not register PatchCaches() properly
-    def test_max_autotune_remote_caching(self, dynamic: bool):
+    def test_max_autotune_remote_caching(self, device, dynamic: bool):
         def mm(a, b):
             a = torch.sin(a)
             return a @ b
 
-        a = torch.randn(100, 10).to(GPU_TYPE)
-        b = torch.randn(10, 100).to(GPU_TYPE)
+        a = torch.randn(100, 10).to(device)
+        b = torch.randn(10, 100).to(device)
 
         class Model(torch.nn.Module):
             def forward(self, x, y):
@@ -4448,8 +4315,8 @@ class TestMaxAutotuneRemoteCache(TestCase):
         def f(x, y):
             return Model()(x, y)
 
-        x = torch.randn(100, 100).to(GPU_TYPE)
-        y = torch.randn(100, 100).to(GPU_TYPE)
+        x = torch.randn(100, 100).to(device)
+        y = torch.randn(100, 100).to(device)
 
         with (
             config.patch(
@@ -4498,6 +4365,8 @@ class _TestTritonTemplateCaller(TritonTemplateCaller):
 
 
 class TestTuningProcess(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def check_healthy(self, p: TuningProcess, device: int | None = None):
         result = random.random()
         bmreq = _TestBenchmarkRequest(result, device=device)
@@ -4557,6 +4426,8 @@ class TestTuningProcess(TestCase):
 class TestTuningProcessPool(TestCase):
     # Use only one device/subprocess so we test the process restarts
     # and is usable after a crash.
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def assert_path_in_dir(self, path, expected_dir):
         self.assertEqual(
             os.path.commonpath([path, expected_dir]),
@@ -4564,7 +4435,7 @@ class TestTuningProcessPool(TestCase):
         )
 
     @config.patch({"autotune_multi_device": False})
-    def test_tuning_pool_cache_env_resets(self):
+    def test_tuning_pool_cache_env_resets(self, device):
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("TRITON_CACHE_DIR", None)
             tuning_pool = TuningProcessPool()
@@ -4589,7 +4460,7 @@ class TestTuningProcessPool(TestCase):
                 tuning_pool.shutdown()
 
     @config.patch({"autotune_multi_device": False})
-    def test_tuning_pool_cache_env_clears_codecache(self):
+    def test_tuning_pool_cache_env_clears_codecache(self, device):
         with (
             mock.patch.dict(os.environ, {}, clear=False),
             tempfile.TemporaryDirectory() as cache_dir_1,
@@ -4611,7 +4482,7 @@ class TestTuningProcessPool(TestCase):
                 tuning_pool.shutdown()
 
     @config.patch({"pipeline_max_autotune_gemm": True})
-    def test_autotune_process_pool_cache_env_resets(self):
+    def test_autotune_process_pool_cache_env_resets(self, device):
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("TRITON_CACHE_DIR", None)
             autotune_pool = AutotuneProcessPool()
@@ -4641,7 +4512,7 @@ class TestTuningProcessPool(TestCase):
                 autotune_pool._shutdown()
 
     @config.patch({"pipeline_max_autotune_gemm": True})
-    def test_autotune_process_pool_cache_env_clears_codecache(self):
+    def test_autotune_process_pool_cache_env_clears_codecache(self, device):
         with (
             mock.patch.dict(os.environ, {}, clear=False),
             tempfile.TemporaryDirectory() as cache_dir_1,
@@ -4669,7 +4540,7 @@ class TestTuningProcessPool(TestCase):
                 autotune_pool._shutdown()
 
     @config.patch({"autotune_multi_device": False})
-    def test_tuning_pool_crash(self):
+    def test_tuning_pool_crash(self, device):
         tuning_pool = TuningProcessPool()
 
         # First force the tuning process to crash.
@@ -4692,7 +4563,7 @@ class TestTuningProcessPool(TestCase):
         tuning_pool.shutdown()
 
     @config.patch({"autotune_multi_device": False})
-    def test_tuning_pool_timeout(self):
+    def test_tuning_pool_timeout(self, device):
         tuning_pool = TuningProcessPool()
 
         # First force the tuning process to timeout.
@@ -4716,16 +4587,16 @@ class TestTuningProcessPool(TestCase):
         tuning_pool.shutdown()
 
     @config.patch({"autotune_multi_device": True})
-    def test_tuning_pool_multiple_devices(self):
+    def test_tuning_pool_multiple_devices(self, device):
         # Adapt the test to the available devices (and whether the backend-specific
         # visible devices env var
         # is already set in the environment); use a subset of the available devices
         # to ensure only the subset are visible to the sub-processes.
-        visible_devices_env_var = get_visible_devices_env_var(GPU_TYPE)
+        visible_devices_env_var = get_visible_devices_env_var(torch.device(device).type)
         if visible_devices_env_var in os.environ:
             visible_devices = os.environ[visible_devices_env_var].split(",")
         else:
-            device_interface = get_interface_for_device(GPU_TYPE)
+            device_interface = get_interface_for_device(torch.device(device).type)
             visible_devices = [str(d) for d in range(device_interface.device_count())]
 
         selected_visible_devices = ",".join(visible_devices[-2:])
@@ -4743,13 +4614,13 @@ class TestTuningProcessPool(TestCase):
 
         tuning_pool.shutdown()
 
-    def test_get_visible_devices_env_var(self):
+    def test_get_visible_devices_env_var(self, device):
         self.assertEqual(get_visible_devices_env_var("cuda"), "CUDA_VISIBLE_DEVICES")
         self.assertEqual(get_visible_devices_env_var("xpu"), "ZE_AFFINITY_MASK")
 
     @config.patch({"autotune_multi_device": True})
-    def test_get_device_list_with_affinity_mask(self):
-        env_var = get_visible_devices_env_var(GPU_TYPE)
+    def test_get_device_list_with_affinity_mask(self, device):
+        env_var = get_visible_devices_env_var(torch.device(device).type)
         env_value = "1,3"
 
         with (
@@ -4761,7 +4632,7 @@ class TestTuningProcessPool(TestCase):
             get_interface_mock.return_value.device_count.return_value = 4
             self.assertEqual(TuningProcessPool.get_device_list(), [1, 3])
 
-    def test_add_feedback_saver(self):
+    def test_add_feedback_saver(self, device):
         """Test that add_feedback_saver correctly adds feedback functions."""
         from torch._inductor.select_algorithm import get_algorithm_selector_cache
 
@@ -4803,7 +4674,7 @@ class TestTuningProcessPool(TestCase):
         # Clean up
         clear_feedback_savers()
 
-    def test_clear_feedback_savers(self):
+    def test_clear_feedback_savers(self, device):
         """Test that clear_feedback_savers removes all feedback functions."""
         from torch._inductor.select_algorithm import get_algorithm_selector_cache
 
@@ -4831,7 +4702,7 @@ class TestTuningProcessPool(TestCase):
         # Verify they were cleared
         self.assertEqual(len(cache.feedback_saver_fns), 0)
 
-    def test_feedback_saver_integration(self):
+    def test_feedback_saver_integration(self, device):
         """Test that feedback savers are actually called during autotuning."""
         # Clear any existing feedback savers
         clear_feedback_savers()
@@ -4858,8 +4729,8 @@ class TestTuningProcessPool(TestCase):
         def mm(a, b):
             return a @ b
 
-        a = torch.randn(32, 32, device=GPU_TYPE)
-        b = torch.randn(32, 32, device=GPU_TYPE)
+        a = torch.randn(32, 32, device=device)
+        b = torch.randn(32, 32, device=device)
 
         with config.patch(
             {
@@ -4888,8 +4759,9 @@ class TestTuningProcessPool(TestCase):
         clear_feedback_savers()
 
 
-@instantiate_parametrized_tests
 class TestPrologueFusion(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -4932,11 +4804,11 @@ class TestPrologueFusion(TestCase):
             ).run(code_str)
 
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
-    def test_upcast(self, sizes):
+    def test_upcast(self, device, sizes):
         M, K, N = sizes
 
-        x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float16, device=device)
+        y = torch.rand([K, N], dtype=torch.float, device=device)
 
         def foo(x, y):
             return x.to(y.dtype) @ y
@@ -4952,12 +4824,12 @@ class TestPrologueFusion(TestCase):
             FileCheck().check("a =").check_not("tl.where").check("tl.dot").run(code[0])
 
     @unittest.skip("Triton bug in compilation")
-    def test_gather_fusion(self):
+    def test_gather_fusion(self, device):
         M, K, N = (64, 128, 256)
-        x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float16, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float16, device=device)
+        y = torch.rand([K, N], dtype=torch.float16, device=device)
 
-        index = torch.randperm(M, device=GPU_TYPE)
+        index = torch.randperm(M, device=device)
 
         def foo(x, y, index):
             return (x[index]) @ y
@@ -4975,16 +4847,13 @@ class TestPrologueFusion(TestCase):
             .run(code[0])
         )
 
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FP8,
-        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
-    )
+    @requires_capabilities(Capability.dtype.fp8)
     @config.patch({"triton.native_matmul": False})
-    def test_low_precision(self):
+    def test_low_precision(self, device):
         M = K = N = 128
 
-        x = torch.rand([M, K], device=GPU_TYPE).to(torch.float8_e4m3fn)
-        y = torch.rand([K, N], dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.rand([M, K], device=device).to(torch.float8_e4m3fn)
+        y = torch.rand([K, N], dtype=torch.bfloat16, device=device)
 
         def foo(x, y):
             return x.to(y.dtype) @ y
@@ -5015,11 +4884,11 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_downcast(self):
+    def test_downcast(self, device):
         # per heuristics, dont fuse a downcast into a mm because it would lead to more reads inside kernel
         M, K, N = (64, 128, 256)
-        x = torch.rand([M, K], dtype=torch.float, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float16, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float, device=device)
+        y = torch.rand([K, N], dtype=torch.float16, device=device)
 
         def foo(x, y):
             return x.to(y.dtype) @ y
@@ -5034,7 +4903,7 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_multiple_fusions(self, sizes, use_async_compile: bool):
+    def test_multiple_fusions(self, device, sizes, use_async_compile: bool):
         M, K, N = sizes
 
         def foo(x, y):
@@ -5043,8 +4912,8 @@ class TestPrologueFusion(TestCase):
         if use_async_compile:
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
-        x = torch.rand([M, K], dtype=torch.float, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float, device=device)
+        y = torch.rand([K, N], dtype=torch.float, device=device)
 
         out, code = run_and_get_code(torch.compile(foo), x, y)
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
@@ -5064,15 +4933,15 @@ class TestPrologueFusion(TestCase):
         }
     )
     @parametrize("use_async_compile", (True, False))
-    def test_pending_fusions_multiple(self, use_async_compile: bool):
+    def test_pending_fusions_multiple(self, device, use_async_compile: bool):
         def multi_use(x, y):
             return (x @ x.T) * (y @ y.T)
 
         if use_async_compile:
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
-        x = torch.rand([128, 16], device=GPU_TYPE)
-        y = torch.rand([128, 32], device=GPU_TYPE)
+        x = torch.rand([128, 16], device=device)
+        y = torch.rand([128, 32], device=device)
 
         # Mock benchmarks to keep this pending-fusion test focused on scheduler
         # behavior instead of noisy GPU microbenchmarks.
@@ -5103,7 +4972,7 @@ class TestPrologueFusion(TestCase):
             def resolve_pending(x):
                 return (x @ x).relu()
 
-            x = torch.rand([128, 128], device=GPU_TYPE)
+            x = torch.rand([128, 128], device=device)
             out, code = run_and_get_code(torch.compile(resolve_pending), x)
             FileCheck().check(get_func_call()).check_count(
                 get_kernel_launch(), 1, exactly=True
@@ -5118,7 +4987,7 @@ class TestPrologueFusion(TestCase):
         }
     )
     @parametrize("use_async_compile", (True, False))
-    def test_pending_fusion_pro_and_epi(self, use_async_compile: bool):
+    def test_pending_fusion_pro_and_epi(self, device, use_async_compile: bool):
         def test_multiple_fusions(x):
             y = x.to(torch.float)
             return (y @ y).relu()
@@ -5126,7 +4995,7 @@ class TestPrologueFusion(TestCase):
         if use_async_compile:
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
-        x = torch.rand([128, 128], dtype=torch.float16, device=GPU_TYPE)
+        x = torch.rand([128, 128], dtype=torch.float16, device=device)
         out, code = run_and_get_code(torch.compile(test_multiple_fusions), x)
         FileCheck().check(get_func_call()).check_count(
             get_kernel_launch(), 1, exactly=True
@@ -5135,7 +5004,7 @@ class TestPrologueFusion(TestCase):
 
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
-    def test_multiple_inputs(self, sizes, use_async_compile: bool):
+    def test_multiple_inputs(self, device, sizes, use_async_compile: bool):
         M, K, N = sizes
 
         def foo(x, y, z):
@@ -5144,21 +5013,21 @@ class TestPrologueFusion(TestCase):
         if use_async_compile:
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
-        x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        y = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        z = torch.rand([K, N], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float16, device=device)
+        y = torch.rand([M, K], dtype=torch.float16, device=device)
+        z = torch.rand([K, N], dtype=torch.float, device=device)
         out_eager = foo(x, y, z)
         out, code = run_and_get_code(torch.compile(foo), x, y, z)
         self.assertEqual(out, out_eager, atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
-    def test_storage_offset_prologue(self):
+    def test_storage_offset_prologue(self, device):
         def foo(a):
             q = a[:64, :]
             k = a[64:, :]
             return torch.mm(q + 2, k - 2)
 
-        inp = torch.randn(128, 64, device=GPU_TYPE)
+        inp = torch.randn(128, 64, device=device)
         out, code = run_and_get_code(torch.compile(foo), inp)
         self.assertEqual(out, foo(inp), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=1)
@@ -5170,7 +5039,7 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_prologue_multiple_nodes(self, sizes, use_async_compile: bool):
+    def test_prologue_multiple_nodes(self, device, sizes, use_async_compile: bool):
         M, K, N = sizes
 
         def foo(x, y):
@@ -5179,33 +5048,33 @@ class TestPrologueFusion(TestCase):
         if use_async_compile:
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
-        x = torch.rand([M, K], dtype=torch.float, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float, device=device)
+        y = torch.rand([K, N], dtype=torch.float, device=device)
 
         out, code = run_and_get_code(torch.compile(foo), x, y)
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
     @parametrize("K", (63, 64))
-    def test_broadcast_x(self, K):
+    def test_broadcast_x(self, device, K):
         def foo(x, y):
             return (x.expand([1, y.shape[0]]) + 1) @ y
 
-        x = torch.rand([1, 1], dtype=torch.float, device=GPU_TYPE)
-        y = torch.rand([K, 128], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([1, 1], dtype=torch.float, device=device)
+        y = torch.rand([K, 128], dtype=torch.float, device=device)
 
         out, code = run_and_get_code(torch.compile(foo, dynamic=True), x, y)
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
-    def test_broadcast_y(self):
+    def test_broadcast_y(self, device):
         def foo(x, y):
             return x @ y
 
         M = 20
         N = K = 1
-        x = torch.rand([M, K], dtype=torch.float, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float, device=GPU_TYPE)
+        x = torch.rand([M, K], dtype=torch.float, device=device)
+        y = torch.rand([K, N], dtype=torch.float, device=device)
         torch._dynamo.mark_dynamic(x, 0)
 
         out, code = run_and_get_code(torch.compile(foo, dynamic=True), x, y)
@@ -5216,7 +5085,7 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_preserves_zero_analysis(self):
+    def test_preserves_zero_analysis(self, device):
         fns = (
             (lambda x: x.relu(), False),  # preserves zero
             (lambda x: x + 1, True),  # does not
@@ -5230,8 +5099,8 @@ class TestPrologueFusion(TestCase):
             return fn(x) @ y
 
         for fn, should_mask in fns:
-            x = torch.rand([64, 127], dtype=torch.float, device=GPU_TYPE)
-            y = torch.rand([127, 64], dtype=torch.float, device=GPU_TYPE)
+            x = torch.rand([64, 127], dtype=torch.float, device=device)
+            y = torch.rand([127, 64], dtype=torch.float, device=device)
 
             out, code = run_and_get_code(torch.compile(foo), x, y, fn)
             self.assertEqual(out, foo(x, y, fn), atol=0.05, rtol=0.05)
@@ -5247,7 +5116,7 @@ class TestPrologueFusion(TestCase):
     @parametrize("benchmark_fusion", (True, False))
     @parametrize("use_async_compile", (True, False))
     def test_prologue_read_into_both_inputs(
-        self, benchmark_fusion, use_async_compile: bool
+        self, device, benchmark_fusion, use_async_compile: bool
     ):
         M = K = 256
 
@@ -5262,7 +5131,7 @@ class TestPrologueFusion(TestCase):
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
         with config.patch(benchmark_epilogue_fusion=benchmark_fusion):
-            x = torch.rand([M, K], dtype=torch.float, device=GPU_TYPE)
+            x = torch.rand([M, K], dtype=torch.float, device=device)
 
             out, code = run_and_get_code(torch.compile(foo), x)
             self.assertEqual(out, foo(x), atol=0.05, rtol=0.05)
@@ -5278,15 +5147,15 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_mismatched_prologue_group(self):
+    def test_mismatched_prologue_group(self, device):
         def foo(x, y, z):
             a = (x + 2) * 2
             b = a * y
             return b @ z
 
-        x = torch.rand([1, 256], device=GPU_TYPE)
-        y = torch.rand([256, 256], device=GPU_TYPE)
-        z = torch.rand([256, 128], device=GPU_TYPE)
+        x = torch.rand([1, 256], device=device)
+        y = torch.rand([256, 256], device=device)
+        z = torch.rand([256, 128], device=device)
 
         out, code = run_and_get_code(torch.compile(foo), x, y, z)
         self.assertEqual(out, foo(x, y, z), atol=0.05, rtol=0.05)
@@ -5308,7 +5177,9 @@ class TestPrologueFusion(TestCase):
         "generated code is different in native matmul",
     )
     @parametrize("use_async_compile", (True, False))
-    def test_lazy_template_fusion_multiple_candidates(self, use_async_compile: bool):
+    def test_lazy_template_fusion_multiple_candidates(
+        self, device, use_async_compile: bool
+    ):
         """
         Test lazy evaluation of template fusions with multiple templates,
         multiple potential prologues, and a shared epilogue.
@@ -5350,10 +5221,10 @@ class TestPrologueFusion(TestCase):
             torch._inductor.async_compile.AsyncCompile.wait_pool_ready()
 
         M, K, N = 64, 128, 64
-        a = torch.rand([M, K], dtype=torch.bfloat16, device=GPU_TYPE)
-        b = torch.rand([K, N], dtype=torch.bfloat16, device=GPU_TYPE)
-        c = torch.rand([M, K], dtype=torch.bfloat16, device=GPU_TYPE)
-        d = torch.rand([K, N], dtype=torch.bfloat16, device=GPU_TYPE)
+        a = torch.rand([M, K], dtype=torch.bfloat16, device=device)
+        b = torch.rand([K, N], dtype=torch.bfloat16, device=device)
+        c = torch.rand([M, K], dtype=torch.bfloat16, device=device)
+        d = torch.rand([K, N], dtype=torch.bfloat16, device=device)
 
         # Mock benchmarks to return deterministic results so fusion decisions
         # don't depend on noisy GPU microbenchmarks.
@@ -5381,14 +5252,14 @@ class TestPrologueFusion(TestCase):
         config.triton.native_matmul,
         "generated code is different in native matmul",
     )
-    def test_prologue_masked_load(self, sizes):
+    def test_prologue_masked_load(self, device, sizes):
         M, K, N = sizes
 
         def foo(x, y):
             return x @ y
 
-        x = torch.rand([250, 245], device=GPU_TYPE)
-        y = torch.rand([245, 128], device=GPU_TYPE)
+        x = torch.rand([250, 245], device=device)
+        y = torch.rand([245, 128], device=device)
 
         # we should not attempt prologue fusion if it turns an aligned load
         # into an unaligned load
@@ -5422,8 +5293,9 @@ def mock_benchmark_choice_wrapper(aten_time, triton_time):
     )
 
 
-@instantiate_parametrized_tests
 class TestEpilogueFusionStaticAnalysis(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -5535,10 +5407,10 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
             yield
 
-    def _get_mm_inputs(self):
+    def _get_mm_inputs(self, device):
         """Common matmul inputs for epilogue fusion tests."""
-        a = torch.randn(512, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = torch.randn(512, 1024, device=device, dtype=torch.bfloat16)
+        b = torch.randn(1024, 2048, device=device, dtype=torch.bfloat16)
         return a, b
 
     def _get_mm_with_epilogue_fn(self):
@@ -5571,14 +5443,14 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
     @parametrize("use_async_compile", (True, False))
-    def test_template_bad_epilogue_fusion(self, use_async_compile: bool):
+    def test_template_bad_epilogue_fusion(self, device, use_async_compile: bool):
         def f(a, b):
             return (a @ b).to(torch.float32)
 
-        a = torch.randn(512, 1152, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(1152, 7680, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = torch.randn(512, 1152, device=device, dtype=torch.bfloat16)
+        b = torch.randn(1152, 7680, device=device, dtype=torch.bfloat16)
 
-        if GPU_TYPE == "xpu":
+        if torch.device(device).type == "xpu":
             tma_heuristic = XPUPersistentTMATemplateConfigHeuristic()
             mm_heuristic = XPUMMTemplateConfigHeuristic()
         else:
@@ -5671,9 +5543,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 mm_heuristic.mm_configs = original_mm_mm_configs
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179695")
-    @unittest.skipIf(
-        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
-    )
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5688,7 +5558,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     )
     @parametrize("use_async_compile", (True, False))
     def test_template_epilogue_fusion_static_analysis(
-        self, test_case: str, use_async_compile: bool
+        self, device, test_case: str, use_async_compile: bool
     ):
         """
         Test static analysis decisions for matmul epilogue fusions.
@@ -5722,7 +5592,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
             raise RuntimeError("Invalid test case")
 
         f = self._get_mm_with_epilogue_fn()
-        a, b = self._get_mm_inputs()
+        a, b = self._get_mm_inputs(device)
 
         with self._setup_mm_heuristic(use_async_compile):
             with self.get_common_patches(
@@ -5746,9 +5616,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @unittest.skipIf(
-        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
-    )
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5756,7 +5624,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     @parametrize("fuse_epilogue", (True, False))
     @parametrize("use_async_compile", (True, False))
     def test_template_epilogue_fusion_extra_reads(
-        self, fuse_epilogue: bool, use_async_compile: bool
+        self, device, fuse_epilogue: bool, use_async_compile: bool
     ):
         """Test epilogue fusion with extra reads (bias and scale tensors)."""
 
@@ -5766,10 +5634,10 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
         torch._dynamo.reset()
 
-        x = torch.randn(512, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        w = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
-        bias = torch.randn(512, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
-        scale = torch.randn(512, 2048, device=GPU_TYPE, dtype=torch.bfloat16)
+        x = torch.randn(512, 1024, device=device, dtype=torch.bfloat16)
+        w = torch.randn(1024, 2048, device=device, dtype=torch.bfloat16)
+        bias = torch.randn(512, 2048, device=device, dtype=torch.bfloat16)
+        scale = torch.randn(512, 2048, device=device, dtype=torch.bfloat16)
 
         epilogue_runtime = 0.5
         aten_time = 1.0
@@ -5806,9 +5674,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179694")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176115")
-    @unittest.skipIf(
-        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
-    )
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5822,7 +5688,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     )
     @parametrize("use_async_compile", (True, False))
     def test_template_epilogue_fusion_occupancy_ratio(
-        self, test_case: str, use_async_compile: bool
+        self, device, test_case: str, use_async_compile: bool
     ):
         """
         Test occupancy ratio branch of _fuse_epilogue.
@@ -5849,7 +5715,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
             raise RuntimeError("Invalid test case")
 
         f = self._get_mm_with_epilogue_fn()
-        a, b = self._get_mm_inputs()
+        a, b = self._get_mm_inputs(device)
 
         with self._setup_mm_heuristic(use_async_compile):
             with self.get_common_patches(
@@ -5874,9 +5740,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176114")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176113")
-    @unittest.skipIf(
-        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
-    )
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
@@ -5890,7 +5754,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     )
     @parametrize("use_async_compile", (True, False))
     def test_template_epilogue_fusion_dominating_epilogue(
-        self, test_case: str, use_async_compile: bool
+        self, device, test_case: str, use_async_compile: bool
     ):
         """
         Test memory-bound epilogue branch of _fuse_epilogue (Branch C).
@@ -5917,7 +5781,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
             raise RuntimeError("Invalid test case")
 
         f = self._get_mm_with_epilogue_fn()
-        a, b = self._get_mm_inputs()
+        a, b = self._get_mm_inputs(device)
 
         with self._setup_mm_heuristic(use_async_compile):
             with self.get_common_patches(
@@ -5940,11 +5804,11 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
-    @unittest.skipIf(
-        not HAS_CUDA_AND_TRITON, "Scheduler static analysis only tested on cuda"
-    )
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("use_async_compile", (True, False))
-    def test_epilogue_prologue_fusion_cache_preserved(self, use_async_compile: bool):
+    def test_epilogue_prologue_fusion_cache_preserved(
+        self, device, use_async_compile: bool
+    ):
         def f(a, b):
             # Prologue: pointwise operation on input 'a' before matmul
             a_transformed = a + 1.0
@@ -5956,8 +5820,8 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         torch._dynamo.reset()
 
         # Use float32 to avoid low precision heuristic rejection
-        a = torch.randn(512, 1024, device=GPU_TYPE, dtype=torch.float32)
-        b = torch.randn(1024, 2048, device=GPU_TYPE, dtype=torch.float32)
+        a = torch.randn(512, 1024, device=device, dtype=torch.float32)
+        b = torch.randn(1024, 2048, device=device, dtype=torch.float32)
 
         triton_time = 0.1
         aten_time = float("inf")
@@ -5998,22 +5862,14 @@ def simple_fn():
 class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAnalysis):
     """Tests for AsyncPipelinedAutotuning path."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     SKIP_TESTS = {
         "test_inf_timing": "Logs not consistent with async pipelined autotuning",
         "test_non_contiguous_input_mm_plus_mm": "Flaky on trunk",
         "test_autotune_device_guard": "Flaky on trunk",
         "test_template_bad_epilogue_fusion": "Benchmarking path is different",
         "test_persistent_tma_epilogue_fusion_store_cache": "Epilogue fusion disabled in async pipelining",
-        # grouped_mm's input_gen_fns forces
-        # return_multi_template=False, so do_autotuning() takes its
-        # pipelined-only branch and returns None instead of timings,
-        # crashing min(timings, ...). Pre-existing bug, not test-
-        # specific -- hits any input_gen_fns op under
-        # pipeline_max_autotune_gemm=True.
-        "test_max_autotune_grouped_mm_large_input_tensor_int64_indexing": "grouped_mm's input_gen_fns forces return_multi_template=False, "
-        "which do_autotuning's pipelined branch does not handle",
-        "test_max_autotune_grouped_mm_large_input_tensor_tma_disabled": "grouped_mm's input_gen_fns forces return_multi_template=False, "
-        "which do_autotuning's pipelined branch does not handle",
     }
 
     @classmethod
@@ -6049,7 +5905,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         AsyncAutotuner.choice_hash_to_future.clear()
 
     @config.patch(max_autotune_gemm=True)
-    def test_async_autotuner_cache_same_inputs(self):
+    def test_async_autotuner_cache_same_inputs(self, device):
         M, K, N = 128, 64, 256
         M2, K2, N2 = 256, 128, 64
 
@@ -6057,14 +5913,14 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
             return torch.mm(a1, b1), torch.mm(a2, b2), torch.mm(a3, b3)
 
         # Same shapes for first two matmuls
-        a1 = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b1 = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
-        a2 = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
-        b2 = torch.randn(K, N, device=GPU_TYPE, dtype=torch.bfloat16)
+        a1 = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b1 = torch.randn(K, N, device=device, dtype=torch.bfloat16)
+        a2 = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+        b2 = torch.randn(K, N, device=device, dtype=torch.bfloat16)
 
         # Different shapes for third matmul
-        a3 = torch.randn(M2, K2, device=GPU_TYPE, dtype=torch.bfloat16)
-        b3 = torch.randn(K2, N2, device=GPU_TYPE, dtype=torch.bfloat16)
+        a3 = torch.randn(M2, K2, device=device, dtype=torch.bfloat16)
+        b3 = torch.randn(K2, N2, device=device, dtype=torch.bfloat16)
 
         compiled_fn = torch.compile(three_matmuls)
         result = compiled_fn(a1, b1, a2, b2, a3, b3)
@@ -6086,7 +5942,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         "torch._inductor.autotune_process.AUTOTUNE_POOL_INACTIVITY_TIMEOUT",
         2,
     )
-    def test_autotune_process_pool_inactivity_shutdown(self):
+    def test_autotune_process_pool_inactivity_shutdown(self, device):
         AutotuneProcessPool.shutdown_instance()
         AutotuneProcessPool._shutdown_for_inactivity = False
 
@@ -6108,7 +5964,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         "torch._inductor.autotune_process.AUTOTUNE_POOL_INACTIVITY_TIMEOUT",
         2,
     )
-    def test_autotune_process_pool_inactivity_shutdown_warmup_only(self):
+    def test_autotune_process_pool_inactivity_shutdown_warmup_only(self, device):
         """Test that the pool shuts down from inactivity even when only warmup is called."""
         AutotuneProcessPool.shutdown_instance()
         AutotuneProcessPool._shutdown_for_inactivity = False
@@ -6130,7 +5986,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         2,
     )
     @config.patch(max_autotune=True)
-    def test_compilation_after_inactivity(self):
+    def test_compilation_after_inactivity(self, device):
         """Test that compilation after pool inactivity shutdown uses synchronous path."""
 
         # Reset state
@@ -6145,10 +6001,10 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         def matmul_fn(a, b):
             return torch.mm(a, b)
 
-        a1 = torch.randn(64, 32, device=GPU_TYPE, dtype=torch.bfloat16)
-        b1 = torch.randn(32, 64, device=GPU_TYPE, dtype=torch.bfloat16)
-        a2 = torch.randn(128, 64, device=GPU_TYPE, dtype=torch.bfloat16)
-        b2 = torch.randn(64, 128, device=GPU_TYPE, dtype=torch.bfloat16)
+        a1 = torch.randn(64, 32, device=device, dtype=torch.bfloat16)
+        b1 = torch.randn(32, 64, device=device, dtype=torch.bfloat16)
+        a2 = torch.randn(128, 64, device=device, dtype=torch.bfloat16)
+        b2 = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
 
         compiled_fn = torch.compile(matmul_fn)
         compiled_fn(a1, b1)
@@ -6173,7 +6029,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         self.assertEqual(cache_entries_after_second, 0)
 
     @config.patch(max_autotune_gemm=True)
-    def test_triton_error_precompilation_and_autotuning(self):
+    def test_triton_error_precompilation_and_autotuning(self, device):
         """
         Test error handling when do_autotuning throws NoValidChoicesError
         for Triton choices. The fallback to extern kernels should still work.
@@ -6182,8 +6038,8 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         def mock_do_autotuning(*args, **kwargs):
             raise NoValidChoicesError("Simulated: all Triton choices failed")
 
-        a = torch.randn(64, 32, device=GPU_TYPE, dtype=torch.bfloat16)
-        b = torch.randn(32, 64, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = torch.randn(64, 32, device=device, dtype=torch.bfloat16)
+        b = torch.randn(32, 64, device=device, dtype=torch.bfloat16)
 
         def mm_func(a, b, epilogue):
             if epilogue:
@@ -6219,9 +6075,63 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
             test_aten_chosen()
 
 
-if __name__ == "__main__":
-    from torch._inductor.utils import is_big_gpu
+# Copy parent test methods into child __dict__ (must be before instantiate calls)
+for _base in (TestMaxAutotune, TestEpilogueFusionStaticAnalysis):
+    for _name, _fn in _base.__dict__.items():
+        if (
+            _name.startswith("test")
+            and _name not in TestMaxAutotuneAsyncPipelined.__dict__
+        ):
+            setattr(TestMaxAutotuneAsyncPipelined, _name, _fn)
 
-    # Set env to make it work in CI.
-    if HAS_GPU and HAS_CPU and is_big_gpu():
-        run_tests()
+instantiate_device_type_tests(
+    TestMaxAutotune, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(TestMaxAutotuneCuda, globals(), only_for="cuda")
+instantiate_device_type_tests(
+    TestTemplateConfigPruning,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestMaxAutotunePrecompile,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestMaxAutotuneSubproc,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestMaxAutotuneRemoteCache,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestTuningProcessPool, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestPrologueFusion, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestEpilogueFusionStaticAnalysis,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+# TestMaxAutotuneAsyncPipelined methods were copied above (see Decision 4)
+instantiate_device_type_tests(
+    TestMaxAutotuneAsyncPipelined,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -183,6 +183,7 @@ class TestMaxAutotune(TestCase):
         b = make_matrix(K, N, *batch_dims, reduction_dim=-2)
         return a, b
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_max_autotune_mm_plus_mm_zero_size_input(
@@ -253,6 +254,7 @@ class TestMaxAutotune(TestCase):
                     "max_autotune should include all pointwise configs from max_autotune_pointwise",
                 )
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -335,6 +337,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     def test_use_triton_tma_template_rejects_descriptor_shapes_exceeding_int32(
         self, device
     ):
@@ -412,6 +415,7 @@ class TestMaxAutotune(TestCase):
                 guard_or_false.assert_called_once_with(condition)
                 statically_known_true.assert_not_called()
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -462,6 +466,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -516,6 +521,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -660,6 +666,7 @@ class TestMaxAutotune(TestCase):
         for size in ws_sizes:
             self.assertEqual(size, expected_bytes)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -728,6 +735,7 @@ class TestMaxAutotune(TestCase):
             check_str = "triton.language.make_tensor_descriptor"
         FileCheck().check("triton_tem_fused_mm").check(check_str).run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -761,6 +769,7 @@ class TestMaxAutotune(TestCase):
         # given the config flags above, we should have no choices left.
         self.assertIn("NoValidChoicesError", str(context.exception))
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -836,6 +845,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -875,6 +885,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_zero_size_input(self, device, dynamic: bool):
         """
@@ -891,6 +902,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    @requires_capabilities(Capability.lib.triton)
     @fresh_cache()
     def test_addmm_1d_bias_no_reinterpret_tensor(self, device):
         """
@@ -946,6 +958,7 @@ class TestMaxAutotune(TestCase):
 
             self.assertEqual((100,), extern_bias_shape)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -1032,6 +1045,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -1104,6 +1118,7 @@ class TestMaxAutotune(TestCase):
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm_zero_size_input(self, device, dynamic):
         """
@@ -1119,6 +1134,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(addmm, dynamic=dynamic)(x, a, b)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     def test_max_autotune_addmm_unrealized_view_bias(self, device, dynamic):
         """
@@ -1135,6 +1151,7 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(fn, dynamic=dynamic)(x, a, b)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_autotune_conv1x1(self, device, search_space):
         # Assuming input has 3 channels and we want to produce 16 channels as output
@@ -1194,6 +1211,7 @@ class TestMaxAutotune(TestCase):
         )
         torch._export.aot_compile(fn, args=inputs)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_cat_addmm(self, device):
         def fn(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):
             return torch.cat(
@@ -1219,6 +1237,7 @@ class TestMaxAutotune(TestCase):
             actual = torch.compile(fn)(*args)
             torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         benchmark_kernel=True,
         fallback_random=True,
@@ -1252,6 +1271,7 @@ class TestMaxAutotune(TestCase):
             print(f"ref\n{ref}\nact\n{act}")
         torch.testing.assert_close(ref, act, atol=1e-1, rtol=1e-1)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         max_autotune_gemm=True,
     )
@@ -1269,6 +1289,7 @@ class TestMaxAutotune(TestCase):
         ref = f(x, y)
         self.assertTrue(torch.allclose(act, ref, atol=4 * 1e-3, rtol=4 * 1e-3))
 
+    @requires_capabilities(Capability.lib.triton)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179777")
     @config.patch(max_autotune=True)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
@@ -1296,6 +1317,7 @@ class TestMaxAutotune(TestCase):
             act = opt_f(x, weight)
             self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(max_autotune_gemm_backends="TRITON")
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_baddmm(self, device, search_space):
@@ -1325,6 +1347,7 @@ class TestMaxAutotune(TestCase):
             if not config.triton.native_matmul:
                 FileCheck().check("triton_tem_fused_baddbmm").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(max_autotune=True)
     def test_conv1x1_with_free_symbols(self, device):
         """
@@ -1395,6 +1418,7 @@ class TestMaxAutotune(TestCase):
         f_c = torch.compile(mode="max-autotune-no-cudagraphs")(f)
         self.assertEqual(f_c(*inps), f(*inps), atol=0.03, rtol=0.25)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch("trace.enabled", True)
     @config.patch({"test_configs.force_extern_kernel_in_multi_template": True})
     @config.patch("triton.native_matmul", False)
@@ -1461,6 +1485,7 @@ class TestMaxAutotune(TestCase):
     def test_cat_max_autotune_triton(self, device):
         self._test_cat_max_autotune_impl(device, using_triton_mm=True)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_conv_cat(self, device, search_space):
         class ToyModel(torch.nn.Module):
@@ -1487,6 +1512,7 @@ class TestMaxAutotune(TestCase):
                 if not TEST_WITH_ROCM:
                     FileCheck().check("def triton_poi_fused_add_cat_").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
     def test_conv3d(self, device, search_space):
         fn = torch.nn.functional.conv3d
@@ -1500,6 +1526,7 @@ class TestMaxAutotune(TestCase):
             actual = torch.compile(fn)(image, filt)
             torch.testing.assert_close(actual, expected, atol=6e-5, rtol=0.001)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         max_autotune=True, max_autotune_conv_backends="", layout_optimization=False
     )
@@ -1514,6 +1541,7 @@ class TestMaxAutotune(TestCase):
 
         self.assertIn("NoValidChoicesError", str(context.exception))
 
+    @requires_capabilities(Capability.lib.triton)
     def test_non_contiguous_input_mm(self, device):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.
@@ -1530,6 +1558,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_non_contiguous_input_addmm(self, device):
         b = torch.randn((768), dtype=torch.bfloat16, device=device)
         x = rand_strided((50257, 2048), (1, 50304), dtype=torch.bfloat16, device=device)
@@ -1543,6 +1572,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_non_contiguous_input_bmm(self, device):
         x = rand_strided(
             (1, 50257, 2048), (0, 1, 50304), dtype=torch.bfloat16, device=device
@@ -1559,6 +1589,7 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",
@@ -1578,6 +1609,7 @@ class TestMaxAutotune(TestCase):
         act = f(x1, y1, x2, y2)
         torch.testing.assert_close(act, ref, atol=1e-1, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="",
@@ -1592,6 +1624,7 @@ class TestMaxAutotune(TestCase):
             torch.compile(lambda a, b: a.matmul(b))(a, b)
         self.assertIn("NoValidChoicesError", str(context.exception))
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.triton.native_matmul, "Only test when template is being called"
     )
@@ -1617,6 +1650,7 @@ class TestMaxAutotune(TestCase):
                 torch.compile(lambda a, b: a.matmul(b))(a, b)
             self.assertIn("NoValidChoicesError", str(context.exception))
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(force_shape_pad=True, max_autotune=True)
     def test_linear_and_cel(self, device):
         """
@@ -1656,142 +1690,6 @@ class TestMaxAutotune(TestCase):
             if not same(expect, actual, tol=1e-2):
                 raise AssertionError(f"ref:\n{expect}\nact:\n{actual}")
 
-    @unittest.skipIf(
-        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
-    )
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "ignore decompose_k when native matmul codegen",
-    )
-    @parametrize("dynamic", (True, False))
-    @parametrize("dtype", (torch.float16, torch.bfloat16))
-    @parametrize("sizes", ((32, 32, 32768), (64, 128, 200000), (64, 64, 177147)))
-    @config.patch(
-        max_autotune=True,
-        max_autotune_gemm_backends="TRITON",
-        comprehensive_padding=False,
-        shape_padding=False,
-    )
-    def test_max_autotune_decompose_k(self, device, sizes, dtype, dynamic):
-        # UT specific change to force testing decompose K feature on ROCm until
-        # enabled by default, same strategy as #169948
-        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
-            fp16_red_setting = (
-                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
-            )
-            bf16_red_setting = (
-                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
-            )
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
-
-            M, N, K = sizes
-
-            atol = 1e-4
-            rtol = 1e-4
-            # K can be huge huge, this is why the data distribution is set to iid N(0, K ** 0.5),
-            # which makes the result of reductions distributed as N(0, 1).
-            a, b = self._make_matrices(
-                M,
-                K,
-                N,
-                dtype=dtype,
-                device=device,
-                requires_grad=True,
-            )
-
-            possible_splits = range(2, min(K // M, K // N) + 1)
-
-            divisors = {split for split in possible_splits if K % split == 0}
-
-            def check_divisors(code):
-                for kernel in code:
-                    if "decompose_k" in kernel:
-                        divisor_found = False
-                        for divisor in divisors:
-                            if f"{divisor}_split" in kernel:
-                                divisor_found = True
-                                break
-
-                        self.assertTrue(
-                            divisor_found,
-                            lambda msg: (
-                                f"{msg}\nCould not find a split in {divisors} in {kernel}"
-                            ),
-                        )
-
-            compiled_func = torch.compile(lambda a, b: a @ b, dynamic=dynamic)
-            # We assume with the large k dim relative to m, n, decompose_k will be most performant
-            out, code = run_and_get_code(compiled_func, a, b)
-
-            if dynamic:
-                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                    "decompose_k"
-                ).run(code[0])
-            else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*.run"
-                ).check("decompose_k").run(code[0])
-                check_divisors(code)
-                torch.testing.assert_close(out, a @ b, atol=atol, rtol=rtol)
-
-            # Test adding epilogue also equivalent to eager
-            compiled_func = torch.compile(lambda a, b: (a @ b).relu(), dynamic=dynamic)
-            out, code = run_and_get_code(compiled_func, a, b)
-            if dynamic:
-                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                    "decompose_k"
-                ).run(code[0])
-            else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*.run"
-                ).check("decompose_k").run(code[0])
-                check_divisors(code)
-                torch.testing.assert_close(
-                    compiled_func(a, b), (a @ b).relu(), atol=atol, rtol=rtol
-                )
-
-            # Test adding reinterpret view before subgraph
-            a = a.transpose(0, 1)
-            compiled_func = torch.compile(
-                lambda a, b: (a.transpose(0, 1) @ b).relu(), dynamic=dynamic
-            )
-            out, code = run_and_get_code(compiled_func, a, b)
-
-            if dynamic:
-                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
-                    "decompose_k"
-                ).run(code[0])
-            else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*_0.run"
-                ).check("decompose_k").run(code[0])
-                check_divisors(code)
-                torch.testing.assert_close(
-                    compiled_func(a, b),
-                    (a.transpose(0, 1) @ b).relu(),
-                    atol=atol,
-                    rtol=rtol,
-                )
-
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
-                fp16_red_setting
-            )
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-                bf16_red_setting
-            )
-
-    @unittest.skipIf(
-        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
-    )
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "ignore decompose_k when native matmul codegen",
-    )
-    @config.patch(
-        max_autotune=True,
-        max_autotune_gemm_backends="TRITON",
-    )
     def test_max_autotune_decompose_k_dynamic_input(self, device):
         # UT specific change to force testing decompose K feature on ROCm until
         # enabled by default, same strategy as #169948
@@ -1834,6 +1732,7 @@ class TestMaxAutotune(TestCase):
                     rtol=1e-4,
                 )
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1900,6 +1799,7 @@ class TestMaxAutotune(TestCase):
                     code[1]
                 )
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
     )
@@ -1951,6 +1851,7 @@ class TestMaxAutotune(TestCase):
                     f" empty_strided_{torch.device(device).type}((256, 1096), (1096, 1), torch.bfloat16)"
                 ).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -1994,6 +1895,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_mm").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("sizes", ((64, 128, 256), (128, 256, 512), (256, 512, 1024)))
@@ -2038,6 +1940,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_addmm").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @parametrize("dynamic", (False, True))
     def test_max_autotune_contiguous_transform_non_contiguous_second_matrix(
@@ -2105,6 +2008,7 @@ class TestMaxAutotune(TestCase):
             out2, expected2_fp64.to(torch.float32), atol=1e-2, rtol=1e-2
         )
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @config.patch(
         max_autotune=True,
@@ -2146,6 +2050,7 @@ class TestMaxAutotune(TestCase):
             # Check that contiguous transform was used
             FileCheck().check("contiguous_mm").run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch(
         max_autotune=True,
         max_autotune_gemm_backends="TRITON",
@@ -2223,6 +2128,7 @@ class TestMaxAutotune(TestCase):
                 self.assertEqual(len(configs), 1)
                 self.assertEqual(configs[0], expected_config)
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
     def test_bmm_out_dtype(self, device):
         def f(a, b):
@@ -2240,6 +2146,7 @@ class TestMaxAutotune(TestCase):
             FileCheck().check("extern_kernels.bmm_dtype").run(code[0])
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(config.cpp_wrapper, "out_dtype override not supported for AOTI")
     def test_triton_bmm_out_dtype(self, device):
         def f(a, b, out_dtype=torch.float32):
@@ -2257,6 +2164,7 @@ class TestMaxAutotune(TestCase):
             FileCheck().check("triton_tem_fused_bmm").run(code[0])
             self.assertEqual(out, expected, atol=1e-3, rtol=1e-3)
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     def test_triton_template_generated_code_cache_key(self, device):
         generate_and_load_args = len(
             inspect.signature(
@@ -2274,6 +2182,7 @@ class TestMaxAutotune(TestCase):
         self.assertEqual(generate_and_load_args - 1, make_key_args)
         self.assertEqual(generate_and_load_args, 21)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @fresh_cache()
     @config.patch(
         {
@@ -2302,6 +2211,7 @@ class TestMaxAutotune(TestCase):
             ):
                 torch.compile(func_test1, dynamic=False)(a, b, a, b)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(
         {
             "max_autotune": True,
@@ -2493,6 +2403,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 0)
             self.assertEqual(misses(), 7)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(
         {
             "max_autotune": True,
@@ -2529,6 +2440,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(
         {
             "max_autotune": True,
@@ -2570,7 +2482,8 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
 
-    def test_generated_code_cache_key_input_aliasing(self):
+    @requires_capabilities(Capability.big_gpu.big_gpu)
+    def test_generated_code_cache_key_input_aliasing(self, device):
         """make_key must distinguish aliased inputs, e.g. mm(x, x), from
         distinct inputs with identical layouts, and stay name-insensitive."""
 
@@ -2608,14 +2521,14 @@ class TestMaxAutotune(TestCase):
         self.assertEqual(key(a, b), key(b, a))
         self.assertIn("'input_aliasing': (0, 1)", key(a, b))
 
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(
         {
             "test_configs.max_mm_configs": 4,
             "max_autotune_gemm_backends": "TRITON",
         }
     )
-    def test_bmm_template_cache_aliased_then_distinct_inputs(self):
+    def test_bmm_template_cache_aliased_then_distinct_inputs(self, device):
         """A bmm whose operands alias one buffer must not share generated-code
         cache entries with a bmm over distinct operands of identical layouts.
 
@@ -2631,9 +2544,9 @@ class TestMaxAutotune(TestCase):
 
         B, N = 2, 128
         with fresh_cache():
-            x = torch.randn(B, N, N, device=GPU_TYPE)
-            a = torch.randn(B, N, N, device=GPU_TYPE)
-            b = torch.randn(B, N, N, device=GPU_TYPE)
+            x = torch.randn(B, N, N, device=device)
+            a = torch.randn(B, N, N, device=device)
+            b = torch.randn(B, N, N, device=device)
 
             compiled = torch.compile(
                 f,
@@ -2646,6 +2559,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(aliased, torch.bmm(x, x), atol=0.1, rtol=0.05)
             self.assertEqual(distinct, torch.bmm(a, b), atol=0.1, rtol=0.05)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @fresh_cache()
     @unittest.skipIf(
         config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
@@ -2695,6 +2609,7 @@ class TestMaxAutotune(TestCase):
                     self.assertTrue(decompose_count > 0)
                     self.assertTrue(decompose_count <= num_decompose_k_splits)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul takes different tuning configs",
@@ -2740,6 +2655,7 @@ class TestMaxAutotune(TestCase):
                 if "benchmark_gpu" in counter:
                     self.assertEqual(counters["inductor"][counter], 2)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -2759,6 +2675,7 @@ class TestMaxAutotune(TestCase):
             out, code = run_and_get_code(compiled_f, a, b)
             torch.testing.assert_close(out, mm(a, b), atol=1e-2, rtol=1e-2)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("op", ("mm", "addmm", "bmm", "baddbmm", "mm_plus_mm"))
     @parametrize("max_autotune", (False, True))
     @config.patch(
@@ -2833,6 +2750,7 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns()
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "ATEN,TRITON"}
     )
@@ -2871,6 +2789,7 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns(clear_defaults=False)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}
     )
@@ -2931,6 +2850,7 @@ class TestMaxAutotune(TestCase):
             _, code_out = run_and_get_code(c_f, *args)
             FileCheck().check(output_code_padding_check).run(code_out[0])
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("k", (15, 16))
     @parametrize("dynamic", (False, True))
     def test_even_k(self, device, k: int, dynamic: bool):
@@ -2950,6 +2870,7 @@ class TestMaxAutotune(TestCase):
         self.assertObjectIn(k, (15, 16))
         self.assertEqual("'EVEN_K': True" in cache_key, k == 16 and not dynamic)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -3001,6 +2922,7 @@ class TestMaxAutotune(TestCase):
             # should force fallback to extern_kernels.bmm
             FileCheck().check_not("triton_tem").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("always_freeze", [True, False])
     def test_mm_layout_freezing_behavior(self, device, always_freeze):
         """Test that mm layout freezing behavior depends on always_freeze_layout.
@@ -3068,6 +2990,7 @@ class TestMaxAutotune(TestCase):
 
         self.assertTrue(flexible_layout_called)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -3119,6 +3042,7 @@ class TestMaxAutotune(TestCase):
 
             FileCheck().check("triton_tem_fused").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune": True,
@@ -3148,6 +3072,7 @@ class TestMaxAutotune(TestCase):
 
         run_and_get_code(compiled_fn, *args)
 
+    @requires_capabilities(Capability.lib.triton)
     @fresh_cache()
     @config.patch(
         {
@@ -3200,6 +3125,7 @@ class TestMaxAutotune(TestCase):
             _, code = run_and_get_code(compiled_fn, a, b, c, idx0, idx1, value)
             FileCheck().check("triton_tem_fused").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/182093")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
@@ -3299,6 +3225,7 @@ class TestMaxAutotune(TestCase):
         else:
             self.assertEqual(out, out_unfused)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float32))
     @parametrize("use_addmm", (False, True))
     def test_triton_gemm_no_epilogue_no_truncation_casts(
@@ -3359,6 +3286,17 @@ class TestMaxAutotune(TestCase):
 class TestMaxAutotuneCuda(TestCase):
     hw_classification = HardwareClassification.CUDA
     """CUDA-specific max-autotune tests that require CUDA-only APIs."""
+
+    def _make_matrices(self, M, K, N, *batch_dims, dtype, device, requires_grad):
+        make_matrix = functools.partial(
+            random_matrix_with_scaled_reduction_dim,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+        )
+        a = make_matrix(M, K, *batch_dims, reduction_dim=-1)
+        b = make_matrix(K, N, *batch_dims, reduction_dim=-2)
+        return a, b
 
     @fresh_cache()
     @skipIfXpu(msg="XPU doesn't support sm carveout")
@@ -3640,6 +3578,168 @@ class TestMaxAutotuneCuda(TestCase):
 
         torch.testing.assert_close(result, torch.mm(a, b), rtol=1e-2, atol=1e-2)
 
+    @unittest.skipIf(
+        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
+    )
+    @unittest.skipIf(
+        config.triton.native_matmul,
+        "ignore decompose_k when native matmul codegen",
+    )
+    @parametrize("dynamic", (True, False))
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @parametrize("sizes", ((32, 32, 32768), (64, 128, 200000), (64, 64, 177147)))
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="TRITON",
+        comprehensive_padding=False,
+        shape_padding=False,
+    )
+    def test_max_autotune_decompose_k(self, device, sizes, dtype, dynamic):
+        # UT specific change to force testing decompose K feature on ROCm until
+        # enabled by default, same strategy as #169948
+        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+            fp16_red_setting = (
+                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+            )
+            bf16_red_setting = (
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+            )
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
+            M, N, K = sizes
+
+            atol = 1e-4
+            rtol = 1e-4
+            # K can be huge huge, this is why the data distribution is set to iid N(0, K ** 0.5),
+            # which makes the result of reductions distributed as N(0, 1).
+            a, b = self._make_matrices(
+                M,
+                K,
+                N,
+                dtype=dtype,
+                device=device,
+                requires_grad=True,
+            )
+
+            possible_splits = range(2, min(K // M, K // N) + 1)
+
+            divisors = {split for split in possible_splits if K % split == 0}
+
+            def check_divisors(code):
+                for kernel in code:
+                    if "decompose_k" in kernel:
+                        divisor_found = False
+                        for divisor in divisors:
+                            if f"{divisor}_split" in kernel:
+                                divisor_found = True
+                                break
+
+                        self.assertTrue(
+                            divisor_found,
+                            lambda msg: (
+                                f"{msg}\nCould not find a split in {divisors} in {kernel}"
+                            ),
+                        )
+
+            compiled_func = torch.compile(lambda a, b: a @ b, dynamic=dynamic)
+            # We assume with the large k dim relative to m, n, decompose_k will be most performant
+            out, code = run_and_get_code(compiled_func, a, b)
+
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_.*.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(out, a @ b, atol=atol, rtol=rtol)
+
+            # Test adding epilogue also equivalent to eager
+            compiled_func = torch.compile(lambda a, b: (a @ b).relu(), dynamic=dynamic)
+            out, code = run_and_get_code(compiled_func, a, b)
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_.*.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(
+                    compiled_func(a, b), (a @ b).relu(), atol=atol, rtol=rtol
+                )
+
+            # Test adding reinterpret view before subgraph
+            a = a.transpose(0, 1)
+            compiled_func = torch.compile(
+                lambda a, b: (a.transpose(0, 1) @ b).relu(), dynamic=dynamic
+            )
+            out, code = run_and_get_code(compiled_func, a, b)
+
+            if dynamic:
+                FileCheck().check_not("extern_kernels.bmm_dtype").check_not(
+                    "decompose_k"
+                ).run(code[0])
+            else:
+                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
+                    "triton_.*_fused_.*_0.run"
+                ).check("decompose_k").run(code[0])
+                check_divisors(code)
+                torch.testing.assert_close(
+                    compiled_func(a, b),
+                    (a.transpose(0, 1) @ b).relu(),
+                    atol=atol,
+                    rtol=rtol,
+                )
+
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+                fp16_red_setting
+            )
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+                bf16_red_setting
+            )
+
+    @unittest.skipIf(
+        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
+    )
+    @unittest.skipIf(
+        config.triton.native_matmul,
+        "ignore decompose_k when native matmul codegen",
+    )
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="TRITON",
+    )
+    @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
+    @parametrize("dynamic", (False, True))
+    def test_max_autotune_addmm(self, device, search_space, dynamic=False):
+        """
+        Make sure autotuning addmm in sub processes work without crashes.
+        """
+
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        def addmm(x, a, b):
+            return torch.addmm(x, a, b)
+
+        x = torch.randn(100).to(device)
+        a = torch.randn(100, 10).to(device)
+        b = torch.randn(10, 100).to(device)
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": True,
+                "max_autotune_gemm_search_space": search_space,
+            }
+        ):
+            Y_compiled = torch.compile(addmm, dynamic=dynamic)(x, a, b)
+            Y = addmm(x, a, b)
+            torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
+
 
 class TestTemplateConfigPruning(TestCase):
     """Test class for pruning logic in GEMM autotuning."""
@@ -3743,6 +3843,7 @@ class TestTemplateConfigPruning(TestCase):
             return bias_1d, mat1, mat2
         return mat1, mat2
 
+    @requires_capabilities(Capability.lib.triton)
     def test_max_autotune_prune_choices(self, device):
         def mm(x, y):
             return x @ y
@@ -3810,6 +3911,7 @@ class TestTemplateConfigPruning(TestCase):
             shared_memory_checker_opts,
         )
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @skipIfXpu(msg="Missing device_properties shared_memory_per_block on xpu.")
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("mat1_transposed", (False, True))
@@ -4000,6 +4102,7 @@ class TestMaxAutotunePrecompile(TestCase):
         finally:
             V.set_debug_handler(old_debug_handler)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_filled_cache_precompile(self, device):
         def fn(a, b, c):
             a = (a @ b) @ c
@@ -4018,6 +4121,7 @@ class TestMaxAutotunePrecompile(TestCase):
         fn_c = torch.compile(mode="max-autotune-no-cudagraphs")(fn)
         self.assertEqual(counters["inductor"]["select_algorithm_precompile"], 0)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(autotune_local_cache=False, autotune_remote_cache=False)
     @unittest.skipIf(config.triton.native_matmul, "native matmul has counter 0")
     def test_precompilations(self, device):
@@ -4123,6 +4227,7 @@ class TestMaxAutotuneSubproc(TestCase):
             child.join()
             self.assertNotEqual(0, child.exitcode)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("autotune_multi_device", (True, False))
     def test_max_autotune_mm_plus_mm(
@@ -4151,6 +4256,7 @@ class TestMaxAutotuneSubproc(TestCase):
         ):
             torch.compile(mm_plus_mm)(a, b, c, d)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm(self, device, dynamic: bool):
         """
@@ -4167,6 +4273,7 @@ class TestMaxAutotuneSubproc(TestCase):
         with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_max_autotune_profiler_benchmarker_smoke(self, device):
         """
         Smoke test that a simple max-autotune matmul runs with profiler
@@ -4216,32 +4323,7 @@ class TestMaxAutotuneSubproc(TestCase):
             ),
         )
 
-    @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))
-    @parametrize("dynamic", (False, True))
-    def test_max_autotune_addmm(self, device, search_space, dynamic=False):
-        """
-        Make sure autotuning addmm in sub processes work without crashes.
-        """
-
-        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
-
-        def addmm(x, a, b):
-            return torch.addmm(x, a, b)
-
-        x = torch.randn(100).to(device)
-        a = torch.randn(100, 10).to(device)
-        b = torch.randn(10, 100).to(device)
-        with config.patch(
-            {
-                "max_autotune": True,
-                "autotune_in_subproc": True,
-                "max_autotune_gemm_search_space": search_space,
-            }
-        ):
-            Y_compiled = torch.compile(addmm, dynamic=dynamic)(x, a, b)
-            Y = addmm(x, a, b)
-            torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
-
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     def test_triton_template_with_epilogues_and_dynamic_shape(self, device):
         def fn(
             x: torch.Tensor, w: torch.Tensor, bias: torch.Tensor, mul: torch.Tensor
@@ -4296,6 +4378,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
         super().tearDown()
         PatchCaches.tearDown()
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("dynamic", (False, True))
     @config.patch(
         {"compile_threads": 1, "prologue_fusion": False}
@@ -4434,6 +4517,7 @@ class TestTuningProcessPool(TestCase):
             expected_dir,
         )
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_cache_env_resets(self, device):
         with mock.patch.dict(os.environ, {}, clear=False):
@@ -4459,6 +4543,7 @@ class TestTuningProcessPool(TestCase):
             finally:
                 tuning_pool.shutdown()
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_cache_env_clears_codecache(self, device):
         with (
@@ -4539,6 +4624,7 @@ class TestTuningProcessPool(TestCase):
             finally:
                 autotune_pool._shutdown()
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_crash(self, device):
         tuning_pool = TuningProcessPool()
@@ -4562,6 +4648,7 @@ class TestTuningProcessPool(TestCase):
 
         tuning_pool.shutdown()
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": False})
     def test_tuning_pool_timeout(self, device):
         tuning_pool = TuningProcessPool()
@@ -4586,6 +4673,7 @@ class TestTuningProcessPool(TestCase):
 
         tuning_pool.shutdown()
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @config.patch({"autotune_multi_device": True})
     def test_tuning_pool_multiple_devices(self, device):
         # Adapt the test to the available devices (and whether the backend-specific
@@ -4702,6 +4790,7 @@ class TestTuningProcessPool(TestCase):
         # Verify they were cleared
         self.assertEqual(len(cache.feedback_saver_fns), 0)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_feedback_saver_integration(self, device):
         """Test that feedback savers are actually called during autotuning."""
         # Clear any existing feedback savers
@@ -4803,6 +4892,7 @@ class TestPrologueFusion(TestCase):
                 "del", num_deallocs, exactly=True
             ).run(code_str)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     def test_upcast(self, device, sizes):
         M, K, N = sizes
@@ -4823,6 +4913,7 @@ class TestPrologueFusion(TestCase):
             # upcast preserves zero mask
             FileCheck().check("a =").check_not("tl.where").check("tl.dot").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @unittest.skip("Triton bug in compilation")
     def test_gather_fusion(self, device):
         M, K, N = (64, 128, 256)
@@ -4847,6 +4938,7 @@ class TestPrologueFusion(TestCase):
             .run(code[0])
         )
 
+    @requires_capabilities(Capability.lib.triton)
     @requires_capabilities(Capability.dtype.fp8)
     @config.patch({"triton.native_matmul": False})
     def test_low_precision(self, device):
@@ -4880,6 +4972,7 @@ class TestPrologueFusion(TestCase):
         # should not be done in low precision, two kernels
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -4897,6 +4990,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=3)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @parametrize("sizes", ((64, 128, 256), (64, 64, 64), (64, 120, 64)))
     @parametrize("use_async_compile", (True, False))
     @unittest.skipIf(
@@ -4924,6 +5018,7 @@ class TestPrologueFusion(TestCase):
             "tl.full([1], 1.1, tl.float32)", 3, exactly=True
         ).check("tl.store").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/152221")
     @config.patch(
         {
@@ -4979,6 +5074,7 @@ class TestPrologueFusion(TestCase):
             ).run(code[0])
             self.assertEqual(out, resolve_pending(x), atol=0.05, rtol=0.05)
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(
         {
             "max_autotune_gemm_backends": "Triton",
@@ -5002,6 +5098,7 @@ class TestPrologueFusion(TestCase):
         ).run(code[0])
         self.assertEqual(out, test_multiple_fusions(x), atol=0.05, rtol=0.05)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
     def test_multiple_inputs(self, device, sizes, use_async_compile: bool):
@@ -5021,6 +5118,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, out_eager, atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     def test_storage_offset_prologue(self, device):
         def foo(a):
             q = a[:64, :]
@@ -5032,6 +5130,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(inp), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=1)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("sizes", ((64, 128, 256), (128, 128, 128), (63, 120, 250)))
     @parametrize("use_async_compile", (True, False))
@@ -5055,6 +5154,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
+    @requires_capabilities(Capability.lib.triton)
     @parametrize("K", (63, 64))
     def test_broadcast_x(self, device, K):
         def foo(x, y):
@@ -5067,6 +5167,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_broadcast_y(self, device):
         def foo(x, y):
             return x @ y
@@ -5081,6 +5182,7 @@ class TestPrologueFusion(TestCase):
         self.assertEqual(out, foo(x, y), atol=0.05, rtol=0.05)
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         config.triton.native_matmul,
         "generated code is different in native matmul",
@@ -5112,6 +5214,7 @@ class TestPrologueFusion(TestCase):
                 f = FileCheck().check("k_idx").check("a =").check_not("tl.where")
             f.check("tl.dot").run(code[0])
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @parametrize("benchmark_fusion", (True, False))
     @parametrize("use_async_compile", (True, False))
@@ -5141,6 +5244,7 @@ class TestPrologueFusion(TestCase):
                     code[0], num_kernels=2, num_allocs=None, num_deallocs=None
                 )
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(realize_reads_threshold=1, realize_opcount_threshold=1)
     @config.patch(allow_buffer_reuse=False)
     @unittest.skipIf(
@@ -5163,6 +5267,7 @@ class TestPrologueFusion(TestCase):
         # not sure why disabling buffer reuse doesn't stop
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @skipIfXpu
     @config.patch(
         {
@@ -5245,6 +5350,7 @@ class TestPrologueFusion(TestCase):
             "to_copy_add_div_mm_mul_relu_sub_tanh_1"
         ).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(shape_padding=True)
     @config.patch(force_shape_pad=True)
     @parametrize("sizes", ((250, 245, 128), (250, 256, 128), (256, 128, 62)))
@@ -5437,6 +5543,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         finally:
             mm_heuristic.mm_configs = original_mm_configs
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support in Triton")
     @skipIfXpu(msg="Bad tma config can be covered by XPU TMA")
     @unittest.skipIf(
@@ -5542,6 +5649,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 tma_heuristic.mm_configs = original_tma_mm_configs
                 mm_heuristic.mm_configs = original_mm_mm_configs
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179695")
     @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
@@ -5616,6 +5724,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
@@ -5672,6 +5781,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused_add_mul"
                     ).run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/179694")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176115")
     @requires_capabilities(Capability.lib.triton)
@@ -5738,6 +5848,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176114")
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/176113")
     @requires_capabilities(Capability.lib.triton)
@@ -5804,6 +5915,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                         "triton_poi_fused__to_copy"
                     ).run(code[0])
 
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @requires_capabilities(Capability.lib.triton)
     @parametrize("use_async_compile", (True, False))
     def test_epilogue_prologue_fusion_cache_preserved(
@@ -5904,6 +6016,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         # Clear the AsyncAutotuner cache to prevent test pollution
         AsyncAutotuner.choice_hash_to_future.clear()
 
+    @requires_capabilities(Capability.lib.triton)
     @config.patch(max_autotune_gemm=True)
     def test_async_autotuner_cache_same_inputs(self, device):
         M, K, N = 128, 64, 256
@@ -5981,6 +6094,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         self.assertIsNone(pool_instance._timer)
         self.assertTrue(AutotuneProcessPool._shutdown_for_inactivity)
 
+    @requires_capabilities(Capability.lib.triton)
     @patch(
         "torch._inductor.autotune_process.AUTOTUNE_POOL_INACTIVITY_TIMEOUT",
         2,
@@ -6028,6 +6142,7 @@ class TestMaxAutotuneAsyncPipelined(TestMaxAutotune, TestEpilogueFusionStaticAna
         cache_entries_after_second = len(AsyncAutotuner.choice_hash_to_future)
         self.assertEqual(cache_entries_after_second, 0)
 
+    @requires_capabilities(Capability.lib.triton, Capability.big_gpu.big_gpu)
     @config.patch(max_autotune_gemm=True)
     def test_triton_error_precompilation_and_autotuning(self, device):
         """


### PR DESCRIPTION
[Testcase Refactoring] Migrate test_max_autotune to instantiate_device_type_tests

### Summary

Migrate test_max_autotune.py from @instantiate_parametrized_tests + GPU_TYPE to
instantiate_device_type_tests + device parameter + hw_classification. Split
CUDA-only methods into TestMaxAutotuneCuda. Add per-method triton and big-GPU
guards to replace the original module-level __main__ gate.

### Changes

- Migrate all classes from @instantiate_parametrized_tests to
  instantiate_device_type_tests with hw_classification (ACCELERATOR/CUDA/GENERIC)
- Split 7 CUDA-specific methods (sm carveout, large tensor indexing, decompose_k,
  addmm with torch.backends.cuda.matmul state) into TestMaxAutotuneCuda
  (only_for="cuda")
- Add @unittest.skipIf(not HAS_TRITON) to 86 triton-codegen test methods across
  all ACCELERATOR classes
- Add @unittest.skipIf(not IS_BIG_GPU) to 2 methods requiring large GPU memory
- Move @config.patch + @unittest.mock.patch class decorators to setUp/tearDown
  in TestMaxAutotune and TestMaxAutotuneCuda (fixes instantiate_device_type_tests
  incompatibility)
- Add @requires_capabilities(Capability.dtype.fp8) on test_low_precision
- Restore has_triton() guard in __main__ block

### Motivation

The original __main__ block (HAS_GPU and is_big_gpu()) coupled execution to large
CUDA GPUs. Migrating to instantiate_device_type_tests broadens coverage to
cuda/xpu/privateuse1. Per-method triton guards ensure tests skip on accelerators
without triton. The __main__ has_triton() guard prevents the entire test file
from running on non-triton environments. Class-level @config.patch on
instantiate_device_type_tests classes causes TypeError due to MRO-blind
cls.__dict__.keys() scanning.

### Test Plan
python test/inductor/test_max_autotune.py

### Dependencies
Depends on: PR #194039 (registers Capability class and Capability.dtype.fp8)