### PR TITLE
[TEST] Add `hw_classification` to `test_scaled_matmul_cuda.py`

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -47,6 +47,7 @@ from torch.testing._internal.common_device_type import (
 
 from torch.testing._internal.common_xpu import Xe2_Or_Later
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     MI350_ARCH,
     parametrize,
@@ -659,6 +660,7 @@ def _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, format):
     return kwargs[format]
 
 class TestFP8Matmul(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _test_tautological_mm(self, device: str,
                               x_dtype: torch.dtype = e4m3_type,


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestFP8Matmul`.
- Uses `instantiate_device_type_tests` with `allow_xpu=True` — tests FP8/scaled matmul across accelerators. 
- Individual tests use `@onlyCUDA` for CUDA-specific features. No split needed.

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590)

## Test Plan

```
python test/test_scaled_matmul_cuda.py -v
Ran 1900 tests — 1 pre-existing failure, 1786 skips (both match baseline)
```

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508