### PR TITLE
[Testcase Refactoring] Classify cudagraph tests by hardware

### DIFF
--- a/test/dynamo/test_cudagraphs.py
+++ b/test/dynamo/test_cudagraphs.py
@@ -10,7 +10,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._inductor.cudagraph_trees as cudagraph_trees
 from torch._dynamo.testing import same
-from torch.testing._internal.common_utils import TEST_CUDA_GRAPH
+from torch.testing._internal.common_utils import HardwareClassification, TEST_CUDA_GRAPH
 
 
 def composed(*decs):
@@ -57,6 +57,8 @@ N_ITERS = 5
 
 @unittest.skipIf(not torch.cuda.is_available(), "these tests require cuda")
 class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @patch_all()
     def test_basic(self):
         def model(x, y):


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo cudagraph tests.

## Changes
- Import HardwareClassification for the test file.
- Mark TestAotCudagraphs as HardwareClassification.CUDA.

## Test plan
```bash
python -m py_compile test/dynamo/test_cudagraphs.py
git diff --check -- test/dynamo/test_cudagraphs.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98