### PR TITLE
[TEST] Add `hw_classification` to `test_cuda_trace.py`

### DIFF
--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -6,7 +6,13 @@ import unittest.mock
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
-from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    NoTest,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 # NOTE: Each test needs to be run in a brand new process, to reset the registered hooks
@@ -19,6 +25,8 @@ if not TEST_CUDA:
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         torch._C._activate_gpu_trace()


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.CUDA` to `TestCudaTrace`.
All 12 tests exercise CUDA GPU trace callbacks (event creation/deletion, stream creation/sync, memory alloc/dealloc). 

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590)

## Test Plan

```
python test/test_cuda_trace.py -v
Ran 12 tests in 1.9s — OK
```

Verified on H200: all 12 pass, 0 skip, 0 fail.

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508