### PR TITLE
[Testcase Refactoring] Mark test_baseexception, test_bool, and test_builtin as GENERIC in cpython/v3_13

### DIFF
--- a/test/cpython/v3_13/test_baseexception.py
+++ b/test/cpython/v3_13/test_baseexception.py
@@ -12,7 +12,7 @@ import torch
 import torch._dynamo.test_case
 import unittest
 from torch._dynamo.test_case import CPythonTestCase
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_TORCHDYNAMO
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TEST_WITH_TORCHDYNAMO
 
 # redirect import statements
 import sys
@@ -56,6 +56,7 @@ from platform import system as platform_system
 
 
 class ExceptionClassTests(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     """Tests for anything relating to exception objects themselves (e.g.,
     inheritance hierarchy)"""
@@ -195,6 +196,7 @@ class ExceptionClassTests(CPythonTestCase):
 
 
 class UsageTests(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     """Test usage of exceptions"""
 

--- a/test/cpython/v3_13/test_bool.py
+++ b/test/cpython/v3_13/test_bool.py
@@ -12,7 +12,10 @@ import torch
 import torch._dynamo.test_case
 import unittest
 from torch._dynamo.test_case import CPythonTestCase
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 
 # ======= END DYNAMO PATCH =======
 
@@ -24,6 +27,7 @@ from test.support import os_helper
 import os
 
 class BoolTest(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_subclass(self):
         try:

--- a/test/cpython/v3_13/test_builtin.py
+++ b/test/cpython/v3_13/test_builtin.py
@@ -15,6 +15,7 @@ from torch._dynamo.test_case import CPythonTestCase
 from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     run_tests,
+    HardwareClassification,
 )
 
 # ======= END DYNAMO PATCH =======
@@ -169,6 +170,8 @@ def map_char(arg):
     return chr(ord(arg)+1)
 
 class BuiltinTest(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Helper to check picklability
     def check_iter_pickle(self, it, seq, proto):
         itorg = it
@@ -2243,6 +2246,8 @@ class BuiltinTest(CPythonTestCase):
 
 
 class TestBreakpoint(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         # These tests require a clean slate environment.  For example, if the
         # test suite is run with $PYTHONBREAKPOINT set to something else, it
@@ -2364,6 +2369,7 @@ class TestBreakpoint(CPythonTestCase):
 class PtyTests(CPythonTestCase):
     """Tests that use a pseudo terminal to guarantee stdin and stdout are
     terminals in the test environment"""
+    hw_classification = HardwareClassification.GENERIC
 
     @staticmethod
     def handle_sighup(signum, frame):
@@ -2541,6 +2547,7 @@ class PtyTests(CPythonTestCase):
         self.assertSequenceEqual(lines, expected)
 
 class TestSorted(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_basic(self):
         data = list(range(100))
@@ -2584,6 +2591,7 @@ class TestSorted(CPythonTestCase):
 
 
 class ShutdownTest(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_cleanup(self):
         # Issue #19255: builtins are still available at shutdown
@@ -2619,6 +2627,7 @@ class ShutdownTest(CPythonTestCase):
 
 @cpython_only
 class ImmortalTests(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     if sys.maxsize < (1 << 32):
         IMMORTAL_REFCOUNT = (1 << 30) - 1
@@ -2647,6 +2656,8 @@ class ImmortalTests(CPythonTestCase):
 
 
 class TestType(CPythonTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_new_type(self):
         A = type('A', (), {})
         self.assertEqual(A.__name__, 'A')


### PR DESCRIPTION
## Summary

This PR adds HardwareClassification.GENERIC annotations to 10 test classes across 3 CPython v3.13 test files so that the test infrastructure can correctly classify these tests as device-unrelated and skip them on accelerator-only CI runners.

## Changes

- Added hw_classification = HardwareClassification.GENERIC to ExceptionClassTests and UsageTests in test/cpython/v3_13/test_baseexception.py.
- Added hw_classification = HardwareClassification.GENERIC to BoolTest in test/cpython/v3_13/test_bool.py.
- Added hw_classification = HardwareClassification.GENERIC to 7 test classes in test/cpython/v3_13/test_builtin.py: BuiltinTest, TestBreakpoint, PtyTests, TestSorted, ShutdownTest, ImmortalTests, and TestType.
- Imported HardwareClassification from torch.testing._internal.common_utils in all three files.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98