### PR TITLE
[Testcase Refactoring] Migrate test_max_autotune_blackwell to hw_classification and device parameter

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -13,11 +13,16 @@ from torch._inductor.heuristics.template.triton import (
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._triton import has_datacenter_blackwell_tma_device
 
 
@@ -47,8 +52,11 @@ def tearDownModule():
         _PRIOR_FP32_MATMUL_PRECISION = None
 
 
-@instantiate_parametrized_tests
 class TestMaxAutotuneBlackwell(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -60,6 +68,7 @@ class TestMaxAutotuneBlackwell(TestCase):
     @parametrize("epilogue_subtile", (1, 2, 4))
     def test_blackwell_max_autotune_regular_mm_persistent_tma(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -83,12 +92,12 @@ class TestMaxAutotuneBlackwell(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
 
         epilogue_subtile_regex = f"EPILOGUE_SUBTILE={epilogue_subtile}"
@@ -118,6 +127,8 @@ class TestMaxAutotuneBlackwell(TestCase):
 
     # NOTE: the current Inductor template verifies that the scaling mode is either per-tensor or per-row
     # TODO: support additional scaling modes for Blackwell
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -126,6 +137,7 @@ class TestMaxAutotuneBlackwell(TestCase):
     @parametrize("tma_store", (False, True))
     def test_blackwell_max_autotune_scaled_mm_per_tensor_persistent_tma(
         self,
+        device,
         dynamic: bool,
         tma_store: bool,
     ):
@@ -142,8 +154,8 @@ class TestMaxAutotuneBlackwell(TestCase):
         # TMA requires 16-byte alignment: here we repeat the dims
         # by the factor of 8, as float16 is 2-byte.
         M, N, K = 32, 16, 48
-        a = (torch.randn((M, K)).to(torch.float16).to(GPU_TYPE)).repeat(8, 8)
-        b = (torch.randn((N, K)).to(torch.float16).to(GPU_TYPE)).repeat(8, 8)
+        a = (torch.randn((M, K)).to(torch.float16).to(device)).repeat(8, 8)
+        b = (torch.randn((N, K)).to(torch.float16).to(device)).repeat(8, 8)
 
         scale_a = get_scale_per_tensor(a)
         scale_b = get_scale_per_tensor(b)
@@ -176,6 +188,8 @@ class TestMaxAutotuneBlackwell(TestCase):
             "triton.language.make_tensor_descriptor"
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -184,6 +198,7 @@ class TestMaxAutotuneBlackwell(TestCase):
     @parametrize("tma_store", (False, True))
     def test_blackwell_max_autotune_scaled_mm_per_row_persistent_tma(
         self,
+        device,
         dynamic: bool,
         tma_store: bool,
     ):
@@ -208,8 +223,8 @@ class TestMaxAutotuneBlackwell(TestCase):
         # TMA requires 16-byte alignment: here we repeat the dims
         # by the factor of 8, as float16 is 2-byte.
         M, N, K = 32, 16, 48
-        a = (torch.randn((M, K)).to(torch.bfloat16).to(GPU_TYPE)).repeat(8, 8)
-        b = (torch.randn((N, K)).to(torch.bfloat16).to(GPU_TYPE)).repeat(8, 8)
+        a = (torch.randn((M, K)).to(torch.bfloat16).to(device)).repeat(8, 8)
+        b = (torch.randn((N, K)).to(torch.bfloat16).to(device)).repeat(8, 8)
 
         scale_a = get_scale_per_row(a)
         scale_b = get_scale_per_row(b)
@@ -242,6 +257,8 @@ class TestMaxAutotuneBlackwell(TestCase):
             "triton.language.make_tensor_descriptor"
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -253,6 +270,7 @@ class TestMaxAutotuneBlackwell(TestCase):
     @parametrize("epilogue_subtile", (1, 2, 4))
     def test_blackwell_max_autotune_addmm_persistent_tma(
         self,
+        device,
         a_transposed: bool,
         b_transposed: bool,
         dynamic: bool,
@@ -278,14 +296,14 @@ class TestMaxAutotuneBlackwell(TestCase):
         a = (
             torch.randn(*((K, M) if a_transposed else (M, K)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
         b = (
             torch.randn(*((N, K) if b_transposed else (K, N)))
             .to(torch.float16)
-            .to(GPU_TYPE)
+            .to(device)
         )
-        x = torch.randn(N).to(torch.float16).to(GPU_TYPE)
+        x = torch.randn(N).to(torch.float16).to(device)
 
         epilogue_subtile_regex = f"EPILOGUE_SUBTILE={epilogue_subtile}"
         with config.patch(
@@ -333,9 +351,10 @@ class TestMaxAutotuneBlackwell(TestCase):
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
 
-@instantiate_parametrized_tests
 class TestBlackwellTMAStoreFusion(TestCase):
     """Tests for TMA store with fused pointwise epilogues on Blackwell."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @staticmethod
     def _make_tma_store_test_config(epilogue_subtile: int) -> BlackwellGPUGemmConfig:
@@ -354,6 +373,8 @@ class TestBlackwellTMAStoreFusion(TestCase):
             flatten=False,
         )
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -362,6 +383,7 @@ class TestBlackwellTMAStoreFusion(TestCase):
     @parametrize("epilogue_subtile", (1, 2))
     def test_blackwell_mm_sigmoid_epilogue_fusion_tma_store(
         self,
+        device,
         shape: tuple[int, int, int],
         epilogue_subtile: int,
     ):
@@ -372,8 +394,8 @@ class TestBlackwellTMAStoreFusion(TestCase):
             return x * (2.0 * torch.sigmoid(mm))
 
         M, N, K = shape
-        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=device)
 
         test_config = self._make_tma_store_test_config(epilogue_subtile)
         # Ensure the heuristic cache is populated, then patch mm_configs.
@@ -410,6 +432,8 @@ class TestBlackwellTMAStoreFusion(TestCase):
             ".store"
         ).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -418,6 +442,7 @@ class TestBlackwellTMAStoreFusion(TestCase):
     @parametrize("epilogue_subtile", (1, 2))
     def test_blackwell_addmm_relu_epilogue_fusion_tma_store(
         self,
+        device,
         shape: tuple[int, int, int],
         epilogue_subtile: int,
     ):
@@ -428,9 +453,9 @@ class TestBlackwellTMAStoreFusion(TestCase):
             return torch.relu(mm + bias)
 
         M, N, K = shape
-        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        bias = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+        bias = torch.randn(N, dtype=torch.bfloat16, device=device)
 
         test_config = self._make_tma_store_test_config(epilogue_subtile)
         # Ensure the heuristic cache is populated, then patch mm_configs.
@@ -468,9 +493,10 @@ class TestBlackwellTMAStoreFusion(TestCase):
         ).run(code[0])
 
 
-@instantiate_parametrized_tests
 class TestBlackwellTMALoadFusion(TestCase):
     """Tests for TMA load with fused pointwise epilogues on Blackwell."""
+
+    hw_classification = HardwareClassification.CUDA
 
     @staticmethod
     def _make_tma_load_test_config(epilogue_subtile: int) -> BlackwellGPUGemmConfig:
@@ -485,6 +511,8 @@ class TestBlackwellTMALoadFusion(TestCase):
             flatten=False,
         )
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -493,6 +521,7 @@ class TestBlackwellTMALoadFusion(TestCase):
     @parametrize("epilogue_subtile", (1, 2))
     def test_blackwell_mm_sigmoid_epilogue_tma_load(
         self,
+        device,
         shape: tuple[int, int, int],
         epilogue_subtile: int,
     ):
@@ -503,8 +532,8 @@ class TestBlackwellTMALoadFusion(TestCase):
             return x * (2.0 * torch.sigmoid(mm))
 
         M, N, K = shape
-        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=device)
 
         test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
         from torch._inductor.heuristics.template.registry import get_template_heuristic
@@ -540,6 +569,8 @@ class TestBlackwellTMALoadFusion(TestCase):
             ".load(["
         ).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -548,6 +579,7 @@ class TestBlackwellTMALoadFusion(TestCase):
     @parametrize("epilogue_subtile", (1, 2))
     def test_blackwell_mm_scale_bias_epilogue_tma_load(
         self,
+        device,
         shape: tuple[int, int, int],
         epilogue_subtile: int,
     ):
@@ -557,10 +589,10 @@ class TestBlackwellTMALoadFusion(TestCase):
             return torch.mm(x, W.T) * scale + bias
 
         M, N, K = shape
-        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        scale = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE)
-        bias = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+        scale = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+        bias = torch.randn(M, N, dtype=torch.bfloat16, device=device)
 
         test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
         from torch._inductor.heuristics.template.registry import get_template_heuristic
@@ -596,6 +628,8 @@ class TestBlackwellTMALoadFusion(TestCase):
             ".load(["
         ).run(code[0])
 
+    @requires_capabilities(Capability.lib.triton)
+    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -604,6 +638,7 @@ class TestBlackwellTMALoadFusion(TestCase):
     @parametrize("epilogue_subtile", (1, 2))
     def test_blackwell_addmm_1d_bias_epilogue_tma_load(
         self,
+        device,
         shape: tuple[int, int, int],
         epilogue_subtile: int,
     ):
@@ -613,9 +648,9 @@ class TestBlackwellTMALoadFusion(TestCase):
             return torch.addmm(bias, x, W.T)
 
         M, N, K = shape
-        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
-        bias = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+        bias = torch.randn(N, dtype=torch.bfloat16, device=device)
 
         test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
         from torch._inductor.heuristics.template.registry import get_template_heuristic
@@ -655,6 +690,8 @@ class TestBlackwellTMALoadFusion(TestCase):
 @instantiate_parametrized_tests
 class TestBlackwellExhaustiveConfigs(TestCase):
     """Tests for exhaustive config generation for Blackwell templates."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     # Expected valid values for each parameter based on _generate_exhaustive_configs
     VALID_BLOCK_SIZES = {32, 64, 128, 256}
@@ -730,9 +767,10 @@ class TestBlackwellExhaustiveConfigs(TestCase):
         )
 
 
-if __name__ == "__main__":
-    from torch._inductor.utils import is_big_gpu
+instantiate_device_type_tests(TestMaxAutotuneBlackwell, globals(), only_for="cuda")
+instantiate_device_type_tests(TestBlackwellTMAStoreFusion, globals(), only_for="cuda")
+instantiate_device_type_tests(TestBlackwellTMALoadFusion, globals(), only_for="cuda")
 
-    # Set env to make it work in CI.
-    if HAS_GPU and HAS_CPU and is_big_gpu():
-        run_tests()
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -13,18 +13,14 @@ from torch._inductor.heuristics.template.triton import (
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
-from torch.utils._triton import has_datacenter_blackwell_tma_device
+from torch.testing._internal.inductor_utils import HAS_CPU
+from torch.utils._triton import has_datacenter_blackwell_tma_device, has_triton
 
 
 def has_tlx() -> bool:
@@ -56,7 +52,6 @@ def tearDownModule():
 class TestMaxAutotuneBlackwell(TestCase):
     hw_classification = HardwareClassification.CUDA
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -127,7 +122,6 @@ class TestMaxAutotuneBlackwell(TestCase):
 
     # NOTE: the current Inductor template verifies that the scaling mode is either per-tensor or per-row
     # TODO: support additional scaling modes for Blackwell
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -187,7 +181,6 @@ class TestMaxAutotuneBlackwell(TestCase):
             "triton.language.make_tensor_descriptor"
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -255,7 +248,6 @@ class TestMaxAutotuneBlackwell(TestCase):
             "triton.language.make_tensor_descriptor"
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -370,7 +362,6 @@ class TestBlackwellTMAStoreFusion(TestCase):
             flatten=False,
         )
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -428,7 +419,6 @@ class TestBlackwellTMAStoreFusion(TestCase):
             ".store"
         ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -506,7 +496,6 @@ class TestBlackwellTMALoadFusion(TestCase):
             flatten=False,
         )
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -563,7 +552,6 @@ class TestBlackwellTMALoadFusion(TestCase):
             ".load(["
         ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -621,7 +609,6 @@ class TestBlackwellTMALoadFusion(TestCase):
             ".load(["
         ).run(code[0])
 
-    @requires_capabilities(Capability.lib.triton)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -767,6 +754,5 @@ instantiate_device_type_tests(TestBlackwellTMALoadFusion, globals(), only_for="c
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu
 
-    # Set env to make it work in CI.
-    if HAS_GPU and HAS_CPU and is_big_gpu():
+    if has_triton() and HAS_CPU and is_big_gpu():
         run_tests()

--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
 from torch.utils._triton import has_datacenter_blackwell_tma_device
 
 
@@ -56,7 +57,6 @@ class TestMaxAutotuneBlackwell(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -128,7 +128,6 @@ class TestMaxAutotuneBlackwell(TestCase):
     # NOTE: the current Inductor template verifies that the scaling mode is either per-tensor or per-row
     # TODO: support additional scaling modes for Blackwell
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -189,7 +188,6 @@ class TestMaxAutotuneBlackwell(TestCase):
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -258,7 +256,6 @@ class TestMaxAutotuneBlackwell(TestCase):
         ).check("tl.load_tensor_descriptor").check(write_api).run(code[0])
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -374,7 +371,6 @@ class TestBlackwellTMAStoreFusion(TestCase):
         )
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -433,7 +429,6 @@ class TestBlackwellTMAStoreFusion(TestCase):
         ).run(code[0])
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -512,7 +507,6 @@ class TestBlackwellTMALoadFusion(TestCase):
         )
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -570,7 +564,6 @@ class TestBlackwellTMALoadFusion(TestCase):
         ).run(code[0])
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -629,7 +622,6 @@ class TestBlackwellTMALoadFusion(TestCase):
         ).run(code[0])
 
     @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.big_gpu.big_gpu)
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -773,4 +765,8 @@ instantiate_device_type_tests(TestBlackwellTMALoadFusion, globals(), only_for="c
 
 
 if __name__ == "__main__":
-    run_tests()
+    from torch._inductor.utils import is_big_gpu
+
+    # Set env to make it work in CI.
+    if HAS_GPU and HAS_CPU and is_big_gpu():
+        run_tests()


### PR DESCRIPTION
### Summary

Migrate 4 test classes in `test_max_autotune_blackwell.py` from `@instantiate_parametrized_tests` + `GPU_TYPE` to the hardware classification framework: 3 CUDA classes use `instantiate_device_type_tests` with `only_for="cuda"` and a `device` parameter, and 1 pure-logic class is labeled `GENERIC`. The `__main__` guard is decoupled from CUDA via `has_triton()`.

### Changes

- Replaced `GPU_TYPE` with a `device` parameter in 9 CUDA test methods across 3 classes.
- Added `hw_classification` to 4 classes: `CUDA` for `TestMaxAutotuneBlackwell`, `TestBlackwellTMAStoreFusion`, `TestBlackwellTMALoadFusion`; `GENERIC` for `TestBlackwellExhaustiveConfigs`.
- Removed `@instantiate_parametrized_tests` from the 3 CUDA classes (handled by `instantiate_device_type_tests`).
- Added 3 `instantiate_device_type_tests(cls, globals(), only_for="cuda")` calls at module bottom.
- `__main__` guard: `HAS_GPU` → `has_triton()` (keep `is_big_gpu()` and `HAS_CPU`), so privateuse1 accelerators are supported.

### Motivation

`GPU_TYPE` coupled tests to a device string without expressing hardware intent. `instantiate_device_type_tests` with `only_for="cuda"` explicitly declares CUDA-only intent and lets the framework inject `device`. The `__main__` `HAS_GPU` check did not cover privateuse1 accelerators; `has_triton()` decouples the guard from CUDA. No per-method capability decorator is added because the original code relied on the `__main__` guard plus per-method `has_datacenter_blackwell_tma_device()` skip.

### Test Plan

```
python test/inductor/test_max_autotune_blackwell.py
```

(On non-Blackwell hardware, the 9 CUDA methods skip via `has_datacenter_blackwell_tma_device()`; the 2 GENERIC methods run on CPU.)

### Dependencies

None. This PR does not depend on any capability registration.
