### PR TITLE
[TEST] Add `hw_classification` to `test_cuda.py`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -71,6 +71,7 @@ from torch.testing._internal.common_utils import (
     gcIfJetson,
     get_cycles_per_ms,
     getRocmVersion,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
@@ -204,6 +205,8 @@ def _check_allocator_settings_on_tear_down(test_case):
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
     FIFTY_MIL_CYCLES = 50000000
@@ -2116,6 +2119,8 @@ import torch
 from torch.testing._internal.common_utils import (TestCase, run_tests, slowTest)
 
 class TestThatContainsCUDAAssertFailure(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
 
     @slowTest
     def test_index_bounds_cuda(self):
@@ -5778,6 +5783,8 @@ print(ret)
     "expandable_segments mode is not supported on ROCm",
 )
 class TestResizeStorageWithAddr(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
@@ -6034,6 +6041,8 @@ class TestResizeStorageWithAddr(TestCase):
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaAllocator(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def tearDown(self):
         super().tearDown()
         _check_allocator_settings_on_tear_down(self)
@@ -7480,6 +7489,8 @@ def reconstruct_from_tensor_metadata(metadata):
 )
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestBlockStateAbsorption(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def expandable_segments(self):
         return EXPANDABLE_SEGMENTS
@@ -7972,6 +7983,8 @@ def caching_host_allocator_max_round_threshold_and_max_cached_size(
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCachingHostAllocatorConfig(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         gc.collect()
@@ -8051,6 +8064,8 @@ class TestCachingHostAllocatorConfig(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCachingHostAllocatorCudaGraph(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # As soon as pinned host memory allocated by a private pool is
     # used (by copy_ in this case) during stream capture, it can never
     # be recycled.
@@ -8179,6 +8194,8 @@ class TestCachingHostAllocatorCudaGraph(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestMemPool(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def tearDown(self):
         super().tearDown()
         _check_allocator_settings_on_tear_down(self)
@@ -9780,6 +9797,8 @@ class TestMemPool(TestCase):
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaOptims(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     # These tests will be instantiate with instantiate_device_type_tests
     # to apply the new OptimizerInfo structure.
 
@@ -10142,6 +10161,8 @@ class TestCudaOptims(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestGDS(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _get_tmp_dir_fs_type(self):
         my_path = os.path.realpath(tempfile.gettempdir())
         root_type = ""
@@ -10252,6 +10273,8 @@ class TestGDS(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaAutocast(TestAutocast):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         self.autocast_lists = AutocastTestLists(torch.device("cuda:0"))
@@ -10798,6 +10821,8 @@ class TestCudaAutocast(TestAutocast):
 
 
 class TestCompileKernel(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel(self):
         # Simple vector addition kernel
@@ -11328,6 +11353,8 @@ class TestCompileKernel(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @skipIfRocmVersionLessThan((7, 0))
     @skipCUDAIf(
         not SM70OrLater, "Compute capability >= SM70 required for relaxed ptx flag"
@@ -11422,6 +11449,8 @@ class TestCudaDeviceParametrized(TestCase):
 
 
 class TestFXMemoryProfiler(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """Tests for memory profiler augmentation with original stack traces."""
 
     class MLPModule(nn.Module):
@@ -11551,6 +11580,8 @@ class TestFXMemoryProfiler(TestCase):
     not PLATFORM_SUPPORTS_GREEN_CONTEXT, "Green contexts are not supported"
 )
 class TestCudaGreenContexts(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
 
@@ -11690,6 +11721,8 @@ class TestCudaGreenContexts(TestCase):
 
 
 class TestCudaArchList(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_get_arch_list_empty_when_cuda_not_compiled(self):
         if torch.cuda._is_compiled():
             self.skipTest("CUDA is compiled")
@@ -11716,6 +11749,8 @@ instantiate_device_type_tests(TestCudaGreenContexts, globals(), except_for="cpu"
 # Tests for fp32_precision flag propagation that don't require an actual CUDA
 # device — they only exercise C++ context state management.
 class TestFP32PrecisionFlags(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/182021"
     )
@@ -11734,6 +11769,8 @@ class TestFP32PrecisionFlags(TestCase):
 
 
 class TestMemoryViz(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_format_flamegraph_download_moves_temp_file(self):
         # Regression test: format_flamegraph downloads flamegraph.pl into a temp
         # file and moves it into place. Previously the temp file was created by a


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.CUDA` to all 18 test classes: `TestCuda`, `TestThatContainsCUDAAssertFailure`, `TestResizeStorageWithAddr`, `TestCudaAllocator`, `TestBlockStateAbsorption`, `TestCachingHostAllocatorConfig`, `TestCachingHostAllocatorCudaGraph`, `TestMemPool`, `TestCudaOptims`, `TestGDS`, `TestCudaAutocast`, `TestCompileKernel`, `TestCudaDeviceParametrized`, `TestFXMemoryProfiler`, `TestCudaGreenContexts`, `TestCudaArchList`, `TestFP32PrecisionFlags`, `TestMemoryViz`.

All classes test CUDA-specific functionality. 

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590).

## Test Plan

```
python test/test_cuda.py
Ran 440 tests in 121s — 4 pre-existing failures, 81 skips 
```

Verified on H200.

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508