### PR TITLE
Fix build_with_debinfo for non-torch_python sources

### DIFF
--- a/tools/build_with_debinfo.py
+++ b/tools/build_with_debinfo.py
@@ -2,9 +2,8 @@
 # Tool to quickly rebuild one or two files with debug info.
 #
 # It recompiles each named source with -g (in place of -O2/-O3), reusing the
-# exact compile command CMake recorded for it, then relinks libtorch_python
-# and symlinks the result into torch/lib so an editable `import torch` picks
-# it up. Use --dry-run to print the plan without building.
+# exact command ninja recorded for it, then follows ninja's command graph to
+# relink its dependents. Use --dry-run to print the plan without building.
 #
 # Why not `ninja -n torch_python | sed 's/-O[23]/-g/' | sh` (the old approach):
 # the build uses file(GLOB ... CONFIGURE_DEPENDS), which wires a glob-check
@@ -12,13 +11,11 @@
 # that check or reload the regenerated graph, so `ninja -n <target>` only ever
 # reports the regeneration step (VerifyGlobs + regenerate-during-build) and
 # never the real compile/link commands. We therefore source the per-file
-# compile command from build/compile_commands.json and the link command from
-# `ninja -t commands` (a graph walk, not a dry run), neither of which is
+# commands from `ninja -t commands` (a graph walk, not a dry run), which is not
 # affected by the glob-check.
 
 from __future__ import annotations
 
-import json
 import shlex
 import subprocess
 import sys
@@ -31,7 +28,6 @@ TORCH_DIR = PYTORCH_ROOTDIR / "torch"
 TORCH_LIB_DIR = TORCH_DIR / "lib"
 BUILD_DIR = PYTORCH_ROOTDIR / "build"
 BUILD_LIB_DIR = BUILD_DIR / "lib"
-COMPILE_COMMANDS = BUILD_DIR / "compile_commands.json"
 
 
 def check_output(args: list[str], cwd: str | None = None) -> str:
@@ -94,57 +90,64 @@ def debugify(cmd: str) -> str:
     return cmd
 
 
-def index_compile_commands(
-    entries: list[dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    """Map each absolute source path to its compile_commands.json entry."""
-    result: dict[str, dict[str, Any]] = {}
-    for entry in entries:
-        src = (Path(entry["directory"]) / entry["file"]).resolve()
-        result[str(src)] = entry
-    return result
+def command_tokens(cmd: str, build_dir: Path) -> list[tuple[str, Path]]:
+    tokens = shlex.split(cmd)
+    cwd = build_dir
+    if len(tokens) > 2 and tokens[0] == "cd" and tokens[2] == "&&":
+        cwd = Path(tokens[1])
+        tokens = tokens[3:]
+    return [(token, (cwd / token).resolve()) for token in tokens]
 
 
-def load_compile_commands() -> dict[str, dict[str, Any]]:
-    return index_compile_commands(json.loads(COMPILE_COMMANDS.read_text()))
+def command_outputs(cmd: str, build_dir: Path) -> set[Path]:
+    tokens = command_tokens(cmd, build_dir)
+    return {
+        tokens[idx + 1][1]
+        for idx, (token, _) in enumerate(tokens[:-1])
+        if token == "-o"
+    }
 
 
-def entry_command(entry: dict[str, Any]) -> str:
-    cmd = entry.get("command")
-    if cmd is None:
-        cmd = " ".join(shlex.quote(arg) for arg in entry["arguments"])
-    return cmd
+def create_build_plan(
+    files: list[str], ninja_commands: str, build_dir: Path
+) -> list[tuple[str, str]]:
+    commands = [line.strip() for line in ninja_commands.splitlines() if line.strip()]
+    sources = {Path(file).resolve() for file in files}
+    parsed = []
+    for cmd in commands:
+        paths = {path for _, path in command_tokens(cmd, build_dir)}
+        parsed.append(
+            (cmd, paths, command_outputs(cmd, build_dir), bool(sources & paths))
+        )
+    selected: set[int] = set()
+    outputs: set[Path] = set()
 
-
-def extract_link_command(ninja_commands: str, lib: str) -> str:
-    """Pick the link command producing `lib` from `ninja -t commands` output.
-
-    The link is the last command mentioning `lib`; ninja wraps linker rules
-    as `: && <cmd> && :`.
-    """
-    link = None
-    for line in ninja_commands.split("\n"):
-        if lib not in line:
+    for idx, (_, _, cmd_outputs, is_source) in enumerate(parsed):
+        if not is_source:
             continue
-        line = line.strip()
-        if line.startswith(": &&") and line.endswith("&& :"):
-            line = line[4:-4].strip()
-        link = line
-    if link is None:
-        raise RuntimeError(f"Could not find the {lib} link command")
-    return link
+        selected.add(idx)
+        outputs.update(cmd_outputs)
 
+    if not selected:
+        raise RuntimeError("Could not find build commands for the requested files")
 
-def torch_python_link_command() -> str:
-    """Return the libtorch_python link command via a ninja graph walk.
+    for idx, (cmd, paths, cmd_outputs, _) in enumerate(parsed):
+        if idx in selected:
+            continue
+        has_embedded_output = any(str(output) in cmd for output in outputs)
+        if outputs.isdisjoint(paths) and not has_embedded_output:
+            continue
+        selected.add(idx)
+        outputs.update(cmd_outputs)
 
-    `ninja -t commands` expands a target's commands without the dry-run
-    staleness logic that CONFIGURE_DEPENDS defeats.
-    """
-    output = check_output(
-        ["ninja", "-t", "commands", "torch_python"], cwd=str(BUILD_DIR)
-    )
-    return extract_link_command(output, f"libtorch_python.{get_lib_extension()}")
+    return [
+        (
+            "debug rebuild" if is_source else "rebuild dependent",
+            debugify(cmd) if is_source else cmd,
+        )
+        for idx, (cmd, _, _, is_source) in enumerate(parsed)
+        if idx in selected
+    ]
 
 
 def main() -> None:
@@ -154,12 +157,6 @@ def main() -> None:
     args = parse_args()
     if not has_build_ninja():
         print("Only ninja build system is supported at the moment")
-        sys.exit(-1)
-    if not COMPILE_COMMANDS.exists():
-        print(
-            f"{COMPILE_COMMANDS} not found; configure with "
-            "CMAKE_EXPORT_COMPILE_COMMANDS=ON (PyTorch's build sets this by default)"
-        )
         sys.exit(-1)
     # The symlink step rewrites torch/lib, so a real run must target the in-tree
     # (editable) torch. --dry-run only reads the build tree, so it works against
@@ -175,39 +172,26 @@ def main() -> None:
     if not files:
         return print("Nothing to do")
 
-    compile_commands = load_compile_commands()
-    plan: list[tuple[str, str, str]] = []
-    for file in files:
-        src = str(Path(file).resolve())
-        entry = compile_commands.get(src)
-        if entry is None:
-            print(
-                f"No compile command for {file}; is it a source compiled into "
-                "the build? (try a path relative to the repo root)"
-            )
-            sys.exit(-1)
-        plan.append((src, debugify(entry_command(entry)), entry["directory"]))
-
-    link = torch_python_link_command()
+    ninja_commands = check_output(
+        ["ninja", "-t", "commands", "torch_python"], cwd=str(BUILD_DIR)
+    )
+    try:
+        plan = create_build_plan(files, ninja_commands, BUILD_DIR)
+    except RuntimeError as error:
+        print(error)
+        sys.exit(-1)
 
     if args.dry_run:
-        for name, cmd, _ in plan:
-            print(f"# debug rebuild: {name}")
+        for kind, cmd in plan:
+            print(f"# {kind}")
             print(cmd)
-        print("# relink libtorch_python")
-        print(link)
         return
 
-    for idx, (name, cmd, cwd) in enumerate(plan):
-        print(f"[{idx + 1} / {len(plan)}] Building {Path(name).name} with debug info")
+    for idx, (kind, cmd) in enumerate(plan):
+        print(f"[{idx + 1} / {len(plan)}] {kind}")
         if args.verbose:
             print(cmd)
-        subprocess.check_call(["sh", "-c", cmd], cwd=cwd)
-
-    print("Relinking libtorch_python")
-    if args.verbose:
-        print(link)
-    subprocess.check_call(["sh", "-c", link], cwd=str(BUILD_DIR))
+        subprocess.check_call(["sh", "-c", cmd], cwd=str(BUILD_DIR))
 
     create_symlinks()
 

--- a/tools/test/test_build_with_debinfo.py
+++ b/tools/test/test_build_with_debinfo.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
-from tools.build_with_debinfo import (
-    debugify,
-    entry_command,
-    extract_link_command,
-    index_compile_commands,
-)
+from tools.build_with_debinfo import create_build_plan, debugify
 
 
 class TestDebugify(unittest.TestCase):
@@ -27,49 +23,51 @@ class TestDebugify(unittest.TestCase):
         self.assertEqual(out, debugify(out))
 
 
-class TestEntryCommand(unittest.TestCase):
-    def test_command_form(self) -> None:
-        self.assertEqual(entry_command({"command": "cc -c a.cpp"}), "cc -c a.cpp")
-
-    def test_arguments_form_is_quoted(self) -> None:
-        entry = {"arguments": ["cc", "-c", "a b.cpp"]}
-        self.assertEqual(entry_command(entry), "cc -c 'a b.cpp'")
-
-
-class TestIndexCompileCommands(unittest.TestCase):
-    def test_maps_resolved_source_paths(self) -> None:
-        entries = [
-            {"directory": "/repo/build", "file": "../torch/csrc/Module.cpp"},
-            {"directory": "/repo/build", "file": "/repo/torch/csrc/Other.cpp"},
-        ]
-        index = index_compile_commands(entries)
-        self.assertIn("/repo/torch/csrc/Module.cpp", index)
-        self.assertIn("/repo/torch/csrc/Other.cpp", index)
-
-
-class TestExtractLinkCommand(unittest.TestCase):
-    def test_strips_ninja_wrapper(self) -> None:
-        out = ": && clang++ -shared -o lib/libtorch_python.so a.o b.o && :"
-        self.assertEqual(
-            extract_link_command(out, "libtorch_python.so"),
-            "clang++ -shared -o lib/libtorch_python.so a.o b.o",
-        )
-
-    def test_picks_link_among_compiles(self) -> None:
-        out = "\n".join(
+class TestCreateBuildPlan(unittest.TestCase):
+    def test_follows_dependent_links(self) -> None:
+        commands = "\n".join(
             [
-                "clang++ -c torch_python.dir/Module.cpp.o",
-                ": && clang++ -shared -o lib/libtorch_python.so a.o && :",
+                "c++ -O3 -o obj/other.o -c /repo/other.cpp",
+                "c++ -O3 -o obj/a.o -c /repo/a.cpp",
+                "c++ -shared -o lib/libtorch_cpu.so obj/a.o obj/other.o",
+                "c++ -shared -o lib/libunrelated.so obj/other.o",
+                "c++ -shared -o lib/libtorch_python.so lib/libtorch_cpu.so",
             ]
         )
         self.assertEqual(
-            extract_link_command(out, "libtorch_python.so"),
-            "clang++ -shared -o lib/libtorch_python.so a.o",
+            create_build_plan(["/repo/a.cpp"], commands, Path("/repo/build")),
+            [
+                ("debug rebuild", "c++ -g -o obj/a.o -c /repo/a.cpp"),
+                (
+                    "rebuild dependent",
+                    "c++ -shared -o lib/libtorch_cpu.so obj/a.o obj/other.o",
+                ),
+                (
+                    "rebuild dependent",
+                    "c++ -shared -o lib/libtorch_python.so lib/libtorch_cpu.so",
+                ),
+            ],
         )
 
-    def test_raises_when_absent(self) -> None:
+    def test_handles_metal_custom_commands(self) -> None:
+        commands = "\n".join(
+            [
+                "cd /repo/build/metal && xcrun metal -c /repo/a.metal -o a.air",
+                "cd /repo/build/metal && xcrun metallib -o a.metallib a.air",
+                "c++ -shared -Wl,-sectcreate,/repo/build/metal/a.metallib -o lib/a.so",
+            ]
+        )
+        plan = create_build_plan(["/repo/a.metal"], commands, Path("/repo/build"))
+        self.assertEqual(len(plan), 3)
+        self.assertIn("-frecord-sources -gline-tables-only", plan[0][1])
+
+    def test_raises_when_source_is_absent(self) -> None:
         with self.assertRaises(RuntimeError):
-            extract_link_command("clang++ -c a.o", "libtorch_python.so")
+            create_build_plan(
+                ["/repo/missing.cpp"],
+                "c++ -o obj/a.o -c /repo/a.cpp",
+                Path("/repo/build"),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #192729
* #192349

https://github.com/pytorch/pytorch/pull/186780 introduced number of regressions to the logic, namely it only rebuilded one file and assumed its part of torch_python, rendering the tool useless for ATen changes (torch_cpu, torch_cuda) and also compile .metal shaders with line information.

Build the plan from Ninja's command graph and transitively run every command that consumes the requested source's outputs. This restores rebuilding through intermediate libraries and custom steps, including Metal commands, while limiting debug flags to the requested source compilation.

Extend test accordingly

Authored with the assistance of Codex (OpenAI).