### PR TITLE
[Testcase Refactoring] Migrate test_graph_transform_observer to device-type test pattern

### DIFF
--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -4,24 +4,23 @@ import math
 import os
 import shutil
 import tempfile
+from unittest import skipIf
 
 import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 class TestGraphTransformObserver(TestCase):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
-    @requires_capabilities(Capability.attention.fused_attention)
+    @skipIf(not HAS_TRITON, "requires triton")
+    @skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "requires fused attention support")
     def test_sdpa_rewriter(self, device):
         if shutil.which("dot") is None:
             self.skipTest("Requires dot")
@@ -65,7 +64,7 @@ class TestGraphTransformObserver(TestCase):
         self.assertTrue(found_output_svg)
 
 
-instantiate_device_type_tests(TestGraphTransformObserver, globals(), only_for="cuda")
+instantiate_device_type_tests(TestGraphTransformObserver, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -4,36 +4,33 @@ import math
 import os
 import shutil
 import tempfile
+import unittest
 
 import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
-
-
-try:
-    import pydot  # noqa: F401
-
-    HAS_PYDOT = True
-except ImportError:
-    HAS_PYDOT = False
-
-
-HAS_DOT = shutil.which("dot") is not None
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
 
 
 class TestGraphTransformObserver(TestCase):
-    def test_sdpa_rewriter(self):
-        if not (
-            HAS_CUDA_AND_TRITON
-            and PLATFORM_SUPPORTS_FUSED_ATTENTION
-            and HAS_PYDOT
-            and HAS_DOT
-        ):
-            return
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipUnless(PLATFORM_SUPPORTS_FUSED_ATTENTION, "Requires fused attention")
+    def test_sdpa_rewriter(self, device):
+        if shutil.which("dot") is None:
+            self.skipTest("Requires dot")
+        try:
+            import pydot  # noqa: F401
+        except ImportError:
+            self.skipTest("Requires pydot")
 
         def dot_prod_attention(
             query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
@@ -52,9 +49,9 @@ class TestGraphTransformObserver(TestCase):
         compiled_fn = torch.compile(dot_prod_attention, fullgraph=True)
 
         tensor_shape = (4, 2, 16, 32)
-        q = torch.randn(tensor_shape, device="cuda")
-        k = torch.randn(tensor_shape, device="cuda")
-        v = torch.randn(tensor_shape, device="cuda")
+        q = torch.randn(tensor_shape, device=device)
+        k = torch.randn(tensor_shape, device=device)
+        v = torch.randn(tensor_shape, device=device)
         compiled_fn(q, k, v)
 
         found_input_svg = False
@@ -68,6 +65,9 @@ class TestGraphTransformObserver(TestCase):
 
         self.assertTrue(found_input_svg)
         self.assertTrue(found_output_svg)
+
+
+instantiate_device_type_tests(TestGraphTransformObserver, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -10,17 +10,24 @@ import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
+from torch._utils import _is_privateuse1_backend_available
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
+def _fused_attention_available() -> bool:
+    # Out-of-tree accelerator backends provide fused SDPA not covered by
+    # PLATFORM_SUPPORTS_FUSED_ATTENTION.
+    return PLATFORM_SUPPORTS_FUSED_ATTENTION or _is_privateuse1_backend_available()
+
+
 class TestGraphTransformObserver(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @skipIf(not HAS_TRITON, "requires triton")
-    @skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "requires fused attention support")
+    @skipIf(not _fused_attention_available(), "requires fused attention support")
     def test_sdpa_rewriter(self, device):
         if shutil.which("dot") is None:
             self.skipTest("Requires dot")

--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -4,13 +4,11 @@ import math
 import os
 import shutil
 import tempfile
-import unittest
 
 import torch
 import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_device_type import (
     Capability,
     instantiate_device_type_tests,
@@ -23,7 +21,7 @@ class TestGraphTransformObserver(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     @requires_capabilities(Capability.lib.triton)
-    @unittest.skipUnless(PLATFORM_SUPPORTS_FUSED_ATTENTION, "Requires fused attention")
+    @requires_capabilities(Capability.attention.fused_attention)
     def test_sdpa_rewriter(self, device):
         if shutil.which("dot") is None:
             self.skipTest("Requires dot")


### PR DESCRIPTION
### Summary

Rewrote TestGraphTransformObserver to use `instantiate_device_type_tests` with `except_for="cpu"` and `hw_classification = HardwareClassification.ACCELERATOR`. Replaced the early-return guard pattern with proper skip decorators and inline `self.skipTest` checks. Migrated `HAS_CUDA_AND_TRITON` to `@skipIf(not HAS_TRITON)` and the fused-attention guard to `@skipIf(not _fused_attention_available())`, which also admits out-of-tree accelerator backends.

### Changes

- Added `hw_classification = HardwareClassification.ACCELERATOR`, `device` parameter to `test_sdpa_rewriter`, and `instantiate_device_type_tests(..., except_for="cpu")`; replaced hardcoded `device="cuda"` with `device` parameter (3 occurrences)
- Replaced early-return guard with proper skip mechanism: `HAS_CUDA_AND_TRITON` -> `@skipIf(not HAS_TRITON, "requires triton")`, fused-attention guard -> `@skipIf(not _fused_attention_available(), "requires fused attention support")` (combines `PLATFORM_SUPPORTS_FUSED_ATTENTION` with out-of-tree accelerator backend availability), `HAS_PYDOT`/`HAS_DOT` -> inline `self.skipTest(...)`
- Updated imports: added `HardwareClassification`, `instantiate_device_type_tests`, `HAS_TRITON`, `skipIf`; removed `HAS_CUDA_AND_TRITON`

### Motivation

The original test used an early-return pattern (`if not condition: return`) which silently passed on non-CUDA environments, giving a false sense of test coverage. By using `instantiate_device_type_tests` with `except_for="cpu"` and proper skip decorators, the test now correctly reports as skipped on unsupported devices rather than silently passing.

### Test Plan

```bash
python test/inductor/test_graph_transform_observer.py
```