### PR TITLE
Fix inconsistent fft dtype promotion for XPU

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -89,11 +89,11 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
     device.is_cuda() || device.is_meta() || device.is_xpu()
   );
   if (maybe_support_half) {
-    // XPU has no native float16 or bfloat16 FFT kernel; promote both to float32.
+    // XPU has no native bfloat16 FFT kernel; promote to float32.
     // ROCm (hipFFT) has no native bfloat16 FFT kernel; promote to float32.
     // On CUDA, cuFFT handles them natively (see CuFFTPlanCache.h for constraints),
     // so we leave them unchanged here and let the cuFFT planner decide.
-    if ((type == kHalf || type == kBFloat16) && device.is_xpu()) {
+    if (type == kBFloat16 && device.is_xpu()) {
       type = kFloat;
     }
     // ROCm/hipFFT does not support bfloat16; promote to float32

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3538,6 +3538,23 @@ class TestXpuAutocast(TestAutocast):
         self.assertEqual(torch.is_autocast_enabled("xpu"), torch.is_autocast_enabled())
         self.assertEqual(is_enabled, torch.is_autocast_enabled())
 
+    def test_fft_fp16_promotion(self):
+        shapes = [tuple(range(5, 5 + ndim)) for ndim in range(1, 6)]
+        for shape in shapes:
+            # r2c: rfftn with float16 input should produce complex32
+            x_r = torch.randn(shape, device="xpu", dtype=torch.float16)
+            result_r2c = torch.fft.rfftn(x_r)
+            self.assertEqual(result_r2c.dtype, torch.complex32)
+            expected_r2c = torch.fft.rfftn(x_r.to(torch.float32)).to(torch.complex32)
+            self.assertEqual(result_r2c, expected_r2c, atol=1e-6, rtol=1e-3)
+
+            # c2r: irfftn with complex32 input should produce float16
+            freq = torch.fft.rfftn(x_r)
+            result_c2r = torch.fft.irfftn(freq)
+            self.assertEqual(result_c2r.dtype, torch.float16)
+            expected_c2r = torch.fft.irfftn(freq.to(torch.complex64)).to(torch.float16)
+            self.assertEqual(result_c2r, expected_c2r, atol=1e-6, rtol=1e-3)
+
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuTrace(TestCase):


### PR DESCRIPTION
`float16` to `float32` promotion for XPU has been added to `promote_type_fft()` in `‎aten/src/ATen/native/SpectralOps.cpp` but Python reference implementation (`torch/_refs/fft.py`) has not been updated to match.

Since FFT XPU implementation already handles float16 correctly via internal promotion and cast-back, this PR removes the XPU fp16 promotion from `promote_type_fft()`.