### PR TITLE
 [Testcase Refactoring] : Add HardwareClassification labels and use onlyAccelerator in inductor tests

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -13,7 +13,10 @@ from torch._inductor import aot_compile, ir
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.package import package_aoti
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import skipIfWindows
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    skipIfWindows,
+)
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
@@ -22,6 +25,8 @@ from torch.testing._internal.torchbind_impls import (
 
 
 class TestTorchbind(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -13,10 +13,7 @@ from torch._inductor import aot_compile, ir
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.package import package_aoti
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    skipIfWindows,
-)
+from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,

--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -10,6 +10,7 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -26,6 +27,8 @@ importlib.import_module("filelock")
 
 @instantiate_parametrized_tests
 class CodegenInductorTest(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def run_and_compare(
         self,
         func: Callable[..., Any],

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -8,6 +8,7 @@ import torch
 from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     MI350_ARCH,
     skipIfRocmArch,
@@ -514,6 +515,8 @@ DynamicShapesCodegenCommonTemplate = make_dynamic_cls(
 
 
 class DynamicShapesCodegenTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -661,6 +661,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
     class DynamicShapesCodegenGPUTests(DynamicShapesCodegenTestCase):
         maxDiff = None
         device = GPU_TYPE
+        hw_classification = HardwareClassification.ACCELERATOR
 
         def common(
             self: TestCase,

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -541,6 +541,7 @@ if HAS_CPU:
     class DynamicShapesCodegenCpuTests(TestCase):
         maxDiff = None
         device = "cpu"
+        hw_classification = HardwareClassification.CPU
 
         @torch._dynamo.config.patch(assume_static_by_default=False)
         def test_assert_dynamic_dims_rejects_specialized_dim(self):
@@ -661,7 +662,7 @@ if HAS_GPU and not TEST_WITH_ASAN:
     class DynamicShapesCodegenGPUTests(DynamicShapesCodegenTestCase):
         maxDiff = None
         device = GPU_TYPE
-        hw_classification = HardwareClassification.ACCELERATOR
+        hw_classification = HardwareClassification.CUDA
 
         def common(
             self: TestCase,

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_device_type import (
     onlyOn,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_FBCODE,
     MI350_ARCH,
@@ -232,6 +233,7 @@ if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:
 
 
 class TestInductorDynamic(DynamicShapesTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     compile_fn = partial(torch.compile, dynamic=True)
 
     def setUp(self):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -23,8 +23,8 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import IS_SM89
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyAccelerator,
     onlyCPU,
-    onlyOn,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -729,7 +729,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
         torch.compile(fullgraph=True)(f)(x, w).sum().backward()
         self.assertEqual(orig_w, w.grad)
 
-    @onlyOn(GPU_TYPE)
+    @onlyAccelerator
     @torch._dynamo.config.patch(
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )
@@ -853,7 +853,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
         res1 = opt(x1)
         self.assertEqual(ref1, res1)
 
-    @onlyOn(GPU_TYPE)
+    @onlyAccelerator
     def test_pad_dynamic(self, device):
         def get_same_padding(x: int, k: int, s: int, d: int):
             return max((math.ceil(x / s) - 1) * s + (k - 1) * d + 1 - x, 0)
@@ -1303,7 +1303,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
         self.assertEqual(fn(x, 4.0), fn_opt(x, 4.0))
         self.assertEqual(cnt.frame_count, 2)
 
-    @onlyOn(GPU_TYPE)
+    @onlyAccelerator
     def test_dynamic_rblock_bounds(self):
         class ForcePersistent(InductorChoices):
             @staticmethod
@@ -1472,7 +1472,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
         actual = compiled_fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6)
         self.assertEqual(actual, expected, atol=1e-2, rtol=1e-2)
 
-    @onlyOn(GPU_TYPE)
+    @onlyAccelerator
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     def test_sympy_infinity_bounds_in_persistent_reduction(self):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1304,7 +1304,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
         self.assertEqual(cnt.frame_count, 2)
 
     @onlyAccelerator
-    def test_dynamic_rblock_bounds(self):
+    def test_dynamic_rblock_bounds(self, device):
         class ForcePersistent(InductorChoices):
             @staticmethod
             def should_use_cooperative_reduction(*args, **kwargs) -> bool:
@@ -1317,21 +1317,24 @@ class TestInductorDynamic(DynamicShapesTestCase):
         def fn(x):
             return x.sum()
 
-        x = torch.rand([31], device=GPU_TYPE)
+        x = torch.rand([31], device=device)
 
         with V.set_choices_handler(ForcePersistent()):
             torch._dynamo.mark_dynamic(x, 0, min=1, max=62)
             fn_c = torch.compile(fn)
             actual, source_codes = run_and_get_code(fn_c, x)
             self.assertEqual(fn(x), actual)
-            FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
+            from torch._inductor.ir import has_triton
+            if has_triton:
+                FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
             torch._dynamo.reset()
 
             torch._dynamo.mark_dynamic(x, 2, min=1, max=64)
             fn_c = torch.compile(fn)
             actual, source_codes = run_and_get_code(fn_c, x)
             self.assertEqual(fn(x), actual)
-            FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
+            if has_triton:
+                FileCheck().check("R0_BLOCK: tl.constexpr = 64").run(source_codes[0])
 
     def test_non_persistent_dynamic_rblock(self):
         def reduce_bounded(x, y):
@@ -1475,7 +1478,7 @@ class TestInductorDynamic(DynamicShapesTestCase):
     @onlyAccelerator
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
-    def test_sympy_infinity_bounds_in_persistent_reduction(self):
+    def test_sympy_infinity_bounds_in_persistent_reduction(self, device):
         """
         Regression test for sympy Infinity bounds handling in should_use_persistent_reduction.
 
@@ -1499,13 +1502,13 @@ class TestInductorDynamic(DynamicShapesTestCase):
             return t15
 
         arg0 = torch.rand(
-            [65, 1024, 10], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
+            [65, 1024, 10], dtype=torch.float32, device=device, requires_grad=True
         )
         arg2 = torch.rand(
-            [134, 4, 640], dtype=torch.float32, device=GPU_TYPE, requires_grad=True
+            [134, 4, 640], dtype=torch.float32, device=device, requires_grad=True
         )
         arg3 = torch.rand(
-            [65, 67, 6], dtype=torch.bfloat16, device=GPU_TYPE, requires_grad=True
+            [65, 67, 6], dtype=torch.bfloat16, device=device, requires_grad=True
         )
 
         compiled_fn = torch.compile(fn, fullgraph=True, dynamic=True)

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_CI,
     IS_LINUX,
@@ -1277,6 +1278,8 @@ def _inductor_extra_samples(op_name, device, dtype, requires_grad):
 
 @wrapper_noop_set_seed_decorator
 class TestInductorOpInfo(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -45,7 +45,7 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyCUDA,
+    onlyAccelerator,
     ops,
 )
 from torch.testing._internal.common_methods_invocations import (
@@ -55,6 +55,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     getRocmVersion,
+    HardwareClassification,
     IS_FBCODE,
     IS_WINDOWS,
     parametrize,
@@ -619,6 +620,8 @@ def compile_fn(fn, backend):
 class TestOpInfoProperties(TestCase):
     """Test op properties under various inductor modes using OpInfo on CUDA."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()
@@ -677,7 +680,7 @@ class TestOpInfoProperties(TestCase):
     # Batch Invariance Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -813,7 +816,7 @@ class TestOpInfoProperties(TestCase):
     # Run-to-Run Determinism Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -885,7 +888,7 @@ class TestOpInfoProperties(TestCase):
     # Bitwise Equivalence with Eager Mode Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -936,7 +939,7 @@ class TestOpInfoProperties(TestCase):
     # Exhaustive/Sampled Unary Ufunc Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_unary_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)
@@ -998,7 +1001,7 @@ class TestOpInfoProperties(TestCase):
     # Sampled Binary Ufunc Tests
     # =========================================================================
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfTorchDynamo("Test uses dynamo already")
     @ops(llm_binary_ops, allowed_dtypes=DTYPES)
     @parametrize("backend", BACKENDS)

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -710,27 +710,32 @@ class TestOpInfoProperties(TestCase):
         # Disable split-k accumulation in GEMM to ensure batch-invariant results.
         # Split-k can produce different rounding based on how work is partitioned.
         # Disabling split-k requires the cuBLASLt backend, so we set it first.
-        prev_blas_library = torch.backends.cuda.preferred_blas_library()
-        torch.backends.cuda.preferred_blas_library("cublaslt")
+        prev_blas_library = None
+        prev_fp16 = None
+        prev_bf16 = None
 
-        # We need to save both the reduced precision and split_k settings.
-        prev_fp16 = (
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction,
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction_split_k,
-        )
-        prev_bf16 = (
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction,
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction_split_k,
-        )
-        # Disable both reduced precision and split-k
-        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
-            False,
-            False,
-        )
-        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-            False,
-            False,
-        )
+        if device_type == "cuda":
+            prev_blas_library = torch.backends.cuda.preferred_blas_library()
+            torch.backends.cuda.preferred_blas_library("cublaslt")
+
+            # We need to save both the reduced precision and split_k settings.
+            prev_fp16 = (
+                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction,
+                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction_split_k,
+            )
+            prev_bf16 = (
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction,
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction_split_k,
+            )
+            # Disable both reduced precision and split-k
+            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+                False,
+                False,
+            )
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+                False,
+                False,
+            )
 
         def run_test():
             tested_any = False
@@ -804,13 +809,14 @@ class TestOpInfoProperties(TestCase):
                 device_type, op.name, backend, "batch_invariance", dtype, run_test
             )
         finally:
-            torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
-                prev_fp16
-            )
-            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-                prev_bf16
-            )
-            torch.backends.cuda.preferred_blas_library(prev_blas_library)
+            if device_type == "cuda":
+                torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (
+                    prev_fp16
+                )
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
+                    prev_bf16
+                )
+                torch.backends.cuda.preferred_blas_library(prev_blas_library)
 
     # =========================================================================
     # Run-to-Run Determinism Tests


### PR DESCRIPTION
## Summary

This PR adds HardwareClassification labels to 6 inductor test files and replaces device-specific decorators with `@onlyAccelerator` for broader accelerator support.

### Changes

**Added `hw_classification` attribute:**
- `test_torchbind.py` → `GENERIC`
- `test_torchinductor_codegen_config_overrides.py` → `GENERIC`
- `test_torchinductor_codegen_dynamic_shapes.py` → `GENERIC`
- `test_torchinductor_dynamic_shapes.py` → `ACCELERATOR`
- `test_torchinductor_opinfo.py` → `ACCELERATOR`
- `test_torchinductor_opinfo_properties.py` → `ACCELERATOR`

**Decorator improvements:**
- Replaced `@onlyCUDA` → `@onlyAccelerator` in `test_torchinductor_opinfo_properties.py` (5 occurrences)
- Replaced `@onlyOn(GPU_TYPE)` → `@onlyAccelerator` in `test_torchinductor_dynamic_shapes.py` (4 occurrences)

### Benefits

1. Enables hardware-based test filtering using `HardwareClassification` enum
2. `@onlyAccelerator` supports all accelerator devices (CUDA, XPU, etc.) instead of just CUDA
3. Better alignment with PyTorch's multi-device strategy

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo