### PR TITLE
Reject misaligned buffers in torch.frombuffer

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4159,6 +4159,26 @@ class TestBufferProtocol(TestCase):
         self.assertEqual(tensor.numel(), 2)
         self.assertSequenceEqual(tensor, [255, 255])
 
+    def test_misaligned_offset(self):
+        # An offset that leaves the data pointer misaligned for the requested
+        # dtype must be rejected: the tensor is in bounds, but the typed load in
+        # c10::LoadImpl assumes natural alignment and reads shifted bytes.
+        buffer = np.zeros(4, dtype=np.complex128)
+        with self.assertRaisesRegex(ValueError,
+                                    r"is not aligned to the required alignment"):
+            torch.frombuffer(buffer, dtype=torch.complex128, count=1, offset=6)
+
+    def test_offset_aligned_below_element_size(self):
+        # complex128 has sizeof 16 but alignof 8, so an 8 byte offset is
+        # naturally aligned and must keep working.
+        buffer = np.zeros(4, dtype=np.complex128)
+        buffer[1] = complex(2, 3)
+        tensor = torch.frombuffer(buffer, dtype=torch.complex128, count=1, offset=16)
+        self.assertEqual(tensor.numel(), 1)
+        self.assertEqual(tensor[0], complex(2, 3))
+        aligned = torch.frombuffer(buffer, dtype=torch.complex128, count=1, offset=8)
+        self.assertEqual(aligned.numel(), 1)
+
 class TestFromBlob(TestCase):
     def _make_data(self, dtype, numel):
         numpy_dtype = torch_to_numpy_dtype_dict[dtype]

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -28,6 +28,7 @@
 #include <c10/core/Layout.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
+#include <cstdint>
 #include <optional>
 
 #include <stdexcept>
@@ -1618,6 +1619,22 @@ Tensor tensor_frombuffer(
       " bytes)");
 
   auto offset_buf = static_cast<char*>(buf) + offset;
+
+  // The required alignment is not always the element size: complex types are
+  // stored as a pair of reals and inherit the alignment of the underlying real
+  // type, so e.g. alignof(c10::complex<double>) is 8 while sizeof is 16.
+  // Checking against elsize would reject naturally aligned offsets that read
+  // correctly today.
+  const size_t alignment = c10::isComplexType(dtype) ? elsize / 2 : elsize;
+  TORCH_CHECK_VALUE(
+      reinterpret_cast<std::uintptr_t>(offset_buf) % alignment == 0,
+      "offset (",
+      offset,
+      " bytes) results in a data pointer that is not aligned to the required "
+      "alignment (",
+      alignment,
+      " bytes) for the requested dtype");
+
   auto options = TensorOptions().dtype(dtype).device(c10::kCPU);
 
   auto tensor = at::for_blob(offset_buf, static_cast<int64_t>(actual_count))


### PR DESCRIPTION
Fixes #190043

`torch.frombuffer` validates that the requested view fits inside the buffer, but never that the resulting data pointer is aligned for the requested dtype. A misaligned view is therefore accepted and only misbehaves later, inside a kernel.

## Root cause

`tensor_frombuffer` checks offset range, the trailing-length multiple (on the `count < 0` path) and the total requested length, then hands `buf + offset` straight to `at::for_blob`. Nothing constrains the alignment of that pointer.

The typed load is `c10::LoadImpl<T>::apply` (`c10/util/Load.h:11`), a plain `*reinterpret_cast<const T*>(src)`, which is only defined for a pointer aligned to `alignof(T)`. With `offset=6` and `complex128` the pointer is 6 mod 8, so the load reads shifted bytes: an ASan SEGV on the vectorized Linux build in the report, silent garbage elsewhere.

## The fix

A `TORCH_CHECK_VALUE` on the resulting data pointer, against the dtype's natural alignment rather than its element size.

**The distinction matters.** Complex types are stored as a pair of reals and inherit the alignment of the underlying real type, so `alignof(c10::complex<double>)` is 8 while `sizeof` is 16. Checking `ptr % elementSize(dtype)` would reject offsets that are correctly aligned and work today. Observed on 2.12.1+cpu with the reporter's buffer:

```
offset=0   data_ptr % 8 == 0   t + t -> tensor([2.+2.j])                      correct
offset=8   data_ptr % 8 == 0   t + t -> tensor([2.+2.j])                      correct
offset=6   data_ptr % 8 == 6   t + t -> tensor([1.6174e-319+1.6174e-319j])    garbage
```

So the check uses `elsize / 2` for complex dtypes and `elsize` otherwise. For every non-complex dtype `alignof == elementSize`, so the two rules coincide there and only the complex cases differ.

This keeps the fix BC-neutral: it rejects exactly the pointers whose typed load is undefined, and nothing else.

## Compatibility

Buffers whose data pointer is naturally aligned are unaffected. The rejected cases are ones that today return a tensor which reads out garbage or crashes, so no correct program changes behaviour. Per @albanD on the issue, this takes the "reject with a hard error" direction rather than making the load path handle unaligned data, which remains open as a larger change.

## Test plan

Two tests in `TestBufferProtocol` (`test/test_tensor_creation_ops.py`):

- `test_misaligned_offset` — `offset=6` with `complex128` now raises `ValueError` instead of producing a tensor that reads out of alignment.
- `test_offset_aligned_below_element_size` — `offset=8` and `offset=16` with `complex128` still succeed and return the expected value, pinning the BC behaviour that an element-size check would have broken.


cc @albanD