### PR TITLE
[Test] Refactor test_optim to improve test reuse and add `HardwareClassification` labels

### DIFF
--- a/test/optim/test_swa_utils.py
+++ b/test/optim/test_swa_utils.py
@@ -10,9 +10,10 @@ from torch.optim.swa_utils import (
     get_swa_multi_avg_fn,
     update_bn,
 )
-from torch.testing._internal.common_device_type import onlyAccelerator, onlyCPU
+from torch.testing._internal.common_device_type import onlyAccelerator
 from torch.testing._internal.common_utils import (
     HardwareClassification,
+    instantiate_parametrized_tests,
     parametrize,
     TestCase,
 )
@@ -134,97 +135,6 @@ class TestSWAUtils(TestCase):
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_avg.device == p_swa.device)
 
-    @onlyCPU
-    def test_averaged_model_state_dict(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
-        )
-        averaged_dnn = AveragedModel(dnn)
-        averaged_dnn2 = AveragedModel(dnn)
-        n_updates = 10
-        for _ in range(n_updates):
-            for p in dnn.parameters():
-                p.detach().add_(torch.randn_like(p))
-            averaged_dnn.update_parameters(dnn)
-        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
-        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
-            self.assertEqual(p_swa, p_swa2)
-        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
-
-    @onlyCPU
-    def test_averaged_model_default_avg_fn_picklable(self, device):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5),
-            torch.nn.Linear(5, 5),
-        )
-        averaged_dnn = AveragedModel(dnn)
-        pickle.dumps(averaged_dnn)
-
-    @onlyCPU
-    @parametrize("use_multi_avg_fn", [True, False])
-    @parametrize("use_buffers", [True, False])
-    def test_averaged_model_exponential(self, device, use_multi_avg_fn, use_buffers):
-        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5, momentum=0.3),
-            torch.nn.Linear(5, 10),
-        )
-        decay = 0.9
-
-        if use_multi_avg_fn:
-            averaged_dnn = AveragedModel(
-                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
-            )
-        else:
-
-            def avg_fn(p_avg, p, n_avg):
-                return decay * p_avg + (1 - decay) * p
-
-            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
-
-        if use_buffers:
-            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
-        else:
-            dnn_params = list(dnn.parameters())
-
-        averaged_params = [
-            torch.zeros_like(param)
-            for param in dnn_params
-            if param.size() != torch.Size([])
-        ]
-
-        n_updates = 10
-        for i in range(n_updates):
-            updated_averaged_params = []
-            for p, p_avg in zip(dnn_params, averaged_params):
-                if p.size() == torch.Size([]):
-                    continue
-                p.detach().add_(torch.randn_like(p))
-                if i == 0:
-                    updated_averaged_params.append(p.clone())
-                else:
-                    updated_averaged_params.append(
-                        (p_avg * decay + p * (1 - decay)).clone()
-                    )
-            averaged_dnn.update_parameters(dnn)
-            averaged_params = updated_averaged_params
-
-        if use_buffers:
-            for p_avg, p_swa in zip(
-                averaged_params,
-                itertools.chain(
-                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
-                ),
-            ):
-                self.assertEqual(p_avg, p_swa)
-        else:
-            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-                self.assertEqual(p_avg, p_swa)
-            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
-                self.assertEqual(b_avg, b_swa)
-
     def _test_update_bn(self, dnn, dl_x, dl_xy, device):
         preactivation_sum = torch.zeros(dnn.n_features, device=device)
         preactivation_squared_sum = torch.zeros(dnn.n_features, device=device)
@@ -296,8 +206,100 @@ class TestSWAUtils(TestCase):
         self._test_update_bn(cnn, dl_x, dl_xy, device)
         self.assertTrue(cnn.training)
 
-    @onlyCPU
-    def test_bn_update_eval_momentum(self, device):
+
+class TestSWAUtilsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+    SWATestCNN = TestSWAUtils.SWATestCNN
+
+    def test_averaged_model_state_dict(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
+        )
+        averaged_dnn = AveragedModel(dnn)
+        averaged_dnn2 = AveragedModel(dnn)
+        n_updates = 10
+        for _ in range(n_updates):
+            for p in dnn.parameters():
+                p.detach().add_(torch.randn_like(p))
+            averaged_dnn.update_parameters(dnn)
+        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
+        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
+            self.assertEqual(p_swa, p_swa2)
+        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
+
+    def test_averaged_model_default_avg_fn_picklable(self):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5),
+            torch.nn.Linear(5, 5),
+        )
+        averaged_dnn = AveragedModel(dnn)
+        pickle.dumps(averaged_dnn)
+
+    @parametrize("use_multi_avg_fn", [True, False])
+    @parametrize("use_buffers", [True, False])
+    def test_averaged_model_exponential(self, use_multi_avg_fn, use_buffers):
+        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Linear(5, 10),
+        )
+        decay = 0.9
+
+        if use_multi_avg_fn:
+            averaged_dnn = AveragedModel(
+                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
+            )
+        else:
+
+            def avg_fn(p_avg, p, n_avg):
+                return decay * p_avg + (1 - decay) * p
+
+            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
+
+        if use_buffers:
+            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
+        else:
+            dnn_params = list(dnn.parameters())
+
+        averaged_params = [
+            torch.zeros_like(param)
+            for param in dnn_params
+            if param.size() != torch.Size([])
+        ]
+
+        n_updates = 10
+        for i in range(n_updates):
+            updated_averaged_params = []
+            for p, p_avg in zip(dnn_params, averaged_params):
+                if p.size() == torch.Size([]):
+                    continue
+                p.detach().add_(torch.randn_like(p))
+                if i == 0:
+                    updated_averaged_params.append(p.clone())
+                else:
+                    updated_averaged_params.append(
+                        (p_avg * decay + p * (1 - decay)).clone()
+                    )
+            averaged_dnn.update_parameters(dnn)
+            averaged_params = updated_averaged_params
+
+        if use_buffers:
+            for p_avg, p_swa in zip(
+                averaged_params,
+                itertools.chain(
+                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
+                ),
+            ):
+                self.assertEqual(p_avg, p_swa)
+        else:
+            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+                self.assertEqual(p_avg, p_swa)
+            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
+                self.assertEqual(b_avg, b_swa)
+
+    def test_bn_update_eval_momentum(self):
         # check that update_bn preserves eval mode
         objects = 100
         input_channels = 3
@@ -312,6 +314,9 @@ class TestSWAUtils(TestCase):
 
         # check that momentum is preserved
         self.assertEqual(cnn.bn.momentum, 0.3)
+
+
+instantiate_parametrized_tests(TestSWAUtilsGeneric)
 
 
 if __name__ == "__main__":

--- a/test/optim/test_swa_utils.py
+++ b/test/optim/test_swa_utils.py
@@ -10,10 +10,9 @@ from torch.optim.swa_utils import (
     get_swa_multi_avg_fn,
     update_bn,
 )
-from torch.testing._internal.common_device_type import onlyAccelerator
+from torch.testing._internal.common_device_type import onlyAccelerator, onlyCPU
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     TestCase,
 )
@@ -135,6 +134,97 @@ class TestSWAUtils(TestCase):
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_avg.device == p_swa.device)
 
+    @onlyCPU
+    def test_averaged_model_state_dict(self, device):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
+        )
+        averaged_dnn = AveragedModel(dnn)
+        averaged_dnn2 = AveragedModel(dnn)
+        n_updates = 10
+        for _ in range(n_updates):
+            for p in dnn.parameters():
+                p.detach().add_(torch.randn_like(p))
+            averaged_dnn.update_parameters(dnn)
+        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
+        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
+            self.assertEqual(p_swa, p_swa2)
+        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
+
+    @onlyCPU
+    def test_averaged_model_default_avg_fn_picklable(self, device):
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5),
+            torch.nn.Linear(5, 5),
+        )
+        averaged_dnn = AveragedModel(dnn)
+        pickle.dumps(averaged_dnn)
+
+    @onlyCPU
+    @parametrize("use_multi_avg_fn", [True, False])
+    @parametrize("use_buffers", [True, False])
+    def test_averaged_model_exponential(self, device, use_multi_avg_fn, use_buffers):
+        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Linear(5, 10),
+        )
+        decay = 0.9
+
+        if use_multi_avg_fn:
+            averaged_dnn = AveragedModel(
+                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
+            )
+        else:
+
+            def avg_fn(p_avg, p, n_avg):
+                return decay * p_avg + (1 - decay) * p
+
+            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
+
+        if use_buffers:
+            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
+        else:
+            dnn_params = list(dnn.parameters())
+
+        averaged_params = [
+            torch.zeros_like(param)
+            for param in dnn_params
+            if param.size() != torch.Size([])
+        ]
+
+        n_updates = 10
+        for i in range(n_updates):
+            updated_averaged_params = []
+            for p, p_avg in zip(dnn_params, averaged_params):
+                if p.size() == torch.Size([]):
+                    continue
+                p.detach().add_(torch.randn_like(p))
+                if i == 0:
+                    updated_averaged_params.append(p.clone())
+                else:
+                    updated_averaged_params.append(
+                        (p_avg * decay + p * (1 - decay)).clone()
+                    )
+            averaged_dnn.update_parameters(dnn)
+            averaged_params = updated_averaged_params
+
+        if use_buffers:
+            for p_avg, p_swa in zip(
+                averaged_params,
+                itertools.chain(
+                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
+                ),
+            ):
+                self.assertEqual(p_avg, p_swa)
+        else:
+            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+                self.assertEqual(p_avg, p_swa)
+            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
+                self.assertEqual(b_avg, b_swa)
+
     def _test_update_bn(self, dnn, dl_x, dl_xy, device):
         preactivation_sum = torch.zeros(dnn.n_features, device=device)
         preactivation_squared_sum = torch.zeros(dnn.n_features, device=device)
@@ -206,100 +296,8 @@ class TestSWAUtils(TestCase):
         self._test_update_bn(cnn, dl_x, dl_xy, device)
         self.assertTrue(cnn.training)
 
-
-class TestSWAUtilsGeneric(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-    SWATestCNN = TestSWAUtils.SWATestCNN
-
-    def test_averaged_model_state_dict(self):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
-        )
-        averaged_dnn = AveragedModel(dnn)
-        averaged_dnn2 = AveragedModel(dnn)
-        n_updates = 10
-        for _ in range(n_updates):
-            for p in dnn.parameters():
-                p.detach().add_(torch.randn_like(p))
-            averaged_dnn.update_parameters(dnn)
-        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
-        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
-            self.assertEqual(p_swa, p_swa2)
-        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
-
-    def test_averaged_model_default_avg_fn_picklable(self):
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5),
-            torch.nn.Linear(5, 5),
-        )
-        averaged_dnn = AveragedModel(dnn)
-        pickle.dumps(averaged_dnn)
-
-    @parametrize("use_multi_avg_fn", [True, False])
-    @parametrize("use_buffers", [True, False])
-    def test_averaged_model_exponential(self, use_multi_avg_fn, use_buffers):
-        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
-        dnn = torch.nn.Sequential(
-            torch.nn.Conv2d(1, 5, kernel_size=3),
-            torch.nn.BatchNorm2d(5, momentum=0.3),
-            torch.nn.Linear(5, 10),
-        )
-        decay = 0.9
-
-        if use_multi_avg_fn:
-            averaged_dnn = AveragedModel(
-                dnn, multi_avg_fn=get_ema_multi_avg_fn(decay), use_buffers=use_buffers
-            )
-        else:
-
-            def avg_fn(p_avg, p, n_avg):
-                return decay * p_avg + (1 - decay) * p
-
-            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
-
-        if use_buffers:
-            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
-        else:
-            dnn_params = list(dnn.parameters())
-
-        averaged_params = [
-            torch.zeros_like(param)
-            for param in dnn_params
-            if param.size() != torch.Size([])
-        ]
-
-        n_updates = 10
-        for i in range(n_updates):
-            updated_averaged_params = []
-            for p, p_avg in zip(dnn_params, averaged_params):
-                if p.size() == torch.Size([]):
-                    continue
-                p.detach().add_(torch.randn_like(p))
-                if i == 0:
-                    updated_averaged_params.append(p.clone())
-                else:
-                    updated_averaged_params.append(
-                        (p_avg * decay + p * (1 - decay)).clone()
-                    )
-            averaged_dnn.update_parameters(dnn)
-            averaged_params = updated_averaged_params
-
-        if use_buffers:
-            for p_avg, p_swa in zip(
-                averaged_params,
-                itertools.chain(
-                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
-                ),
-            ):
-                self.assertEqual(p_avg, p_swa)
-        else:
-            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-                self.assertEqual(p_avg, p_swa)
-            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
-                self.assertEqual(b_avg, b_swa)
-
-    def test_bn_update_eval_momentum(self):
+    @onlyCPU
+    def test_bn_update_eval_momentum(self, device):
         # check that update_bn preserves eval mode
         objects = 100
         input_channels = 3
@@ -314,9 +312,6 @@ class TestSWAUtilsGeneric(TestCase):
 
         # check that momentum is preserved
         self.assertEqual(cnn.bn.momentum, 0.3)
-
-
-instantiate_parametrized_tests(TestSWAUtilsGeneric)
 
 
 if __name__ == "__main__":

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
 from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
-from optim.test_swa_utils import TestSWAUtils
+from optim.test_swa_utils import TestSWAUtils, TestSWAUtilsGeneric  # noqa: F401
 
 import torch
 from torch.nn import Parameter
@@ -20,14 +20,11 @@ from torch.optim.optimizer import (
     register_optimizer_step_post_hook,
     register_optimizer_step_pre_hook,
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import (
+    deviceCountAtLeast,
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
-    onlyCPU,
-    onlyCUDA,
-    onlyNativeDeviceTypes,
     skipMPS,
     TEST_WITH_ROCM,
 )
@@ -41,6 +38,7 @@ from torch.testing._internal.common_optimizers import (
     TensorTracker,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     markDynamoStrictTest,
     parametrize,
     run_tests,
@@ -144,7 +142,8 @@ class TestOptimRenewed(TestCase):
         * Grads can also be None, empty, or zero-valued, and this should not disrupt training.
     """
 
-    @onlyCPU
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @optims(optim_db)
     def test_optim_infos_do_not_specify_global_cliquey_kwargs(
         self, device, dtype, optim_info
@@ -189,7 +188,6 @@ class TestOptimRenewed(TestCase):
             else:
                 raise NotImplementedError(f"Unknown error type {error_input.error_on}")
 
-    @onlyCPU
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_with_empty_param_group(self, device, dtype, optim_info):
         # An empty param group means there is nothing to optimize, so step() should
@@ -275,12 +273,12 @@ class TestOptimRenewed(TestCase):
                 else:
                     self.assertLess(closure().item(), initial_value)
 
-    @onlyCUDA
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @onlyAccelerator
+    @deviceCountAtLeast(2)
     @parametrize("with_lrsched", [True, False])
     @optims(optim_db, dtypes=[torch.float32])
     def test_forloop_goes_right_direction_multigpu(
-        self, device, dtype, optim_info, with_lrsched
+        self, devices, dtype, optim_info, with_lrsched
     ):
         optim_cls = optim_info.optim_cls
         schedulers_constructors = (
@@ -289,14 +287,14 @@ class TestOptimRenewed(TestCase):
         for schedulers_constructor in schedulers_constructors:
             # We need a fresh set of inputs if we have a tensor LR
             # to not carry mutations across iterations.
-            optim_inputs = optim_info.optim_inputs_func(device=device)
+            optim_inputs = optim_info.optim_inputs_func(device=devices[0])
             for optim_input in optim_inputs:
                 if "foreach" in optim_info.supported_impls:
                     optim_input.kwargs["foreach"] = False  # force forloop
 
-                weight = Parameter(torch.randn((10, 5), device="cuda:0", dtype=dtype))
-                bias = Parameter(torch.randn((10), device="cuda:1", dtype=dtype))
-                inpt = torch.randn(5, device="cuda:0", dtype=dtype)
+                weight = Parameter(torch.randn((10, 5), device=devices[0], dtype=dtype))
+                bias = Parameter(torch.randn((10), device=devices[1], dtype=dtype))
+                inpt = torch.randn(5, device=devices[0], dtype=dtype)
 
                 params = [weight, bias] if optim_cls.__name__ != "Muon" else [weight]
                 optimizer = optim_cls(params, **optim_input.kwargs)
@@ -308,9 +306,9 @@ class TestOptimRenewed(TestCase):
                 def closure():
                     optimizer.zero_grad()
                     wo = (
-                        weight.mv(inpt).cuda(1)
+                        weight.mv(inpt).to(devices[1])
                         if optim_cls.__name__ == "Muon"
-                        else weight.mv(inpt).cuda(1) + bias
+                        else weight.mv(inpt).to(devices[1]) + bias
                     )
                     loss = wo.pow(2).sum()
                     loss.backward()
@@ -889,8 +887,9 @@ class TestOptimRenewed(TestCase):
     def test_foreach_matches_forloop(self, device, dtype, optim_info):
         self._test_derived_optimizers(device, dtype, optim_info, "foreach")
 
-    @onlyCUDA
-    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    @onlyAccelerator
+    @skipMPS
+    @deviceCountAtLeast(2)
     @parametrize("impl", ["foreach", "fused"])
     @optims(
         [
@@ -899,7 +898,7 @@ class TestOptimRenewed(TestCase):
             if "foreach" in optim.supported_impls or "fused" in optim.supported_impls
         ]
     )
-    def test_mixed_device_dtype(self, device, dtype, optim_info, impl):
+    def test_mixed_device_dtype(self, devices, dtype, optim_info, impl):
         """
         Similar in essence to _test_derived_optimizers above. The main difference is that
         _test_derived_optimizers uses model parameters whereas we randomly pass in
@@ -919,16 +918,32 @@ class TestOptimRenewed(TestCase):
             )
 
         params = [
-            torch.rand(2, 3, dtype=torch.float64, device="cuda:0", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.float32, device="cuda:0", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.float16, device="cuda:0", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.bfloat16, device="cuda:0", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.float64, device="cuda:1", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.float32, device="cuda:1", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.float16, device="cuda:1", requires_grad=True),
-            torch.rand(2, 3, dtype=torch.bfloat16, device="cuda:1", requires_grad=True),
+            torch.rand(
+                2, 3, dtype=torch.float64, device=devices[0], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.float32, device=devices[0], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.float16, device=devices[0], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.bfloat16, device=devices[0], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.float64, device=devices[1], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.float32, device=devices[1], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.float16, device=devices[1], requires_grad=True
+            ),
+            torch.rand(
+                2, 3, dtype=torch.bfloat16, device=devices[1], requires_grad=True
+            ),
             torch.randint(
-                1024, (2, 3), dtype=torch.int64, device="cuda:1", requires_grad=False
+                1024, (2, 3), dtype=torch.int64, device=devices[1], requires_grad=False
             ),
         ]
 
@@ -937,12 +952,15 @@ class TestOptimRenewed(TestCase):
                 p.grad = torch.rand_like(p, device=p.device, dtype=p.dtype)
 
         kIterations = 7 if impl == "foreach" else 1
-        optim_inputs = optim_info.optim_inputs_func(device=device)
+        optim_inputs = optim_info.optim_inputs_func(device=devices[0])
         optim_cls = optim_info.optim_cls
         for optim_input in optim_inputs:
             updated_params, state = [], []
             kwargs = deepcopy(optim_input.kwargs)
-            if kwargs.get("capturable", False) and _get_device_type(device) == "cpu":
+            if (
+                kwargs.get("capturable", False)
+                and _get_device_type(devices[0]) == "cpu"
+            ):
                 # capturable is not supported on CPU
                 continue
             for use_impl in (False, True):
@@ -1011,7 +1029,8 @@ class TestOptimRenewed(TestCase):
             finally:
                 torch.set_default_dtype(old_default_dtype)
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @largeTensorTest("72GB", "cuda")
     @serialTest()
     @optims(
@@ -1048,7 +1067,8 @@ class TestOptimRenewed(TestCase):
             optim_cls([ref], foreach=True, **optim_input.kwargs).step()
             self.assertEqual(params[0][0], ref[0])
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @optims(
         [optim for optim in optim_db if "foreach" in optim.supported_impls],
         dtypes=[torch.float32],
@@ -1243,7 +1263,6 @@ class TestOptimRenewed(TestCase):
             p.grad = torch.rand_like(p)
         optimizer.step()
 
-    @onlyNativeDeviceTypes
     @largeTensorTest("64GB")
     @serialTest()
     @optims(
@@ -2427,7 +2446,8 @@ class TestOptimRenewed(TestCase):
                 optimizers.append(optimizer)
             self._compare_between(inpts, models, optimizers)
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @optims(
         [
             o
@@ -2495,7 +2515,8 @@ class TestOptimRenewed(TestCase):
             for state in optim.state.values():
                 self.assertGreater(len(state), 0)
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @parametrize("amsgrad", [False, True])
     @optims(
         [o for o in optim_db if o.optim_cls.__name__ in ["Adam", "AdamW"]],
@@ -2534,7 +2555,8 @@ class TestOptimRenewed(TestCase):
             if amsgrad:
                 self.assertEqual(state["max_exp_avg_sq"].dtype, torch.bfloat16)
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @parametrize("amsgrad", [False, True])
     @optims(
         [o for o in optim_db if o.optim_cls.__name__ in ["Adam", "AdamW"]],
@@ -2591,7 +2613,8 @@ class TestOptimRenewed(TestCase):
             if amsgrad:
                 self.assertEqual(state["max_exp_avg_sq"].dtype, torch.bfloat16)
 
-    @onlyCUDA
+    @onlyAccelerator
+    @skipMPS
     @optims(
         [o for o in optim_db if o.optim_cls.__name__ in ["Adam", "AdamW"]],
         dtypes=[torch.float32],

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
 from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
-from optim.test_swa_utils import TestSWAUtils, TestSWAUtilsGeneric  # noqa: F401
+from optim.test_swa_utils import TestSWAUtils
 
 import torch
 from torch.nn import Parameter


### PR DESCRIPTION

Change | Detail
-- | --
Remove onlyCPU import | Line 28 — no longer needed
Add HardwareClassification import | In common_utils block (alphabetical)
Add hw_classification | HardwareClassification.ACCELERATOR on TestOptimRenewed
Remove @onlyCPU × 2 | test_optim_infos_do_not_specify_global_cliquey_kwargs (metadata inspection) and test_step_with_empty_param_group (device-agnostic)
Enlarge @onlyCUDA → @onlyAccelerator | test_defaults_changed_to_foreach (mock-based, no Category C API)

--- 

Generated by my agent