### PR TITLE
[Testcase Refactoring] Add HardwareClassification to dynamo test classes in test_nb_multiply.py and test_nb_unary.py

### DIFF
--- a/test/dynamo/test_nb_multiply.py
+++ b/test/dynamo/test_nb_multiply.py
@@ -8,6 +8,7 @@ import sys
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
 )
@@ -100,6 +101,8 @@ class _InheritedSub(_BaseWithMul):
 
 @torch._dynamo.config.patch(enable_trace_unittest=True)
 class TestNbMultiply(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- Integer multiply ---
 
     @make_dynamo_test

--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -8,6 +8,7 @@ import torch
 import torch._dynamo.testing
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -29,6 +30,8 @@ ALL_UNARY_OPS = UNARY_OPS + [
 
 
 class NbUnaryTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # --- int (ConstantVariable) ---
 
     @parametrize("op,dunder", ALL_UNARY_OPS)


### PR DESCRIPTION
## Summary

Add HardwareClassification labels to dynamo test classes (`test_nb_multiply.py` and `test_nb_unary.py`) for hardware decoupling so that CI runners can route tests by hardware capability.

## Changes

- test/dynamo/test_nb_multiply.py:
   - Import `HardwareClassification`
   - Add `hw_classification = HardwareClassification.GENERIC` to `TestNbMultiply`
- test/dynamo/test_nb_unary.py:
   - Import `HardwareClassification`
   - Add `hw_classification = HardwareClassification.GENERIC` to `NbUnaryTests`

## Test Plan

`python test/dynamo/test_nb_multiply.py --hw-classification GENERIC -v`
`python test/dynamo/test_nb_unary.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
