### PR TITLE
[Testcase Refactoring] Add hw_classification in test/test_fx_experimental.py

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -50,14 +50,15 @@ from torch.fx.passes.split_module import split_module, split_module_simple
 from torch.fx.passes.annotate_getitem_nodes import annotate_getitem_nodes
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyCPU,
     ops,
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_nn import module_tests, get_new_module_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
+    skipIfMPS,
     TEST_Z3,
     run_tests,
     TestCase,
@@ -88,6 +89,8 @@ def symbolic_trace_with_rewrite(root: torch.nn.Module | Callable) -> GraphModule
 
 
 class TestFXExperimental(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_find_single_partition(self):
         class TestModule(torch.nn.Module):
             def forward(self, a, b):
@@ -2128,7 +2131,9 @@ class {test_classname}(torch.nn.Module):
 
 
 class TestNormalizeOperators(JitTestCase):
-    @onlyCPU
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIfMPS
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_normalize_operator_exhaustive(self, device, dtype, op):
         # These ops currently don't trace in FX for various reasons (i.e. they take a list of tensors)
@@ -2300,6 +2305,8 @@ if TEST_Z3:
     from torch.utils._sympy.functions import FloorDiv, Mod, BitwiseFn_bitwise_and
 
     class TestTranslationValidation(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def _prepare_for_translation_validation(self):
             validator = TranslationValidator()
 

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -58,7 +58,6 @@ from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
-    skipIfMPS,
     TEST_Z3,
     run_tests,
     TestCase,
@@ -2133,7 +2132,6 @@ class {test_classname}(torch.nn.Module):
 class TestNormalizeOperators(JitTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @skipIfMPS
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_normalize_operator_exhaustive(self, device, dtype, op):
         # These ops currently don't trace in FX for various reasons (i.e. they take a list of tensors)

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -2130,7 +2130,7 @@ class {test_classname}(torch.nn.Module):
 
 
 class TestNormalizeOperators(JitTestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CPU
 
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_normalize_operator_exhaustive(self, device, dtype, op):
@@ -2257,6 +2257,9 @@ class TestModule(torch.nn.Module):
 
             test_out = traced(*param_values)
             self.assertEqual(test_out, ref_out)
+
+class TestNormalizeOperatorsGeneric(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_normalize_quantized_eb(self):
         target = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
@@ -2472,7 +2475,7 @@ if TEST_Z3:
 
 
 instantiate_parametrized_tests(TestFXExperimental)
-instantiate_device_type_tests(TestNormalizeOperators, globals())
+instantiate_device_type_tests(TestNormalizeOperators, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -55,14 +55,14 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_nn import module_tests, get_new_module_tests
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    instantiate_parametrized_tests,
-    parametrize,
-    TEST_Z3,
-    run_tests,
-    TestCase,
-    TEST_WITH_CROSSREF,
-)
+     HardwareClassification,
+     instantiate_parametrized_tests,
+     parametrize,
+     run_tests,
+     TEST_WITH_CROSSREF,
+     TEST_Z3,
+     TestCase,
+ )
 from torch.testing._internal.jit_utils import JitTestCase
 import torch.utils._pytree as pytree
 
@@ -2257,6 +2257,7 @@ class TestModule(torch.nn.Module):
 
             test_out = traced(*param_values)
             self.assertEqual(test_out, ref_out)
+
 
 class TestNormalizeOperatorsGeneric(JitTestCase):
     hw_classification = HardwareClassification.GENERIC

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -55,14 +55,14 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_nn import module_tests, get_new_module_tests
 from torch.testing._internal.common_utils import (
-     HardwareClassification,
-     instantiate_parametrized_tests,
-     parametrize,
-     run_tests,
-     TEST_WITH_CROSSREF,
-     TEST_Z3,
-     TestCase,
- )
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TEST_WITH_CROSSREF,
+    TEST_Z3,
+    TestCase,
+)
 from torch.testing._internal.jit_utils import JitTestCase
 import torch.utils._pytree as pytree
 


### PR DESCRIPTION
## Summary
Replace `@onlyCPU` with `hw_classification` and extract the hardware-agnostic `test_normalize_quantized_eb` into its own class, adding the `hw_classification` attribute (TestFXExperimental, TestTranslationValidation, and the new TestNormalizeOperatorsGeneric as GENERIC; TestNormalizeOperators as CPU), enabling hardware-based test classification and filtering.
## Changes
test/test_fx_experimental.py : drop the `onlyCPU` import and import `HardwareClassification`, add `hw_classification = GENERIC` to TestFXExperimental and TestTranslationValidation, reclassify TestNormalizeOperators from `@onlyCPU` to `hw_classification = CPU` with `only_for="cpu"` on its `instantiate_device_type_tests`, and extract `test_normalize_quantized_eb` into a new `TestNormalizeOperatorsGeneric` class annotated `GENERIC`.
## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.
## Test Plan
CI: python -m pytest -q test/test_fx_experimental.py
## Notes
This is part of the test case refactoring initiative tracked in #185590.