### PR TITLE
[Testcase RefactoringEnable tensor ops tests for out-of-tree accelerators via capability gates

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -5,11 +5,13 @@ import copy
 import torch
 import torch.distributed._shard.sharded_tensor as sharded_tensor
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
-from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     TEST_GPU_NUM,
@@ -17,17 +19,14 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
 )
 
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
-backend = torch.distributed.get_default_backend_for_device(device_type)
-
-
 class TestTensorOps(ShardedTensorTestBase):
-    @with_comms(init_rpc=False, backend=backend)
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_deep_copy(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_deep_copy(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -43,10 +42,11 @@ class TestTensorOps(ShardedTensorTestBase):
         self.assertEqual(copied_st.local_tensor(), st.local_tensor())
         self.assertFalse(copied_st is st)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_inplace_copy(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_inplace_copy(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -70,10 +70,11 @@ class TestTensorOps(ShardedTensorTestBase):
             st_with_grad.copy_(ones_st)
             self.assertEqual(st_with_grad.local_tensor(), ones_st.local_tensor())
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_clone(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_clone(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -89,10 +90,11 @@ class TestTensorOps(ShardedTensorTestBase):
         self.assertEqual(copied_st.local_tensor(), st.local_tensor())
         self.assertFalse(copied_st is st)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_detach(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_detach(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -114,10 +116,11 @@ class TestTensorOps(ShardedTensorTestBase):
         for local_shard in detached_st.local_shards():
             self.assertFalse(local_shard.tensor.requires_grad)
 
-    @with_comms(init_rpc=False, backend=backend)
+    @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_set_requires_grad(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_set_requires_grad(self, device):
+        device_type = torch.device(device).type
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -139,6 +142,10 @@ class TestTensorOps(ShardedTensorTestBase):
         for local_shard in local_shards:
             self.assertTrue(local_shard.tensor.requires_grad)
 
+
+instantiate_device_type_tests(
+    TestTensorOps, globals(), except_for="cpu", allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

`test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py` tests
ShardedTensor operations (deepcopy, inplace_copy, clone, detach,
set_requires_grad) across 4 distributed ranks. The test class uses
`@requires_accelerator_dist_backend(["nccl", "xccl"])`, which prevents
out-of-tree accelerators (PrivateUse1-based backends) from running these
tests because the hardcoded backend list does not include `privateuse1`.

This PR keeps `ShardedTensorTestBase` + `with_comms` + `TEST_GPU_NUM`
intact and makes minimal changes to enable out-of-tree accelerator
support:
- Replaces `@requires_accelerator_dist_backend(["nccl", "xccl"])` with
  `@requires_capabilities(Capability.distributed.backend)`, which gates
  on device-declared capability rather than a hardcoded backend name list.
- Adds `hw_classification = HardwareClassification.ACCELERATOR`.
- Adds `instantiate_device_type_tests(TestTensorOps, globals(),
  except_for="cpu", allow_xpu=True)` to generate per-accelerator test
  variants while excluding CPU. `allow_xpu=True` preserves the original
  XPU coverage (the original `["nccl", "xccl"]` list included `xccl`).
- Adds `device` parameter to all 5 test methods. The `device` parameter
  is injected by `instantiate_device_type_tests`; test methods extract
  the bare device type via `torch.device(device).type` for
  `ChunkShardingSpec` placements.
- Removes module-level `device_type`/`backend` globals. `@with_comms(init_rpc=False)`
  relies on `ShardedTensorTestBase.backend` property (PR #194992) for
  dynamic backend resolution per device variant.

## Changes

- Replaced `@requires_accelerator_dist_backend(["nccl", "xccl"])` with
  `@requires_capabilities(Capability.distributed.backend)` on all 5
  test methods.
- Added `hw_classification = HardwareClassification.ACCELERATOR` class
  attribute.
- Added `instantiate_device_type_tests(TestTensorOps, globals(),
  except_for="cpu", allow_xpu=True)` at file end.
- Added `device` parameter to all 5 test method signatures:
  `def test_xxx(self)` → `def test_xxx(self, device)`.
- Added `device_type = torch.device(device).type` at the start of each
  test method body to extract the bare device type from the injected
  `device` parameter (e.g., `"npu:0"` → `"npu"`).
- Removed module-level `device_type` and `backend` globals.
- Changed `@with_comms(init_rpc=False, backend=backend)` to
  `@with_comms(init_rpc=False)` on all 5 test methods.
- Added imports: `Capability`, `instantiate_device_type_tests`,
  `requires_capabilities` from `common_device_type`;
  `HardwareClassification` from `common_utils`.
- Removed import: `requires_accelerator_dist_backend` from
  `common_distributed`.

## Dependencies

This PR relies on the following upstream PRs (submitted but not yet merged):

| Infrastructure | Source PR | Status |
|---|---|---|
| `ShardedTensorTestBase` backend property + `with_comms(backend=None)` + `init_pg` device binding | #194992 | Pending merge |
| `Capability` class + `requires_capabilities` decorator | #191919 | Pending merge |
| `PrivateUse1TestBase._capabilities()` override | #193080 | Pending merge (depends on #191919) |
| `skip_if_lt_x_gpu` hardware-agnostic | #187650 | Pending merge |

Without these, non-CUDA device variants are either skipped or fail at
process group initialization. The `@requires_capabilities` decorator
degrades to skipped (not failed) when `#193080` is not applied, so this
PR can be merged before #193080 without risk.

## Not changed

- Base class remains `ShardedTensorTestBase`.
- `with_comms(init_rpc=False)` decorator retained on all test methods
  (backend resolved dynamically via `ShardedTensorTestBase.backend`
  property, no longer passed as a module-level global).
- `TEST_GPU_NUM` retained for `@skip_if_lt_x_gpu(TEST_GPU_NUM)`.
- All 5 test method bodies and assertions are unchanged (only the
  `device` parameter and `device_type` derivation added).
- `ChunkShardingSpec` configuration (dim=0, 4 placements, shape (12, 5))
  is unchanged.
- Test count is preserved (5 tests).

## Test plan

- `python test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py`
  on CUDA (A100, PyTorch 2.13.0a0, CUDA 12.8, 8 GPUs):
  `OK` — all 5 tests passed in 47.675s
  (`test_deep_copy_cuda`, `test_inplace_copy_cuda`, `test_clone_cuda`,
  `test_detach_cuda`, `test_set_requires_grad_cuda`).
  This confirms the refactoring does not break existing CUDA behavior.
- `python test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py`
  on an out-of-tree accelerator backend (PrivateUse1, torch_npu
  2.13.0+git45fbeae on PyTorch 2.13.0a0+gitfad7424, Ascend 910B3, 4 NPUs,
  with #194992, #191919, #193080, #187650 applied):
  `OK` — all 5 tests passed in 89.379s
  (`test_deep_copy_npu`, `test_inplace_copy_npu`, `test_clone_npu`,
  `test_detach_npu`, `test_set_requires_grad_npu`).
- CPU: no variants generated (`except_for="cpu"`).
- `lintrunner`: all 62 checks passed (PYFMT/FLAKE8/RUFF/CODESPELL etc.).
- `ruff check`: All checks passed.