### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to dynamo test classes in test_profiler.py, test_pycode.py, and test_reorder_logs.py

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -10,10 +10,15 @@ from torch._dynamo.utils import chromium_event_timed, ChromiumEventLogger, dynam
 from torch._dynamo.variables.constant import ConstantVariable
 from torch._dynamo.variables.ctx_manager import ProfilerRecordFunctionContextVariable
 from torch.profiler import record_function
-from torch.testing._internal.common_utils import TemporaryFileName
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TemporaryFileName,
+)
 
 
 class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dynamo_timed_profiling_isolated(self):
         # dynamo_timed functions should appear in profile traces.
         def inner_fn(x):

--- a/test/dynamo/test_pycode.py
+++ b/test/dynamo/test_pycode.py
@@ -6,7 +6,11 @@ import torch
 import torch._dynamo.test_case
 from torch._dynamo.convert_frame import fullgraph_capture
 from torch._dynamo.utils import get_metrics_context
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+)
 
 
 class SimpleLinearModule(torch.nn.Module):
@@ -21,6 +25,8 @@ class SimpleLinearModule(torch.nn.Module):
 @torch._dynamo.config.patch(generate_pycode=True)
 @skipIfTorchDynamo("Not suitable for generate_pycode=True")
 class TestPycode(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_pycode_module(self):
         mod = SimpleLinearModule()
         x = torch.randn(3, 3)

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -11,6 +11,7 @@ import torch._dynamo.testing
 from torch._dynamo.testing import same
 from torch._dynamo.utils import counters
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -59,6 +60,8 @@ def f_warning_once(x):
 
 @instantiate_parametrized_tests
 class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "ignore_method, fn, captured_logger, should_ignore_logger",
         [
@@ -186,6 +189,8 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
 
 
 class ReorderLogsTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dont_reorder_print(self):
         def f(x):
             x = x + x


### PR DESCRIPTION
## Summary

Add HardwareClassification labels to dynamo test classes (`test_profiler.py`, `test_pycode.py`, and `test_reorder_logs.py`) for hardware decoupling so that CI runners can route tests by hardware capability.

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` to `DynamoProfilerTests` in `test/dynamo/test_profiler.py`
- Added `hw_classification = HardwareClassification.GENERIC` to `TestPycode` in `test/dynamo/test_pycode.py`
- Added `hw_classification = HardwareClassification.GENERIC` to `IgnoreLogsTests` and `ReorderLogsTests` in `test/dynamo/test_reorder_logs.py`
- Imported `HardwareClassification` from `torch.testing._internal.common_utils` in all three files

## Test Plan

`python test/dynamo/test_profiler.py --hw-classification GENERIC -v`
`python test/dynamo/test_pycode.py --hw-classification GENERIC -v`
`python test/dynamo/test_reorder_logs.py --hw-classification GENERIC -v`

- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98