### PR TITLE
[TEST] Add `hw_classification` to `test/package/test_misc.py`

### DIFF
--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -12,6 +12,7 @@ from unittest import skipIf
 from torch.package import is_from_package, PackageExporter, PackageImporter
 from torch.package.package_exporter import PackagingError
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_FBCODE,
     IS_SANDCASTLE,
     run_tests,
@@ -28,6 +29,8 @@ except ImportError:
 
 class TestMisc(PackageTestCase):
     """Tests for one-off or random functionality. Try not to add to this!"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_file_structure(self):
         """


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.GENERIC` to `TestMisc`.
- All 11 tests exercise `torch.package` APIs. Pure Python, no accelerator dependency.

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590).

## Test Plan

```
python test/package/test_misc.py -v
Ran 11 tests in 1.8s — OK
```

Verified on H200 — all 11 pass.

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508