### PR TITLE
[TEST] Fix hw_classification in test_convolution.py and add it to test_packed_sequence.py

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -12,7 +12,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import TEST_CUDA, tf32_on_and_off
+from torch.testing._internal.common_cuda import tf32_on_and_off
 from torch.testing._internal.common_device_type import (
     disablecuDNN,
     disableMkldnn,
@@ -561,55 +561,6 @@ class TestConvolutionNN(NNTestCase):
                 padding="same",
                 stride=(5, 1, 1),
             )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_thnn_conv_strided_padded_dilated(self):
-        for convfn, dims, transposed in (
-            (torch.nn.functional.conv2d, 2, False),
-            (torch.nn.functional.conv_transpose2d, 2, True),
-            (torch.nn.functional.conv3d, 3, False),
-            (torch.nn.functional.conv_transpose3d, 3, True),
-        ):
-            for stride, padding, dilation in (
-                (2, 0, 1),
-                (1, 1, 1),
-                (2, 1, 1),
-                (1, 0, 2),
-            ):
-                kwargs = {"stride": stride, "padding": padding, "dilation": dilation}
-                inp_shape = (1, 2) + dims * (4,)
-                weight_shape = (2, 2) + dims * (1,)
-                inputs = torch.randn(
-                    inp_shape, dtype=torch.double, device="cuda", requires_grad=True
-                )
-                weight = torch.randn(
-                    weight_shape, dtype=torch.double, device="cuda", requires_grad=True
-                )
-                bias = torch.randn(
-                    2, dtype=torch.double, device="cuda", requires_grad=True
-                )
-                with torch.backends.cudnn.flags(enabled=False):
-                    res = convfn(inputs, weight, bias, **kwargs)
-                res_cpu = convfn(inputs.cpu(), weight.cpu(), bias.cpu(), **kwargs)
-                self.assertEqual(res, res_cpu)
-                with torch.backends.cudnn.flags(enabled=False):
-                    torch.autograd.gradcheck(
-                        lambda x, w, b: convfn(x, w, b, **kwargs),
-                        (inputs, weight, bias),
-                    )
-                    torch.autograd.gradcheck(
-                        lambda x, w, b: convfn(x, w, b, **kwargs),
-                        (inputs.cpu(), weight.cpu(), bias.cpu()),
-                    )
-
-                # Non-batched must match batched-then-squeezed.
-                inputs_nb = inputs[0]
-                with torch.backends.cudnn.flags(enabled=False):
-                    res_nb = convfn(inputs_nb, weight, bias, **kwargs)
-                    res_via_batched = convfn(
-                        inputs_nb.unsqueeze(0), weight, bias, **kwargs
-                    ).squeeze(0)
-                self.assertEqual(res_nb, res_via_batched)
 
     def test_Conv2d_inconsistent_types(self):
         inputs = torch.randn(4, 1, 7, 7, dtype=torch.float)
@@ -1333,6 +1284,15 @@ class TestConvolutionNNDevice(NNTestCase):
                         lambda x, w, b: convfn(x, w, b, **kwargs),
                         (inputs.cpu(), weight.cpu(), bias.cpu()),
                     )
+
+                # Non-batched must match batched-then-squeezed.
+                inputs_nb = inputs[0]
+                with torch.backends.cudnn.flags(enabled=False):
+                    res_nb = convfn(inputs_nb, weight, bias, **kwargs)
+                    res_via_batched = convfn(
+                        inputs_nb.unsqueeze(0), weight, bias, **kwargs
+                    ).squeeze(0)
+                self.assertEqual(res_nb, res_via_batched)
 
     @onlyAccelerator
     @skipMPS

--- a/test/nn/test_packed_sequence.py
+++ b/test/nn/test_packed_sequence.py
@@ -6,27 +6,19 @@ import unittest
 
 import torch
 import torch.nn.utils.rnn as rnn_utils
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
 
 
-class PackedSequenceTest(TestCase):
-    _type_by_name = {
-        "torch.DoubleTensor": (torch.DoubleTensor, "double"),
-        "torch.FloatTensor": (torch.FloatTensor, "float"),
-        # We leave out `'torch.HalfTensor': (torch.HalfTensor, 'half'),`
-        # because of an error in `pad_packed_sequence`
-        # > AttributeError: 'torch.HalfTensor' object has no attribute 'fill_'
-        "torch.LongTensor": (torch.LongTensor, "long"),
-        "torch.IntTensor": (torch.IntTensor, "int"),
-        "torch.ShortTensor": (torch.ShortTensor, "short"),
-        "torch.CharTensor": (torch.CharTensor, "char"),
-        "torch.ByteTensor": (torch.ByteTensor, "byte"),
-    }
-
+class _TestPackedSequenceBase:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.batch_size = 5
@@ -52,14 +44,32 @@ class PackedSequenceTest(TestCase):
         padded_tensor = rnn_utils.pad_sequence(ordered)
         return padded_tensor, lengths
 
+
+class TestPackedSequence(_TestPackedSequenceBase, TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @unittest.skipIf(
         TEST_WITH_TORCHDYNAMO and sys.version_info[:2] < (3, 12),
         "Frame Handling Difference between Python versions",
     )
     def test_type_casts(self):
         """Test type casting of `PackedSequence` against type casting of tensor"""
-        for input_type, _ in self._type_by_name.values():
-            for expected_type_str, (_, cast_str) in self._type_by_name.items():
+
+        _type_by_name = {
+            "torch.DoubleTensor": (torch.DoubleTensor, "double"),
+            "torch.FloatTensor": (torch.FloatTensor, "float"),
+            # We leave out `'torch.HalfTensor': (torch.HalfTensor, 'half'),`
+            # because of an error in `pad_packed_sequence`
+            # > AttributeError: 'torch.HalfTensor' object has no attribute 'fill_'
+            "torch.LongTensor": (torch.LongTensor, "long"),
+            "torch.IntTensor": (torch.IntTensor, "int"),
+            "torch.ShortTensor": (torch.ShortTensor, "short"),
+            "torch.CharTensor": (torch.CharTensor, "char"),
+            "torch.ByteTensor": (torch.ByteTensor, "byte"),
+        }
+
+        for input_type, _ in _type_by_name.values():
+            for expected_type_str, (_, cast_str) in _type_by_name.items():
                 for enforce_sorted in [True, False]:
                     padded, lengths = self._padded_sequence(input_type)
                     packed = rnn_utils.pack_padded_sequence(
@@ -158,20 +168,6 @@ class PackedSequenceTest(TestCase):
             self.assertIs(a, a.cpu())
             self.assertIs(a, a.to("cpu", dtype=torch.int32))
             self.assertEqual(a.long(), a.to(torch.int64))
-
-            if torch.cuda.is_available():
-                for cuda in [
-                    "cuda",
-                    "cuda:0" if torch.cuda.device_count() == 1 else "cuda:1",
-                ]:
-                    b = a.cuda(device=cuda)
-                    self.assertIs(b, b.to(cuda))
-                    self.assertIs(b, b.cuda())
-                    self.assertEqual(a, b.to("cpu"))
-                    self.assertEqual(b, a.to(cuda))
-                    self.assertEqual(a, b.to("cpu", dtype=torch.int32))
-                    self.assertIs(b, b.to(dtype=torch.int32))
-                    self.assertEqual(b.long(), b.to(dtype=torch.int64))
 
     def test_to_memory_format(self):
         m = torch.nn.Conv2d(in_channels=16, out_channels=32, kernel_size=2, bias=True)
@@ -538,6 +534,33 @@ class PackedSequenceTest(TestCase):
         # Should not crash - either return empty list or raise informative error
         with self.assertRaises(RuntimeError):
             rnn_utils.unpack_sequence(packed)
+
+
+class TestPackedSequenceDevice(_TestPackedSequenceBase, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @unittest.skipIf(
+        TEST_WITH_TORCHDYNAMO and sys.version_info[:2] < (3, 13),
+        "Frame Handling Difference between Python versions",
+    )
+    def test_to(self, device):
+        for enforce_sorted in (True, False):
+            padded, lengths = self._padded_sequence(torch.IntTensor)
+            a = rnn_utils.pack_padded_sequence(
+                padded, lengths, enforce_sorted=enforce_sorted
+            ).cpu()
+
+            b = a.to(device)
+            self.assertIs(b, b.to(device))
+            self.assertEqual(a, b.to("cpu"))
+            self.assertEqual(b, a.to(device))
+            self.assertEqual(a, b.to("cpu", dtype=torch.int32))
+            self.assertIs(b, b.to(dtype=torch.int32))
+            self.assertEqual(b.long(), b.to(dtype=torch.int64))
+
+
+instantiate_device_type_tests(TestPackedSequenceDevice, globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

**test/nn/test_convolution.py:**
- `hw_classification` was already set on all classes (`TestConvolutionNN` = GENERIC (40 tests), `TestConvolutionNNDeviceType` = ACCELERATOR (1069 tests), `TestConvolutionNNCUDA` = CUDA (48 tests)) — not changed by this PR
- Fix: remove CUDA-hardcoded `test_thnn_conv_strided_padded_dilated` duplicate from the GENERIC class; merge its unique non-batched assertion into the existing ACCELERATOR version
- Remove unused `TEST_CUDA` import

**test/nn/test_packed_sequence.py:**
- Extract shared helpers (`__init__`, `_ordered_sequence`, `_padded_sequence`) into `_TestPackedSequenceBase` mixin
- `PackedSequenceTest` -> `TestPackedSequence`, hw_classification = HardwareClassification.GENERIC (13 tests)
- Move `_type_by_name` dict from a class attribute into `test_type_casts`, the only method that reads it
- Split CUDA device-transfer assertions out of `test_to` into new `TestPackedSequenceDevice`, hw_classification = HardwareClassification.ACCELERATOR, decorated `@onlyAccelerator` and instantiated via `instantiate_device_type_tests`

Closes #192768

## Test Plan

Verified on an NVIDIA H200 MIG slice for CUDA/ACCELERATOR runs.

```
python test/nn/test_convolution.py --hw-classification GENERIC      # Ran 40
python test/nn/test_convolution.py --hw-classification CUDA         # Ran 48 (skipped=3, xfail=1)
python test/nn/test_convolution.py --hw-classification ACCELERATOR  # Ran 1069 (skipped=426, xfail=24)

python test/nn/test_packed_sequence.py --hw-classification GENERIC      # Ran 13
python test/nn/test_packed_sequence.py --hw-classification ACCELERATOR  # Ran 2 (skipped=1)
```

Authored with AI assistance (Claude Code); all changes reviewed before submission.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @EikanWang @voznesenskym @penguinwu @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk @RiyaP2508