### PR TITLE
[TEST] Add `hw_classification` to `test_pruning_op.py`

### DIFF
--- a/test/test_pruning_op.py
+++ b/test/test_pruning_op.py
@@ -4,12 +4,18 @@ import hypothesis.strategies as st
 from hypothesis import given
 import numpy as np
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 import torch.testing._internal.hypothesis_utils as hu
 hu.assert_deadline_disabled()
 
 
 class PruningOpTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     # Generate rowwise mask vector based on indicator and threshold value.
     # indicator is a vector that contains one value per weight row and it


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.GENERIC` to `PruningOpTest`.
- Both tests exercise `torch._rowwise_prune` on CPU with hypothesis-based property testing (random embedding dims/dtypes). No accelerator dependency.

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590).

## Test Plan

```
python test/test_pruning_op.py -v
Ran 2 tests in 1.7s — OK
```

Verified on H200 — all 2 pass.

cc @vishalgoyal316 @mansiag05 @RiyaP2508