### PR TITLE
[Testcase Refactoring] Add hw_classification to AOTI copy_tests and package tests

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -59,8 +59,10 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_device_type import (
     _has_sufficient_memory,
+    Capability,
     e4m3_type,
     e5m2_type,
+    requires_capabilities,
     skipCUDAIf,
 )
 from torch.testing._internal.common_dtype import (
@@ -74,6 +76,7 @@ from torch.testing._internal.common_quantization import (
 )
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
+    HardwareClassification,
     IS_CI,
     IS_FBCODE,
     IS_MACOS,
@@ -9144,6 +9147,8 @@ torch._inductor.aoti_load_package("{model_path}")
 
 
 class AOTInductorLoggingTest(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @make_logging_test(dynamic=logging.DEBUG)
     def test_shape_env_reuse(self, records):
         # make sure ShapeEnv is only created once and reused afterwards
@@ -9181,6 +9186,8 @@ class AOTInductorLoggingTest(LoggingTestCase):
 
 
 class TestAOTInductorConfig(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_no_compile_standalone(self):
         with config.patch({"aot_inductor_mode.compile_standalone": False}):
             result = maybe_aoti_standalone_config({})
@@ -9346,6 +9353,8 @@ MPS_TEST_FAILURES = {
 
 
 class AOTInductorTestABICompatibleCpu(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -9365,6 +9374,8 @@ copy_tests(
 
 @unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
 class AOTInductorTestABICompatibleGpu(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     device = GPU_TYPE
     device_type = GPU_TYPE
     check_model = check_model
@@ -9372,6 +9383,10 @@ class AOTInductorTestABICompatibleGpu(TestCase):
     code_check_count = code_check_count
     allow_stack_allocation = False
     use_minimal_arrayref_interface = False
+
+    @requires_capabilities(Capability.lib.triton)
+    def setUp(self):
+        super().setUp()
 
 
 copy_tests(
@@ -9393,6 +9408,8 @@ class AOTInductorTestDualWrapper(TestCase):
     """Run AOTInductor tests with autotune_at_compile_time=False, exercising
     the lazy Triton compile + dual-wrapper-mode codegen path."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     device = GPU_TYPE
     device_type = GPU_TYPE
     check_model = check_model
@@ -9401,6 +9418,7 @@ class AOTInductorTestDualWrapper(TestCase):
     allow_stack_allocation = False
     use_minimal_arrayref_interface = False
 
+    @requires_capabilities(Capability.lib.triton)
     def setUp(self):
         super().setUp()
         ctx = torch._inductor.config.patch("triton.autotune_at_compile_time", False)
@@ -9418,6 +9436,8 @@ copy_tests(
 
 @unittest.skipIf(not torch.backends.mps.is_available(), "No MPS backend available")
 class AOTInductorTestABICompatibleMps(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     device = "mps"
     device_type = "mps"
     check_model = check_model
@@ -9436,6 +9456,8 @@ copy_tests(
 
 
 class TestCheckLowerboundConfig(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aoti_check_lowerbound_codegen(self):
         """
         Test that check_lowerbound config controls lowerbound check codegen.

--- a/test/inductor/test_aot_inductor_custom_ops.py
+++ b/test/inductor/test_aot_inductor_custom_ops.py
@@ -15,12 +15,14 @@ from torch.export import Dim, export
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import (
     find_library_location,
+    HardwareClassification,
     IS_CI,
     IS_FBCODE,
     IS_MACOS,
     IS_SANDCASTLE,
     IS_WINDOWS,
 )
+from torch.testing._internal.common_device_type import Capability, requires_capabilities
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -544,6 +546,8 @@ class AOTInductorTestsTemplate:
 
 
 class AOTInductorLoggingTest(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @make_logging_test(dynamic=logging.DEBUG)
     def test_shape_env_reuse(self, records):
         # make sure ShapeEnv is only created once and reused afterwards
@@ -610,6 +614,8 @@ GPU_TEST_FAILURES = {
 
 
 class AOTInductorTestABICompatibleCpu(AOTICustomOpTestCase):
+    hw_classification = HardwareClassification.CPU
+
     device = "cpu"
     device_type = "cpu"
     check_model = check_model
@@ -629,6 +635,8 @@ copy_tests(
 
 @unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
 class AOTInductorTestABICompatibleGpu(AOTICustomOpTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     device = GPU_TYPE
     device_type = GPU_TYPE
     check_model = check_model
@@ -636,6 +644,10 @@ class AOTInductorTestABICompatibleGpu(AOTICustomOpTestCase):
     code_check_count = code_check_count
     allow_stack_allocation = False
     use_minimal_arrayref_interface = False
+
+    @requires_capabilities(Capability.lib.triton)
+    def setUp(self):
+        super().setUp()
 
 
 copy_tests(

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -33,7 +33,8 @@ from torch.testing._internal.common_cuda import (
     requires_triton_ptxas_compat,
     TRITON_PTXAS_VERSION,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
+from torch.testing._internal.common_device_type import Capability, requires_capabilities
+from torch.testing._internal.common_utils import HardwareClassification, IS_FBCODE, TEST_CUDA
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -73,31 +74,34 @@ def compile(
     return loaded
 
 
-@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
-@parameterized_class(
-    [
-        {"device": "cpu", "package_cpp_only": False},
-    ]
-    + (
-        [
-            # FIXME: AssertionError: AOTInductor compiled library does not exist at
-            {"device": "cpu", "package_cpp_only": True}
-        ]
-        if not IS_FBCODE
-        else []
+def _package_class_name(cls, _, params):
+    return (
+        f"TestAOTInductorPackage{'Cpp' if params['package_cpp_only'] else ''}_"
+        f"{params['device']}"
     )
-    + (
-        [
-            {"device": GPU_TYPE, "package_cpp_only": False},
-            {"device": GPU_TYPE, "package_cpp_only": True},
-        ]
-        if sys.platform != "darwin"
-        else []
-    ),
-    class_name_func=lambda cls,
-    _,
-    params: f"{cls.__name__}{'Cpp' if params['package_cpp_only'] else ''}_{params['device']}",
+
+
+_CPU_PACKAGE_PARAMS = [
+    {"device": "cpu", "package_cpp_only": False},
+] + (
+    [
+        # FIXME: AssertionError: AOTInductor compiled library does not exist at
+        {"device": "cpu", "package_cpp_only": True}
+    ]
+    if not IS_FBCODE
+    else []
 )
+
+_GPU_PACKAGE_PARAMS = (
+    [
+        {"device": GPU_TYPE, "package_cpp_only": False},
+        {"device": GPU_TYPE, "package_cpp_only": True},
+    ]
+    if sys.platform != "darwin"
+    else []
+)
+
+
 class TestAOTInductorPackage(TestCase):
     def check_model(
         self: TestCase,
@@ -1183,6 +1187,22 @@ class TestAOTInductorPackage(TestCase):
             "Failed to find a generated cpp file or so file for model 'forward' in the zip archive.",
         ):
             load_package(package_path, model_name="forward")
+
+
+@parameterized_class(_CPU_PACKAGE_PARAMS, class_name_func=_package_class_name)
+class TestAOTInductorPackageCpu(TestAOTInductorPackage):
+    hw_classification = HardwareClassification.CPU
+
+
+if _GPU_PACKAGE_PARAMS:
+
+    @parameterized_class(_GPU_PACKAGE_PARAMS, class_name_func=_package_class_name)
+    class TestAOTInductorPackageGpu(TestAOTInductorPackage):
+        hw_classification = HardwareClassification.ACCELERATOR
+
+        @requires_capabilities(Capability.lib.triton)
+        def setUp(self):
+            super().setUp()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add `hw_classification` and Triton capability gates to the three WAIT AOTI suites so CI can filter via `--hw-classification` (PR: `ACCELERATOR`; Nightly: `ACCELERATOR GENERIC`). Labeling only — no `instantiate_device_type_tests`, no `GPU_TYPE` / means-2 device-matrix changes. Depends on #190846 for `Capability` / `@requires_capabilities`.

## Changes
- `test/inductor/test_aot_inductor.py`:
  - `AOTInductorTestABICompatibleCpu` → `CPU`; gpu / dual-wrapper → `ACCELERATOR` + `@requires_capabilities(Capability.lib.triton)` on `setUp`
  - `AOTInductorTestABICompatibleMps` → `MPS`
  - logging / config / check-lowerbound classes → `GENERIC`
- `test/inductor/test_aot_inductor_custom_ops.py`:
  - cpu shell → `CPU`; gpu shell → `ACCELERATOR` + triton `setUp` gate
  - `AOTInductorLoggingTest` → `GENERIC`
- `test/inductor/test_aot_inductor_package.py`:
  - split `@parameterized_class` into cpu vs gpu subclasses (class names unchanged)
  - `TestAOTInductorPackageCpu` → `CPU`; `TestAOTInductorPackageGpu` → `ACCELERATOR` + triton `setUp` gate

## Test Plan
```bash
python test/inductor/test_aot_inductor.py --hw-classification ACCELERATOR -k AOTInductorTestABICompatibleGpu
python test/inductor/test_aot_inductor.py --hw-classification GENERIC -k AOTInductorLoggingTest
python test/inductor/test_aot_inductor_custom_ops.py --hw-classification ACCELERATOR -k AOTInductorTestABICompatibleGpu
python test/inductor/test_aot_inductor_package.py --hw-classification ACCELERATOR -k TestAOTInductorPackage_cuda
python test/inductor/test_aot_inductor_package.py --hw-classification CPU -k TestAOTInductorPackage_cpu
```
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo