### PR TITLE
Set per-rank device index in MultiProcContinuousTest._init_pg

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1881,6 +1881,16 @@ class MultiProcContinuousTest(TestCase):
             timeout=cls.timeout,
         )
         cls.pg = c10d.distributed_c10d._get_default_group()
+        # Set the per-rank device for the current accelerator backend.
+        accelerator = torch.accelerator.current_accelerator()
+        if accelerator is not None:
+            device_type = accelerator.type
+            if (
+                device_type != "hpu"
+                and cls.backend_str()
+                == c10d.get_default_backend_for_device(device_type)
+            ):
+                torch.accelerator.set_device_index(rank)
 
     @classmethod
     def _run_test_given_id(cls, test_id: str, **kwargs) -> None:


### PR DESCRIPTION
## Summary

`MultiProcContinuousTest._init_pg` initializes the process group but
does not set the per-rank device index via
`torch.accelerator.set_device_index(rank)`. On multi-accelerator
backends (e.g. NPU/HCCL with 4+ devices), all ranks default to device 0,
causing HCCL to fail with:

  Communication_Error_Ranktable_Detect(EI0015): Rank0 has the same
  physical device ID0 as the rank1.

This PR adds the device-index binding after `init_process_group`,
mirroring the logic already present in `ShardedTensorTestBase.init_pg`
(PR #190528) and `C10dTorchCommsTestBase._init_pg`.

## Changes

- Added `torch.accelerator.set_device_index(rank)` in
  `MultiProcContinuousTest._init_pg` after `init_process_group`.
- The condition preserves existing HPU/HCCL behavior unchanged (HPU uses
  a different device-binding path) and only activates when the current
  accelerator's default backend matches `cls.backend_str()`.

## Not changed

- `C10dTorchCommsTestBase._init_pg` already has its own device-binding
  logic; this PR does not touch it.
- `ShardedTensorTestBase.init_pg` device binding (PR #190528) is
  independent and unaffected.

## Test plan

- NPU (Ascend 910B3, 4 NPUs): `test_tensor_ops.py` 10/10 pass
  (without patch: 2 errors HCCL "Rank0 has same physical device ID0
  as rank1"; with patch: all pass)
- CUDA (A100, 8 GPUs): 10/10 pass (no regression)
- CPU: 5/5 skip (unaffected — no accelerator, device binding skipped)