### PR TITLE
[TEST] Refactor test_multihead_attention.py with hw_classification

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize as parametrize_test,
     run_tests,
@@ -34,6 +35,8 @@ if TEST_NUMPY:
 
 
 class TestMultiheadAttentionNN(NNTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     if TEST_CUDA:
         _do_cuda_memory_leak_check = True
         _do_cuda_non_default_stream = True
@@ -754,6 +757,8 @@ class TestMultiheadAttentionNN(NNTestCase):
 
 
 class TestMultiheadAttentionNNDeviceType(NNTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_multihead_self_attn_two_masks_fast_path(self, device):
         """
         Multihead self-attention should give the same result on the fast path (BetterTransformer) as on the slow path


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `TestMultiheadAttentionNN` — 7 CPU-only tests
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestMultiheadAttentionNNDeviceType` — 26 device-typed tests (already uses `instantiate_device_type_tests`)

No structural changes needed — each class already follows single-responsibility.

## Test Plan

```
python test/nn/test_multihead_attention.py -v --hw-classification GENERIC
OK — Ran 7

python test/nn/test_multihead_attention.py -v --hw-classification ACCELERATOR
OK — Ran 26 (skipped=6)

python test/nn/test_multihead_attention.py -v
OK — Ran 33 (skipped=6)
```

cc @RiyaP2508