### PR TITLE
[Testcase Refactoring] Decouple attention flop counter tests from CUDA

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1531,7 +1531,7 @@ class TestFlexAttentionEstimation(TestCase):
 
 
 instantiate_device_type_tests(
-    TestFlopCounterDeviceType, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+    TestFlopCounterDeviceType, globals(), except_for=("cpu",), allow_xpu=True
 )
 
 

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1531,7 +1531,10 @@ class TestFlexAttentionEstimation(TestCase):
 
 
 instantiate_device_type_tests(
-    TestFlopCounterDeviceType, globals(), except_for=("cpu",), allow_xpu=True
+    TestFlopCounterDeviceType,
+    globals(),
+    except_for=("cpu", "mps", "hpu", "privateuse1"),
+    allow_xpu=True,
 )
 
 

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -13,8 +13,14 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_device_type import (
+    Capability,
+    e4m3_type,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
@@ -487,70 +493,6 @@ class TestFlopCounter(TestCase):
         flops_fw_bw_math, flops_fw_bw_efficient = flops
         self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
         self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
-
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Flash attention not supported (pre-SM80 hardware on CUDA)",
-    )
-    def test_sdpa_gqa(self):
-        """Test flop counting for grouped-query attention (GQA)."""
-        batch_size = 2
-        n_heads_q = 32
-        n_heads_kv = 8
-        seq_len = 128
-        head_dim = 64
-        dtype = torch.float16
-
-        query = torch.randn(
-            batch_size,
-            n_heads_q,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-        key = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-        value = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-
-        mode = FlopCounterMode()
-        with mode:
-            out = F.scaled_dot_product_attention(
-                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
-            )
-        gqa_flops = int(get_total_flops(mode))
-
-        # Compare with MHA (KV heads expanded to match Q heads)
-        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        mode_mha = FlopCounterMode()
-        with mode_mha:
-            out_mha = F.scaled_dot_product_attention(
-                query,
-                key_expanded,
-                value_expanded,
-                dropout_p=0,
-                is_causal=True,
-            )
-        mha_flops = int(get_total_flops(mode_mha))
-
-        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
-        self.assertEqual(gqa_flops, mha_flops)
-        self.assertTrue(gqa_flops > 0)
 
     @unittest.skipIf(not HAS_CUDA, "CUDA not available")
     @unittest.skipIf(
@@ -1351,6 +1293,73 @@ class TestFlopCounter(TestCase):
         self.assertExpectedInline(str(fw_bw_flops), """146800640""")
 
 
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestFlopCounterDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.attention.flash_attention)
+    def test_sdpa_gqa(self, device):
+        """Test flop counting for grouped-query attention (GQA)."""
+        batch_size = 2
+        n_heads_q = 32
+        n_heads_kv = 8
+        seq_len = 128
+        head_dim = 64
+        dtype = torch.float16
+
+        query = torch.randn(
+            batch_size,
+            n_heads_q,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        key = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        value = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+        mode = FlopCounterMode()
+        with mode:
+            out = F.scaled_dot_product_attention(
+                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
+            )
+        gqa_flops = int(get_total_flops(mode))
+
+        # Compare with MHA (KV heads expanded to match Q heads)
+        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        mode_mha = FlopCounterMode()
+        with mode_mha:
+            out_mha = F.scaled_dot_product_attention(
+                query,
+                key_expanded,
+                value_expanded,
+                dropout_p=0,
+                is_causal=True,
+            )
+        mha_flops = int(get_total_flops(mode_mha))
+
+        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
+        self.assertEqual(gqa_flops, mha_flops)
+        self.assertTrue(gqa_flops > 0)
+
+
 class TestFlexAttentionEstimation(TestCase):
     def test_flex_attention_flop_registration(self):
         """flex_attention HOPs are registered in flop_registry and recognized as compute nodes."""
@@ -1519,6 +1528,11 @@ class TestFlexAttentionEstimation(TestCase):
         sparse_flops = get_flops(sparse_node)
         self.assertGreater(dense_flops, 0)
         self.assertEqual(sparse_flops, dense_flops // 2)
+
+
+instantiate_device_type_tests(
+    TestFlopCounterDeviceType, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I reviewed the code and the quoted PR draft below, verified the reported results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590.
>
> ## Summary
> Move attention and GQA flop-counter coverage out of the generic test class and keep this PR limited to the attention consumer.
>
> ## Changes
> - Keep the attention consumer in `TestFlopCounterDeviceType` with the existing `Capability.attention.flash_attention` requirement.
> - Preserve generic coverage separately from accelerator-specific attention coverage.
> - Use the current device-type harness admission with `except_for=("cpu", "mps", "hpu", "privateuse1")` and `allow_xpu=True`; the extra exclusions avoid missing-capability assertions on bases that do not declare the required attention capability.
> - Keep FP8 `scaled_mm` and Triton custom-op coverage in #193564, #195972, and #195973.
>
> ## Motivation
> The attention tests exercise accelerator capabilities, while the remaining flop-counter tests are hardware-independent. Separating the classes keeps collection and capability failures aligned with the behavior under test.
>
> ## Checklist
> - [x] Added/updated tests.
> - [x] Preserved existing assertions and coverage boundaries.
> - [ ] Passed lint: `spin fixlint` is unavailable because `spin` is not installed in the WSL environment.
> - [x] Updated documentation: not applicable for this test-only refactor.
> - [x] Included benchmark results: not applicable; no performance behavior change.
>
> ## Test Plan
> - `PYTHONPYCACHEPREFIX=/tmp/pr192765-runtime2-pycache /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python test/test_flop_counter.py TestFlopCounterDeviceTypeCUDA.test_sdpa_gqa_cuda -v`: PASS (1 test, 1 passed).
> - `python -m py_compile test/test_flop_counter.py`: PASS.
> - `git diff --check`: PASS.
> - Non-CUDA accelerator CI: not run; hardware-specific validation remains pending.
>
> ## BC-breaking?
> No. This changes test collection and device admission only.
>
> ## Notes
> - Base: `main@a8787e209c34a4a239318dd54855dac77d240abf`.
> - Head: `71799f2d487f31fe7dfd6846c017d214cb145514`.
> - Current remote Files Changed: 1 file, `test/test_flop_counter.py`, `+82/-65`.
> - Depends on #190846. The PR remains Draft pending maintainer review and hardware CI.