### PR TITLE
[TEST] Add `hw_classification` to `test_linalg.py`

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -26,7 +26,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
+     freeze_rng_state, HardwareClassification, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
@@ -126,6 +126,8 @@ def get_tunableop_untuned_filename():
 
 
 class TestLinalg(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         # Snapshot fp32_precision (not allow_tf32) so the round-trip is exact:
@@ -9214,6 +9216,8 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
 class TestLinalgCudaOnly(TestCase):
     """CUDA/ROCm-specific linalg tests (TunableOp, backend library selection)."""
+
+    hw_classification = HardwareClassification.CUDA
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

Add `hw_classification` to both test classes:
- `TestLinalg`: `ACCELERATOR` — 259 tests, uses `instantiate_device_type_tests`, device-agnostic linalg ops
- `TestLinalgCudaOnly`: `CUDA` — 37 tests, `only_for=("cuda")`, TunableOp and backend library selection

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590)

## Test Plan

```
python test/test_linalg.py
Ran 3025 tests in 213s — 1 pre-existing failure, 17 pre-existing errors, 1052 skips 
```

Verified on H200.

cc @vishalgoyal316 @mansiag05 @RiyaP2508