### PR TITLE
[TEST] Refactor test_packed_sequence.py with hw_classification

### DIFF
--- a/test/nn/test_packed_sequence.py
+++ b/test/nn/test_packed_sequence.py
@@ -6,27 +6,19 @@ import unittest
 
 import torch
 import torch.nn.utils.rnn as rnn_utils
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
 
 
-class PackedSequenceTest(TestCase):
-    _type_by_name = {
-        "torch.DoubleTensor": (torch.DoubleTensor, "double"),
-        "torch.FloatTensor": (torch.FloatTensor, "float"),
-        # We leave out `'torch.HalfTensor': (torch.HalfTensor, 'half'),`
-        # because of an error in `pad_packed_sequence`
-        # > AttributeError: 'torch.HalfTensor' object has no attribute 'fill_'
-        "torch.LongTensor": (torch.LongTensor, "long"),
-        "torch.IntTensor": (torch.IntTensor, "int"),
-        "torch.ShortTensor": (torch.ShortTensor, "short"),
-        "torch.CharTensor": (torch.CharTensor, "char"),
-        "torch.ByteTensor": (torch.ByteTensor, "byte"),
-    }
-
+class _PackedSequenceTestBase:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.batch_size = 5
@@ -51,6 +43,23 @@ class PackedSequenceTest(TestCase):
         lengths = [len(i) for i in ordered]
         padded_tensor = rnn_utils.pad_sequence(ordered)
         return padded_tensor, lengths
+
+
+class PackedSequenceTest(_PackedSequenceTestBase, TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    _type_by_name = {
+        "torch.DoubleTensor": (torch.DoubleTensor, "double"),
+        "torch.FloatTensor": (torch.FloatTensor, "float"),
+        # We leave out `'torch.HalfTensor': (torch.HalfTensor, 'half'),`
+        # because of an error in `pad_packed_sequence`
+        # > AttributeError: 'torch.HalfTensor' object has no attribute 'fill_'
+        "torch.LongTensor": (torch.LongTensor, "long"),
+        "torch.IntTensor": (torch.IntTensor, "int"),
+        "torch.ShortTensor": (torch.ShortTensor, "short"),
+        "torch.CharTensor": (torch.CharTensor, "char"),
+        "torch.ByteTensor": (torch.ByteTensor, "byte"),
+    }
 
     @unittest.skipIf(
         TEST_WITH_TORCHDYNAMO and sys.version_info[:2] < (3, 12),
@@ -158,20 +167,6 @@ class PackedSequenceTest(TestCase):
             self.assertIs(a, a.cpu())
             self.assertIs(a, a.to("cpu", dtype=torch.int32))
             self.assertEqual(a.long(), a.to(torch.int64))
-
-            if torch.cuda.is_available():
-                for cuda in [
-                    "cuda",
-                    "cuda:0" if torch.cuda.device_count() == 1 else "cuda:1",
-                ]:
-                    b = a.cuda(device=cuda)
-                    self.assertIs(b, b.to(cuda))
-                    self.assertIs(b, b.cuda())
-                    self.assertEqual(a, b.to("cpu"))
-                    self.assertEqual(b, a.to(cuda))
-                    self.assertEqual(a, b.to("cpu", dtype=torch.int32))
-                    self.assertIs(b, b.to(dtype=torch.int32))
-                    self.assertEqual(b.long(), b.to(dtype=torch.int64))
 
     def test_to_memory_format(self):
         m = torch.nn.Conv2d(in_channels=16, out_channels=32, kernel_size=2, bias=True)
@@ -538,6 +533,33 @@ class PackedSequenceTest(TestCase):
         # Should not crash - either return empty list or raise informative error
         with self.assertRaises(RuntimeError):
             rnn_utils.unpack_sequence(packed)
+
+
+class PackedSequenceDeviceTypeTest(_PackedSequenceTestBase, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @unittest.skipIf(
+        TEST_WITH_TORCHDYNAMO and sys.version_info[:2] < (3, 13),
+        "Frame Handling Difference between Python versions",
+    )
+    def test_to(self, device):
+        for enforce_sorted in (True, False):
+            padded, lengths = self._padded_sequence(torch.IntTensor)
+            a = rnn_utils.pack_padded_sequence(
+                padded, lengths, enforce_sorted=enforce_sorted
+            ).cpu()
+
+            b = a.to(device)
+            self.assertIs(b, b.to(device))
+            self.assertEqual(a, b.to("cpu"))
+            self.assertEqual(b, a.to(device))
+            self.assertEqual(a, b.to("cpu", dtype=torch.int32))
+            self.assertIs(b, b.to(dtype=torch.int32))
+            self.assertEqual(b.long(), b.to(dtype=torch.int64))
+
+
+instantiate_device_type_tests(PackedSequenceDeviceTypeTest, globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `PackedSequenceTest` — 13 CPU-only tests for RNN packing/padding utilities
- Split CUDA device-transfer assertions from `test_to` into new `PackedSequenceDeviceTypeTest` (ACCELERATOR, 1 test) with `@onlyAccelerator` and `instantiate_device_type_tests`, converting `"cuda"` → `device` parameter
- Extract shared helpers (`__init__`, `_ordered_sequence`, `_padded_sequence`) into `_PackedSequenceTestBase` base class

Intentional scope reductions in the ACCELERATOR `test_to`:
- Dropped `.cuda()` identity assertion — CUDA-specific API with no device-agnostic equivalent
- Dropped multi-device iteration (`cuda:0`/`cuda:1`) — tests device dispatch behavior, not PackedSequence-specific logic

## Test Plan

```
python test/nn/test_packed_sequence.py -v
Ran 15 tests in 1.219s -- OK (skipped=1)

python test/nn/test_packed_sequence.py -v --hw-classification GENERIC
Ran 13 tests in 1.175s -- OK

python test/nn/test_packed_sequence.py -v --hw-classification ACCELERATOR
Ran 2 tests in 0.865s -- OK (skipped=1)
```

cc @RiyaP2508