### PR TITLE
[CD] Use cuda-bindings pre-release in CUDA 13.4 CI image

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -65,6 +65,7 @@ COPY ./ci_commit_pins/nccl* /ci_commit_pins/
 COPY ./common/install_cusparselt.sh install_cusparselt.sh
 RUN bash ./install_cuda.sh ${CUDA_VERSION} && rm install_cuda.sh install_nccl.sh /ci_commit_pins/nccl* install_cusparselt.sh
 # Relies on pip replacing cuda-bindings installed from requirements-ci.txt / install_python.sh above.
+# Note: this is temporary, it needs to be updated once cuda-bindings 13.4 is released
 RUN case "${CUDA_VERSION}" in 13.4*) python -mpip install cuda-bindings==13.4.0b1 ;; esac
 ENV DESIRED_CUDA=${CUDA_VERSION}
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -65,7 +65,7 @@ COPY ./ci_commit_pins/nccl* /ci_commit_pins/
 COPY ./common/install_cusparselt.sh install_cusparselt.sh
 RUN bash ./install_cuda.sh ${CUDA_VERSION} && rm install_cuda.sh install_nccl.sh /ci_commit_pins/nccl* install_cusparselt.sh
 # Relies on pip replacing cuda-bindings installed from requirements-ci.txt / install_python.sh above.
-RUN if [ "${CUDA_VERSION}" = "13.4.0" ]; then python -mpip install cuda-bindings==13.4.0b1; fi
+RUN case "${CUDA_VERSION}" in 13.4*) python -mpip install cuda-bindings==13.4.0b1 ;; esac
 ENV DESIRED_CUDA=${CUDA_VERSION}
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -64,6 +64,8 @@ COPY ./common/install_nccl.sh install_nccl.sh
 COPY ./ci_commit_pins/nccl* /ci_commit_pins/
 COPY ./common/install_cusparselt.sh install_cusparselt.sh
 RUN bash ./install_cuda.sh ${CUDA_VERSION} && rm install_cuda.sh install_nccl.sh /ci_commit_pins/nccl* install_cusparselt.sh
+# Relies on pip replacing cuda-bindings installed from requirements-ci.txt / install_python.sh above.
+RUN if [ "${CUDA_VERSION}" = "13.4.0" ]; then python -mpip install cuda-bindings==13.4.0b1; fi
 ENV DESIRED_CUDA=${CUDA_VERSION}
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 


### PR DESCRIPTION
Small PR building on top of https://github.com/pytorch/pytorch/pull/190639 / https://github.com/pytorch/pytorch/pull/192256 to use the cuda-bindings 13.4 beta for the CUDA 13.4 image specifically.

This unblocks testing of PRs requiring CUDA 13.4 + cuda-bindings (e.g. https://github.com/pytorch/pytorch/pull/190656)

CC: @tinglvv @nWEIdia @atalman @malfet @eqy @ptrblck 