### PR TITLE
[Testcase Refactoring] Add hardware classification for test_tp_checkpoint.py

### DIFF
--- a/test/distributed/checkpoint/test_tp_checkpoint.py
+++ b/test/distributed/checkpoint/test_tp_checkpoint.py
@@ -44,7 +44,8 @@ class TestTpCheckpoint(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
-    def test_tp_checkpoint(self):
+    def test_tp_checkpoint(self, device):
+        self.device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
         mesh_shpe = (self.world_size,)
         tp_mesh = init_device_mesh(self.device_type, mesh_shpe)
@@ -91,7 +92,8 @@ class TestTpCheckpoint(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
-    def test_tp_checkpoint_load_on_meta_device(self):
+    def test_tp_checkpoint_load_on_meta_device(self, device):
+        self.device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
         mesh_shpe = (self.world_size,)
         tp_mesh = init_device_mesh(self.device_type, mesh_shpe)
@@ -153,6 +155,7 @@ class TestTpCheckpoint(DTensorTestBase):
 instantiate_device_type_tests(
     TestTpCheckpoint,
     globals(),
+    except_for="cpu",
     allow_xpu=True
 )
 

--- a/test/distributed/checkpoint/test_tp_checkpoint.py
+++ b/test/distributed/checkpoint/test_tp_checkpoint.py
@@ -45,7 +45,6 @@ class TestTpCheckpoint(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_tp_checkpoint(self, device):
-        self.device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
         mesh_shpe = (self.world_size,)
         tp_mesh = init_device_mesh(self.device_type, mesh_shpe)
@@ -93,7 +92,6 @@ class TestTpCheckpoint(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_tp_checkpoint_load_on_meta_device(self, device):
-        self.device_type = torch.device(device).type
         CHECKPOINT_DIR = self.temp_dir
         mesh_shpe = (self.world_size,)
         tp_mesh = init_device_mesh(self.device_type, mesh_shpe)
@@ -153,10 +151,7 @@ class TestTpCheckpoint(DTensorTestBase):
 
 
 instantiate_device_type_tests(
-    TestTpCheckpoint,
-    globals(),
-    except_for="cpu",
-    allow_xpu=True
+    TestTpCheckpoint, globals(), except_for="cpu", allow_xpu=True
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_tp_checkpoint.py
+++ b/test/distributed/checkpoint/test_tp_checkpoint.py
@@ -14,7 +14,8 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MLPModule,
@@ -38,6 +39,8 @@ class UnevenShardedModel(torch.nn.Module):
 
 
 class TestTpCheckpoint(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
@@ -146,6 +149,12 @@ class TestTpCheckpoint(DTensorTestBase):
             self.assertEqual(param.to_local(), param_to_load.to_local())
             self.assertEqual(param.to_local(), param_after_load.to_local())
 
+
+instantiate_device_type_tests(
+    TestTpCheckpoint,
+    globals(),
+    allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary:
  Add hardware classification for `test_tp_checkpoint.py` and classify
  `TestTpCheckpoint` as `ACCELERATOR`.

## Changes:
  Set `hw_classification = HardwareClassification.ACCELERATOR` on
  `TestTpCheckpoint`.

## Test Plan:
  `python test/distributed/checkpoint/test_tp_checkpoint.py -v --hw-classification ACCELERATOR`

This PR depends on the merge of #187650.