### PR TITLE
[Test] Enable XPU for `test_hop.py` and add hardware classification

### DIFF
--- a/test/export/test_hop.py
+++ b/test/export/test_hop.py
@@ -16,7 +16,11 @@ from torch.testing._internal.common_device_type import (
     skipOps,
     xfail,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+)
 from torch.testing._internal.hop_db import (
     FIXME_hop_that_doesnt_have_opinfo_test_allowlist,
     hop_db,
@@ -44,7 +48,9 @@ hop_export_failures = {
 
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
-class TestHOP(TestCase):
+class TestHOPDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _compare(self, eager_model, export, args, kwargs):
         eager_args = copy.deepcopy(args)
         eager_kwargs = copy.deepcopy(kwargs)
@@ -144,7 +150,7 @@ class TestHOP(TestCase):
         torchdynamo._reset_guarded_backend_cache()
 
 
-instantiate_device_type_tests(TestHOP, globals())
+instantiate_device_type_tests(TestHOPDevice, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
This PR enables XPU coverage for `test_hop.py` by opting `TestHOP` into XPU instantiation with `allow_xpu=True` and classifying it as `ACCELERATOR`. Previously, the file collected zero XPU tests under the XPU CI device filter because `XPUTestBase` was never added. This change ensures the file is exercised on XPU instead of silently being dropped.

The tests are already device-generic, so no logic changes were needed beyond the XPU registration/classification.

On a single-XPU machine:
Before: 44 tests (35 passed, 9 xfailed), all `TestHOPCPU`
After: 88 tests (70 passed, 18 xfailed)

Test plan:
```bash
python -m pytest test/export/test_hop.py -q
PYTORCH_TESTING_DEVICE_ONLY_FOR=xpu python -m pytest test/export/test_hop.py -q
```