### PR TITLE
[Testcase Refactoring] Classify flat apply tests by hardware

### DIFF
--- a/test/dynamo/test_flat_apply.py
+++ b/test/dynamo/test_flat_apply.py
@@ -18,7 +18,7 @@ from torch._higher_order_ops.flat_apply import (
     is_graphable,
     to_graphable,
 )
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+from torch.testing._internal.common_utils import HardwareClassification, skipIfTorchDynamo
 from torch.testing._internal.dynamo_pytree_test_utils import PytreeRegisteringTestCase
 
 
@@ -86,6 +86,8 @@ class OutputInvalid:
 
 
 class FlatApplyTests(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_simple(self):
         tensor = torch.tensor
 
@@ -231,6 +233,8 @@ class <lambda>(torch.nn.Module):
 
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")
 class TestInputOutput(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_simple(self):
         a = 4
         b = torch.randn(4, 4)


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo flat apply tests.

## Changes
- Import HardwareClassification for the test file.
- Mark FlatApplyTests as HardwareClassification.GENERIC.
- Mark TestInputOutput as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_flat_apply.py
git diff --check -- test/dynamo/test_flat_apply.py
npu-run-suite npu  ./test_flat_apply.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98