### PR TITLE
Use STD_TORCH_CHECK in the x86 complex vec headers

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -7,6 +7,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/complex.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 
 #if defined(CPU_CAPABILITY_AVX2)
 #define SLEEF_STATIC_LIBS
@@ -335,19 +336,19 @@ class Vectorized<c10::complex<double>> {
   }
   Vectorized<c10::complex<double>> operator<(
       const Vectorized<c10::complex<double>>& /*unused*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator<=(
       const Vectorized<c10::complex<double>>& /*unused*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator>(
       const Vectorized<c10::complex<double>>& /*unused*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator>=(
       const Vectorized<c10::complex<double>>& /*unused*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<double>> eq(

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -7,6 +7,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/complex.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 #if defined(CPU_CAPABILITY_AVX2)
 #define SLEEF_STATIC_LIBS
 #include <sleef.h>
@@ -416,19 +417,19 @@ class Vectorized<c10::complex<float>> {
   }
   Vectorized<c10::complex<float>> operator<(
       const Vectorized<c10::complex<float>>& /*other*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator<=(
       const Vectorized<c10::complex<float>>& /*other*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator>(
       const Vectorized<c10::complex<float>>& /*other*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator>=(
       const Vectorized<c10::complex<float>>& /*other*/) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<float>> eq(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -7,6 +7,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/complex.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 #if defined(CPU_CAPABILITY_AVX512)
 #define SLEEF_STATIC_LIBS
 #include <sleef.h>
@@ -450,19 +451,19 @@ class Vectorized<c10::complex<double>> {
   }
   Vectorized<c10::complex<double>> operator<(
       const Vectorized<c10::complex<double>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator<=(
       const Vectorized<c10::complex<double>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator>(
       const Vectorized<c10::complex<double>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> operator>=(
       const Vectorized<c10::complex<double>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<double>> eq(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -7,6 +7,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/complex.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 #if defined(CPU_CAPABILITY_AVX512)
 #define SLEEF_STATIC_LIBS
 #include <sleef.h>
@@ -995,19 +996,19 @@ class Vectorized<c10::complex<float>> {
   }
   Vectorized<c10::complex<float>> operator<(
       const Vectorized<c10::complex<float>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator<=(
       const Vectorized<c10::complex<float>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator>(
       const Vectorized<c10::complex<float>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> operator>=(
       const Vectorized<c10::complex<float>>& other [[maybe_unused]]) const {
-    TORCH_CHECK(false, "not supported for complex numbers");
+    STD_TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<float>> eq(


### PR DESCRIPTION
Summary:
First of three changes converting ATen's vec headers off TORCH_CHECK, so
ExecuTorch can stop defining STANDALONE_TORCH_HEADER. That flag changes what
TORCH_CHECK expands to -- std::runtime_error with it, c10::Error without -- and
it is an exported preprocessor flag, so a binary that links both libtorch and
ExecuTorch ends up compiling the same header-inline functions two different
ways. That is an ODR violation.

STD_TORCH_CHECK is the header-only equivalent and takes the same arguments. The
16 sites converted here are all unconditional "not supported for complex
numbers" rejections on the ordering operators, so the only behavioural
difference is the exception type: std::runtime_error instead of c10::Error.
Both surface as RuntimeError in Python; what is lost is the C++ backtrace on
these specific messages.

x86 headers only. The VSX and zarch complex headers have the same sites and are
converted in a later change in this series, kept separate because verifying
them needs ppc64le and s390x.

STD_TORCH_CHECK was suggested by janeyx99 in review of
https://github.com/pytorch/pytorch/pull/192264, an earlier attempt at the
same ODR problem that tried to make c10::Error itself header-only. That PR
was dismissed; this series takes the suggested approach instead.

Test Plan:
- ATen CPU and the AVX2 kernels build unchanged.
- Also compiled with -DCPU_CAPABILITY_AVX512 to cover the vec512 complex
  headers; every translation unit compiles. That configuration was compiled
  but not linked.

Differential Revision: D115044089




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01