### PR TITLE
[TEST] Add `hw_classification` to `test_sparse_semi_structured.py`

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_dtype import all_types_and_complex
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     parametrize,
     run_tests,
@@ -182,6 +183,8 @@ def rand_sparse_semi_structured_all_patterns(r, c, dtype, device):
 
 
 class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) == 0:
             self.skipTest("semi-structured sparsity has no available backend!")
@@ -337,6 +340,8 @@ class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
 
 
 class TestSparseSemiStructured(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) == 0:
@@ -695,6 +700,8 @@ def create_random_mask(shape) -> torch.Tensor:
 
 
 class TestSparseSemiStructuredTraining(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         if not _IS_SM8X:
@@ -1091,6 +1098,8 @@ class TestSparseSemiStructuredTraining(TestCase):
 
 
 class TestSparseSemiStructuredCUTLASS(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """
     This contains CUTLASS specific tests for
          - torch._sparse_semi_structured_linear
@@ -1355,6 +1364,8 @@ def to_float8(x, dtype=torch.float8_e4m3fn):
 
 
 class TestSparseSemiStructuredCUSPARSELT(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """
     This contains cuSPARSELt specific tests for
         torch._cslt_compress


### PR DESCRIPTION
## Summary

- Add `hw_classification = HardwareClassification.CUDA` to all 5 test classes.
- All require CUDA SM80+ with CUTLASS or cuSPARSELt backends for semi-structured 2:4 sparsity. Uses `instantiate_device_type_tests(..., only_for="cuda")`.

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590) 

## Test Plan

```
python test/test_sparse_semi_structured.py
Ran 57 tests — OK (skipped=57, no sparse backend on test machine)
```

Baseline produces identical results.

cc @vishalgoyal316 @mansiag05 @RiyaP2508