### PR TITLE
[Testcase Refactoring] Classify Dynamo export tests by hardware

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -36,7 +36,11 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_LINUX, TEST_WITH_SLOW
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_LINUX,
+    TEST_WITH_SLOW,
+)
 
 
 @torch._dynamo.assume_constant_result
@@ -45,6 +49,8 @@ def dynamo_assume_constant_result_global_function():
 
 
 class ExportTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # TODO(voz): Refactor to a shared test function.
     # The tests in this file are a little redundant,
     # They all take a func, run it with eager, then export it, then compare
@@ -4586,6 +4592,8 @@ def forward(self, x, b, y):
 
 
 class ExportTestsSubprocess(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_strict_export_under_pythonoptimize(self):
         env = dict(os.environ)
         env["PYTHONOPTIMIZE"] = "1"
@@ -4607,11 +4615,15 @@ torch.testing.assert_close(out_export, out_orig)
         self.assertEqual(
             result.returncode,
             0,
-            msg=lambda msg: f"{msg}\nstrict export under PYTHONOPTIMIZE=1 failed: stdout={result.stdout!r} stderr={result.stderr!r}",
+            msg=lambda msg: (
+                f"{msg}\nstrict export under PYTHONOPTIMIZE=1 failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+            ),
         )
 
 
 class ExportTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181344"
     )

--- a/test/dynamo/test_export_mutations.py
+++ b/test/dynamo/test_export_mutations.py
@@ -4,10 +4,12 @@ import unittest
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
-from torch.testing._internal.common_utils import IS_FBCODE
+from torch.testing._internal.common_utils import HardwareClassification, IS_FBCODE
 
 
 class MutationExportTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def check_failure_on_export(self, mod, *args):
         with self.assertRaises(AssertionError):
             torch._dynamo.export(mod)(*args)

--- a/test/dynamo/test_flat_apply.py
+++ b/test/dynamo/test_flat_apply.py
@@ -18,7 +18,10 @@ from torch._higher_order_ops.flat_apply import (
     is_graphable,
     to_graphable,
 )
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    skipIfTorchDynamo,
+)
 from torch.testing._internal.dynamo_pytree_test_utils import PytreeRegisteringTestCase
 
 
@@ -86,6 +89,8 @@ class OutputInvalid:
 
 
 class FlatApplyTests(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_simple(self):
         tensor = torch.tensor
 
@@ -231,6 +236,8 @@ class <lambda>(torch.nn.Module):
 
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")
 class TestInputOutput(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_simple(self):
         a = 4
         b = torch.randn(4, 4)

--- a/test/dynamo/test_frame_init.py
+++ b/test/dynamo/test_frame_init.py
@@ -5,6 +5,7 @@ import torch._dynamo.test_case
 from torch._C._dynamo.eval_frame import set_eval_frame
 from torch._dynamo.types import ConvertFrameReturn, GuardedCode, wrap_guarded_code
 from torch._guards import CompileId
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 def target_with_varkwargs(arg1, /, positional_only_arg, *, keyword_only_arg, **kwargs):
@@ -78,6 +79,8 @@ def varargs_code2(arg1, /, positional_only_arg, *varargs, **kwargs):
 
 
 class FrameInitTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_frame_init(self):
         code_map1 = {
             target_with_varargs.__code__: varargs_code1.__code__,

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -12,6 +12,7 @@ from torch._dynamo.testing import (
     normalize_gm,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -22,6 +23,8 @@ from torch.testing._internal.common_utils import (
 @torch._dynamo.config.patch(trace_autograd_ops=True)
 @skipIfTorchDynamo()
 class TestForwardLossBackward(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_backward_test(self, fn, mod, x, backend=None):
         """
         Shared utility for running backward tests.


### PR DESCRIPTION
## Summary
Classifies Dynamo export, flat apply, frame init, and forward-loss-backward tests with hardware metadata.

## Changes
- Add HardwareClassification coverage for export mutation tests.
- Add HardwareClassification coverage for export tests.
- Add HardwareClassification coverage for flat apply tests.
- Add HardwareClassification coverage for frame init tests.
- Add HardwareClassification coverage for forward loss backward tests.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_export_mutations.py test/dynamo/test_export.py test/dynamo/test_flat_apply.py test/dynamo/test_frame_init.py test/dynamo/test_fwd_loss_bwd.py
python -m py_compile test/dynamo/test_export_mutations.py test/dynamo/test_export.py test/dynamo/test_flat_apply.py test/dynamo/test_frame_init.py test/dynamo/test_fwd_loss_bwd.py
git diff --check -- test/dynamo/test_export_mutations.py test/dynamo/test_export.py test/dynamo/test_flat_apply.py test/dynamo/test_frame_init.py test/dynamo/test_fwd_loss_bwd.py
```