### PR TITLE
[Testcase Refactoring] Classify export tests by hardware

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -36,7 +36,11 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_LINUX, TEST_WITH_SLOW
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_LINUX,
+    TEST_WITH_SLOW,
+)
 
 
 @torch._dynamo.assume_constant_result
@@ -45,6 +49,8 @@ def dynamo_assume_constant_result_global_function():
 
 
 class ExportTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # TODO(voz): Refactor to a shared test function.
     # The tests in this file are a little redundant,
     # They all take a func, run it with eager, then export it, then compare
@@ -4586,6 +4592,8 @@ def forward(self, x, b, y):
 
 
 class ExportTestsSubprocess(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_strict_export_under_pythonoptimize(self):
         env = dict(os.environ)
         env["PYTHONOPTIMIZE"] = "1"
@@ -4612,6 +4620,8 @@ torch.testing.assert_close(out_export, out_orig)
 
 
 class ExportTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181344"
     )


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo export tests.

## Changes
- Import HardwareClassification for the test file.
- Mark generic export test classes as HardwareClassification.GENERIC.
- Mark device-instantiated export coverage as HardwareClassification.ACCELERATOR.

## Test plan
```bash
python -m py_compile test/dynamo/test_export.py
git diff --check -- test/dynamo/test_export.py
npu-run-suite npu  ./test_export.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98