### PR TITLE
[Testcase Refactoring] Classify einops tests by hardware

### DIFF
--- a/test/dynamo/test_einops.py
+++ b/test/dynamo/test_einops.py
@@ -11,6 +11,7 @@ from torch import nn
 from torch._dynamo.test_case import TestCase
 from torch._vendor.packaging.version import InvalidVersion, Version
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -44,6 +45,8 @@ class TestEinops(TestCase):
     versions of einops. Our goal is to prevent regressions in einops from changes
     in PyTorch.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize("version", [einops_version_sanitized])
     def test_functions(self, version):


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo einops tests.

## Changes
- Import HardwareClassification for the test file.
- Mark TestEinops as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_einops.py
git diff --check -- test/dynamo/test_einops.py
npu-run-suite npu  ./test_einops.py

```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98