### PR TITLE
[Testcase Refactoring] Classify exception tests by hardware

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -16,6 +16,7 @@ from torch._dynamo.exc import Unsupported
 from torch._dynamo.symbolic_convert import SpeculationLog, SpeculationLogDivergence
 from torch._dynamo.testing import CompileCounter
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     make_dynamo_test,
     parametrize,
@@ -46,6 +47,8 @@ class MyException(OSError):
 
 
 class ExceptionTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_exception(self):
         def fn(x):
             x = torch.cos(x)


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo exception tests.

## Changes
- Import HardwareClassification for the test file.
- Mark ExceptionTests as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_exceptions.py
git diff --check -- test/dynamo/test_exceptions.py
npu-run-suite npu  ./test_exceptions.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98