### PR TITLE
Inductor: fuse CUDA FNUZ FP8 conversions into Triton kernels

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -957,7 +957,7 @@ def helper(x):
             )
         )
 
-    def test_signature_of_float8_e4m3fn_uses_uint8_on_pre_sm89_cuda_inputs(self):
+    def test_signature_of_unsupported_cuda_fp8_uses_uint8_inputs(self):
         class FakeGraph:
             mutated_buffers = set()
 
@@ -976,16 +976,39 @@ def helper(x):
         )
         arg = TensorArg(name="in_ptr0", buffer="buf0", dtype=torch.float8_e4m3fn)
         out_arg = TensorArg(name="out_ptr0", buffer="buf0", dtype=torch.float8_e4m3fn)
+        fnuz_args = (
+            TensorArg(name="in_ptr1", buffer="buf1", dtype=torch.float8_e4m3fnuz),
+            TensorArg(name="in_ptr2", buffer="buf2", dtype=torch.float8_e5m2fnuz),
+        )
+        fnuz_out_args = (
+            TensorArg(name="out_ptr1", buffer="buf1", dtype=torch.float8_e4m3fnuz),
+            TensorArg(name="out_ptr2", buffer="buf2", dtype=torch.float8_e5m2fnuz),
+        )
+        fnuz_out_signatures = ("*fp8e4b8", "*fp8e5b16")
 
         with (
             patch.object(torch.version, "hip", None),
             V.set_graph_handler(FakeGraph()),
             patch.object(DeviceProperties, "create", return_value=props),
+            patch.object(
+                triton_utils,
+                "is_triton_fp8_dtype_supported",
+                return_value=False,
+            ),
         ):
             self.assertEqual(triton_utils.signature_of(arg, size_dtype=None), "*u8")
+            for fnuz_arg in fnuz_args:
+                self.assertEqual(
+                    triton_utils.signature_of(fnuz_arg, size_dtype=None), "*u8"
+                )
             self.assertEqual(
                 triton_utils.signature_of(out_arg, size_dtype=None), "*fp8e4nv"
             )
+            for fnuz_out_arg, signature in zip(fnuz_out_args, fnuz_out_signatures):
+                self.assertEqual(
+                    triton_utils.signature_of(fnuz_out_arg, size_dtype=None),
+                    signature,
+                )
 
         with (
             patch.object(torch.version, "hip", None),
@@ -993,10 +1016,19 @@ def helper(x):
             patch.object(
                 DeviceProperties, "create", return_value=props._replace(cc=89)
             ),
+            patch.object(
+                triton_utils,
+                "is_triton_fp8_dtype_supported",
+                return_value=False,
+            ),
         ):
             self.assertEqual(
                 triton_utils.signature_of(arg, size_dtype=None), "*fp8e4nv"
             )
+            for fnuz_arg in fnuz_args:
+                self.assertEqual(
+                    triton_utils.signature_of(fnuz_arg, size_dtype=None), "*u8"
+                )
 
     @inductor_config.patch("_use_fp64_for_unbacked_floats", True)
     @patch(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -9,6 +9,7 @@ import torch
 import torch._inductor.lowering as inductor_lowering
 from torch import Tensor
 from torch._C import FileCheck
+from torch._higher_order_ops import foreach_map
 from torch._inductor import config, inductor_prims, ir, utils
 from torch._inductor.fx_passes.misc_patterns import _misc_patterns_init
 from torch._inductor.lowering import clone as lowering_clone, register_lowering
@@ -149,12 +150,12 @@ def _simulate_float8_e4m3fn_uint8_storage():
     with (
         mock.patch.object(
             triton_utils,
-            "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
+            "use_uint8_triton_storage_for_cuda_fp8",
             force_uint8_storage,
         ),
         mock.patch.object(
             triton_codegen,
-            "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
+            "use_uint8_triton_storage_for_cuda_fp8",
             force_uint8_storage,
         ),
         mock.patch.object(
@@ -170,10 +171,6 @@ class TestFP8Types(TestCase):
     @onlyCUDA
     @skipIfRocm
     @config.patch({"force_disable_caches": True})
-    @unittest.skip(
-        "Disabled due to CI failures; see "
-        "https://github.com/pytorch/pytorch/issues/189560"
-    )
     def test_float8_e4m3fn_uint8_decode_codegen(self, device):
         from torch._inductor.graph import GraphLowering
 
@@ -305,6 +302,270 @@ class TestFP8Types(TestCase):
 
         torch.testing.assert_close(y0_fp8, x, rtol=5e-1, atol=5e-1)
         torch.testing.assert_close(y1_fp8, x, rtol=5e-1, atol=5e-1)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @skipIfRocm
+    @onlyCUDA
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "test_configs.runtime_triton_dtype_assert": True,
+        }
+    )
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    def test_cuda_unsupported_fp8_dequant_codegen(self, device, src_dtype):
+        def fp8_dequant_add(x, y):
+            value = x.to(torch.bfloat16)
+            return value + y, torch.isnan(value).int()
+
+        bits = torch.arange(256, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+        y = torch.arange(256, device=device, dtype=torch.bfloat16)
+        expected = fp8_dequant_add(x, y)
+        actual, code = run_and_get_code(
+            torch.compile(fp8_dequant_add, backend="inductor", fullgraph=True), x, y
+        )
+        source = "\n".join(code)
+        helper = {
+            torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
+            torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
+        }[src_dtype]
+
+        self.assertEqual(actual, expected)
+        self.assertIn("'*u8'", source)
+        self.assertIn(f"triton_helpers.{helper}", source)
+        self.assertIn(".dtype == tl.uint8", source)
+        self.assertNotIn("torch.ops.aten._to_copy", source)
+        self.assertNotIn("= torch.ops.prims.convert_element_type.default(", source)
+        self.assertEqual(source.count("async_compile.triton("), 1)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @skipIfRocm
+    @onlyCUDA
+    @config.patch({"force_disable_caches": True, "triton.use_block_ptr": True})
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    def test_cuda_unsupported_fp8_dequant_block_ptr(self, device, src_dtype):
+        def fp8_dequant_sum(x):
+            return x.float().sum(dim=-1)
+
+        bits = torch.full((17, 255), 0x40, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+        expected = fp8_dequant_sum(x)
+        actual, code = run_and_get_code(
+            torch.compile(fp8_dequant_sum, backend="inductor", fullgraph=True), x
+        )
+        source = "\n".join(code)
+        helper = {
+            torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
+            torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
+        }[src_dtype]
+
+        self.assertEqual(actual, expected)
+        self.assertIn("tl.make_block_ptr", source)
+        self.assertIn(f"triton_helpers.{helper}", source)
+        self.assertNotIn("= torch.ops.prims.convert_element_type.default(", source)
+        self.assertEqual(source.count("async_compile.triton("), 1)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @unittest.skipIf(
+        not has_triton_tma_device(), "Requires device-side TMA support in Triton"
+    )
+    @skipIfRocm
+    @onlyCUDA
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.use_tensor_descriptor": True,
+            "triton.enable_host_side_tma": False,
+            "assume_aligned_inputs": True,
+        }
+    )
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    def test_cuda_unsupported_fp8_dequant_tensor_descriptor(self, device, src_dtype):
+        def fp8_dequant_sum(x):
+            return x.float().sum(dim=-1)
+
+        # Keep the outer stride 16-byte aligned while making the inner extent
+        # require a masked descriptor load.
+        bits = torch.empty_strided(
+            (17, 255), (256, 1), device=device, dtype=torch.uint8
+        ).fill_(0x40)
+        x = bits.view(src_dtype)
+        expected = fp8_dequant_sum(x)
+        actual, code = run_and_get_code(
+            torch.compile(fp8_dequant_sum, backend="inductor", fullgraph=True), x
+        )
+        source = "\n".join(code)
+        helper = {
+            torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
+            torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
+        }[src_dtype]
+
+        self.assertEqual(actual, expected)
+        self.assertIn("tl.make_tensor_descriptor", source)
+        self.assertIn(f"triton_helpers.{helper}", source)
+        self.assertNotIn("= torch.ops.prims.convert_element_type.default(", source)
+        self.assertEqual(source.count("async_compile.triton("), 1)
+
+    def test_fnuz_conversion_missing_metadata_falls_back(self, device):
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("x")
+        conversion = graph.call_function(
+            torch.ops.prims.convert_element_type.default,
+            args=(inp, torch.float32),
+        )
+        graph.call_function(torch.ops.aten.clone.default, args=(conversion,))
+
+        self.assertTrue(
+            inductor_lowering._fnuz_conversion_leaves_floating_domain(conversion)
+        )
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @skipIfRocm
+    @onlyCUDA
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    @parametrize(
+        "dst_dtype",
+        (torch.float16, torch.bfloat16, torch.float32, torch.float64),
+    )
+    def test_cuda_unsupported_fp8_dequant_all_encodings(
+        self, device, src_dtype, dst_dtype
+    ):
+        uint_dtype = {
+            torch.float16: torch.uint16,
+            torch.bfloat16: torch.uint16,
+            torch.float32: torch.uint32,
+            torch.float64: torch.uint64,
+        }[dst_dtype]
+
+        def fp8_dequant(x):
+            return x.to(dst_dtype)
+
+        bits = torch.arange(256, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+        expected = fp8_dequant(x)
+        actual, code = run_and_get_code(
+            torch.compile(fp8_dequant, backend="inductor", fullgraph=True), x
+        )
+        source = "\n".join(code)
+        helper = {
+            torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
+            torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
+        }[src_dtype]
+
+        finite = bits != 0x80
+        self.assertEqual(
+            actual[finite].view(uint_dtype), expected[finite].view(uint_dtype)
+        )
+        self.assertEqual(torch.isnan(actual), torch.isnan(expected))
+        self.assertEqual(torch.signbit(actual), torch.signbit(expected))
+        self.assertIn(f"triton_helpers.{helper}", source)
+        self.assertNotIn("= torch.ops.prims.convert_element_type.default(", source)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @skipIfRocm
+    @onlyCUDA
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    def test_cuda_unsupported_fp8_dequant_non_float_users_fall_back(
+        self, device, src_dtype
+    ):
+        def fp8_dequant_integral_casts(x):
+            value = x.float()
+            return value.long(), (value + 1).int()
+
+        bits = torch.full((8,), 0x80, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+        expected = fp8_dequant_integral_casts(x)
+        actual, code = run_and_get_code(
+            torch.compile(
+                fp8_dequant_integral_casts,
+                backend="inductor",
+                fullgraph=True,
+            ),
+            x,
+        )
+        source = "\n".join(code)
+
+        self.assertEqual(actual, expected)
+        self.assertIn("torch.ops.prims.convert_element_type.default", source)
+        self.assertNotIn("fnuz_to_float32", source)
+        self.assertNotIn("'*u8'", source)
+
+        def fp8_dequant_copy(x):
+            return torch.empty(x.shape, device=x.device, dtype=torch.int64).copy_(
+                x.float()
+            )
+
+        def fp8_dequant_slice_scatter(x):
+            dst = torch.zeros((x.numel() + 2,), device=x.device, dtype=torch.int64)
+            return torch.slice_scatter(
+                dst, x.float(), dim=0, start=1, end=x.numel() + 1
+            )
+
+        for op in (fp8_dequant_copy, fp8_dequant_slice_scatter):
+            with self.subTest(op=op):
+                expected = op(x)
+                actual, code = run_and_get_code(
+                    torch.compile(op, backend="inductor", fullgraph=True), x
+                )
+                source = "\n".join(code)
+
+                self.assertEqual(actual, expected)
+                self.assertIn("torch.ops.prims.convert_element_type.default", source)
+                self.assertNotIn("fnuz_to_float32", source)
+                self.assertNotIn("'*u8'", source)
+
+        def fp8_dequant_foreach_map(x):
+            value = x.float()
+            return foreach_map(lambda item: item.long().float(), [value])
+
+        expected = fp8_dequant_foreach_map(x)
+        actual, code = run_and_get_code(
+            torch.compile(
+                fp8_dequant_foreach_map,
+                backend="inductor",
+                fullgraph=True,
+            ),
+            x,
+        )
+        source = "\n".join(code)
+
+        self.assertEqual(actual, expected)
+        self.assertIn("torch.ops.prims.convert_element_type.default", source)
+        self.assertNotIn("fnuz_to_float32", source)
+        self.assertNotIn("'*u8'", source)
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
+    @skipIfRocm
+    @onlyCUDA
+    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
+    def test_cuda_unsupported_fp8_ops_fall_back(self, device, src_dtype):
+        def fp8_equal(x):
+            return x == x
+
+        def to_int64(x):
+            return x.to(torch.int64)
+
+        bits = torch.arange(256, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+
+        ops_and_fallbacks = (
+            (fp8_equal, "torch.ops.aten.eq.Tensor"),
+            (torch.isnan, "torch.ops.aten.isnan.default"),
+            (to_int64, "torch.ops.prims.convert_element_type.default"),
+        )
+        for op, fallback in ops_and_fallbacks:
+            with self.subTest(op=op):
+                expected = op(x)
+                actual, code = run_and_get_code(
+                    torch.compile(op, backend="inductor", fullgraph=True), x
+                )
+                source = "\n".join(code)
+
+                self.assertEqual(actual, expected)
+                self.assertIn(fallback, source)
+                self.assertNotIn("fnuz_to_float32", source)
+                self.assertNotIn("'*u8'", source)
 
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
     @skipIfRocm

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -137,7 +137,7 @@ from .triton_utils import (
     should_unwrap_unspec_arg,
     signature_to_meta,
     use_block_ptr_enabled,
-    use_uint8_triton_storage_for_cuda_float8_e4m3fn,
+    use_uint8_triton_storage_for_cuda_fp8,
 )
 from .wrapper import SymbolicCallArg
 
@@ -1380,10 +1380,13 @@ class TritonOverrides(OpOverrides):
                 V.kernel.min_elem_per_thread,
             )
 
-        if src_dtype is not None and use_uint8_triton_storage_for_cuda_float8_e4m3fn(
-            src_dtype
-        ):
-            x = f"triton_helpers.fp8e4m3fn_to_float32({x})"
+        if src_dtype is not None and use_uint8_triton_storage_for_cuda_fp8(src_dtype):
+            helper = {
+                torch.float8_e4m3fn: "fp8e4m3fn_to_float32",
+                torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
+                torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
+            }[src_dtype]
+            x = f"triton_helpers.{helper}({x})"
             src_dtype = torch.float32
 
         if dtype == torch.bool:
@@ -4332,6 +4335,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             - other: Modified additional parameters string with boundary check options
         """
         check = indexing.boundary_check()
+        # Raw-byte FP8 loads spell zero padding as an integer.  Triton's block
+        # pointer and tensor descriptor APIs use the floating-point spelling
+        # for the same zero-padding semantics.
+        if other == ", other=0":
+            other = ", other=0.0"
         if isinstance(indexing, TensorDescriptorOptions):
             if check and other:
                 # The TMA API currently does not support padding values
@@ -4888,7 +4896,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         indirect_indexing = self.is_indirect_indexing(index)
         original_index = index
         dtype = V.graph.get_dtype(name)
-        uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
+        uses_uint8_storage = use_uint8_triton_storage_for_cuda_fp8(dtype, var)
+        if uses_uint8_storage:
+            # The graph dtype remains FP8 so a following to_dtype can select
+            # the software decoder, but the load itself reads a *u8 argument.
+            dtype = torch.uint8
 
         if config.triton.enable_host_side_tma:
             if self._host_tma_non_materializable_buffers is None:

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -15,6 +15,7 @@ from ..utils import (
     _type_of,
     device_supports_fp64,
     expr_fits_within_32bit,
+    is_triton_fp8_dtype_supported,
     triton_version_uses_attrs_dict,
 )
 from ..virtualized import V
@@ -69,15 +70,23 @@ def should_unwrap_unspec_arg(name: str):
     return False
 
 
-def use_uint8_triton_storage_for_cuda_float8_e4m3fn(
+def use_uint8_triton_storage_for_cuda_fp8(
     dtype: torch.dtype,
     arg_name: str | None = None,
     *,
     device: torch.device | None = None,
 ) -> bool:
-    # Triton rejects fp8e4nv pointer types before sm89, but eager CUDA can
-    # still dequantize float8_e4m3fn values by treating storage as raw bytes.
-    if dtype != torch.float8_e4m3fn or torch.version.hip is not None:
+    # Triton rejects these pointer types on CUDA targets where they are not
+    # supported, but eager CUDA can still dequantize them from raw bytes.
+    if (
+        dtype
+        not in (
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2fnuz,
+        )
+        or torch.version.hip is not None
+    ):
         return False
     if arg_name is not None and not arg_name.startswith("in_ptr"):
         return False
@@ -91,7 +100,17 @@ def use_uint8_triton_storage_for_cuda_float8_e4m3fn(
     if device.type != "cuda":
         return False
 
-    return DeviceProperties.create(device).cc < 89
+    properties = DeviceProperties.create(device)
+    if dtype == torch.float8_e4m3fn:
+        # Preserve the established precursor behavior even if a mismatched
+        # Triton build does not expose target capability metadata.
+        return properties.cc < 89
+    return not is_triton_fp8_dtype_supported(
+        dtype,
+        triton_backend="cuda",
+        triton_arch=properties.cc,
+        warp_size=32,
+    )
 
 
 def signature_of(
@@ -110,7 +129,7 @@ def signature_of(
                 return "fp32"
             else:
                 return new_typ
-        elif use_uint8_triton_storage_for_cuda_float8_e4m3fn(arg.dtype, arg.name):
+        elif use_uint8_triton_storage_for_cuda_fp8(arg.dtype, arg.name):
             return "*u8"
         else:
             return typ

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2781,6 +2781,42 @@ def _warn_complex_not_supported():
     )
 
 
+def _fnuz_conversion_leaves_floating_domain(node: torch.fx.Node) -> bool:
+    """Return whether floating dataflow produces a non-floating numeric tensor."""
+    pending = list(node.users)
+    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    while pending:
+        user = pending.pop()
+        if user in seen:
+            continue
+        seen.add(user)
+        if user.op == "output":
+            continue
+        # Higher-order operators can inline subgraphs whose intermediate
+        # dtypes are not represented by the outer node's metadata.  Keep the
+        # conversion materialized at that boundary so a hidden float-to-int
+        # cast cannot observe LLVM's target-dependent NaN conversion.
+        if isinstance(user.target, torch._ops.HigherOrderOperator):
+            return True
+        if "val" not in user.meta:
+            # Missing dtype metadata cannot prove that this branch stays in
+            # the floating domain. Keep the conversion materialized.
+            return True
+        tensor_values = [
+            value
+            for value in pytree.tree_leaves(user.meta["val"])
+            if isinstance(value, torch.Tensor)
+        ]
+        for value in tensor_values:
+            if not value.dtype.is_floating_point and value.dtype != torch.bool:
+                return True
+        # Boolean predicates do not perform a numeric NaN conversion.  Stop
+        # those branches so a later bool-to-int cast does not cause fallback.
+        if any(value.dtype.is_floating_point for value in tensor_values):
+            pending.extend(user.users)
+    return False
+
+
 # There are some types (CPU) which we accept as input but not as
 # output.
 def unsupported_input_tensor(t: torch.Tensor, node=None):
@@ -2796,33 +2832,53 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
     if t.is_sparse:
         return True
 
+    # Keep these checks here because they are specific to Inductor/Triton.
     if not is_triton_fp8_dtype_supported(t.dtype, t.device):
-        from .codegen.triton_utils import (
-            use_uint8_triton_storage_for_cuda_float8_e4m3fn,
-        )
+        from .codegen.triton_utils import use_uint8_triton_storage_for_cuda_fp8
 
-        if not use_uint8_triton_storage_for_cuda_float8_e4m3fn(
-            t.dtype, device=t.device
-        ):
+        if not use_uint8_triton_storage_for_cuda_fp8(t.dtype, device=t.device):
             return True
 
-        # uint8 storage reinterprets fp8 bytes: allow bitcast, views, memory
-        # movement, and dequant (convert out of fp8)
+        # uint8 storage reinterprets fp8 bytes. Bitcasts, views, and memory
+        # movement preserve those bytes. CUDA scaled_mm only supports e4m3fn,
+        # while FNUZ inputs are limited to conversion into an ordinary float.
         if not node:
             return True
-        return not (
-            isinstance(node.target, torch._ops.OpOverload)
-            and node.target
-            in (
-                aten.view.dtype,
-                aten.cat.default,
-                aten.clone.default,
-                aten._scaled_mm.default,
-                aten._scaled_mm_v2.default,
-                prims.convert_element_type.default,
+        if not isinstance(node.target, torch._ops.OpOverload):
+            return True
+        if node.target in (
+            aten.view.dtype,
+            aten.cat.default,
+            aten.clone.default,
+        ) or is_view(node.target):
+            return False
+        if t.dtype == torch.float8_e4m3fn and node.target in (
+            aten._scaled_mm.default,
+            aten._scaled_mm_v2.default,
+        ):
+            return False
+        if node.target == prims.convert_element_type.default:
+            if t.dtype == torch.float8_e4m3fn:
+                return False
+            dst_dtype = (
+                node.args[1] if len(node.args) >= 2 else node.kwargs.get("dtype")
             )
-            or (isinstance(node.target, torch._ops.OpOverload) and is_view(node.target))
-        )
+            if dst_dtype not in (
+                torch.float16,
+                torch.bfloat16,
+                torch.float32,
+                torch.float64,
+            ):
+                return True
+            # Triton and eager CUDA differ when a NaN is converted to an
+            # integral dtype, and compiler scheduling can expose LLVM poison
+            # values.  This includes implicit casts in copy/scatter lowerings,
+            # so keep the original conversion on fallback if its floating
+            # dataflow reaches any non-floating numeric tensor.
+            if _fnuz_conversion_leaves_floating_domain(node):
+                return True
+            return False
+        return True
 
     if t.dtype == torch.float8_e8m0fnu:
         if not node:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -187,6 +187,42 @@ def fp8e4m3fn_to_float32(x):
 
 
 @triton.jit
+def fp8e4m3fnuz_to_float32(x):
+    x_u32 = x.to(tl.uint32)
+    sign = (x_u32 & 0x80) << 24
+    exp = (x_u32 >> 3) & 0xF
+    mant = x_u32 & 0x7
+
+    normal_bits = sign | ((exp + 119) << 23) | (mant << 20)
+    normal = normal_bits.to(tl.float32, bitcast=True)
+
+    subnormal_abs = mant.to(tl.float32) * 0.0009765625
+    subnormal_bits = subnormal_abs.to(tl.uint32, bitcast=True) | sign
+    subnormal = subnormal_bits.to(tl.float32, bitcast=True)
+
+    result = tl.where(exp == 0, subnormal, normal)
+    return tl.where(x_u32 == 0x80, float("nan"), result)
+
+
+@triton.jit
+def fp8e5m2fnuz_to_float32(x):
+    x_u32 = x.to(tl.uint32)
+    sign = (x_u32 & 0x80) << 24
+    exp = (x_u32 >> 2) & 0x1F
+    mant = x_u32 & 0x3
+
+    normal_bits = sign | ((exp + 111) << 23) | (mant << 21)
+    normal = normal_bits.to(tl.float32, bitcast=True)
+
+    subnormal_abs = mant.to(tl.float32) * 0.00000762939453125
+    subnormal_bits = subnormal_abs.to(tl.uint32, bitcast=True) | sign
+    subnormal = subnormal_bits.to(tl.float32, bitcast=True)
+
+    result = tl.where(exp == 0, subnormal, normal)
+    return tl.where(x_u32 == 0x80, float("nan"), result)
+
+
+@triton.jit
 def div_floor_integer(a, b):
     # NOTE: a // b is C division, but we want floor division
     # Based on c10::div_floor_integer


### PR DESCRIPTION
CUDA Inductor currently lowers an unsupported FNUZ FP8 input conversion to a separate ATen kernel before it schedules the graph. This occurs in vLLM MoE inference when an FP8 expert output is converted before a residual add and RMSNorm:

```py
shared_output + fused_output.to(shared_output.dtype)
```

This pattern starts two CUDA kernels and materializes the converted tensor. An `unrolled_elementwise_kernel` converts the FNUZ tensor. A Triton kernel then performs the add and RMSNorm. The extra launch and temporary tensor are especially expensive for latency-bound inference.

This PR reads unsupported CUDA FNUZ inputs through `uint8` pointers and decodes each value inside the generated Triton kernel. The target pattern then runs as one CUDA kernel. This lets Inductor fuse the conversion, add, and RMSNorm instead of materializing a temporary BF16 tensor.

The measured speedup ranged from 1.277–4.299× on H100 and 1.526–4.205× on GB200 across verified latency-, memory-, and compute-bound cases.

The new path applies only to direct conversions to FP16, BF16, FP32, or FP64. Byte-preserving views and data movement keep the existing behavior.

## Implementation

The Triton NVIDIA backend does not list `fp8e4b8` or `fp8e5b16` as supported pointer types. `is_triton_fp8_dtype_supported()` rejects these inputs during lowering. This rejection occurs before code generation, so Inductor cannot fuse the conversion.

PR #189561 recently fixed lowering for E4M3FN inputs that use `uint8` storage on pre-SM89 CUDA devices. This PR builds on that path:

- generalizes the private input-storage helper to E4M3FN, E4M3FNUZ, and
  E5M2FNUZ
- keeps the existing E4M3FN rule for CUDA targets below SM89
- queries the Triton `supported_fp8_dtypes` list for each FNUZ type
- adds software decoders for E4M3FNUZ bias 8 and E5M2FNUZ bias 16
- decodes subnormal values, signed values, and the `0x80` NaN encoding
- permits FNUZ value conversion only for supported floating destinations
- keeps implicit copy and scatter casts on fallback when they produce
  integral values
- materializes the conversion before higher-order-operator boundaries
- treats missing downstream dtype metadata as unsafe
- tracks raw-byte loads as `uint8` for runtime dtype assertions and descriptors
- accepts integer zero padding from raw-byte block-pointer loads
- keeps the existing check that rejects unsupported FNUZ outputs

If Triton adds native support for a FNUZ type, the target query disables the software storage path for that type.

The existing fallback remains for:

- direct FNUZ arithmetic
- FNUZ output tensors
- unsupported destination types
- FNUZ `scaled_mm`
- decoded values that reach an integral or complex tensor
- decoded values that reach a higher-order operator

The last rule protects inlined subgraphs that hide intermediate types from the outer graph. Boolean predicate branches can still fuse.

## Validation

The tests convert all 256 storage bytes for both FNUZ formats. They use FP16, BF16, FP32, and FP64 destinations. The tests compare all 255 finite encodings bit-for-bit. For byte `0x80`, they compare `isnan` and `signbit` behavior. PyTorch does not guarantee NaN payload propagation.

New tests:

- `TestCodegenTriton.test_signature_of_unsupported_cuda_fp8_uses_uint8_inputs`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_codegen`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_block_ptr`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_tensor_descriptor`
- `TestFP8Types.test_fnuz_conversion_missing_metadata_falls_back`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_all_encodings`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_non_float_users_fall_back`
- `TestFP8Types.test_cuda_unsupported_fp8_ops_fall_back`

Direct-operation fallback protects the `0x80` NaN encoding. Older Triton paths decoded this byte as zero. A direct `abs` operation could then produce `+0`.

<details>
<summary>Performance results and profiler evidence</summary>

## Performance

The benchmark used this order: baseline, patch, patch, baseline. Each pass started a new process with new Inductor and Triton caches. The table reports the mean of two medians. The paired range shows the speedup from each baseline and patch pair. Each baseline case launched two CUDA kernels. Each patched case launched one CUDA kernel.

| GPU | Case | Dtype | Baseline (µs) | Patched (µs) | Speedup | Paired range |
|---|---|---|---:|---:|---:|---:|
| H100 80GB HBM3 | latency RMS, 1×4096 | E4M3FNUZ | 22.882 | 6.276 | 3.646× | 3.521–3.775× |
| H100 80GB HBM3 | latency RMS, 1×4096 | E5M2FNUZ | 23.411 | 6.362 | 3.680× | 3.599–3.760× |
| H100 80GB HBM3 | target RMS, 64×4096 | E4M3FNUZ | 13.741 | 6.086 | 2.258× | 2.221–2.296× |
| H100 80GB HBM3 | target RMS, 64×4096 | E5M2FNUZ | 26.119 | 6.075 | 4.299× | 4.124–4.483× |
| H100 80GB HBM3 | memory streams, 33,554,432 elements | E4M3FNUZ | 601.597 | 457.809 | 1.314× | 1.314–1.314× |
| H100 80GB HBM3 | memory streams, 33,554,432 elements | E5M2FNUZ | 603.457 | 458.042 | 1.317× | 1.317–1.318× |
| H100 80GB HBM3 | compute FMA, 4,194,304 elements | E4M3FNUZ | 59.011 | 46.223 | 1.277× | 1.274–1.279× |
| H100 80GB HBM3 | compute FMA, 4,194,304 elements | E5M2FNUZ | 61.075 | 46.243 | 1.321× | 1.319–1.323× |
| GB200 | latency RMS, 1×4096 | E4M3FNUZ | 145.569 | 43.618 | 3.337× | 3.134–3.523× |
| GB200 | latency RMS, 1×4096 | E5M2FNUZ | 143.637 | 42.747 | 3.360× | 3.038–3.679× |
| GB200 | target RMS, 64×4096 | E4M3FNUZ | 108.127 | 25.715 | 4.205× | 3.828–4.599× |
| GB200 | target RMS, 64×4096 | E5M2FNUZ | 141.018 | 43.058 | 3.275× | 3.135–3.410× |
| GB200 | memory streams, 33,554,432 elements | E4M3FNUZ | 306.866 | 201.105 | 1.526× | 1.525–1.527× |
| GB200 | memory streams, 33,554,432 elements | E5M2FNUZ | 311.990 | 201.050 | 1.552× | 1.550–1.554× |
| GB200 | compute FMA, 4,194,304 elements | E4M3FNUZ | 106.027 | 38.970 | 2.721× | 2.557–2.884× |
| GB200 | compute FMA, 4,194,304 elements | E5M2FNUZ | 139.695 | 54.055 | 2.584× | 2.441–2.740× |

Nsight Compute measurements on each GPU define the regime labels. Tensor size alone did not define a regime.

| GPU | Regime | Grid / waves per SM | DRAM throughput | SM throughput | FMA active / occupancy |
|---|---|---:|---:|---:|---:|
| H100 | latency | 1 / 0 | 0.197–0.210% | 0.166–0.182% | underfilled |
| H100 | memory | 65,536 / 62.06 | 91.379–91.646% | 11.635–11.668% | DRAM-bound |
| H100 | compute | 8,192 / 7.76 | 15.90–15.95% | 84.51–84.66% | 78.30–78.44% / 88.12–88.57% |
| GB200 | latency | 1 / 0 | 0.059–0.065% | 0.080–0.089% | underfilled |
| GB200 | memory | 65,536 / 53.89 | 92.198–92.798% | 22.978–23.056% | DRAM-bound |
| GB200 | compute | 8,192 / 6.74 | 6.79–6.80% | 78.39–78.58% | 78.35–78.55% / 88.43–88.58% |

The memory case transfers 41 algorithmic bytes per element through eight side streams. The compute case executes 519 algorithmic FLOPs and transfers 9 bytes per element. It uses four FMAs in each of 64 iterations.

</details>

<details>
<summary>Inline PTX experiment</summary>

## Why this does not use inline PTX

PTX provides packed OCP `.e4m3x2` and `.e5m2x2` conversions. It does not provide a FNUZ conversion. An adapted instruction improved E4M3FNUZ decoder performance by 1.17–1.20×. E5M2FNUZ performance fell to 0.73–0.74× of the software decoder. Fused and memory tests gave mixed or slower results. The patch therefore keeps the portable integer and bitcast decoder.

</details>

<details>
<summary>References and related issues</summary>

## References

- E4M3FN `uint8`-storage precursor:
  https://github.com/pytorch/pytorch/commit/53648df8a70b7acdc52d6dbd8e92add8f64015f7
- Bit-decoder precedent: https://github.com/pytorch/pytorch/pull/190593

## Related Issues

- standard E4M3FN support on older CUDA targets:
  https://github.com/pytorch/pytorch/issues/184081 and
  https://github.com/pytorch/pytorch/issues/189560
- ROCm FNUZ mappings: https://github.com/pytorch/ao/issues/4135
- Triton FNUZ conversion behavior:
  https://github.com/triton-lang/triton/pull/10747 and
  https://github.com/triton-lang/triton/pull/9603
- PyTorch NaN-payload scope:
  https://github.com/pytorch/pytorch/issues/188680

</details>

## BC

This PR changes no public API. ROCm behavior does not change. Unsupported CUDA cases outside the direct floating-point conversion path keep the existing fallback.

Generated with Codex and GPT-5.6-sol


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo