### PR TITLE
[Testcase Refactoring] Classify exitstack tests by hardware

### DIFF
--- a/test/dynamo/test_exitstack.py
+++ b/test/dynamo/test_exitstack.py
@@ -4,7 +4,7 @@ import sys
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 @contextlib.contextmanager
@@ -18,6 +18,8 @@ def set_default_dtype(dtype):
 
 
 class TestExitStack(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.enable_trace_unittest


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo exitstack tests.

## Changes
- Import HardwareClassification for the test file.
- Mark TestExitStack as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_exitstack.py
git diff --check -- test/dynamo/test_exitstack.py
npu-run-suite npu  ./test_exitstack.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98