### PR TITLE
[Testcase Refactoring] Classify exc tests by hardware

### DIFF
--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -27,6 +27,7 @@ from torch._dynamo.exc import (
 from torch._dynamo.variables.base import SourceLocation
 from torch.testing._internal.common_device_type import skipIf
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_FBCODE,
     munge_exc,
     skipIfWindows,
@@ -67,6 +68,8 @@ def _format_multiline_source_location() -> str:
 
 
 class ExcTests(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     maxDiff = None
 
     @torch._dynamo.config.patch(suppress_errors=True)


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo exception diagnostics tests.

## Changes
- Import HardwareClassification for the test file.
- Mark ExcTests as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_exc.py
git diff --check -- test/dynamo/test_exc.py
npu-run-suite npu  ./test_exc.py
```
ok

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98