### PR TITLE
[Testcase Refactoring] Classify enum tests by hardware

### DIFF
--- a/test/dynamo/test_enum.py
+++ b/test/dynamo/test_enum.py
@@ -7,10 +7,13 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same, skipIfNotPy312
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class EnumTests(torch._dynamo.test_case.TestCase):
     """Tests for enum support in torch.compile."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_enum_as_dict_key(self):
         class MyEnum(enum.Enum):


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo enum tests.

## Changes
- Import HardwareClassification for the test file.
- Mark EnumTests as HardwareClassification.GENERIC.

## Test plan
```bash
python -m py_compile test/dynamo/test_enum.py
git diff --check -- test/dynamo/test_enum.py
npu-run-suite npu  ./test_enum.py
```
ok
### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98