### PR TITLE
[Testcase Refactoring] 1. Add ‘instantiate_device_type_tests‘ to generalize device types. 2. Add proper ‘hw_classification’ attribute to test classes

### DIFF
--- a/test/inductor/test_mem_estimation.py
+++ b/test/inductor/test_mem_estimation.py
@@ -25,6 +25,11 @@ def tensor_storage_id(tensor):
     return tensor._typed_storage()._cdata
 
 
+def make_device_filter(device):
+    dev_type = torch.device(device).type
+    return lambda d: d.type == dev_type
+
+
 class FakeTensorMemoryProfilerMode(TorchDispatchMode):
     def __init__(self, device_filter: Callable[[torch.device], bool] | None = None):
         # counter of storage ids to live references
@@ -175,9 +180,7 @@ class TestMemoryTracker(InductorTestCase):
 
     def test_memory_tracker_original_order(self, device):
         """Test that MemoryTracker works correctly with original scheduling order and matches runtime profiling."""
-
-        dev_type = torch.device(device).type
-        df = lambda device: device.type == dev_type
+        device_filter = make_device_filter(device)
 
         def create_inputs_and_weights():
             """Create inputs and weights on device."""
@@ -201,7 +204,7 @@ class TestMemoryTracker(InductorTestCase):
             fx_graph = make_fx(fn)(x, w1, w2)
 
             # Test MemoryTracker with original order
-            memory_tracker = MemoryTracker(fx_graph.graph, device_filter=df)
+            memory_tracker = MemoryTracker(fx_graph.graph, device_filter=device_filter)
 
             # Schedule nodes in original order
             compute_nodes = [
@@ -216,7 +219,7 @@ class TestMemoryTracker(InductorTestCase):
             memory_tracker_peak = memory_tracker.get_current_memory_bytes()
 
             # Compare with runtime profiling using FakeTensorMemoryProfilerMode
-            profiler = FakeTensorMemoryProfilerMode(device_filter=df)
+            profiler = FakeTensorMemoryProfilerMode(device_filter=device_filter)
 
             with profiler:
                 x_runtime, w1_runtime, w2_runtime = create_inputs_and_weights()
@@ -235,9 +238,7 @@ class TestMemoryTracker(InductorTestCase):
 
     def test_memory_tracker_different_scheduling(self, device):
         """Test that different scheduling orders produce different memory usage patterns."""
-
-        dev_type = torch.device(device).type
-        df = lambda device: device.type == dev_type
+        device_filter = make_device_filter(device)
 
         def foo(primals_1):
             zeros = torch.zeros_like(primals_1)  # Create zeros tensor
@@ -263,7 +264,7 @@ class TestMemoryTracker(InductorTestCase):
 
             # Test original order: zeros_like, add, sum
             # zeros gets freed after sum (last use of zeros)
-            memory_tracker1 = MemoryTracker(fx_graph.graph, device_filter=df)
+            memory_tracker1 = MemoryTracker(fx_graph.graph, device_filter=device_filter)
             memory_profile1 = []
             initial_mem = memory_tracker1.get_current_memory_bytes()
 
@@ -276,7 +277,7 @@ class TestMemoryTracker(InductorTestCase):
 
             # Test different order: zeros_like, sum, add
             # zeros gets freed after add (last use of zeros in new order)
-            memory_tracker2 = MemoryTracker(fx_graph.graph, device_filter=df)
+            memory_tracker2 = MemoryTracker(fx_graph.graph, device_filter=device_filter)
             memory_profile2 = []
 
             # Alternative schedule: change which operation is the last use of zeros

--- a/test/inductor/test_mem_estimation.py
+++ b/test/inductor/test_mem_estimation.py
@@ -13,18 +13,16 @@ from torch._inductor.fx_passes.memory_estimator import (
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_map_only
+from torch.utils._triton import has_triton
 from torch.utils.weak import WeakIdKeyDictionary
 
 
 def tensor_storage_id(tensor):
     return tensor._typed_storage()._cdata
-
-
-def device_filter(device):
-    return device.type == GPU_TYPE
 
 
 class FakeTensorMemoryProfilerMode(TorchDispatchMode):
@@ -79,15 +77,17 @@ class FakeTensorMemoryProfilerMode(TorchDispatchMode):
 
 
 class TestMemoryProfilingResNet(InductorTestCase):
-    def test_simple_linear_layers(self):
-        """Test with a simple sequential model with explicit weights on CUDA."""
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_simple_linear_layers(self, device):
+        """Test with a simple sequential model with explicit weights on device."""
 
         def create_inputs_and_weights():
-            """Create inputs and weights on CUDA."""
-            x = torch.randn(32, 1000, device=GPU_TYPE)
-            w1 = torch.randn(500, 1000, device=GPU_TYPE)
-            w2 = torch.randn(100, 500, device=GPU_TYPE)
-            w3 = torch.randn(10, 100, device=GPU_TYPE)
+            """Create inputs and weights on device."""
+            x = torch.randn(32, 1000, device=device)
+            w1 = torch.randn(500, 1000, device=device)
+            w2 = torch.randn(100, 500, device=device)
+            w3 = torch.randn(10, 100, device=device)
             return x, w1, w2, w3
 
         def fn(x, w1, w2, w3):
@@ -124,15 +124,15 @@ class TestMemoryProfilingResNet(InductorTestCase):
 
             self.assertEqual(fx_peak, runtime_peak)
 
-    def test_conv_network(self):
+    def test_conv_network(self, device):
         """Test with a convolutional network."""
 
         def create_inputs_and_weights():
-            """Create inputs and weights on CUDA."""
-            x = torch.randn(8, 3, 224, 224, device=GPU_TYPE)
-            conv1_weight = torch.randn(64, 3, 3, 3, device=GPU_TYPE)
-            conv2_weight = torch.randn(128, 64, 3, 3, device=GPU_TYPE)
-            linear_weight = torch.randn(10, 128 * 56 * 56, device=GPU_TYPE)
+            """Create inputs and weights on device."""
+            x = torch.randn(8, 3, 224, 224, device=device)
+            conv1_weight = torch.randn(64, 3, 3, 3, device=device)
+            conv2_weight = torch.randn(128, 64, 3, 3, device=device)
+            linear_weight = torch.randn(10, 128 * 56 * 56, device=device)
             return x, conv1_weight, conv2_weight, linear_weight
 
         def fn(x, conv1_weight, conv2_weight, linear_weight):
@@ -171,14 +171,19 @@ class TestMemoryProfilingResNet(InductorTestCase):
 
 
 class TestMemoryTracker(InductorTestCase):
-    def test_memory_tracker_original_order(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_memory_tracker_original_order(self, device):
         """Test that MemoryTracker works correctly with original scheduling order and matches runtime profiling."""
 
+        dev_type = torch.device(device).type
+        df = lambda device: device.type == dev_type
+
         def create_inputs_and_weights():
-            """Create inputs and weights on CUDA."""
-            x = torch.randn(32, 100, device=GPU_TYPE)
-            w1 = torch.randn(100, 50, device=GPU_TYPE)
-            w2 = torch.randn(50, 10, device=GPU_TYPE)
+            """Create inputs and weights on device."""
+            x = torch.randn(32, 100, device=device)
+            w1 = torch.randn(100, 50, device=device)
+            w2 = torch.randn(50, 10, device=device)
             return x, w1, w2
 
         def fn(x, w1, w2):
@@ -196,7 +201,7 @@ class TestMemoryTracker(InductorTestCase):
             fx_graph = make_fx(fn)(x, w1, w2)
 
             # Test MemoryTracker with original order
-            memory_tracker = MemoryTracker(fx_graph.graph, device_filter=device_filter)
+            memory_tracker = MemoryTracker(fx_graph.graph, device_filter=df)
 
             # Schedule nodes in original order
             compute_nodes = [
@@ -211,7 +216,7 @@ class TestMemoryTracker(InductorTestCase):
             memory_tracker_peak = memory_tracker.get_current_memory_bytes()
 
             # Compare with runtime profiling using FakeTensorMemoryProfilerMode
-            profiler = FakeTensorMemoryProfilerMode(device_filter=device_filter)
+            profiler = FakeTensorMemoryProfilerMode(device_filter=df)
 
             with profiler:
                 x_runtime, w1_runtime, w2_runtime = create_inputs_and_weights()
@@ -228,8 +233,11 @@ class TestMemoryTracker(InductorTestCase):
                 runtime_peak, 0, "Runtime profiler should track memory usage"
             )
 
-    def test_memory_tracker_different_scheduling(self):
+    def test_memory_tracker_different_scheduling(self, device):
         """Test that different scheduling orders produce different memory usage patterns."""
+
+        dev_type = torch.device(device).type
+        df = lambda device: device.type == dev_type
 
         def foo(primals_1):
             zeros = torch.zeros_like(primals_1)  # Create zeros tensor
@@ -241,7 +249,7 @@ class TestMemoryTracker(InductorTestCase):
 
         with FakeTensorMode():
             # Create input
-            primals_1 = torch.randn(1000, 1000, device=GPU_TYPE)
+            primals_1 = torch.randn(1000, 1000, device=device)
 
             # Trace the function
             fx_graph = make_fx(foo)(primals_1)
@@ -255,7 +263,7 @@ class TestMemoryTracker(InductorTestCase):
 
             # Test original order: zeros_like, add, sum
             # zeros gets freed after sum (last use of zeros)
-            memory_tracker1 = MemoryTracker(fx_graph.graph, device_filter=device_filter)
+            memory_tracker1 = MemoryTracker(fx_graph.graph, device_filter=df)
             memory_profile1 = []
             initial_mem = memory_tracker1.get_current_memory_bytes()
 
@@ -268,7 +276,7 @@ class TestMemoryTracker(InductorTestCase):
 
             # Test different order: zeros_like, sum, add
             # zeros gets freed after add (last use of zeros in new order)
-            memory_tracker2 = MemoryTracker(fx_graph.graph, device_filter=device_filter)
+            memory_tracker2 = MemoryTracker(fx_graph.graph, device_filter=df)
             memory_profile2 = []
 
             # Alternative schedule: change which operation is the last use of zeros
@@ -341,6 +349,14 @@ class TestMemoryTracker(InductorTestCase):
             )
 
 
+instantiate_device_type_tests(
+    TestMemoryProfilingResNet, globals(), except_for="cpu", allow_xpu=True
+)
+
+instantiate_device_type_tests(
+    TestMemoryTracker, globals(), except_for="cpu", allow_xpu=True
+)
+
 if __name__ == "__main__":
-    if HAS_GPU:
+    if has_triton():
         run_tests(needs="filelock")


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Adds `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_mem_estimation.py
python test/inductor/test_mem_estimation.py -v --hw-classification ACCELERATOR

Verified locally that 'TestMemoryProfilingResNet' and 'TestMemoryTracker' are supported accelerator types, and multiple test cases are generated.

## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo