### PR TITLE
[autograd] Fix torch.sum backward when dtype= requests complex output from real input

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3571,6 +3571,27 @@ class TestReductions(TestCase):
         test_reduction(torch.cumprod, False)
         test_reduction(torch.logcumsumexp, False, takes_dtype=False)
 
+    @ops(filter(lambda op: op.name == 'sum', reduction_ops),
+         dtypes=OpDTypes.none)
+    @skipIfMPS
+    def test_reduce_dtype_real_to_complex(self, device, dtype, op):
+        """Test backward of reduction ops with real->complex dtype
+        conversion (Issue #192719)."""
+        x = torch.randn(3, 3, dtype=torch.float, requires_grad=True, device=device)
+
+        for complex_dtype in (torch.complex64, torch.complex128):
+            # Without dim
+            out = op(x, dtype=complex_dtype)
+            grad, = torch.autograd.grad([out], [x])
+            self.assertEqual(grad.dtype, torch.float)
+
+            # With dim
+            gi = torch.randn(out.shape, dtype=complex_dtype, device=device)
+            grad, = torch.autograd.grad(
+                [op(x, dim=0, dtype=complex_dtype)], [x], gi,
+            )
+            self.assertEqual(grad.dtype, torch.float)
+
     @ops(reference_masked_ops)
     def test_reference_masked(self, device, dtype, op):
         """Test masked reduction operations on strided-only tensors using

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1714,17 +1714,17 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes())
+      self: grad.to(self.scalar_type()).expand_symint(self.sym_sizes())
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) when that is supported
-      self: ones_like(self) * grad
+      self: ones_like(self) * grad.to(self.scalar_type())
       result: auto_linear
 
 - name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: sum_backward(grad, self.sym_sizes(), dim, keepdim)
+      self: sum_backward(grad.to(self.scalar_type()), self.sym_sizes(), dim, keepdim)
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this function once semantics for nested tensor expand have been settled on


### PR DESCRIPTION
## Summary

Fixes #192719 — `torch.sum(x, dtype=torch.complex128)` on a real-valued `x` with `requires_grad` raises `RuntimeError` during `backward()`.

### Root cause

When `sum(x, dtype=complex_dtype)` is called on a real input, the forward output is complex. The autograd backward formula (`grad.expand_symint(self.sym_sizes())`) passes the complex gradient directly to the real input, which the engine rejects.

### Fix

Cast the gradient back to the input's scalar type before expanding, matching the pattern already used by `nansum`, `cumprod`, and `cumsum`:

- `sum(Tensor self, *, ScalarType? dtype=None)`: `grad.to(self.scalar_type()).expand_symint(self.sym_sizes())`
- `sum.dim_IntList`: `sum_backward(grad.to(self.scalar_type()), ...)`
- AutogradNestedTensor: `ones_like(self) * grad.to(self.scalar_type())`

When dtypes already match, `.to()` is a no-op. When casting from complex back to real, `.to()` extracts the real part, which is the mathematically correct gradient.

### Duplicate check

No open PRs reference issue #192719.

### AI Disclosure

> This PR was developed with AI assistance (Claude Code). The implementation has been reviewed by a human.