### PR TITLE
Fix backward of torch.sum with dtype=complex on real-valued input

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1714,7 +1714,7 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes())
+      self: grad.to(self.scalar_type()).expand_symint(self.sym_sizes())
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) when that is supported
@@ -1724,7 +1724,7 @@
 - name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: sum_backward(grad, self.sym_sizes(), dim, keepdim)
+      self: sum_backward(grad.to(self.scalar_type()), self.sym_sizes(), dim, keepdim)
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this function once semantics for nested tensor expand have been settled on

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22407,6 +22407,10 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         promotes_int_to_int64=True,
+        generate_args_kwargs=lambda t, dim=None, keepdim=False: (
+            (yield ((), {})) or
+            (t.dtype.is_floating_point and (yield ((), {"dtype": torch.complex128 if t.dtype == torch.float64 else torch.complex64})))
+        ),
         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
         ref=reference_reduction_numpy(np.sum),


### PR DESCRIPTION
## Summary

When `torch.sum(x, dtype=complex_dtype)` is called on a real-valued `x` with `requires_grad=True`, the forward pass correctly produces a complex output, but the backward pass raises:

```
RuntimeError: Expected isFloatingType(grad.scalar_type()) || (input_is_complex == grad_is_complex) to be true, but got false.
```

**Root cause:** The derivative formula for `sum` in `tools/autograd/derivatives.yaml` returns `grad` (complex dtype) directly as the gradient for `self` (real dtype). The autograd engine requires gradient dtype to match the input dtype.

**Fix:** Cast `grad` to `self.scalar_type()` before returning it, matching the pattern already used by `nansum_backward` in the same file.

## Changes

- `tools/autograd/derivatives.yaml`: Added `grad.to(self.scalar_type())` to both `sum` overloads (`sum.Tensor` and `sum.dim_IntList`)

## Test Plan

```python
import torch
x = torch.ones([2, 2], dtype=torch.float64, requires_grad=True)
y_sum = torch.sum(x, dtype=torch.complex128)
y_sum.backward(torch.ones_like(y_sum))
print(x.grad)  # tensor([[1., 1.], [1., 1.]], dtype=torch.float64)
# Previously raised RuntimeError
```

---

*This PR was partially authored with an AI assistant.*