### PR TITLE
Fix MemoryTracker operation count after loading stats

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,6 +1,13 @@
 # Owner(s): ["oncall: distributed"]
 import os
+import pickle
+import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+
+import hypothesis.strategies as st
+from hypothesis import example, given, settings
 
 import torch
 import torch.nn as nn
@@ -9,6 +16,64 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestMemoryTracker(TestCase):
+    @settings(max_examples=10, deadline=200000)
+    @given(
+        memory_values=st.lists(
+            st.floats(
+                min_value=0.0,
+                max_value=1_000_000.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            min_size=2,
+            max_size=10,
+        )
+    )
+    @example(memory_values=[1.0, 3.0])
+    def test_save_and_load(self, memory_values):
+        tracker = MemoryTracker()
+        tracker.memories_allocated = {
+            index: (f"operation_{index}", value)
+            for index, value in enumerate(memory_values)
+        }
+        tracker.memories_active = {
+            index: (f"operation_{index}", value + 1.0)
+            for index, value in enumerate(memory_values)
+        }
+        tracker.memories_reserved = {
+            index: (f"operation_{index}", value + 2.0)
+            for index, value in enumerate(memory_values)
+        }
+        tracker._op_index = len(memory_values)
+
+        with redirect_stdout(StringIO()) as expected_output:
+            tracker.summary()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "memory.trace")
+            tracker.save_stats(path)
+
+            loaded_tracker = MemoryTracker()
+            loaded_tracker.load(path)
+            with redirect_stdout(StringIO()) as loaded_output:
+                loaded_tracker.summary()
+
+            with open(path, "rb") as f:
+                legacy_stats = pickle.load(f)
+            legacy_stats.pop("op_index")
+            with open(path, "wb") as f:
+                pickle.dump(legacy_stats, f, pickle.HIGHEST_PROTOCOL)
+
+            legacy_tracker = MemoryTracker()
+            legacy_tracker.load(path)
+            with redirect_stdout(StringIO()) as legacy_output:
+                legacy_tracker.summary()
+
+            self.assertEqual(loaded_tracker._op_index, tracker._op_index)
+            self.assertEqual(legacy_tracker._op_index, tracker._op_index)
+            self.assertEqual(loaded_output.getvalue(), expected_output.getvalue())
+            self.assertEqual(legacy_output.getvalue(), expected_output.getvalue())
+
     @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
     def test_local_model(self):
         """

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,7 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
## Issue

Fixes #191397

## Summary

- Persist `MemoryTracker`'s operation count when saving statistics.
- Restore the operation count when loading statistics, with a fallback for traces saved before the new field was added.
- Add randomized save/load coverage for both current and legacy trace formats.

## Checklist

- [x] Passes lint (targeted `spin lint` for the changed files)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No.

## Testing

- `test/distributed/_tools/test_memory_tracker.py`
  - 2 tests passed, including 10 Hypothesis-generated save/load cases and an explicit regression case.
- Targeted `spin lint` passed for:
  - `torch/distributed/_tools/memory_tracker.py`
  - `test/distributed/_tools/test_memory_tracker.py`