### PR TITLE
Fix unnecessary origDist allocation in CUDA multinomial

### DIFF
--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -381,18 +381,6 @@ void multinomial_with_replacement_kernel_impl(
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       // Generic, slow implementation with memory allocations
-
-      // For sampling without replacement, we modify the distribution
-      // for subsequent samples in this space
-      Tensor origDist = native::empty_like(
-          self_v,
-          std::nullopt /* dtype */,
-          std::nullopt /* layout */,
-          std::nullopt /* device */,
-          std::nullopt /* pin_memory */,
-          LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-      origDist.copy_(self_v);
-
       Tensor normDist = native::empty_like(
           self_v,
           std::nullopt /* dtype */,
@@ -410,7 +398,7 @@ void multinomial_with_replacement_kernel_impl(
           LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
       // Renorm along rows
-      normDist.copy_(origDist);
+      normDist.copy_(self_v);
       renormRows(normDist);
 
       // Prefix sum along rows


### PR DESCRIPTION
Fixes #192594

### Description
This PR removes an unnecessary input-sized memory allocation (`origDist`) in the generic path of `torch.multinomial` for CUDA when `replacement=True` and `num_samples > 1`. 

As noted in the issue, `origDist` was a leftover from an older implementation and was simply acting as an unused pass-through to `normDist` without being modified. Removing it reduces the peak extra memory overhead during this operation.

cc @fxlin0261 
