### PR TITLE
Deprecate the profiler's with_modules option

### DIFF
--- a/benchmarks/distributed/bench_all_to_all_nd.py
+++ b/benchmarks/distributed/bench_all_to_all_nd.py
@@ -236,7 +236,6 @@ class AllToAllNdBenchmark(MultiProcContinuousTest):
             schedule=step_schedule,
             record_shapes=True,
             with_stack=True,
-            with_modules=True,
         ) as prof:
             for _ in range(profile_steps):
                 symm_mem.all_to_all_nd(

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4698,7 +4698,6 @@ def run(runner, args, original_dir=None):
                 "record_shapes": True,
                 "profile_memory": True,
                 "with_stack": True,
-                "with_modules": True,
                 "activities": activities,
             }
 

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -56,7 +56,6 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
             ],
             record_shapes=True,
             with_stack=True,
-            with_modules=True,
         )
         return group_name, prof
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -758,18 +758,20 @@ class TestProfiler(TestCase):
             "TOP(C)::forward.",
         ]
         with TemporaryFileName(mode="w+") as fname:
-            with profile(
-                activities=[torch.profiler.ProfilerActivity.CPU],
-                with_modules=True,
-            ) as prof:
-                model(input_a, input_b)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                with profile(
+                    activities=[torch.profiler.ProfilerActivity.CPU],
+                    with_modules=True,
+                ) as prof:
+                    model(input_a, input_b)
             prof.export_chrome_trace(fname)
             with open(fname) as f:
                 trace = json.load(f)
                 if "traceEvents" not in trace:
                     raise AssertionError("Expected 'traceEvents' in trace")
                 events = trace["traceEvents"]
-                found_memory_events = False
+                checked = 0
                 for evt in events:
                     if "name" not in evt:
                         raise AssertionError("Expected 'name' in event")
@@ -778,10 +780,14 @@ class TestProfiler(TestCase):
                         if "Module Hierarchy" in evt["args"]:
                             hierarchy = evt["args"]["Module Hierarchy"]
                             if op_name in op_to_module_hierarchy:
+                                checked += 1
                                 if hierarchy not in op_to_module_hierarchy[op_name]:
                                     raise AssertionError(
                                         f"Expected hierarchy '{hierarchy}' in {op_to_module_hierarchy[op_name]}"
                                     )
+                # Without this the comparisons above are vacuous: a trace with no
+                # module hierarchy at all satisfies every branch.
+                self.assertGreater(checked, 0)
 
     def test_high_level_trace(self):
         """Checks that python side high level events are recorded."""
@@ -1018,6 +1024,13 @@ class TestProfiler(TestCase):
                     experimental_config=cfg,
                 ):
                     pass
+
+    def test_with_modules_deprecated(self):
+        # with_modules only collects data for TorchScript models and is on its
+        # way out: passing it must warn with FutureWarning and not error.
+        with self.assertWarnsRegex(FutureWarning, "with_modules is deprecated"):
+            with profile(activities=[ProfilerActivity.CPU], with_modules=True):
+                torch.ones(1)
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @parametrize("use_cuda", [False, True])

--- a/test/test_tsan.py
+++ b/test/test_tsan.py
@@ -39,7 +39,7 @@ class TestTSan(TestCase):
 
         def profile_work():
             for _ in range(30):
-                with torch.profiler.profile(with_stack=True, with_modules=True):
+                with torch.profiler.profile(with_stack=True):
                     torch.ones(10)
 
         run_concurrently([profile_work] + [work] * 8)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -152,8 +152,12 @@ class profile:
             corresponding to the callstack of the op. e.g. If module A's forward call's
             module B's forward which contains an aten::add op,
             then aten::add's module hierarchy is A.B
-            Note that this support exist, at the moment, only for TorchScript models
-            and not eager mode models.
+
+            .. deprecated::
+                ``with_modules`` is deprecated and will be removed in a future version.
+                It only collects data for TorchScript models, which are themselves
+                deprecated, and does nothing in eager mode. Use ``with_stack=True``,
+                which records ``nn.Module`` events for eager models.
 
         use_kineto (bool, optional): experimental, enable profiling with Kineto profiler.
 
@@ -260,6 +264,15 @@ class profile:
             warn(
                 "profiler_metrics and profiler_measure_per_kernel are deprecated "
                 "and ignored. These options will be removed in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if with_modules:
+            warn(
+                "with_modules is deprecated and will be removed in a future release. "
+                "It only collects data for TorchScript models, which are themselves "
+                "deprecated, and does nothing in eager mode. Use with_stack=True, "
+                "which records nn.Module events for eager models.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -176,8 +176,12 @@ class _KinetoProfile:
             corresponding to the callstack of the op. e.g. If module A's forward call's
             module B's forward which contains an aten::add op,
             then aten::add's module hierarchy is A.B
-            Note that this support exists, at the moment, only for TorchScript models
-            and not eager mode models.
+
+            .. deprecated::
+                ``with_modules`` is deprecated and will be removed in a future version.
+                It only collects data for TorchScript models, which are themselves
+                deprecated, and does nothing in eager mode. Use ``with_stack=True``,
+                which records ``nn.Module`` events for eager models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
         execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Observer object.
@@ -901,8 +905,12 @@ class profile(_KinetoProfile):
             corresponding to the callstack of the op. e.g. If module A's forward call's
             module B's forward which contains an aten::add op,
             then aten::add's module hierarchy is A.B
-            Note that this support exists, at the moment, only for TorchScript models
-            and not eager mode models.
+
+            .. deprecated::
+                ``with_modules`` is deprecated and will be removed in a future version.
+                It only collects data for TorchScript models, which are themselves
+                deprecated, and does nothing in eager mode. Use ``with_stack=True``,
+                which records ``nn.Module`` events for eager models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used for Kineto library features. Note, backward compatibility is not guaranteed.
         execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Observer object.


### PR DESCRIPTION
**Motivation**

`with_modules` attaches a "Module Hierarchy" string to each op, but it only collects anything for TorchScript models. It reads the TorchScript interpreter's thread-local frame stack, which is empty in eager mode, so an eager run pays for the argument and gets nothing back. TorchScript has been deprecated since 2.5 and `torch.jit.script` now raises a `FutureWarning`, so the option has no supported way left to produce data. Its other consumer, `KinetoEdgeCPUProfiler`, serves Lite Interpreter, deprecated in favor of ExecuTorch.

Nothing downstream reads the field. It is written by `AddTensorboardFields`, but the TensorBoard plugin only ever consumed "Call stack" and has since been deleted from kineto. `KinetoEvent::moduleHierarchy` is not bound to Python, and `hasModuleHierarchy` has no callers anywhere.

Eager users wanting module attribution already get `nn.Module` events from `with_stack=True`.

**Approach**

The warning goes in `torch.autograd.profiler.profile.__init__`, the one constructor every public path reaches, since `torch.profiler.profile` and `_KinetoProfile` both build one in `prepare_trace`. Warning there fires once per profiler rather than once per layer, and sits beside the `profiler_metrics` deprecation that solves the same plumbing problem the same way. 

The four in-tree callers passing `with_modules=True` are all eager, so they collect nothing today and are dropped rather than carried through the deprecation.

`test_module_hierarchy` asserted only inside `if "Module Hierarchy" in args`, so it passed with zero comparisons whenever the feature emitted nothing; the feature could have been gutted without turning CI red. It now counts its comparisons and requires at least one.

Only the Python surface is deprecated here. The C++ `ProfilerConfig` field, `collection.cpp`, the edge profiler, and kineto's `ClientInterface::prepare` signature are untouched; that removal belongs with Lite Interpreter's.

Authored with assistance from Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98