### PR TITLE
[pytorch] Add scoped custom-op opt-in to the FakeTensor dispatch cache (#192809)

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -12,8 +12,10 @@ import itertools
 import pickle
 import subprocess
 import sys
+import threading
 import unittest
 import weakref
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import numpy as np
@@ -3801,6 +3803,235 @@ class FakeTensorDispatchCache(TestCase):
 
             x.unsqueeze_(0)
             self.assertBypasses("inplace view", 1)
+
+    def test_cache_custom_ops_isolates_default_policy(self):
+        with torch.library._scoped_library(
+            "fake_tensor_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("identity(Tensor x) -> Tensor")
+            fake_kernel_calls = 0
+
+            @torch.library.register_fake(
+                "fake_tensor_cache_policy_test::identity", lib=lib
+            )
+            def identity_fake(x):
+                nonlocal fake_kernel_calls
+                fake_kernel_calls += 1
+                return torch.empty_strided(
+                    x.shape, x.stride(), dtype=x.dtype, device=x.device
+                )
+
+            op = torch.ops.fake_tensor_cache_policy_test.identity.default
+            mode = FakeTensorMode()
+            mode.cache_crosscheck_enabled = False
+            x = mode.from_tensor(torch.randn(3, 4).t())
+            FakeTensorMode.cache_clear()
+
+            try:
+                with mode:
+                    uncached = op(x)
+                    before_policy = FakeTensorMode.cache_info()
+                    self.assertBypasses("non-builtin", 1)
+
+                    with mode.cache_custom_ops((op,)):
+                        self.assertFalse(torch._library.utils.is_builtin(op))
+                        cache_miss = op(x)
+                        after_miss = FakeTensorMode.cache_info()
+                        cache_hit = op(x)
+                        after_hit = FakeTensorMode.cache_info()
+                        self.assertEqual(fake_kernel_calls, 2)
+
+                    default_policy = op(x)
+                    after_default = FakeTensorMode.cache_info()
+
+                expected_metadata = extract_tensor_metadata(uncached)
+                self.assertEqual(extract_tensor_metadata(cache_miss), expected_metadata)
+                self.assertEqual(extract_tensor_metadata(cache_hit), expected_metadata)
+                self.assertEqual(
+                    extract_tensor_metadata(default_policy), expected_metadata
+                )
+                self.assertEqual(after_miss.misses, before_policy.misses + 1)
+                self.assertEqual(after_hit.hits, after_miss.hits + 1)
+                self.assertEqual(after_default.bypasses.get("non-builtin"), 2)
+                self.assertEqual(fake_kernel_calls, 3)
+            finally:
+                FakeTensorMode.cache_clear()
+
+    def test_cache_custom_ops_nested_scope(self):
+        with torch.library._scoped_library(
+            "fake_tensor_nested_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("first(Tensor x) -> int")
+            lib.define("second(Tensor x) -> int")
+
+            @torch.library.register_fake(
+                "fake_tensor_nested_cache_policy_test::first", lib=lib
+            )
+            def first_fake(_x):
+                return 1
+
+            @torch.library.register_fake(
+                "fake_tensor_nested_cache_policy_test::second", lib=lib
+            )
+            def second_fake(_x):
+                return 2
+
+            first = torch.ops.fake_tensor_nested_cache_policy_test.first.default
+            second = torch.ops.fake_tensor_nested_cache_policy_test.second.default
+            mode = FakeTensorMode()
+            x = mode.from_tensor(torch.randn(4))
+            FakeTensorMode.cache_clear()
+
+            try:
+                with mode, mode.cache_custom_ops((first,)):
+                    first(x)
+                    first(x)
+                    with mode.cache_custom_ops((second,)):
+                        second(x)
+                        second(x)
+
+                    after_inner = FakeTensorMode.cache_info()
+                    second(x)
+                    after_second = FakeTensorMode.cache_info()
+                    first(x)
+                    after_first = FakeTensorMode.cache_info()
+
+                first(x)
+                after_outer = FakeTensorMode.cache_info()
+
+                self.assertEqual(after_inner.hits, 2)
+                self.assertEqual(after_inner.misses, 2)
+                self.assertEqual(after_second.bypasses.get("non-builtin"), 1)
+                self.assertEqual(after_first.hits, after_second.hits + 1)
+                self.assertEqual(after_outer.bypasses.get("non-builtin"), 2)
+            finally:
+                FakeTensorMode.cache_clear()
+
+    def test_cache_custom_ops_isolates_modes(self):
+        with torch.library._scoped_library(
+            "fake_tensor_mode_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("first(Tensor x) -> int")
+            lib.define("second(Tensor x) -> int")
+
+            @torch.library.register_fake(
+                "fake_tensor_mode_cache_policy_test::first", lib=lib
+            )
+            def first_fake(_x):
+                return 1
+
+            @torch.library.register_fake(
+                "fake_tensor_mode_cache_policy_test::second", lib=lib
+            )
+            def second_fake(_x):
+                return 2
+
+            first = torch.ops.fake_tensor_mode_cache_policy_test.first.default
+            second = torch.ops.fake_tensor_mode_cache_policy_test.second.default
+            first_mode = FakeTensorMode()
+            second_mode = FakeTensorMode()
+            first_x = first_mode.from_tensor(torch.randn(4))
+            second_x = second_mode.from_tensor(torch.randn(4))
+            FakeTensorMode.cache_clear()
+
+            try:
+                with (
+                    first_mode.cache_custom_ops((first,)),
+                    second_mode.cache_custom_ops((second,)),
+                ):
+                    with first_mode:
+                        first(first_x)
+                        first(first_x)
+                        second(first_x)
+                    with second_mode:
+                        first(second_x)
+                        second(second_x)
+                        second(second_x)
+
+                cache_info = FakeTensorMode.cache_info()
+                self.assertEqual(cache_info.hits, 2)
+                self.assertEqual(cache_info.misses, 2)
+                self.assertEqual(cache_info.bypasses.get("non-builtin"), 2)
+            finally:
+                FakeTensorMode.cache_clear()
+
+    def test_cache_custom_ops_isolates_threads(self):
+        with torch.library._scoped_library(
+            "fake_tensor_thread_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("first(Tensor x) -> int")
+            lib.define("second(Tensor x) -> int")
+            first = torch.ops.fake_tensor_thread_cache_policy_test.first.default
+            second = torch.ops.fake_tensor_thread_cache_policy_test.second.default
+            mode = FakeTensorMode()
+            barrier = threading.Barrier(2)
+
+            def active_ops(op):
+                with mode.cache_custom_ops((op,)):
+                    barrier.wait(timeout=5)
+                    return mode._cacheable_custom_ops()
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                first_future = executor.submit(active_ops, first)
+                second_future = executor.submit(active_ops, second)
+                self.assertEqual(first_future.result(timeout=5), frozenset((first,)))
+                self.assertEqual(second_future.result(timeout=5), frozenset((second,)))
+
+            self.assertEqual(mode._cacheable_custom_ops(), frozenset())
+
+    def test_cache_custom_ops_deepcopy_isolates_policy(self):
+        with torch.library._scoped_library(
+            "fake_tensor_deepcopy_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("identity(Tensor x) -> int")
+            op = torch.ops.fake_tensor_deepcopy_cache_policy_test.identity.default
+            mode = FakeTensorMode()
+
+            with mode.cache_custom_ops((op,)):
+                copied_mode = copy.deepcopy(mode)
+                self.assertEqual(mode._cacheable_custom_ops(), frozenset((op,)))
+                self.assertEqual(copied_mode._cacheable_custom_ops(), frozenset())
+
+            self.assertEqual(mode._cacheable_custom_ops(), frozenset())
+
+    def test_cache_custom_ops_bypasses_unbacked_symint(self):
+        with torch.library._scoped_library(
+            "fake_tensor_symint_cache_policy_test", "DEF"
+        ) as lib:
+            lib.define("dynamic_size(Tensor x) -> SymInt")
+
+            @torch.library.register_fake(
+                "fake_tensor_symint_cache_policy_test::dynamic_size", lib=lib
+            )
+            def dynamic_size_fake(_x):
+                return torch.library.get_ctx().new_dynamic_size()
+
+            op = torch.ops.fake_tensor_symint_cache_policy_test.dynamic_size.default
+            mode = FakeTensorMode(shape_env=ShapeEnv())
+            x = mode.from_tensor(torch.randn(4), static_shapes=True)
+            FakeTensorMode.cache_clear()
+
+            try:
+                with mode, mode.cache_custom_ops((op,)):
+                    first = op(x)
+                    second = op(x)
+
+                self.assertTrue(free_unbacked_symbols(first))
+                self.assertTrue(free_unbacked_symbols(second))
+                self.assertNotEqual(first.node.expr, second.node.expr)
+                self.assertHitsMisses(0, 0)
+                self.assertBypasses("unbacked symbol in output", 2)
+            finally:
+                FakeTensorMode.cache_clear()
+
+    def test_cache_custom_ops_reports_invalid_value(self):
+        invalid_op = "not an OpOverload"
+
+        with self.assertRaises(TypeError) as error:
+            with FakeTensorMode().cache_custom_ops((invalid_op,)):
+                pass
+
+        self.assertIn(repr(invalid_op), str(error.exception))
 
     def test_cache_default_dtype(self):
         """

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -13,6 +13,7 @@ import types
 import typing
 import weakref
 from collections import defaultdict
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, cast, Literal, TYPE_CHECKING, TypeGuard, TypeVar, Union
 from typing_extensions import Self, TypedDict, Unpack
@@ -81,6 +82,11 @@ pytree = torch.utils._pytree
 T = TypeVar("T")
 
 aten = torch._ops.ops.aten
+
+_EMPTY_CACHEABLE_CUSTOM_OPS: frozenset[OpOverload] = frozenset()
+_CACHEABLE_CUSTOM_OPS_BY_MODE: ContextVar[
+    dict[FakeTensorMode, frozenset[OpOverload]] | None
+] = ContextVar("fake_tensor_cacheable_custom_ops_by_mode", default=None)
 
 CONSTANT_NUMEL_LIMIT = 1
 
@@ -1759,6 +1765,46 @@ class FakeTensorMode(TorchDispatchMode):
     def is_infra_mode(cls) -> bool:
         return True
 
+    def _cacheable_custom_ops(self) -> frozenset[OpOverload]:
+        cacheable_ops_by_mode = _CACHEABLE_CUSTOM_OPS_BY_MODE.get()
+        if cacheable_ops_by_mode is None:
+            return _EMPTY_CACHEABLE_CUSTOM_OPS
+        return cacheable_ops_by_mode.get(self, _EMPTY_CACHEABLE_CUSTOM_OPS)
+
+    @contextlib.contextmanager
+    def cache_custom_ops(
+        self, ops: Iterable[OpOverload]
+    ) -> Generator[None, None, None]:
+        """Temporarily allow exact custom operator overloads in the dispatch cache.
+
+        For every op in ``ops``, the caller asserts that the fake kernel's output
+        metadata is a pure function of the input metadata: no unbacked SymInts
+        from ``ctx.new_dynamic_size()``, no aliasing returns, and no dependence
+        on mutable global state.
+        """
+        validated_ops: set[OpOverload] = set()
+        for op in ops:
+            if not isinstance(op, torch._ops.OpOverload):
+                raise TypeError(
+                    f"cache_custom_ops expects OpOverload values, got {op!r}"
+                )
+            validated_ops.add(op)
+
+        if not validated_ops:
+            yield
+            return
+
+        cacheable_ops_by_mode = _CACHEABLE_CUSTOM_OPS_BY_MODE.get()
+        updated_ops_by_mode = dict(cacheable_ops_by_mode or {})
+        updated_ops_by_mode[self] = (
+            updated_ops_by_mode.get(self, _EMPTY_CACHEABLE_CUSTOM_OPS) | validated_ops
+        )
+        token = _CACHEABLE_CUSTOM_OPS_BY_MODE.set(updated_ops_by_mode)
+        try:
+            yield
+        finally:
+            _CACHEABLE_CUSTOM_OPS_BY_MODE.reset(token)
+
     @classmethod
     def cache_info(cls) -> DispatchCacheInfo:
         """
@@ -1894,6 +1940,8 @@ class FakeTensorMode(TorchDispatchMode):
         is_tracing = torch.fx.experimental.proxy_tensor.get_proxy_mode() is not None
         key_values = [
             func,
+            # Keep opted-in custom-op entries separate from default negative entries.
+            func in self._cacheable_custom_ops(),
             # Capture the default_dtype mode since that can affect the output tensor,
             # e.g., when operating on constant float values.
             torch.get_default_dtype(),
@@ -1997,7 +2045,10 @@ class FakeTensorMode(TorchDispatchMode):
         if func.name() == "inductor::resize_storage_bytes_":
             raise _BypassDispatchCache("inductor::resize_storage_bytes_")
 
-        if not torch._library.utils.is_builtin(func):
+        if (
+            not library_utils.is_builtin(func)
+            and func not in self._cacheable_custom_ops()
+        ):
             raise _BypassDispatchCache("non-builtin")
 
         # In order to handle storage aliasing, we need to establish the alias
@@ -2253,6 +2304,8 @@ class FakeTensorMode(TorchDispatchMode):
                 )
 
         if isinstance(output, (int, torch.SymInt, type(None))):
+            if isinstance(output, torch.SymInt) and has_free_unbacked_symbols(output):
+                raise _BypassDispatchCache("unbacked symbol in output")
             output_info = _DispatchCacheEntryOutputInfo(
                 inplace_idx=None, metadata=None, view_idx=None, constant_value=output
             )


### PR DESCRIPTION
Summary:

ExecuTorch lowering is very slow because it repeatedly runs fake implementations for its backend operators. Many of these are safe to cache afaik as their output shapes, types, and devices depend only on their inputs. PyTorch currently skips all custom operators because it cannot make that assumption for arbitrary user code.

This diff adds a narrow opt-in: Callers can temporarily name exact custom `OpOverload` values they know are safe. Unselected custom operators keep the existing behavior. The selection is limited to the current execution and restored when the scope exits, including after errors. It is also included in the cache key, so cached results cannot leak outside the opt-in.

A single module-level `ContextVar` keeps nested and concurrent uses separate. A follow-up addition to Executorch will use this API for selected ExecuTorch backend operators and improves CombinedControl U55 lowering by 11.9%.

Test Plan:
Formatting, lint, and types:
- `arc f` and `arc lint` on all four changed files — clean
- `arc lint -e extra` on all four changed files — clean
- `arc pyre check-changed-targets` — no type errors

Correctness:
- `buck2 test fbcode//caffe2/test:fake_tensor -- test_cache_custom_ops` — 4 pass
- Exact `test_cpu_lower_aoti_ep_called` optimized invocation from CI — 1 pass
- Exact `test_cpu_lower_aoti_ep_called_split_after_export` optimized invocation — 1 pass
- Full `fbcode//caffe2/test:fake_tensor` — 342 pass, 105 skip; the same two thread-heavy guard tests hit their existing 60-second timeout and the pre-existing sparse `spdiags` test failed. The guard tests pass in isolation, and `spdiags` reproduces on the untouched parent.
- The tests verify default-policy isolation, cache miss then hit inside the opt-in, unchanged builtin classification, nested-scope restoration, isolation between modes, informative invalid-value errors, and that modes remain deepcopy-safe.

Differential Revision: D115385597


