### PR TITLE
Fix test_gather_object assertion for Python 3.14 PicklingError

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6,6 +6,7 @@ import json
 import math
 import operator
 import os
+import pickle
 import random
 import re
 import sys
@@ -6843,7 +6844,10 @@ class DistributedTest:
 
             b = Bar()
             gather_objects = [b for _ in range(dist.get_world_size())]
-            with self.assertRaises(AttributeError):
+            # Pickling a local class fails; the exception type depends on the
+            # Python version: AttributeError on <=3.13, PicklingError on >=3.14
+            # (CPython gh-139806). pickle.PickleError covers PicklingError.
+            with self.assertRaises((AttributeError, pickle.PickleError)):
                 dist.all_gather_object(
                     [None for _ in range(dist.get_world_size())],
                     gather_objects[self.rank],


### PR DESCRIPTION
## Summary

`test_gather_object` / `test_gather_object_subgroup` fail on Python 3.14. The test calls `all_gather_object` on a **local class** (unpicklable) and asserts an error. The exception type changed: **<=3.13** raised `AttributeError`, but **3.14** ([CPython gh-139806](https://github.com/python/cpython/issues/139806)) raises `PicklingError` eagerly from `pickle.whichmodule()` for `'<locals>'` names. `PicklingError` is a `PickleError`, not an `AttributeError`, so the stale `assertRaises(AttributeError)` no longer matches.

## Fix

Assert on the types raised across all supported versions (`python_min_version = 3.10`):

```python
with self.assertRaises((AttributeError, pickle.PickleError)):
    dist.all_gather_object(...)
```

## Test plan

On Python 3.14.4, assertRaises(AttributeError) around pickle.Pickler().dump() of a local class ERRORS with PicklingError, while assertRaises((AttributeError, pickle.PickleError)) PASSES; on 3.10-3.13 the real AttributeError is also matched (issubclass). Full test needs a 4-GPU nccl world:
`python -m pytest torch/testing/_internal/distributed/distributed_test.py -k test_gather_object -v`