### PR TITLE
[ROCm] Unskip expandable segment UTs on rocm 10.0+

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -645,12 +645,11 @@ print(t.is_pinned())
     @unittest.skipIf(
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
+    @unittest.skipIf(
+        EXPANDABLE_SEGMENTS and TEST_WITH_ROCM and getRocmVersion() < (10, 0),
+        "ROCm expandable segments OOM regression; fixed in ROCm 10.0",
+    )
     def test_out_of_memory(self):
-        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
-            self.skipTest(
-                "TestCuda.test_out_of_memory: OOM tensor flag is False on ROCm "
-                "expandable segments (7.14+)"
-            )
         tensor = torch.zeros(1024, device="cuda")
 
         oom_regex = (
@@ -752,13 +751,11 @@ print("RECOVERED")
     @unittest.skipIf(
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
+    @unittest.skipIf(
+        EXPANDABLE_SEGMENTS and TEST_WITH_ROCM and getRocmVersion() < (10, 0),
+        "ROCm expandable segments OOM regression; fixed in ROCm 10.0",
+    )
     def test_set_per_process_memory_fraction(self):
-        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
-            self.skipTest(
-                "ROCm 7.14+ expandable segments reports OOM below the expected "
-                "per-process memory fraction limit"
-            )
-
         torch.cuda.empty_cache()
         orig = torch.cuda.get_per_process_memory_fraction(0)
         torch.cuda.reset_peak_memory_stats(0)
@@ -10074,6 +10071,10 @@ class TestMemPool(TestCase):
         return original_ptr, new_ptr
 
     @serialTest()
+    @unittest.skipIf(
+        EXPANDABLE_SEGMENTS and TEST_WITH_ROCM and getRocmVersion() < (10, 0),
+        "ROCm expandable segments OOM recovery regression; fixed in ROCm 10.0",
+    )
     def test_mempool_oom_recovery_releases_cached_blocks(self):
         """Test that the allocator can release default-pool cached blocks to
         satisfy a new allocation when a user mempool is active.
@@ -10084,12 +10085,6 @@ class TestMemPool(TestCase):
           1. Default pool -- OOM recovery releases cached blocks, succeeds.
           2. use_mem_pool -- same recovery should work (the fix).
         """
-        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
-            self.skipTest(
-                "ROCm 7.14+ expandable segments OOMs before mempool cached "
-                "blocks can be recovered"
-            )
-
         MB = 1024 * 1024
         device = torch.device("cuda:0")
 


### PR DESCRIPTION
## Summary

Main still skips these expandable-segment OOM tests for `ROCm >= 7.14`, which also keeps them off ROCm 10.0. This PR inverts that gate: skip the **expandable-segment copies** on **ROCm < 10.0**, and run them on 10.0+. The default-allocator copies of the same tests are not skipped; those never hit the VMM bugs.

The skip is `EXPANDABLE_SEGMENTS and getRocmVersion() < (10, 0)` on:

- `test_out_of_memory`
- `test_set_per_process_memory_fraction`
- `test_mempool_oom_recovery_releases_cached_blocks`

`getRocmVersion()` is the product/SDK version (`torch.version.rocm`), not HIP. ROCm 10.0 reports HIP 7.15, so a HIP comparison against `(10, 0)` would skip 10.0 incorrectly.

Two separate ROCm bugs, both expandable-segments only:

1. **dma-buf FD leak on VMM shareable handles (ROCm 7.14).** Expandable segments allocate ~20 MiB `hipMemCreate` chunks with POSIX FD handles. 7.14 left dma-buf FDs open, so allocations failed at the FD cap while HIP still reported hundreds of GiB free. This is what `test_set_per_process_memory_fraction` and `test_mempool_oom_recovery_releases_cached_blocks` hit. Fixed by [ROCm/rocm-systems#7786](https://github.com/ROCm/rocm-systems/pull/7786); present in ROCm 10.0.

2. **Stale large-BAR CPU load after VMM physical OOM.** After a catchable expandable-segment OOM, GPU memory and D2H copies are correct, but a host load of the device pointer (large-BAR `.item()` fast path from #177023) can return the pre-OOM value. That fails `test_out_of_memory` after it catches OOM and does `tensor.fill_(1)`. This is HIP/HSA/KFD, not PyTorch allocator bookkeeping. A CUDAScalar workaround was tried and removed; later 10.x no longer reproduced.

## Test plan

- [x] ROCm 10.0+: expandable copies of the three tests run
- [x] CUDA / non-ROCm: no new skip

This PR is authored with AI assistance

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben