### PR TITLE
Honor configured shutdown timeout when stopping workers

### DIFF
--- a/test/distributed/elastic/agent/server/test/shutdown_timeout_test.py
+++ b/test/distributed/elastic/agent/server/test/shutdown_timeout_test.py
@@ -132,6 +132,25 @@ class ShutdownTimeoutTest(TestCase):
             # Verify close was called with correct timeout
             mock_pcontext.close.assert_called_once_with(signal.SIGTERM, 150)
 
+    def test_stop_workers_uses_configured_shutdown_timeout(self):
+        mock_spec = Mock(spec=WorkerSpec)
+        mock_spec.max_restarts = 3
+        mock_spec.rdzv_handler = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logs_specs = DefaultLogsSpecs(log_dir=tmpdir)
+            agent = LocalElasticAgent(
+                spec=mock_spec,
+                logs_specs=logs_specs,
+                start_method="spawn",
+                shutdown_timeout=150,
+            )
+            agent._pcontext = MagicMock()
+
+            agent._stop_workers(agent.get_worker_group())
+
+            agent._pcontext.close.assert_called_once_with(signal.SIGTERM, 150)
+
     @patch("torch.distributed.elastic.multiprocessing.api.PContext")
     def test_pcontext_close_receives_timeout(self, mock_pcontext_class):
         mock_pcontext = MagicMock()

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -395,7 +395,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
     def _stop_workers(self, worker_group: WorkerGroup) -> None:
-        self._shutdown()
+        self._shutdown(timeout=self._shutdown_timeout)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.


### PR DESCRIPTION
Fix for #119856. Follow-up to #172596.

PR #172596 wired shutdown_timeout through the SIGTERM signal path._stop_workers() (invoked during worker failures and elastic restarts) still silently reverted to 30 s.

The issue was detected on Codex (GPT-5.6 Sol) and fixed by the same and verified by me.