### PR TITLE
Return the documented shape from pixel_unshuffle for a zero-element input

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -47,10 +47,6 @@ Tensor pixel_shuffle_cpu(const Tensor& self, int64_t upscale_factor) {
 Tensor pixel_unshuffle_cpu(const Tensor& self, int64_t downscale_factor) {
   check_pixel_unshuffle_shapes(self, downscale_factor);
 
-  if (self.numel() == 0) {
-    return self.clone();
-  }
-
   // Format: (B1, ..., Bn), C, H, W
   std::vector<int64_t> output_sizes(self.sizes().begin(), self.sizes().end() - 3);
   output_sizes.insert(output_sizes.end(),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9843,6 +9843,16 @@ def sample_inputs_pixel_unshuffle(op_info, device, dtype, requires_grad, **kwarg
             (1, 1, 1, 0),
         ]
     )
+    # A downscale_factor of 1 leaves the shape alone, so the empty samples above
+    # cannot tell a correct output shape from the input shape being returned.
+    yield from (
+        SampleInput(make_arg(shape), downscale_factor=3)
+        for shape in [
+            (1, 0, 6, 6),
+            (1, 1, 0, 6),
+            (1, 1, 6, 0),
+        ]
+    )
 
 def sample_inputs_channel_shuffle(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)


### PR DESCRIPTION
`pixel_unshuffle_cpu` early-returns `self.clone()` when the input has no elements, before `output_sizes` is computed, so it hands back the **input** shape. Every other backend computes the documented one.

```python
x = torch.zeros(1, 0, 4, 4)
F.pixel_unshuffle(x, 2).shape            # (1, 0, 4, 4)   cpu
F.pixel_unshuffle(x.to("meta"), 2).shape # (1, 0, 2, 2)   meta
F.pixel_unshuffle(x.to("mps"), 2).shape  # (1, 0, 2, 2)   mps
```

`nn.PixelUnshuffle` documents `C_out = C * r^2`, `H_out = H / r`, `W_out = W / r` with no exception for empty inputs, and CUDA and meta both get there through the `CompositeExplicitAutogradNonFunctional` path. Every zero-element shape diverges, not just the zero-channel one:

```
shape           r   meta            cpu
(1, 0, 4, 4)    2   (1, 0, 2, 2)    (1, 0, 4, 4)
(0, 3, 4, 4)    2   (0, 12, 2, 2)   (0, 3, 4, 4)
(1, 2, 0, 4)    2   (1, 8, 0, 2)    (1, 2, 0, 4)
(1, 2, 4, 0)    2   (1, 8, 2, 0)    (1, 2, 4, 0)
(0, 4, 4)       2   (0, 2, 2)       (0, 4, 4)
```

The sibling `pixel_shuffle` matches meta on all the analogous shapes.

Beyond the shape itself, eager and `torch.compile` disagree on whether a program is even valid, because tracing uses the meta shape and CPU execution uses this one:

```python
def g(t):
    return F.pixel_unshuffle(t, 2) + torch.zeros(1, 0, 2, 2)

g(x)                  # RuntimeError: size mismatch, 4 vs 2
torch.compile(g)(x)   # runs, (1, 0, 2, 2)
```

## Why deleting it is safe

The early return came from #86262, which fixed the floating point exception reported in #85155. The fix that actually did that is the `output.numel() == 0` guard the same PR added lower down, and it is still there. That PR added the guard to **both** functions and additionally added this `self.numel() == 0` branch to `pixel_unshuffle_cpu` only; `pixel_shuffle_cpu` has never had it and is correct today.

Deleting it cannot bring the crash back. `check_pixel_unshuffle_shapes` runs first and has already established `downscale_factor > 0` and that both `H` and `W` divide by it, so the size arithmetic in between is safe, and the later guard still returns before `pixel_unshuffle_kernel`. The two functions become structurally identical again.

I cannot build ATen here, so I transcribed `pixel_unshuffle_cpu` line for line into Python and ran both variants against `meta` over twelve empty shape and factor combinations: 12 disagreements with the early return, 0 without it, and the `output.numel() == 0` guard returns before the kernel in every one of them. CI is the real check.

## Test

The reason this was never caught is in the OpInfo samples. `sample_inputs_pixel_unshuffle` has empty samples, but all of them use `downscale_factor=1`, where the input and output shapes coincide, so they cannot tell a correct output shape from the input being returned. Adding the same shapes at `downscale_factor=3` makes the CPU-vs-meta comparison in `test_meta` and `test_ops` fail before this change and pass after.

If you would rather not touch the shared samples, a direct assertion works too:

```python
self.assertEqual(F.pixel_unshuffle(torch.zeros(1, 0, 4, 4), 2).shape, torch.Size([1, 0, 2, 2]))
```

Happy to switch. I went with the samples because that is the shape of what #86262 itself added, and it covers every backend at once.


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki