### PR TITLE
[inductor] Only build the fx_graph_runnable repro when something logs it

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1430,11 +1430,22 @@ class _InProcessFxCompile(FxCompile):
                 f"graph {graph_id}",
             )
 
-            fd = io.StringIO()
-            torch._dynamo.repro.after_aot.save_graph_repro(
-                fd, gm, example_inputs, "inductor", save_dir=None
-            )
-            runnable_graph_str = fd.getvalue()
+            # Building this parses the source of every Triton kernel in the
+            # graph, and it is only ever used as a structured-trace artifact:
+            # logged here, and logged again by the FX graph cache when this
+            # graph is loaded from it. Produce it from payload_fn so that
+            # trace_structured's own "is anyone listening" check decides
+            # whether the work happens at all, and keep what it produced for
+            # the cache to replay.
+            produced: list[str] = []
+
+            def _fx_graph_runnable_payload() -> str:
+                fd = io.StringIO()
+                torch._dynamo.repro.after_aot.save_graph_repro(
+                    fd, gm, example_inputs, "inductor", save_dir=None
+                )
+                produced.append(fd.getvalue())
+                return produced[0]
 
             trace_structured(
                 "artifact",
@@ -1442,8 +1453,9 @@ class _InProcessFxCompile(FxCompile):
                     "name": "fx_graph_runnable",
                     "encoding": "string",
                 },
-                payload_fn=lambda: runnable_graph_str,
+                payload_fn=_fx_graph_runnable_payload,
             )
+            runnable_graph_str = produced[0] if produced else ""
 
             V.debug.fx_graph(gm, example_inputs)
             # TODO: Should we actually dump this?  It should be redundant with the aot


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #192821
* #192820
* #192817
* #192009
* #192675
* #192677
* __->__ #192818

runnable_graph_str is built on every Inductor compile and is only ever used as
a structured-trace artifact: logged here, and logged again by the FX graph cache
when the graph is loaded from it. Building it parses the source of every Triton
kernel in the graph. It was constructed eagerly and then handed to
trace_structured as a lambda, so the lazy-looking call site did the work
regardless of whether anything was listening.

Build it from payload_fn instead, so trace_structured's own "are there any trace
handlers" check decides whether the work happens, and keep whatever it produced
for the FX cache to replay. No duplicated enablement check, and it stays correct
if that gating ever becomes per-artifact.

Two effects on a FairChem UMA compile with no TORCH_TRACE:
  cold compile        54.9s -> 54.0s
  FX cache on disk     111MB -> 108MB

The disk figure is the more interesting one. The string is ~271KB per graph
(2.4MB across the 9 graphs here), prepare_for_serialization does not clear it,
so it is pickled into every cache entry: megabytes of debug text persisted by
default to re-log an artifact for a run that never asked for tracing.

Caveat: a graph compiled with tracing off now stores an empty string, so a later
FX-cache hit under tracing logs an empty fx_graph_runnable for that graph. With
tracing on at compile time the artifact is unchanged (verified: 9 artifacts,
2.4MB). Dropping the cached copy altogether would remove the disk cost too, and
is arguably more coherent since a repro belongs to the compile that produced it,
but that is a bigger behavioural call.

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo