### PR TITLE
[inductor] Skip symbolic size comparison when the sizes are the same objects

### DIFF
--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -92,6 +92,15 @@ def _is_fake_tensor_same(
     be supplied by users of this function."""
 
     def is_intlist_same(new, old):
+        # sym_eq builds a symbolic conjunction and statically_known_true then
+        # evaluates it, which is a lot of work for the common case where the
+        # two sizes/strides are the very same objects. Identity, or equality
+        # between concrete ints, already implies equality.
+        if len(new) == len(old) and all(
+            a is b or (type(a) is int and type(b) is int and a == b)
+            for a, b in zip(new, old)
+        ):
+            return True
         return statically_known_true(sym_eq(new, old))
 
     if type(new) is not type(old):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #192821
* #192820
* #192817
* #192675
* #192009
* #192677
* #192818
* __->__ #192819

_is_fake_tensor_same compares two FakeTensors' sizes and strides with
statically_known_true(sym_eq(new, old)), which builds a symbolic conjunction and
then evaluates it. In the common case the two sizes are the very same SymInt
objects, so all that machinery proves something already known.

Take an identity fast path first. Identity, or equality between concrete ints,
already implies equality, so this only skips work and never changes an answer.

This is on the post-grad path: on a FairChem UMA compile the comparison runs
9422 times, 4392 of them (47%) satisfy the fast path, and the symbolic
comparisons it avoids were a large part of the 55k SymNode operations inside
reinplace_inplaceable_ops alone.

Measured on UMA, interleaved runs: cold compile 54.05s -> 53.58s.

Test Plan:

```
python test/inductor/test_torchinductor.py
```

Failure set identical to baseline. The fast path was also checked against the
symbolic result on every call for a full compile: 9422 comparisons, 4392
fast-path hits, 0 cases where the fast path claimed equality that the symbolic
comparison denied.

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo