### PR TITLE
Remove ndmitchell as a typechecking approver

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -534,7 +534,6 @@
   approved_by:
   - lolpack
   - maggiemoss
-  - ndmitchell
   - kinto0
   mandatory_checks_name:
   - EasyCLA


### PR DESCRIPTION
Removed 'ndmitchell' from the list of approved reviewers. I used to be very active on the Pytorch type checking with Pyrefly, but now am working on other projects. The remaining approvers are all experts, so no loss of knowledge.