### PR TITLE
[Test][XPU] Enable XPU device coverage for SymPy tensor interpolation tests

### DIFF
--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -12,7 +12,10 @@ import sympy
 import torch
 import torch.fx as fx
 from sympy.core.relational import is_ge, is_gt, is_le, is_lt
-from torch.testing._internal.common_device_type import skipIf
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipIf,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -744,7 +747,7 @@ class TestSympyInterpDevice(TestCase):
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS
     )
-    def test_tensor_interp(self, fn):
+    def test_tensor_interp(self, device, fn):
         # Skip operations not implemented or not applicable for tensors
         if fn in ("div", "truncdiv", "int_truediv", "mod", "round_decimal"):
             return
@@ -779,7 +782,9 @@ class TestSympyInterpDevice(TestCase):
             with self.subTest(args=args):
                 tensor_args = [
                     torch.tensor(
-                        a, dtype=torch.double if isinstance(a, float) else torch.int64
+                        a,
+                        dtype=torch.double if isinstance(a, float) else torch.int64,
+                        device=device,
                     )
                     for a in args
                 ]
@@ -1325,7 +1330,7 @@ class TestCCodePrinting(TestCase):
 
 instantiate_parametrized_tests(TestValueRanges)
 instantiate_parametrized_tests(TestSympyInterp)
-instantiate_parametrized_tests(TestSympyInterpDevice)
+instantiate_device_type_tests(TestSympyInterpDevice, globals(), allow_xpu=True)
 instantiate_parametrized_tests(TestSympySolve)
 
 

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_device_type import (
     skipIf,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -623,6 +624,8 @@ class TestValueRanges(TestCase):
 
 
 class TestSympyInterp(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS
     )
@@ -743,6 +746,8 @@ class TestSympyInterp(TestCase):
 
 
 class TestSympyInterpDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
 
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -738,6 +738,9 @@ class TestSympyInterp(TestCase):
                     gm(*args),
                 )
 
+
+class TestSympyInterpDevice(TestCase):
+
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS
     )
@@ -1322,6 +1325,7 @@ class TestCCodePrinting(TestCase):
 
 instantiate_parametrized_tests(TestValueRanges)
 instantiate_parametrized_tests(TestSympyInterp)
+instantiate_parametrized_tests(TestSympyInterpDevice)
 instantiate_parametrized_tests(TestSympySolve)
 
 


### PR DESCRIPTION
Refactor test_sympy_utils.py to enable XPU support for tensor interpolation tests:

1) Split TestSympyInterp into two classes:
- TestSympyInterp: CPU-only symbolic tests (no device I/O)
- TestSympyInterpDevice: Device-generic tensor tests with XPU enabled

2) Add device parameter to test_tensor_interp() and generalize tensor creation

3) Add hardware classification (GENERIC and ACCELERATOR) for both classes 