### PR TITLE
Rename test owner label oncall: package/deploy -> module: package/deploy

### DIFF
--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -692,6 +692,10 @@
       "description": "Related to torch.optim"
     },
     {
+      "name": "module: package/deploy",
+      "description": "Add issue/PR to torch.package TODO board"
+    },
+    {
       "name": "module: padding",
       "description": ""
     },
@@ -1042,10 +1046,6 @@
     {
       "name": "oncall: mobile",
       "description": "Related to mobile support, including iOS and Android"
-    },
-    {
-      "name": "oncall: package/deploy",
-      "description": "Add issue/PR to torch.package TODO board"
     },
     {
       "name": "oncall: profiler",

--- a/test/package/package_a/test_all_leaf_modules_tracer.py
+++ b/test/package/package_a/test_all_leaf_modules_tracer.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from torch.fx import Tracer
 

--- a/test/package/package_a/test_module.py
+++ b/test/package/package_a/test_module.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import torch
 from torch.fx import wrap

--- a/test/package/package_a/test_nn_module.py
+++ b/test/package/package_a/test_nn_module.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import torch
 

--- a/test/package/package_c/test_module.py
+++ b/test/package/package_c/test_module.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import torch
 

--- a/test/package/test_analyze.py
+++ b/test/package/test_analyze.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import unittest
 

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import importlib
 from io import BytesIO

--- a/test/package/test_dependency_hooks.py
+++ b/test/package/test_dependency_hooks.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from torch.package._digraph import DiGraph
 from torch.testing._internal.common_utils import run_tests

--- a/test/package/test_directory_reader.py
+++ b/test/package/test_directory_reader.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import os
 import zipfile

--- a/test/package/test_glob_group.py
+++ b/test/package/test_glob_group.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from collections.abc import Iterable
 

--- a/test/package/test_importer.py
+++ b/test/package/test_importer.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 

--- a/test/package/test_load_bc_packages.py
+++ b/test/package/test_load_bc_packages.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from pathlib import Path
 from unittest import skipIf

--- a/test/package/test_mangling.py
+++ b/test/package/test_mangling.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 

--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import inspect
 import os

--- a/test/package/test_model.py
+++ b/test/package/test_model.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 from textwrap import dedent

--- a/test/package/test_package_fx.py
+++ b/test/package/test_package_fx.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 

--- a/test/package/test_package_script.py
+++ b/test/package/test_package_script.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 from textwrap import dedent

--- a/test/package/test_repackage.py
+++ b/test/package/test_repackage.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 

--- a/test/package/test_resources.py
+++ b/test/package/test_resources.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from io import BytesIO
 from sys import version_info

--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 import pickle
 from io import BytesIO

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -1,4 +1,4 @@
-# Owner(s): ["oncall: package/deploy"]
+# Owner(s): ["module: package/deploy"]
 
 from package.package_a.test_all_leaf_modules_tracer import (  # noqa: F401
     TestAllLeafModulesTracer,


### PR DESCRIPTION
## Author Notes

Renaming following the label update.

## Agent Notes

The text below was generated by an AI assistant (Claude Code), which also
authored the commit. It describes the root cause of the trunk lint failure and
the scope of the rename:

> The `oncall: package/deploy` GitHub label is being renamed to
> `module: package/deploy`. The TESTOWNERS lint validates every `# Owner(s):`
> header against the live PyTorch label list published at
> `ossci-metrics.s3.amazonaws.com/pytorch_labels.json`, so once the old label
> stopped appearing there the `lintrunner-noclang-all` job started failing on
> trunk with 21 `[invalid-label]` errors, one per `torch.package` test file.
> Trunk is green again only because the old label was temporarily re-created as
> a stopgap; this change is what lets it be deleted for good.
>
> This updates the owner headers in the 21 affected test files to the new
> label. The triage skill's cached label snapshot in
> `.claude/skills/triaging-issues/labels.json` carried the same stale entry, so
> it is moved to its new alphabetical position as well; that file is a local
> snapshot and does not affect CI.
>
> A repo-wide sweep found no remaining references to the old label in
> `.github/labeler.yml`, `label_to_label.yml`, `merge_rules.yaml`,
> `pytorch-probot.yml`, `CODEOWNERS`, `.ci/`, or `tools/`.
>
> Test plan:
>
> ```
> spin lint
> ```
>
> TESTOWNERS is the check that was failing and the only in-tree consumer of
> these headers; no test behavior changes.