### PR TITLE
[ROCm][CI] Update trunk-rocm-sandbox workflow to use new MI350 DPX runner labels

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -110,14 +110,10 @@ runner_mapping:
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
-  # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
-  # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
-  amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
-  amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
-  # amd-sandbox experiment routes trunk-rocm-sandbox gfx942 tests to AMD's dedicated
+  # amd-sandbox experiment routes trunk-rocm-sandbox tests to AMD's dedicated
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
-  amd-sandbox-linux.rocm.gpu.gfx942.1: amd-sandbox-linux.rocm.gpu.gfx942.1
-  amd-sandbox-linux.rocm.gpu.gfx942.2: amd-sandbox-linux.rocm.gpu.gfx942.2
+  amd-sandbox-linux.rocm.gpu.mi350.1: amd-sandbox-linux.rocm.gpu.mi350.1
+  amd-sandbox-linux.rocm.gpu.mi350.2: amd-sandbox-linux.rocm.gpu.mi350.2
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -42,15 +42,15 @@ jobs:
       check_experiments: amd-sandbox
 
   linux-noble-rocm-py3_12-build:
-    name: linux-noble-rocm-py3.12-mi300
+    name: linux-noble-rocm-py3.12-mi350
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      build-environment: linux-noble-rocm-py3.12-mi300
+      build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
-      # The amd-sandbox experiment routes the gfx942 test shards onto the
+      # The amd-sandbox experiment routes the mi350 test shards onto the
       # amd-sandbox- prefixed runner scale sets via the dedicated
       # amd-sandbox-label-type output (empty when the experiment is disabled, in
       # which case the canonical linux.rocm.gpu.mi350.* labels are used).
@@ -73,7 +73,7 @@ jobs:
     secrets: inherit
 
   linux-noble-rocm-py3_12-test:
-    name: linux-noble-rocm-py3.12-mi300
+    name: linux-noble-rocm-py3.12-mi350
     uses: ./.github/workflows/_rocm-test.yml
     needs:
       - linux-noble-rocm-py3_12-build

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -53,24 +53,22 @@ jobs:
       # The amd-sandbox experiment routes the gfx942 test shards onto the
       # amd-sandbox- prefixed runner scale sets via the dedicated
       # amd-sandbox-label-type output (empty when the experiment is disabled, in
-      # which case the canonical linux.rocm.gpu.gfx942.* labels are used).
+      # which case the canonical linux.rocm.gpu.mi350.* labels are used).
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "inductor", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.gfx942.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "default", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.1" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-sandbox-label-type }}linux.rocm.gpu.mi350.2", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
## Motivation:
To use the limited ROCm CI capacity efficiently, we are experimenting with running ROCm CI on MI350 runners in [DPX mode](https://instinct.docs.amd.com/projects/virt-drv/en/latest/userguides/GPU_partitioning.html#amd-instinct-mi300x-mi325x-mi35xx-architecture). This will allow us to increase the number of GPU partitions, and hence CI runners, available for PyTorch CI, thus helping reduce TTS and queue times.

## Changes
* Updated test matrix to use mi350 labels instead of gfx942.
* Decreased inductor shard counts from 4 to 2, to allow a single workflow run to use 16 GPU partitions, which would fit on a single 8-GPU MI355 node in DPX mode (since that provides 16 GPU partitions).

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang