### PR TITLE
[Inductor][autoWS] Use a curated autoWS config set for DEFAULT max-autotune

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -1,11 +1,14 @@
 # Owner(s): ["module: inductor"]
 import unittest
+import unittest.mock
 
 import torch
 from torch._inductor import config
 from torch._inductor.heuristics.registry import _HEURISTIC_CACHE
 from torch._inductor.heuristics.template.triton import (
+    BaseHeuristicSingleton,
     BlackwellGPUGemmConfig,
+    BlackwellTMATemplateConfigMixin,
     CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
     CUDABlackwellPersistentTMATemplateConfigHeuristic,
     CUDAScaledBlackwellTMATemplateConfigHeuristic,
@@ -727,6 +730,39 @@ class TestBlackwellExhaustiveConfigs(TestCase):
             len(heuristic.mm_configs),
             len(addmm_configs),
             "Scaled TMA should use the larger scaled_persistent list, not the small addmm list",
+        )
+
+
+class TestBlackwellAutoWSConfigs(TestCase):
+    """autoWS config selection for the Blackwell persistent-TMA template."""
+
+    def test_autows_heuristic_uses_autows_configs(self):
+        with (
+            unittest.mock.patch(
+                "torch._inductor.heuristics.template.triton.USE_META_WS", True
+            ),
+            config.patch({"triton.enable_template_autows": True}),
+        ):
+            _HEURISTIC_CACHE.clear()
+            BaseHeuristicSingleton._instances.pop(
+                CUDABlackwellPersistentTMATemplateConfigHeuristic, None
+            )
+            heuristic = CUDABlackwellPersistentTMATemplateConfigHeuristic()
+
+        mixin = BlackwellTMATemplateConfigMixin
+        self.assertEqual(heuristic.mm_configs, mixin._generate_autows_default_configs())
+        self.assertEqual(
+            len(heuristic.exhaustive_configs), len(mixin._generate_autows_configs())
+        )
+        for cfg in heuristic.mm_configs:
+            self.assertIsInstance(cfg, BlackwellGPUGemmConfig)
+            self.assertTrue(cfg.use_meta_ws)
+
+    def tearDown(self):
+        super().tearDown()
+        _HEURISTIC_CACHE.clear()
+        BaseHeuristicSingleton._instances.pop(
+            CUDABlackwellPersistentTMATemplateConfigHeuristic, None
         )
 
 

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -2761,16 +2761,38 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 return False
         return True
 
-    def _get_config_generator(
-        self,
-    ) -> partial[Generator[TritonConfig, None, None]]:
-        # No curated autoWS set yet: sweep the full autoWS space for both default
-        # and exhaustive search, and let _get_template_configs_impl prune it.
-        if _use_template_autows():
-            return partial(
-                self.preprocess_mm_configs, configs=self._generate_autows_configs()
+    @staticmethod
+    def _generate_autows_default_configs() -> list[BaseConfig]:
+        """autoWS configs for DEFAULT search. Placeholder pending benchmark data.
+
+        EPILOGUE_SUBTILE spans the same values as the non-autoWS Blackwell sets:
+        _scale_mm_configs shrinks BLOCK_N to fit N and _autows_constraints_ok then
+        drops BLOCK_N // EPILOGUE_SUBTILE < 32, so omitting 1 leaves narrow-N
+        shapes with no config at all.
+        """
+        return [
+            BlackwellGPUGemmConfig(
+                block_m=block_m,
+                block_n=block_n,
+                block_k=64,
+                # 2-CTA caps the pipeline at 2 stages (see _autows_constraints_ok)
+                num_stages=2 if two_ctas else 3,
+                num_warps=8,
+                group_m=8,
+                epilogue_subtile=epilogue_subtile,
+                use_meta_ws=True,
+                data_partition_factor=data_partition_factor,
+                separate_epilogue_store=True,
+                two_ctas=two_ctas,
+                warp_specialize=True,
+                flatten=False,
             )
-        return super()._get_config_generator()
+            for block_m in [128, 256]
+            for block_n in [128, 256]
+            for epilogue_subtile in [1, 2, 4]
+            for data_partition_factor in [1, 2]
+            for two_ctas in [False, True]
+        ]
 
     @staticmethod
     def _generate_autows_configs() -> list[BaseConfig]:
@@ -3169,8 +3191,12 @@ class CUDABlackwellPersistentTMATemplateConfigHeuristic(
 
     def __init__(self) -> None:
         super().__init__()
-        self.mm_configs = self.blackwell_persistent_mm_configs
-        self.exhaustive_configs = self._generate_exhaustive_configs()
+        if _use_template_autows():
+            self.mm_configs = self._generate_autows_default_configs()
+            self.exhaustive_configs = self._generate_autows_configs()
+        else:
+            self.mm_configs = self.blackwell_persistent_mm_configs
+            self.exhaustive_configs = self._generate_exhaustive_configs()
 
 
 @register_template_heuristic(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192830
* __->__ #192835
* #190769

Before this, autoWS overrode `_get_config_generator` and returned the full
sweep -- 20480 configs, 5248 after `_autows_constraints_ok` -- for both DEFAULT
and EXHAUSTIVE. Set `mm_configs` and `exhaustive_configs` in `__init__` instead,
matching how every other config set in this file is wired, so the base
`_get_config_generator` does the DEFAULT/EXHAUSTIVE routing and the override
goes away.

DEFAULT now gets a placeholder set pending benchmark data. Each tile is emitted
with `two_ctas` off and on so the autotuner picks between them per shape; their
`num_stages` differ because 2-CTA is capped at 2, and matching the arms would
force the non-2-CTA arm to a shallower pipeline than it can use.

Test plan:
```
python -m pytest test/inductor/test_max_autotune_blackwell.py \
  -k "TestBlackwellAutoWSConfigs or TestBlackwellExhaustiveConfigs"
```
4 passed.