### PR TITLE
[CI] Add addmm linalg tests to B200 smoke suite

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -466,6 +466,7 @@ test_python_smoke_b200() {
       test_varlen_attention \
       $PYTHON_TEST_EXTRA_OPTION \
       --upload-artifacts-while-running
+  time python test/run_test.py --include test_linalg -k "mm or addmv" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 


### PR DESCRIPTION
A regression introduced in #191706 was caught internally on GB200 via `TestLinalgCUDA.test_addmm_out_distinct_c_and_d`, but that test was not included in the `ciflow/b200` smoke job. This adds a targeted `test_linalg -k "mm or addmv"` run to `test_python_smoke_b200()`, covering `test_mm*`, `test_addmm*`, and `test_addmv*` in test_linalg (~1000 small-tensor parametrized cases) without meaningfully extending the ~1.5-hour smoke job runtime. Note that `test_matmul_cuda` and `test_scaled_matmul_cuda` are already included in the smoke suite and cover mm and scaled mm independently.
[Human note: to verify the increase of test time]
Human update: 
This PR's smoke test (with keep-going) took 1hr 35 minutes. https://github.com/pytorch/pytorch/actions/runs/31434627639/job/93657733055?pr=192836#logs 
Trunk job https://github.com/pytorch/pytorch/actions/runs/31437490081/job/93620093271 took 1hr 30 minutes. 

**So 5 minute in crease in test time.** 

> [!NOTE]
> This PR was authored with the assistance of an AI assistant.

cc @ptrblck @eqy @tinglvv @atalman @malfet @ngimel 