### PR TITLE
[c10d] Tests for the flight recorder hook

### DIFF
--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -161,6 +161,34 @@ class WorkerServerTest(TestCase):
             )
             self.assertEqual(resp.status, 200)
 
+    def test_fr_dump_file_without_rank(self) -> None:
+        with local_worker_server() as pool:
+            # No process group has registered with the generic flight recorder
+            # in this process, so it has no rank to name the dump file with and
+            # must refuse rather than write a bogus file.
+            resp = pool.request("POST", "/handler/fr_dump_file")
+            self.assertEqual(resp.status, 503)
+            self.assertIn(b"Flight Recorder rank is unset", resp.data)
+            # Every backend has a recorder instance of its own, so the check is
+            # per instance too.
+            resp = pool.request("POST", "/handler/fr_dump_file?backend=nccl2")
+            self.assertEqual(resp.status, 503)
+            self.assertIn(b"Flight Recorder rank is unset", resp.data)
+
+    def test_fr_trace_json_selects_a_backend(self) -> None:
+        with local_worker_server() as pool:
+            # No argument reads the default instance, the one ProcessGroupGloo
+            # records into; naming a backend reads that backend's instance.
+            # Both are empty here, so this covers the routing, not the content.
+            for path in (
+                "/handler/fr_trace_json",
+                "/handler/fr_trace_json?backend=gloo",
+                "/handler/fr_trace_json?backend=nccl2",
+            ):
+                resp = pool.request("POST", path)
+                self.assertEqual(resp.status, 200, msg=path)
+                self.assertIn("pg_status", json.loads(resp.data))
+
     @skipIfRocmArch(MI200_ARCH)
     def test_tcp(self) -> None:
         import requests

--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -25,14 +25,16 @@ def create_one_event(
     collective_seq_id=0,
     p2p_seq_id=0,
     output_dtypes="float32",
+    input_dtypes="float32",
+    backend="nccl",
 ):
     return {
-        "profiling_name": f"nccl:{collective_name}",
+        "profiling_name": f"{backend}:{collective_name}",
         "state": state,
         "process_group": pg_info,
         "input_sizes": input_sizes,
         "output_sizes": output_sizes,
-        "input_dtypes": "float32",
+        "input_dtypes": input_dtypes,
         "output_dtypes": output_dtypes,
         "collective_seq_id": str(collective_seq_id),
         "p2p_seq_id": str(p2p_seq_id),
@@ -169,7 +171,7 @@ class FlightRecorderEventTest(TestCase):
                 "all_gather_into_tensor_coalesced",
             ]:
                 output_sizes = [[math.prod(input_sizes[0]) * 2]]
-            if collective == "all_to_all":
+            if collective in ["all_to_all", "all_to_all_single"]:
                 expectedState = MatchState.UNDECIDED
             event = create_one_event(
                 collective, ("0", "default"), input_sizes, output_sizes, "scheduled", 1
@@ -177,6 +179,94 @@ class FlightRecorderEventTest(TestCase):
             membership = {"0": {0, 1}}
             result = match_one_event(event, event, membership, "0").state
             self.assertEqual(result, expectedState)
+
+    def test_collective_variants_are_distinct_types(self):
+        # c10d's FlightRecorderHook used to record every allgather variant as
+        # "all_gather" and both alltoalls as "all_to_all", so a rank calling
+        # one could match a peer calling the other.
+        membership = {"0": {0, 1}}
+        for a, b in (
+            ("all_gather", "_all_gather_base"),
+            ("all_reduce", "allreduce_coalesced"),
+            ("reduce_scatter", "_reduce_scatter_base"),
+            ("all_to_all", "all_to_all_single"),
+        ):
+            ea = create_one_event(a, ("0", "default"), [[8]], [[8]], "scheduled", 1)
+            eb = create_one_event(b, ("0", "default"), [[8]], [[8]], "scheduled", 1)
+            self.assertEqual(
+                match_one_event(ea, eb, membership, "0").state,
+                MatchState.COLLECTIVE_TYPE_MISMATCH,
+                msg=f"{a} vs {b}",
+            )
+
+    def test_all_gather_base_numel_is_checked(self):
+        # The rule was spelled "all_gather_base"; no producer has ever written
+        # that, so the branch never ran and a flattened all-gather with the
+        # wrong output numel passed.
+        membership = {"0": {0, 1}}
+        good = create_one_event(
+            "_all_gather_base", ("0", "default"), [[8]], [[16]], "scheduled", 1
+        )
+        bad = create_one_event(
+            "_all_gather_base", ("0", "default"), [[8]], [[24]], "scheduled", 1
+        )
+        self.assertEqual(
+            match_one_event(good, good, membership, "0").state,
+            MatchState.FULLY_MATCHED,
+        )
+        self.assertEqual(
+            match_one_event(bad, bad, membership, "0").state,
+            MatchState.SIZE_OR_SYNTAX_MISMATCH,
+        )
+
+    def test_all_to_all_single_uneven_splits_are_not_a_mismatch(self):
+        # alltoall_base with uneven splits gives each rank a different buffer
+        # size, so only the summed numel across the group can be checked --
+        # the same treatment "all_to_all" gets, which is why it is not folded
+        # into the per-rank size comparison.
+        membership = {"0": {0, 1}}
+        e0 = create_one_event(
+            "all_to_all_single", ("0", "default"), [[8]], [[12]], "scheduled", 1
+        )
+        e1 = create_one_event(
+            "all_to_all_single", ("0", "default"), [[12]], [[8]], "scheduled", 1
+        )
+        self.assertEqual(
+            match_one_event(e0, e1, membership, "0").state, MatchState.UNDECIDED
+        )
+
+    def test_recv_any_source_has_no_peer(self):
+        # recv_any_source names no peer. Reading it as rank -1 made
+        # _init_global_src_dst index the group's rank list from the end and
+        # pin the recv on the highest-ranked member.
+        membership = {"0": {2, 5}}
+        recv = create_one_event(
+            "recv 1<-?", ("0", "default"), [[8]], [[8]], "scheduled", 0, 1
+        )
+        op = Op(recv, membership, "0")
+        self.assertIsNone(op.src)
+        self.assertIsNone(op._src_g)
+        self.assertEqual((op.dst, op._dst_g), (1, 5))
+        # ... and it matches whichever rank actually sent to it.
+        send = create_one_event(
+            "send 0->1", ("0", "default"), [[8]], [[8]], "scheduled", 0, 1
+        )
+        self.assertEqual(
+            match_one_event(send, recv, membership, "0").state,
+            MatchState.FULLY_MATCHED,
+        )
+        self.assertEqual(
+            match_one_event(recv, send, membership, "0").state,
+            MatchState.FULLY_MATCHED,
+        )
+        # A genuine size mismatch is still caught.
+        short = create_one_event(
+            "send 0->1", ("0", "default"), [[4]], [[4]], "scheduled", 0, 1
+        )
+        self.assertEqual(
+            match_one_event(short, recv, membership, "0").state,
+            MatchState.SIZE_OR_SYNTAX_MISMATCH,
+        )
 
 
 class FlightRecorderOpBackendTest(TestCase):
@@ -213,9 +303,43 @@ class FlightRecorderOpBackendTest(TestCase):
         op = Op(self._make_event("xccl"), {"0": {0, 1}}, "0")
         self.assertEqual(op.type, "all_reduce")
 
-    def test_unsupported_backend_raises(self):
+    def test_nccl2_backend(self):
+        # c10d's FlightRecorderHook writes the backend's own name, so a group
+        # running nccl2 produces "nccl2:<op>".
+        op = Op(self._make_event("nccl2"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_c10d_backend(self):
+        # Fallback name the hook writes when it cannot identify the backend.
+        op = Op(self._make_event("c10d"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_nccl2_backend_p2p(self):
+        send = self._make_event("nccl2", "send 0->1")
+        op = Op(send, {"0": {0, 1}}, "0")
+        self.assertEqual((op.type, op.src, op.dst), ("send", 0, 1))
+        recv = self._make_event("nccl2", "recv 1<-0")
+        op = Op(recv, {"0": {0, 1}}, "0")
+        self.assertEqual((op.type, op.src, op.dst), ("recv", 0, 1))
+
+    def test_unsupported_backend_is_not_fatal(self):
+        # The hook attaches to any backend and records under whatever name it
+        # reports, so an unknown comm library must not cost us the collective.
+        op = Op(self._make_event("unknown_backend"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_backend_name_with_colon(self):
+        # A stray colon in the comm library name must not eat the op name.
+        op = Op(self._make_event("weird:backend"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_missing_colon_raises(self):
         with self.assertRaises(AssertionError):
-            Op(self._make_event("unknown_backend"), {"0": {0, 1}}, "0")
+            Op(
+                {**self._make_event("nccl"), "profiling_name": "all_reduce"},
+                {"0": {0, 1}},
+                "0",
+            )
 
 
 class FlightMatchInfoTest(TestCase):
@@ -258,6 +382,8 @@ def create_one_entry(
     p2p_seq_id=0,
     output_dtypes="float32",
     pg_info=("0", "default"),
+    input_dtypes="float32",
+    backend="nccl",
 ):
     event = create_one_event(
         collective_name,
@@ -268,6 +394,8 @@ def create_one_entry(
         collective_seq_id,
         p2p_seq_id,
         output_dtypes,
+        input_dtypes,
+        backend,
     )
     event.update({"record_id": record_id})
     event.update({"is_p2p": False})
@@ -424,6 +552,107 @@ class FlightRecorderE2ETest(TestCase):
         self.assertEqual(db.collectives[1].collective_name, "nccl:_reduce_oop")
         self.assertEqual(db.collectives[1].record_id, 1)
         self.assertEqual(db.collectives[1].pass_check, True)
+
+
+class FlightRecorderHookShapeTest(TestCase):
+    """Analysis of traces written by c10d's FlightRecorderHook.
+
+    The hook records the tensors the dispatcher hands it. For the in-place
+    collectives that is the same buffer on both sides, and for the list-form
+    all_gather / reduce_scatter it is one shard-shaped buffer per rank rather
+    than the single flattened buffer a native backend records. Both spellings
+    have to analyze with no mismatch, or a real desync ends up buried under
+    fabricated ones.
+    """
+
+    version = "2.8"  # Same as the version in FlightRecorder.hpp
+
+    def _entry(self, record_id, collective_name, input_sizes, output_sizes, seq):
+        return create_one_entry(
+            record_id,
+            collective_name,
+            input_sizes,
+            output_sizes,
+            state="scheduled",
+            collective_seq_id=seq,
+            input_dtypes=["Float"] * len(input_sizes),
+            output_dtypes=["Float"] * len(output_sizes),
+            backend="nccl2",
+        )
+
+    def _build_db(self, entries_per_rank):
+        details = copy.deepcopy(LOADED_FR_DETAIL_TEMPLATE)
+        for rank, entries in enumerate(entries_per_rank):
+            details[f"dump_file_rank_{rank}"]["version"] = self.version
+            details[f"dump_file_rank_{rank}"]["entries"] = entries
+        return build_db(details, JobConfig().parse_args([]), self.version)
+
+    def _build_db_symmetric(self, entries):
+        # Both ranks recorded the same thing, so anything build_db reports is
+        # the analyzer misreading the shape, not a desync.
+        return self._build_db([copy.deepcopy(entries), copy.deepcopy(entries)])
+
+    def _match(self, entry):
+        membership = {"0": {0, 1}}
+        return match_one_event(entry, copy.deepcopy(entry), membership, "0").state
+
+    def test_matcher_accepts_hook_shapes(self):
+        for name, input_sizes, output_sizes in (
+            ("all_reduce", [[8]], [[8]]),
+            ("allreduce_coalesced", [[8], [4]], [[8], [4]]),
+            ("reduce", [[8]], [[8]]),
+            ("all_gather", [[8]], [[8], [8]]),
+            ("reduce_scatter", [[8], [8]], [[8]]),
+        ):
+            entry = self._entry(0, name, input_sizes, output_sizes, 1)
+            self.assertEqual(self._match(entry), MatchState.FULLY_MATCHED, msg=name)
+
+    def test_hook_shaped_run_has_no_mismatch(self):
+        db = self._build_db_symmetric(
+            [
+                self._entry(0, "all_reduce", [[8]], [[8]], 1),
+                self._entry(1, "reduce", [[8]], [[8]], 2),
+                self._entry(2, "all_gather", [[8]], [[8], [8]], 3),
+                self._entry(3, "reduce_scatter", [[8], [8]], [[8]], 4),
+                self._entry(4, "allreduce_coalesced", [[8], [4]], [[8], [4]], 5),
+            ]
+        )
+        self.assertEqual(
+            [c.collective_name for c in db.collectives],
+            [
+                "nccl2:all_reduce",
+                "nccl2:reduce",
+                "nccl2:all_gather",
+                "nccl2:reduce_scatter",
+                "nccl2:allreduce_coalesced",
+            ],
+        )
+        self.assertEqual([c.pass_check for c in db.collectives], [True] * 5)
+
+    def test_list_form_all_gather_mismatch_is_caught(self):
+        # The list form must not become a blanket accept: one buffer per rank
+        # is the whole point, so a list of the wrong length is still wrong.
+        db = self._build_db_symmetric(
+            [self._entry(0, "all_gather", [[8]], [[8], [8], [8]], 1)]
+        )
+        self.assertEqual([c.pass_check for c in db.collectives], [False])
+
+    def test_list_form_reduce_scatter_mismatch_is_caught(self):
+        db = self._build_db_symmetric(
+            [self._entry(0, "reduce_scatter", [[8], [8], [8]], [[8]], 1)]
+        )
+        self.assertEqual([c.pass_check for c in db.collectives], [False])
+
+    def test_flattened_form_mismatch_is_still_caught(self):
+        # Native shapes keep their old verdict.
+        for name, input_sizes, output_sizes in (
+            ("all_gather", [[8]], [[17]]),
+            ("reduce_scatter", [[17]], [[8]]),
+        ):
+            db = self._build_db_symmetric(
+                [self._entry(0, name, input_sizes, output_sizes, 1)]
+            )
+            self.assertEqual([c.pass_check for c in db.collectives], [False], msg=name)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_fr_hook.py
+++ b/test/distributed/test_c10d_fr_hook.py
@@ -9,7 +9,10 @@
 
 import json
 import os
+import pickle
 import sys
+import tempfile
+import time
 import unittest
 from datetime import timedelta
 
@@ -22,12 +25,19 @@ if not dist.is_available():
     sys.exit(0)
 
 from torch._C._distributed_c10d import FlightRecorderHook
+from torch.distributed.distributed_c10d import _world
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
+# CPU coverage of the hook comes from "fake" rather than gloo: gloo has its own
+# FlightRecorder integration, so the hook deliberately skips its ops and
+# recording nothing is all a gloo group can show. What is left to cover on CPU
+# is the null-start-event path, and "fake" exercises it through the same c10d
+# ops as any other backend.
 FR_HOOK_BACKENDS = [
-    ("gloo", "cpu"),
+    ("fake", "cpu"),
     ("nccl2", "cuda"),
 ]
 
@@ -45,25 +55,35 @@ class AbstractFlightRecorderHookTest:
 
     def setUp(self):
         super().setUp()
-        # Note: gloo also records natively into the same recorder; keying
-        # entries by the hook's profiling_name prefix ("c10d:") keeps the
-        # assertions backend-agnostic.
         os.environ["TORCH_FR_BUFFER_SIZE"] = "2000"
+        # Spawned children do not re-run setUp, so they pick the dump prefix
+        # out of the inherited environment rather than off self.
+        self.tempdir = tempfile.TemporaryDirectory()
+        os.environ["TORCH_FR_DUMP_TEMP_FILE"] = os.path.join(
+            self.tempdir.name, "trace_"
+        )
         self._spawn_processes()
 
     def tearDown(self):
         if dist.is_initialized():
             dist.destroy_process_group()
+        os.environ.pop("TORCH_FR_DUMP_TEMP_FILE", None)
         super().tearDown()
         try:
             os.remove(self.file_name)
         except OSError:
             pass
 
+    def _dump_file_name(self):
+        return os.environ["TORCH_FR_DUMP_TEMP_FILE"] + str(self.rank)
+
     def _init_pg(self):
         if self.device_type == "cuda":
             torch.cuda.set_device(self.rank)
-        store = dist.FileStore(self.file_name, self.world_size)
+        if self._communicates:
+            store = dist.FileStore(self.file_name, self.world_size)
+        else:
+            store = FakeStore()
         dist.init_process_group(
             self.backend_name,
             world_size=self.world_size,
@@ -73,17 +93,77 @@ class AbstractFlightRecorderHookTest:
         )
         return dist.group.WORLD
 
+    def _all_entries(self, backend=None):
+        trace = json.loads(
+            torch._C._distributed_c10d._dump_fr_trace_json(
+                backend=backend if backend is not None else self.backend_name
+            )
+        )
+        return trace.get("entries", [])
+
+    def _name(self, op):
+        # The hook writes the backend's own name as the comm_lib field, so
+        # profiling names are backend-specific.
+        return f"{self.backend_name}:{op}"
+
     def _hook_entries(self):
-        trace = json.loads(torch._C._distributed_c10d._dump_fr_trace_json())
-        return [
-            e
-            for e in trace.get("entries", [])
-            if e["profiling_name"].startswith("c10d:")
-        ]
+        # Every backend under test here is hooked, and each hooked backend
+        # records into a recorder instance of its own, so nothing else writes
+        # to the one being read.
+        return self._all_entries()
+
+    @property
+    def _auto_attached(self):
+        # _maybe_attach_flight_recorder skips a group whose every device is
+        # served by a backend that either records itself or never
+        # communicates, so "fake" has to be attached by hand.
+        return self.backend_name == "nccl2"
+
+    @property
+    def _communicates(self):
+        return self.backend_name != "fake"
+
+    @property
+    def _push_completion(self):
+        # Two tiers. A backend with completion hooks pushes real completion, so
+        # an entry is retired when its collective actually finished and reads
+        # "completed" with the backend's own duration. A backend without them
+        # ("fake") is retired by the post-hook, at issue: honest but degraded,
+        # since nothing will ever tell the hook the op finished.
+        return self.backend_name == "nccl2"
+
+    def _completed_state(self):
+        return "completed" if self._push_completion else "scheduled"
+
+    def _await_retired(self, count=0, timeout=60.0):
+        # Completion arrives when the backend establishes it: on its watchdog,
+        # which ticks about once a second, or on the next collective through the
+        # same group. Nothing polls at dump time any more, so a dump taken the
+        # instant after cuda.synchronize() can be one tick early. Returns as soon
+        # as it can, which for the retire-at-issue tier is immediately.
+        deadline = time.time() + timeout
+        while True:
+            entries = self._hook_entries()
+            done = len(entries) >= count and all(e["retired"] for e in entries)
+            if done or time.time() >= deadline:
+                return entries
+            time.sleep(0.05)
+
+    def _fr_hook(self, pg):
+        # Groups whose backends have no native recording already got a hook at
+        # creation time; reuse it rather than attaching a second one, which
+        # would record every collective twice. A hand-attached hook is given
+        # the same global rank mapping _maybe_attach_flight_recorder passes,
+        # which is the only source of one for a backend that does not fill in
+        # Options::global_ranks_in_group.
+        hook = _world.pg_flight_recorder_hooks.get(pg)
+        if hook is not None:
+            return hook
+        return FlightRecorderHook.attach(pg, dist.get_process_group_ranks(pg))
 
     def test_records_and_retires_collectives(self):
         pg = self._init_pg()
-        hook = FlightRecorderHook.attach(pg)
+        hook = self._fr_hook(pg)
         before = len(self._hook_entries())
 
         t = torch.ones(8, device=self.device)
@@ -93,29 +173,341 @@ class AbstractFlightRecorderHookTest:
         if self.device_type == "cuda":
             torch.cuda.synchronize()
 
-        entries = self._hook_entries()[before:]
+        entries = self._await_retired(before + 3)[before:]
         names = [e["profiling_name"] for e in entries]
-        self.assertIn("c10d:allreduce", names)
-        self.assertIn("c10d:broadcast", names)
-        self.assertIn("c10d:barrier", names)
-        # Post-hooks fire after issue, so every recorded op must be retired.
-        # With null start/end events (no GPU timing) the state stays
-        # "scheduled"; retired is the completion signal, as with Gloo's
-        # native FR recording.
+        self.assertIn(self._name("all_reduce"), names)
+        self.assertIn(self._name("broadcast"), names)
+        self.assertIn(self._name("barrier"), names)
+        # Every entry is retired, on both tiers. Only a backend that pushes
+        # completion can also say the collective finished.
         for e in entries:
             self.assertTrue(e["retired"], msg=str(e))
+            self.assertEqual(e["state"], self._completed_state(), msg=str(e))
+        hook.remove()
+
+    def test_entry_state_from_pushed_completion(self):
+        # Tier one: the backend pushes completion from where its watchdog
+        # establishes it, so "completed" is reachable without the hook polling
+        # anything. See test_retires_at_issue_without_completion_hooks for the
+        # other tier.
+        if not self._push_completion:
+            self.skipTest("backend pushes no completion")
+        self._init_pg()
+        sub_pg = dist.new_group(list(range(self.world_size)))
+        hook = self._fr_hook(sub_pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(8, device=self.device)
+        for _ in range(3):
+            dist.all_reduce(t, group=sub_pg)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        entries = self._await_retired(before + 3)[before:]
+        self.assertEqual(len(entries), 3)
+        # Discovery is when the backend told the hook, so it is always set for a
+        # completed entry.
+        for e in entries:
+            self.assertEqual(e["state"], "completed", msg=str(e))
+            self.assertGreater(e["time_discovered_completed_ns"], 0, msg=str(e))
+            self.assertGreater(e["time_discovered_started_ns"], 0, msg=str(e))
+        hook.remove()
+
+    def test_retires_at_issue_without_completion_hooks(self):
+        # Tier two: a backend with no completion hook. The post-hook has to
+        # retire the entry itself, at issue, because nothing else ever will and
+        # an entry nothing retires is indistinguishable from a hang. What it must
+        # not do is claim a completion nobody observed, so the entry reads
+        # "scheduled" and carries no duration.
+        if self._push_completion:
+            self.skipTest("backend pushes completion")
+        pg = self._init_pg()
+        self.assertFalse(pg.supports_completion_hooks)
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(8, device=self.device)
+        for _ in range(3):
+            dist.all_reduce(t)
+
+        entries = self._hook_entries()[before:]
+        self.assertEqual(len(entries), 3)
+        for e in entries:
+            self.assertTrue(e["retired"], msg=str(e))
+            self.assertEqual(e["state"], "scheduled", msg=str(e))
+            self.assertEqual(e["time_discovered_completed_ns"], 0, msg=str(e))
+            self.assertNotIn("duration_ms", e, msg=str(e))
+        hook.remove()
+
+    def test_duration_ms_absent_without_backend_timing(self):
+        # duration_ms comes from the backend, which reports none unless it was
+        # asked to time collectives. There is deliberately no host clock stand-in:
+        # the report arrives on a watchdog tick, so a wall clock would measure how
+        # late the push was, not the collective.
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(8, device=self.device)
+        for _ in range(3):
+            dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        entries = self._await_retired(before + 3)[before:]
+        self.assertEqual(len(entries), 3)
+        for e in entries:
+            self.assertEqual(e["state"], self._completed_state(), msg=str(e))
+            self.assertNotIn("duration_ms", e, msg=str(e))
+        hook.remove()
+
+    def test_duration_ms_from_backend_timing(self):
+        # With timing on, duration_ms is the backend's own device measurement
+        # of the collective, not a host-side upper bound.
+        pg = self._init_pg()
+        if self.backend_name != "nccl2":
+            self.skipTest("backend cannot time collectives")
+        # Before the first collective: works created earlier carry untimed
+        # events, so their completion can report no duration.
+        pg._enable_collectives_timing()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(1024, device=self.device)
+        for _ in range(3):
+            dist.all_reduce(t)
+        torch.cuda.synchronize()
+
+        entries = self._await_retired(before + 3)[before:]
+        self.assertEqual(len(entries), 3)
+        for e in entries:
+            self.assertIn("duration_ms", e, msg=str(e))
+            self.assertGreater(e["duration_ms"], 0.0, msg=str(e))
+            self.assertLess(e["duration_ms"], 60000.0, msg=str(e))
+        hook.remove()
+
+    def test_hung_collective_reads_not_completed(self):
+        # The property the whole design exists for: a dump taken while a
+        # collective is stuck must show that collective as not completed, and
+        # must still show the ones before it as completed. Rank 1 joins late,
+        # so rank 0's second all_reduce is genuinely in flight while it dumps.
+        if not self._communicates or self.device_type != "cuda":
+            self.skipTest("needs a backend whose collectives really block")
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        t = torch.ones(8, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        before = len(self._await_retired(1))
+
+        if self.rank == 0:
+            # Returns as soon as it is issued: a c10d wait() on CUDA only
+            # orders the caller's stream after the collective.
+            dist.all_reduce(t)
+            # Long enough for several watchdog ticks, so this is the backend
+            # having found nothing to report rather than not having looked.
+            time.sleep(5)
+            entries = self._hook_entries()
+            hung = entries[before:]
+            self.assertEqual(len(hung), 1, msg=str(hung))
+            self.assertNotEqual(hung[0]["state"], "completed", msg=str(hung[0]))
+            self.assertFalse(hung[0]["retired"], msg=str(hung[0]))
+            self.assertEqual(hung[0]["time_discovered_completed_ns"], 0)
+            # ... and the healthy ones before it are unaffected.
+            self.assertEqual(entries[before - 1]["state"], "completed")
+        else:
+            time.sleep(15)
+            dist.all_reduce(t)
+
+        torch.cuda.synchronize()
+        # Once it finishes, the backend pushes that too.
+        self.assertEqual(self._await_retired()[-1]["state"], "completed")
+        hook.remove()
+
+    def test_op_names_distinguish_collective_variants(self):
+        # The op name is what the analyzer keys its per-collective size rules
+        # off, so every dispatcher op has to keep its own spelling. Folding
+        # _allgather_base into "all_gather" made the list-form numel rule apply
+        # to a flattened buffer, and folding alltoall_base into "all_to_all"
+        # meant a rank doing one could match a peer doing the other.
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        n = self.world_size
+        shard = torch.ones(8, device=self.device)
+        flat = torch.ones(8 * n, device=self.device)
+        dist.all_reduce(shard)
+        dist.all_gather([torch.empty_like(shard) for _ in range(n)], shard)
+        dist.all_gather_into_tensor(torch.empty_like(flat), shard)
+        dist.reduce_scatter(
+            torch.empty_like(shard), [torch.ones_like(shard) for _ in range(n)]
+        )
+        dist.reduce_scatter_tensor(torch.empty_like(shard), flat)
+        dist.all_to_all(list(torch.empty_like(flat).chunk(n)), list(flat.chunk(n)))
+        dist.all_to_all_single(torch.empty_like(shard), shard)
+        with dist._coalescing_manager():
+            for _ in range(2):
+                dist.all_reduce(torch.ones(4, device=self.device))
+        with dist._coalescing_manager():
+            for _ in range(2):
+                dist.all_gather_into_tensor(torch.empty_like(flat), shard)
+        with dist._coalescing_manager():
+            for _ in range(2):
+                dist.reduce_scatter_tensor(torch.empty_like(shard), flat)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        entries = self._hook_entries()[before:]
+        self.assertEqual(
+            [e["profiling_name"] for e in entries],
+            [
+                self._name(op)
+                for op in (
+                    "all_reduce",
+                    "all_gather",
+                    "_all_gather_base",
+                    "reduce_scatter",
+                    "_reduce_scatter_base",
+                    "all_to_all",
+                    "all_to_all_single",
+                    "allreduce_coalesced",
+                    "all_gather_into_tensor_coalesced",
+                    "reduce_scatter_tensor_coalesced",
+                )
+            ],
+        )
+        # Every one of them has to be a name the analyzer accepts, or the
+        # entry is dropped from the timeline entirely.
+        from torch.distributed.flight_recorder.components.types import Op
+
+        for e in entries:
+            pg_name = e["process_group"][0]
+            Op(e, {pg_name: set(range(n))}, pg_name)
+        # allreduce_coalesced has no output tensors of its own either, so it
+        # needs the same input mirroring as all_reduce.
+        coalesced = entries[-3]
+        self.assertEqual(coalesced["input_sizes"], coalesced["output_sizes"])
+        hook.remove()
+
+    def test_recv_any_source_records_unknown_peer(self):
+        # recv_any_source has no peer until a message arrives. Writing -1 made
+        # the analyzer index the group's rank list from the end and pin the
+        # recv on the highest-ranked member.
+        from torch.distributed.flight_recorder.components.types import Op
+
+        if self.backend_name != "fake":
+            # NCCL has no recvAnysource; only mpi, ucc and fake do.
+            self.skipTest("backend does not support recv_any_source")
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        # Not dist.recv(t, src=None): it asks the returned Work who the sender
+        # was, which the fake backend cannot answer.
+        pg.recv_anysource([torch.empty(4, device=self.device)], 0).wait()
+
+        entries = self._hook_entries()[before:]
+        self.assertEqual(len(entries), 1, msg=str(entries))
+        e = entries[0]
+        self.assertEqual(e["profiling_name"], self._name(f"recv {self.rank}<-?"))
+        pg_name = e["process_group"][0]
+        op = Op(e, {pg_name: set(range(self.world_size))}, pg_name)
+        self.assertIsNone(op.src)
+        self.assertIsNone(op._src_g)
+        self.assertEqual(op.dst, self.rank)
+        hook.remove()
+
+    def test_subgroup_publishes_real_global_ranks(self):
+        # A subgroup's membership and this rank's dump file name both come from
+        # the global rank mapping. Falling back to 0..size-1 when the backend
+        # has none made every member of a subgroup claim a global rank that
+        # belongs to someone else: the analyzer then saw a membership that
+        # never existed, and -- since the file is <prefix><rank> and the loader
+        # parses the rank back out of the name -- several ranks wrote the same
+        # file and all but one post-mortem was lost.
+        import ast
+
+        import requests
+
+        from torch._C._distributed_c10d import _WorkerServer
+
+        last = self.world_size - 1
+        if last == 0:
+            self.skipTest("needs a subgroup that excludes rank 0")
+        pg = self._init_pg()
+        self._fr_hook(pg)
+        sub = dist.new_group([last])
+        if self.rank != last:
+            return
+        hook = self._fr_hook(sub)
+
+        dist.all_reduce(torch.ones(4, device=self.device), group=sub)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        trace = json.loads(
+            torch._C._distributed_c10d._dump_fr_trace_json(backend=self.backend_name)
+        )
+        ranks = ast.literal_eval(trace["pg_config"][sub.group_name]["ranks"])
+        self.assertEqual(ranks, [last])
+
+        # The handler names the file from the rank the recorder was told, so
+        # this is what catches setRank being overwritten with a group-local one.
+        server = _WorkerServer("", 0)
+        self.addCleanup(server.shutdown)
+        res = requests.post(
+            f"http://localhost:{server.port}/handler/fr_dump_file"
+            f"?backend={self.backend_name}",
+            timeout=60,
+        )
+        self.assertEqual(res.status_code, 200)
+        path = self._dump_file_name()
+        deadline = time.time() + 60
+        while not os.path.exists(path) and time.time() < deadline:
+            time.sleep(0.1)
+        self.assertTrue(os.path.exists(path), msg=f"no dump written to {path}")
+        self.assertFalse(os.path.exists(os.environ["TORCH_FR_DUMP_TEMP_FILE"] + "0"))
+        hook.remove()
+
+    def test_attach_without_rank_mapping_publishes_nothing(self):
+        # Nothing is invented when neither the caller nor the backend can say
+        # what this group's global ranks are: the collectives are still
+        # recorded, but no membership is published for the group.
+        if self.backend_name != "fake":
+            # Backends that fill in Options::global_ranks_in_group cannot
+            # reach this path.
+            self.skipTest("backend supplies its own global rank mapping")
+        last = self.world_size - 1
+        pg = self._init_pg()
+        self._fr_hook(pg)
+        sub = dist.new_group([last])
+        if self.rank != last:
+            return
+        hook = FlightRecorderHook.attach(sub)
+
+        before = len(self._hook_entries())
+        dist.all_reduce(torch.ones(4, device=self.device), group=sub)
+
+        trace = json.loads(
+            torch._C._distributed_c10d._dump_fr_trace_json(backend=self.backend_name)
+        )
+        self.assertEqual(len(trace["entries"]) - before, 1)
+        self.assertNotIn(sub.group_name, trace["pg_config"])
         hook.remove()
 
     def test_records_tensor_metadata(self):
         pg = self._init_pg()
-        hook = FlightRecorderHook.attach(pg)
+        hook = self._fr_hook(pg)
         before = len(self._hook_entries())
 
         t = torch.ones(4, 8, device=self.device)
         dist.all_reduce(t)
 
         entries = self._hook_entries()[before:]
-        allreduce = [e for e in entries if e["profiling_name"] == "c10d:allreduce"]
+        allreduce = [
+            e for e in entries if e["profiling_name"] == self._name("all_reduce")
+        ]
         self.assertEqual(len(allreduce), 1)
         self.assertEqual(allreduce[0]["input_sizes"], [[4, 8]])
         self.assertEqual(allreduce[0]["input_dtypes"], ["Float"])
@@ -123,7 +515,7 @@ class AbstractFlightRecorderHookTest:
 
     def test_p2p_and_collective_seq_ids(self):
         pg = self._init_pg()
-        hook = FlightRecorderHook.attach(pg)
+        hook = self._fr_hook(pg)
         before = len(self._hook_entries())
 
         t = torch.ones(4, device=self.device)
@@ -141,19 +533,215 @@ class AbstractFlightRecorderHookTest:
             torch.cuda.synchronize()
 
         entries = self._hook_entries()[before:]
-        p2p = [e for e in entries if e["profiling_name"] in ("c10d:send", "c10d:recv")]
-        coll = [e for e in entries if e["profiling_name"] == "c10d:allreduce"]
+        p2p = [e for e in entries if e["is_p2p"]]
+        coll = [e for e in entries if e["profiling_name"] == self._name("all_reduce")]
         self.assertEqual(len(p2p), 2)
         self.assertEqual(len(coll), 1)
         # P2P ops advance p2p_seq_id only; collectives advance
         # collective_seq_id only.
         self.assertEqual(sorted(e["p2p_seq_id"] for e in p2p), [1, 2])
         self.assertEqual(coll[0]["collective_seq_id"], 1)
+        # The peer goes into the name the way the analyzer parses it, with
+        # group-local ranks.
+        self.assertEqual(
+            sorted(e["profiling_name"] for e in p2p),
+            sorted(
+                [
+                    self._name(f"send {self.rank}->{peer}"),
+                    self._name(f"recv {self.rank}<-{peer}"),
+                ]
+            ),
+        )
+        hook.remove()
+
+    def test_entries_parse_with_trace_analyzer(self):
+        # The dumped entries must be readable by torchfrtrace; parsing them
+        # with its Op class is what catches a profiling_name that the analyzer
+        # rejects (unknown backend prefix, unknown op name, missing p2p peer).
+        from torch.distributed.flight_recorder.components.types import Op
+
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        dist.broadcast(t, src=0)
+        dist.all_gather([torch.empty_like(t) for _ in range(self.world_size)], t)
+        peer = 1 - self.rank
+        if self.rank == 0:
+            dist.send(t, peer)
+        else:
+            dist.recv(t, peer)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        entries = self._hook_entries()[before:]
+        self.assertGreaterEqual(len(entries), 4)
+        for e in entries:
+            pg_name = e["process_group"][0]
+            memberships = {pg_name: set(range(self.world_size))}
+            op = Op(e, memberships, pg_name)
+            if op.type in ("send", "recv"):
+                self.assertEqual(op.src if op.type == "send" else op.dst, self.rank)
+        hook.remove()
+
+    def test_hook_trace_analyzes_without_mismatch(self):
+        # The property the recording exists for: every rank's entries, fed to
+        # torchfrtrace's own analysis, must produce no mismatch. The hook
+        # records what the dispatcher hands it, which for these is not the
+        # shape a native backend records -- all_reduce, reduce and broadcast
+        # have no output tensor of their own, and the list forms have one
+        # shard-shaped buffer per rank instead of one flattened buffer. Each
+        # used to be reported as a cross-rank size mismatch, which then poisons
+        # the process group so no later collective can match either.
+        from torch.distributed.flight_recorder.components.builder import build_db
+        from torch.distributed.flight_recorder.components.config_manager import (
+            JobConfig,
+        )
+
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(8, device=self.device)
+        dist.all_reduce(t)
+        dist.reduce(t, dst=0)
+        dist.broadcast(t, src=0)
+        dist.all_gather([torch.empty_like(t) for _ in range(self.world_size)], t)
+        dist.reduce_scatter(
+            torch.empty_like(t), [torch.ones_like(t) for _ in range(self.world_size)]
+        )
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        # Before the cross-rank comparison: an entry the backend has not reported
+        # yet reads "scheduled" on one rank and "completed" on another, which the
+        # analyzer is right to call a state mismatch.
+        entries = self._await_retired(before + 5)[before:]
+        trace = json.loads(
+            torch._C._distributed_c10d._dump_fr_trace_json(backend=self.backend_name)
+        )
+        collectives = (
+            "all_reduce",
+            "reduce",
+            "broadcast",
+            "all_gather",
+            "reduce_scatter",
+        )
+        self.assertEqual(
+            [e["profiling_name"] for e in entries],
+            [self._name(c) for c in collectives],
+        )
+        shard = [8]
+        self.assertEqual(
+            [(e["input_sizes"], e["output_sizes"]) for e in entries],
+            [
+                ([shard], [shard]),
+                ([shard], [shard]),
+                ([shard], [shard]),
+                ([shard], [shard] * self.world_size),
+                ([shard] * self.world_size, [shard]),
+            ],
+        )
+
+        for e in entries:
+            self.assertEqual(e["state"], self._completed_state(), msg=str(e))
+        local = {
+            "entries": entries,
+            "pg_config": trace["pg_config"],
+            "version": trace["version"],
+        }
+        if self._communicates:
+            gathered = [None] * self.world_size
+            dist.all_gather_object(gathered, local)
+        else:
+            # The backend moves no data, so a gather would return nothing
+            # usable; every rank issued the same collectives, which is what the
+            # cross-rank comparison below needs.
+            gathered = [local] * self.world_size
+        details = {
+            f"trace_{r}": {"host_name": f"host_rank{r}", "rank": r, **g}
+            for r, g in enumerate(gathered)
+        }
+        db = build_db(details, JobConfig().parse_args([]), trace["version"])
+        self.assertEqual(len(db.collectives), len(collectives))
+        for c in db.collectives:
+            self.assertTrue(
+                c.pass_check, msg=f"{c.collective_name}: {c.type_of_mismatch}"
+            )
+        hook.remove()
+
+    def test_dump_to_file(self):
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        torch._C._distributed_c10d._dump_fr_trace_file(
+            self.rank, backend=self.backend_name
+        )
+        with open(self._dump_file_name(), "rb") as f:
+            dump = pickle.load(f)
+        self.assertIn("version", dump)
+        self.assertIn("entries", dump)
+        self.assertIn("pg_config", dump)
+        names = [e["profiling_name"] for e in dump["entries"]]
+        self.assertIn(self._name("all_reduce"), names)
+        hook.remove()
+
+    def test_control_plane_dump_file(self):
+        # Over the real control plane rather than _get_handler, because the
+        # backend to dump arrives as a query parameter and Python cannot
+        # implement Request::params().
+        import requests
+
+        from torch._C._distributed_c10d import _WorkerServer
+
+        pg = self._init_pg()
+        # attach() is what tells the recorder which rank it is running on,
+        # which is how the handler names the file.
+        hook = self._fr_hook(pg)
+
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        server = _WorkerServer("", 0)
+        self.addCleanup(server.shutdown)
+        res = requests.post(
+            f"http://localhost:{server.port}/handler/fr_dump_file"
+            f"?backend={self.backend_name}",
+            timeout=60,
+        )
+        self.assertEqual(res.status_code, 200)
+
+        # The handler dumps on a worker thread, so poll until the file is
+        # there and complete -- it appears empty before the write lands.
+        path = self._dump_file_name()
+        dump = None
+        deadline = time.time() + 60
+        while dump is None and time.time() < deadline:
+            try:
+                with open(path, "rb") as f:
+                    dump = pickle.load(f)
+            except (OSError, EOFError, pickle.UnpicklingError):
+                time.sleep(0.1)
+        self.assertIsNotNone(dump, msg=f"no dump written to {path}")
+        self.assertIn("version", dump)
+        self.assertIn("entries", dump)
+        self.assertIn("pg_config", dump)
+        names = [e["profiling_name"] for e in dump["entries"]]
+        self.assertIn(self._name("all_reduce"), names)
         hook.remove()
 
     def test_remove_stops_recording(self):
         pg = self._init_pg()
-        hook = FlightRecorderHook.attach(pg)
+        hook = self._fr_hook(pg)
         t = torch.ones(4, device=self.device)
         dist.all_reduce(t)
         count_attached = len(self._hook_entries())
@@ -165,7 +753,7 @@ class AbstractFlightRecorderHookTest:
 
     def test_multiple_collectives_entry_order(self):
         pg = self._init_pg()
-        hook = FlightRecorderHook.attach(pg)
+        hook = self._fr_hook(pg)
         before = len(self._hook_entries())
 
         t = torch.ones(4, device=self.device)
@@ -176,11 +764,241 @@ class AbstractFlightRecorderHookTest:
         seqs = [
             e["collective_seq_id"]
             for e in entries
-            if e["profiling_name"] == "c10d:allreduce"
+            if e["profiling_name"] == self._name("all_reduce")
         ]
         self.assertEqual(seqs, sorted(seqs))
         self.assertEqual(len(seqs), 5)
         hook.remove()
+
+    def test_auto_attach_records_without_explicit_attach(self):
+        # TORCH_FR_BUFFER_SIZE is set in setUp, so creating the group is all it
+        # takes for a backend that needs the hook (nccl2) to be traced.
+        pg = self._init_pg()
+        self.assertEqual(pg in _world.pg_flight_recorder_hooks, self._auto_attached)
+
+        before = len(self._hook_entries())
+        t = torch.ones(8, device=self.device)
+        dist.all_reduce(t)
+        dist.broadcast(t, src=0)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        names = [e["profiling_name"] for e in self._hook_entries()[before:]]
+        if self._auto_attached:
+            self.assertEqual(names, [self._name("all_reduce"), self._name("broadcast")])
+        else:
+            self.assertEqual(names, [])
+
+    def test_records_only_into_its_own_instance(self):
+        # A collective produces exactly one entry, and it lands in the hooked
+        # backend's own recorder instance. Nothing reaches the default
+        # instance, which is the one ProcessGroupGloo records into.
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._all_entries())
+        before_default = len(self._all_entries(backend="gloo"))
+
+        t = torch.ones(8, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        names = [e["profiling_name"] for e in self._all_entries()[before:]]
+        self.assertEqual(names, [self._name("all_reduce")])
+        self.assertEqual(len(self._all_entries(backend="gloo")), before_default)
+        hook.remove()
+
+    def test_reset_fr_trace(self):
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+
+        t = torch.ones(4, device=self.device)
+        for _ in range(3):
+            dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        self.assertGreaterEqual(len(self._all_entries()), 3)
+
+        torch._C._distributed_c10d._reset_fr_trace(backend=self.backend_name)
+        # Soft delete: the ring buffer keeps the entries but bumps the reset
+        # epoch, so a dump filters out everything recorded before the reset.
+        self.assertEqual(self._all_entries(), [])
+
+        for _ in range(2):
+            dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        entries = self._all_entries()
+        self.assertEqual(len(entries), 2)
+        # Record ids restart at 0 for the new epoch.
+        self.assertEqual([e["record_id"] for e in entries], [0, 1])
+        hook.remove()
+
+    def test_attach_without_abort_hook_support(self):
+        # Abort hooks are what trigger the dump on a collective failure, but
+        # they are optional: most backends have none, and Backend's default
+        # registerAbortHook throws rather than no-opping. attach() must ask
+        # first and keep working -- only the dump-on-failure trigger is lost,
+        # recording is unaffected.
+        pg = self._init_pg()
+        backend = pg._get_backend(self.device)
+        supported = self.backend_name == "nccl2"
+        self.assertEqual(pg.supports_abort_hooks, supported)
+        self.assertEqual(backend.supports_abort_hooks, supported)
+        if not supported:
+            with self.assertRaisesRegex(
+                RuntimeError, "does not support registerAbortHook"
+            ):
+                backend.register_abort_hook(0, lambda: None)
+
+        before = len(self._hook_entries())
+        hook = self._fr_hook(pg)
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        self.assertEqual(len(self._hook_entries()), before + 1)
+        # remove() must not throw either: unregisterAbortHook throws on a
+        # backend that has none, so it may only be called if attach()
+        # registered one.
+        hook.remove()
+
+    def test_attach_without_completion_hook_support(self):
+        # Completion hooks are optional in the same way abort hooks are, and
+        # Backend's default registerCompletionHook throws rather than no-opping,
+        # so attach() must ask first. A backend without them still records; it
+        # only loses the ability to say a collective finished.
+        pg = self._init_pg()
+        backend = pg._get_backend(self.device)
+        self.assertEqual(pg.supports_completion_hooks, self._push_completion)
+        self.assertEqual(backend.supports_completion_hooks, self._push_completion)
+
+        before = len(self._hook_entries())
+        hook = self._fr_hook(pg)
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        entries = self._await_retired(before + 1)[before:]
+        self.assertEqual(len(entries), 1)
+        self.assertTrue(entries[0]["retired"], msg=str(entries[0]))
+        # remove() must not throw either: unregisterCompletionHook throws on a
+        # backend that has none, so it may only be called if attach() registered
+        # one.
+        hook.remove()
+
+    def test_profiling_name_carries_backend_name(self):
+        # The comm_lib field must be the backend's own name, not a placeholder
+        # and not ProcessGroup::getBackendName(), which answers "custom" for
+        # anything outside the built-in BackendType enum (nccl2 included).
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        before = len(self._hook_entries())
+
+        t = torch.ones(4, device=self.device)
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+
+        entries = self._hook_entries()[before:]
+        self.assertEqual(len(entries), 1)
+        name = entries[0]["profiling_name"]
+        self.assertEqual(name, f"{self.backend_name}:all_reduce")
+        # The analyzer splits on ":" and expects exactly two fields.
+        self.assertEqual(name.count(":"), 1)
+        hook.remove()
+
+    def test_inflight_op_is_not_reported_completed(self):
+        # Regression test: the hook used to publish an end event that is only
+        # recorded when the entry is retired, and query() answers true for an
+        # event that was never recorded, so an op still in flight read as
+        # "completed" -- and a dump with TORCH_INCLUDE_ONLY_ACTIVE then skipped
+        # it, losing exactly the collective a post-mortem is for.
+        #
+        # An op whose post-hook never runs is what makes that permanent, and a
+        # backend that rejects its arguments produces one deterministically:
+        # Ops.cpp fires the pre-hook, the backend throws, and firePostHook is
+        # never reached (there is no try/catch around it).
+        if not self._communicates:
+            self.skipTest("needs a backend that validates its arguments")
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+        t = torch.ones(4, device=self.device)
+        # Warm up so lazy communicator setup does not add entries of its own.
+        dist.all_reduce(t)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        before = len(self._all_entries())
+
+        with self.assertRaises(RuntimeError):
+            # One output tensor for a world of two.
+            dist.all_gather([torch.empty_like(t)], t)
+
+        # The backend validates before it records natively, so the only new
+        # entry is the hook's.
+        entries = self._all_entries()[before:]
+        self.assertEqual(len(entries), 1, msg=str(entries))
+        e = entries[0]
+        self.assertEqual(e["profiling_name"], self._name("all_gather"))
+        self.assertFalse(e["retired"], msg=str(e))
+        self.assertNotEqual(e["state"], "completed", msg=str(e))
+        self.assertEqual(e["time_discovered_completed_ns"], 0, msg=str(e))
+        hook.remove()
+
+    def test_no_recording_during_cuda_graph_capture(self):
+        # A collective issued under capture does not run here, it runs at
+        # replay, and its Work cannot be polled: querying a CUDA event recorded
+        # on a capturing stream invalidates the capture rather than merely
+        # failing, and the failure then surfaces from cudaStreamEndCapture. An
+        # entry the hook could never observe would read as a collective that
+        # never finished, so nothing is recorded at all -- which is also what
+        # stock ProcessGroupNCCL does under capture.
+        if self.device_type != "cuda":
+            self.skipTest("capture test is CUDA only")
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+
+        t = torch.ones(4, device=self.device)
+        # Warm up so comm initialization does not happen inside the capture.
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        before = len(self._hook_entries())
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            dist.all_reduce(t)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertEqual(self._hook_entries()[before:], [])
+        # Recording resumes once the capture is over.
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        entries = self._await_retired(before + 1)[before:]
+        self.assertEqual(len(entries), 1, msg=str(entries))
+        self.assertEqual(entries[0]["profiling_name"], self._name("all_reduce"))
+        self.assertEqual(entries[0]["state"], "completed", msg=str(entries[0]))
+        hook.remove()
+
+    def test_buffer_size_zero_attaches_nothing(self):
+        # The gate is read when the group is created, so flip it before init.
+        saved = os.environ["TORCH_FR_BUFFER_SIZE"]
+        os.environ["TORCH_FR_BUFFER_SIZE"] = "0"
+        try:
+            pg = self._init_pg()
+            sub_pg = dist.new_group(list(range(self.world_size)))
+        finally:
+            os.environ["TORCH_FR_BUFFER_SIZE"] = saved
+        self.assertNotIn(pg, _world.pg_flight_recorder_hooks)
+        self.assertNotIn(sub_pg, _world.pg_flight_recorder_hooks)
+
+        before = len(self._hook_entries())
+        t = torch.ones(8, device=self.device)
+        dist.all_reduce(t)
+        dist.all_reduce(t, group=sub_pg)
+        if self.device_type == "cuda":
+            torch.cuda.synchronize()
+        self.assertEqual(self._hook_entries()[before:], [])
 
 
 def _make_fr_hook_test_class(backend_name, device_type):
@@ -209,6 +1027,198 @@ for backend_name, device_type in FR_HOOK_BACKENDS:
     globals()[f"{backend_name.capitalize()}FlightRecorderHookTest"] = (
         _make_fr_hook_test_class(backend_name, device_type)
     )
+
+
+class FlightRecorderHookGlooTest(MultiProcessTestCase):
+    """The hook must leave a natively recording backend's ops alone.
+
+    ProcessGroupGloo records in enqueue(), into the very instance the dump APIs
+    return by default. Recording gloo ops on top would put two entries with two
+    independent collective_seq_ids in the trace for every gloo collective.
+    """
+
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TORCH_FR_BUFFER_SIZE"] = "2000"
+        self._spawn_processes()
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    def _init_pg(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "gloo",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            timeout=timedelta(seconds=60),
+        )
+        return dist.group.WORLD
+
+    @staticmethod
+    def _entries(**kwargs):
+        trace = json.loads(torch._C._distributed_c10d._dump_fr_trace_json(**kwargs))
+        return trace.get("entries", [])
+
+    def test_pure_gloo_group_is_not_auto_attached(self):
+        # A hook there would record nothing, so do not pay for one.
+        pg = self._init_pg()
+        self.assertNotIn(pg, _world.pg_flight_recorder_hooks)
+
+    def test_gloo_collectives_recorded_exactly_once(self):
+        pg = self._init_pg()
+        hook = FlightRecorderHook.attach(pg)
+        before = len(self._entries())
+
+        t = torch.ones(8)
+        dist.all_reduce(t)
+        dist.broadcast(t, src=0)
+
+        entries = self._entries()[before:]
+        self.assertEqual(
+            [e["profiling_name"] for e in entries],
+            ["gloo:all_reduce", "gloo:broadcast"],
+        )
+        # Only the hook fills duration_ms in; gloo's native recording retires
+        # with compute_duration=false and leaves the field out.
+        for e in entries:
+            self.assertNotIn("duration_ms", e, msg=str(e))
+        hook.remove()
+
+    def test_default_dump_returns_the_gloo_instance(self):
+        pg = self._init_pg()
+        FlightRecorderHook.attach(pg)
+        dist.all_reduce(torch.ones(8))
+
+        default = pickle.loads(torch._C._distributed_c10d._dump_fr_trace())
+        named = pickle.loads(torch._C._distributed_c10d._dump_fr_trace(backend="gloo"))
+        self.assertEqual(
+            [e["profiling_name"] for e in default["entries"]],
+            [e["profiling_name"] for e in named["entries"]],
+        )
+        self.assertIn(
+            "gloo:all_reduce", [e["profiling_name"] for e in named["entries"]]
+        )
+
+
+@unittest.skipIf(
+    not TEST_CUDA or torch.cuda.device_count() < 2,
+    "mixed backend tests require at least 2 GPUs",
+)
+@unittest.skipIf(
+    not dist.is_backend_available("nccl2"), "nccl2 backend is not available"
+)
+class FlightRecorderHookMixedBackendTest(MultiProcessTestCase):
+    """A group whose CPU half records itself and whose CUDA half does not."""
+
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TORCH_FR_BUFFER_SIZE"] = "2000"
+        self._spawn_processes()
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _entries(**kwargs):
+        trace = json.loads(torch._C._distributed_c10d._dump_fr_trace_json(**kwargs))
+        return trace.get("entries", [])
+
+    def test_mixed_group_records_the_cuda_half_only(self):
+        torch.cuda.set_device(self.rank)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "cpu:gloo,cuda:nccl2",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            timeout=timedelta(seconds=60),
+        )
+        pg = dist.group.WORLD
+        # The whole-group skip used to lose the nccl2 half of a mixed group;
+        # the hook now filters per op, so it is attached again.
+        self.assertIn(pg, _world.pg_flight_recorder_hooks)
+
+        before_gloo = len(self._entries())
+        before_nccl2 = len(self._entries(backend="nccl2"))
+        dist.all_reduce(torch.ones(8))
+        dist.all_reduce(torch.ones(16, device=f"cuda:{self.rank}"))
+        torch.cuda.synchronize()
+
+        # The CPU collective is gloo's own entry, recorded once, and the CUDA
+        # one is the hook's, in nccl2's instance.
+        gloo_entries = self._entries()[before_gloo:]
+        self.assertEqual(
+            [(e["profiling_name"], e["input_sizes"]) for e in gloo_entries],
+            [("gloo:all_reduce", [[8]])],
+        )
+        nccl2_entries = self._entries(backend="nccl2")[before_nccl2:]
+        self.assertEqual(
+            [(e["profiling_name"], e["input_sizes"]) for e in nccl2_entries],
+            [("nccl2:all_reduce", [[16]])],
+        )
+
+    def test_two_hooked_backends_do_not_share_a_buffer(self):
+        torch.cuda.set_device(self.rank)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "nccl2",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            timeout=timedelta(seconds=60),
+        )
+        fake_pg = dist.new_group(backend="fake")
+        fake_hook = FlightRecorderHook.attach(
+            fake_pg, dist.get_process_group_ranks(fake_pg)
+        )
+
+        before_nccl2 = len(self._entries(backend="nccl2"))
+        before_fake = len(self._entries(backend="fake"))
+        dist.all_reduce(torch.ones(16, device=f"cuda:{self.rank}"))
+        torch.cuda.synchronize()
+        dist.all_reduce(torch.ones(8), group=fake_pg)
+
+        self.assertEqual(
+            [
+                e["profiling_name"]
+                for e in self._entries(backend="nccl2")[before_nccl2:]
+            ],
+            ["nccl2:all_reduce"],
+        )
+        self.assertEqual(
+            [e["profiling_name"] for e in self._entries(backend="fake")[before_fake:]],
+            ["fake:all_reduce"],
+        )
+        # pg_ids come from one process-wide counter, so two hooked groups never
+        # collide even if they did share an instance.
+        pg_ids = {
+            self._entries(backend="nccl2")[-1]["pg_id"],
+            self._entries(backend="fake")[-1]["pg_id"],
+        }
+        self.assertEqual(len(pg_ids), 2)
+        fake_hook.remove()
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -5,6 +5,7 @@
 import ctypes
 import json
 import os
+import pickle
 import subprocess
 import sys
 import tempfile
@@ -535,6 +536,146 @@ class ProcessGroupNCCL2BlockingWaitTest(_ProcessGroupNCCL2SubgroupTest):
                 work.wait()
         else:
             time.sleep(30)
+
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+class ProcessGroupNCCL2DumpOnTimeoutTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_flight_recorder_dumped_on_timeout(self) -> None:
+        # The dump is written by the abort hook c10d::FlightRecorderHook
+        # registers, which nccl2 runs when it detects the timeout. NoHandling
+        # both keeps the process alive so the test can read the artifact back,
+        # and is the configuration where abortProcess() returns without running
+        # any hook -- so this only passes if the hooks fire at detection.
+        tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tempdir.cleanup)
+        env = {
+            "TORCH_NCCL_ASYNC_ERROR_HANDLING": "0",
+            "TORCH_FR_DUMP_TEMP_FILE": os.path.join(tempdir.name, "trace_"),
+        }
+        with mock.patch.dict(os.environ, env):
+            pg = self._new_subgroup(timeout=timedelta(seconds=5))
+            self._check_all_reduce(pg)
+            # Gloo records into a FlightRecorder instance of its own. Give it
+            # something to hold so the dump below is evidence that only the
+            # backend whose abort hook fired reaches disk.
+            gloo_pg = dist.new_group(backend="gloo")
+            dist.all_reduce(torch.ones(7), group=gloo_pg)
+
+            path = env["TORCH_FR_DUMP_TEMP_FILE"] + str(self.rank)
+            if self.rank == 0:
+                # Nobody else joins, so this can never complete and the
+                # watchdog trips on it.
+                dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+                # Healthy collectives must not have dumped anything, or the
+                # artifact below would not be evidence of the timeout.
+                self.assertFalse(os.path.exists(path))
+                # The watchdog wakes once a second; poll until the file is
+                # there and complete -- it reads back empty mid-write.
+                dump = None
+                deadline = time.time() + 60
+                while dump is None and time.time() < deadline:
+                    try:
+                        with open(path, "rb") as f:
+                            dump = pickle.load(f)
+                    except (OSError, EOFError, pickle.UnpicklingError):
+                        time.sleep(0.5)
+                self.assertIsNotNone(dump, msg=f"no trace written to {path}")
+                self.assertIn("version", dump)
+                self.assertIn("pg_config", dump)
+                self.assertIn("pg_status", dump)
+                # The collective that hung has to be in the trace -- that is the
+                # whole point of the post-mortem. timeout_ms pins it to the
+                # subgroup that timed out rather than the default group.
+                hung = [e for e in dump["entries"] if e["input_sizes"] == [[1024]]]
+                self.assertEqual(len(hung), 1)
+                self.assertEqual(hung[0]["profiling_name"], "nccl2:all_reduce")
+                self.assertEqual(hung[0]["timeout_ms"], 5000)
+                # ... and it has to read as unfinished. The watchdog marked this
+                # work TIMEDOUT, which Work::isCompleted() also answers true to,
+                # so a completion report on a failed work would retire the entry
+                # and hide the culprit. Only successful completion is pushed.
+                self.assertFalse(hung[0]["retired"], msg=str(hung[0]))
+                self.assertNotEqual(hung[0]["state"], "completed", msg=str(hung[0]))
+                # Unset reads None here; the JSON dump spells the same thing 0.
+                self.assertIsNone(hung[0]["time_discovered_completed_ns"])
+                # The healthy collectives on the same group did get their
+                # completion pushed, so the dump distinguishes them.
+                healthy = [e for e in dump["entries"] if e["input_sizes"] == [[4]]]
+                self.assertTrue(healthy)
+                for e in healthy:
+                    self.assertTrue(e["retired"], msg=str(e))
+                    self.assertEqual(e["state"], "completed", msg=str(e))
+                # A culprit with no code location is most of the diagnostic
+                # value gone, so the abort dump attempts stack traces (default
+                # on, TORCH_INCLUDE_STACK_TRACE) instead of giving up on them
+                # because symbolizing may need the GIL. Symbolizing is what is
+                # bounded, not skipped.
+                frames = hung[0]["frames"]
+                self.assertTrue(frames, msg=str(hung[0]))
+                self.assertTrue(
+                    any(f["filename"].endswith("test_c10d_nccl2.py") for f in frames),
+                    msg=str(frames),
+                )
+                # Only nccl2's instance, matching stock, whose sole
+                # DebugInfoWriter caller is ProcessGroupNCCL::dumpDebuggingInfo.
+                self.assertEqual(
+                    {e["profiling_name"].split(":")[0] for e in dump["entries"]},
+                    {"nccl2"},
+                )
+            else:
+                # A rank that saw no failure must not have written a trace.
+                time.sleep(30)
+                self.assertFalse(os.path.exists(path))
+
+        dist.destroy_process_group(gloo_pg)
+        dist.destroy_process_group(pg)
+        self._check_all_reduce()
+
+
+# Its own class because the abort hook dumps at most once per process, and
+# MultiProcContinuousTest reuses the processes across a class's tests.
+class ProcessGroupNCCL2DumpTimeoutBoundTest(_ProcessGroupNCCL2SubgroupTest):
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_flight_recorder_dump_is_bounded(self) -> None:
+        # Symbolizing a traceback may need the GIL, so the attempt that
+        # includes stack traces is made under a bounded wait and abandoned for
+        # one without them if it does not land in time. What may never happen
+        # is the rank hanging in the abort hook instead of dying: the hook's
+        # one-shot mutex queues every other thread behind it. A zero bound runs
+        # both attempts out of time, and the rank still has to come back and a
+        # readable trace still has to reach disk.
+        tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tempdir.cleanup)
+        env = {
+            "TORCH_NCCL_ASYNC_ERROR_HANDLING": "0",
+            "TORCH_FR_DUMP_TEMP_FILE": os.path.join(tempdir.name, "trace_"),
+            "TORCH_FR_WAIT_TIMEOUT_DUMP_MILSEC": "0",
+        }
+        with mock.patch.dict(os.environ, env):
+            pg = self._new_subgroup(timeout=timedelta(seconds=5))
+            self._check_all_reduce(pg)
+            path = env["TORCH_FR_DUMP_TEMP_FILE"] + str(self.rank)
+            if self.rank == 0:
+                dist.all_reduce(torch.ones(1024, device=self.device), group=pg)
+                dump = None
+                deadline = time.time() + 60
+                while dump is None and time.time() < deadline:
+                    try:
+                        with open(path, "rb") as f:
+                            dump = pickle.load(f)
+                    except (OSError, EOFError, pickle.UnpicklingError):
+                        time.sleep(0.5)
+                self.assertIsNotNone(dump, msg=f"no trace written to {path}")
+                hung = [e for e in dump["entries"] if e["input_sizes"] == [[1024]]]
+                self.assertEqual(len(hung), 1)
+                self.assertEqual(hung[0]["profiling_name"], "nccl2:all_reduce")
+            else:
+                time.sleep(30)
 
         dist.destroy_process_group(pg)
         self._check_all_reduce()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192858
* __->__ #192837
* #192233

Tests for the commit below this one, split out to keep each PR under the 2000 LOC
review limit. They do not stand alone -- the implementation is in that commit.

test_c10d_fr_hook.py is the bulk, parameterized over a backend that pushes
completion (nccl2) and one that does not (fake), so both tiers are covered: the
pushed path gets a real device duration and reaches "completed", the fallback
retires at issue with neither. The gloo cases assert the hook records nothing,
since ProcessGroupGloo records itself and a second recording would duplicate
every collective.

The ones worth knowing about, because they encode properties rather than
behaviour:

- a hung collective must read not-completed, and flip to completed once the peer
  arrives. This is the property the whole feature exists for, so it is a test and
  not just a drill.
- an op still in flight must not report completed. Driven deterministically by
  making the backend throw between the pre- and post-hook rather than by timing.
- recording inside torch.cuda.graph must not invalidate the capture.
- a subgroup on a backend with no rank mapping must publish neither ranks nor a
  process-wide rank, since a fabricated one collides dump filenames.
- hook-produced entries must survive the real analyzer: test_fr_analysis.py runs
  build_db over hook-shaped entries for the in-place and list-form collectives,
  with negative cases so the list-form allowance cannot silently accept anything.

Test Plan:

```
python test/distributed/test_c10d_fr_hook.py -v
python test/distributed/test_c10d_nccl2.py -v
python test/distributed/flight_recorder/test_fr_analysis.py
python test/distributed/elastic/test_control_plane.py
```

Results are quoted in the implementation commit's message; these files are the
tests that produced them.

Authored with the assistance of an AI coding agent.