### PR TITLE
[DO NOT MERGE][cuDNN][cuDNN V8 API] Add bias-handling back to cuDNN convs under V8 API

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -104,6 +104,12 @@ inline bool cudnnv8_enabled_check_debug() {
   return cudnnv8_flag == 1;
 }
 
+inline bool cudnnv8_conv_bias_enabled() {
+  static const bool enabled =
+      c10::utils::check_env("TORCH_CUDNN_V8_API_CONV_BIAS_ENABLED") == true;
+  return enabled && cudnnv8_enabled_check_debug();
+}
+
 inline bool cudnnv8_use_heur_mode_b() {
   return is_cudnnv8_heuristic_mode_b();
 }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1605,11 +1605,20 @@ at::Tensor _convolution(
       break;
     case ConvBackend::Cudnn:
       check_input_same_type_as_parameters(input, weight, bias);
-      output = at::cudnn_convolution(
-          input.contiguous(backend_memory_format), weight, params.padding, params.stride,
-          params.dilation, params.groups, params.benchmark, params.deterministic, params.allow_tf32);
-      if (bias.defined()) {
-        output.add_(reshape_bias(input.dim(), bias));
+      if (bias.defined() && cudnnv8_conv_bias_enabled() &&
+          (input.scalar_type() == kFloat || input.scalar_type() == kHalf ||
+           input.scalar_type() == kBFloat16)) {
+        output = at::cudnn_convolution(
+            input.contiguous(backend_memory_format), weight, bias, params.padding,
+            params.stride, params.dilation, params.groups, params.benchmark,
+            params.deterministic, params.allow_tf32);
+      } else {
+        output = at::cudnn_convolution(
+            input.contiguous(backend_memory_format), weight, params.padding, params.stride,
+            params.dilation, params.groups, params.benchmark, params.deterministic, params.allow_tf32);
+        if (bias.defined()) {
+          output.add_(reshape_bias(input.dim(), bias));
+        }
       }
       break;
     case ConvBackend::CudnnTranspose:

--- a/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
+++ b/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
@@ -37,6 +37,21 @@ at::Tensor cudnn_convolution(
   TORCH_CHECK(false, "cudnn_convolution: ATen not compiled with cuDNN support");
 }
 
+at::Tensor cudnn_convolution_bias(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool allow_tf32) {
+  TORCH_CHECK(
+      false, "cudnn_convolution: ATen not compiled with cuDNN support");
+}
+
 at::Tensor& cudnn_convolution_out(
     const Tensor& input_t,
     const Tensor& weight_t,
@@ -180,6 +195,23 @@ void raw_cudnn_convolution_forward_out(
   TORCH_CHECK(
       false,
       "raw_cudnn_convolution_forward_out: ATen not compiled with cuDNN support");
+}
+
+void raw_cudnn_convolution_bias_out(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool allow_tf32) {
+  TORCH_CHECK(
+      false,
+      "raw_cudnn_convolution_bias_out: ATen not compiled with cuDNN support");
 }
 
 void raw_cudnn_convolution_backward_input_out(

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -39,7 +39,8 @@
 //
 // NOTE [ Convolution design ]
 //
-// cuDNN convolutions does not handle bias. Bias is handled outside.
+// The ordinary cuDNN convolution path does not handle bias. An experimental
+// cuDNN v8 operation-graph path can fuse bias for forward convolutions.
 //
 // The general strategy:
 //
@@ -276,6 +277,86 @@ Tensor cudnn_convolution(
       allow_tf32);
   return *output;
 }
+
+Tensor cudnn_convolution_bias(
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_t,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool allow_tf32) {
+  if (!bias_t.has_value()) {
+    return cudnn_convolution(
+        input_t,
+        weight_t,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        allow_tf32);
+  }
+
+  TensorArg input{input_t, "input", 1}, weight{weight_t, "weight", 2},
+      bias{*bias_t, "bias", 3};
+  CheckedFrom c = "cudnn_convolution";
+  checkAllSameType(c, {input, weight, bias});
+  checkAllSameGPU(c, {input, weight, bias});
+  checkSize(c, bias, {weight_t.size(0)});
+
+  const auto scalar_type = input_t.scalar_type();
+  const bool supported_graph_dtype = scalar_type == kFloat ||
+      scalar_type == kHalf || scalar_type == kBFloat16;
+  if (!cudnnv8_enabled_check_debug() || !supported_graph_dtype) {
+    Tensor output = cudnn_convolution(
+        input_t,
+        weight_t,
+        padding,
+        stride,
+        dilation,
+        groups,
+        benchmark,
+        deterministic,
+        allow_tf32);
+    output.add_(reshape_bias(input_t.dim(), *bias_t));
+    return output;
+  }
+
+  auto memory_format = cudnn_conv_suggest_memory_format(input_t, weight_t);
+  Tensor output_t = at::detail::empty_cuda(
+      conv_output_size(
+          input_t.sizes(), weight_t.sizes(), padding, stride, dilation),
+      input->options().memory_format(memory_format));
+  if (output_t.numel() == 0) {
+    return output_t;
+  }
+
+  TensorArg output{output_t, "result", 0};
+  convolution_shape_check(
+      c, input, weight, output, padding, stride, dilation, groups);
+  Tensor input_contig = input->contiguous(memory_format);
+  Tensor weight_contig = weight->contiguous(memory_format);
+  Tensor bias_contig = bias->contiguous();
+  raw_cudnn_convolution_bias_out(
+      *output,
+      input_contig,
+      weight_contig,
+      bias_contig,
+      padding,
+      stride,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      allow_tf32);
+  return *output;
+}
+
 at::Tensor& cudnn_convolution_out(
     const Tensor& input_t,
     const Tensor& weight_t,

--- a/aten/src/ATen/native/cudnn/ConvShared.h
+++ b/aten/src/ATen/native/cudnn/ConvShared.h
@@ -73,6 +73,19 @@ void raw_cudnn_convolution_forward_out(
     bool deterministic,
     bool allow_tf32);
 
+void raw_cudnn_convolution_bias_out(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool allow_tf32);
+
 void raw_cudnn_convolution_backward_input_out(
     const at::Tensor& grad_input,
     const at::Tensor& grad_output,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -188,6 +188,14 @@ struct CacheKeyFused {
   float alpha;
 };
 
+struct CacheKeyBias {
+  ConvolutionParams params;
+  uint8_t x_alignment;
+  uint8_t w_alignment;
+  uint8_t y_alignment;
+  uint8_t b_alignment;
+};
+
 struct CacheKeyWrapper : ParamsWrapper<CacheKey> {
   CacheKeyWrapper(
       const cudnnBackendDescriptorType_t operation,
@@ -251,6 +259,37 @@ struct CacheKeyFusedWrapper : ParamsWrapper<CacheKeyFused> {
     this->pod.z_alignment = getAlignment(z);
     this->pod.b_alignment = getAlignment(b);
     this->pod.alpha = alpha;
+  }
+};
+
+struct CacheKeyBiasWrapper : ParamsWrapper<CacheKeyBias> {
+  CacheKeyBiasWrapper(
+      const Tensor& y,
+      const Tensor& x,
+      const Tensor& w,
+      const Tensor& b,
+      const IntArrayRef padding,
+      const IntArrayRef stride,
+      const IntArrayRef dilation,
+      int64_t groups,
+      bool deterministic,
+      bool allow_tf32) {
+    at::MemoryFormat memory_format = cudnn_conv_suggest_memory_format(x, w);
+    setConvolutionParams(
+        &(this->pod).params,
+        x,
+        w,
+        padding,
+        stride,
+        dilation,
+        groups,
+        deterministic,
+        allow_tf32,
+        memory_format);
+    this->pod.x_alignment = getAlignment(x);
+    this->pod.y_alignment = getAlignment(y);
+    this->pod.w_alignment = getAlignment(w);
+    this->pod.b_alignment = getAlignment(b);
   }
 };
 
@@ -369,6 +408,15 @@ _get_benchmark_cache_fused() {
       new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyFusedWrapper>();
   return benchmark_cache_fused;
 }
+
+BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyBiasWrapper>*
+_get_benchmark_cache_bias() {
+  static thread_local BenchmarkCache<
+      cudnn_frontend::ExecutionPlan,
+      CacheKeyBiasWrapper>* benchmark_cache_bias =
+      new BenchmarkCache<cudnn_frontend::ExecutionPlan, CacheKeyBiasWrapper>();
+  return benchmark_cache_bias;
+}
 } // namespace
 
 void run_conv_plan(
@@ -442,6 +490,29 @@ void run_conv_plan_fused(
       handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
 }
 
+void run_conv_plan_bias(
+    cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b,
+    const cudnn_frontend::ExecutionPlan& plan) {
+  c10::DeviceGuard g(x.options().device());
+  auto workspace_size = plan.getWorkspaceSize();
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  void* data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr(), b.data_ptr()};
+  int64_t uids[] = {'x', 'y', 'w', 'b'};
+  auto variantPack =
+      cudnn_frontend::VariantPackBuilder()
+          .setWorkspacePointer(workspace_size ? workspace_ptr.get() : nullptr)
+          .setDataPointers(4, data_ptrs)
+          .setUids(4, uids)
+          .build();
+  AT_CUDNN_CHECK(cudnnBackendExecute(
+      handle, plan.get_raw_desc(), variantPack.get_raw_desc()));
+}
+
 auto build_opgraph(
     const cudnnHandle_t handle,
     const cudnnBackendDescriptorType_t desc,
@@ -472,6 +543,59 @@ auto build_opgraph(
                      .setOperationGraph(ops.size(), ops.data())
                      .build();
   return opGraph;
+}
+
+auto build_opgraph_bias(
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b,
+    const CacheKeyBiasWrapper& key,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation) {
+  // Match the existing conv-add-relu graph: convolution accumulation and the
+  // bias pointwise operation use FP32 for reduced-precision inputs.
+  const auto precision = CUDNN_DATA_FLOAT;
+  auto add_bias_desc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_ADD)
+                           .setMathPrecision(precision)
+                           .build();
+  auto conv_desc = getConvDescriptor(
+      key.pod.params.dataType, padding, stride, dilation, x.scalar_type());
+  auto conv_op =
+      cudnn_frontend::OperationBuilder(
+          CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+          .setxDesc(getTensorDescriptor(
+              x, 'x', key.pod.x_alignment, key.pod.params.memory_format))
+          .setyDesc(getTensorDescriptorWithTypeVirtual(
+              y,
+              'C',
+              key.pod.y_alignment,
+              precision,
+              key.pod.params.memory_format,
+              true))
+          .setwDesc(getTensorDescriptor(
+              w, 'w', key.pod.w_alignment, key.pod.params.memory_format))
+          .setcDesc(conv_desc)
+          .build();
+  auto add_bias_op =
+      cudnn_frontend::OperationBuilder(
+          CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setxDesc(conv_op.getOutputTensor())
+          .setbDesc(getTensorDescriptor(
+              b, 'b', key.pod.b_alignment, key.pod.params.memory_format))
+          .setyDesc(getTensorDescriptor(
+              y, 'y', key.pod.y_alignment, key.pod.params.memory_format))
+          .setpwDesc(add_bias_desc)
+          .build();
+  auto ops = std::to_array<cudnn_frontend::Operation const*>(
+      {&conv_op, &add_bias_op});
+  return cudnn_frontend::OperationGraphBuilder()
+      .setHandle(handle)
+      .setOperationGraph(ops.size(), ops.data())
+      .build();
 }
 
 auto build_opgraph_fused(
@@ -865,6 +989,58 @@ auto get_plans_from_find(
   return sorted_plans;
 }
 
+auto get_plans_from_find_bias(
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b,
+    const CacheKeyBiasWrapper& key,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation,
+    const bool deterministic,
+    const bool allow_tf32) {
+  auto opGraph =
+      build_opgraph_bias(handle, x, y, w, b, key, padding, stride, dilation);
+  void* data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr(), b.data_ptr()};
+  int64_t uids[] = {'x', 'y', 'w', 'b'};
+  auto sources = get_generator_sources(
+      CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR,
+      x,
+      deterministic,
+      allow_tf32,
+      CUDNN_HEUR_MODE_INSTANT,
+      true,
+      true,
+      true);
+  cudnn_frontend::EngineConfigGenerator generator(
+      sources.size(), sources.data());
+  cudnn_frontend::executionPlans_t valid_plans;
+  c10::DeviceGuard g(x.options().device());
+  at::DataPtr workspace_ptr;
+  generate_and_filter_plans(
+      handle, opGraph, generator, x, valid_plans, workspace_ptr);
+  auto variantPack =
+      cudnn_frontend::VariantPackBuilder()
+          .setDataPointers(4, data_ptrs)
+          .setUids(4, uids)
+          .setWorkspacePointer(workspace_ptr ? workspace_ptr.get() : nullptr)
+          .build();
+
+  auto benchmark_limit = at::globalContext().benchmarkLimitCuDNN();
+  benchmark_limit = benchmark_limit ? benchmark_limit : 10000;
+  auto plans = cudnn_frontend::time_sorted_plan<
+      cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_ONCE>(
+      handle, std::move(valid_plans), variantPack, benchmark_limit);
+
+  cudnn_frontend::executionPlans_t sorted_plans;
+  for (auto& plan : plans) {
+    sorted_plans.emplace_back(std::move(plan));
+  }
+  return sorted_plans;
+}
+
 auto get_plans_from_find_fused(
     const cudnnHandle_t handle,
     const Tensor& x,
@@ -962,6 +1138,45 @@ auto get_configs_from_heuristics(
   return EngineConfigResult{std::move(configs), heuristic_config_count};
 }
 
+auto get_configs_from_heuristics_bias(
+    const cudnnHandle_t handle,
+    std::string& opgraph_tag,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b,
+    const CacheKeyBiasWrapper& key,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation,
+    const bool deterministic,
+    const bool allow_tf32,
+    const bool fallback,
+    const bool get_all_heuristic_configs = false) {
+  auto opGraph =
+      build_opgraph_bias(handle, x, y, w, b, key, padding, stride, dilation);
+  opgraph_tag = opGraph.getTag();
+  auto heuristic_mode = at::native::cudnnv8_use_heur_mode_b()
+      ? CUDNN_HEUR_MODE_B
+      : CUDNN_HEUR_MODE_INSTANT;
+  int64_t heuristic_config_count = -1;
+  auto sources = get_generator_sources(
+      CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR,
+      x,
+      deterministic,
+      allow_tf32,
+      heuristic_mode,
+      !fallback,
+      fallback,
+      get_all_heuristic_configs,
+      &heuristic_config_count);
+
+  cudnn_frontend::EngineConfigGenerator generator(
+      sources.size(), sources.data());
+  auto configs = generator.generate_engine_config(opGraph);
+  return EngineConfigResult{std::move(configs), heuristic_config_count};
+}
+
 auto get_configs_from_heuristics_fused(
     const cudnnHandle_t handle,
     std::string& opgraph_tag,
@@ -1015,6 +1230,29 @@ void try_plans(
     try {
       run_conv_plan(handle, x, y, w, plan, operation);
       _get_benchmark_cache()->update(key, plan);
+      return;
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
+    }
+  }
+  TORCH_CHECK(
+      false, "FIND was unable to find an engine to execute this computation");
+}
+
+void try_plans_bias(
+    cudnn_frontend::executionPlans_t& plans,
+    const CacheKeyBiasWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b) {
+  for (auto& plan : plans) {
+    try {
+      run_conv_plan_bias(handle, x, y, w, b, plan);
+      _get_benchmark_cache_bias()->update(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException&) {
     } catch (CuDNNError&) {
@@ -1083,6 +1321,39 @@ bool try_configs(
   return false;
 }
 
+bool try_configs_bias(
+    cudnn_frontend::EngineConfigList::iterator configs_begin,
+    cudnn_frontend::EngineConfigList::iterator configs_end,
+    const std::string& opgraph_tag,
+    const CacheKeyBiasWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b) {
+  for (auto config_iter = configs_begin; config_iter != configs_end;
+       ++config_iter) {
+    try {
+      auto& config = *config_iter;
+      auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                      .setHandle(handle)
+                      .setEngineConfig(config, opgraph_tag)
+                      .build();
+      if (plan_errata_exception(handle, plan, x)) {
+        continue;
+      }
+      run_conv_plan_bias(handle, x, y, w, b, plan);
+      _get_benchmark_cache_bias()->update(key, plan);
+      return true;
+    } catch (cudnn_frontend::cudnnException&) {
+    } catch (CuDNNError&) {
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
+    }
+  }
+  return false;
+}
+
 bool try_configs_fused(
     cudnn_frontend::EngineConfigList::iterator configs_begin,
     cudnn_frontend::EngineConfigList::iterator configs_end,
@@ -1136,6 +1407,19 @@ bool try_configs(
       y,
       w,
       operation);
+}
+
+bool try_configs_bias(
+    cudnn_frontend::EngineConfigList& configs,
+    const std::string& opgraph_tag,
+    const CacheKeyBiasWrapper& key,
+    const cudnnHandle_t handle,
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b) {
+  return try_configs_bias(
+      configs.begin(), configs.end(), opgraph_tag, key, handle, x, y, w, b);
 }
 
 bool try_configs_fused(
@@ -1303,6 +1587,146 @@ void run_single_conv(
   }
 }
 
+void run_bias_conv(
+    const Tensor& x,
+    const Tensor& y,
+    const Tensor& w,
+    const Tensor& b,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups,
+    const bool benchmark,
+    const bool deterministic,
+    const bool allow_tf32) {
+  cudnnHandle_t handle = getCudnnHandle();
+  CacheKeyBiasWrapper key(
+      y,
+      x,
+      w,
+      b,
+      padding,
+      stride,
+      dilation,
+      groups,
+      deterministic,
+      allow_tf32);
+  auto search = _get_benchmark_cache_bias()->find(key);
+  if (search) {
+    try {
+      run_conv_plan_bias(handle, x, y, w, b, *search);
+      return;
+    } catch (c10::OutOfMemoryError&) {
+      std::ignore = cudaGetLastError(); // clear CUDA error
+    }
+  }
+  if (!benchmark) {
+    std::string opgraph_tag;
+    auto engine_config_result = get_configs_from_heuristics_bias(
+        handle,
+        opgraph_tag,
+        x,
+        y,
+        w,
+        b,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32,
+        false);
+    const bool tried_top_config = !engine_config_result.configs.empty();
+    if (tried_top_config &&
+        try_configs_bias(
+            engine_config_result.configs,
+            opgraph_tag,
+            key,
+            handle,
+            x,
+            y,
+            w,
+            b)) {
+      return;
+    }
+    if (engine_config_result.heuristic_config_count > 0) {
+      engine_config_result = get_configs_from_heuristics_bias(
+          handle,
+          opgraph_tag,
+          x,
+          y,
+          w,
+          b,
+          key,
+          padding,
+          stride,
+          dilation,
+          deterministic,
+          allow_tf32,
+          false,
+          true);
+      auto configs_begin = engine_config_result.configs.begin();
+      if (tried_top_config &&
+          configs_begin != engine_config_result.configs.end()) {
+        configs_begin += 1;
+      }
+      if (try_configs_bias(
+              configs_begin,
+              engine_config_result.configs.end(),
+              opgraph_tag,
+              key,
+              handle,
+              x,
+              y,
+              w,
+              b)) {
+        return;
+      }
+    }
+    engine_config_result = get_configs_from_heuristics_bias(
+        handle,
+        opgraph_tag,
+        x,
+        y,
+        w,
+        b,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32,
+        true);
+    if (try_configs_bias(
+            engine_config_result.configs,
+            opgraph_tag,
+            key,
+            handle,
+            x,
+            y,
+            w,
+            b)) {
+      return;
+    }
+    TORCH_CHECK(
+        false, "GET was unable to find an engine to execute this computation");
+  } else {
+    auto plans = get_plans_from_find_bias(
+        handle,
+        x,
+        y,
+        w,
+        b,
+        key,
+        padding,
+        stride,
+        dilation,
+        deterministic,
+        allow_tf32);
+    try_plans_bias(plans, key, handle, x, y, w, b);
+  }
+}
+
 void run_fused_conv(
     const Tensor& x,
     const Tensor& y,
@@ -1462,6 +1886,39 @@ void run_fused_conv(
         allow_tf32);
     try_plans_fused(plans, key, handle, x, y, w, z, b);
   }
+}
+
+void raw_cudnn_convolution_bias_out(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation,
+    const int64_t groups,
+    const bool benchmark,
+    const bool deterministic,
+    const bool allow_tf32) {
+  if (output.numel() == 0) {
+    return;
+  }
+  TORCH_INTERNAL_ASSERT(cudnnv8_enabled_check_debug());
+  for (long it : dilation) {
+    TORCH_CHECK_VALUE(it > 0, "Expected positive dilation in convolution.");
+  }
+  run_bias_conv(
+      input,
+      output,
+      weight,
+      reshape_bias(input.dim(), bias),
+      stride,
+      padding,
+      dilation,
+      groups,
+      benchmark,
+      deterministic,
+      allow_tf32);
 }
 
 void raw_cudnn_convolution_forward_out(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1886,6 +1886,10 @@
   dispatch:
     CUDA: cudnn_convolution
 
+- func: cudnn_convolution.bias(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
+  dispatch:
+    CUDA: cudnn_convolution_bias
+
 - func: cudnn_convolution.out(Tensor self, Tensor weight, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CUDA: cudnn_convolution_out

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4436,6 +4436,60 @@ class TestConvolutionNNCUDA(NNTestCase):
         o.sum().backward()
 
     @skipCUDAIfNoCudnn
+    @skipCUDAIfRocm
+    @dtypes(torch.float, torch.float16, torch.bfloat16)
+    @torch.backends.cudnn.flags(
+        enabled=True, deterministic=True, benchmark=False, allow_tf32=False
+    )
+    @precisionOverride({torch.half: 5e-3, torch.bfloat16: 5e-2, torch.float: 1e-5})
+    def test_cudnn_convolution_bias(self, device, dtype):
+        if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+            self.skipTest("bfloat16 is not supported on this GPU")
+
+        for memory_format in (torch.contiguous_format, torch.channels_last):
+            inp = torch.randn(
+                2, 4, 8, 8, device=device, dtype=dtype, requires_grad=True
+            ).to(memory_format=memory_format)
+            weight = torch.randn(
+                6, 4, 3, 3, device=device, dtype=dtype, requires_grad=True
+            ).to(memory_format=memory_format)
+            bias = torch.randn(6, device=device, dtype=dtype, requires_grad=True)
+
+            actual = torch.ops.aten.cudnn_convolution.bias(
+                inp,
+                weight,
+                bias,
+                [1, 1],
+                [1, 1],
+                [1, 1],
+                1,
+                False,
+                True,
+                False,
+            )
+            expected = torch.ops.aten.cudnn_convolution.default(
+                inp,
+                weight,
+                [1, 1],
+                [1, 1],
+                [1, 1],
+                1,
+                False,
+                True,
+                False,
+            ) + bias.view(1, -1, 1, 1)
+
+            self.assertTrue(actual.is_contiguous(memory_format=memory_format))
+            self.assertEqual(actual, expected)
+
+            grad = torch.randn_like(actual)
+            actual_grads = torch.autograd.grad(actual, (inp, weight, bias), grad)
+            expected_grads = torch.autograd.grad(
+                expected, (inp, weight, bias), grad
+            )
+            self.assertEqual(actual_grads, expected_grads)
+
+    @skipCUDAIfNoCudnn
     @dtypes(torch.float, torch.float16)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @precisionOverride({torch.half: 0.002, torch.float: 1e-4})

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2765,6 +2765,9 @@
 - name: cudnn_convolution(Tensor self, Tensor weight, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   self, weight: "_cudnn_convolution_backward(self, grad, weight, padding, std::vector<c10::SymInt>(padding.size(), 0), stride, dilation, false, groups, {grad_input_mask[0], grad_input_mask[1]})"
 
+- name: cudnn_convolution.bias(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
+  self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, false, std::vector<c10::SymInt>(padding.size(), 0), groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
+
 - name: cudnn_grid_sampler(Tensor self, Tensor grid) -> Tensor output
   self, grid: "grad.defined() ? cudnn_grid_sampler_backward(self, grid, grad) : std::tuple<Tensor, Tensor>()"
 


### PR DESCRIPTION
#31524 originally moved bias handling outside of cuDNN convolutions for performance reasons, however this change predates the V8 API which allows for bias fusion due to its AOT opgraph construction.

regular convs are seeing ~10% gain but regressions for depthwise (we likely wouldn't enable it for depthwise)
backward currently remains unchanged

authored with codex

cc @csarofeen @ptrblck @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01