### PR TITLE
Fix silently-wrong gradients from subgraphs inheriting bw_donated_idxs

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -388,6 +388,44 @@ class CondTests(TestCase):
         )
 
     @requires_gpu
+    def test_cond_backward_does_not_reuse_donated_subgraph_input(self):
+        # Regression for a SubgraphLowering donation bug: bw_donated_idxs is
+        # computed for the top-level backward's inputs, but a subgraph's
+        # placeholders live in a different index space. If a SubgraphLowering
+        # inherits those indices, a cond branch input can be classified a
+        # DonatedBuffer and reused in place for an output -- corrupting a saved
+        # tensor the parent backward still holds (here `h`, used after the cond),
+        # yielding grossly wrong gradients. See SubgraphLowering.__init__.
+        device = GPU_TYPE
+
+        def model(x, w):
+            h = torch.matmul(x, w)
+
+            def true_fn(a):
+                return a.sigmoid() * a
+
+            def false_fn(a):
+                return a.relu() * a
+
+            r = torch.cond(h.sum() > 0, true_fn, false_fn, (h,))
+            return ((h + r) * 3.0).sum()  # `h` is live after the cond
+
+        def make():
+            return (
+                torch.randn(64, 64, device=device, requires_grad=True),
+                torch.randn(64, 64, device=device, requires_grad=True),
+            )
+
+        torch.manual_seed(0)
+        xe, we = make()
+        model(xe, we).backward()
+        torch.manual_seed(0)
+        xc, wc = make()
+        torch.compile(model, fullgraph=True, backend="inductor")(xc, wc).backward()
+        self.assertEqual(xc.grad, xe.grad)
+        self.assertEqual(wc.grad, we.grad)
+
+    @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     def test_cond_simple_with_int_closure(self, device):
         self._run_test(

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -198,6 +198,10 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
             extern_node_serializer=V.graph.extern_node_serializer,
             is_inference=V.graph.is_inference,
             is_backward=V.graph.is_backward,
+            # A subgraph GraphLowering must not inherit the top-level backward's
+            # donated indices (different index space, caller-held inputs); see
+            # SubgraphLowering. Benchmark-only path, same latent bug.
+            donate_inputs=False,
             name=f"benchmark_{safe_name}",
         )
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -418,6 +418,7 @@ class GraphLowering(torch.fx.Interpreter):
         inputs_to_check: Sequence[int] | None = None,
         fx_wrapper: bool = False,
         get_decomp_fn: Callable[..., dict[Any, Callable[..., Any]]] | None = None,
+        donate_inputs: bool = True,
     ) -> None:
         super().__init__(gm)
         self.get_decomp_fn = get_decomp_fn
@@ -621,7 +622,10 @@ class GraphLowering(torch.fx.Interpreter):
         # track the current placeholder index that we are processing
         self.placeholder_idx = -1
 
-        self.bw_donated_idxs = get_donated_idxs()
+        # Subgraphs pass donate_inputs=False: their inputs are caller-held and the
+        # top-level backward's donated indices are a different index space (see
+        # SubgraphLowering and the "subgraphs inheriting bw_donated_idxs" fix).
+        self.bw_donated_idxs = get_donated_idxs() if donate_inputs else None
 
         # Cache for dep size hints to avoid expensive recomputation
         self.dep_size_hint_cache: dict[tuple[Dep, bool], int] = {}
@@ -3199,7 +3203,11 @@ class SubgraphLowering(GraphLowering):
 
     def __init__(self, parent: GraphLowering, *args: Any, **kwargs: Any) -> None:
         self.parent = parent
-        super().__init__(*args, **kwargs)
+        # A subgraph's inputs are caller-held (owned by the parent graph) and the
+        # subgraph may be invoked from multiple call sites, so no input is ever
+        # safe to donate; donate_inputs=False keeps the base __init__ from
+        # inheriting the top-level backward's (differently-indexed) donated set.
+        super().__init__(*args, donate_inputs=False, **kwargs)
 
     def allocate_non_dup_const_name(self, name: str | None, data: Tensor) -> str:
         name = super().allocate_non_dup_const_name(name, data)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192847
* #192846
* #192845
* #192842
* #192841
* __->__ #192840

Background: bw_donated_idxs marks which of a backward graph's inputs the graph
may overwrite in place -- reuse an input buffer's storage for one of its own
outputs -- to save an allocation. That is only sound when nothing outside the
graph still needs the input after the graph runs, so donation is a per-graph,
per-call-site liveness property. For the top-level backward AOT autograd proves
it (a saved tensor that aliases no forward input, forward output, or backward
output), and it holds because that backward has exactly one call site: the
autograd engine invokes it once.

Bug: a subgraph GraphLowering inherited that same index list (via
get_donated_idxs(), which reads it off the tracing context) even though a
subgraph's placeholders are a different, unrelated index space. Index k in the
top-level backward is a different tensor than input k of the subgraph, so a
subgraph input could be classified a DonatedBuffer and overwritten in place --
corrupting a tensor the parent still holds after the call, i.e. silently wrong
gradients.

The indices are not merely mis-numbered for a subgraph; donation is conceptually
inapplicable there. A subgraph's inputs are owned by its caller (the parent
graph), and the subgraph cannot see whether the parent reads them again after
the call, so it must treat them all as still live. Worse, invoke_subgraph is
compile-once / call-many by design (the checkpoint forward subgraph is invoked
by both the forward and the backward), so a donation baked into the single
lowered subgraph would have to be sound at every call site at once -- something
the top-level's single-call-site proof says nothing about. The only correct
universal answer for a subgraph is to donate nothing.

Fix: subgraph inputs are never donated. GraphLowering.__init__ gains a
donate_inputs flag (default True) that gates the get_donated_idxs() fetch, so the
decision is made once at construction instead of fetched-then-discarded.
SubgraphLowering passes donate_inputs=False, covering all subgraph HOPs
(invoke_subgraph / cond / while_loop). SubgraphChoiceCaller._compile_for_benchmarking
builds a plain GraphLowering (not a SubgraphLowering) for a subgraph and had the
identical latent hazard, so it passes donate_inputs=False too; that path is
autotuning-benchmark only (throwaway timing runs, no gradients fed back), making
it a consistency fix with no observable failure of its own.

Test Plan:

```
python test/inductor/test_control_flow.py -k test_cond_backward_does_not_reuse_donated_subgraph_input
```

The added torch.cond backward regression reproduces the corruption without the
fix (a reused donated buffer changes the gradient) and passes with it. The
benchmarking path has no observable failure to regression-test (results are
discarded), so it is covered by the same reasoning rather than a separate test.
Run on CUDA (A100).

Authored with Claude.