### PR TITLE
Fix zero tangents for make_fx-captured invoke_subgraph subgraphs

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -73,6 +73,37 @@ def _aot_eager_with_runtime_epilogue():
 
 @skipIfTorchDynamo("Not a torch._dynamo test")
 class TestInvokeSubgraph(TestCase):
+    def test_make_fx_traced_subgraph_joint(self):
+        # A subgraph captured by make_fx records its output meta["val"] below
+        # autograd, so requires_grad is False there even though the region does
+        # need a gradient. get_output_metadata must not take that at face value:
+        # if it does, the backward is built with zero tangents and tracing the
+        # joint dies with "outs_to_grad length (1) != tangents length (0)".
+        from torch._functorch.aot_autograd import aot_export_joint_simple
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def gn(x, y):
+            return (torch.sigmoid(torch.matmul(x, y)),)
+
+        subgraph = make_fx(gn)(
+            torch.randn(4, 4, requires_grad=True),
+            torch.randn(4, 4, requires_grad=True),
+        )
+
+        hop = torch._higher_order_ops.invoke_subgraph
+
+        def fn(x, y):
+            return hop(subgraph, "subgraph_0", x, y)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        y = torch.randn(4, 4, requires_grad=True)
+        joint = aot_export_joint_simple(fn, (x, y), trace_joint=True)
+
+        # The region stays a HOP in both halves of the joint (fw call + bw
+        # recompute), rather than being dropped for lack of tangents.
+        num_hops = len([n for n in joint.graph.nodes if n.target is hop])
+        self.assertEqual(num_hops, 2)
+
     def test_simple(self):
         def gn(x, y):
             return torch.mul(x, y)

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -626,6 +626,9 @@ def get_output_metadata(subgraph, *operands):
     output_node = next(reversed(subgraph.graph.find_nodes(op="output")))
     output_metadata.num_fw_outs = len(output_node.args[0])
 
+    # The one signal a below-autograd trace can get wrong; see the check below.
+    has_tensor_out_without_grad = False
+
     for idx, output_arg in enumerate(output_node.args[0]):
         if not isinstance(output_arg, torch.fx.Node):
             if isinstance(output_arg, int):
@@ -648,9 +651,24 @@ def get_output_metadata(subgraph, *operands):
             # Check if tensor requires grad from metadata
             if hasattr(val, "requires_grad") and not val.requires_grad:
                 output_metadata.indexes_with_no_grad.add(idx)
+                has_tensor_out_without_grad = True
         else:
             # Non-tensor, non-symint (shouldn't happen but be safe)
             output_metadata.indexes_with_no_grad.add(idx)
+
+    # A tensor's requires_grad=False is unreliable when the subgraph was traced
+    # below autograd (make_fx detaches every output), and believing it builds the
+    # backward with zero tangents. Any recorded True means grad-ness was tracked,
+    # so only re-derive by execution when nothing claims grad yet an operand does.
+    if (
+        has_tensor_out_without_grad
+        and len(output_metadata.indexes_with_no_grad) == output_metadata.num_fw_outs
+        and any(
+            isinstance(operand, torch.Tensor) and operand.requires_grad
+            for operand in operands
+        )
+    ):
+        return _get_output_metadata_by_execution(subgraph, *operands)
 
     return output_metadata
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192847
* #192846
* #192845
* #192842
* __->__ #192841
* #192840

get_output_metadata decides how many tangents the backward needs by reading the
subgraph's output node meta["val"].requires_grad. That is only trustworthy if
the subgraph was traced above autograd. A subgraph captured by make_fx traces
*below* it, so every output's recorded value comes back detached
(requires_grad=False) whether or not the region needs a gradient -- even when
traced under FakeTensorMode with grad enabled.

Believing that marks every output no-grad and builds the backward with zero
tangents, while the joint's own mask (prepare_fw_with_masks, which runs the
region under grad) says otherwise, so tracing the joint dies with
"outs_to_grad length (N) != tangents length (0)". Dynamo-captured subgraphs are
unaffected because their output nodes carry no meta["val"], which already routes
them to the execution-based fallback.

Fix: when static analysis concludes that no output needs a gradient but a
differentiable operand does, re-derive the metadata by execution, which is
authoritative. This keeps the "avoid running side effects twice" intent of the
static path for every other case; a region that genuinely has no grad-requiring
outputs reaches the same answer, just more slowly.

Test Plan:

```
python test/higher_order_ops/test_invoke_subgraph.py -k test_make_fx_traced_subgraph_joint
PYTHONPATH=test python test/higher_order_ops/test_invoke_subgraph.py
```

The added test builds a subgraph with make_fx, invokes it through the HOP, and
traces a joint with aot_export_joint_simple; it raises the tangents assertion
without this fix and passes with it, leaving the region as a HOP in both halves
of the joint. The full file passes 133 tests (1 skipped, 1 expected failure).
Run on CUDA (A100). PYTHONPATH=test is needed for an unrelated helper import in
that file.

Authored with Claude.