### PR TITLE
Fix caching for graphs holding a nested invoke_subgraph

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -489,6 +489,42 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_nested_invoke_subgraph(self):
+        """
+        A subgraph HOP nested inside another subgraph must not defeat the cache.
+
+        Loading a cached GraphModule re-traces it symbolically, which calls
+        invoke_subgraph with Proxy operands; rejecting those makes every load
+        fail, so the entry is saved on every run and never hit.
+        """
+        from torch.compiler import nested_compile_region
+
+        @nested_compile_region
+        def inner(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        @nested_compile_region
+        def outer(x, y):
+            return inner(x, y) + inner(y, x)
+
+        def fn(x, y):
+            return outer(x, y) + outer(y, x)
+
+        x = torch.randn(8, 8, requires_grad=True)
+        y = torch.randn(8, 8, requires_grad=True)
+        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+
+        compiled_fn(x, y).sum().backward()
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+        compiled_fn(x, y).sum().backward()
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     def test_basic(self):
         """
         Verify the interactions between FXGraphCache and AOTAutogradCache.

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -104,6 +104,39 @@ class TestInvokeSubgraph(TestCase):
         num_hops = len([n for n in joint.graph.nodes if n.target is hop])
         self.assertEqual(num_hops, 2)
 
+    def test_graph_module_pickle_roundtrip(self):
+        # Unpickling a GraphModule re-traces it symbolically, replaying calls with
+        # Proxy operands -- the path the FX/AOTAutograd caches load through. The
+        # region must come back as the *same* invoke_subgraph call, not inlined:
+        # a graph that silently flattens on reload loses the shared subgraph (and
+        # with it the no-drift guarantee) while still counting as a cache hit.
+        import pickle
+
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def gn(x, y):
+            return (torch.sigmoid(torch.matmul(x, y)),)
+
+        subgraph = make_fx(gn)(torch.randn(4, 4), torch.randn(4, 4))
+        hop = torch._higher_order_ops.invoke_subgraph
+
+        def fn(x, y):
+            (out,) = hop(subgraph, "subgraph_0", x, y)
+            return out
+
+        gm = make_fx(fn)(torch.randn(4, 4), torch.randn(4, 4))
+        reloaded = pickle.loads(pickle.dumps(gm))
+
+        def count_hops(g):
+            return len([n for n in g.graph.nodes if n.target is hop])
+
+        self.assertEqual(count_hops(gm), 1)
+        self.assertEqual(count_hops(reloaded), 1)
+
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+        self.assertEqual(gm(x, y), reloaded(x, y))
+
     def test_simple(self):
         def gn(x, y):
             return torch.mul(x, y)

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -275,9 +275,22 @@ class InvokeSubgraphHOP(HigherOrderOperator):
                 f"identifier must be None or a string, got {type(identifier)}"
             )
 
+        # Proxy is allowed because symbolically re-tracing a GraphModule replays
+        # its calls with proxies rather than values -- notably when unpickling a
+        # cached graph (_deserialize_graph_module), where rejecting them makes
+        # every cache load fail and silently disables caching for any graph
+        # holding an invoke_subgraph call.
         if not all(
             isinstance(
-                o, (torch.Tensor, int, torch.SymInt, torch.Generator, FakeScriptObject)
+                o,
+                (
+                    torch.Tensor,
+                    int,
+                    torch.SymInt,
+                    torch.Generator,
+                    FakeScriptObject,
+                    torch.fx.Proxy,
+                ),
             )
             or is_custom_class(type(o))
             for o in operands


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192847
* #192846
* #192845
* __->__ #192842
* #192841
* #192840

Loading a cached GraphModule re-traces it symbolically
(_deserialize_graph_module -> Tracer.trace), which replays every call with Proxy
operands instead of values. invoke_subgraph's __call__ validated its operands
against a fixed list of value types that did not include Proxy, so the re-trace
raised

  AssertionError: invoke_subgraph operands must be a list of
  tensors/ints/SymInts/Generator, got (Proxy(primals_1), ...)

and the load failed. The entry was then saved again on the next run, so any
graph holding an invoke_subgraph call inside another subgraph never hit the
cache and recompiled every time -- silently, since a failed load is
indistinguishable from a cold miss.

This is not specific to any caller: a nested_compile_region nested inside
another one reproduces it with no other feature enabled. It does affect
checkpoint_via_invoke_subgraph in particular, because recompute-as-call always
rewrites the backward to re-invoke the forward subgraph and therefore always
produces the nested form.

Fix: accept Proxy as an operand type, since symbolic re-tracing is a legitimate
caller. Verified that the re-trace preserves the HOP rather than inlining it, so
a reloaded graph keeps the shared subgraph (and its no-drift guarantee) instead
of silently flattening.

Test Plan:

```
PYTHONPATH=test python test/higher_order_ops/test_invoke_subgraph.py -k test_graph_module_pickle_roundtrip
python test/dynamo/test_aot_autograd_cache.py -k test_nested_invoke_subgraph
PYTHONPATH=test python test/higher_order_ops/test_invoke_subgraph.py
```

Two tests, both failing before this change: a pickle round-trip asserting the
graph comes back with exactly one invoke_subgraph node and identical numerics
(the structural contract -- a counter-based test alone would still pass if the
reload inlined the region), and an end-to-end cache test asserting a nested
region hits on the second compile. Measured warm-start behaviour before and
after: nested nested_compile_region and checkpoint_via_invoke_subgraph both go
from miss+saved on every run to a cache hit. The full invoke_subgraph file
passes 134 tests (1 skipped, 1 expected failure). Run on CUDA (A100).
PYTHONPATH=test is needed for an unrelated helper import in that file.

Authored with Claude.