### PR TITLE
Add opt-in checkpoint-via-invoke_subgraph with recompute-as-call

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -140,6 +140,28 @@ def count_ops(
     return gm
 
 
+def count_ops_recursive(gm, args, freq=None, freq_ge=None, op=None):
+    """Like count_ops, but counts `op` across gm and every nested subgraph module.
+
+    Needed when the checkpointed region is an invoke_subgraph HOP: its ops --
+    including any recomputed in the backward via a re-invoked forward subgraph --
+    live in nested GraphModules, not the top-level graph.
+    """
+    actual = 0
+    for mod in gm.modules():
+        if isinstance(mod, torch.fx.GraphModule):
+            actual += sum(1 for node in mod.graph.nodes if node.target == op)
+    if freq is not None and actual != freq:
+        raise AssertionError(
+            f"Expected {op} to occur {freq} times across {gm} and its subgraphs, got {actual}."
+        )
+    if freq_ge is not None and actual < freq_ge:
+        raise AssertionError(
+            f"Expected {op} to occur >= {freq_ge} times across {gm} and its subgraphs, got {actual}."
+        )
+    return gm
+
+
 def collect_fwd_graph_outputs(graph: torch.fx.Graph, *, fwd_outputs: set[str]):
     if not torch._dynamo.compiled_autograd.in_compiled_autograd_region:  # fwd graph
         return_node = list(graph.nodes)[-1]
@@ -344,6 +366,240 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
             partition_fn=partition_fn,
         )
         self._validate(fn, backend, x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_internals_recomputed(self, device):
+        # checkpoint lowered to invoke_subgraph + recompute-as-call: the region's
+        # interior mm is recomputed in the backward (by re-invoking the shared
+        # forward subgraph), not saved -- so it reappears in the bwd graph. Counts
+        # recurse because the ops live inside the HOP subgraphs.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+
+        fw_compiler = functools.partial(
+            count_ops_recursive, freq=1, op=torch.ops.aten.mm.default
+        )
+        bw_compiler = functools.partial(
+            count_ops_recursive, freq=3, op=torch.ops.aten.mm.default
+        )  # 2 grad mms + 1 recomputed fwd mm
+        backend = aot_autograd(
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        self._validate(fn, backend, x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_stacked(self, device):
+        # Stacked checkpoint regions still produce correct grads; each region is
+        # recomputed via its own re-invoked forward subgraph.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            a = torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+            return torch.utils.checkpoint.checkpoint(gn, a, y, use_reentrant=False)
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_nested(self, device):
+        # A checkpoint region nested inside another. The inner region is atomic
+        # within the outer (recomputed as part of it, not with its own
+        # save/recompute split -- that would need recursive partitioning), but
+        # gradients must be correct.
+        def inner(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def outer(x, y):
+            return torch.utils.checkpoint.checkpoint(inner, x, y, use_reentrant=False)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(outer, x, y, use_reentrant=False)
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_context_fn(self, device):
+        # Selective checkpointing (context_fn) is not supported on this path yet;
+        # it must raise rather than silently ignore the policy.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "selective activation checkpointing"):
+            torch.compile(fn, fullgraph=True, backend="eager")(x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_rng(self, device):
+        # RNG in a recompute-as-call region is unsupported: re-invoking the
+        # forward would draw fresh values, so it must raise rather than corrupt.
+        def gn(x, y):
+            return torch.nn.functional.dropout(torch.matmul(x, y), p=0.5, training=True)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "does not support RNG"):
+            torch.compile(fn, fullgraph=True, backend="aot_eager")(
+                x, y
+            ).sum().backward()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_nested_rng(self, device):
+        # RNG inside a nested HOP within the checkpoint region must also be
+        # rejected -- the ban scans nested subgraph modules recursively, not just
+        # the region's top-level graph.
+        from torch.compiler import nested_compile_region
+
+        @nested_compile_region
+        def inner(x, y):
+            return torch.nn.functional.dropout(torch.matmul(x, y), p=0.5, training=True)
+
+        # Call inner from two sites so it is preserved as a nested HOP (a
+        # single-use region would be inlined, moving the RNG to the top level and
+        # not exercising the recursive scan).
+        def gn(x, y):
+            return inner(x, y) + inner(y, x)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "does not support RNG"):
+            torch.compile(fn, fullgraph=True, backend="aot_eager")(
+                x, y
+            ).sum().backward()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    @torch._dynamo.config.patch(inline_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_full_inline(self, device):
+        # Full invoke_subgraph inlining would flatten the region and erase the
+        # recompute marker; the combination must raise, not silently save-all.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False
+            ).sum()
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "cannot flatten a checkpoint region"):
+            torch.compile(fn, fullgraph=True, backend="eager")(x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_checkpoint_kwargs(self, device):
+        # Options that only affect the eager checkpoint impl (debug here; also
+        # early_stop and non-default determinism_check) are rejected, not
+        # silently ignored, on the invoke_subgraph path.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False, debug=True
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "debug is not supported"):
+            torch.compile(fn, fullgraph=True, backend="eager")(x, y)
+
+    @requires_cuda_and_triton
+    @torch._inductor.config.patch(force_disable_caches=True)
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_inductor_correctness(self, device):
+        # End-to-end through the real Inductor backend: recompute-as-call on a
+        # reduction region produces gradients matching eager. This checks the
+        # full lowering is correct; it does NOT reproduce the gh-186572 bf16 drift
+        # (that needs the affected reduction-config heuristic, so it's fp32 here
+        # to avoid unrelated bf16 eager-vs-Inductor reduction-order noise). The
+        # drift fix itself is structural -- forward and recompute lower from the
+        # same subgraph.
+        def gn(x):
+            scale = torch.rsqrt((x.float() * x.float()).mean(-1, keepdim=True) + 1e-6)
+            return x * scale.to(x.dtype)
+
+        def fn(x):
+            y = torch.utils.checkpoint.checkpoint(gn, x, use_reentrant=False)
+            return (y * 3.0 + x).square().sum()
+
+        x = torch.randn(
+            512, 1024, dtype=torch.float32, device=device, requires_grad=True
+        )
+        self._validate(fn, "inductor", x)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_dynamic_shapes(self, device):
+        # Exercises the symint (num_sym > 0) path in the backward rewrite: a
+        # dynamic dim flows symints through the region's save/recompute set
+        # (verified to reach num_sym == 2 saved symints for this shape).
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False
+            ).sum()
+
+        def make():
+            return (
+                torch.randn(8, 4, device=device, requires_grad=True),
+                torch.randn(4, 4, device=device, requires_grad=True),
+            )
+
+        torch.manual_seed(0)
+        xe, ye = make()
+        fn(xe, ye).backward()
+        torch.manual_seed(0)
+        xc, yc = make()
+        torch.compile(fn, fullgraph=True, backend="aot_eager", dynamic=True)(
+            xc, yc
+        ).backward()
+        self.assertEqual(xc.grad, xe.grad)
+        self.assertEqual(yc.grad, ye.grad)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_multi_output(self, device):
+        # Exercises num_fw_outputs > 1 in the rewrite/restitch arithmetic.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y)), torch.tanh(torch.matmul(y, x))
+
+        def fn(x, y):
+            a, b = torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+            return a.sum() + b.sum()
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
 
     @requires_gpu_and_triton
     @parametrize(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4427,6 +4427,15 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
         self.allow_side_effects = (
             torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint
         )
+        if torch._functorch.config.checkpoint_via_invoke_subgraph:
+            # On this path the region stays a HOP (not desugared), so it must
+            # honor invoke_subgraph's aliasing contract: inputs/outputs may not
+            # alias, and aliased intermediates are filtered rather than returned.
+            # (allow_side_effects intentionally keeps checkpoint's own semantics
+            # above -- driven by skip_fwd_side_effects_in_bwd_under_checkpoint --
+            # rather than invoke_subgraph's always-True.)
+            self.supports_aliasing = False
+            self.filter_aliased_intermediates = True
 
     def _call_function(
         self,
@@ -4451,17 +4460,48 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
                     f"checkpoint not implemented for {type(ctx)} context_fn"
                 )
 
+        if (
+            context_fn is not None
+            and torch._functorch.config.checkpoint_via_invoke_subgraph
+        ):
+            # Selective activation checkpointing routes the policy through the
+            # tag path's re-trace; the invoke_subgraph path does not consume it
+            # yet, so reject rather than silently ignoring the policy.
+            raise NotImplementedError(
+                "context_fn (selective activation checkpointing) is not yet "
+                "supported with torch._functorch.config.checkpoint_via_invoke_subgraph; "
+                "disable the flag or remove context_fn."
+            )
+
         checkpoint_kwargs, gmod_kwargs = TagActivationCheckpoint.divide_kwargs(kwargs)
+
+        if torch._functorch.config.checkpoint_via_invoke_subgraph:
+            # determinism_check / debug / early_stop only affect the eager
+            # checkpoint impl, which the invoke_subgraph path bypasses. Reject
+            # non-default values (this also catches invalid determinism_check
+            # strings that eager would reject) rather than silently ignoring them.
+            for name, default in (
+                ("determinism_check", "default"),
+                ("debug", False),
+                ("early_stop", True),
+            ):
+                opt = checkpoint_kwargs.get(name)
+                if opt is not None and opt.as_python_constant() != default:
+                    raise NotImplementedError(
+                        f"checkpoint {name} is not supported with "
+                        "torch._functorch.config.checkpoint_via_invoke_subgraph; use "
+                        "the default or disable the flag."
+                    )
 
         # Here we use checkpoint_kwargs (and not gmod kwargs). gmod_kwargs are
         # already flattened above and managed inside the fx graph.
         (
             p_args,
-            _,
+            p_kwargs,
             example_value,
             _body_r,
             checkpointed_gmod,
-            _,
+            body_name,
             body_graph_output_vts,
             _,
         ) = self.create_wrapped_node(
@@ -4473,6 +4513,30 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
         )
         if context_fn is not None:
             checkpointed_gmod.meta["_checkpoint_context_fn"] = context_fn
+
+        if torch._functorch.config.checkpoint_via_invoke_subgraph:
+            # Route the region through invoke_subgraph so it stays a shared HOP
+            # through the partitioner (see config docs). invoke_subgraph's
+            # autograd prefixes the identifier fw/bw; run_joint_graph_passes_on_hops
+            # then partitions the region and, keyed off the `_checkpoint_region`
+            # mark below, rewrites the backward to re-invoke the shared forward
+            # subgraph. The mark also makes the single-use inlining pass preserve
+            # the region as a HOP -- a checkpoint region is single-call at trace
+            # time but must survive to the partitioner for recompute-as-call.
+            # checkpoint_kwargs (determinism_check, debug) only affect the eager
+            # checkpoint impl on the tag path and are inert here; preserve_rng_state
+            # is moot since RNG regions are rejected downstream.
+            checkpointed_gmod.meta["_checkpoint_region"] = True
+            p_args = (p_args[0], body_name, *p_args[1:])
+            return _call_function_with_auto_output_flattening(  # type: ignore[return-value]
+                tx,
+                torch._higher_order_ops.invoke_subgraph,
+                tuple(p_args),
+                p_kwargs,
+                example_value,
+                _body_r,
+                body_graph_output_vts,
+            )
 
         _, checkpoint_kwargs = proxy_args_kwargs([], checkpoint_kwargs)
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -816,6 +816,108 @@ def _has_invoke_subgraph_node(gm: torch.fx.GraphModule):
     return False
 
 
+def _rewrite_bw_hop_to_recompute_fw(
+    new_bw_hop_gm: torch.fx.GraphModule,
+    new_fw_hop_gm: torch.fx.GraphModule,
+    fw_identifier: str,
+    num_primals: int,
+    num_fw_outputs: int,
+    num_saved: int,
+    num_sym: int,
+    num_tangents: int,
+) -> None:
+    """Turn a save-partitioned region backward into a recompute-as-call one.
+
+    The region is partitioned save-all, so new_fw_hop_gm outputs
+    (*fw_outs, *saved, *sym_nodes) and new_bw_hop_gm takes
+    (*sym_nodes, *saved, *tangents) -> (*grads), where `saved` is the
+    non-symint saved values (num_saved of them) and `sym_nodes` are the symints
+    (num_sym of them, always last). This pass relies on the forward's extra
+    outputs and the backward's leading inputs sharing that relative ordering.
+
+    We rewrite new_bw_hop_gm in place so it instead takes (*primals, *tangents)
+    and re-invokes new_fw_hop_gm(*primals) to regenerate (*saved, *sym_nodes)
+    internally. Because the forward subgraph is invoked from both the forward
+    graph and inside this backward subgraph, the two lower from the same
+    GraphModule (structurally identical kernels), so a recomputed reduction
+    matches the original forward (gh-186572), while only primals -- not
+    activations -- cross the outer fwd/bwd boundary.
+    """
+    from torch._higher_order_ops import invoke_subgraph
+
+    g = new_bw_hop_gm.graph
+    placeholders = g.find_nodes(op="placeholder")
+    # The bw signature must be exactly (*sym, *saved, *tangents). Extra placeholder
+    # classes (opaque objects, backward_state, bwd_seed_offset) would be silently
+    # misclassified as tangents, so fail loudly instead. bwd_seed_offset can't
+    # appear here since RNG is banned upstream.
+    if len(placeholders) != num_sym + num_saved + num_tangents:
+        raise AssertionError(
+            "recompute-as-call expected bw placeholders "
+            f"= {num_sym} sym + {num_saved} saved + {num_tangents} tangents, got "
+            f"{len(placeholders)} (unsupported placeholder class in the region)"
+        )
+    old_sym = placeholders[:num_sym]
+    old_saved = placeholders[num_sym : num_sym + num_saved]
+
+    fw_placeholders = new_fw_hop_gm.graph.find_nodes(op="placeholder")
+    if len(fw_placeholders) != num_primals:
+        raise AssertionError(
+            f"expected {num_primals} fw placeholders, got {len(fw_placeholders)}"
+        )
+    fw_out_vals = [
+        n.meta.get("val") if n is not None else None
+        for n in new_fw_hop_gm.graph.find_nodes(op="output")[0].args[0]
+    ]
+    if len(fw_out_vals) != num_fw_outputs + num_saved + num_sym:
+        raise AssertionError(
+            "recompute-as-call expected fw outputs "
+            f"= {num_fw_outputs} fw_outs + {num_saved} saved + {num_sym} sym, got "
+            f"{len(fw_out_vals)}"
+        )
+
+    new_bw_hop_gm.add_module("recompute_fw_subgraph", new_fw_hop_gm)
+
+    # New primal placeholders go at the very front (before existing placeholders).
+    new_primals = []
+    with g.inserting_before(placeholders[0]):
+        for i in range(num_primals):
+            p = g.placeholder(f"recompute_primal_{i}")
+            p.meta.update(copy.copy(fw_placeholders[i].meta))
+            new_primals.append(p)
+
+    # The re-invoke and getitems must come after all placeholders.
+    body_start = next(n for n in g.nodes if n.op != "placeholder")
+    with g.inserting_before(body_start):
+        get_attr_node = g.get_attr("recompute_fw_subgraph")
+        fw_call = g.call_function(
+            invoke_subgraph, args=(get_attr_node, fw_identifier, *new_primals)
+        )
+        fw_call.meta["val"] = tuple(fw_out_vals)
+        saved_gis = []
+        for j in range(num_saved):
+            gi = g.call_function(operator.getitem, args=(fw_call, num_fw_outputs + j))
+            gi.meta["val"] = fw_out_vals[num_fw_outputs + j]
+            saved_gis.append(gi)
+        sym_gis = []
+        for k in range(num_sym):
+            idx = num_fw_outputs + num_saved + k
+            gi = g.call_function(operator.getitem, args=(fw_call, idx))
+            gi.meta["val"] = fw_out_vals[idx]
+            sym_gis.append(gi)
+
+    for old, new in zip(old_sym, sym_gis):
+        old.replace_all_uses_with(new)
+    for old, new in zip(old_saved, saved_gis):
+        old.replace_all_uses_with(new)
+    for old in [*old_sym, *old_saved]:
+        g.erase_node(old)
+
+    g.eliminate_dead_code()
+    g.lint()
+    new_bw_hop_gm.recompile()
+
+
 def run_joint_graph_passes_on_hops(
     joint_gm: torch.fx.GraphModule,
     joint_inputs: Any,
@@ -861,6 +963,10 @@ def run_joint_graph_passes_on_hops(
     from torch._higher_order_ops.invoke_subgraph import (
         get_backward_nested_region_config,
     )
+
+    # Identifiers of checkpoint regions rewritten to recompute-as-call, so the
+    # restitch loop can pass primals+tangents (not saved tensors) to them.
+    recompute_ac_ids: set[str] = set()
 
     def num_outputs(mod: torch.fx.GraphModule) -> int:
         return len(mod.graph.find_nodes(op="output")[0].args[0])
@@ -995,6 +1101,20 @@ def run_joint_graph_passes_on_hops(
         new_hop_graphs[identifier].old_num_fw_inputs = num_fw_inputs
         new_hop_graphs[identifier].old_num_fw_outputs = num_fw_outputs
 
+        # Only rewrite checkpoint regions (marked by the front-door and
+        # propagated to node meta by invoke_subgraph) to recompute-as-call; leave
+        # nested_compile_region and other invoke_subgraph HOPs -- including any
+        # with their own partitioner config -- untouched.
+        # A checkpoint region (the front-door marked it) always recomputes via a
+        # shared-subgraph call. Recompute is coupled to the front-door rather than
+        # a separate flag, so enabling checkpoint_via_invoke_subgraph can't
+        # silently turn checkpoint into save-everything.
+        region_recompute = fw_hop_node.meta.get("custom", {}).get(
+            "_checkpoint_region", False
+        )
+        if region_recompute:
+            recompute_ac_ids.add(identifier)
+
         # Step 1) - Get the `joint_hop_gm`. As mentioned earlier, the
         # backward graph is the joint graph.
         joint_hop_gm = getattr(joint_gm, node.args[0].target)
@@ -1012,9 +1132,56 @@ def run_joint_graph_passes_on_hops(
         # so it can propagate them to the partitioner (and use in cudagraphs)
         static_lifetime_input_indices: list[int] = []
 
-        used_hop_custom_partition, partition_fn = _get_partition_fn(
-            fw_hop_node, aot_config, default_partition_fn
-        )
+        if region_recompute:
+            # The backward recomputes by re-invoking the forward subgraph, so the
+            # forward must expose every backward-needed activation as an output --
+            # that is the save-all partition. RNG in the region is not yet
+            # supported: re-invoking would draw fresh values (see flag docs). Note
+            # the ban is on presence of RNG ops, not on `must_recompute` tags,
+            # since the save-all partition marks nothing must_recompute.
+            # Recurse into nested subgraph modules: an RNG op inside a nested HOP
+            # would otherwise be missed, and re-invoking the region would draw
+            # fresh values on recompute. `is_rng_op` only catches aten ops tagged
+            # nondeterministic_seeded; with functionalize_rng_ops the RNG becomes
+            # run_*_rng_state HOPs (no such tag), so match those explicitly too.
+            from torch._prims.rng_prims import (
+                graphsafe_run_with_rng_state,
+                run_and_save_rng_state,
+                run_dtensor_rng_op,
+                run_with_rng_state,
+            )
+
+            rng_hops = (
+                run_and_save_rng_state,
+                run_with_rng_state,
+                graphsafe_run_with_rng_state,
+                run_dtensor_rng_op,
+            )
+            if any(
+                torch._functorch.partitioners.is_rng_op(n)
+                or (n.op == "call_function" and n.target in rng_hops)
+                for m in joint_hop_gm.modules()
+                if isinstance(m, torch.fx.GraphModule)
+                for n in m.graph.nodes
+            ):
+                raise RuntimeError(
+                    "checkpoint_via_invoke_subgraph does not support RNG ops in "
+                    f"the checkpointed region (invoke_subgraph {fw_hop_node.name}); "
+                    "move RNG out of the region or disable the flag."
+                )
+            from torch._inductor.compile_fx import (
+                partition_fn as _inductor_partition_fn,
+            )
+
+            used_hop_custom_partition = False
+            partition_fn = functools.partial(
+                _inductor_partition_fn,
+                partitioner_fn_override=torch._functorch.partitioners.default_partition,
+            )
+        else:
+            used_hop_custom_partition, partition_fn = _get_partition_fn(
+                fw_hop_node, aot_config, default_partition_fn
+            )
 
         # Step 2) and 3) - Run joint graph passes and partitioner
         try:
@@ -1041,10 +1208,27 @@ def run_joint_graph_passes_on_hops(
         extra_outputs = new_fw_out_nodes[num_fw_outputs:]
         symint_outputs = [n for n in extra_outputs if is_sym_node(n)]
 
-        new_hop_graphs[identifier].new_num_sym_nodes = len(symint_outputs)
-        new_hop_graphs[identifier].new_num_saved_nodes = len(extra_outputs) - len(
-            symint_outputs
-        )
+        new_num_sym_nodes = len(symint_outputs)
+        new_num_saved_nodes = len(extra_outputs) - new_num_sym_nodes
+        new_hop_graphs[identifier].new_num_sym_nodes = new_num_sym_nodes
+        new_hop_graphs[identifier].new_num_saved_nodes = new_num_saved_nodes
+
+        if region_recompute:
+            # Rewrite the backward to re-invoke the forward subgraph instead of
+            # consuming its saved activations (see helper docstring). The bw HOP
+            # node's args are (subgraph, identifier, *primals, *tangents), so the
+            # tangent count is what remains after the primals.
+            num_tangents = len(node.args) - 2 - num_fw_inputs
+            _rewrite_bw_hop_to_recompute_fw(
+                new_bw_hop_gm,
+                new_fw_hop_gm,
+                f"recompute_fw_{identifier}",
+                num_fw_inputs,
+                num_fw_outputs,
+                new_num_saved_nodes,
+                new_num_sym_nodes,
+                num_tangents,
+            )
 
         new_hop_graphs[identifier].partitioning_done = True
 
@@ -1204,16 +1388,24 @@ def run_joint_graph_passes_on_hops(
                 f"new_bw_hop_gm for identifier {identifier} must not be None"
             )
 
-        saved_tensor_nodes = extra_fw_outputs[:new_num_saved_nodes]
-        sym_nodes = extra_fw_outputs[new_num_saved_nodes:]
-
         num_primals = new_hop_graphs[identifier].old_num_fw_inputs
         if num_primals is None:
             raise AssertionError(
                 f"num_primals for identifier {identifier} must not be None"
             )
-        tangents = list(bw_node.args[2 + num_primals :])
-        operands = sym_nodes + saved_tensor_nodes + tangents
+
+        if identifier in recompute_ac_ids:
+            # new_bw_hop_gm was rewritten to take (*primals, *tangents) and
+            # re-invoke the forward subgraph internally to regenerate its
+            # activations -- so pass primals+tangents straight through (exactly
+            # bw_node's original operands). The forward's saved-tensor getitems
+            # (extra_fw_outputs) go unused here and are cleaned up by DCE.
+            operands = list(bw_node.args[2:])
+        else:
+            saved_tensor_nodes = extra_fw_outputs[:new_num_saved_nodes]
+            sym_nodes = extra_fw_outputs[new_num_saved_nodes:]
+            tangents = list(bw_node.args[2 + num_primals :])
+            operands = sym_nodes + saved_tensor_nodes + tangents
 
         # Insert the new_bw_hop_gm into the joint_gm
         with joint_gm.graph.inserting_after(bw_node):

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -456,6 +456,16 @@ selective_decompose: bool = False
 enable_complex_wrapper: bool = False
 
 
+# Experimental: lower torch.utils.checkpoint regions to invoke_subgraph instead
+# of tag_activation_checkpoint. This keeps the region as a shared HOP through the
+# partitioner and makes the backward recompute re-invoke the *same* compiled
+# forward subgraph -- rather than a separately-compiled duplicate that can drift
+# (gh-186572). Recompute is coupled to this flag (a checkpoint region always
+# recomputes), so enabling it never silently degrades checkpoint into
+# save-everything. RNG in a checkpointed region is not yet supported (rejected).
+checkpoint_via_invoke_subgraph: bool = False
+
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F403
 

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -1348,21 +1348,24 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
     # module (set by InvokeSubgraphAutogradOp.backward) but may be wrapped
     # by FunctionalizeCtxWrapper — unwrap to find it.
     nested_config = None
+    # Marks regions lowered from torch.utils.checkpoint (see the front-door in
+    # CheckpointHigherOrderVariable). Propagated to node meta so downstream
+    # passes (run_joint_graph_passes_on_hops) can scope AC-specific handling to
+    # checkpoint regions rather than all invoke_subgraph HOPs.
+    is_checkpoint_region = False
     orig_subgraph = (
         subgraph.subgraph if isinstance(subgraph, FunctionalizeCtxWrapper) else subgraph
     )
     for gm in (graph, orig_subgraph):
-        if (
-            isinstance(gm, torch.fx.GraphModule)
-            and hasattr(gm, "meta")
-            and "nested_region_config" in gm.meta
-        ):
-            nested_config = gm.meta["nested_region_config"]
-            break
+        if isinstance(gm, torch.fx.GraphModule) and hasattr(gm, "meta"):
+            if nested_config is None and "nested_region_config" in gm.meta:
+                nested_config = gm.meta["nested_region_config"]
+            if gm.meta.get("_checkpoint_region"):
+                is_checkpoint_region = True
 
     call_id = _current_invoke_subgraph_call_id()
 
-    if nested_config is not None or call_id is not None:
+    if nested_config is not None or call_id is not None or is_checkpoint_region:
         node = out_proxy.node
         if "custom" not in node.meta:
             node.meta["custom"] = {}
@@ -1370,6 +1373,8 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
             node.meta["custom"]["nested_region_config"] = nested_config
         if call_id is not None:
             node.meta["custom"]["call_id"] = call_id
+        if is_checkpoint_region:
+            node.meta["custom"]["_checkpoint_region"] = True
 
     example_out = invoke_subgraph(graph, identifier, *operands)
     return track_tensor_tree(

--- a/torch/_higher_order_ops/passes/inline_invoke_subgraph.py
+++ b/torch/_higher_order_ops/passes/inline_invoke_subgraph.py
@@ -53,14 +53,17 @@ def inline_single_use_recursive(gm: GraphModule, global_counts: Counter[str]) ->
     if not invoke_nodes:
         return
 
-    single_use_nodes = [
-        node
-        for node in invoke_nodes
-        if global_counts[str(node.args[1])] == 1
-        and not getattr(gm, str(node.args[0].target)).meta.get(
-            "nested_region_config", None
-        )
-    ]
+    single_use_nodes = []
+    for node in invoke_nodes:
+        if global_counts[str(node.args[1])] != 1:
+            continue
+        # Preserve regions that must survive as HOPs even when single-use:
+        # nested_compile_region (carries dedup config) and checkpoint regions
+        # (needed for recompute-as-call in the partitioner).
+        sub_meta = getattr(gm, str(node.args[0].target)).meta
+        if sub_meta.get("nested_region_config") or sub_meta.get("_checkpoint_region"):
+            continue
+        single_use_nodes.append(node)
     if not single_use_nodes:
         return
 
@@ -148,6 +151,22 @@ def inline_invoke_subgraph(gm: GraphModule) -> GraphModule:
     )
     if not invoke_nodes:
         return gm
+
+    # Full inlining flattens the region away, erasing the `_checkpoint_region`
+    # marker before AOTAutograd and silently disabling checkpoint recompute-as-
+    # call. A fully flat graph and keeping the region as a HOP are mutually
+    # exclusive, so reject rather than silently break either one.
+    for node in invoke_nodes:
+        subgraph = getattr(gm, str(node.args[0].target))
+        if isinstance(subgraph, GraphModule) and subgraph.meta.get(
+            "_checkpoint_region"
+        ):
+            raise RuntimeError(
+                "inline_invoke_subgraph=True cannot flatten a checkpoint region "
+                "created with checkpoint_via_invoke_subgraph: inlining would erase "
+                "the recompute-as-call marker and silently disable checkpoint "
+                "recompute. Disable one of the two flags."
+            )
 
     inline_invoke_subgraph_nodes(gm, invoke_nodes)
     return gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192847
* #192846
* __->__ #192845
* #192842
* #192841
* #192840

Under torch.compile, `torch.utils.checkpoint` lowers to
`tag_activation_checkpoint`, which is inlined into the joint graph; the
partitioner then *duplicates* the region's recompute nodes into the backward.
The forward copy and the recomputed backward copy are compiled independently, so
Inductor can pick different reduction/autotune configs for each -- making the
recomputed activations differ from the forward bit-for-bit (silent correctness
bug, gh-186572).

This adds one opt-in flag (default off),
`torch._functorch.config.checkpoint_via_invoke_subgraph`, that instead keeps the
region as an `invoke_subgraph` HOP and makes the backward recompute by
re-invoking the shared forward subgraph, so the forward and its recompute lower
from the same GraphModule and cannot drift.

Mechanism:
- Dynamo lowers `checkpoint` regions to `invoke_subgraph` (instead of
  `tag_activation_checkpoint`) and marks them (`_checkpoint_region`). The mark is
  propagated onto the invoke_subgraph node meta (invoke_subgraph.py) so it
  survives autograd tracing to the partitioner, and the single-use inlining pass
  preserves marked regions as HOPs.
- In `run_joint_graph_passes_on_hops`, any `_checkpoint_region` is partitioned
  save-all and its backward subgraph is rewritten to re-invoke the forward
  subgraph internally (`_rewrite_bw_hop_to_recompute_fw`). Doing the re-invoke
  inside the backward subgraph keeps it out of the outer partitioner's
  save/recompute decision, sidestepping the fact that the partitioner cannot
  recompute a HOP call.

Recompute is coupled to the flag -- a checkpoint region always recomputes. There
is intentionally no separate "front-door without recompute" knob, since that
would silently degrade checkpoint into save-everything. For the same reason,
enabling `inline_invoke_subgraph` (full HOP flattening) together with this flag
is rejected: flattening the region would erase the recompute marker.

An alternative -- inserting the re-invoke in the outer backward graph and tagging
it MUST_RECOMPUTE -- was rejected: the outer partitioner cannot recompute an
`invoke_subgraph` call (not in the aten allowlist, tuple output), so it either
hard-fails or hoists the call into the forward and saves the activations.

Scope and limitations of this step:
- AC granularity only (the whole region is recomputed); selective checkpointing
  (context_fn), RNG in the region (aten ops and functionalized-RNG HOPs, scanned
  recursively into nested subgraphs), and unsupported checkpoint options
  (determinism_check/debug/early_stop) are rejected rather than silently
  mishandled. SAC's selective slice is future work.
- Nested checkpoint regions are correct but treated atomically (the inner region
  is recomputed as part of the outer, without its own save/recompute split;
  recursive partitioning is future work).
- Region outputs consumed by the surrounding graph are saved, not recomputed,
  since the outer partitioner cannot recompute a HOP call to regenerate them.

Test Plan:

New tests in test/dynamo/test_activation_checkpointing.py assert: the interior
op is recomputed in the backward (not saved); stacked and nested regions,
dynamic shapes, multi-output regions, and a real-Inductor (fp32) run produce
correct gradients; and context_fn (SAC), RNG (direct and inside a nested
region), unsupported checkpoint kwargs, and inline_invoke_subgraph all raise.

```
python test/dynamo/test_activation_checkpointing.py \
    ActivationCheckpointingViaTagsTestsCUDA -k invoke_subgraph
```

Existing tag-path checkpoint tests (including the dropout/RNG path) still pass:

```
python test/dynamo/test_activation_checkpointing.py \
    ActivationCheckpointingViaTagsTestsCUDA -k test_tags_function
python test/dynamo/test_activation_checkpointing.py \
    ActivationCheckpointingViaTagsTestsCUDA -k test_tags_dropout
```

Authored with Claude.