### PR TITLE
Add selective activation checkpointing to checkpoint-via-invoke_subgraph

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -83,6 +83,26 @@ requires_distributed = functools.partial(
 )
 
 
+# A throwaway effectful op (defined once at import to avoid re-registration) used
+# to exercise the effectful-op rejection in the checkpoint_via_invoke_subgraph path.
+@torch.library.custom_op("_sac_test::side_effect", mutates_args=())
+def _sac_side_effect(x: torch.Tensor) -> None:
+    return None
+
+
+@_sac_side_effect.register_fake
+def _(x):
+    return None
+
+
+from torch._higher_order_ops.effects import _EffectType as _SacEffectType
+
+
+torch.library._register_effectful_op(
+    torch.ops._sac_test.side_effect.default, _SacEffectType.ORDERED
+)
+
+
 def checkpoint_wrapper(fn):
     def inner(*args):
         return torch.utils.checkpoint.checkpoint(fn, *args, use_reentrant=True)
@@ -158,6 +178,32 @@ def count_ops_recursive(gm, args, freq=None, freq_ge=None, op=None):
     if freq_ge is not None and actual < freq_ge:
         raise AssertionError(
             f"Expected {op} to occur >= {freq_ge} times across {gm} and its subgraphs, got {actual}."
+        )
+    return gm
+
+
+def count_sac_slice_calls(gm):
+    """Count invoke_subgraph calls to a SAC shared recompute slice, across gm and
+    all nested subgraph modules. The forward and backward of a selectively
+    checkpointed region each invoke the same shared slice, so a shared slice
+    shows up as one such call in the fw graph and one in the bw graph."""
+    from torch._higher_order_ops import invoke_subgraph
+
+    count = 0
+    for mod in gm.modules():
+        if not isinstance(mod, torch.fx.GraphModule):
+            continue
+        for node in mod.graph.find_nodes(op="call_function", target=invoke_subgraph):
+            if isinstance(node.args[1], str) and node.args[1].startswith("sac_slice_"):
+                count += 1
+    return count
+
+
+def count_sac_slice_calls_assert(gm, args, expected):
+    actual = count_sac_slice_calls(gm)
+    if actual != expected:
+        raise AssertionError(
+            f"Expected {expected} SAC shared-slice call(s) in {gm}, got {actual}."
         )
     return gm
 
@@ -430,9 +476,12 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         self._validate(fn, "aot_eager", x, y)
 
     @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
-    def test_checkpoint_via_invoke_subgraph_rejects_context_fn(self, device):
-        # Selective checkpointing (context_fn) is not supported on this path yet;
-        # it must raise rather than silently ignore the policy.
+    def test_checkpoint_via_invoke_subgraph_sac_saves_expensive(self, device):
+        # Selective checkpointing: a policy that MUST_SAVE mm keeps the matmul in
+        # the forward (saved, not recomputed) and recomputes only the cheap
+        # sigmoid. The saved mm means the backward does NOT recompute it -- so mm
+        # appears once in fw and only as the two grad mms in bw (2), versus 3 for
+        # vanilla whole-region recompute (2 grad + 1 recomputed).
         def gn(x, y):
             return torch.sigmoid(torch.matmul(x, y))
 
@@ -450,31 +499,471 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
 
         x = torch.randn(4, 4, device=device, requires_grad=True)
         y = torch.randn(4, 4, device=device, requires_grad=True)
-        with self.assertRaisesRegex(Exception, "selective activation checkpointing"):
-            torch.compile(fn, fullgraph=True, backend="eager")(x, y)
+        fw_compiler = functools.partial(
+            count_ops_recursive, freq=1, op=torch.ops.aten.mm.default
+        )
+        bw_compiler = functools.partial(
+            count_ops_recursive, freq=2, op=torch.ops.aten.mm.default
+        )
+        backend = aot_autograd(
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        self._validate(fn, backend, x, y)
 
     @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
-    def test_checkpoint_via_invoke_subgraph_rejects_rng(self, device):
-        # RNG in a recompute-as-call region is unsupported: re-invoking the
-        # forward would draw fresh values, so it must raise rather than corrupt.
+    def test_checkpoint_via_invoke_subgraph_sac_shared_slice(self, device):
+        # The recomputed slice (sigmoid) is extracted into one shared subgraph
+        # invoked by both the forward and the backward, so it lowers from a single
+        # GraphModule and cannot drift. Assert exactly one sac_slice call shows up
+        # in the fw graph and one in the bw graph.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        fw_compiler = functools.partial(count_sac_slice_calls_assert, expected=1)
+        bw_compiler = functools.partial(count_sac_slice_calls_assert, expected=1)
+        backend = aot_autograd(
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        self._validate(fn, backend, x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_recompute_all_fallback(self, device):
+        # A policy that recomputes everything is equivalent to vanilla AC: it must
+        # fall back to whole-region recompute (no shared slice), and the interior
+        # mm is recomputed in the backward (3 mms: 2 grad + 1 recomputed).
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(create_selective_checkpoint_contexts, []),
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        fw_compiler = functools.partial(
+            count_ops_recursive, freq=1, op=torch.ops.aten.mm.default
+        )
+        bw_compiler = functools.partial(
+            count_ops_recursive, freq=3, op=torch.ops.aten.mm.default
+        )
+        backend = aot_autograd(
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        self._validate(fn, backend, x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_cycle_fallback(self, device):
+        # A saved value that depends on a recomputed one can't be expressed as a
+        # single shared slice, so the region transparently falls back to
+        # whole-region recompute. Grads must still match eager. Here the policy
+        # saves the second mm but recomputes the first, which feeds it. Fresh
+        # per-call state (a new closure per context_fn()) so the forward and the
+        # policy-replay each count from zero.
+        def context_fn():
+            seen = [0]
+
+            def policy(ctx, func, *args, **kwargs):
+                if func is torch.ops.aten.mm.default:
+                    seen[0] += 1
+                    if seen[0] == 2:
+                        return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            return create_selective_checkpoint_contexts(policy)
+
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(torch.matmul(x, y), y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False, context_fn=context_fn
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_multi_output(self, device):
+        # var_mean is a genuine tuple-output aten op: recomputing it in the slice
+        # exercises the tuple-output handling (the producer stays in the slice
+        # body but is never returned directly; its getitems carry the values).
+        # Grads must match eager.
+        def gn(x, y):
+            h = torch.matmul(x, y)
+            v, m = torch.var_mean(h, dim=-1, keepdim=True)
+            return (h - m) * torch.rsqrt(v + 1e-5)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_multi_output_bw_getitems(self, device):
+        # A recomputed multi-output op whose backward needs getitems the forward
+        # doesn't (native_layer_norm exposes mean/rstd used only by its own
+        # backward). A single shared slice can't express this, so it must
+        # transparently fall back to whole-region recompute -- not crash -- and
+        # still produce correct gradients.
+        def gn(x, w):
+            h = torch.matmul(x, w)
+            return torch.ops.aten.native_layer_norm(
+                h, (h.shape[-1],), None, None, 1e-5
+            )[0]
+
+        def fn(x, w):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                w,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        w = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, w)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_policy_inspects_list_arg(self, device):
+        # A policy that keys off an op taking a node-list arg (aten.cat) exercises
+        # the arg-tree fake-val mapping in the policy replay (the policy must see
+        # tensors, not fx.Nodes, inside the list).
+        seen_cat = []
+
+        def policy(ctx, func, *args, **kwargs):
+            if func is torch.ops.aten.cat.default:
+                seen_cat.append(all(isinstance(t, torch.Tensor) for t in args[0]))
+                return CheckpointPolicy.MUST_SAVE
+            if func is torch.ops.aten.mm.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def gn(x, y):
+            a = torch.matmul(x, y)
+            return torch.cat([a.relu(), a.sigmoid()], dim=-1).sum(-1, keepdim=True) * a
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, policy
+                ),
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+        # The policy saw aten.cat with a list of real tensors (not fx.Nodes).
+        self.assertTrue(seen_cat and all(seen_cat))
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_factory_slice(self, device):
+        # A recomputed factory op (aten.arange) has no external node inputs, so
+        # the shared slice has zero operands. This must not crash the extraction
+        # and grads must match eager.
+        def gn(x, y):
+            h = torch.matmul(x, y)
+            c = torch.arange(h.shape[-1], device=x.device, dtype=x.dtype)
+            return h * c
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_rejects_cpu_offload(self, device):
+        # CPU-offload checkpoint policies aren't implemented on this path; they
+        # must raise rather than silently save/recompute the tensor on device.
+        def policy(ctx, func, *args, **kwargs):
+            if func is torch.ops.aten.mm.default:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, policy
+                ),
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "CPU-offload"):
+            torch.compile(fn, fullgraph=True, backend="aot_eager")(
+                x, y
+            ).sum().backward()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_policy_on_hop(self, device):
+        # A policy may target a HigherOrderOperator (create_selective_checkpoint_
+        # contexts accepts HOPs), and the replay must consult it for HOP nodes,
+        # not just aten ops. A single-use nested_compile_region is inlined before
+        # the replay, so call it twice to keep it a preserved invoke_subgraph HOP
+        # in the joint graph. Assert the policy actually saw invoke_subgraph
+        # (structural) and that grads match eager (correctness).
+        from torch._higher_order_ops import invoke_subgraph
+        from torch.compiler import nested_compile_region
+
+        @nested_compile_region
+        def inner(a):
+            return a.sigmoid()
+
+        mm = torch.ops.aten.mm.default
+        seen = []
+
+        def policy(ctx, func, *args, **kwargs):
+            seen.append(func)
+            if func is mm or func is invoke_subgraph:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def gn(x, y):
+            # Two call sites keep `inner` a preserved HOP (a single-use region is
+            # inlined and the policy would never see invoke_subgraph).
+            return inner(torch.matmul(x, y)) + inner(torch.matmul(y, x))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts, policy
+                ),
+            )
+
+        def clone(t):
+            return t.detach().clone().requires_grad_(t.requires_grad)
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        xe, ye = clone(x), clone(y)
+        fn(xe, ye).sum().backward()
+        # Compile fn directly (not a deepcopy) so `seen` is the shared list.
+        xc, yc = clone(x), clone(y)
+        torch.compile(fn, fullgraph=True, backend="aot_eager")(xc, yc).sum().backward()
+        self.assertEqual(xc.grad, xe.grad)
+        self.assertEqual(yc.grad, ye.grad)
+        # The region's caching dispatch mode consulted the policy on the preserved
+        # HOP under compile (eager SAC only sees the inner aten ops).
+        self.assertIn(invoke_subgraph, seen)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_saves_decomposed_op(self, device):
+        # The policy is applied by the region's dispatch mode during tracing (not
+        # replayed post-hoc), so a MUST_SAVE on a composite op that AOT decomposes
+        # (silu -> primitives) is still honored: silu is saved and only the
+        # remainder recomputed, keeping the region selective (a shared slice
+        # exists) rather than falling back to whole-region recompute. Uses a
+        # decomposition table so silu actually decomposes.
+        from torch._decomp import core_aten_decompositions
+
+        def gn(x, y):
+            return torch.matmul(torch.nn.functional.silu(torch.matmul(x, y)), y)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.silu.default],
+                ),
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        # One shared slice in fw and bw proves silu (decomposed) was saved and the
+        # region stayed selective; a whole-region fallback would have zero.
+        backend = aot_autograd(
+            fw_compiler=functools.partial(count_sac_slice_calls_assert, expected=1),
+            bw_compiler=functools.partial(count_sac_slice_calls_assert, expected=1),
+            partition_fn=min_cut_rematerialization_partition,
+            decompositions=core_aten_decompositions(),
+        )
+        self._validate(fn, backend, x, y)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_dynamic_shapes(self, device):
+        # Selective checkpointing composes with dynamic shapes (symints flowing
+        # through the saved/recomputed split).
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            ).sum()
+
+        def make():
+            return (
+                torch.randn(8, 4, device=device, requires_grad=True),
+                torch.randn(4, 4, device=device, requires_grad=True),
+            )
+
+        torch.manual_seed(0)
+        xe, ye = make()
+        fn(xe, ye).backward()
+        torch.manual_seed(0)
+        xc, yc = make()
+        torch.compile(fn, fullgraph=True, backend="aot_eager", dynamic=True)(
+            xc, yc
+        ).backward()
+        self.assertEqual(xc.grad, xe.grad)
+        self.assertEqual(yc.grad, ye.grad)
+
+    @requires_cuda_and_triton
+    @torch._inductor.config.patch(force_disable_caches=True)
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_inductor(self, device):
+        # End-to-end through Inductor: a selectively checkpointed region (save the
+        # matmul, recompute the norm) produces gradients matching eager.
+        def gn(x, w):
+            h = torch.matmul(x, w)
+            scale = torch.rsqrt((h.float() * h.float()).mean(-1, keepdim=True) + 1e-6)
+            return h * scale.to(h.dtype)
+
+        def fn(x, w):
+            y = torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                w,
+                use_reentrant=False,
+                context_fn=functools.partial(
+                    create_selective_checkpoint_contexts,
+                    [torch.ops.aten.mm.default],
+                ),
+            )
+            return (y * 3.0 + x).sum()
+
+        x = torch.randn(
+            512, 512, dtype=torch.float32, device=device, requires_grad=True
+        )
+        w = torch.randn(
+            512, 512, dtype=torch.float32, device=device, requires_grad=True
+        )
+        self._validate(fn, "inductor", x, w)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_sac_rejects_custom_context_fn(self, device):
+        # Only the create_selective_checkpoint_contexts form (a
+        # _CachingTorchDispatchMode forward context) is supported: its recompute
+        # context is replaced structurally by the partition. A custom context_fn
+        # whose recompute semantics can't be reproduced must raise rather than be
+        # silently dropped.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False, context_fn=_invalid_context_gen
+            )
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "custom context_fn"):
+            torch.compile(fn, fullgraph=True, backend="aot_eager")(
+                x, y
+            ).sum().backward()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rng_dropout(self, device):
+        # RNG (dropout) is force-saved (drawn once on the forward, saved, reused by
+        # the backward) rather than recomputed, so the backward uses the SAME mask
+        # as the forward -- matching eager checkpoint, not a ban. _validate checks
+        # the compiled output and gradients equal eager, and
+        # _compare_orig_and_checkpointed_fns checks they equal the non-checkpointed
+        # version.
         def gn(x, y):
             return torch.nn.functional.dropout(torch.matmul(x, y), p=0.5, training=True)
 
         def fn(x, y):
             return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
 
-        x = torch.randn(4, 4, device=device, requires_grad=True)
-        y = torch.randn(4, 4, device=device, requires_grad=True)
-        with self.assertRaisesRegex(Exception, "does not support RNG"):
-            torch.compile(fn, fullgraph=True, backend="aot_eager")(
-                x, y
-            ).sum().backward()
+        x = torch.randn(16, 16, device=device, requires_grad=True)
+        y = torch.randn(16, 16, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
+        self._compare_orig_and_checkpointed_fns(gn, fn, x, y)
 
     @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
     def test_checkpoint_via_invoke_subgraph_rejects_nested_rng(self, device):
-        # RNG inside a nested HOP within the checkpoint region must also be
-        # rejected -- the ban scans nested subgraph modules recursively, not just
-        # the region's top-level graph.
+        # RNG that can be force-saved is now supported, but RNG inside a nested
+        # HOP within the region is recomputed atomically (re-run) and can't be
+        # force-saved, so it must still be rejected. The scan recurses into nested
+        # subgraph modules.
         from torch.compiler import nested_compile_region
 
         @nested_compile_region
@@ -496,6 +985,76 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
             torch.compile(fn, fullgraph=True, backend="aot_eager")(
                 x, y
             ).sum().backward()
+
+    @requires_distributed()
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_collective(self):
+        # A collective inside a checkpoint region is recomputed on the backward --
+        # the same as the standard partitioner does for user-annotated AC regions
+        # (deterministic and symmetric across ranks) -- not force-saved, not banned.
+        # A single-rank gloo group makes the collective well-defined; verify the
+        # checkpointed version matches eager and the non-checkpointed version.
+        import torch.distributed._functional_collectives as ft_c
+
+        dist.init_process_group(
+            backend="gloo", store=dist.HashStore(), rank=0, world_size=1
+        )
+        try:
+
+            def gn(x, y):
+                h = torch.matmul(x, y)
+                h = ft_c.all_reduce(h, "sum", dist.group.WORLD)
+                return torch.sigmoid(h)
+
+            def fn(x, y):
+                return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+
+            x = torch.randn(8, 8, requires_grad=True)
+            y = torch.randn(8, 8, requires_grad=True)
+            self._validate(fn, "aot_eager", x, y)
+            self._compare_orig_and_checkpointed_fns(gn, fn, x, y)
+        finally:
+            dist.destroy_process_group()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_rejects_effectful(self, device):
+        # An effectful op in the region breaks the compiled backward -- the
+        # recompute rewrites don't thread effect tokens, so gradients silently come
+        # back as None -- so it is rejected loudly on the Dynamo-traced region body
+        # (before the effectful op is lifted out of the joint the partitioner sees).
+        def gn(x, y):
+            h = torch.matmul(x, y)
+            torch.ops._sac_test.side_effect(h)
+            return torch.sigmoid(h)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False)
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        with self.assertRaisesRegex(Exception, "does not support effectful ops"):
+            torch.compile(fn, fullgraph=True, backend="aot_eager")(
+                x, y
+            ).sum().backward()
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_explicit_noop_context_fn(self, device):
+        # Explicit context_fn=noop_context_fn must be treated as no policy (the
+        # region recomputes wholesale), not misread as an unsupported custom
+        # context_fn -- regardless of which VariableTracker flavor it realizes to.
+        from torch.utils.checkpoint import noop_context_fn
+
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn, x, y, use_reentrant=False, context_fn=noop_context_fn
+            )
+
+        x = torch.randn(8, 8, device=device, requires_grad=True)
+        y = torch.randn(8, 8, device=device, requires_grad=True)
+        self._validate(fn, "aot_eager", x, y)
 
     @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
     @torch._dynamo.config.patch(inline_invoke_subgraph=True)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4447,9 +4447,18 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
         from torch.utils.checkpoint import noop_context_fn
 
         context_fn = None
-        if "context_fn" in kwargs and kwargs["context_fn"] is not noop_context_fn:
-            ctx = kwargs.pop("context_fn")
-            if isinstance(ctx, torch._dynamo.variables.UserFunctionVariable):
+        if "context_fn" in kwargs:
+            # Realize first: the value may be a LazyVariableTracker, and the type
+            # checks / error message below need the concrete variant.
+            ctx = kwargs.pop("context_fn").realize()
+            # Resolve the underlying fn regardless of the VT flavor: a skipped fn
+            # exposes it as .value, an inlined one as .fn. Explicit
+            # context_fn=noop_context_fn is the default no-op; treat it as no
+            # context_fn either way.
+            underlying = getattr(ctx, "value", None) or getattr(ctx, "fn", None)
+            if underlying is noop_context_fn:
+                context_fn = None
+            elif isinstance(ctx, torch._dynamo.variables.UserFunctionVariable):
                 context_fn = ctx.fn
             elif isinstance(
                 ctx, torch._dynamo.variables.functions.FunctoolsPartialVariable
@@ -4457,21 +4466,8 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
                 context_fn = ctx.guard_as_python_constant()
             else:
                 raise NotImplementedError(
-                    f"checkpoint not implemented for {type(ctx)} context_fn"
+                    f"checkpoint not implemented for {type(ctx).__name__} context_fn"
                 )
-
-        if (
-            context_fn is not None
-            and torch._functorch.config.checkpoint_via_invoke_subgraph
-        ):
-            # Selective activation checkpointing routes the policy through the
-            # tag path's re-trace; the invoke_subgraph path does not consume it
-            # yet, so reject rather than silently ignoring the policy.
-            raise NotImplementedError(
-                "context_fn (selective activation checkpointing) is not yet "
-                "supported with torch._functorch.config.checkpoint_via_invoke_subgraph; "
-                "disable the flag or remove context_fn."
-            )
 
         checkpoint_kwargs, gmod_kwargs = TagActivationCheckpoint.divide_kwargs(kwargs)
 
@@ -4512,6 +4508,11 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
             "torch.utils.checkpoint.checkpoint",
         )
         if context_fn is not None:
+            # Selective activation checkpointing: the policy is stashed on the
+            # subgraph gm.meta. During joint tracing (trace_joint_graph_as_bwd)
+            # the region's forward is run under this policy's caching dispatch
+            # mode, which tags the region's nodes save/recompute for the
+            # partitioner. Without a context_fn the region recomputes wholesale.
             checkpointed_gmod.meta["_checkpoint_context_fn"] = context_fn
 
         if torch._functorch.config.checkpoint_via_invoke_subgraph:
@@ -4525,7 +4526,53 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
             # time but must survive to the partitioner for recompute-as-call.
             # checkpoint_kwargs (determinism_check, debug) only affect the eager
             # checkpoint impl on the tag path and are inert here; preserve_rng_state
-            # is moot since RNG regions are rejected downstream.
+            # is moot since top-level RNG is force-saved (drawn once) and only RNG
+            # in a nested subgraph is rejected downstream.
+            #
+            # Reject effectful ops here, on the Dynamo-traced region body: the
+            # recompute path can't thread effect tokens and the region's compiled
+            # backward would silently produce no gradients. This is the reliable
+            # detection point -- by the time the region is a joint the effectful op
+            # has been lifted out of the graph the partitioner sees.
+            from torch._higher_order_ops.effects import _get_effect
+
+            def _is_effectful(n: torch.fx.Node) -> bool:
+                if n.op != "call_function":
+                    return False
+                # Dynamo-level targets can be OpOverloadPackets (e.g. a custom op
+                # called as torch.ops.ns.foo); resolve to overloads, the concrete
+                # identifiers _get_effect accepts. Non-op targets (plain builtins)
+                # can't be effectful.
+                target = n.target
+                if isinstance(target, torch._ops.OpOverloadPacket):
+                    candidates = [getattr(target, o) for o in target.overloads()]
+                elif isinstance(
+                    target, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)
+                ):
+                    candidates = [target]
+                else:
+                    return False
+                for c in candidates:
+                    try:
+                        if _get_effect(c) is not None:
+                            return True
+                    except Exception:
+                        pass
+                return False
+
+            for m in checkpointed_gmod.modules():
+                if not isinstance(m, torch.fx.GraphModule):
+                    continue
+                effectful = next((n for n in m.graph.nodes if _is_effectful(n)), None)
+                if effectful is not None:
+                    raise NotImplementedError(
+                        "checkpoint_via_invoke_subgraph does not support effectful "
+                        f"ops ({effectful.target}) inside the checkpointed region; "
+                        "the recompute path can't thread effect tokens and the "
+                        "backward would silently produce no gradients. Move it out "
+                        "of the region or disable the flag."
+                    )
+
             checkpointed_gmod.meta["_checkpoint_region"] = True
             p_args = (p_args[0], body_name, *p_args[1:])
             return _call_function_with_auto_output_flattening(  # type: ignore[return-value]

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -816,6 +816,114 @@ def _has_invoke_subgraph_node(gm: torch.fx.GraphModule):
     return False
 
 
+def _scan_sac_tags(joint_hop_gm: torch.fx.GraphModule) -> tuple[bool, bool]:
+    """Inspect the SAC recompute tags on a checkpoint region's forward nodes.
+
+    A region with a context_fn policy has its forward nodes (and their
+    decompositions) tagged node.meta["recompute"] by the policy's caching
+    dispatch mode during joint tracing (see trace_joint_graph_as_bwd), exactly as
+    the tag path / eager SAC do. Returns (has_save, has_cpu_offload):
+    has_save   -- any op is MUST_SAVE/PREFER_SAVE (the region is genuinely
+                  selective and the partitioner should honor the tags);
+    has_cpu_offload -- any op requests CPU offload, which this path can't emit and
+                  the caller rejects.
+    """
+    from torch.utils.checkpoint import CheckpointPolicy
+
+    _has_tag_is_forward = torch._functorch.partitioners._has_tag_is_forward
+    save = {CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE}
+    offload = {CheckpointPolicy.MUST_CPU_OFFLOAD, CheckpointPolicy.PREFER_CPU_OFFLOAD}
+    has_save = has_cpu_offload = False
+    for node in joint_hop_gm.graph.nodes:
+        if not _has_tag_is_forward(node):
+            continue
+        policy = node.meta.get("recompute")
+        if policy in save:
+            has_save = True
+        elif policy in offload:
+            has_cpu_offload = True
+    return has_save, has_cpu_offload
+
+
+def _force_save_rng(joint_hop_gm: torch.fx.GraphModule) -> tuple[bool, bool]:
+    """Force-save RNG ops in a checkpoint region so the backward doesn't re-draw.
+
+    RNG can't be recomputed naively: re-running it on the backward draws fresh
+    values (e.g. a different dropout mask), so the backward would use a different
+    mask than the forward -- silently wrong gradients. The standard partitioner
+    avoids this by functionalizing recomputed RNG (run_and_save_rng_state on the
+    forward / run_with_rng_state on the backward, sharing the drawn state). That
+    functionalization makes the forward and backward RNG ops structurally
+    different, which the shared-slice mechanism can't express (it needs fw/bw to
+    run the *same* GraphModule), so here we instead tag the RNG op (and its
+    getitems, e.g. native_dropout's mask) MUST_SAVE: drawn once on the forward,
+    saved, and consumed by the backward -- no re-draw, no drift. This runs before
+    default_partition, whose own RNG functionalization then sees nothing to do.
+
+    Collectives are intentionally left alone: recomputing a collective in an AC
+    region is standard, correct behavior (deterministic and symmetric across
+    ranks -- the expected communication cost of recompute), matching what the
+    standard partitioner does for user-annotated AC regions.
+
+    We only force-save *forward* RNG in the top-level joint graph (where
+    default_partition operates and where a forward op would otherwise be
+    recomputed); a backward RNG op is part of grad computation, not recomputed, so
+    it is left alone. RNG inside a nested subgraph module would be recomputed
+    atomically, so the caller rejects that. Returns (has_top_level_rng,
+    has_nested_rng).
+    """
+    from torch._prims.rng_prims import (
+        graphsafe_run_with_rng_state,
+        run_and_save_rng_state,
+        run_dtensor_rng_op,
+        run_with_rng_state,
+    )
+    from torch.utils.checkpoint import CheckpointPolicy
+
+    rng_hops = (
+        run_and_save_rng_state,
+        run_with_rng_state,
+        graphsafe_run_with_rng_state,
+        run_dtensor_rng_op,
+    )
+    is_rng_op = torch._functorch.partitioners.is_rng_op
+    _has_tag_is_forward = torch._functorch.partitioners._has_tag_is_forward
+
+    def _is_rng(n: torch.fx.Node) -> bool:
+        return n.op == "call_function" and (is_rng_op(n) or n.target in rng_hops)
+
+    has_top = False
+    for node in joint_hop_gm.graph.nodes:
+        if _is_rng(node) and _has_tag_is_forward(node):
+            has_top = True
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+            for user in node.users:
+                if user.op == "call_function" and user.target is operator.getitem:
+                    user.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+    has_nested = any(
+        _is_rng(n)
+        for m in joint_hop_gm.modules()
+        if isinstance(m, torch.fx.GraphModule) and m is not joint_hop_gm
+        for n in m.graph.nodes
+    )
+    return has_top, has_nested
+
+
+def _clear_sac_tags(joint_hop_gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """Strip SAC recompute tags so the partitioner saves everything.
+
+    Used for the whole-region recompute-as-call path (vanilla AC, a policy that
+    saves nothing, or the shared-slice fallback): with the tags removed
+    default_partition saves all backward-needed activations, which
+    _rewrite_bw_hop_to_recompute_fw then turns into a re-invoke of the forward.
+    """
+    for node in joint_hop_gm.graph.nodes:
+        node.meta.pop("recompute", None)
+        node.meta.pop("ac_graph_id", None)
+    return joint_hop_gm
+
+
 def _rewrite_bw_hop_to_recompute_fw(
     new_bw_hop_gm: torch.fx.GraphModule,
     new_fw_hop_gm: torch.fx.GraphModule,
@@ -850,7 +958,8 @@ def _rewrite_bw_hop_to_recompute_fw(
     # The bw signature must be exactly (*sym, *saved, *tangents). Extra placeholder
     # classes (opaque objects, backward_state, bwd_seed_offset) would be silently
     # misclassified as tangents, so fail loudly instead. bwd_seed_offset can't
-    # appear here since RNG is banned upstream.
+    # appear here: a region with RNG is force-saved and routed as selective, so it
+    # never reaches this whole-region recompute-as-call path.
     if len(placeholders) != num_sym + num_saved + num_tangents:
         raise AssertionError(
             "recompute-as-call expected bw placeholders "
@@ -916,6 +1025,274 @@ def _rewrite_bw_hop_to_recompute_fw(
     g.eliminate_dead_code()
     g.lint()
     new_bw_hop_gm.recompile()
+
+
+def _splice_shared_slice_call(
+    parent_gm: torch.fx.GraphModule,
+    slice_gm: torch.fx.GraphModule,
+    identifier: str,
+    slice_out_vals: list[Any],
+    operands: list[torch.fx.Node],
+    replace: dict[str, torch.fx.Node],
+    slice_index: dict[str, int],
+    erase_names: set[str],
+    insert_after: torch.fx.Node,
+) -> None:
+    """Replace slice nodes in ``parent_gm`` with a call to the shared slice.
+
+    Inserts ``invoke_subgraph(slice_gm, identifier, *operands)`` after
+    ``insert_after``, swaps each node in ``replace`` for the corresponding getitem
+    of the call's output tuple, and erases every node named in ``erase_names``
+    (``replace`` plus multi-output op nodes whose getitems were replaced). Both
+    the forward and backward call the same ``slice_gm``, so the recomputed ops
+    lower from one GraphModule and cannot drift (gh-186572).
+    """
+    from torch._higher_order_ops import invoke_subgraph
+
+    g = parent_gm.graph
+    attr_name = f"{identifier}_mod"
+    parent_gm.register_module(attr_name, slice_gm)
+    with g.inserting_after(insert_after):
+        get_attr_node = g.get_attr(attr_name)
+    with g.inserting_after(get_attr_node):
+        call = g.call_function(
+            invoke_subgraph, args=(get_attr_node, identifier, *operands)
+        )
+        call.meta["val"] = tuple(slice_out_vals)
+    anchor = call
+    for name, tgt in replace.items():
+        idx = slice_index[name]
+        with g.inserting_after(anchor):
+            gi = g.call_function(operator.getitem, args=(call, idx))
+        gi.meta["val"] = slice_out_vals[idx]
+        tgt.replace_all_uses_with(gi)
+        anchor = gi
+    # Erase in reverse topological order so no node is erased before its users.
+    for n in reversed([n for n in g.nodes if n.name in erase_names]):
+        g.erase_node(n)
+
+
+def _extract_sac_shared_slice(
+    new_fw_hop_gm: torch.fx.GraphModule,
+    new_bw_hop_gm: torch.fx.GraphModule,
+    num_fw_outputs: int,
+    identifier: str,
+) -> bool:
+    """Share the recomputed forward slice of a selectively-checkpointed region.
+
+    ``default_partition`` (honoring the SAC recompute tags) already produced a
+    correct split: ``new_fw`` saves the MUST_SAVE activations and ``new_bw``
+    recomputes the rest inline. But those two copies of the recomputed forward
+    ops compile independently and can drift (gh-186572). This pass lifts the
+    recomputed (transient, i.e. not-saved) forward nodes into one shared slice
+    subgraph and makes both ``new_fw`` and ``new_bw`` invoke it, so the slice
+    lowers from a single GraphModule in forward and backward.
+
+    Returns True on success, False if the region isn't expressible as a single
+    shared slice (e.g. a saved value depends on a recomputed one, or a slice
+    input isn't available in the backward), in which case the caller falls back
+    to whole-region recompute-as-call.
+    """
+    fw_graph = new_fw_hop_gm.graph
+    bw_graph = new_bw_hop_gm.graph
+    bw_by_name = {n.name: n for n in bw_graph.nodes}
+    fw_out_node = fw_graph.find_nodes(op="output")[0]
+    fw_out_vals = list(fw_out_node.args[0])
+    saved_set = {n for n in fw_out_vals[num_fw_outputs:] if n is not None}
+
+    # The shared slice is only the forward ops the backward actually recomputes:
+    # transient (not-saved) forward nodes whose recomputed copy (matched by name)
+    # appears in new_bw. Transient ops that only feed the region output (never
+    # recomputed in the backward, e.g. the final elementwise of a norm) stay
+    # inline in new_fw. Pulling them into the slice would make the backward
+    # compute values it does not need and, worse, let Inductor reuse a saved
+    # input's buffer for those dead outputs -- corrupting the saved tensor.
+    bw_body_names = {
+        n.name for n in bw_graph.nodes if n.op not in ("placeholder", "output")
+    }
+    # get_attr (constants/params) are left inline in both fw and bw rather than
+    # lifted into the slice: they carry no drift risk and have no meta['val'] to
+    # return through the slice's flat output tuple.
+    s_nodes = [
+        n
+        for n in fw_graph.nodes
+        if n.op not in ("placeholder", "output", "get_attr")
+        and n not in saved_set
+        and n.name in bw_body_names
+    ]
+    if not s_nodes:
+        # Nothing the backward needs is recomputed, so there is no cross-graph
+        # copy to drift. Leave the partition as-is.
+        return True
+    s_set = set(s_nodes)
+
+    # Slice inputs: inputs to slice nodes from outside the slice (primals or saved
+    # values), in first-seen order for a stable signature.
+    s_inputs: list[torch.fx.Node] = []
+    seen: set[torch.fx.Node] = set()
+    for n in s_nodes:
+        for inp in n.all_input_nodes:
+            if inp not in s_set and inp not in seen:
+                seen.add(inp)
+                s_inputs.append(inp)
+
+    # Slice inputs must be recoverable in new_bw: only primals (placeholders) and
+    # saved values cross the fw/bw boundary. A get_attr (constant/param/nested
+    # module ref) consumed by a recomputed node is neither, so it lands here and
+    # forces a bail -- the region then falls back to whole-region recompute (or is
+    # rejected if it has force-saved RNG). Lifting such get_attrs into the slice is
+    # future work; it is rare (a recomputed op reading a lifted constant).
+    for inp in s_inputs:
+        if inp.op != "placeholder" and inp not in saved_set:
+            return False
+
+    # The slice becomes one node in new_fw. That is only valid if every slice
+    # input is defined before every consumer of a slice output; otherwise the
+    # contracted graph would be cyclic (a saved/region value interleaves with the
+    # recomputed slice). Detect via original node order and bail if so.
+    node_index = {n: i for i, n in enumerate(fw_graph.nodes)}
+    consumers = [
+        n
+        for n in fw_graph.nodes
+        if n not in s_set and any(inp in s_set for inp in n.all_input_nodes)
+    ]
+    if consumers:
+        first_consumer_idx = min(node_index[c] for c in consumers)
+        last_s_input_idx = max((node_index[i] for i in s_inputs), default=-1)
+        if last_s_input_idx >= first_consumer_idx:
+            return False
+
+    # Multi-output ops (tuple/list-valued) are kept in the slice body but never
+    # returned directly (invoke_subgraph outputs must be flat tensors/symints);
+    # their getitems carry the values.
+    def _is_tuple_val(n: torch.fx.Node) -> bool:
+        return isinstance(n.meta.get("val"), (tuple, list))
+
+    all_s_names = {n.name for n in s_nodes}
+    for n in s_nodes:
+        if not _is_tuple_val(n):
+            continue
+        # Forward: every getitem of a multi-output producer must be in the slice,
+        # else one shared slice can't express the region.
+        if any(u not in s_set for u in n.users):
+            return False
+        # Backward: the recomputed producer may have MORE getitem users than the
+        # forward (e.g. native_layer_norm / SDPA expose mean/rstd that only the
+        # op's own backward consumes). Those getitems are absent from the
+        # fw-derived slice, so erasing the producer in the backward would leave
+        # them dangling -- bail to whole-region recompute rather than crash.
+        bw_n = bw_by_name.get(n.name)
+        if bw_n is not None and any(u.name not in all_s_names for u in bw_n.users):
+            return False
+
+    # Values the slice returns: every slice node except the tuple producers.
+    s_out_nodes = [n for n in s_nodes if not _is_tuple_val(n)]
+
+    # Build the shared slice subgraph S: (s_inputs) -> (s_out_nodes).
+    s_graph = torch.fx.Graph()
+    env: dict[torch.fx.Node, torch.fx.Node] = {}
+    for inp in s_inputs:
+        p = s_graph.placeholder(inp.name)
+        p.meta = copy.copy(inp.meta)
+        env[inp] = p
+    for n in fw_graph.nodes:  # iterate in topological order
+        if n in s_set:
+            env[n] = s_graph.node_copy(n, lambda x: env[x])
+            env[n].meta = copy.copy(n.meta)
+    s_graph.output(tuple(env[n] for n in s_out_nodes))
+    s_graph.lint()
+    slice_gm = torch.fx.GraphModule(new_fw_hop_gm, s_graph)
+    slice_out_vals = [n.meta.get("val") for n in s_out_nodes]
+    slice_index = {n.name: i for i, n in enumerate(s_out_nodes)}
+    # Forward and backward call the *same* slice_gm object (so it lowers from one
+    # GraphModule -> no drift) but under distinct identifiers. A shared identifier
+    # would let Inductor's invoke_subgraph cache reuse the forward-specialized
+    # compilation for the backward call, whose saved-tensor operand can have a
+    # different layout -- silently corrupting the backward (mirrors AC
+    # recompute-as-call, which likewise uses a distinct backward identifier).
+    fw_slice_identifier = f"sac_slice_fw_{identifier}"
+    bw_slice_identifier = f"sac_slice_bw_{identifier}"
+
+    # Validate that the backward is expressible BEFORE mutating new_fw, so a bail
+    # returns with both graphs untouched (the caller then re-partitions a pristine
+    # copy for whole-region recompute). new_bw's recomputed slice nodes all follow
+    # its placeholders, so the call is inserted right after the last placeholder;
+    # its slice inputs must be the corresponding saved/primal placeholders.
+    bw_operands: list[torch.fx.Node] = []
+    for inp in s_inputs:
+        m = bw_by_name.get(inp.name)
+        # A slice input is a primal/saved value, which is a placeholder in the
+        # backward. If the name instead resolves to a recomputed body node the
+        # invariant is broken (the call would reference a not-yet-defined value);
+        # bail to whole-region recompute rather than emit an invalid graph.
+        if m is None or m.op != "placeholder":
+            return False
+        bw_operands.append(m)
+    bw_replace = {
+        name: bw_by_name[name]
+        for name in slice_index
+        if name in bw_by_name and bw_by_name[name].op != "placeholder"
+    }
+    bw_last_ph = None
+    for n in bw_graph.nodes:
+        if n.op == "placeholder":
+            bw_last_ph = n
+    if bw_replace and bw_last_ph is None:
+        return False
+
+    # Rewrite new_fw: replace the slice nodes with the shared-slice call, inserted
+    # after the last slice input (all inputs defined, before any consumer). With
+    # no external inputs (e.g. the slice is a recomputed factory like aten.ones),
+    # insert right after the last placeholder so the call precedes all consumers.
+    if s_inputs:
+        last_input = max(s_inputs, key=lambda n: node_index[n])
+    else:
+        fw_placeholders = fw_graph.find_nodes(op="placeholder")
+        last_input = (
+            fw_placeholders[-1] if fw_placeholders else next(iter(fw_graph.nodes))
+        )
+    _splice_shared_slice_call(
+        new_fw_hop_gm,
+        slice_gm,
+        fw_slice_identifier,
+        slice_out_vals,
+        operands=s_inputs,
+        replace={n.name: n for n in s_out_nodes},
+        slice_index=slice_index,
+        erase_names=all_s_names,
+        insert_after=last_input,
+    )
+
+    # Rewrite new_bw in place using the operands/placeholders validated above.
+    if bw_replace:
+        # bw_last_ph is non-None here (the bail above returns when bw_replace and
+        # it is None); re-assert to narrow the type.
+        if bw_last_ph is None:
+            raise AssertionError("bw_last_ph must not be None")
+        bw_erase = {
+            name
+            for name in all_s_names
+            if name in bw_by_name and bw_by_name[name].op != "placeholder"
+        }
+        _splice_shared_slice_call(
+            new_bw_hop_gm,
+            slice_gm,
+            bw_slice_identifier,
+            slice_out_vals,
+            operands=bw_operands,
+            replace=bw_replace,
+            slice_index=slice_index,
+            erase_names=bw_erase,
+            insert_after=bw_last_ph,
+        )
+
+    new_fw_hop_gm.graph.eliminate_dead_code()
+    new_fw_hop_gm.graph.lint()
+    new_fw_hop_gm.recompile()
+    new_bw_hop_gm.graph.eliminate_dead_code()
+    new_bw_hop_gm.graph.lint()
+    new_bw_hop_gm.recompile()
+    return True
 
 
 def run_joint_graph_passes_on_hops(
@@ -1112,8 +1489,6 @@ def run_joint_graph_passes_on_hops(
         region_recompute = fw_hop_node.meta.get("custom", {}).get(
             "_checkpoint_region", False
         )
-        if region_recompute:
-            recompute_ac_ids.add(identifier)
 
         # Step 1) - Get the `joint_hop_gm`. As mentioned earlier, the
         # backward graph is the joint graph.
@@ -1128,47 +1503,65 @@ def run_joint_graph_passes_on_hops(
             joint_hop_gm, num_fw_inputs, num_fw_outputs
         )
 
+        # Selective activation checkpointing (SAC): a checkpoint region carrying a
+        # context_fn policy already had its forward nodes tagged
+        # node.meta["recompute"] by the policy's caching dispatch mode during
+        # joint tracing (see trace_joint_graph_as_bwd) -- the same mechanism the
+        # tag path and eager SAC use, so decompositions and HOPs are tagged too.
+        # Here we just read those tags: the partitioner honors them (save the
+        # MUST_SAVE ops, recompute the rest) and the recomputed slice is shared.
+        # `pristine_joint_hop_gm` is a tag-cleared copy for the whole-region
+        # recompute fallback (region not expressible as one shared slice).
+        region_is_selective = False
+        # Force-saved RNG can't be safely re-invoked, so a region containing it
+        # must go through the save+shared-slice path, never the whole-region
+        # recompute-as-call fallback.
+        region_has_forced_save_rng = False
+        pristine_joint_hop_gm: torch.fx.GraphModule | None = None
+        if region_recompute:
+            has_save, has_cpu_offload = _scan_sac_tags(joint_hop_gm)
+            if has_cpu_offload:
+                # CPU offload needs forward->CPU / backward->GPU transfers this
+                # path doesn't emit; reject rather than silently saving on device.
+                raise NotImplementedError(
+                    "checkpoint_via_invoke_subgraph does not support CPU-offload "
+                    "checkpoint policies (MUST_CPU_OFFLOAD / PREFER_CPU_OFFLOAD); "
+                    "use MUST_SAVE / PREFER_RECOMPUTE or disable the flag."
+                )
+            # (Effectful ops are rejected earlier, on the Dynamo-traced region body
+            # in CheckpointHigherOrderVariable, before the effectful op is lifted
+            # out of the graph the partitioner sees.)
+            # RNG can't be recomputed on the backward re-invoke (it would re-draw);
+            # force-save it (run once) rather than banning, matching the standard
+            # partitioner. RNG inside a nested subgraph can't be force-saved here.
+            has_top_rng, has_nested_rng = _force_save_rng(joint_hop_gm)
+            if has_nested_rng:
+                raise RuntimeError(
+                    "checkpoint_via_invoke_subgraph does not support RNG inside a "
+                    f"nested subgraph of the region (invoke_subgraph "
+                    f"{fw_hop_node.name}); move it out or disable the flag."
+                )
+            region_has_forced_save_rng = has_top_rng
+            # A region is routed through save + shared-slice (rather than
+            # whole-region recompute-as-call) when it selectively saves ops (a
+            # policy) or contains force-saved RNG.
+            region_is_selective = has_save or has_top_rng
+            if region_is_selective:
+                # Keep a tag-cleared copy for the shared-slice fallback.
+                pristine_joint_hop_gm = _clear_sac_tags(copy.deepcopy(joint_hop_gm))
+            else:
+                # Vanilla AC: clear any recompute tags so default_partition saves
+                # all and the whole-region recompute-as-call path takes over.
+                _clear_sac_tags(joint_hop_gm)
+
         # TODO: invoke_subgraph should track which of its inputs static indices
         # so it can propagate them to the partitioner (and use in cudagraphs)
         static_lifetime_input_indices: list[int] = []
 
         if region_recompute:
-            # The backward recomputes by re-invoking the forward subgraph, so the
-            # forward must expose every backward-needed activation as an output --
-            # that is the save-all partition. RNG in the region is not yet
-            # supported: re-invoking would draw fresh values (see flag docs). Note
-            # the ban is on presence of RNG ops, not on `must_recompute` tags,
-            # since the save-all partition marks nothing must_recompute.
-            # Recurse into nested subgraph modules: an RNG op inside a nested HOP
-            # would otherwise be missed, and re-invoking the region would draw
-            # fresh values on recompute. `is_rng_op` only catches aten ops tagged
-            # nondeterministic_seeded; with functionalize_rng_ops the RNG becomes
-            # run_*_rng_state HOPs (no such tag), so match those explicitly too.
-            from torch._prims.rng_prims import (
-                graphsafe_run_with_rng_state,
-                run_and_save_rng_state,
-                run_dtensor_rng_op,
-                run_with_rng_state,
-            )
-
-            rng_hops = (
-                run_and_save_rng_state,
-                run_with_rng_state,
-                graphsafe_run_with_rng_state,
-                run_dtensor_rng_op,
-            )
-            if any(
-                torch._functorch.partitioners.is_rng_op(n)
-                or (n.op == "call_function" and n.target in rng_hops)
-                for m in joint_hop_gm.modules()
-                if isinstance(m, torch.fx.GraphModule)
-                for n in m.graph.nodes
-            ):
-                raise RuntimeError(
-                    "checkpoint_via_invoke_subgraph does not support RNG ops in "
-                    f"the checkpointed region (invoke_subgraph {fw_hop_node.name}); "
-                    "move RNG out of the region or disable the flag."
-                )
+            # Partition checkpoint regions with default_partition so it respects
+            # the save/recompute tags (MUST_SAVE from a policy or force-saved RNG).
+            # Route through Inductor's partition_fn so joint-graph passes run first.
             from torch._inductor.compile_fx import (
                 partition_fn as _inductor_partition_fn,
             )
@@ -1199,21 +1592,51 @@ def run_joint_graph_passes_on_hops(
             else:
                 raise
 
+        def _sym_saved_counts(fw_gm: torch.fx.GraphModule) -> tuple[int, int]:
+            outs = fw_gm.graph.find_nodes(op="output")[0].args[0]
+            extra = outs[num_fw_outputs:]
+            n_sym = len([n for n in extra if is_sym_node(n)])
+            return n_sym, len(extra) - n_sym
+
+        if region_is_selective:
+            # The partition already saves the MUST_SAVE ops and recomputes the
+            # rest. Share the recomputed slice between fw and bw so it lowers from
+            # one GraphModule and can't drift. If the region can't be expressed as
+            # a single shared slice, fall back to whole-region recompute on the
+            # untagged joint.
+            if not _extract_sac_shared_slice(
+                new_fw_hop_gm, new_bw_hop_gm, num_fw_outputs, identifier
+            ):
+                # Whole-region recompute-as-call would re-invoke the whole forward,
+                # re-drawing force-saved RNG -- unsafe. Such a region can't fall
+                # back, so reject rather than silently corrupt.
+                if region_has_forced_save_rng:
+                    raise RuntimeError(
+                        "checkpoint_via_invoke_subgraph: region with RNG cannot be "
+                        f"expressed as a shared recompute slice (invoke_subgraph "
+                        f"{fw_hop_node.name}); restructure it or disable the flag."
+                    )
+                region_is_selective = False
+                if pristine_joint_hop_gm is None:
+                    raise AssertionError("pristine_joint_hop_gm must not be None")
+                new_fw_hop_gm, new_bw_hop_gm = partition_fn(
+                    pristine_joint_hop_gm,
+                    [],
+                    num_fwd_outputs=num_fw_outputs,
+                    static_lifetime_input_indices=static_lifetime_input_indices,
+                )
+
         # Save the new forward and backward graph modules
         new_hop_graphs[identifier].new_fw_hop_gm = new_fw_hop_gm
         new_hop_graphs[identifier].new_bw_hop_gm = new_bw_hop_gm
 
         # Save the number of symints and saved tensors
-        new_fw_out_nodes = new_fw_hop_gm.graph.find_nodes(op="output")[0].args[0]
-        extra_outputs = new_fw_out_nodes[num_fw_outputs:]
-        symint_outputs = [n for n in extra_outputs if is_sym_node(n)]
-
-        new_num_sym_nodes = len(symint_outputs)
-        new_num_saved_nodes = len(extra_outputs) - new_num_sym_nodes
+        new_num_sym_nodes, new_num_saved_nodes = _sym_saved_counts(new_fw_hop_gm)
         new_hop_graphs[identifier].new_num_sym_nodes = new_num_sym_nodes
         new_hop_graphs[identifier].new_num_saved_nodes = new_num_saved_nodes
 
-        if region_recompute:
+        if region_recompute and not region_is_selective:
+            recompute_ac_ids.add(identifier)
             # Rewrite the backward to re-invoke the forward subgraph instead of
             # consuming its saved activations (see helper docstring). The bw HOP
             # node's args are (subgraph, identifier, *primals, *tangents), so the

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -462,7 +462,27 @@ enable_complex_wrapper: bool = False
 # forward subgraph -- rather than a separately-compiled duplicate that can drift
 # (gh-186572). Recompute is coupled to this flag (a checkpoint region always
 # recomputes), so enabling it never silently degrades checkpoint into
-# save-everything. RNG in a checkpointed region is not yet supported (rejected).
+# save-everything.
+#
+# RNG is handled like the standard partitioner: rather than recomputing (which
+# would re-draw, e.g. a different dropout mask), the RNG op is force-saved so the
+# backward reuses the forward's values. Collectives are recomputed, matching the
+# standard partitioner's behavior for user-annotated AC regions (deterministic
+# and symmetric across ranks). Effectful ops (with_effects) are rejected, since
+# the recompute rewrites can't preserve their effect-token ordering; so is RNG
+# inside a nested subgraph module (it would be recomputed atomically).
+#
+# Selective activation checkpointing via a context_fn from
+# create_selective_checkpoint_contexts is honored: the region's forward is traced
+# under the policy's dispatch mode (the same mechanism the tag path and eager SAC
+# use, so an op's decompositions are tagged too), the partitioner saves the
+# MUST_SAVE ops, and the recomputed slice is extracted into a single shared
+# subgraph invoked from both the forward and backward so it, too, cannot drift.
+# Regions that can't be expressed as one shared slice (e.g. a saved value depends
+# on a recomputed one) transparently fall back to whole-region recompute.
+# CPU-offload policies are rejected (this path emits no host/device transfers), as
+# are arbitrary custom context_fns (only the create_selective_checkpoint_contexts
+# form is supported, since its recompute context is replaced structurally).
 checkpoint_via_invoke_subgraph: bool = False
 
 

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 import functools
+import itertools
 import threading
 from collections import defaultdict
 from collections.abc import Callable
@@ -44,6 +45,12 @@ from torch.utils.checkpoint import _CachedTorchDispatchMode, _CachingTorchDispat
 
 
 invoke_subgraph_counter = 0
+
+# Unique per-checkpoint-region id, stamped as node.meta["ac_graph_id"] by the
+# SAC caching dispatch mode (see _checkpoint_context_fn handling in
+# trace_joint_graph_as_bwd) so the partitioner's cleanup_recompute_tags can order
+# save/recompute boundaries.
+_sac_ac_graph_id = itertools.count()
 
 
 # During the tracing of the joint graph, we construct this information. This is
@@ -746,6 +753,48 @@ def trace_joint_graph_as_bwd(
     else:
         fn = subgraph
 
+    # Selective activation checkpointing: if this is a checkpoint region carrying
+    # a context_fn policy, run the *forward* under the policy's caching dispatch
+    # mode so its ops -- and, crucially, the nodes they decompose into -- are
+    # tagged node.meta["recompute"] exactly as the tag path / eager SAC do (the
+    # mode stamps fx_traceback.current_meta, which decompositions inherit). The
+    # partitioner then honors those tags. Only the forward is wrapped; the joint's
+    # grad computation must stay untagged. The tags survive onto the joint graph
+    # this traces, which run_joint_graph_passes_on_hops partitions.
+    sg = (
+        subgraph.subgraph if isinstance(subgraph, FunctionalizeCtxWrapper) else subgraph
+    )
+    checkpoint_context_fn = None
+    if isinstance(sg, torch.fx.GraphModule) and hasattr(sg, "meta"):
+        checkpoint_context_fn = sg.meta.get("_checkpoint_context_fn")
+    if checkpoint_context_fn is not None:
+        fwd_ctx, recomp_ctx = checkpoint_context_fn()
+        # We only support the create_selective_checkpoint_contexts form, whose
+        # forward context is a _CachingTorchDispatchMode. For that form the second
+        # (recompute) context is a _CachedTorchDispatchMode that, in *eager* SAC,
+        # replays cached values so MUST_SAVE ops are not re-run -- a mechanism this
+        # path replaces structurally (the partitioner genuinely saves the MUST_SAVE
+        # ops; the shared slice recomputes only the rest), so recomp_ctx is
+        # correctly not entered here. An arbitrary custom context_fn's recompute
+        # context may carry semantics we can't reproduce, so reject it rather than
+        # silently drop it.
+        if not isinstance(fwd_ctx, _CachingTorchDispatchMode):
+            raise NotImplementedError(
+                "checkpoint_via_invoke_subgraph supports selective checkpointing "
+                "only via create_selective_checkpoint_contexts; a custom context_fn "
+                f"(forward context {type(fwd_ctx).__name__}) is not supported "
+                "because its recomputation context can't be preserved on this path."
+            )
+        del recomp_ctx
+        # Plumb a unique ac_graph_id so _CachingTorchDispatchMode tags every node
+        # (mirrors wrap.py's context_fn_with_graph_id).
+        fwd_ctx.ac_graph_id = next(_sac_ac_graph_id)
+        _fw_fn = fn
+
+        def fn(*args):
+            with fwd_ctx:
+                return _fw_fn(*args)
+
     # This joint_fn is inserted as the backward graph as is. This simplifies the
     # min-cut partitioner work later on.
     #   Input signature - (*primals, *tangents)
@@ -1274,15 +1323,23 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
                     subgraph, subgraph_decomp_table=subgraph_decomp_table
                 )(*operands)
 
-        # Propagate nested_region_config from the original subgraph to the
-        # re-traced graph so it's available for regional compilation.
-        if (
-            isinstance(subgraph, torch.fx.GraphModule)
-            and hasattr(subgraph, "meta")
-            and "nested_region_config" in subgraph.meta
-            and "nested_region_config" not in graph.meta
-        ):
-            graph.meta["nested_region_config"] = subgraph.meta["nested_region_config"]
+        # Propagate region metadata from the original subgraph to the re-traced
+        # graph (which starts with empty meta) so it survives to the proxy node
+        # and the partitioner. nested_region_config drives regional compilation;
+        # _checkpoint_region marks a checkpoint region for recompute-as-call, and
+        # _checkpoint_context_fn is the SAC policy that trace_joint_graph_as_bwd
+        # runs the forward under (its caching dispatch mode tags save/recompute).
+        # Without this, downstream would rely on the incoming subgraph arg still
+        # carrying the meta -- re-propagate for parity with the tag path (see
+        # wrap.py after its own reenter_make_fx).
+        if isinstance(subgraph, torch.fx.GraphModule) and hasattr(subgraph, "meta"):
+            for key in (
+                "nested_region_config",
+                "_checkpoint_region",
+                "_checkpoint_context_fn",
+            ):
+                if key in subgraph.meta and key not in graph.meta:
+                    graph.meta[key] = subgraph.meta[key]
 
         from torch._guards import detect_fake_mode
 
@@ -1365,6 +1422,10 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
 
     call_id = _current_invoke_subgraph_call_id()
 
+    # The SAC context_fn is read from the subgraph's gm.meta (by
+    # trace_joint_graph_as_bwd, which runs the forward under it); it does not need
+    # to travel on node.meta. Only _checkpoint_region is propagated to node.meta so
+    # run_joint_graph_passes_on_hops can scope AC handling to checkpoint regions.
     if nested_config is not None or call_id is not None or is_checkpoint_region:
         node = out_proxy.node
         if "custom" not in node.meta:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192847
* __->__ #192846
* #192845
* #192842
* #192841
* #192840

Builds on the opt-in checkpoint_via_invoke_subgraph flow (which lowers
torch.utils.checkpoint to invoke_subgraph and recomputes the whole region by
re-invoking the shared forward subgraph). This teaches that flow to honor a
selective-checkpointing policy (a context_fn from
create_selective_checkpoint_contexts): the ops the policy marks MUST_SAVE are
saved and only the cheap remainder is recomputed, while preserving the no-drift
guarantee that motivated the feature (gh-186572).

Review in this order:

1. Policy plumbing. CheckpointHigherOrderVariable stops rejecting context_fn and
   stashes the policy on the region gm.meta; invoke_subgraph re-propagates that
   meta onto the re-traced subgraph module. An explicit context_fn=noop_context_fn
   is treated as no policy.

2. Policy tagging via the dispatch mode. When the region's joint graph is traced
   (trace_joint_graph_as_bwd), the *forward* is run under the policy's caching
   dispatch mode -- the same mechanism the tag path and eager SAC use -- so its
   ops, and crucially the nodes they decompose into, are tagged
   node.meta["recompute"]. The partitioner (default_partition) then saves the
   MUST_SAVE ops and recomputes the rest. run_joint_graph_passes_on_hops just
   reads these tags; it no longer replays the policy, so decomposing ops (silu,
   gelu) and HigherOrderOperator targets are honored identically to eager SAC.

3. Shared recompute slice. default_partition alone would leave the recomputed ops
   in a separately-compiled backward that can drift from the forward (the
   original bug). _extract_sac_shared_slice lifts exactly the forward ops the
   backward recomputes into one subgraph that BOTH the forward and backward
   invoke, so the recomputed slice lowers from a single GraphModule and cannot
   drift. A recomputed factory (no external inputs) yields a zero-operand slice.

4. RNG, collectives, and effectful ops -- parity with the standard partitioner,
   not a blanket ban. RNG cannot be recomputed naively (a re-invoked forward would
   draw a fresh dropout mask -> silently wrong gradients). The standard
   partitioner functionalizes recomputed RNG to share state, but that makes the
   forward and backward RNG ops structurally different, which the shared slice
   can't express; instead _force_save_rng tags the RNG op (and its getitems, e.g.
   the dropout mask) MUST_SAVE, so it is drawn once and the backward reuses it.
   Collectives are left to recompute, exactly as the standard partitioner does for
   user-annotated AC regions (deterministic and symmetric across ranks -- the
   expected communication cost of recompute). Effectful ops (with_effects) are
   rejected on the Dynamo-traced region body -- the recompute rewrites don't thread
   effect tokens, so the compiled backward would otherwise silently produce no
   gradients (detection happens at trace time, before the effectful op is lifted
   out of the joint the partitioner sees).

5. Fallbacks and rejections. Regions not expressible as one shared slice -- a
   saved value that depends on a recomputed one, or a multi-output op whose
   backward needs getitems the forward doesn't (e.g. native_layer_norm/SDPA) --
   transparently fall back to whole-region recompute-as-call, which is still
   correct and drift-free; a region with force-saved RNG can't use that fallback
   (it would re-draw) and is rejected instead. Rejected outright: CPU-offload
   policies (this path emits no host/device transfers), arbitrary custom
   context_fns (only the create_selective_checkpoint_contexts form is supported,
   since its recompute context is replaced structurally), and RNG inside a nested
   subgraph module (recomputed atomically, so it can't be force-saved).

This feature surfaced a latent SubgraphLowering donation bug (silently-wrong
gradients when a subgraph input is reused in place for an output); the fix is a
prerequisite commit at the bottom of this stack.

Known limitation (correct grads, not wrong-grads): a recomputed multi-output op
whose backward needs forward-unused getitems falls back to whole-region recompute
rather than staying selective; keeping it selective is future work.

Test Plan:

```
python test/dynamo/test_activation_checkpointing.py -k checkpoint_via_invoke_subgraph
python test/dynamo/test_activation_checkpointing.py
```

Run on CUDA (A100). The full checkpointing file passes 126 tests (2 skipped). The
SAC subset (27 tests) covers save-expensive, shared-slice structure, recompute-
all / cycle / multi-output-backward-getitem fallbacks, factory (zero-operand)
slices, list-arg policies, a preserved-HOP-targeting policy (asserting the
dispatch mode consults the HOP), a MUST_SAVE on a decomposing op honored under a
decomposition table, a custom context_fn rejection, an explicit noop_context_fn
treated as no policy, CPU-offload rejection, var_mean multi-output, dynamic
shapes, end-to-end Inductor gradient correctness, force-saved dropout matching
eager and the non-checkpointed version, a single-rank-gloo collective recomputed
and matching eager, effectful-op rejection, and nested-RNG rejection.

Authored with Claude.