### PR TITLE
Support checkpoint-via-invoke_subgraph under non-strict tracing

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1057,6 +1057,63 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         self._validate(fn, "aot_eager", x, y)
 
     @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_non_strict(self, device):
+        # Non-strict tracing never goes through dynamo, so torch.utils.checkpoint
+        # itself lowers the region to an invoke_subgraph HOP when a proxy mode is
+        # active. The result must match what strict produces: the region survives
+        # as a HOP carrying _checkpoint_region, and the backward recomputes it
+        # (the forward's mm/sigmoid appear again) rather than saving it.
+        from torch._functorch.aot_autograd import aot_export_joint_simple
+
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        def fn(x, y):
+            return (torch.utils.checkpoint.checkpoint(gn, x, y, use_reentrant=False),)
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        joint = aot_export_joint_simple(fn, (x, y), trace_joint=True)
+
+        hop = torch._higher_order_ops.invoke_subgraph
+        hops = [n for n in joint.graph.nodes if n.target is hop]
+        # One call in the forward, one for the backward's recompute.
+        self.assertEqual(len(hops), 2)
+        self.assertTrue(hops[0].meta.get("custom", {}).get("_checkpoint_region"))
+
+        def count(name):
+            return sum(
+                1
+                for m in joint.modules()
+                if isinstance(m, torch.fx.GraphModule)
+                for n in m.graph.nodes
+                if name in str(n.target)
+            )
+
+        # Recomputed, so the region's ops appear in both halves of the joint.
+        self.assertGreater(count("sigmoid"), 1)
+        self.assertGreater(count("mm"), 1)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
+    def test_checkpoint_via_invoke_subgraph_eager_unaffected(self, device):
+        # The non-strict front door keys off an active proxy mode, so plain eager
+        # checkpoint (no tracing) must be untouched even with the flag enabled.
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(x, y))
+
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
+        xr = x.detach().clone().requires_grad_()
+        yr = y.detach().clone().requires_grad_()
+
+        torch.utils.checkpoint.checkpoint(
+            gn, x, y, use_reentrant=False
+        ).sum().backward()
+        gn(xr, yr).sum().backward()
+        self.assertEqual(x.grad, xr.grad)
+        self.assertEqual(y.grad, yr.grad)
+
+    @torch._functorch.config.patch(checkpoint_via_invoke_subgraph=True)
     @torch._dynamo.config.patch(inline_invoke_subgraph=True)
     def test_checkpoint_via_invoke_subgraph_rejects_full_inline(self, device):
         # Full invoke_subgraph inlining would flatten the region and erase the

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -413,6 +413,67 @@ def checkpoint(
 # looks likes this
 #  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
 #     speculatively checking if the forward function is safe to trace.
+_checkpoint_region_counter = itertools.count()
+
+
+def _should_checkpoint_via_invoke_subgraph() -> bool:
+    """Whether to lower this region to an invoke_subgraph HOP while tracing.
+
+    This is the non-strict counterpart of the dynamo front door in
+    CheckpointHigherOrderVariable: under strict tracing dynamo intercepts
+    ``checkpoint`` symbolically and never runs this function, so reaching here
+    with a proxy mode active means we are being traced non-strictly (make_fx /
+    non-strict export). Emitting the HOP here gives those flows the same
+    representation -- and therefore the same joint-graph passes, shared
+    recompute slice, and no-drift guarantee -- as the strict path.
+    """
+    if not torch._functorch.config.checkpoint_via_invoke_subgraph:
+        return False
+    return (
+        torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.PROXY) is not None
+    )
+
+
+def _checkpoint_via_invoke_subgraph(function, args, kwargs, context_fn):
+    """Emit the checkpoint region as an invoke_subgraph HOP under proxy tracing."""
+    from torch._higher_order_ops.invoke_subgraph import invoke_subgraph
+    from torch._higher_order_ops.utils import materialize_as_graph
+
+    if kwargs:
+        raise NotImplementedError(
+            "checkpoint_via_invoke_subgraph does not support keyword arguments to "
+            "the checkpointed function under non-strict tracing; pass them "
+            "positionally or disable the flag."
+        )
+
+    import torch.utils._pytree as pytree
+
+    # invoke_subgraph returns a flat tuple, so trace a flattened wrapper and
+    # restore the region's real output structure afterwards.
+    out_spec = None
+
+    def flat_fn(*flat_args):
+        nonlocal out_spec
+        flat_out, out_spec = pytree.tree_flatten(function(*flat_args))
+        return tuple(flat_out)
+
+    # materialize_as_graph (not make_fx/reenter_make_fx) is required here: we are
+    # already inside the caller's functionalized proxy trace, and it suspends
+    # those modes correctly to trace the region.
+    gm = materialize_as_graph(flat_fn, tuple(args))
+    gm.meta["_checkpoint_region"] = True
+    if context_fn is not noop_context_fn:
+        # The SAC policy; trace_joint_graph_as_bwd runs the region's forward
+        # under it so its caching dispatch mode tags save/recompute.
+        gm.meta["_checkpoint_context_fn"] = context_fn
+
+    identifier = f"checkpoint_{next(_checkpoint_region_counter)}"
+    flat_res = invoke_subgraph(gm, identifier, *args)
+    if out_spec is None:
+        raise AssertionError("expected materialize_as_graph to trace the region")
+    return pytree.tree_unflatten(list(flat_res), out_spec)
+
+
 #  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
 #     order op. As a result, TorchDynamo does not look inside utils.checkpoint.
 #  3) If not, then TorchDynamo falls back to eager by performing a graph
@@ -661,6 +722,11 @@ def _checkpoint_impl(
             )
         return CheckpointFunction.apply(function, preserve, *args)
     else:
+        if _should_checkpoint_via_invoke_subgraph():
+            return _checkpoint_via_invoke_subgraph(
+                function, args, kwargs, context_fn
+            )
+
         gen = _checkpoint_without_reentrant_generator_impl(
             function,
             args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192847
* #192846
* #192845
* #192842
* #192841
* #192840

checkpoint_via_invoke_subgraph was wired only into the dynamo front door
(CheckpointHigherOrderVariable), so it was silently inert under non-strict
tracing: nothing read the config, nothing stamped the region marks, and the
region fell back to the eager checkpoint implementation. Only the *capture* of
the forward graph differs between the two modes, so the feature should not.

torch.utils.checkpoint now lowers the region itself when the flag is set and a
proxy mode is active. Reaching that code with a proxy mode active means we are
being traced non-strictly, because under strict tracing dynamo intercepts
checkpoint symbolically and this function never runs. The region is captured to
a GraphModule, marked with _checkpoint_region (and _checkpoint_context_fn for a
selective policy), and emitted as an invoke_subgraph HOP -- the same
representation dynamo produces. Everything downstream is unchanged: the joint
graph passes key off those marks rather than the config, so non-strict gets the
same partitioning, shared recompute slice, and no-drift guarantee.

Two details worth noting for review. The region must be captured with
materialize_as_graph rather than make_fx / reenter_make_fx: checkpoint runs
inside the caller's already-functionalized proxy trace, where the latter two
fail with "cannot find FakeTensor in tensor_tracker"; materialize_as_graph
suspends those modes correctly, as cond's autograd does. And invoke_subgraph
returns a flat tuple, so the region is traced through a flattening wrapper and
its real output structure is restored with pytree afterwards.

Known limitation: a region whose RNG is a multi-output op (native_dropout) is
rejected under non-strict with "region with RNG cannot be expressed as a shared
recompute slice". This is the existing multi-output-getitem limitation of the
shared slice colliding with force-saved RNG, which may not fall back to
whole-region recompute (it would re-draw). Single-output RNG (e.g. rand_like)
and non-RNG regions work; strict is unaffected. The failure is a loud rejection,
not silent miscompilation.

Test Plan:

```
python test/dynamo/test_activation_checkpointing.py -k checkpoint_via_invoke_subgraph
python test/dynamo/test_activation_checkpointing.py
```

Run on CUDA (A100); the full file passes 128 tests (2 skipped). The two added
tests cover the non-strict lowering (the region survives as a HOP carrying
_checkpoint_region and is recomputed in the backward half of the joint) and that
plain eager checkpoint is untouched with the flag on, since the front door keys
off an active proxy mode. Selective checkpointing was verified end to end under
non-strict by confirming trace_joint_graph_as_bwd receives the context_fn and
the partitioner sees the resulting MUST_SAVE tags.

Authored with Claude.