### PR TITLE
[RAWTHROW][0] Lexically-aware linter (no exclude_patterns change)

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -618,19 +618,7 @@ exclude_patterns = [
 ]
 command = [
     'python3',
-    'tools/linter/adapters/grep_linter.py',
-    '--pattern=\bthrow\b',
-    '--allowlist-pattern=@allow-raw-throw',
-    '--linter-name=RAWTHROW',
-    '--error-name=raw throw statement',
-    """--error-description=\
-        Do not use raw `throw` in C++ code. Use TORCH_CHECK, \
-        TORCH_CHECK_WITH, C10_THROW_ERROR, or other error-reporting macros \
-        instead. See c10/util/Exception.h for available macros. If this is a \
-        re-throw (throw;), restructure the code to avoid try/catch/throw or \
-        add the file to the RAWTHROW exclude list in .lintrunner.toml with \
-        justification.\
-    """,
+    'tools/linter/adapters/raw_throw_linter.py',
     '--',
     '@{{PATHSFILE}}'
 ]

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -69,7 +69,9 @@ _THROW = re.compile(r"\bthrow\b")
 _WORD = re.compile(r"[A-Za-z]")
 # The marker has to be the whole point of its comment. Prose that merely
 # mentions it - as the docs for this linter do - must not license anything.
-_MARKER_LINE = re.compile(rf"^\s*(?://+|/\*)\s*{re.escape(MARKER)}\b(?P<rest>.*)")
+_MARKER_LINE = re.compile(
+    rf"^\s*(?://+!?|/\*+!?|\*)\s*{re.escape(MARKER)}\b(?P<rest>.*)"
+)
 
 
 def scan_source(text: str) -> tuple[str, str]:
@@ -126,16 +128,19 @@ def scan_source(text: str) -> tuple[str, str]:
             prefix_start = i
             while prefix_start > 0 and _IDENT_CHARS.match(text[prefix_start - 1]):
                 prefix_start -= 1
+            end = None
             if text[prefix_start:i] in _RAW_STRING_PREFIXES:
-                open_paren = text.find("(", i + 1)
-                if open_paren != -1:
-                    terminator = ")" + text[i + 1 : open_paren] + '"'
-                    close = text.find(terminator, open_paren + 1)
-                    end = n if close == -1 else close + len(terminator)
-                    blank(code, i, end)
-                    i = end
-                    continue
-            end = _end_of_quoted(text, i, '"')
+                delimiter = _raw_string_delimiter(text, i)
+                if delimiter is not None:
+                    terminator = ")" + delimiter + '"'
+                    close = text.find(terminator, i + len(delimiter) + 2)
+                    if close != -1:
+                        end = close + len(terminator)
+            if end is None:
+                # Not a well-formed raw string, or one that is never
+                # terminated. Fall back to the line-bounded scan so a malformed
+                # literal cannot blank the rest of the file.
+                end = _end_of_quoted(text, i, '"')
             blank(code, i, end)
             i = end
             continue
@@ -158,6 +163,18 @@ def scan_source(text: str) -> tuple[str, str]:
         i += 1
 
     return "".join(code), "".join(comments)
+
+
+def _raw_string_delimiter(text: str, quote: int) -> str | None:
+    """The d-char sequence of the raw string opening at `quote`, or None if this
+    is not a well-formed raw string. The standard caps the delimiter at 16
+    characters and excludes whitespace, parentheses and backslash."""
+    for j in range(quote + 1, min(quote + 18, len(text))):
+        if text[j] == "(":
+            return text[quote + 1 : j]
+        if text[j] in ' ()\\"\n\r\t\v\f':
+            return None
+    return None
 
 
 def _is_continued(text: str, newline: int) -> bool:
@@ -286,12 +303,19 @@ def check_source(path: str, text: str) -> list[LintMessage]:
     # trailing marker would silently cover the *next* line's throw.
     licensed: set[int] = set()
     messages = []
+    code_lines = code.split("\n")
     for lineno, comment in enumerate(comments.split("\n"), 1):
         marker = _MARKER_LINE.search(comment)
         if marker is None:
             continue
+        # The marker gets a line to itself, so that it cannot trail a throw (and
+        # appear to license the next one) or hide at the end of a line of code.
+        # A trailing `\` is a line continuation, not code, so that a marker can
+        # sit inside a multi-line macro body - which is the only placement
+        # available there.
+        alone = not code_lines[lineno - 1].strip().rstrip("\\").strip()
         target = lineno + 1
-        if lineno in throw_lines or target not in throw_lines:
+        if not alone or target not in throw_lines:
             messages.append(
                 message(
                     lineno,

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""
+RAWTHROW: flags raw `throw` statements in C++ code.
+
+Unlike a plain grep this understands C++ lexical structure: comments and
+string/char literal bodies are blanked out before matching, so the word
+"throw" in prose or in a message never counts, and a clang-format-wrapped
+
+    throw(
+        SomeError(...));
+
+is recognised as a single `throw SomeError(...)` rather than a bare `throw(`.
+
+A throw that is genuinely correct can be kept by putting
+
+    // @allow-raw-throw: <why this throw must stay>
+
+on the line immediately above it. The reason is mandatory, and the marker only
+applies to the next line - there is no way to switch the check off for a whole
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from enum import Enum
+from typing import NamedTuple
+
+
+LINTER_CODE = "RAWTHROW"
+
+MARKER = "@allow-raw-throw"
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: str | None
+    line: int | None
+    char: int | None
+    code: str
+    severity: LintSeverity
+    name: str
+    original: str | None
+    replacement: str | None
+    description: str | None
+
+
+class Throw(NamedTuple):
+    line: int
+    expression: str
+
+
+# Prefixes that turn a `"` into the start of a raw string literal.
+_RAW_STRING_PREFIXES = frozenset({"R", "LR", "uR", "UR", "u8R"})
+
+_IDENT_CHARS = re.compile(r"\w")
+_NUMBER_CHARS = re.compile(r"[\w']")
+_THROW = re.compile(r"\bthrow\b")
+_MARKER_LINE = re.compile(rf"{re.escape(MARKER)}(?P<rest>.*)")
+
+
+def scan_source(text: str) -> tuple[str, str]:
+    """Split `text` into a code view and a comment view.
+
+    Both views have the same length and the same newlines as `text`, so an
+    offset means the same thing in all three. `code` has comment and literal
+    text replaced by spaces; `comments` has everything *but* comment text
+    replaced by spaces.
+    """
+    n = len(text)
+    code = list(text)
+    comments = [c if c == "\n" else " " for c in text]
+
+    def blank(target: list[str], start: int, end: int) -> None:
+        for k in range(start, end):
+            if target[k] != "\n":
+                target[k] = " "
+
+    def keep(start: int, end: int) -> None:
+        comments[start:end] = list(text[start:end])
+        blank(code, start, end)
+
+    i = 0
+    while i < n:
+        c = text[i]
+
+        if c == "/" and text.startswith("//", i):
+            # A `//` comment runs to the end of the line, unless the line ends
+            # with a backslash, in which case it continues onto the next one.
+            end = i
+            while True:
+                nl = text.find("\n", end)
+                if nl == -1:
+                    end = n
+                    break
+                cont = nl - 1
+                if cont >= 0 and text[cont] == "\r":
+                    cont -= 1
+                if cont >= 0 and text[cont] == "\\":
+                    end = nl + 1
+                    continue
+                end = nl
+                break
+            keep(i, end)
+            i = end
+            continue
+
+        if c == "/" and text.startswith("/*", i):
+            close = text.find("*/", i + 2)
+            end = n if close == -1 else close + 2
+            keep(i, end)
+            i = end
+            continue
+
+        if c == '"':
+            prefix_start = i
+            while prefix_start > 0 and _IDENT_CHARS.match(text[prefix_start - 1]):
+                prefix_start -= 1
+            if text[prefix_start:i] in _RAW_STRING_PREFIXES:
+                open_paren = text.find("(", i + 1)
+                if open_paren != -1:
+                    terminator = ")" + text[i + 1 : open_paren] + '"'
+                    close = text.find(terminator, open_paren + 1)
+                    end = n if close == -1 else close + len(terminator)
+                    blank(code, i, end)
+                    i = end
+                    continue
+            end = _end_of_quoted(text, i, '"')
+            blank(code, i, end)
+            i = end
+            continue
+
+        if c == "'":
+            # A quote glued to the end of a number is a C++14 digit separator
+            # (1'000'000), not a literal. A quote glued to an encoding prefix
+            # (L'a', u8'a') is a literal.
+            token_start = i
+            while token_start > 0 and _NUMBER_CHARS.match(text[token_start - 1]):
+                token_start -= 1
+            if text[token_start:i][:1].isdigit():
+                i += 1
+                continue
+            end = _end_of_quoted(text, i, "'")
+            blank(code, i, end)
+            i = end
+            continue
+
+        i += 1
+
+    return "".join(code), "".join(comments)
+
+
+def _end_of_quoted(text: str, start: int, quote: str) -> int:
+    """Offset just past the literal opening at `start`, or end of line if the
+    literal is unterminated."""
+    i = start + 1
+    n = len(text)
+    while i < n:
+        if text[i] == "\\":
+            i += 2
+            continue
+        if text[i] == quote:
+            return i + 1
+        if text[i] == "\n":
+            return i
+        i += 1
+    return n
+
+
+def find_throws(code: str) -> list[Throw]:
+    """Find every `throw` token in `code` (which must already have comments and
+    literals blanked out) together with the expression it throws."""
+    throws = []
+    n = len(code)
+    for match in _THROW.finditer(code):
+        depth = 0
+        i = match.end()
+        while i < n:
+            ch = code[i]
+            if ch in "([{":
+                depth += 1
+            elif ch in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif ch in ";," and depth == 0:
+                break
+            i += 1
+        expression = " ".join(code[match.end() : i].split())
+        throws.append(Throw(code.count("\n", 0, match.start()) + 1, expression))
+    return throws
+
+
+def replacement_macro(path: str) -> str:
+    """The error-reporting macro available to code in `path`. Not everything can
+    depend on c10."""
+    posix = path.replace("\\", "/")
+    if "torch/csrc/inductor/aoti_runtime/" in posix:
+        return "AOTI_RUNTIME_CHECK"
+    if "torch/headeronly/" in posix or "torch/csrc/stable/" in posix:
+        return "STD_TORCH_CHECK"
+    return "TORCH_CHECK"
+
+
+def describe(path: str, expression: str) -> str:
+    if not expression:
+        return (
+            "`throw;` re-raises the exception being handled. If the try/catch "
+            f"cannot be restructured away, put `// {MARKER}: <reason>` on the "
+            "line immediately above it."
+        )
+    macro = replacement_macro(path)
+    if len(expression) > 80:
+        expression = expression[:77] + "..."
+    lines = [
+        f"`throw {expression}` is a raw throw. Use {macro} instead.",
+    ]
+    if macro == "TORCH_CHECK":
+        lines.append(
+            "Preserve the exception type: std::runtime_error -> TORCH_CHECK, "
+            "std::invalid_argument -> TORCH_CHECK_VALUE, "
+            "std::out_of_range -> TORCH_CHECK_INDEX. "
+            "See c10/util/Exception.h for the full list."
+        )
+    lines.append(
+        f"If this throw is correct and must stay, put `// {MARKER}: <reason>` "
+        "on the line immediately above it."
+    )
+    return " ".join(lines)
+
+
+def check_source(path: str, text: str) -> list[LintMessage]:
+    code, comments = scan_source(text)
+
+    def message(line: int, name: str, description: str) -> LintMessage:
+        return LintMessage(
+            path=path,
+            line=line,
+            char=None,
+            code=LINTER_CODE,
+            severity=LintSeverity.ERROR,
+            name=name,
+            original=None,
+            replacement=None,
+            description=description,
+        )
+
+    throws = find_throws(code)
+    throw_lines = {throw.line for throw in throws}
+
+    # A marker licenses exactly one throw: the first one on the line below it.
+    # A marker sharing a line with a throw licenses nothing - otherwise a
+    # trailing marker would silently cover the *next* line's throw.
+    licensed: set[int] = set()
+    messages = []
+    for lineno, comment in enumerate(comments.split("\n"), 1):
+        marker = _MARKER_LINE.search(comment)
+        if marker is None:
+            continue
+        target = lineno + 1
+        if lineno in throw_lines or target not in throw_lines:
+            messages.append(
+                message(
+                    lineno,
+                    "orphaned-allow-raw-throw",
+                    f"`{MARKER}` does not apply to anything: it must sit on the "
+                    "line immediately above the throw it allows. It is not a "
+                    "file-level opt-out and it cannot trail the throw itself.",
+                )
+            )
+            continue
+        licensed.add(target)
+        rest = marker.group("rest").strip()
+        if not (rest.startswith(":") and rest[1:].strip()):
+            messages.append(
+                message(
+                    lineno,
+                    "allow-raw-throw-without-reason",
+                    f"`{MARKER}` must state why the throw is correct, as "
+                    f"`// {MARKER}: <reason>`.",
+                )
+            )
+
+    for throw in throws:
+        if throw.line in licensed:
+            licensed.discard(throw.line)
+            continue
+        messages.append(
+            message(throw.line, "raw throw statement", describe(path, throw.expression))
+        )
+
+    messages.sort(key=lambda m: (m.line or 0, m.name))
+    return messages
+
+
+def check_file(path: str) -> list[LintMessage]:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError as err:
+        return [
+            LintMessage(
+                path=path,
+                line=None,
+                char=None,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="file-access-error",
+                original=None,
+                replacement=None,
+                description=f"Failed to read file: {err}",
+            )
+        ]
+    if "throw" not in text:
+        return []
+    return check_source(path, text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="raw throw linter",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("filenames", nargs="+", help="paths to lint")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="<%(threadName)s:%(levelname)s> %(message)s",
+        level=logging.NOTSET if args.verbose else logging.DEBUG,
+        stream=sys.stderr,
+    )
+
+    for filename in args.filenames:
+        for lint_message in check_file(filename):
+            print(json.dumps(lint_message._asdict()), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -66,7 +66,10 @@ _RAW_STRING_PREFIXES = frozenset({"R", "LR", "uR", "UR", "u8R"})
 _IDENT_CHARS = re.compile(r"\w")
 _NUMBER_CHARS = re.compile(r"[\w']")
 _THROW = re.compile(r"\bthrow\b")
-_MARKER_LINE = re.compile(rf"{re.escape(MARKER)}(?P<rest>.*)")
+_WORD = re.compile(r"[A-Za-z]")
+# The marker has to be the whole point of its comment. Prose that merely
+# mentions it - as the docs for this linter do - must not license anything.
+_MARKER_LINE = re.compile(rf"^\s*(?://+|/\*)\s*{re.escape(MARKER)}\b(?P<rest>.*)")
 
 
 def scan_source(text: str) -> tuple[str, str]:
@@ -103,10 +106,7 @@ def scan_source(text: str) -> tuple[str, str]:
                 if nl == -1:
                     end = n
                     break
-                cont = nl - 1
-                if cont >= 0 and text[cont] == "\r":
-                    cont -= 1
-                if cont >= 0 and text[cont] == "\\":
+                if _is_continued(text, nl):
                     end = nl + 1
                     continue
                 end = nl
@@ -160,6 +160,14 @@ def scan_source(text: str) -> tuple[str, str]:
     return "".join(code), "".join(comments)
 
 
+def _is_continued(text: str, newline: int) -> bool:
+    """Whether the newline at `newline` is a backslash line continuation."""
+    i = newline - 1
+    if i >= 0 and text[i] == "\r":
+        i -= 1
+    return i >= 0 and text[i] == "\\"
+
+
 def _end_of_quoted(text: str, start: int, quote: str) -> int:
     """Offset just past the literal opening at `start`, or end of line if the
     literal is unterminated."""
@@ -184,9 +192,12 @@ def find_throws(code: str) -> list[Throw]:
     n = len(code)
     for match in _THROW.finditer(code):
         depth = 0
+        seen = False
         i = match.end()
         while i < n:
             ch = code[i]
+            if not ch.isspace():
+                seen = True
             if ch in "([{":
                 depth += 1
             elif ch in ")]}":
@@ -195,8 +206,18 @@ def find_throws(code: str) -> list[Throw]:
                 depth -= 1
             elif ch in ";," and depth == 0:
                 break
+            elif ch == "\n" and depth == 0 and seen and not _is_continued(code, i):
+                # A macro body has no trailing `;`, so without this the scan
+                # would run to the end of the file. Requiring `seen` keeps an
+                # operand written on the next line attached to its throw, so
+                # that it cannot be mistaken for a bare `throw;`, and a
+                # clang-format-wrapped throw is inside brackets here anyway.
+                break
             i += 1
-        expression = " ".join(code[match.end() : i].split())
+        # Line continuations inside a macro body are noise, not part of the
+        # expression.
+        tokens = (t.rstrip("\\") for t in code[match.end() : i].split())
+        expression = " ".join(t for t in tokens if t)
         throws.append(Throw(code.count("\n", 0, match.start()) + 1, expression))
     return throws
 
@@ -227,10 +248,12 @@ def describe(path: str, expression: str) -> str:
     ]
     if macro == "TORCH_CHECK":
         lines.append(
-            "Preserve the exception type: std::runtime_error -> TORCH_CHECK, "
-            "std::invalid_argument -> TORCH_CHECK_VALUE, "
-            "std::out_of_range -> TORCH_CHECK_INDEX. "
-            "See c10/util/Exception.h for the full list."
+            "c10::Error surfaces as RuntimeError, which is already what "
+            "HANDLE_TH_ERRORS does with every std:: exception, so TORCH_CHECK "
+            "is usually an exact swap. The type only matters if this throw "
+            "escapes through a bare pybind11 binding, which maps "
+            "std::invalid_argument to ValueError and std::out_of_range to "
+            "IndexError; TORCH_CHECK_VALUE and TORCH_CHECK_INDEX preserve those."
         )
     lines.append(
         f"If this throw is correct and must stay, put `// {MARKER}: <reason>` "
@@ -281,7 +304,7 @@ def check_source(path: str, text: str) -> list[LintMessage]:
             continue
         licensed.add(target)
         rest = marker.group("rest").strip()
-        if not (rest.startswith(":") and rest[1:].strip()):
+        if not (rest.startswith(":") and _WORD.search(rest)):
             messages.append(
                 message(
                     lineno,
@@ -296,7 +319,7 @@ def check_source(path: str, text: str) -> list[LintMessage]:
             licensed.discard(throw.line)
             continue
         messages.append(
-            message(throw.line, "raw throw statement", describe(path, throw.expression))
+            message(throw.line, "raw-throw", describe(path, throw.expression))
         )
 
     messages.sort(key=lambda m: (m.line or 0, m.name))

--- a/tools/test/test_raw_throw_linter.py
+++ b/tools/test/test_raw_throw_linter.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(REPO_ROOT))
+
+from tools.linter.adapters.raw_throw_linter import (
+    check_source,
+    find_throws,
+    replacement_macro,
+    scan_source,
+)
+
+
+PATH = "torch/csrc/example.cpp"
+
+
+def code_of(source: str) -> str:
+    return scan_source(source)[0]
+
+
+def comments_of(source: str) -> str:
+    return scan_source(source)[1]
+
+
+def names(source: str, path: str = PATH) -> list[str]:
+    return [m.name for m in check_source(path, source)]
+
+
+def lines_flagged(source: str, path: str = PATH) -> list[int | None]:
+    return [
+        m.line for m in check_source(path, source) if m.name == "raw throw statement"
+    ]
+
+
+class TestScanSource(unittest.TestCase):
+    def assertBlanked(self, source: str, expected_code: str) -> None:
+        code = code_of(source)
+        self.assertEqual(len(code), len(source))
+        self.assertEqual(code, expected_code)
+
+    def test_line_comment(self) -> None:
+        self.assertBlanked("a; // throw\nb;\n", "a;         \nb;\n")
+
+    def test_block_comment(self) -> None:
+        self.assertBlanked("a; /* throw\n throw */ b;\n", "a;         \n          b;\n")
+
+    def test_string_literal(self) -> None:
+        self.assertBlanked('f("throw");\n', "f(       );\n")
+
+    def test_string_with_escaped_quote(self) -> None:
+        self.assertBlanked('f("a\\"throw");\n', "f(          );\n")
+
+    def test_char_literal(self) -> None:
+        self.assertBlanked("c = ';';\n", "c =    ;\n")
+
+    def test_digit_separator_is_not_a_char_literal(self) -> None:
+        # 1'000'000 must not be read as a char literal swallowing the throw.
+        source = "n = 1'000'000;\nthrow std::runtime_error(x);\n"
+        self.assertEqual(len(find_throws(code_of(source))), 1)
+
+    def test_prefixed_char_literal_is_not_a_digit_separator(self) -> None:
+        for prefix in ("L", "u", "U", "u8"):
+            with self.subTest(prefix=prefix):
+                source = f"wchar_t c = {prefix}'a';\nthrow std::runtime_error(x);\n"
+                self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
+
+    def test_hex_digit_separator(self) -> None:
+        source = "n = 0xFF'FF;\nthrow Foo();\n"
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
+
+    def test_raw_string(self) -> None:
+        source = 'auto s = R"(throw "x" )";\nthrow Foo();\n'
+        throws = find_throws(code_of(source))
+        self.assertEqual([t.line for t in throws], [2])
+
+    def test_raw_string_with_delimiter(self) -> None:
+        source = 'auto s = R"py(throw)py";\nthrow Foo();\n'
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
+
+    def test_backslash_continued_line_comment(self) -> None:
+        source = "// a \\\nthrow Foo();\nthrow Bar();\n"
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [3])
+
+    def test_comment_view_keeps_only_comments(self) -> None:
+        source = 'x; // @allow-raw-throw: ok\ny("@allow-raw-throw: no");\n'
+        comments = comments_of(source)
+        self.assertEqual(comments.splitlines()[0].strip(), "// @allow-raw-throw: ok")
+        self.assertEqual(comments.splitlines()[1].strip(), "")
+
+    def test_apostrophe_in_comment_does_not_swallow_code(self) -> None:
+        source = "// don't do this\nthrow Foo();\n"
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
+
+    def test_slashes_inside_a_string_do_not_start_a_comment(self) -> None:
+        source = 'auto url = "http://x";\nthrow Foo();\n'
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
+
+    def test_unterminated_block_comment_swallows_the_rest(self) -> None:
+        self.assertEqual(find_throws(code_of("/* x\nthrow Foo();\n")), [])
+
+    def test_line_numbers_are_preserved(self) -> None:
+        source = '/* a\n b */ "c\\n"\nthrow Foo();\n'
+        self.assertEqual([t.line for t in find_throws(code_of(source))], [3])
+
+
+class TestFindThrows(unittest.TestCase):
+    def test_expression(self) -> None:
+        throws = find_throws(code_of("throw std::runtime_error(msg);\n"))
+        self.assertEqual([t.expression for t in throws], ["std::runtime_error(msg)"])
+
+    def test_wrapped_throw_is_one_occurrence(self) -> None:
+        source = "throw(\n    ErrorReport(loc)\n    << what);\n"
+        throws = find_throws(code_of(source))
+        self.assertEqual(len(throws), 1)
+        self.assertEqual(throws[0].line, 1)
+        self.assertEqual(throws[0].expression, "( ErrorReport(loc) << what)")
+
+    def test_bare_rethrow(self) -> None:
+        throws = find_throws(code_of("throw;\n"))
+        self.assertEqual([t.expression for t in throws], [""])
+
+    def test_rethrow_word_is_not_a_throw(self) -> None:
+        self.assertEqual(find_throws(code_of("std::rethrow_exception(p);\n")), [])
+
+    def test_throw_specifier_in_identifier(self) -> None:
+        self.assertEqual(find_throws(code_of("int throwing_count = 0;\n")), [])
+
+
+class TestBuckets(unittest.TestCase):
+    """Every kind of throw is flagged at this stage; the allow-by-rule policy
+    for typed exceptions is a separate change."""
+
+    def test_all_shapes_are_flagged(self) -> None:
+        for expression in (
+            "std::runtime_error(x)",
+            "std::invalid_argument(x)",
+            "std::out_of_range(x)",
+            "python_error()",
+            "py::value_error(x)",
+            "c10::Error(x, y)",
+            "ErrorReport(loc) << x",
+            "std::move(e)",
+            "",
+        ):
+            source = f"throw {expression};\n"
+            with self.subTest(expression=expression):
+                self.assertEqual(names(source), ["raw throw statement"])
+
+    def test_word_throw_in_comment_or_string_is_not_flagged(self) -> None:
+        source = (
+            "// we throw here\n"
+            "/* throw */\n"
+            'TORCH_CHECK(false, "cannot throw");\n'
+            "int throwaway = 0;\n"
+        )
+        self.assertEqual(names(source), [])
+
+
+class TestAllowMarker(unittest.TestCase):
+    def test_marker_on_preceding_line_allows_the_throw(self) -> None:
+        source = "// @allow-raw-throw: rethrow keeps the original error\nthrow;\n"
+        self.assertEqual(names(source), [])
+
+    def test_marker_without_reason_is_rejected(self) -> None:
+        source = "// @allow-raw-throw\nthrow;\n"
+        self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
+
+    def test_marker_with_empty_reason_is_rejected(self) -> None:
+        source = "// @allow-raw-throw:   \nthrow;\n"
+        self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
+
+    def test_trailing_marker_does_not_allow_the_throw(self) -> None:
+        source = "throw Foo(); // @allow-raw-throw: nope\n"
+        self.assertEqual(
+            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
+        )
+
+    def test_file_level_marker_is_orphaned(self) -> None:
+        source = "// @allow-raw-throw\n#include <x.h>\nthrow Foo();\n"
+        self.assertEqual(
+            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
+        )
+
+    def test_marker_separated_by_blank_line_is_orphaned(self) -> None:
+        source = "// @allow-raw-throw: reason\n\nthrow Foo();\n"
+        self.assertEqual(
+            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
+        )
+
+    def test_marker_in_string_is_not_a_marker(self) -> None:
+        source = 'const char* s = "@allow-raw-throw: x";\nthrow Foo();\n'
+        self.assertEqual(names(source), ["raw throw statement"])
+
+    def test_marker_allows_only_the_next_throw(self) -> None:
+        source = "// @allow-raw-throw: reason\nthrow Foo();\nthrow Bar();\n"
+        self.assertEqual(lines_flagged(source), [3])
+
+    def test_trailing_marker_does_not_license_the_next_line(self) -> None:
+        source = "throw A(); // @allow-raw-throw: about A\nthrow B();\n"
+        self.assertEqual(lines_flagged(source), [1, 2])
+
+    def test_marker_licenses_only_one_throw_on_the_target_line(self) -> None:
+        source = "// @allow-raw-throw: reason\nif (a) throw A(); else throw B();\n"
+        self.assertEqual(names(source), ["raw throw statement"])
+
+    def test_form_feed_does_not_desync_marker_and_throw_lines(self) -> None:
+        source = "\f\n// @allow-raw-throw: reason\nthrow Foo();\n"
+        self.assertEqual(names(source), [])
+
+    def test_marker_above_a_wrapped_throw(self) -> None:
+        source = "// @allow-raw-throw: reason\nthrow(\n    Foo());\n"
+        self.assertEqual(names(source), [])
+
+
+class TestReplacementMacro(unittest.TestCase):
+    def test_per_directory(self) -> None:
+        cases = {
+            "aten/src/ATen/Foo.cpp": "TORCH_CHECK",
+            "c10/util/Foo.cpp": "TORCH_CHECK",
+            "torch/headeronly/util/Foo.h": "STD_TORCH_CHECK",
+            "torch/csrc/stable/foo.h": "STD_TORCH_CHECK",
+            "torch/csrc/inductor/aoti_runtime/model.h": "AOTI_RUNTIME_CHECK",
+            "torch/csrc/inductor/aoti_torch/foo.cpp": "TORCH_CHECK",
+        }
+        for path, macro in cases.items():
+            with self.subTest(path=path):
+                self.assertEqual(replacement_macro(path), macro)
+
+    def test_bare_rethrow_is_not_told_to_use_a_check_macro(self) -> None:
+        (message,) = check_source(PATH, "throw;\n")
+        self.assertNotIn("TORCH_CHECK", message.description or "")
+
+    def test_description_names_the_macro(self) -> None:
+        (message,) = check_source("torch/headeronly/util/Foo.h", "throw Foo();\n")
+        self.assertIn("STD_TORCH_CHECK", message.description or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test/test_raw_throw_linter.py
+++ b/tools/test/test_raw_throw_linter.py
@@ -233,6 +233,25 @@ class TestAllowMarker(unittest.TestCase):
         source = "// @allow-raw-throw: .\nthrow Foo();\n"
         self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
 
+    def test_doxygen_comment_marker(self) -> None:
+        for comment in ("/** @allow-raw-throw: r */", "//! @allow-raw-throw: r"):
+            with self.subTest(comment=comment):
+                self.assertEqual(names(f"{comment}\nthrow Foo();\n"), [])
+
+    def test_marker_inside_a_macro_body(self) -> None:
+        # A line continuation is the only way to write a multi-line macro, so
+        # it must not count as code sharing the marker's line.
+        source = (
+            "#define M(x)                      \\\n"
+            "  /* @allow-raw-throw: reason */  \\\n"
+            "  throw Foo(x)\n"
+        )
+        self.assertEqual(names(source), [])
+
+    def test_marker_must_have_its_own_line(self) -> None:
+        source = "int x = 1; // @allow-raw-throw: sneaky\nthrow Foo();\n"
+        self.assertEqual(names(source), ["orphaned-allow-raw-throw", "raw-throw"])
+
     def test_marker_in_string_is_not_a_marker(self) -> None:
         source = 'const char* s = "@allow-raw-throw: x";\nthrow Foo();\n'
         self.assertEqual(names(source), ["raw-throw"])
@@ -256,6 +275,19 @@ class TestAllowMarker(unittest.TestCase):
     def test_marker_above_a_wrapped_throw(self) -> None:
         source = "// @allow-raw-throw: reason\nthrow(\n    Foo());\n"
         self.assertEqual(names(source), [])
+
+
+class TestMalformedLiterals(unittest.TestCase):
+    def test_malformed_raw_string_does_not_blank_the_file(self) -> None:
+        source = 'const char* p = R"x";\nthrow Foo();\n'
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_unterminated_raw_string_stops_at_the_line(self) -> None:
+        source = 'auto s = R"(abc\nthrow Foo();\n'
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_exception_specification_is_not_a_rethrow(self) -> None:
+        self.assertEqual(names("void f() throw();\n"), ["raw-throw"])
 
 
 class TestReplacementMacro(unittest.TestCase):

--- a/tools/test/test_raw_throw_linter.py
+++ b/tools/test/test_raw_throw_linter.py
@@ -32,9 +32,7 @@ def names(source: str, path: str = PATH) -> list[str]:
 
 
 def lines_flagged(source: str, path: str = PATH) -> list[int | None]:
-    return [
-        m.line for m in check_source(path, source) if m.name == "raw throw statement"
-    ]
+    return [m.line for m in check_source(path, source) if m.name == "raw-throw"]
 
 
 class TestScanSource(unittest.TestCase):
@@ -120,6 +118,35 @@ class TestFindThrows(unittest.TestCase):
         self.assertEqual(throws[0].line, 1)
         self.assertEqual(throws[0].expression, "( ErrorReport(loc) << what)")
 
+    def test_macro_body_without_a_semicolon_stops_at_the_newline(self) -> None:
+        source = "#define SHAPE_ASSERT(c) if (!(c)) throw propagation_error()\nint x;\n"
+        throws = find_throws(code_of(source))
+        self.assertEqual([t.expression for t in throws], ["propagation_error()"])
+
+    def test_a_continued_macro_line_keeps_going(self) -> None:
+        source = (
+            "#define C10_THROW(t, m) \\\n  throw ::c10::t( \\\n      {__func__}, m)\n"
+        )
+        throws = find_throws(code_of(source))
+        self.assertEqual(throws[0].expression, "::c10::t( {__func__}, m)")
+
+    def test_throw_ending_a_macro_is_not_taken_for_a_rethrow(self) -> None:
+        # Only `throw;` counts as a rethrow. A macro that expands to a bare
+        # `throw` runs on to the next line and is reported rather than allowed.
+        source = "#define RETHROW throw\n#define OTHER 1\n"
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_operand_on_the_next_line_is_not_a_bare_rethrow(self) -> None:
+        for source in (
+            "if (x)\n  throw\n      std::runtime_error(y);\n",
+            "throw // NOLINT\n    std::runtime_error(y);\n",
+        ):
+            with self.subTest(source=source):
+                throws = find_throws(code_of(source))
+                self.assertEqual(
+                    [t.expression for t in throws], ["std::runtime_error(y)"]
+                )
+
     def test_bare_rethrow(self) -> None:
         throws = find_throws(code_of("throw;\n"))
         self.assertEqual([t.expression for t in throws], [""])
@@ -149,7 +176,7 @@ class TestBuckets(unittest.TestCase):
         ):
             source = f"throw {expression};\n"
             with self.subTest(expression=expression):
-                self.assertEqual(names(source), ["raw throw statement"])
+                self.assertEqual(names(source), ["raw-throw"])
 
     def test_word_throw_in_comment_or_string_is_not_flagged(self) -> None:
         source = (
@@ -176,25 +203,39 @@ class TestAllowMarker(unittest.TestCase):
 
     def test_trailing_marker_does_not_allow_the_throw(self) -> None:
         source = "throw Foo(); // @allow-raw-throw: nope\n"
-        self.assertEqual(
-            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
-        )
+        self.assertEqual(names(source), ["orphaned-allow-raw-throw", "raw-throw"])
 
     def test_file_level_marker_is_orphaned(self) -> None:
         source = "// @allow-raw-throw\n#include <x.h>\nthrow Foo();\n"
-        self.assertEqual(
-            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
-        )
+        self.assertEqual(names(source), ["orphaned-allow-raw-throw", "raw-throw"])
 
     def test_marker_separated_by_blank_line_is_orphaned(self) -> None:
         source = "// @allow-raw-throw: reason\n\nthrow Foo();\n"
-        self.assertEqual(
-            names(source), ["orphaned-allow-raw-throw", "raw throw statement"]
-        )
+        self.assertEqual(names(source), ["orphaned-allow-raw-throw", "raw-throw"])
+
+    def test_prose_mentioning_the_marker_licenses_nothing(self) -> None:
+        source = "// Use @allow-raw-throw: <reason> to keep a throw.\nthrow Foo();\n"
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_marker_must_be_the_whole_comment(self) -> None:
+        source = "int y; // see @allow-raw-throw: below\nthrow Foo();\n"
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_a_longer_word_is_not_the_marker(self) -> None:
+        source = "// @allow-raw-throwing nonsense\nthrow Foo();\n"
+        self.assertEqual(names(source), ["raw-throw"])
+
+    def test_block_comment_marker(self) -> None:
+        source = "/* @allow-raw-throw: reason */\nthrow Foo();\n"
+        self.assertEqual(names(source), [])
+
+    def test_punctuation_is_not_a_reason(self) -> None:
+        source = "// @allow-raw-throw: .\nthrow Foo();\n"
+        self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
 
     def test_marker_in_string_is_not_a_marker(self) -> None:
         source = 'const char* s = "@allow-raw-throw: x";\nthrow Foo();\n'
-        self.assertEqual(names(source), ["raw throw statement"])
+        self.assertEqual(names(source), ["raw-throw"])
 
     def test_marker_allows_only_the_next_throw(self) -> None:
         source = "// @allow-raw-throw: reason\nthrow Foo();\nthrow Bar();\n"
@@ -206,7 +247,7 @@ class TestAllowMarker(unittest.TestCase):
 
     def test_marker_licenses_only_one_throw_on_the_target_line(self) -> None:
         source = "// @allow-raw-throw: reason\nif (a) throw A(); else throw B();\n"
-        self.assertEqual(names(source), ["raw throw statement"])
+        self.assertEqual(names(source), ["raw-throw"])
 
     def test_form_feed_does_not_desync_marker_and_throw_lines(self) -> None:
         source = "\f\n// @allow-raw-throw: reason\nthrow Foo();\n"

--- a/tools/test/test_raw_throw_linter.py
+++ b/tools/test/test_raw_throw_linter.py
@@ -97,7 +97,7 @@ class TestScanSource(unittest.TestCase):
         self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
 
     def test_slashes_inside_a_string_do_not_start_a_comment(self) -> None:
-        source = 'auto url = "http://x";\nthrow Foo();\n'
+        source = 'auto sep = "a // b";\nthrow Foo();\n'
         self.assertEqual([t.line for t in find_throws(code_of(source))], [2])
 
     def test_unterminated_block_comment_swallows_the_rest(self) -> None:

--- a/torch/csrc/mps/Stream.cpp
+++ b/torch/csrc/mps/Stream.cpp
@@ -118,12 +118,14 @@ void THPMPSStream_init(PyObject* module) {
   THPMPSStreamType.tp_base = THPStreamClass;
   THPMPSStreamClass = (PyObject*)&THPMPSStreamType;
   if (PyType_Ready(&THPMPSStreamType) < 0) {
-    throw python_error(); // @allow-raw-throw
+    // @allow-raw-throw: rethrows the error PyType_Ready has already set
+    throw python_error();
   }
   Py_INCREF(&THPMPSStreamType);
   if (PyModule_AddObject(
           module, "_MPSStreamBase", (PyObject*)&THPMPSStreamType) < 0) {
-    throw python_error(); // @allow-raw-throw
+    // @allow-raw-throw: rethrows the error PyModule_AddObject has already set
+    throw python_error();
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193005
* __->__ #192848

## Author Notes

I wanted to get a better system to catch things we don't want (bare throws) but accept the patterns we handle properly.
This lead to this rabbit hole of re-implementing a parser haha.
I think it's ok as it's only for the linter and it is easy to adapt if we have issue. At least for the current state of the codebase it catches everything I want.

## Agent Notes

Written by Claude Code:

> RAWTHROW is `grep_linter.py --pattern='\bthrow\b'`, so it matches the word
> "throw" in prose and inside string literals. Repo-wide it flags 1741 lines but
> only 1465 of them are real throws; the other 276 are comments and messages.
> That noise is a large part of why the linter still carries 31 exclude_patterns
> entries, and it makes the list impossible to burn down, because a hit cannot be
> judged without opening the file.
>
> This replaces the grep with tools/linter/adapters/raw_throw_linter.py. It blanks
> out comments and string/char/raw-string literal bodies before matching the
> `throw` token, preserving offsets so line numbers stay right, and it walks each
> throw to its terminating `;` so a clang-format-wrapped
>
>     throw(
>         ErrorReport(loc) << what);
>
> is a single `throw ErrorReport(loc) << what` rather than a bare `throw(`. The
> diagnostic now names the macro that is actually reachable from that directory:
> STD_TORCH_CHECK under torch/headeronly and torch/csrc/stable,
> AOTI_RUNTIME_CHECK under torch/csrc/inductor/aoti_runtime, TORCH_CHECK
> elsewhere, plus a reminder that TORCH_CHECK_VALUE and TORCH_CHECK_INDEX exist
> so a conversion does not silently change the Python-visible exception type.
>
> `@allow-raw-throw` changes meaning at the same time. It was file-scoped: a
> single marker anywhere in a file disabled the check for that entire file,
> permanently, with no justification required. It is now line-scoped -
> `// @allow-raw-throw: <reason>` on the line immediately above the throw,
> licensing that one throw, reason mandatory. A marker that is not directly above
> a throw, including one trailing the throw itself, is reported as orphaned, so
> the old file-header form cannot go on looking like it still protects something.
> The marker goes above rather than after the statement because clang-format
> relocates trailing comments on long throws.
>
> An alternative considered and rejected was extending the existing grep with
> `--line-allowlist-pattern`. A regex over raw lines cannot separate the token
> `throw` from the word "throw": `throw\(` would whitelist every wrapped throw
> whatever its type, and `"[^"]*throw` would whitelist
> `throw std::runtime_error("cannot throw")`.
>
> exclude_patterns is deliberately untouched, so this change is behaviour-neutral
> except in torch/csrc/mps/Stream.cpp - the only non-excluded file in the repo
> that contains a `throw` token. Its two markers move onto the preceding line and
> gain a reason. Every subsequent PR in this stack deletes exclude entries; this
> one is the only exception, because there is nothing yet to prove against.
>
> Note for the phases that follow: 29 legacy markers survive in 14 files that are
> still excluded (torch/csrc/Generator.cpp x6, torch/csrc/dynamo/guards.cpp x6,
> torch/csrc/dynamo/init.cpp x5, c10/util/Exception.h, ...). 27 are now orphaned
> and 2 lack a reason, so each will start firing the moment its directory leaves
> the exclude list, and the PR that removes that entry has to rewrite them.
>
> Test Plan:
>
> Unit tests, which CI also runs via lint.yml's `pytest tools/test`:
>
> ```
> PYTHONPATH=$(pwd) python -m pytest tools/test/test_raw_throw_linter.py -q
> ```
>
> 38 passed, 19 subtests passed.
>
> Full lint, not quicklint:
>
> ```
> spin lint
> ```
>
> Whole-repo counts over the 4445 tracked .cpp/.h files. The old linter, run on
> origin/main (on this branch it reports 1743, because the two new marker
> comments themselves contain the word "throw"):
>
> ```
> git checkout origin/main
> grep -nEHI '\bthrow\b' $(git ls-files '*.cpp' '*.h') | wc -l
> ```
>
> 1741. The new linter, on this branch:
>
> ```
> python tools/linter/adapters/raw_throw_linter.py $(git ls-files '*.cpp' '*.h') \
>     | python -c 'import json,sys,collections; print(collections.Counter(json.loads(l)["name"] for l in sys.stdin))'
> ```
>
> 1490 messages: 1461 raw throws, 27 orphaned markers and 2 markers without a
> reason. Those reconcile to the same 1465 real throws - the 4 missing from the
> 1461 are the 2 in mps/Stream.cpp that are now licensed and the 2 in
> dynamo/guards.cpp whose pre-existing markers are reported for lacking a reason
> instead.
>
> The 1465 were cross-checked against an independent classification and agree
> exactly: 389 std::runtime_error, 22 std::invalid_argument, 15 std::out_of_range,
> 15 std::logic_error, 6 std::bad_alloc, 3 each std::system_error,
> std::range_error and std::exception, 2 std::length_error, 258
> `throw python_error()`, and 749 typed non-std exceptions, py::*, c10::* or bare
> rethrows. Restricted to the 125 tracked files that survive exclude_patterns the
> adapter reports nothing, so `lintrunner --all-files` stays green.
>
> Local build with `bash -ic 'BUILD_CONFIG spin develop'`. The only C++ touched is
> two comment lines under `#ifdef USE_MPS`, which a Linux build does not compile.