### PR TITLE
[aotinductor] Add unsafe_skip_scalar_range_asserts to skip bounds against a constant (#192857)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7381,6 +7381,187 @@ class AOTInductorTestsTemplate:
         with config.patch({"scalar_asserts": False}):
             AOTIRunnerUtil.run_multiple(model, [example_inputs, unexpected_inputs])
 
+    def test_scalar_range_asserts_disabled_drops_inferred_bound(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c):
+                nz = torch.nonzero(a)
+                ones = a.new_ones([nz.size(0), b.size(0)])
+                return torch.add(ones, c)
+
+        model = Model()
+        nonzero_input = torch.ones(64, device=self.device)
+        width = torch.randn((32,), device=self.device)
+        backed_dim_input = torch.randn((64, 32), device=self.device)
+        # 0/1 specialization floors this dim at 2, and u0 is tied to it.
+        torch._dynamo.mark_dynamic(backed_dim_input, 0)
+        example_inputs = (nonzero_input, width, backed_dim_input)
+        INFERRED_BOUND = "u0 >= 2"
+
+        _, code = run_and_get_cpp_code(
+            AOTIRunnerUtil.legacy_compile, model, example_inputs
+        )
+        FileCheck().check(INFERRED_BOUND).run(code)
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check_not(INFERRED_BOUND).run(code)
+
+    def test_scalar_range_asserts_disabled_keeps_equality_asserts(self):
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c):
+                nz = torch.nonzero(a)
+                ones = a.new_ones([nz.size(0), b.size(0)])
+                return torch.add(ones, c)
+
+        model = Model()
+        nonzero_input = torch.ones(8, device=self.device)
+        width = torch.randn((32,), device=self.device)
+        backed_dim_input = torch.randn((8, 32), device=self.device)
+        torch._dynamo.mark_dynamic(backed_dim_input, 0)
+        example_inputs = (nonzero_input, width, backed_dim_input)
+        EQUALITY_ASSERT = "Eq(u0, s"
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            so_path, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+
+        FileCheck().check(EQUALITY_ASSERT).run(code)
+
+        compiled = AOTIRunnerUtil.legacy_load(self.device, so_path)
+        compiled(*example_inputs)
+
+    def test_scalar_range_asserts_disabled_drops_user_check(self):
+        # Input must be dynamic. Against a static one the inferred range
+        # already implies u0 < 10 and ShapeEnv folds the check away.
+        class Model(torch.nn.Module):
+            def forward(self, a):
+                nz = torch.nonzero(a)
+                unbacked = nz.size(0)
+                torch._check(unbacked < 10)
+                return a.new_ones([unbacked])
+
+        model = Model()
+        nonzero_input = torch.ones(8, device=self.device)
+        torch._dynamo.mark_dynamic(nonzero_input, 0)
+        example_inputs = (nonzero_input,)
+        USER_CHECK = "u0 < 10"
+
+        _, code = run_and_get_cpp_code(
+            AOTIRunnerUtil.legacy_compile, model, example_inputs
+        )
+        FileCheck().check(USER_CHECK).run(code)
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            so_path, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check_not(USER_CHECK).run(code)
+
+        # The point of the flag: 16 nonzeros exceeds the dropped bound, and runs.
+        compiled = AOTIRunnerUtil.legacy_load(self.device, so_path)
+        over_the_bound = torch.ones(16, device=self.device)
+        self.assertEqual(compiled(over_the_bound).shape, torch.Size([16]))
+
+    def test_scalar_range_asserts_disabled_keeps_two_sided_inequality(self):
+        # Relates two data-dependent sizes, so ShapeEnv cannot fold it into
+        # var_to_range and it survives as its own assert.
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                shorter = torch.nonzero(a).size(0)
+                longer = torch.nonzero(b).size(0)
+                torch._check(shorter <= longer)
+                return a.new_ones([shorter]), b.new_ones([longer])
+
+        model = Model()
+        example_inputs = (
+            torch.ones(4, device=self.device),
+            torch.ones(8, device=self.device),
+        )
+        TWO_SIDED = "Expected u0 <= u1"
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check(TWO_SIDED).run(code)
+
+    def test_scalar_range_asserts_disabled_keeps_unbacked_vs_backed_bound(self):
+        # Bounded by a dim the caller declared, so a contract, not a sample.
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                count = torch.nonzero(a).size(0)
+                torch._check(count <= b.size(0))
+                return b.new_ones([count])
+
+        model = Model()
+        nonzero_input = torch.ones(4, device=self.device)
+        backed_dim_input = torch.randn((8, 2), device=self.device)
+        torch._dynamo.mark_dynamic(backed_dim_input, 0)
+        example_inputs = (nonzero_input, backed_dim_input)
+        MIXED_BOUND = r"Expected u\d+ <= s\d+"
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check_regex(MIXED_BOUND).run(code)
+
+    def test_scalar_range_asserts_disabled_keeps_sum_equality(self):
+        # The jagged total-length contract -- highest-value assert we keep.
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c):
+                total = torch.cat([a, b]).size(0)
+                count = torch.nonzero(c).size(0)
+                torch._check(count == total)
+                return c.new_ones([count])
+
+        model = Model()
+        first = torch.randn(4, device=self.device)
+        second = torch.randn(4, device=self.device)
+        torch._dynamo.mark_dynamic(first, 0)
+        torch._dynamo.mark_dynamic(second, 0)
+        example_inputs = (first, second, torch.ones(8, device=self.device))
+        SUM_EQUALITY = r"Expected Eq\(u\d+, s\d+ \+ s\d+\)"
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check_regex(SUM_EQUALITY).run(code)
+
+    @patch.dict(os.environ, {"TORCHINDUCTOR_SCALAR_ASSERTS_FULL": "1"})
+    def test_scalar_range_asserts_disabled_under_full_runtime_assert(self):
+        # Here asserts arrive as lowered aten._assert_scalar args rather than
+        # from var_to_range. It is a JK rollout in fbcode, so flipping it must
+        # not silently un-drop these bounds.
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c):
+                nz = torch.nonzero(a)
+                ones = a.new_ones([nz.size(0), b.size(0)])
+                return torch.add(ones, c)
+
+        model = Model()
+        nonzero_input = torch.ones(64, device=self.device)
+        width = torch.randn((32,), device=self.device)
+        backed_dim_input = torch.randn((64, 32), device=self.device)
+        torch._dynamo.mark_dynamic(backed_dim_input, 0)
+        example_inputs = (nonzero_input, width, backed_dim_input)
+        INFERRED_BOUND = "u0 >= 2"
+
+        _, code = run_and_get_cpp_code(
+            AOTIRunnerUtil.legacy_compile, model, example_inputs
+        )
+        FileCheck().check(INFERRED_BOUND).run(code)
+
+        with config.patch({"unsafe_skip_scalar_range_asserts": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, model, example_inputs
+            )
+        FileCheck().check_not(INFERRED_BOUND).run(code)
+
     def test_multi_input_nonzero_slice_shared_dim(self):
         # Regression: when multiple inputs share a dynamic batch dim and are
         # sliced with the same nonzero result, the generated C++ guard code

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -236,6 +236,14 @@ runtime_triton_nan_asserts = (
 )
 scalar_asserts = os.environ.get("TORCHINDUCTOR_SCALAR_ASSERTS", "1") == "1"
 
+# Skips codegen for range bounds, a subset of scalar_asserts. These are
+# inequalities between a symbol and a constant (e.g. u0 >= 4). This is unsafe
+# because the skipped assertions check expected shape invariants, including
+# hand-written torch._check().
+unsafe_skip_scalar_range_asserts = (
+    os.environ.get("TORCHINDUCTOR_UNSAFE_SKIP_SCALAR_RANGE_ASSERTS") == "1"
+)
+
 # Disable by default in fbcode
 alignment_asserts = (
     os.environ.get("TORCHINDUCTOR_ALIGNMENT_ASSERTS", "0" if is_fbcode() else "1")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -111,6 +111,7 @@ from .loop_body import LoopBody
 from .ops_handler import OpCounterCSE, OpCountResult, ReductionType, StoreMode
 from .runtime.benchmarking import benchmarker
 from .runtime.hints import DeviceProperties, ReductionHint
+from .sizevars import is_range_bound
 from .utils import (
     argsort,
     argsort_sym,
@@ -9482,6 +9483,8 @@ class AssertScalar(ExternKernel):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         if not config.scalar_asserts:
+            return
+        if config.unsafe_skip_scalar_range_asserts and is_range_bound(self.scalar):
             return
         # NB: It is EXTREMELY important not to simplify the scalar under assertion here,
         # because simplify is done with respect to runtime asserts.  So if you have

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -54,6 +54,29 @@ log = logging.getLogger(__name__)
 Width = int | IntInfinity
 
 
+_RANGE_BOUND_OPS = (
+    sympy.StrictLessThan,
+    sympy.LessThan,
+    sympy.StrictGreaterThan,
+    sympy.GreaterThan,
+)
+
+
+def is_range_bound(expr: sympy.Basic) -> bool:
+    """Whether expr bounds a quantity against a constant, e.g. "u0 >= 4".
+
+    Eq/Ne and relations with symbols on both sides are shape contracts, not
+    sampled ranges. Compound And/Or are not inspected.
+
+    Sound only because canonicalize_bool_expr sign-splits, leaving "u0 <= u1"
+    two-sided. Its docstring claims it moves every non-constant term to the
+    rhs, which would make this match contracts too; it does not do that.
+    """
+    return isinstance(expr, _RANGE_BOUND_OPS) and (
+        not expr.lhs.free_symbols or not expr.rhs.free_symbols
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class LaneContiguity:
     """How an index expression varies across lanes.


### PR DESCRIPTION
Summary:

## Context
`scalar_asserts` emits two kinds of assert: 
1) **Equalities** (e.g. `Eq(s0 + s1, u0)`): ties unbacked symints to a backed symint. These catch real shape-contract violations that can be exposed as an IMA.
2) **Range bounds** (e.g. `u0 >= 4`): depends on both the user's dynamic shape spec and what was inferred during tracing.

Sometimes, the inferred range bounds can be overly restrictive. In other words, the range check stops an input that would've worked fine in AOTI. In this scenario, it'd be nice to disable the range check but keep equality checks.

## How?
We add a feature flag `scalar_range_asserts` default to `True` to preserve existing behavior. When `scalar_asserts=True` + `unsafe_skip_scalar_range_asserts=True`, we keep **equality** checks but remove **range bound** checks. This is a compile-time decision, so you'd need to re-compile if you want to change `scalar_asserts`/`scalar_range_asserts`.

In Inductor's codegen-time is when we check the feature flag. We are defining **range bounds** to be any inequality (`<`, `<=`, `>`, `>=`) with a constant scalar on one side.

### What checks are keep with `scalar_asserts=True` + `unsafe_skip_scalar_range_asserts=True`?

| Shape | Example |
|---|---|
| Equalities | `Eq(u0, s43)`, `Eq(s13 + s193, u137)` |
| Disequalities | `Ne(u0, 0)` |
| Compound booleans | `Eq(s13, 1) | Eq(s13, u132)` |
| Inequalities with symbols on both sides | `u0 <= s0`, `u0 <= u1` |


### Disclaimers:
* a hand-written `torch._check(u0 < N)` matches the predicate and is dropped too. Codegen sees the expression, not its origin.
* compound `And`/`Or` are not recursed into, so a bound nested in one survives. Every compound seen in a real wrapper so far is equality-only.

This diff was authored with Claude.

Test Plan:
### Asserts for internal model, grepped from the generated AOTI wrapper:
```text
// scalar_range_asserts = True
if (!(u0 >= 2L)) { throw std::runtime_error("Expected u0 >= 2 but received " + std::to_string(u0)); }
if (!(u0 <= 8L)) { throw std::runtime_error("Expected u0 <= 8 but received " + std::to_string(u0)); }
if (!(u0 == s43)) { throw std::runtime_error("Expected Eq(u0, s43) but received " + std::to_string(s43)); }

// scalar_range_asserts = False
if (!(u0 == s43)) { throw std::runtime_error("Expected Eq(u0, s43) but received " + std::to_string(s43)); }
```

### Dropped, through real lowerings:
- `..._drops_inferred_bound` -- `u0 >= 2` present, then gone
- `..._drops_user_check` -- user `torch._check` gone, and the artifact then serves 16 nonzeros
- `..._under_full_runtime_assert` -- same, with asserts arriving as lowered `_assert_scalar` args instead of from `var_to_range`

### Kept, through real lowerings:
- `..._keeps_equality_asserts` -- `Eq(u0, s43)`
- `..._keeps_sum_equality` -- `Eq(u0, s0 + s1)`
- `..._keeps_unbacked_vs_backed_bound` -- `u0 <= s0`
- `..._keeps_two_sided_inequality` -- `u0 <= u1`

### Predicate directly, for shapes a lowering cannot produce:
- `test_shape_contracts_are_not_range_bounds` -- 4 kept shapes
- `test_bound_against_constant_is_a_range_bound` -- 5 dropped shapes; without it the suite passes on the feature deleted

Reviewed By: laithsakka

Differential Revision: D114917678




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo