### PR TITLE
[c10d] Fix flight recorder attach for the default nccl name, and a completion race

### DIFF
--- a/test/distributed/test_c10d_fr_hook.py
+++ b/test/distributed/test_c10d_fr_hook.py
@@ -945,6 +945,77 @@ class AbstractFlightRecorderHookTest:
         self.assertEqual(e["time_discovered_completed_ns"], 0, msg=str(e))
         hook.remove()
 
+    def test_completion_arriving_before_registration_still_retires(self):
+        # A Work and its op_id are only ever seen together in the post-hook, so
+        # a backend that establishes completion before that runs has nothing to
+        # hand the callback to. Dropping it retires nothing and the collective
+        # reads "scheduled" for ever -- the false hang this feature exists to
+        # rule out -- so the completion has to be stashed and claimed.
+        #
+        # Constructed, not raced. Post-hooks fire in hook_id order and the
+        # flight recorder hook's ids start far above any hand-picked one, so
+        # the hook below runs first and holds the window open. It waits on a
+        # sentinel collective issued behind the target on the same stream: the
+        # backend retires that queue in order, so once the sentinel's entry is
+        # retired the target's completion has already been pushed -- into a
+        # post-hook that has not run yet, because it is waiting on this one.
+        if not self._push_completion:
+            self.skipTest("backend pushes no completion")
+        pg = self._init_pg()
+        pg._enable_collectives_timing()
+        hook = self._fr_hook(pg)
+        t = torch.ones(1024, device=self.device)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        before = len(self._await_retired())
+        observed = {}
+
+        def hold_post_hook_open(args):
+            if args.work is None or observed.get("running"):
+                return
+            observed["running"] = True
+            try:
+                dist.all_reduce(torch.ones(8, device=self.device))
+                deadline = time.time() + 60
+                while time.time() < deadline:
+                    entries = self._hook_entries()
+                    if len(entries) > before + 1 and entries[before + 1]["retired"]:
+                        break
+                    time.sleep(0.05)
+                entries = self._hook_entries()
+                observed["target"] = entries[before]
+                observed["sentinel"] = entries[before + 1]
+            finally:
+                observed["running"] = False
+
+        pg.register_post_hook(1, hold_post_hook_open)
+        try:
+            dist.all_reduce(t)
+            torch.cuda.synchronize()
+        finally:
+            pg.unregister_post_hook(1)
+
+        # The completion really did arrive with no op_id to match it to: had the
+        # hook registered the Work first, the same push would have retired the
+        # entry before this snapshot was taken.
+        sentinel = observed["sentinel"]
+        self.assertTrue(sentinel["retired"], msg=str(sentinel))
+        target = observed["target"]
+        self.assertFalse(target["retired"], msg=str(target))
+        self.assertNotEqual(target["state"], "completed", msg=str(target))
+        # ... and the post-hook then claims it, rather than leaving a finished
+        # collective looking hung for the rest of the job.
+        entries = self._await_retired(before + 2)[before:]
+        self.assertEqual(len(entries), 2, msg=str(entries))
+        e = entries[0]
+        self.assertTrue(e["retired"], msg=str(e))
+        self.assertEqual(e["state"], "completed", msg=str(e))
+        self.assertGreater(e["time_discovered_completed_ns"], 0, msg=str(e))
+        # The backend's own measurement is kept, not recomputed or dropped.
+        self.assertIn("duration_ms", e, msg=str(e))
+        self.assertGreater(e["duration_ms"], 0.0, msg=str(e))
+        hook.remove()
+
     def test_no_recording_during_cuda_graph_capture(self):
         # A collective issued under capture does not run here, it runs at
         # replay, and its Work cannot be polled: querying a CUDA event recorded
@@ -1219,6 +1290,96 @@ class FlightRecorderHookMixedBackendTest(MultiProcessTestCase):
         }
         self.assertEqual(len(pg_ids), 2)
         fake_hook.remove()
+
+
+@unittest.skipIf(
+    not TEST_CUDA or torch.cuda.device_count() < 2,
+    "default nccl backend tests require at least 2 GPUs",
+)
+@unittest.skipIf(not dist.is_backend_available("nccl"), "nccl backend is not available")
+class FlightRecorderHookDefaultNcclTest(MultiProcessTestCase):
+    """The "nccl" name does not always build the same thing.
+
+    TORCH_DIST_USE_NCCL2 decides whether it is stock ProcessGroupNCCL, which
+    feeds a FlightRecorder by itself, or nccl2, which is invisible without the
+    hook. Whichever one the name resolved to is what the auto-attach has to
+    follow: skipping a group that turned out to be nccl2 leaves the default
+    backend with no flight recorder at all, and says nothing about it.
+    """
+
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TORCH_FR_BUFFER_SIZE"] = "2000"
+        self._spawn_processes()
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        os.environ.pop("TORCH_DIST_USE_NCCL2", None)
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _entries(backend):
+        trace = json.loads(
+            torch._C._distributed_c10d._dump_fr_trace_json(backend=backend)
+        )
+        return trace.get("entries", [])
+
+    def _init_nccl(self, use_nccl2):
+        # Read once, where the backend is registered, which is the first time a
+        # group asks for "nccl" -- so it has to be set before init.
+        os.environ["TORCH_DIST_USE_NCCL2"] = use_nccl2
+        torch.cuda.set_device(self.rank)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            timeout=timedelta(seconds=60),
+        )
+        pg = dist.group.WORLD
+        # The backend's own name, which is what decides whether it records
+        # itself. Asserting on it rather than on the env var is the point: the
+        # default this variable implies has changed before.
+        backend = pg._get_backend(torch.device("cuda", self.rank))
+        return pg, backend.name()
+
+    def test_nccl_name_built_on_nccl2_is_hooked(self):
+        pg, name = self._init_nccl("1")
+        self.assertEqual(name, "nccl2")
+        self.assertIn(pg, _world.pg_flight_recorder_hooks)
+
+        before = len(self._entries("nccl2"))
+        dist.all_reduce(torch.ones(8, device=f"cuda:{self.rank}"))
+        torch.cuda.synchronize()
+        self.assertEqual(
+            [e["profiling_name"] for e in self._entries("nccl2")[before:]],
+            ["nccl2:all_reduce"],
+        )
+
+    def test_nccl_name_built_on_stock_is_not_hooked(self):
+        pg, name = self._init_nccl("0")
+        self.assertEqual(name, "nccl")
+        self.assertNotIn(pg, _world.pg_flight_recorder_hooks)
+
+        before = len(self._entries("nccl"))
+        dist.all_reduce(torch.ones(8, device=f"cuda:{self.rank}"))
+        torch.cuda.synchronize()
+        # Nothing in the hook's instance, and the native recording that made
+        # the hook unnecessary is still there.
+        self.assertEqual(self._entries("nccl")[before:], [])
+        native = json.loads(torch._C._distributed_c10d._dump_nccl_trace_json())
+        names = [e["profiling_name"] for e in native.get("entries", [])]
+        self.assertIn("nccl:all_reduce", names)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_fr_hook.py
+++ b/test/distributed/test_c10d_fr_hook.py
@@ -1052,6 +1052,43 @@ class AbstractFlightRecorderHookTest:
         self.assertEqual(entries[0]["state"], "completed", msg=str(entries[0]))
         hook.remove()
 
+    def test_no_recording_of_tensorless_op_during_capture(self):
+        # barrier() is the one op that reaches the hook with no tensors at all:
+        # Ops.cpp binds a dummy tensor to pick the dispatch key and does not
+        # forward it. The capture guard therefore has no device from the op
+        # itself and has to take one from the group. Reading "no device" as "not
+        # capturing" recorded the barrier, and the post-hook then asked its Work
+        # whether it had already completed -- a cudaEventQuery on a capturing
+        # stream, which invalidates the capture and surfaces from
+        # cudaStreamEndCapture as an unrelated cudaErrorStreamCaptureInvalidated.
+        if self.device_type != "cuda":
+            self.skipTest("capture test is CUDA only")
+        pg = self._init_pg()
+        hook = self._fr_hook(pg)
+
+        t = torch.ones(4, device=self.device)
+        # Warm up so comm initialization does not happen inside the capture.
+        dist.all_reduce(t)
+        dist.barrier(device_ids=[self.rank])
+        torch.cuda.synchronize()
+        before = len(self._hook_entries())
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            dist.barrier(device_ids=[self.rank])
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertEqual(self._hook_entries()[before:], [])
+        # ... and a tensorless op outside a capture is still recorded, so the
+        # guard is not simply refusing every op it cannot get a device from.
+        dist.barrier(device_ids=[self.rank])
+        torch.cuda.synchronize()
+        entries = self._await_retired(before + 1)[before:]
+        self.assertEqual(len(entries), 1, msg=str(entries))
+        self.assertEqual(entries[0]["profiling_name"], self._name("barrier"))
+        hook.remove()
+
     def test_buffer_size_zero_attaches_nothing(self):
         # The gate is read when the group is created, so flip it before init.
         saved = os.environ["TORCH_FR_BUFFER_SIZE"]

--- a/test/distributed/test_c10d_fr_hook.py
+++ b/test/distributed/test_c10d_fr_hook.py
@@ -950,7 +950,8 @@ class AbstractFlightRecorderHookTest:
         # a backend that establishes completion before that runs has nothing to
         # hand the callback to. Dropping it retires nothing and the collective
         # reads "scheduled" for ever -- the false hang this feature exists to
-        # rule out -- so the completion has to be stashed and claimed.
+        # rule out -- so the post-hook asks the Work whether it has already
+        # finished instead of waiting for a push that is not coming.
         #
         # Constructed, not raced. Post-hooks fire in hook_id order and the
         # flight recorder hook's ids start far above any hand-picked one, so
@@ -1003,7 +1004,7 @@ class AbstractFlightRecorderHookTest:
         target = observed["target"]
         self.assertFalse(target["retired"], msg=str(target))
         self.assertNotEqual(target["state"], "completed", msg=str(target))
-        # ... and the post-hook then claims it, rather than leaving a finished
+        # ... and the post-hook then retires it, rather than leaving a finished
         # collective looking hung for the rest of the job.
         entries = self._await_retired(before + 2)[before:]
         self.assertEqual(len(entries), 2, msg=str(entries))

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/distributed/c10d/Hooks.hpp>
 #include <torch/csrc/distributed/c10d/Work.hpp>
 #include <atomic>
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -1229,9 +1230,11 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // collective. They are invoked from the dispatcher kernels (Ops.cpp) rather
   // than here, so they fire wherever a c10d op is dispatched -- including
   // replay of a captured graph that re-dispatches the op directly. See
-  // Hooks.hpp.
-  std::unordered_map<int64_t, PreHook> preHooks_;
-  std::unordered_map<int64_t, PostHook> postHooks_;
+  // Hooks.hpp. Ordered, so hooks fire in hook_id order: a consumer that has to
+  // observe another hook's state (or be observed by it) picks its id instead of
+  // depending on an unspecified traversal.
+  std::map<int64_t, PreHook> preHooks_;
+  std::map<int64_t, PostHook> postHooks_;
   // Monotonic id correlating a pre-hook call with its matching post-hook call.
   std::atomic<int64_t> hookOpIdCounter_{0};
 

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
@@ -151,11 +151,6 @@ std::optional<c10::Device> opDevice(const PreHookArgs& args) {
 // hooked groups get distinct ids from here whether or not they share one.
 std::atomic<size_t> next_pg_id{0};
 
-// Cap on stashed early completions, see FlightRecorderHook::onCompletion. Only
-// ops issued concurrently on different threads can queue up here, so this is
-// generous; it exists so an unclaimable entry cannot accumulate.
-constexpr size_t kMaxEarlyCompletions = 16;
-
 // Both accessors throw rather than return empty on a backend that does not
 // implement them (Backend's defaults, which custom backends keep), and neither
 // is required to record, so ask by trying.
@@ -222,7 +217,7 @@ std::shared_ptr<FlightRecorderHook> FlightRecorderHook::attach(
     hook->pg_->registerCompletionHook(
         hook->hook_id_, [weak](const CompletionHookArgs& args) {
           if (auto self = weak.lock()) {
-            self->onCompletion(args);
+            self->retireCompleted(args.work, args.duration_ms);
           }
         });
     hook->push_completion_ = true;
@@ -369,7 +364,6 @@ void FlightRecorderHook::remove() {
     inflight = std::move(inflight_);
     inflight_.clear();
     work_ids_.clear();
-    early_completions_.clear();
     had_completion_hook = std::exchange(push_completion_, false);
     had_abort_hook = std::exchange(abort_hook_registered_, false);
   }
@@ -387,35 +381,22 @@ void FlightRecorderHook::remove() {
   inflight.clear();
 }
 
-void FlightRecorderHook::onCompletion(const CompletionHookArgs& args) {
-  // Runs on whichever thread the backend established completion on, usually its
-  // watchdog. Only the map lookup happens under mutex_; the recorder call does
-  // not, for the same reason onPre's does not -- see the lock-order note.
+void FlightRecorderHook::retireCompleted(
+    const Work* work,
+    std::optional<float> duration) {
+  // From the completion hook this runs on whichever thread the backend
+  // established completion on, usually its watchdog. Only the map lookup
+  // happens under mutex_; the recorder call does not, for the same reason
+  // onPre's does not -- see the lock-order note.
   InflightOp op;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto id_it = work_ids_.find(args.work);
+    auto id_it = work_ids_.find(work);
     if (id_it == work_ids_.end()) {
-      // Either not one of ours -- an op recorded by a natively recording
-      // backend, one issued under a graph capture, one already evicted, or one
-      // from before this hook was attached -- or the post-hook that registers
-      // the Work has not run yet. The backend wins that race whenever it
-      // establishes completion for a fast op between issue and firePostHook,
-      // and a dropped callback retires nothing, so the collective reads
-      // "scheduled" for ever: the false hang this hook exists to rule out.
-      // Stash it for onPost to claim instead.
-      //
-      // Only while an op is between its pre- and post-hook: with none
-      // outstanding this cannot be that race, and an entry nothing claims could
-      // later be matched by a Work that reuses the address. The cap bounds what
-      // an op whose post-hook never runs (the backend threw after enqueueing)
-      // leaves behind.
-      if (inflight_.size() > work_ids_.size()) {
-        early_completions_.emplace_back(args.work, args.duration_ms);
-        if (early_completions_.size() > kMaxEarlyCompletions) {
-          early_completions_.pop_front();
-        }
-      }
+      // Not one of ours -- an op recorded by a natively recording backend, one
+      // issued under a graph capture, one already evicted, or one from before
+      // this hook was attached -- or already retired, since erasing the entry
+      // here is what claims it and only one caller can win that.
       return;
     }
     auto op_id = id_it->second;
@@ -426,13 +407,27 @@ void FlightRecorderHook::onCompletion(const CompletionHookArgs& args) {
     }
     op = std::move(it->second);
     inflight_.erase(it);
-    // The hook only hears about successful completion, so this is the last op
-    // known to have finished.
+    // Only successful completion gets here, so this is the last op known to
+    // have finished.
     pg_status_->lastCompletedSeq = op_id;
     pg_status_->lastCompletedWorkName = std::string(hookOpName(op.name));
   }
   op.recorder->retire_completed(
-      op.trace_id.id, op.trace_id.reset_epoch, args.duration_ms);
+      op.trace_id.id, op.trace_id.reset_epoch, duration);
+}
+
+std::optional<float> FlightRecorderHook::workDuration(const Work& work) {
+  if (!work_can_time_.load(std::memory_order_relaxed)) {
+    return std::nullopt;
+  }
+  try {
+    return work.getDuration();
+  } catch (const std::exception&) {
+    // Refused because the backend does not time collectives, which is a
+    // property of the backend and not of the op -- so ask no further op.
+    work_can_time_.store(false, std::memory_order_relaxed);
+    return std::nullopt;
+  }
 }
 
 void FlightRecorderHook::onPre(const PreHookArgs& args) {
@@ -650,29 +645,16 @@ void FlightRecorderHook::onPost(const PostHookArgs& args) {
       // it names the op by this Work.
       it->second.work = args.work;
       work_ids_[args.work.get()] = args.op_id;
-      // Unless it already finished: a completion the backend pushed before this
-      // registration was stashed rather than dropped (see onCompletion), and
-      // now that the Work resolves to an op_id it can be replayed, keeping the
-      // backend's own duration.
-      std::optional<float> duration;
-      bool early = false;
-      for (auto e = early_completions_.begin(); e != early_completions_.end();
-           ++e) {
-        if (e->first == args.work.get()) {
-          duration = e->second;
-          early_completions_.erase(e);
-          early = true;
-          break;
-        }
-      }
-      if (inflight_.size() == work_ids_.size()) {
-        // Nothing is between its pre- and post-hook any more, so nothing left
-        // in the stash can ever be claimed.
-        early_completions_.clear();
-      }
       lock.unlock();
-      if (early) {
-        onCompletion(CompletionHookArgs{args.work.get(), duration});
+      // A completion established before that registration found no mapping and
+      // retired nothing, leaving a finished collective reading "scheduled" for
+      // ever, so ask the Work rather than wait for a push that has been and
+      // gone. isSuccess() as well: isCompleted() is true for failed and
+      // timed-out work too, which stays un-retired so a dump keeps saying it
+      // was never seen to finish (Hooks.hpp). Asked with the lock dropped,
+      // since isCompleted() calls into the backend -- see the lock-order note.
+      if (args.work->isCompleted() && args.work->isSuccess()) {
+        retireCompleted(args.work.get(), workDuration(*args.work));
       }
       return;
     }

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
@@ -174,16 +174,22 @@ c10::intrusive_ptr<Backend::Options> tryGetOptions(
 }
 
 // Whether a CUDA graph capture (or the equivalent on another accelerator) is
-// active on the stream this op will be issued on. Asked through the device
-// guard impl so the hook stays device agnostic; a device type with no impl
-// registered simply has no capture concept.
-bool streamIsCapturing(std::optional<c10::Device> device) {
-  if (!device || device->is_cpu()) {
+// active on the stream an op on this device would be issued on. Asked through
+// the device guard impl so the hook stays device agnostic.
+//
+// Both ways of answering false here are positive facts, not guesses: a device
+// type with no guard impl registered has no capture mechanism at all, and a
+// device whose current stream cannot even be obtained -- CUDA linked in but no
+// visible GPU, say -- has no stream for a capture to be running on. "I do not
+// know which device to ask" is a different answer and is not expressed here;
+// see captureActive.
+bool streamIsCapturing(c10::Device device) {
+  if (device.is_cpu() || !c10::impl::hasDeviceGuardImpl(device.type())) {
     return false;
   }
   try {
-    auto* guard_impl = c10::impl::getDeviceGuardImpl(device->type());
-    return guard_impl->getStream(*device).is_capturing();
+    auto* guard_impl = c10::impl::getDeviceGuardImpl(device.type());
+    return guard_impl->getStream(device).is_capturing();
   } catch (const std::exception&) {
     return false;
   }
@@ -336,6 +342,35 @@ const FlightRecorderHook::BackendTarget& FlightRecorderHook::targetFor(
   return default_target_;
 }
 
+std::optional<bool> FlightRecorderHook::captureActive(
+    std::optional<c10::Device> device) const {
+  if (device) {
+    return streamIsCapturing(*device);
+  }
+  // barrier() is the one op that reaches the hook with no tensors: Ops.cpp
+  // binds a dummy tensor to pick the dispatch key and does not forward it, so
+  // the device it was dispatched on is invisible here. It did go to one of the
+  // group's own backends though, and that is enough to answer this question --
+  // if none of the devices the group serves is on a capturing stream, then
+  // neither is this op, whichever of them it went to. For the usual
+  // single-device group that is one query, on CUDA for a CUDA group.
+  //
+  // Not getBoundDeviceId(): it is only set when init_process_group was given a
+  // device_id, so it answers nothing for the groups that hit this, and its
+  // index names the bound device rather than the one the calling thread is
+  // capturing on. The unset index used here resolves to the current device,
+  // which is where the capture is.
+  if (targets_.empty()) {
+    return std::nullopt;
+  }
+  for (const auto& [type, target] : targets_) {
+    if (streamIsCapturing(c10::Device(type))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 FlightRecorderHook::~FlightRecorderHook() {
   remove();
 }
@@ -441,15 +476,21 @@ void FlightRecorderHook::onPre(const PreHookArgs& args) {
   if (!recorder->enabled_) {
     return;
   }
-  if (streamIsCapturing(device)) {
-    // Nothing is recorded under an active graph capture. The collective does
-    // not run here, it runs at replay, and its Work cannot be polled: querying
-    // a CUDA event recorded on a capturing stream does not merely fail, it
-    // invalidates the capture, which then surfaces from cudaStreamEndCapture
-    // nowhere near this code. An entry we could never observe would read as a
-    // collective that never finished, i.e. as a hang. Stock ProcessGroupNCCL
-    // skips recording under capture too (initWork's record flag follows
-    // whether the work can be enqueued for the watchdog).
+  // Not recorded under an active graph capture, nor when the hook cannot
+  // establish that there is none. The collective does not run here, it runs at
+  // replay, and its Work cannot be polled: querying a CUDA event recorded on a
+  // capturing stream does not merely fail, it invalidates the capture, which
+  // then surfaces from cudaStreamEndCapture nowhere near this code. An entry we
+  // could never observe would also read as a collective that never finished,
+  // i.e. as a hang. Stock ProcessGroupNCCL skips recording under capture too
+  // (initWork's record flag follows whether the work can be enqueued for the
+  // watchdog).
+  //
+  // So "unknown" defaults to "capturing": recording costs the user's graph,
+  // while not recording costs one entry in the trace. That default only bites a
+  // group that reports no device types at all, which cannot serve a collective
+  // through the c10d ops in the first place.
+  if (captureActive(device).value_or(true)) {
     return;
   }
   InflightOp op;

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
@@ -151,6 +151,11 @@ std::optional<c10::Device> opDevice(const PreHookArgs& args) {
 // hooked groups get distinct ids from here whether or not they share one.
 std::atomic<size_t> next_pg_id{0};
 
+// Cap on stashed early completions, see FlightRecorderHook::onCompletion. Only
+// ops issued concurrently on different threads can queue up here, so this is
+// generous; it exists so an unclaimable entry cannot accumulate.
+constexpr size_t kMaxEarlyCompletions = 16;
+
 // Both accessors throw rather than return empty on a backend that does not
 // implement them (Backend's defaults, which custom backends keep), and neither
 // is required to record, so ask by trying.
@@ -364,6 +369,7 @@ void FlightRecorderHook::remove() {
     inflight = std::move(inflight_);
     inflight_.clear();
     work_ids_.clear();
+    early_completions_.clear();
     had_completion_hook = std::exchange(push_completion_, false);
     had_abort_hook = std::exchange(abort_hook_registered_, false);
   }
@@ -390,9 +396,26 @@ void FlightRecorderHook::onCompletion(const CompletionHookArgs& args) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto id_it = work_ids_.find(args.work);
     if (id_it == work_ids_.end()) {
-      // Not one of ours: an op recorded by a natively recording backend, one
-      // issued under a graph capture, one already evicted, or one from before
-      // this hook was attached.
+      // Either not one of ours -- an op recorded by a natively recording
+      // backend, one issued under a graph capture, one already evicted, or one
+      // from before this hook was attached -- or the post-hook that registers
+      // the Work has not run yet. The backend wins that race whenever it
+      // establishes completion for a fast op between issue and firePostHook,
+      // and a dropped callback retires nothing, so the collective reads
+      // "scheduled" for ever: the false hang this hook exists to rule out.
+      // Stash it for onPost to claim instead.
+      //
+      // Only while an op is between its pre- and post-hook: with none
+      // outstanding this cannot be that race, and an entry nothing claims could
+      // later be matched by a Work that reuses the address. The cap bounds what
+      // an op whose post-hook never runs (the backend threw after enqueueing)
+      // leaves behind.
+      if (inflight_.size() > work_ids_.size()) {
+        early_completions_.emplace_back(args.work, args.duration_ms);
+        if (early_completions_.size() > kMaxEarlyCompletions) {
+          early_completions_.pop_front();
+        }
+      }
       return;
     }
     auto op_id = id_it->second;
@@ -613,7 +636,7 @@ void FlightRecorderHook::onAbort() {
 void FlightRecorderHook::onPost(const PostHookArgs& args) {
   InflightOp retire_at_issue;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     auto it = inflight_.find(args.op_id);
     if (it == inflight_.end()) {
       // Nothing was recorded for this op -- the backend records natively, the
@@ -627,6 +650,30 @@ void FlightRecorderHook::onPost(const PostHookArgs& args) {
       // it names the op by this Work.
       it->second.work = args.work;
       work_ids_[args.work.get()] = args.op_id;
+      // Unless it already finished: a completion the backend pushed before this
+      // registration was stashed rather than dropped (see onCompletion), and
+      // now that the Work resolves to an op_id it can be replayed, keeping the
+      // backend's own duration.
+      std::optional<float> duration;
+      bool early = false;
+      for (auto e = early_completions_.begin(); e != early_completions_.end();
+           ++e) {
+        if (e->first == args.work.get()) {
+          duration = e->second;
+          early_completions_.erase(e);
+          early = true;
+          break;
+        }
+      }
+      if (inflight_.size() == work_ids_.size()) {
+        // Nothing is between its pre- and post-hook any more, so nothing left
+        // in the stash can ever be claimed.
+        early_completions_.clear();
+      }
+      lock.unlock();
+      if (early) {
+        onCompletion(CompletionHookArgs{args.work.get(), duration});
+      }
       return;
     }
     // Either there is no handle a completion could name (the hook contract

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
@@ -52,6 +52,7 @@
 
 #pragma once
 
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -176,8 +177,12 @@ class TORCH_API FlightRecorderHook
   // by its Work, since op_id is assigned above the backend and a Work does not
   // carry it, and the post-hook is where the two are seen together. Kept in
   // step with inflight_ -- every entry here has a live entry there holding the
-  // Work.
+  // Work -- so inflight_.size() - work_ids_.size() is the number of ops sitting
+  // between their pre-hook and their post-hook.
   std::unordered_map<const Work*, int64_t> work_ids_;
+  // Completions that arrived before the post-hook could register their Work,
+  // waiting for it to claim them. Bounded; see onCompletion.
+  std::deque<std::pair<const Work*, std::optional<float>>> early_completions_;
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
@@ -133,6 +133,12 @@ class TORCH_API FlightRecorderHook
   // The target serving an op, or the group's default backend for ops the
   // dispatcher gives us no tensors for (barrier).
   const BackendTarget& targetFor(std::optional<c10::Device> device) const;
+  // Whether a graph capture is active on the stream the op would be issued on.
+  // nullopt when that cannot be established, which onPre reads as "capturing":
+  // recording an op under capture and then querying its Work is what
+  // invalidates the capture. An op with no device of its own falls back to the
+  // devices the group serves.
+  std::optional<bool> captureActive(std::optional<c10::Device> device) const;
   void onPre(const PreHookArgs& args);
   void onPost(const PostHookArgs& args);
   // Retires the entry of an op whose Work completed successfully, unless it is

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.hpp
@@ -13,8 +13,14 @@
 // That is stock ProcessGroupNCCL's model -- its watchdog retires on real
 // completion -- and it is what lets a dump tell a finished collective from a
 // hung one: a collective that never completes is never retired and reads
-// "scheduled", one that finished reads "completed". Nothing is polled: a hang
-// needs no observer, since work that never completes is simply never reported.
+// "scheduled", one that finished reads "completed". A hang needs no observer,
+// since work that never completes is simply never reported.
+//
+// The post-hook is the only place a Work and its op_id are seen together, so
+// it is where the completion hook's key is registered -- and a fast collective
+// can be finished before it runs. So the post-hook also asks the Work whether
+// it has already finished: a completion earlier than the registration is
+// caught there, a later one finds the mapping, and none falls between.
 //
 // Backends with no completion hook fall back to retiring in the post-hook, i.e.
 // at issue. Such an entry carries no duration and never reads "completed", only
@@ -52,7 +58,7 @@
 
 #pragma once
 
-#include <deque>
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -129,9 +135,13 @@ class TORCH_API FlightRecorderHook
   const BackendTarget& targetFor(std::optional<c10::Device> device) const;
   void onPre(const PreHookArgs& args);
   void onPost(const PostHookArgs& args);
-  // Retires the entry of the op whose Work just completed. Fires on the
-  // backend's thread; see the lock-order note on mutex_.
-  void onCompletion(const CompletionHookArgs& args);
+  // Retires the entry of an op whose Work completed successfully, unless it is
+  // already retired: the entry is claimed out of inflight_ under mutex_, so
+  // the backend's completion hook and the post-hook's own check retire it
+  // exactly once between them however they race.
+  void retireCompleted(const Work* work, std::optional<float> duration);
+  // The backend's own measurement, or nullopt if it cannot time collectives.
+  std::optional<float> workDuration(const Work& work);
   // Dumps the trace to disk, at most once per process. Deliberately takes no
   // hook lock; see the definition.
   void onAbort();
@@ -148,6 +158,9 @@ class TORCH_API FlightRecorderHook
   // the one ProcessGroup routes hook registration to, so a mixed group whose
   // default backend has no completion hooks falls back for all of its ops.
   bool push_completion_{false};
+  // Whether Work::getDuration() is worth asking: it throws when the backend
+  // does not time its collectives, so the first refusal is remembered.
+  std::atomic<bool> work_can_time_{true};
   size_t pg_id_;
   // Cap on inflight_, see onPre.
   size_t max_inflight_{0};
@@ -177,12 +190,8 @@ class TORCH_API FlightRecorderHook
   // by its Work, since op_id is assigned above the backend and a Work does not
   // carry it, and the post-hook is where the two are seen together. Kept in
   // step with inflight_ -- every entry here has a live entry there holding the
-  // Work -- so inflight_.size() - work_ids_.size() is the number of ops sitting
-  // between their pre-hook and their post-hook.
+  // Work.
   std::unordered_map<const Work*, int64_t> work_ids_;
-  // Completions that arrived before the post-hook could register their Work,
-  // waiting for it to claim them. Bounded; see onCompletion.
-  std::deque<std::pair<const Work*, std::optional<float>>> early_completions_;
 };
 
 } // namespace c10d

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -835,6 +835,16 @@ def _register_builtin_nccl_backend() -> None:
         if os.environ.get("TORCH_DIST_USE_NCCL2") == "1"
         else _create_nccl_process_group
     )
+    # Record what "nccl" actually resolved to for _maybe_attach_flight_recorder,
+    # which must skip a group only if every one of its backends feeds a
+    # FlightRecorder by itself: stock ProcessGroupNCCL does, nccl2 needs the
+    # hook. Derived from the creator picked above rather than re-read from the
+    # environment, which is only consulted here and could otherwise disagree
+    # with what was built.
+    if creator_fn is _create_nccl_process_group:
+        _FR_SELF_RECORDING_BACKENDS.add(Backend.NCCL)
+    else:
+        _FR_SELF_RECORDING_BACKENDS.discard(Backend.NCCL)
     Backend.register_backend(
         Backend.NCCL,
         creator_fn,
@@ -2661,11 +2671,20 @@ def _get_split_source(pg: ProcessGroup) -> C10DBackend | None:
 # Backends that feed a FlightRecorder without any help: ProcessGroupGloo
 # unconditionally, ProcessGroupNCCL and ProcessGroupXCCL through their own
 # integrations. "fake" and "undefined" never communicate, so recording them is
-# pure noise. Everything else -- nccl2, mpi, ucc, out-of-tree plugins -- is
-# invisible to the flight recorder unless a hook is attached.
-_FR_SELF_RECORDING_BACKENDS = frozenset(
-    {Backend.GLOO, Backend.NCCL, Backend.XCCL, Backend.FAKE, Backend.UNDEFINED}
-)
+# pure noise. Everything else -- nccl2, nccl-lazy, mpi, ucc, out-of-tree
+# plugins -- is invisible to the flight recorder unless a hook is attached.
+#
+# Backend.NCCL is not in here by construction: which implementation the name
+# builds is a runtime choice, so _register_builtin_nccl_backend puts it in or
+# takes it out when it makes that choice, and this stays the single answer to
+# "does this backend record itself".
+_FR_SELF_RECORDING_BACKENDS = {
+    Backend.GLOO,
+    "nccl-legacy",
+    Backend.XCCL,
+    Backend.FAKE,
+    Backend.UNDEFINED,
+}
 
 
 def _maybe_attach_flight_recorder(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192858
* #192837
* #192233

Two defects in the flight recorder, found in review. Separate from the commits
below only because they do not fit inside the 2000 LOC review limit.

The backend string "nccl" had two sources of truth for what it builds, and only
one of them read TORCH_DIST_USE_NCCL2. _register_builtin_nccl_backend picks its
creator from that flag; _FR_SELF_RECORDING_BACKENDS hard-coded Backend.NCCL as
self-recording regardless. They agree today by luck, because the flag defaults
off and "nccl" builds stock ProcessGroupNCCL, which does record natively. The
moment the default flips, "nccl" builds nccl2 and the flight recorder skips it as
self-recording -- so the default path loses the feature entirely, and silently.
Existing tests never caught it because they all request "nccl2" explicitly.

Rather than special-case the name, the registration now records what it actually
built: the set is derived from the creator that was chosen, keyed off creator
identity rather than re-reading the env, so flipping the default is still a
one-line change to the existing ternary and there is no second site to keep in
sync. Ordering holds because _ensure_backend_registered runs well before the
attach decision, for both new_group and split_group. "nccl-legacy" is added to
the set for the same reason -- it builds stock, so the hook it was getting could
never record anything.

The second is a race. A completion is delivered with the Work, and the hook can
only map a Work to its trace entry from the post-hook, which is the one place
op_id and the Work are both visible. A fast collective can be completed by the
backend's watchdog after it is enqueued but before that post-hook runs, and the
callback was then dropped on the floor -- leaving a healthy op unretired and
reading "scheduled" forever, which is precisely the false hang signal this
feature exists to rule out.

A completion that arrives early is no longer a special case. The post-hook, once
it has registered the mapping, simply asks the Work whether it already finished
successfully and retires it if so. There is then no interval in which a
completion can be missed: if it landed before registration this catches it, and
if after, the callback finds the mapping.

Retirement is claiming rather than checking, so it happens exactly once however
the two interleave -- the lookup and both erases happen under one lock, and the
loser takes the same early return a Work that was never ours would. An earlier
version of this fix stashed early completions keyed by Work* and replayed them,
bounded three ways. That was a workaround: Work* is not a stable identity, since
the allocator can reuse the address once the original is destroyed, and a stale
entry would then report a *different* op as completed while it was still in
flight -- a false "completed", which is worse than the false "hang" being fixed.
The bounds only shrank the window in which the key could lie.

One consequence worth knowing: asking the Work also advances its status, so a
short healthy collective now usually retires on the issuing thread rather than
from the watchdog push, and pays one event query per op on the issue path.

Hook maps become ordered so hooks fire by id. That is what lets the race be
tested deterministically rather than with a sleep, and the flight recorder hook's
id already assumed ordering against user hooks.

Test Plan:

The race test does not sleep. A user post-hook with a lower id holds the window
open and, inside it, issues a sentinel collective behind the target on the same
stream queue; nccl2 pops that queue in order, so a retired sentinel proves the
target's completion was already delivered. It then asserts the target is not yet
retired -- i.e. the race really occurred -- and that it is retired, completed and
still carries a duration once the post-hook returns. Without the fix the last
assertion fails, since the completion fires once per Work and no second one is
coming.

The attach test asserts on what was built rather than on the env var, so it holds
either side of the default flip.

```
python test/distributed/test_c10d_fr_hook.py
python test/distributed/test_c10d_nccl2.py
python test/distributed/test_c10d_nccl.py NCCLTraceTest
python test/distributed/flight_recorder/test_fr_analysis.py
python test/distributed/test_c10d_hooks.py
python test/distributed/test_c10d_nan_check.py
```
```
Ran 63 tests in 323.043s  OK (skipped=9)
Ran 50 tests in 345.898s  OK (skipped=1)
Ran 61 tests in 496.705s  OK
Ran 23 tests in   1.790s  OK
Ran  2 tests in   7.803s  OK
Ran 20 tests in 102.351s  OK
```
The last two cover the other consumers of the hook plumbing whose map ordering
changed.

lintrunner --revision HEAD: clean.

Authored with the assistance of an AI coding agent.