### PR TITLE
Remove condition preventing registration of some vmap decompositions

### DIFF
--- a/torch/_functorch/predispatch.py
+++ b/torch/_functorch/predispatch.py
@@ -142,12 +142,6 @@ def lazy_load_decompositions() -> None:
         if DECOMPOSITIONS_LOADED:
             return
 
-        import os
-
-        if not (os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__):
-            DECOMPOSITIONS_LOADED = True
-            return
-
         # use an alternate way to register an operator into the decomposition table
         # _register_jit_decomposition doesn't work for some operators, e.g. addr,
         #  because the Tensor types generated cannot be unioned by torchscript


### PR DESCRIPTION
- Fixes #146697

Most vmap decompositions are registered through C++ (in `aten/src/ATen/functorch/BatchRulesDecompositions.cpp`).

The remaining 8 decompositions are registered through python (in `torch/_functorch/predispatch.py`). These are `mse_loss_backward`, `smooth_l1_loss_backward`, `huber_loss_backward`, `nll_loss_forward`, `nll_loss2d_forward`, `nll_loss_backward`, `nll_loss2d_backward` and `addr`.

The problem is that there is a condition that prevents the registration of those 8 decompositions:
```python
if not (os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__):
    DECOMPOSITIONS_LOADED = True
    return
```

This means that when using either the environment variable `PYTORCH_JIT=0` or the python flag `-O` (as in `python -O train.py`), which sets `__debug__` to `False`, we'll go into this condition and disable the registration of these 8 vmap decompositions. We end up falling back to for-loop vmap and raising a warning, as in #146697.

This PR fixes my reproducer, posted [here](https://github.com/pytorch/pytorch/issues/146697#issuecomment-5244136999).

I don't fully understand why the condition was there to begin with, but I believe that it is now outdated: neither jit or `__debug__` are required to make those decompositions work.

According to claude's investigation, this condition was there since the addition of the [lazy_load_decompositions](https://github.com/pytorch/pytorch/blob/ca0f6df86c40cdce1e1b8e0fff3d8a5997517435/torch/_functorch/predispatch.py#L119-L180) function for vmap. It is likely a copy-paste from [similar code](https://github.com/pytorch/pytorch/blob/ca0f6df86c40cdce1e1b8e0fff3d8a5997517435/torch/autograd/forward_ad.py#L72-L74)  from `torch/autograd/forward_ad.py` (see the associated [note](https://github.com/pytorch/pytorch/blob/ca0f6df86c40cdce1e1b8e0fff3d8a5997517435/torch/autograd/forward_ad.py#L106-L116)). But this applies to a different kind of decomposition: `torch/_decomp/decompositions_for_jvp.py`, which does use jit, as opposed to `torch/_decomp/decompositions.py`, which doesn't.

cc @zou3519 @Chillee @samdow @kshitij12345