### PR TITLE
[NOCOMMIT][docs] No-op change to validate docs-preview pipeline

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -34,3 +34,5 @@ community/index
 
 * {ref}`genindex`
 * {ref}`modindex`
+
+<!-- docs-preview validation: no-op change to confirm the docs preview build/upload still works; safe to revert. -->


### PR DESCRIPTION
Appends an invisible HTML comment to docs/source/index.md to trigger a docs build and exercise the docs-preview upload/serve path (docs-preview.pytorch.org) after a change to the doc-previews S3 bucket policy. No rendered output changes; this is a throwaway validation PR.

Test Plan:
- Open a draft PR and confirm the docs build job runs and pytorchbot posts a "Doc Preview" link.
- Load https://docs-preview.pytorch.org/pytorch/pytorch/<PR>/index.html and confirm it renders.

Authored with the assistance of an AI agent (Claude Code).