### PR TITLE
[cuda][nccl] Use `ncclAlltoAll` for the NCCLX all-to-all path

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -767,12 +767,14 @@ void all2all_single_equal_split(
   const auto* sendbuff = reinterpret_cast<const char*>(input.const_data_ptr());
   auto* recvbuff = reinterpret_cast<char*>(output.mutable_data_ptr());
   auto comm = to_nccl_comm(_comm);
-#if defined(USE_ROCM) || defined(NCCL_ALLTOALL_SUPPORTED)
-  // NCCL_ALLTOALL_SUPPORTED is used so NCCL can differentiate send/recv
-  // operations issued as a part of the collective (e.g. alltoall) vs those
-  // inside traditional p2p operations.
+#if defined(USE_ROCM)
+  // RCCL spells the collective with a capital T.
   NCCL_CHECK(ncclAllToAll(sendbuff, recvbuff, count, type, comm, stream));
-#elif NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+#elif defined(NCCL_ALLTOALL_SUPPORTED) || \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+  // Using the collective rather than a send/recv loop lets NCCL differentiate
+  // send/recv operations issued as part of the collective (e.g. alltoall) vs
+  // those inside traditional p2p operations.
   NCCL_CHECK(ncclAlltoAll(sendbuff, recvbuff, count, type, comm, stream));
 #else
   int numranks = 0;


### PR DESCRIPTION
Summary:
Part of the stack that de-dups NCCLX's two all-to-all entry points down to the
upstream-named `ncclAlltoAll`. See the base diff for the full rationale.

`all2all_single_equal_split` had a three-arm preprocessor ladder whose first arm
covered both ROCm and NCCLX:

```
#if defined(USE_ROCM) || defined(NCCL_ALLTOALL_SUPPORTED)
  ncclAllToAll(...)
#elif NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
  ncclAlltoAll(...)
#else
  ncclGroupStart() / ncclSend / ncclRecv loop
#endif
```

Those two platforms need to diverge now: RCCL spells its symbol with a capital T
(and is out of scope for this stack), while NCCLX is dropping that spelling. So ROCm
gets its own arm and `NCCL_ALLTOALL_SUPPORTED` folds in with the upstream
version check, both of which now resolve to `ncclAlltoAll`.

The `#else` send/recv fallback for pre-2.28 vanilla NCCL is untouched.

`NCCL_ALLTOALL_SUPPORTED` is retained rather than dropped in favor of a pure version
check: NCCLX keeps defining it, and it still usefully means "this NCCL has an
all-to-all collective" — for NCCLX specifically it now also implies the CTRAN
dispatch added earlier in this stack.

I also reworded the explanatory comment, which had drifted: it described why the
collective is preferable to a hand-rolled send/recv loop, but was attached to the
`NCCL_ALLTOALL_SUPPORTED` macro as though it were about that macro specifically.

The `ncclAllToAllv` ladder further down (`NCCL_ALLTOALLV_SUPPORTED`) is deliberately
left alone — upstream never added a lowercase `ncclAlltoAllv`, so there is nothing to
de-dup against.

`xplat/caffe2/torch/csrc/cuda/nccl.cpp` is an hg-dirsync mirror of this file
(`.hgdirsync`: `caffe2.fbcode = fbcode/caffe2` / `caffe2.xplat = xplat/caffe2`, with
no exclude covering `torch/csrc/cuda/`), so it is updated automatically by the commit
rather than hand-edited.

Test Plan:
Built `fbcode//caffe2:torch-cpp-cuda` under both relevant configurations:

- against NCCLX (exercises the `NCCL_ALLTOALL_SUPPORTED` arm):
  `-c hpc_comms.use_ncclx=2.30`
- against the default NCCL (exercises the `NCCL_VERSION_CODE >= 2.28` arm): no
  `use_ncclx` override

both with:
```
--modifier=ovr_config//cpu:x86_64 \
--modifier=ovr_config//runtime/constraints:platform010
```
Both succeeded. The ROCm arm is unchanged code and cannot be built on this host.

`arc lint caffe2/torch/csrc/cuda/nccl.cpp`: `ok No lint issues.`

Differential Revision: D115510409


