### PR TITLE
[Testcase Refactoring] Device classification for test_install_free_tensors.py (GENERIC)

### DIFF
--- a/test/dynamo/test_install_free_tensors.py
+++ b/test/dynamo/test_install_free_tensors.py
@@ -9,6 +9,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import EagerAndRecordGraphs
 from torch.fx.graph_module import GraphModule
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 def compile_and_extract_graph(
@@ -80,6 +81,8 @@ class ResBlock(torch.nn.Module):
 
 
 class InstallParamsAsGraphAttrTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(install_free_tensors=False)
     def check_num_inputs_and_equality_no_install(
         self,
@@ -331,6 +334,8 @@ class InstallParamsAsGraphAttrTests(torch._dynamo.test_case.TestCase):
 
 
 class InstallParamsWhenExport(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(install_free_tensors=True)
     def check_export_matches_expectation(
         self,


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC`) class attributes to Dynamo test file `test/dynamo/test_install_free_tensors.py` so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_install_free_tensors.py**
  - Import `HardwareClassification`; tag `InstallParamsAsGraphAttrTests` and `InstallParamsWhenExport` as `GENERIC`.

## Test plan

`python test/dynamo/test_install_free_tensors.py --hw-classification GENERIC` - 25 tests, `OK (expected failures=1)`, `HW classification mode active (["GENERIC"]): total=25, passed=25, unclassified=0, mismatched=0`

No runtime behavior is changed; the annotation only enables hardware-generic test admission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98