### PR TITLE
[CUDA][cuBLAS] Clear cuBLAS workspaces for graph captures

### DIFF
--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -90,12 +90,27 @@ TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API void clearCublasWorkspacesForStream(cudaStream_t stream);
+TORCH_CUDA_CPP_API void notifyCublasCaptureBegin();
 
 // Thread-local workspace map keyed by (device, stream).
 // No mutex is needed because cuBLAS handles are unique per thread
 // (guaranteed by DeviceThreadHandlePool), so each thread's workspace
 // map is only ever accessed by that thread.
-using WorkspaceMap = std::unordered_map<std::pair<int, void*>, std::pair<at::DataPtr, size_t>, c10::hash<std::pair<int, void*>>>;
+struct Workspace {
+  at::DataPtr data;
+  size_t size;
+  // Zero means the workspace was allocated outside capture. Otherwise this is
+  // the capture id whose private pool owns the allocation.
+  uint64_t capture_id;
+  // Global capture epoch at which capture_id was last checked. This avoids a
+  // cudaStreamGetCaptureInfo call on every cuBLAS invocation.
+  uint64_t capture_epoch;
+};
+
+using WorkspaceMap = std::unordered_map<
+    std::pair<int, void*>,
+    Workspace,
+    c10::hash<std::pair<int, void*>>>;
 
 TORCH_CUDA_CPP_API WorkspaceMap& cublas_stream_to_workspace();
 TORCH_CUDA_CPP_API WorkspaceMap& cublaslt_stream_to_workspace();

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -143,6 +143,13 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
   capture_stream_ = stream;
   capture_dev_ = c10::cuda::current_device();
 
+  // A workspace allocated before capture belongs to the ordinary caching
+  // allocator pool, so a captured cuBLAS kernel must not retain its address.
+  // Clear the capture stream's workspace on this thread before pool routing is
+  // enabled. Threads that join the capture lazily replace stale workspaces in
+  // setCublasWorkspace/getCUDABlasLtWorkspace after observing the capture id.
+  clearCublasWorkspacesForStream(capture_stream_.stream());
+
 #if defined(USE_ROCM)
   // hipBLASLt handles are per-(device, stream) on ROCm and lazily created.
   // Ensure the handle for the intended capture stream exists before
@@ -185,6 +192,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
   // prevent potentially unsafe CUDA API calls during capture.  See
   // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
   AT_CUDA_CHECK(cudaStreamBeginCapture(capture_stream_, capture_mode));
+  notifyCublasCaptureBegin();
   c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
 
   auto capture_id_opt = c10::cuda::captureIdMayInitCtx(stream);

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -3,6 +3,7 @@
 #include <ATen/cuda/detail/DeviceThreadHandles.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
 
 #include <atomic>
 #include <map>
@@ -43,7 +44,12 @@ namespace {
 // -1 means no override; use env var / default
 std::atomic<int64_t> cublas_workspace_override{-1};
 std::atomic<int64_t> cublaslt_workspace_override{-1};
+std::atomic<uint64_t> cublas_capture_epoch{0};
 } // namespace
+
+void notifyCublasCaptureBegin() {
+  cublas_capture_epoch.fetch_add(1, std::memory_order_release);
+}
 
 namespace {
 
@@ -295,6 +301,37 @@ at::DataPtr getNewCUDABlasLtWorkspace() {
   return c10::cuda::CUDACachingAllocator::get()->allocate(getCUDABlasLtWorkspaceSize());
 }
 
+struct CaptureState {
+  uint64_t id;
+  uint64_t epoch;
+};
+
+CaptureState captureState(cudaStream_t stream, const Workspace* workspace) {
+  const uint64_t epoch =
+      cublas_capture_epoch.load(std::memory_order_acquire);
+  if (workspace != nullptr && workspace->capture_epoch == epoch) {
+    return {workspace->capture_id, epoch};
+  }
+  auto capture_id = c10::cuda::captureIdMayInitCtx(stream);
+  return {
+      capture_id.has_value() ? static_cast<uint64_t>(*capture_id) : 0, epoch};
+}
+
+bool workspaceCanBeReused(
+    Workspace& workspace,
+    size_t required_size,
+    CaptureState capture_state) {
+  // A workspace created outside the current capture may point into the
+  // ordinary allocator pool, whose lifetime is not retained by the graph.
+  // Replace it on first use during capture so the replacement comes from the
+  // graph-private pool. Outside capture, preserve existing reuse behavior.
+  const bool compatible = capture_state.id == 0 ||
+      workspace.capture_id == capture_state.id;
+  workspace.capture_id = capture_state.id;
+  workspace.capture_epoch = capture_state.epoch;
+  return workspace.size >= required_size && compatible;
+}
+
 void setCublasWorkspace(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
   c10::DeviceIndex device = stream.device_index();
   cudaStream_t _stream = stream;
@@ -303,18 +340,27 @@ void setCublasWorkspace(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
   auto& workspace_map = cublas_stream_to_workspace();
 
   size_t workspace_size = getChosenWorkspaceSize();
-
   auto workspace_it = workspace_map.find(key);
-  if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
+  CaptureState capture_state = captureState(
+      _stream,
+      workspace_it == workspace_map.end() ? nullptr : &workspace_it->second);
+  if (workspace_it != workspace_map.end() &&
+      workspaceCanBeReused(
+          workspace_it->second, workspace_size, capture_state)) {
     TORCH_CUDABLAS_CHECK(cublasSetWorkspace(
-        handle, workspace_it->second.first.get(), workspace_size));
+        handle, workspace_it->second.data.get(), workspace_size));
     return;
   }
 
   auto [it, _] = workspace_map.insert_or_assign(
-      key, std::make_pair(getNewWorkspace(), workspace_size));
+      key,
+      Workspace{
+          getNewWorkspace(),
+          workspace_size,
+          capture_state.id,
+          capture_state.epoch});
   TORCH_CUDABLAS_CHECK(
-      cublasSetWorkspace(handle, it->second.first.get(), workspace_size));
+      cublasSetWorkspace(handle, it->second.data.get(), workspace_size));
 }
 
 void* getCUDABlasLtWorkspace() {
@@ -327,23 +373,43 @@ void* getCUDABlasLtWorkspace() {
     auto& workspace_map = at::cuda::cublas_stream_to_workspace();
     size_t workspace_size = getChosenWorkspaceSize();
     auto workspace_it = workspace_map.find(key);
-    if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
-      return workspace_it->second.first.mutable_get();
+    CaptureState capture_state = captureState(
+        _stream,
+        workspace_it == workspace_map.end() ? nullptr : &workspace_it->second);
+    if (workspace_it != workspace_map.end() &&
+        workspaceCanBeReused(
+            workspace_it->second, workspace_size, capture_state)) {
+      return workspace_it->second.data.mutable_get();
     }
     auto [it, _] = workspace_map.insert_or_assign(
-        key, std::make_pair(getNewWorkspace(), workspace_size));
-    return it->second.first.mutable_get();
+        key,
+        Workspace{
+            getNewWorkspace(),
+            workspace_size,
+            capture_state.id,
+            capture_state.epoch});
+    return it->second.data.mutable_get();
   }
 #endif
   auto& workspace_map = cublaslt_stream_to_workspace();
   size_t workspace_size = getCUDABlasLtWorkspaceSize();
   auto workspace_it = workspace_map.find(key);
-  if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
-    return workspace_it->second.first.mutable_get();
+  CaptureState capture_state = captureState(
+      _stream,
+      workspace_it == workspace_map.end() ? nullptr : &workspace_it->second);
+  if (workspace_it != workspace_map.end() &&
+      workspaceCanBeReused(
+          workspace_it->second, workspace_size, capture_state)) {
+    return workspace_it->second.data.mutable_get();
   }
   auto [it, _] = workspace_map.insert_or_assign(
-      key, std::make_pair(getNewCUDABlasLtWorkspace(), workspace_size));
-  return it->second.first.mutable_get();
+      key,
+      Workspace{
+          getNewCUDABlasLtWorkspace(),
+          workspace_size,
+          capture_state.id,
+          capture_state.epoch});
+  return it->second.data.mutable_get();
 }
 
 cublasHandle_t getCurrentCUDABlasHandle(bool setup) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3951,6 +3951,66 @@ exit(2)
     )
     @serialTest()
     @blas_library_context("cublas")
+    def test_graph_capture_cublas_workspace_cross_thread(self):
+        if torch.cuda.get_device_capability()[0] != 9:
+            self.skipTest("The regression requires an SM90 split-K cuBLAS kernel")
+
+        torch.cuda._clear_cublas_workspaces()
+        x = torch.randn(32, 10944, device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn(2048, 10944, device="cuda", dtype=torch.bfloat16)
+        expected = torch.nn.functional.linear(x, weight)
+        torch.cuda.synchronize()
+
+        stream = torch.cuda.Stream()
+        ready = threading.Event()
+        launch = threading.Event()
+        state = {}
+
+        def worker():
+            try:
+                with torch.cuda.stream(stream):
+                    # Allocate this thread's workspace before capture, in the
+                    # ordinary pool. The operation below must replace it after
+                    # this stream begins capture on the main thread.
+                    torch.cuda.current_blas_handle()
+                ready.set()
+                if not launch.wait(timeout=30):
+                    raise RuntimeError("capture thread did not release worker")
+                with torch.cuda.stream(stream):
+                    state["output"] = torch.nn.functional.linear(x, weight)
+            except BaseException as error:
+                state["error"] = error
+                ready.set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        self.assertTrue(ready.wait(timeout=30))
+        if "error" in state:
+            raise state["error"]
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            launch.set()
+            thread.join(timeout=30)
+            self.assertFalse(thread.is_alive())
+            if "error" in state:
+                raise state["error"]
+
+        # Force an ordinary-pool stale pointer to become an illegal address.
+        # A correctly replaced graph-pool workspace remains mapped.
+        torch.cuda.empty_cache()
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            state["output"], expected, rtol=1e-2, atol=2e-1
+        )
+
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @serialTest()
+    @blas_library_context("cublas")
     def test_repeat_graph_capture_cublas_workspace_memory(self):
         (x, y, z) = 1024, 512, 64
         a = torch.rand((x, y), device="cuda")


### PR DESCRIPTION
To fix #192061 
simply clearing workspaces on the capturing thread doesn't seem to be sufficient as vLLM appears to explicitly capture across multiple threads (???)

authored with codex