### PR TITLE
[dynamo] Type the opaque `.value` a VariableTracker wraps as object instead of Any

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -662,7 +662,7 @@ class GraphArg:
     # TODO: storing a SymInt here but not a FakeTensor is a pretty strange
     # thing to do.  Probably should have example (which stores an int) and
     # fake_example
-    _example: Any
+    _example: object
     # When True, this indicates that this GraphArg is a Python quantity (e.g.,
     # a float or int) which we pass to the FX graph as a Tensor.  This
     # controls how we codegen calls into the Dynamo graph: we will call
@@ -707,7 +707,11 @@ class GraphArg:
                 raise AssertionError("TensorWeakRef expired unexpectedly")
             return r
         else:
-            return self._example
+            # The declared return type is known-incomplete: torch.ScriptObject
+            # and list-of-tensor graphargs also reach here, and output_graph.py
+            # reads them back (1827, 3424, 3441). Do not tighten `_example` to
+            # this union without fixing those paths first.
+            return cast("torch.SymInt | BackwardState | None", self._example)
 
     def __post_init__(self) -> None:
         if isinstance(self._example, torch.Tensor):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2353,7 +2353,7 @@ class SkipFunctionVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, value: Any, reason: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, value: object, reason: str | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
         self.reason = reason
@@ -2423,8 +2423,9 @@ class SkipFunctionVariable(VariableTracker):
         if self.value in (importlib.util.find_spec, importlib.metadata.version) and all(
             a.is_python_constant() for a in args
         ):
+            fn = cast(Callable[..., Any], self.value)
             return VariableTracker.build(
-                tx, self.value(*(a.as_python_constant() for a in args))
+                tx, fn(*(a.as_python_constant() for a in args))
             )
 
         if (
@@ -2432,7 +2433,8 @@ class SkipFunctionVariable(VariableTracker):
             and all(a.is_python_constant() for a in args)
             and all(v.is_python_constant() for v in kwargs.values())
         ):
-            result = self.value(
+            fold_fn = cast(Callable[..., Any], self.value)
+            result = fold_fn(
                 *(a.as_python_constant() for a in args),
                 **{k: v.as_python_constant() for k, v in kwargs.items()},
             )
@@ -2546,7 +2548,7 @@ class SkipFunctionVariable(VariableTracker):
             module_or = getattr(self.value, "__module__", None)
             module_name = "<unknown module>" if module_or is None else str(module_or)
             try:
-                path = inspect.getfile(self.value)
+                path = inspect.getfile(cast(Callable[..., Any], self.value))
                 explanation = (
                     f"Dynamo developers have intentionally marked that the function `{qualname}` "
                     f"in file `{path}` should not be traced."
@@ -3340,7 +3342,7 @@ class PolyfilledFunctionVariable(VariableTracker):
 
 
 class SysFunctionVariable(VariableTracker):
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -3926,7 +3928,7 @@ class SparseTensorCreationSkipVariable(SkipFunctionVariable):
     Skip variable for sparse tensor factory functions with clear messaging regarding lack of support.
     """
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         reason = "sparse tensor creation is not supported in torch.compile"
         super().__init__(value, reason=reason, **kwargs)
 
@@ -4005,7 +4007,7 @@ class TritonSetAllocatorVariable(VariableTracker):
     graph so that it executes at the right point at runtime, ordered by
     effect tokens."""
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -4025,7 +4027,8 @@ class TritonSetAllocatorVariable(VariableTracker):
         alloc_fn = args[0].as_python_constant()
 
         # Emit an invoke_leaf_function node so it runs at runtime.
-        set_allocator = self.value
+        # The builder only produces this VT for triton.set_allocator itself.
+        set_allocator = cast(Callable[..., Any], self.value)
 
         def real_impl():
             set_allocator(alloc_fn)

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 class LazyCache:
     """Container to cache the real VariableTracker"""
 
-    def __init__(self, value: Any, source: Any) -> None:
+    def __init__(self, value: object, source: Any) -> None:
         if not isinstance(value, LazySymNodeFormatString):
             if not source:
                 raise AssertionError(
@@ -68,7 +68,7 @@ class ComputedLazyCache:
 
     def __init__(
         self,
-        value: Any,
+        value: object,
         lazy_vars: list[LazyConstantVariable],
         args: list[VariableTracker],
         op: Callable[..., Any],
@@ -133,7 +133,7 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
 
     @staticmethod
     def create(
-        value: Any,
+        value: object,
         source: Any,
         *,
         tx: InstructionTranslatorBase | None = None,
@@ -327,7 +327,7 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
         # Checks that the underlying value is hashable without realizing the VT.
         # This is used by the is_hashable() function in hashable.py as a fast
         # path for unrealized LazyVTs.
-        def _helper(value: Any) -> bool:
+        def _helper(value: object) -> bool:
             # TODO: Add support for more types
             return (
                 inspect.isbuiltin(value)
@@ -388,7 +388,7 @@ class LazyConstantVariable(LazyVariableTracker):
 
     @staticmethod
     def create(
-        value: Any,
+        value: object,
         source: Any,
         **options: Any,
     ) -> VariableTracker:

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -32,7 +32,7 @@ import weakref
 from collections.abc import Callable, Sequence
 from random import Random
 from types import BuiltinFunctionType
-from typing import Any, TYPE_CHECKING, TypeGuard, Union
+from typing import Any, cast, TYPE_CHECKING, TypeGuard, Union
 
 import torch._C
 import torch._numpy as tnp
@@ -90,6 +90,11 @@ from .user_defined import call_random_fn, is_standard_setattr, UserDefinedObject
 
 
 if TYPE_CHECKING:
+    # numpy is an optional runtime dependency, so it is only imported for the
+    # dtype annotation below. Everything that actually touches numpy at runtime
+    # goes through torch._numpy or a guarded import inside a class body.
+    import numpy as np
+
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
@@ -1793,7 +1798,7 @@ class PythonModuleVariable(VariableTracker):
 
 
 class TypingVariable(VariableTracker):
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -1810,7 +1815,7 @@ class TypingVariable(VariableTracker):
                 explanation=f"Cannot subscript typing construct {self.value} with a non-constant key.",
                 hints=[*graph_break_hints.SUPPORTABLE],
             )
-        new_typing = self.value[key.as_python_constant()]
+        new_typing = cast(Any, self.value)[key.as_python_constant()]
         return TypingVariable(new_typing)
 
     def tp_richcompare_impl(
@@ -1950,7 +1955,7 @@ class NumpyVariable(VariableTracker):
 
     constant_fold_functions = (tnp.issubdtype,)
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -2018,7 +2023,7 @@ class NumpyVariable(VariableTracker):
         from ..utils import numpy_to_tensor_wrapper
         from .tensor import NumpyNdarrayVariable
 
-        func = get_np_to_tnp_map().get(self.value)
+        func = get_np_to_tnp_map().get(cast(BuiltinFunctionType, self.value))
         if func is None:
             unimplemented(
                 gb_type="attempted to trace numpy function unsupported by PyTorch",
@@ -2039,7 +2044,7 @@ class NumpyVariable(VariableTracker):
         ) is not None:
             try:
                 return collection_variable_typ(
-                    self.value(
+                    self.as_python_constant()(
                         *[x.as_python_constant() for x in args],
                         **{k: v.as_python_constant() for k, v in kwargs.items()},
                     )
@@ -2110,7 +2115,10 @@ class NumpyVariable(VariableTracker):
         )
 
     def as_python_constant(self) -> BuiltinFunctionType:
-        return self.value
+        # The declared type is what callers rely on (they call the result), but
+        # the builder also routes numpy dtypes and `np._CopyMode` here, so this
+        # is a widening the annotation already claimed before `value` was typed.
+        return cast(BuiltinFunctionType, self.value)
 
     def as_proxy(self) -> Any:
         if config.trace_numpy:
@@ -2288,7 +2296,7 @@ class DebuggingVariable(VariableTracker):
     registered to config.reorderable_logging_functions.
     """
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -2315,7 +2323,7 @@ class DebuggingVariable(VariableTracker):
             # For export cases, we can just make debugging functions no-ops
             return ConstantVariable.create(None)
 
-        if not self.can_reorder_logs(self.value, args, kwargs):
+        if not self.can_reorder_logs(args, kwargs):
             unimplemented(
                 gb_type="attempted to reorder a debugging function that can't actually be reordered",
                 context=f"fn: {self.value}, args: {args}, kwargs: {kwargs}",
@@ -2338,7 +2346,7 @@ class DebuggingVariable(VariableTracker):
         return self.source.reconstruct(codegen)
 
     @staticmethod
-    def can_reorder_logs(fn: Any, args: Sequence[Any], kwargs: dict[str, Any]) -> bool:
+    def can_reorder_logs(args: Sequence[Any], kwargs: dict[str, Any]) -> bool:
         """
         Run some additional checks for what sort of function calls can we
         actually reorder.
@@ -2367,7 +2375,7 @@ class IgnoredFunctionVariable(VariableTracker):
     Represents a call to an arbitrary function that should be ignored.
     """
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -2457,7 +2465,7 @@ class ConstantLikeVariable(VariableTracker):
         # type: ignore[misc, assignment]
         np_dtype = type("invalid_type", (), {})
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.value = value
 
@@ -2547,7 +2555,11 @@ class NumpyDTypeVariable(ConstantLikeVariable):
         np.dtype() objects are serialized as strings, torch._numpy wrappers will normalize to the torch dtype.
         This also handles unsupported things nicely (i.e. structured arrays and object arrays).
         """
-        return self.value.type.__name__
+        # All three construction paths produce a real numpy.dtype: the
+        # np_constant_collections_map entry for tnp.dtype, builder.py's
+        # is_numpy_dtype branch, and ConstantLikeVariable.getattro_impl's
+        # isinstance(result, self.np_dtype) branch.
+        return cast("np.dtype[Any]", self.value).type.__name__
 
 
 np_constant_collections_map = {

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -4488,7 +4488,7 @@ class UserDefinedConstantVariable(UserDefinedObjectVariable):
     Uses a ConstantVariable as _base_vt for the underlying constant value.
     """
 
-    def __init__(self, value: Any, **kwargs: Any) -> None:
+    def __init__(self, value: object, **kwargs: Any) -> None:
         from .constant import ConstantVariable
 
         super().__init__(value, **kwargs)


### PR DESCRIPTION

A family of VariableTrackers exist only to carry one raw Python object
through tracing: `TypingVariable`, `NumpyVariable`, `DebuggingVariable`,
`IgnoredFunctionVariable`, `ConstantLikeVariable`, `SkipFunctionVariable`,
`SysFunctionVariable`, `TritonSetAllocatorVariable`, plus `LazyCache.value`
and `GraphArg._example`. All of them declared that payload as `Any`, which
propagated unchecked into every caller that touched it.
`UserDefinedObjectVariable.value` is already `object`; this extends that
pattern to the rest of the family.

Review in three groups, mirroring how the sites cluster:

1. `variables/misc.py` -- the plain wrappers. `IgnoredFunctionVariable` and
   `DebuggingVariable` need no casts at all. `DebuggingVariable`'s
   `can_reorder_logs(fn, ...)` parameter is dropped outright rather than
   widened: the body never reads it (only `args`/`kwargs`) and there is a
   single call site. `TypingVariable` needs one cast at the subscript,
   `NumpyVariable` two, and `ConstantLikeVariable` one in the
   `NumpyDTypeVariable.as_proxy` override.
2. `variables/lazy.py` and `variables/builder.py` -- the raw
   "example value" carriers. `LazyCache.value`, `ComputedLazyCache.value`,
   both `create()` entry points and the `is_hashable_lazy` helper widen with
   zero casts. `GraphArg._example` needs one cast, in the `example` property.
   That cast targets the property's pre-existing return annotation, which is
   itself known-incomplete -- `torch.ScriptObject` and list-of-tensor
   graphargs also flow through, and `output_graph.py` reads them back -- so
   the comment there warns against tightening `_example` to that union.
3. `variables/functions.py` and `variables/user_defined.py` -- the opaque
   callables. `SysFunctionVariable` compares by identity only, so it needs
   nothing; `SkipFunctionVariable` and `TritonSetAllocatorVariable` need
   casts only where they actually invoke the payload.

Two choices worth calling out.

The `SkipFunctionVariable` casts are all `Callable[..., Any]`, and each one
sits behind a gate that already establishes the value is callable: two are
inside `self.value in (...)` membership tests against concrete function
objects, and the third is the `inspect.getfile` call whose surrounding
`except TypeError` is precisely the branch taken when the payload is not a
Python-level callable. The alternative -- annotating `value: Callable[...]`
on the class -- was rejected because the payload genuinely is not always
callable (`SkipFunctionVariable` also wraps descriptors and module-level
objects), so it would push the dishonesty up to the field instead of
localizing it at the two call sites.

`NumpyVariable.as_python_constant()` keeps its declared
`-> BuiltinFunctionType` and casts. That annotation was already inaccurate
before this change -- the builder routes numpy dtypes and `np._CopyMode`
through the same VT -- so the cast makes an existing lie explicit rather
than introducing one. Tightening it is a separate change. For the same
reason `LazyVariableTracker.peek_value()` / `original_value()` still return
`Any`: their results feed arithmetic and `op(*values)` in
`ComputedLazyConstantVariable.create`, so widening them is a larger change
than retyping the field they read.

The additions the task description explicitly scopes out are left alone:
`ConstantVariable.value` (its literal interface is used pervasively and
wants a literal union, not `object`), `BaseTorchVariable.value` /
`BuiltinVariable.fn` (called throughout, so they want `Callable`/a
`Protocol`), and the context-manager `target_values` / `initial_values`
(a sequence interface).

Test Plan:

Type checking over the whole project plus every linter that applies to the
changed files (the PYREFLY adapter type-checks the full project regardless
of the paths passed):

```
lintrunner --take PYREFLY,PYFMT,RUFF,CODESPELL,FLAKE8 \
  torch/_dynamo/variables/misc.py \
  torch/_dynamo/variables/lazy.py \
  torch/_dynamo/variables/functions.py \
  torch/_dynamo/variables/user_defined.py \
  torch/_dynamo/variables/builder.py
```

Dynamo suites covering each retyped VT -- typing/numpy/constant-like
wrappers, reorderable logging, skipped functions and their context-manager
wrapper, lazy constants, graph args under dynamic shapes, and the Triton
allocator path:

```
python test/dynamo/test_misc.py
python test/dynamo/test_functions.py
python test/dynamo/test_repros.py
python test/dynamo/test_unspec.py
python test/dynamo/test_logging.py
python test/dynamo/test_ctx_manager.py
python test/dynamo/test_higher_order_ops.py
python test/dynamo/test_subclasses.py
python test/dynamo/test_modules.py
python test/dynamo/test_export.py
python test/dynamo/test_dynamic_shapes.py
python test/dynamo/test_decorators.py
python test/dynamo/test_lazy_constant.py
python test/dynamo/test_error_messages.py
python test/dynamo/test_guard_manager.py
python test/dynamo/test_python_dispatcher.py
python test/dynamo/test_trace_rules.py
python test/dynamo/test_sources.py
python test/inductor/test_triton_kernels.py
```

All pass except for failures that reproduce identically on the unmodified
base in the same environment, confirmed by re-running each one under `git
stash`:

- `ReproTests.test_multi_import` and its `test_dynamic_shapes` mirror
  (`operator torchvision::nms does not exist`) -- a stale local torchvision
  built against a different torch.
- Four `test_triton_kernels` cases (`CustomOpTests.test_autotune_unbacked`,
  `KernelTests.test_triton_kernel_dtype_view_cfg_cpp_wrapper`, and both
  `test_tma_capture_and_functionalize_*_tma_version_new`) -- local Triton
  version skew.

This PR was authored with the assistance of an AI coding assistant.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98