### PR TITLE
[inductor] Hold GPU lock across multi-kernel comparison

### DIFF
--- a/test/inductor/test_multi_kernel.py
+++ b/test/inductor/test_multi_kernel.py
@@ -1,14 +1,17 @@
 # Owner(s): ["module: inductor"]
 
+import contextlib
 import os
 import re
 import unittest
+from types import SimpleNamespace
 
 import torch
 from torch import nn
 from torch._dynamo.testing import reset_rng_state
 from torch._inductor import config, test_operators
 from torch._inductor.codegen.multi_kernel import MultiKernelCall
+from torch._inductor.runtime.benchmarking import set_gpu_benchmark_lock_context
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.nn import functional as F
@@ -92,6 +95,91 @@ def make_cpp_wrapper_test(orig_test, **extra_args):
 )
 @instantiate_parametrized_tests
 class MultiKernelTest(TestCase):
+    @staticmethod
+    def _benchmark_lock_call(events):
+        def kernel(index):
+            return SimpleNamespace(
+                clone_args=lambda *args, **kwargs: (args, kwargs),
+                run=lambda *args, **kwargs: events.append(f"run_{index}"),
+                device_props=SimpleNamespace(type="cuda"),
+            )
+
+        multi_kernel_call = object.__new__(MultiKernelCall)
+        multi_kernel_call._kernels = [kernel(0), kernel(1)]
+        multi_kernel_call.arg_index = {
+            0: [slice(0, 1)],
+            1: [slice(0, 1)],
+        }
+        return multi_kernel_call
+
+    def test_benchmark_sub_kernels_holds_gpu_lock_across_candidates(self):
+        events = []
+        multi_kernel_call = self._benchmark_lock_call(events)
+
+        @contextlib.contextmanager
+        def benchmark_lock():
+            events.append("lock_enter")
+            try:
+                yield
+            finally:
+                events.append("lock_exit")
+
+        def benchmark(fn, **kwargs):
+            index = len([event for event in events if event.startswith("benchmark_")])
+            events.append(f"benchmark_{index}")
+            fn()
+            return 2.0 - index
+
+        previous = set_gpu_benchmark_lock_context(benchmark_lock)
+        try:
+            with unittest.mock.patch(
+                "torch._inductor.codegen.multi_kernel.benchmarker.benchmark",
+                side_effect=benchmark,
+            ):
+                timings = multi_kernel_call.benchmark_sub_kernels("arg")
+        finally:
+            set_gpu_benchmark_lock_context(previous)
+
+        self.assertEqual(timings, [2.0, 1.0])
+        self.assertEqual(
+            events,
+            [
+                "lock_enter",
+                "benchmark_0",
+                "run_0",
+                "benchmark_1",
+                "run_1",
+                "lock_exit",
+            ],
+        )
+
+    def test_benchmark_sub_kernels_releases_gpu_lock_on_failure(self):
+        events = []
+        multi_kernel_call = self._benchmark_lock_call(events)
+
+        @contextlib.contextmanager
+        def benchmark_lock():
+            events.append("lock_enter")
+            try:
+                yield
+            finally:
+                events.append("lock_exit")
+
+        previous = set_gpu_benchmark_lock_context(benchmark_lock)
+        try:
+            with (
+                unittest.mock.patch(
+                    "torch._inductor.codegen.multi_kernel.benchmarker.benchmark",
+                    side_effect=RuntimeError("benchmark failed"),
+                ),
+                self.assertRaisesRegex(RuntimeError, "benchmark failed"),
+            ):
+                multi_kernel_call.benchmark_sub_kernels("arg")
+        finally:
+            set_gpu_benchmark_lock_context(previous)
+
+        self.assertEqual(events, ["lock_enter", "lock_exit"])
+
     def test_softmax(self, expect_multi_kernel=True):
         x = torch.rand(2, 1024).to(GPU_TYPE)
         ref = torch.softmax(x, -1)

--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -12,7 +12,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from .. import config
 from ..codecache import code_hash, CodeCacheFuture, get_path, write_atomic
-from ..runtime.benchmarking import benchmarker
+from ..runtime.benchmarking import benchmarker, gpu_benchmark_lock
 from ..utils import cache_on_self, IndentedBuffer
 from ..virtualized import V
 from .common import TensorArg, WorkspaceArg
@@ -391,6 +391,7 @@ class MultiKernelCall:
 
         return self._kernels
 
+    @gpu_benchmark_lock
     def benchmark_sub_kernels(self, *args, **kwargs):
         """
         Benchmark all the sub kernels and return the execution time


### PR DESCRIPTION
## Summary

Benchmark all candidates in a runtime multi-kernel comparison under one registered GPU benchmark lock. This prevents concurrent compile workers from interleaving candidate measurements on the same GPU. Existing per-candidate benchmark locking remains nested through the reentrant lock contract.

Candidate ordering, forced and cached choices, and benchmark failure behavior are unchanged.

## Test plan

- `python -m pytest -q test/inductor/test_multi_kernel.py -k "benchmark_sub_kernels_holds_gpu_lock_across_candidates or benchmark_sub_kernels_releases_gpu_lock_on_failure"`
- Existing multi-kernel softmax variants on B200

The focused lock tests verify one lock scope covers all candidates and that exceptions release the lock.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo