### PR TITLE
[inductor] Share repeated graph-output computation without aliasing outputs

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -25,6 +25,7 @@ from torch._inductor.utils import (
     run_and_get_code,
     run_and_get_graph_lowering,
     run_fw_bw_and_get_code,
+    using_b200,
 )
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.attention import sdpa_kernel, SDPBackend
@@ -2396,6 +2397,32 @@ class CudaReproTests(TestCase):
         else:
             self.assertEqual(2, persistent_code.count("tl.load(in_ptr0 +"))
         self.assertLessEqual(persistent_code.count("libdevice.exp"), 1)
+
+    @config.patch("dedupe_graph_outputs", True)
+    @unittest.skipIf(not using_b200(), "requires B200")
+    def test_identical_graph_outputs_share_compute_not_storage(self):
+        if device_type != "cuda":
+            raise unittest.SkipTest("requires CUDA")
+
+        def fn(x):
+            return tuple((torch.sin(x) + 1).to(torch.bfloat16) for _ in range(8))
+
+        x = torch.randn(8192, device=device_type)
+        expected = fn(x)
+        counters.clear()
+        actual, code = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(len({out.data_ptr() for out in actual}), len(actual))
+        unmodified = actual[1][0].item()
+        actual[0][0].add_(1)
+        self.assertEqual(actual[1][0].item(), unmodified)
+        self.assertEqual(counters["inductor"]["dedupe_graph_outputs"], 7)
+
+        source = "\n".join(code)
+        self.assertEqual(source.count("@triton_heuristics.pointwise"), 1)
+        self.assertEqual(source.count("tl.store("), 8)
+        self.assertEqual(source.count("tl_math.sin("), 1)
 
     def test_scaled_dot_product_efficient_attention_backward(self):
         from torch import nn, Tensor

--- a/test/inductor/test_dedupe_graph_outputs.py
+++ b/test/inductor/test_dedupe_graph_outputs.py
@@ -1,0 +1,340 @@
+# Owner(s): ["module: inductor"]
+
+from unittest import mock
+
+import torch
+from torch import fx
+from torch._inductor import config
+from torch._inductor.fx_passes.dedupe_graph_outputs import (
+    _is_shareable_node,
+    _structural_classes,
+    dedupe_graph_outputs_pass,
+    is_output_computation_sharing_supported,
+)
+from torch._inductor.test_case import run_tests, TestCase
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+
+
+def _propagate(gm: fx.GraphModule, *inputs: torch.Tensor) -> None:
+    mode = FakeTensorMode()
+    FakeTensorProp(gm, mode=mode).propagate(
+        *(mode.from_tensor(value) for value in inputs)
+    )
+
+
+def _count(graph: fx.Graph, target) -> int:
+    return sum(node.target is target for node in graph.nodes)
+
+
+def _sin_graph(count: int = 8) -> fx.GraphModule:
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    graph.output(
+        tuple(
+            graph.call_function(torch.ops.aten.sin.default, (x,)) for _ in range(count)
+        )
+    )
+    gm = fx.GraphModule({}, graph)
+    _propagate(gm, torch.randn(8))
+    return gm
+
+
+class TestDedupeGraphOutputs(TestCase):
+    def test_shares_compute_and_preserves_storage(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        output_only = graph.call_function(torch.ops.aten.sin.default, (x,))
+        canonical = graph.call_function(torch.ops.aten.sin.default, (x,))
+        internal = graph.call_function(torch.ops.aten.add.Tensor, (canonical, 1))
+        siblings = [
+            graph.call_function(torch.ops.aten.sin.default, (x,)) for _ in range(6)
+        ]
+        graph.output((output_only, canonical, *siblings, internal))
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.randn(8))
+
+        dedupe_graph_outputs_pass(graph)
+        gm.recompile()
+        result = gm(torch.randn(8))
+
+        self.assertEqual(len({value.data_ptr() for value in result[:8]}), 8)
+        torch.testing.assert_close(result[-1], result[0] + 1)
+        self.assertEqual(_count(graph, torch.ops.aten.sin.default), 1)
+        self.assertEqual(_count(graph, torch.ops.aten.clone.default), 7)
+
+    def test_branch_count_and_identity_bounds(self):
+        for count in (7, 33):
+            with self.subTest(count=count):
+                gm = _sin_graph(count)
+                dedupe_graph_outputs_pass(gm.graph)
+                self.assertEqual(_count(gm.graph, torch.ops.aten.sin.default), count)
+                self.assertEqual(_count(gm.graph, torch.ops.aten.clone.default), 0)
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        value = graph.call_function(torch.ops.aten.sin.default, (x,))
+        graph.output((value,) * 8)
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.randn(8))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, torch.ops.aten.clone.default), 0)
+
+    def test_effectful_graphs_fail_closed(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        replacement = graph.placeholder("replacement")
+        before = [
+            graph.call_function(torch.ops.aten.sin.default, (x,)) for _ in range(4)
+        ]
+        graph.call_function(torch.ops.aten.copy_.default, (x, replacement))
+        after = [
+            graph.call_function(torch.ops.aten.sin.default, (x,)) for _ in range(4)
+        ]
+        graph.output((*before, *after))
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.zeros(8), torch.ones(8))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, torch.ops.aten.sin.default), 8)
+
+        for target in (
+            torch.ops.aten.rand_like.default,
+            torch.ops.aten.empty_like.default,
+        ):
+            with self.subTest(target=target):
+                graph = fx.Graph()
+                x = graph.placeholder("x")
+                graph.output(tuple(graph.call_function(target, (x,)) for _ in range(8)))
+                gm = fx.GraphModule({}, graph)
+                _propagate(gm, torch.randn(8))
+                dedupe_graph_outputs_pass(graph)
+                self.assertEqual(_count(graph, target), 8)
+                self.assertEqual(_count(graph, torch.ops.aten.clone.default), 0)
+
+    def test_collectives_fail_closed(self):
+        import torch.distributed._functional_collectives
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        target = torch.ops._c10d_functional.all_reduce.default
+        graph.output(
+            tuple(graph.call_function(target, (x, "sum", "0")) for _ in range(8))
+        )
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.randn(8))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, target), 8)
+
+    def test_uninitialized_and_special_ops_are_not_shareable(self):
+        graph = fx.Graph()
+        scales = graph.placeholder("scales")
+        zero_points = graph.placeholder("zero_points")
+        qtensor = graph.placeholder("qtensor")
+        nodes = [
+            graph.call_function(
+                torch.ops.aten._empty_affine_quantized.default,
+                ((8,),),
+                {"dtype": torch.quint8, "scale": 1.0, "zero_point": 0},
+            ),
+            graph.call_function(
+                torch.ops.aten._empty_per_channel_affine_quantized.default,
+                ((8,),),
+                {
+                    "scales": scales,
+                    "zero_points": zero_points,
+                    "axis": 0,
+                    "dtype": torch.quint8,
+                },
+            ),
+            graph.call_function(
+                torch.ops.aten.empty_quantized.default, ((8,), qtensor)
+            ),
+            graph.call_function(
+                torch.ops.aten._efficientzerotensor.default,
+                ((8,),),
+                {"dtype": torch.float32, "device": torch.device("cuda")},
+            ),
+        ]
+        self.assertTrue(all(not _is_shareable_node(node) for node in nodes))
+
+        for target, dtype in (
+            (torch.ops.aten._conj.default, torch.complex64),
+            (torch.ops.aten._neg_view.default, torch.float32),
+        ):
+            with self.subTest(target=target):
+                graph = fx.Graph()
+                x = graph.placeholder("x")
+                graph.output(tuple(graph.call_function(target, (x,)) for _ in range(8)))
+                gm = fx.GraphModule({}, graph)
+                _propagate(gm, torch.randn(8, dtype=dtype))
+                dedupe_graph_outputs_pass(graph)
+                self.assertEqual(_count(graph, target), 8)
+
+    def test_aliases_and_unsupported_storage_fail_closed(self):
+        for inter_output_alias in (False, True):
+            with self.subTest(inter_output_alias=inter_output_alias):
+                graph = fx.Graph()
+                x = graph.placeholder("x")
+                source = (
+                    graph.call_function(torch.ops.aten.sin.default, (x,))
+                    if inter_output_alias
+                    else x
+                )
+                outputs = [
+                    graph.call_function(torch.ops.aten.view.default, (source, (2, 4)))
+                    for _ in range(8)
+                ]
+                graph.output(tuple(outputs))
+                gm = fx.GraphModule({}, graph)
+                _propagate(gm, torch.randn(8))
+                dedupe_graph_outputs_pass(graph)
+                self.assertEqual(_count(graph, torch.ops.aten.clone.default), 0)
+
+        mode = FakeTensorMode()
+        sparse = mode.from_tensor(
+            torch.sparse_coo_tensor(
+                torch.tensor([[0], [1]]), torch.tensor([1.0]), (2, 2)
+            )
+        )
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = sparse
+        outputs = []
+        for _ in range(8):
+            node = graph.call_function(torch.ops.aten.clone.default, (x,))
+            node.meta["val"] = sparse
+            outputs.append(node)
+        graph.output(tuple(outputs))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, torch.ops.aten.clone.default), 8)
+
+    def test_unrelated_sparse_and_dense_strided_outputs(self):
+        graph = fx.Graph()
+        graph.placeholder("unused")
+        x = graph.placeholder("x")
+        outputs = []
+        for _ in range(8):
+            value = graph.call_function(torch.ops.aten.sin.default, (x,))
+            outputs.append(
+                graph.call_function(torch.ops.aten.permute.default, (value, (1, 0)))
+            )
+        graph.output(tuple(outputs))
+        gm = fx.GraphModule({}, graph)
+
+        mode = FakeTensorMode()
+        sparse = mode.from_tensor(
+            torch.sparse_coo_tensor(
+                torch.tensor([[0], [1]]), torch.tensor([1.0]), (2, 2)
+            )
+        )
+        dense = mode.from_tensor(torch.randn(3, 5))
+        FakeTensorProp(gm, mode=mode).propagate(sparse, dense)
+        dedupe_graph_outputs_pass(graph)
+        gm.recompile()
+        result = gm(
+            torch.sparse_coo_tensor(
+                torch.tensor([[0], [1]]), torch.tensor([1.0]), (2, 2)
+            ),
+            torch.randn(3, 5),
+        )
+        self.assertEqual(_count(graph, torch.ops.aten.sin.default), 1)
+        self.assertEqual(len({value.data_ptr() for value in result}), 8)
+        self.assertTrue(all(value.stride() == (1, 5) for value in result))
+
+    def test_dynamic_outputs_fail_closed(self):
+        gm = make_fx(
+            lambda x: tuple(torch.sin(x) for _ in range(8)),
+            tracing_mode="symbolic",
+        )(torch.randn(5))
+        dedupe_graph_outputs_pass(gm.graph)
+        self.assertEqual(_count(gm.graph, torch.ops.aten.sin.default), 8)
+
+    def test_structural_keys_cover_nested_constants_and_deep_graphs(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        outputs = []
+        for _ in range(8):
+            lhs = graph.call_function(torch.ops.aten.sin.default, (x,))
+            rhs = graph.call_function(torch.ops.aten.cos.default, (x,))
+            outputs.append(
+                graph.call_function(torch.ops.aten.cat.default, ([lhs, rhs], 0))
+            )
+        graph.output(tuple(outputs))
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.randn(8))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, torch.ops.aten.cat.default), 1)
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        with_int = graph.call_function(torch.ops.aten.add.Tensor, (x, 1), {"alpha": 1})
+        with_bool = graph.call_function(
+            torch.ops.aten.add.Tensor, (x, 1), {"alpha": True}
+        )
+        classes = _structural_classes(graph)
+        self.assertNotEqual(classes[with_int], classes[with_bool])
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        deep_outputs = []
+        for _ in range(8):
+            value = x
+            for _ in range(1100):
+                value = graph.call_function(torch.ops.aten.sin.default, (value,))
+            deep_outputs.append(value)
+        graph.output(tuple(deep_outputs))
+        classes = _structural_classes(graph)
+        self.assertEqual(len({classes[node] for node in deep_outputs}), 1)
+
+    def test_prims_and_view_branches_are_shared(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        outputs = []
+        for _ in range(8):
+            value = graph.call_function(
+                torch.ops.prims.convert_element_type.default,
+                (x, torch.bfloat16),
+            )
+            value = graph.call_function(torch.ops.aten.unsqueeze.default, (value, 0))
+            value = graph.call_function(torch.ops.aten.view.default, (value, (1, 2, 4)))
+            outputs.append(graph.call_function(torch.ops.aten.squeeze.dim, (value, 0)))
+        graph.output(tuple(outputs))
+        gm = fx.GraphModule({}, graph)
+        _propagate(gm, torch.randn(2, 4))
+        dedupe_graph_outputs_pass(graph)
+        self.assertEqual(_count(graph, torch.ops.prims.convert_element_type.default), 1)
+        self.assertEqual(_count(graph, torch.ops.aten.clone.default), 7)
+
+    @config.patch("cuda_backend", "triton")
+    def test_production_gate_uses_graph_device_and_sm(self):
+        mode = FakeTensorMode()
+        with mode:
+            fake_cuda = torch.empty(8, device="cuda:3")
+
+        graph = fx.Graph()
+        output = graph.placeholder("output")
+        output.meta["val"] = fake_cuda
+        graph.output((output,))
+        gm = fx.GraphModule({}, graph)
+
+        for major, expected in ((10, True), (9, False)):
+            with self.subTest(major=major):
+                worker = mock.Mock()
+                worker.get_device_properties.return_value = mock.Mock(major=major)
+                device_interface = mock.Mock(Worker=worker)
+                with mock.patch(
+                    "torch._inductor.fx_passes.dedupe_graph_outputs."
+                    "get_interface_for_device",
+                    return_value=device_interface,
+                ):
+                    self.assertEqual(
+                        is_output_computation_sharing_supported(gm), expected
+                    )
+                worker.get_device_properties.assert_called_once_with(
+                    torch.device("cuda:3")
+                )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1285,6 +1285,14 @@ partitioned_scatter_force: bool = (
     os.environ.get("TORCHINDUCTOR_PARTITIONED_SCATTER_FORCE", "0") == "1"
 )
 
+# Share 8-32 structurally identical inference-output computations while
+# retaining a distinct storage allocation for every output. Default-on
+# admission is currently limited to NVIDIA SM100 Triton.
+dedupe_graph_outputs: bool = Config(
+    env_name_force="TORCHINDUCTOR_DEDUPE_GRAPH_OUTPUTS",
+    default=True,
+)
+
 
 class _collective:
     auto_select: bool = False

--- a/torch/_inductor/fx_passes/dedupe_graph_outputs.py
+++ b/torch/_inductor/fx_passes/dedupe_graph_outputs.py
@@ -1,0 +1,298 @@
+# mypy: allow-untyped-defs
+"""Share equivalent output computation without aliasing returned tensors."""
+
+import struct
+from collections import defaultdict
+
+import torch
+from torch import fx
+from torch._dynamo.device_interface import get_interface_for_device
+from torch._dynamo.utils import counters
+from torch._subclasses.fake_tensor import FakeTensor
+from torch.utils._ordered_set import OrderedSet
+
+from .. import config
+
+
+_MIN_OUTPUTS = 8
+_MAX_OUTPUTS = 32
+_SAFE_NAMESPACES = frozenset(("aten", "prims"))
+_REJECTED_TAGS = frozenset(
+    (
+        torch.Tag.cudagraph_unsafe,
+        torch.Tag.data_dependent_output,
+        torch.Tag.dynamic_output_shape,
+        torch.Tag.inplace,
+        torch.Tag.maybe_aliasing_or_mutating,
+        torch.Tag.nondeterministic_bitwise,
+        torch.Tag.nondeterministic_seeded,
+        torch.Tag.out,
+        torch.Tag.out_variant,
+    )
+)
+# These allocate unspecified values or carry tensor metadata that clone does not
+# preserve. Descendants must not be CSE'd through them either.
+_REJECTED_PACKETS = frozenset(
+    (
+        torch.ops.aten._conj,
+        torch.ops.aten._empty_affine_quantized,
+        torch.ops.aten._empty_per_channel_affine_quantized,
+        torch.ops.aten._efficientzerotensor,
+        torch.ops.aten._neg_view,
+        torch.ops.aten.empty,
+        torch.ops.aten.empty_like,
+        torch.ops.aten.empty_permuted,
+        torch.ops.aten.empty_quantized,
+        torch.ops.aten.empty_strided,
+        torch.ops.aten.new_empty,
+        torch.ops.aten.new_empty_strided,
+        torch.ops.prims.empty,
+        torch.ops.prims.empty_permuted,
+        torch.ops.prims.empty_strided,
+    )
+)
+_StorageKey = tuple[int, torch.device]
+
+
+def _output_node(graph: fx.Graph) -> fx.Node | None:
+    return next((node for node in graph.nodes if node.op == "output"), None)
+
+
+def is_output_computation_sharing_supported(gm: fx.GraphModule) -> bool:
+    """Restrict default-on use to the audited NVIDIA SM100 Triton cohort."""
+    if torch.version.hip is not None or config.cuda_backend != "triton":
+        return False
+
+    output = _output_node(gm.graph)
+    if output is None:
+        return False
+
+    devices = OrderedSet(
+        [
+            leaf.device
+            for arg in torch.utils._pytree.arg_tree_leaves(
+                *output.args, **output.kwargs
+            )
+            if isinstance(arg, fx.Node)
+            for leaf in torch.utils._pytree.tree_leaves(arg.meta.get("val"))
+            if isinstance(leaf, torch.Tensor)
+        ]
+    )
+    if len(devices) != 1:
+        return False
+    device = next(iter(devices))
+    if device.type != "cuda":
+        return False
+
+    properties = get_interface_for_device("cuda").Worker.get_device_properties(device)
+    return properties.major == 10
+
+
+def _constant_key(value):
+    """Return a type-sensitive key, or None for unsupported constants."""
+    value_type = type(value)
+    if value is None:
+        return (value_type,)
+    if value_type in (bool, int, str, bytes):
+        return (value_type, value)
+    if value_type is float:
+        return (value_type, struct.pack("!d", value))
+    if value_type is complex:
+        return (
+            value_type,
+            struct.pack("!d", value.real),
+            struct.pack("!d", value.imag),
+        )
+    if value_type in (torch.dtype, torch.device, torch.layout, torch.memory_format):
+        return (value_type, value)
+    return None
+
+
+def _is_functional_op(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.OpOverload)
+        and node.target.namespace in _SAFE_NAMESPACES
+        and not node.is_impure()
+    )
+
+
+def _is_shareable_node(node: fx.Node) -> bool:
+    if not _is_functional_op(node):
+        return False
+    target = node.target
+    if not isinstance(target, torch._ops.OpOverload):
+        return False
+    if target.overloadpacket in _REJECTED_PACKETS or not _REJECTED_TAGS.isdisjoint(
+        target.tags
+    ):
+        return False
+    return not any(
+        arg.alias_info is not None and arg.alias_info.is_write
+        for arg in target._schema.arguments
+    )
+
+
+def _is_pure_functional_graph(graph: fx.Graph) -> bool:
+    return all(
+        node.op in ("placeholder", "get_attr", "output") or _is_functional_op(node)
+        for node in graph.nodes
+    )
+
+
+def _structural_classes(graph: fx.Graph) -> dict[fx.Node, int]:
+    """Intern collision-free structural keys in topological order."""
+    classes: dict[fx.Node, int] = {}
+    interned: dict[tuple[object, ...], int] = {}
+
+    for node in graph.nodes:
+        key = None
+        if _is_shareable_node(node):
+            leaves, spec = torch.utils._pytree.tree_flatten(
+                (node.args, tuple(sorted(node.kwargs.items())))
+            )
+            leaf_keys: list[object] = []
+            for leaf in leaves:
+                if isinstance(leaf, fx.Node):
+                    leaf_keys.append(("node", classes[leaf]))
+                elif (constant := _constant_key(leaf)) is not None:
+                    leaf_keys.append(("constant", constant))
+                else:
+                    break
+            else:
+                key = (node.target, spec, *leaf_keys)
+
+        class_id = interned.get(key) if key is not None else None
+        if class_id is None:
+            class_id = len(classes)
+            if key is not None:
+                interned[key] = class_id
+        classes[node] = class_id
+
+    return classes
+
+
+def _storage_key(value) -> _StorageKey | None:
+    if (
+        type(value) is not FakeTensor
+        or value.layout is not torch.strided
+        or not torch._C._has_storage(value)
+    ):
+        return None
+    try:
+        return (value.untyped_storage()._cdata, value.device)
+    except RuntimeError:
+        return None
+
+
+def _storage_keys(value) -> OrderedSet[_StorageKey]:
+    return OrderedSet(
+        [
+            key
+            for leaf in torch.utils._pytree.tree_leaves(value)
+            if (key := _storage_key(leaf)) is not None
+        ]
+    )
+
+
+def _has_distinct_dense_storage(
+    node: fx.Node,
+    input_storage: OrderedSet[_StorageKey],
+    output_storage_users: dict[_StorageKey, OrderedSet[fx.Node]],
+) -> bool:
+    value = node.meta.get("val")
+    if type(value) is not FakeTensor:
+        return False
+    key = _storage_key(value)
+    if (
+        key is None
+        or not all(isinstance(size, int) for size in value.size())
+        or not all(isinstance(stride, int) for stride in value.stride())
+        or not isinstance(value.storage_offset(), int)
+        or value.storage_offset() != 0
+        or not torch._prims_common.is_non_overlapping_and_dense_or_false(value)
+    ):
+        return False
+    try:
+        storage_nbytes = value.untyped_storage().nbytes()
+    except RuntimeError:
+        return False
+    return (
+        key not in input_storage
+        and len(output_storage_users[key]) == 1
+        and storage_nbytes == value.numel() * value.element_size()
+    )
+
+
+def dedupe_graph_outputs_pass(graph: fx.Graph) -> None:
+    """Share 8-32 equivalent output branches and clone their returned values."""
+    output = _output_node(graph)
+    if output is None:
+        return
+
+    output_nodes = list(
+        dict.fromkeys(
+            node
+            for node in torch.utils._pytree.arg_tree_leaves(
+                *output.args, **output.kwargs
+            )
+            if isinstance(node, fx.Node)
+        )
+    )
+    if len(output_nodes) < _MIN_OUTPUTS or not _is_pure_functional_graph(graph):
+        return
+
+    groups: dict[int, list[fx.Node]] = defaultdict(list)
+    classes = _structural_classes(graph)
+    for node in output_nodes:
+        groups[classes[node]].append(node)
+    candidates = [
+        group for group in groups.values() if _MIN_OUTPUTS <= len(group) <= _MAX_OUTPUTS
+    ]
+    if not candidates:
+        return
+
+    input_storage: OrderedSet[_StorageKey] = OrderedSet()
+    for node in graph.nodes:
+        if node.op in ("placeholder", "get_attr"):
+            input_storage.update(_storage_keys(node.meta.get("val")))
+
+    output_storage_users: dict[_StorageKey, OrderedSet[fx.Node]] = defaultdict(
+        OrderedSet
+    )
+    for node in output_nodes:
+        if (key := _storage_key(node.meta.get("val"))) is not None:
+            output_storage_users[key].add(node)
+
+    replacements = 0
+    for group in candidates:
+        eligible = [
+            node
+            for node in group
+            if _has_distinct_dense_storage(node, input_storage, output_storage_users)
+        ]
+        if len(eligible) < _MIN_OUTPUTS:
+            continue
+
+        def is_output_only(node: fx.Node) -> bool:
+            return len(node.users) == 1 and output in node.users
+
+        canonical = next(
+            (node for node in eligible if not is_output_only(node)), eligible[0]
+        )
+        duplicates = [
+            node for node in eligible if node is not canonical and is_output_only(node)
+        ]
+        if len(duplicates) + 1 < _MIN_OUTPUTS:
+            continue
+
+        for node in duplicates:
+            with graph.inserting_before(output):
+                clone = graph.call_function(torch.ops.aten.clone.default, (canonical,))
+            node.replace_all_uses_with(clone)
+            replacements += 1
+
+    if replacements:
+        graph.eliminate_dead_code()
+        graph.lint()
+        counters["inductor"]["dedupe_graph_outputs"] += replacements

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -309,6 +309,19 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     GraphTransformObserver(gm, "stable_sort").apply_graph_pass(stable_topological_sort)
 
+    # Share structurally identical graph-output computation while retaining a
+    # distinct storage allocation for each originally distinct output.
+    if config.dedupe_graph_outputs and is_inference:
+        from .dedupe_graph_outputs import (
+            dedupe_graph_outputs_pass,
+            is_output_computation_sharing_supported,
+        )
+
+        if is_output_computation_sharing_supported(gm):
+            GraphTransformObserver(gm, "dedupe_graph_outputs").apply_graph_pass(
+                dedupe_graph_outputs_pass
+            )
+
     GraphTransformObserver(gm, "move_constructors_to_cuda").apply_graph_pass(
         move_constructors_to_gpu
     )


### PR DESCRIPTION
## Summary

Canonicalize 8-32 structurally equivalent pure inference-output branches, compute one canonical value, and emit clones so every returned tensor retains distinct dense storage.

The initial default scope is deliberately bounded to static NVIDIA SM100 Triton graphs. The pass fails closed for mutation/effects, randomness, aliases, dynamic shapes, special tensor metadata, uninitialized values, unsupported layouts, and storage-less outputs.

## Performance

B200, `hf_XLNetLMHeadModel_infer`, canonical `pointwise_fc28348c6da6`:

- `2478.0us -> 143.3us` (`17.3x`)
- 24 generated kernels -> 1
- Generated kernel retains 24 distinct stores while evaluating the shared sin/cos chain once

A prior 4,977-point activation audit of this admission policy had zero failures and changed kernel count for only this XLNet point.

## Test plan

- `python -m pytest -q test/inductor/test_dedupe_graph_outputs.py` (11 tests, 10 subtests)
- `python -m pytest -q test/inductor/test_cuda_repro.py -k identical_graph_outputs_share_compute_not_storage`
- Fresh-cache canonical B200 on/off A/B above

The tests cover storage isolation, input/output aliases, mutation/effects, randomness, dynamic and sparse metadata, uninitialized and quantized outputs, lazy metadata views, nested arguments, type-sensitive constants, deep graphs, device gating, and branch-count bounds.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo