### PR TITLE
[Eager] Add a CuTeDSL inner-tree prod reduction override

### DIFF
--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -207,6 +207,45 @@ class TestInstrumentation(_LoggerCaptureTest):
         self.assertEqual(len(self.messages), 1)
         self.assertIn("error", self.messages[0])
 
+    def test_callable_op_label_used_in_log(self):
+        # op may be a callable evaluated per-call (e.g. to derive the aten
+        # symbol from the compile args).
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile(lambda N, K: f"aten::topk_{N}")(fake)
+
+        compile_fn(256, 64)
+
+        self.assertIn("aten::topk_256", self.messages[0])
+
+    def test_op_label_failure_preserves_result(self):
+        # The label callback runs in the finally block; if it raises it must not
+        # turn a successful compile into a failure. Falls back to a safe label.
+        fake = _FakeJitCache()
+
+        def bad_op(*args, **kwargs):
+            raise ValueError("label boom")
+
+        compile_fn = instrument_cutedsl_compile(bad_op)(fake)
+
+        result = compile_fn(256, 64)  # must not raise
+        self.assertIsNotNone(result)
+        self.assertEqual(len(self.messages), 1)
+        self.assertIn("<op-label-error>", self.messages[0])
+
+    def test_op_label_failure_preserves_original_error(self):
+        # If the wrapped fn raises, a failing label callback must not mask the
+        # original exception.
+        fake = _FakeJitCache()
+        fake.raise_on_call = True
+
+        def bad_op(*args, **kwargs):
+            raise ValueError("label boom")
+
+        compile_fn = instrument_cutedsl_compile(bad_op)(fake)
+
+        with self.assertRaises(RuntimeError):  # original "boom", not ValueError
+            compile_fn(256, 64)
+
     def test_cache_attrs_forwarded(self):
         fake = _FakeJitCache()
         compile_fn = instrument_cutedsl_compile("aten::topk")(fake)

--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -13,6 +13,7 @@
 import contextlib
 import os
 import unittest
+from unittest import mock
 
 import torch
 from torch.testing._internal.common_cuda import (
@@ -383,6 +384,38 @@ class TestSumCuteDSLOverride(TestCase):
         with self._inner_tree_flag():
             got = x.prod(dim=1)
         self.assertFalse(torch.equal(got, ref))
+
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_prod_low_precision_matches_aten(self, dtype):
+        # 0.75 and 1.25 are exactly representable in fp16/bf16; a sparse set of
+        # them keeps the length-n product bounded and non-1.0 (a near-1 input
+        # collapses to 1.0 at low precision, giving a vacuous test). fp16/bf16
+        # are functionally supported but not part of the bitwise contract, so
+        # compare to ATen with a low-precision tolerance. Covers the multirow,
+        # looped, and two-kernel paths.
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        for m, n in [(64, 32), (8, 4096), (8, 65536)]:
+            with self.subTest(m=m, n=n):
+                x = torch.ones(m, n, device="cuda", dtype=dtype)
+                idx = torch.linspace(0, n - 1, 8, dtype=torch.long)
+                x[:, idx[0::2]] = 0.75
+                x[:, idx[1::2]] = 1.25
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = x.prod(dim=1)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_prod_into",
+                        wraps=inner_tree_kernel.inner_tree_prod_into,
+                    ) as prod_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = x.prod(dim=1)
+                # Proves fp16/bf16 route through the CuTeDSL override, not a
+                # silent ATen fall-through (which a tolerance compare misses).
+                self.assertEqual(prod_into.call_count, 1)
+                self.assertEqual(got, ref, rtol=2e-2, atol=2e-2)
 
     def test_prod_override_out_variant(self):
         x = self._make_prod_input(128, 8192, torch.float32)

--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -341,6 +341,88 @@ class TestSumCuteDSLOverride(TestCase):
                         f"{dtype_name} m={m} n={n}: got {sha}, expected {expected}",
                     )
 
+    # --- prod (shares the inner-tree geometry/eligibility with sum) ---
+
+    def _make_prod_input(self, m, n, dtype):
+        # Perturb each element by O(1)/n so the length-``n`` product stays
+        # bounded (~e^O(1)) for any ``n`` -- otherwise a per-row factor raised
+        # to the n-th power overflows and fp reorder error swamps the tolerance.
+        # Still order-sensitive (alternating sign + per-row shift).
+        compute_dtype = torch.float64 if dtype == torch.float64 else torch.float32
+        cols = torch.arange(n, device="cuda", dtype=compute_dtype).reshape(1, n)
+        pattern = (cols % 2) * 2 - 1  # +/-1 alternating
+        if m > 1:
+            rows = torch.arange(m, device="cuda", dtype=compute_dtype).reshape(m, 1)
+            pattern = pattern + ((rows % 5) - 2)  # per-row shift in [-2, 2]
+        return (1.0 + pattern / n).to(dtype)
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_prod_override_matches_aten(self, dtype):
+        # A length-n product accumulates ~n*eps of rounding, so inner-tree and
+        # ATen (different orders) diverge by that much -- both track the fp64
+        # truth equally well, so use a product-appropriate tolerance.
+        rtol, atol = (2e-3, 2e-3) if dtype == torch.float32 else (1e-9, 1e-12)
+        # Covers the multirow, looped, and two-kernel prod paths.
+        for m, n in [(128, 32), (128, 8192), (8, 200000)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_prod_input(m, n, dtype)
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = x.prod(dim=1)
+                with self._inner_tree_flag():
+                    got = x.prod(dim=1)
+                self.assertEqual(got, ref, rtol=rtol, atol=atol)
+
+    def test_prod_override_engaged(self):
+        # Proves the CuTeDSL prod override actually executes: its inner-tree
+        # order differs bit-for-bit from ATen's default order for an
+        # order-sensitive input. If the override silently fell through to ATen,
+        # ``got`` would equal ``ref`` and this fails -- guarding the dispatch.
+        x = self._make_prod_input(128, 8192, torch.float32)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = x.prod(dim=1)
+        with self._inner_tree_flag():
+            got = x.prod(dim=1)
+        self.assertFalse(torch.equal(got, ref))
+
+    def test_prod_override_out_variant(self):
+        x = self._make_prod_input(128, 8192, torch.float32)
+        with self._inner_tree_flag():
+            ref = x.prod(dim=1)
+            out = torch.empty(128, device="cuda", dtype=torch.float32)
+            torch.prod(x, dim=1, out=out)
+        # The out= path runs the same kernel as the functional path.
+        self.assertEqual(out, ref, rtol=0, atol=0)
+
+    def test_prod_strided_outer_input(self):
+        # Ragged tails must pad with the multiplicative identity (1), not 0;
+        # otherwise every row collapses to 0.
+        base = torch.ones(256, 32, device="cuda", dtype=torch.float32)
+        base[1::2, :] = 5
+        x = base[::2, :]
+        with self._inner_tree_flag():
+            result = x.prod(dim=1)
+        self.assertEqual(result, torch.ones(128, device="cuda", dtype=x.dtype))
+
+    def test_prod_looped_partial_last_block(self):
+        x = torch.ones(129, 256, device="cuda", dtype=torch.float32)
+        with self._inner_tree_flag():
+            result = x.prod(dim=1)
+        self.assertEqual(result, torch.ones(129, device="cuda", dtype=x.dtype))
+
+    def test_prod_deterministic(self):
+        x = self._make_prod_input(64, 12000, torch.float32)
+        with self._inner_tree_flag():
+            first = x.prod(dim=1)
+            second = x.prod(dim=1)
+        self.assertEqual(first, second, rtol=0, atol=0)
+
+    @parametrize("dtype", [torch.int64, torch.complex64])
+    def test_prod_integer_and_complex_fall_through(self, dtype):
+        x = torch.ones(17, 8192, device="cuda", dtype=dtype)
+        with self._inner_tree_flag():
+            result = x.prod(dim=1)
+        self.assertEqual(result, torch.ones(17, device="cuda", dtype=dtype))
+
 
 instantiate_parametrized_tests(TestSumCuteDSLOverride)
 

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -186,7 +186,7 @@ def _format_key(args: tuple, kwargs: dict, key_fn: Callable | None) -> str:
 
 def _make_wrapper(
     fn: Callable[..., R],
-    op: str,
+    op: str | Callable[..., str],
     dsl: str,
     key_fn: Callable[..., str] | None,
     sample: Callable[[], tuple[int | None, int | None]],
@@ -230,7 +230,7 @@ def _make_wrapper(
                 outcome = "compiled" if compiled else "cache_hit"
             _emit(
                 CompileEvent(
-                    op=op,
+                    op=op(*args, **kwargs) if callable(op) else op,
                     dsl=dsl,
                     outcome=outcome,
                     compiled=compiled,
@@ -267,7 +267,7 @@ def _cache_info_sampler(fn: Any) -> Callable[[], tuple[int | None, int | None]]:
 
 
 def instrument_cutedsl_compile(
-    op: str,
+    op: str | Callable[..., str],
     *,
     key_fn: Callable[..., str] | None = None,
 ) -> Callable[[Callable[..., R]], Callable[..., R]]:
@@ -469,7 +469,7 @@ def instrument_helion_kernel(
 
 
 def instrumented_cutedsl_cache(
-    op: str,
+    op: str | Callable[..., str],
     *,
     key_fn: Callable[..., str] | None = None,
 ) -> Callable[[Callable[..., R]], Callable[..., R]]:

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -228,9 +228,19 @@ def _make_wrapper(
                 outcome = "error"
             else:
                 outcome = "compiled" if compiled else "cache_hit"
+            if callable(op):
+                # A label callback must never change the wrapped fn's outcome:
+                # this runs in the finally block, so a raised exception would
+                # mask the real result/error. Fall back to a safe label.
+                try:
+                    op_label = op(*args, **kwargs)
+                except Exception:
+                    op_label = "<op-label-error>"
+            else:
+                op_label = op
             _emit(
                 CompileEvent(
-                    op=op(*args, **kwargs) if callable(op) else op,
+                    op=op_label,
                     dsl=dsl,
                     outcome=outcome,
                     compiled=compiled,
@@ -274,7 +284,11 @@ def instrument_cutedsl_compile(
     """Instrument a CuTeDSL (``@jit_cache``-decorated) compile function.
 
     Args:
-        op: Operator symbol being compiled for, e.g. ``"aten::topk"``.
+        op: Operator symbol being compiled for, e.g. ``"aten::topk"``. May
+            instead be a callable receiving the wrapped function's arguments
+            and returning the label per call; if that callable raises, the
+            label falls back to ``"<op-label-error>"`` without changing the
+            wrapped function's result or exception.
         key_fn: Optional callable with the wrapped function's signature
             returning a short string describing the compile key for logs.
             Defaults to a repr of the args/kwargs.

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -1,17 +1,21 @@
-"""CuTeDSL override registrations for ``aten::sum`` (inner-tree reduction).
+"""CuTeDSL override registrations for ``aten::sum`` / ``aten::prod`` (inner-tree).
 
-CuTeDSL port of the Triton-style inner-tree reduction sum kernel that
+CuTeDSL port of the Triton-style inner-tree reduction kernel that
 otherwise lives in ``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu``
 (``try_inner_tree_reduction`` + the inner-tree kernels). This override
 runs only when ``PYTORCH_SUM_INNER_TREE`` is set to a truthy value, which
-is the feature-rollout gate for this operator -- it is *not* gated by the
+is the feature-rollout gate for these operators -- it is *not* gated by the
 global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
 ``cutedsl_utils`` at registration time).
 
-We register two ATen dispatcher entries on ``CUDA``:
+We register four ATen dispatcher entries on ``CUDA``:
 
-* ``sum.dim_IntList`` -- functional/method ``x.sum(dim=...)``.
-* ``sum.IntList_out`` -- the structured ``.out`` target.
+* ``sum.dim_IntList`` / ``sum.IntList_out`` -- ``x.sum(dim=...)`` + ``.out``.
+* ``prod.dim_int`` / ``prod.int_out`` -- ``x.prod(dim=...)`` + ``.out``.
+
+sum/prod share the identical inner-tree geometry and eligibility; only the
+combiner (``+`` vs ``*``) and its identity (``0`` vs ``1``) differ, threaded
+through the kernel in ``inner_tree_kernel.py``.
 
 ``sum.dim_IntList`` is ``structured_delegate: sum.IntList_out``, so its
 delegation to the ``.out`` kernel happens *below* the dispatcher; overriding
@@ -211,45 +215,74 @@ def _out_cond(self, dim, keepdim=False, *, dtype=None, out) -> bool:
     return _eligibility(self, d, out_kd) is not None
 
 
-def _kernel():
+def _sum_into():
     from .inner_tree_kernel import inner_tree_sum_into
 
     return inner_tree_sum_into
 
 
-def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor) -> None:
-    """Run the kernel writing the reduction of ``self`` along ``d`` into the
-    keepdim-shaped ``out_kd``. Caller has validated eligibility."""
+def _prod_into():
+    from .inner_tree_kernel import inner_tree_prod_into
+
+    return inner_tree_prod_into
+
+
+def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
+    """Run ``reduce_into`` writing the reduction of ``self`` along ``d`` into
+    the keepdim-shaped ``out_kd``. Caller has validated eligibility."""
     it = _eligibility(self, d, out_kd)
     if it is None:
-        raise RuntimeError("sum cutedsl: cond approved but iter rebuild failed")
+        raise RuntimeError("cutedsl reduce: cond approved but iter rebuild failed")
     m, n, in_rs, out_rs = _geometry(self, out_kd, it)
     if m == 0 or n == 0:
         return
     in_2d = self.as_strided((m, n), (in_rs, 1))
     out_1d = out_kd.as_strided((m,), (out_rs,))
-    _kernel()(out_1d, in_2d)
+    reduce_into()(out_1d, in_2d)
 
 
-def _impl(self, dim, keepdim=False, *, dtype=None):
-    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
-    out_kd = torch.empty(
-        _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
-    )
-    _run(self, d, out_kd)
-    return out_kd if keepdim else out_kd.squeeze(d)
+def _make_impl(reduce_into):
+    def _impl(self, dim, keepdim=False, *, dtype=None):
+        d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+        out_kd = torch.empty(
+            _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
+        )
+        _run(self, d, out_kd, reduce_into)
+        return out_kd if keepdim else out_kd.squeeze(d)
+
+    return _impl
 
 
-def _out_impl(self, dim, keepdim=False, *, dtype=None, out):
-    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
-    out_kd = _out_keepdim_view(self, d, keepdim, out)
-    assert out_kd is not None  # noqa: S101  # _out_cond guarantees non-None
-    _run(self, d, out_kd)
-    return out
+def _make_out_impl(reduce_into):
+    def _out_impl(self, dim, keepdim=False, *, dtype=None, out):
+        d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+        out_kd = _out_keepdim_view(self, d, keepdim, out)
+        if out_kd is None:
+            # _out_cond guarantees a reduced-shape out; raise explicitly rather
+            # than assert so the invariant survives `python -O`.
+            raise AssertionError("_out_cond guaranteed a reduced-shape out")
+        _run(self, d, out_kd, reduce_into)
+        return out
+
+    return _out_impl
 
 
 def register_to_dispatch() -> None:
-    cu.register_op_override("aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_impl)
+    # Eligibility (_cond/_out_cond) is reduction-agnostic; only the kernel
+    # entry differs between sum and prod.
     cu.register_op_override(
-        "aten", "sum.IntList_out", "CUDA", cond=_out_cond, impl=_out_impl
+        "aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_make_impl(_sum_into)
+    )
+    cu.register_op_override(
+        "aten",
+        "sum.IntList_out",
+        "CUDA",
+        cond=_out_cond,
+        impl=_make_out_impl(_sum_into),
+    )
+    cu.register_op_override(
+        "aten", "prod.dim_int", "CUDA", cond=_cond, impl=_make_impl(_prod_into)
+    )
+    cu.register_op_override(
+        "aten", "prod.int_out", "CUDA", cond=_out_cond, impl=_make_out_impl(_prod_into)
     )

--- a/torch/_native/ops/reductions/inner_tree_kernel.py
+++ b/torch/_native/ops/reductions/inner_tree_kernel.py
@@ -43,6 +43,8 @@ identities, so this reproduces the ragged CUDA loop bit-for-bit.
 
 from __future__ import annotations
 
+from typing import NamedTuple, TYPE_CHECKING
+
 import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]  # noqa: TC002
 
 import cutlass
@@ -65,6 +67,10 @@ from .inner_tree_plan import (
     InnerTreeParams,
     vec_size as _vec_size,
 )
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 _MULTIROW_THREADS = 128
@@ -95,37 +101,64 @@ _ACC_TORCH_DTYPE = {
 
 
 # ---------------------------------------------------------------------------
+# Reduction combiners. ``op`` runs at trace time and keeps the existing
+# accumulator on the left so the emitted DAG order is unchanged for sum
+# (``a + b``) and mirrored for prod (``a * b``). ``identity`` is the value that
+# pads ragged tails and initializes accumulators -- 0.0 for sum (``x + 0 == x``)
+# and 1.0 for prod (``x * 1 == x``); using the wrong one corrupts every row.
+# ---------------------------------------------------------------------------
+
+
+def _add(a, b):
+    return a + b
+
+
+def _mul(a, b):
+    return a * b
+
+
+class _Reduction(NamedTuple):
+    name: str  # aten op name ("sum" / "prod"); disambiguates the compile cache
+    op: Callable  # trace-time combiner: _add / _mul
+    identity: float  # reduction identity: 0.0 for sum, 1.0 for prod
+
+
+_SUM = _Reduction("sum", _add, 0.0)
+_PROD = _Reduction("prod", _mul, 1.0)
+
+
+# ---------------------------------------------------------------------------
 # Trace-time reduction helpers. These run during ``cute.compile`` tracing and
 # emit the exact add DAG; ``vals`` / ``tree`` are Python lists of cute
 # ``Numeric`` register values.
 # ---------------------------------------------------------------------------
 
 
-def _linear_reduce(vals):
+def _linear_reduce(vals, op):
     acc = vals[0]
     for i in range(1, len(vals)):
-        acc = acc + vals[i]
+        acc = op(acc, vals[i])
     return acc
 
 
-def _inner_tree_reduce(vals):
+def _inner_tree_reduce(vals, op):
     v = list(vals)
     n = len(v)
     stride = 1
     while stride < n:
         i = 0
         while i + stride < n:
-            v[i] = v[i] + v[i + stride]
+            v[i] = op(v[i], v[i + stride])
             i += stride * 2
         stride *= 2
     return v[0]
 
 
-def _reduce_vec(vals, vec_size: int):
-    return _inner_tree_reduce(vals) if vec_size >= 4 else _linear_reduce(vals)
+def _reduce_vec(vals, vec_size: int, op):
+    return _inner_tree_reduce(vals, op) if vec_size >= 4 else _linear_reduce(vals, op)
 
 
-def _streaming_push(tree, val, load: int, max_depth: int) -> None:
+def _streaming_push(tree, val, load: int, max_depth: int, op) -> None:
     """Port of ``streaming_inner_tree_step``: merge count is the number of
     trailing zero bits of ``load + 1`` (``__ffs(load + 1) - 1``), capped at
     ``max_depth``. ``carry = tree_accs[--top] + carry`` keeps the existing
@@ -133,29 +166,32 @@ def _streaming_push(tree, val, load: int, max_depth: int) -> None:
     trailing_zeros = ((load + 1) & -(load + 1)).bit_length() - 1
     carry = val
     for _ in range(min(trailing_zeros, max_depth)):
-        carry = tree.pop() + carry
+        carry = op(tree.pop(), carry)
     tree.append(carry)
 
 
-def _warp_butterfly(val):
-    """Ascending-offset shuffle-XOR butterfly add reduce (matches the CUDA
+def _warp_butterfly(val, op):
+    """Ascending-offset shuffle-XOR butterfly reduce (matches the CUDA
     ``warp_reduce`` ASCENDING direction)."""
     offset = 1
     while offset < _WARP_SIZE:
-        val = val + cute.arch.shuffle_sync_bfly(
-            val, offset=offset, mask_and_clamp=_WARP_SIZE - 1
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=offset, mask_and_clamp=_WARP_SIZE - 1
+            ),
         )
         offset <<= 1
     return val
 
 
-def _load_vec_static(mIn, row, base: int, N: int, vec_size: int, acc, zero):
+def _load_vec_static(mIn, row, base: int, N: int, vec_size: int, acc, zero, op):
     """Load + reduce one vector group with compile-time ``base`` (multirow)."""
     vals = []
     for i in range(vec_size):
         off = base + i
         vals.append(acc(mIn[row, off]) if off < N else zero)
-    return _reduce_vec(vals, vec_size)
+    return _reduce_vec(vals, vec_size, op)
 
 
 @cute.jit
@@ -167,6 +203,7 @@ def _load_vec_dyn(
     vec_size: cutlass.Constexpr,
     acc: cutlass.Constexpr,
     zero,
+    op: cutlass.Constexpr,
 ):
     """Load + reduce one vector group with a runtime ``base`` (warp paths).
 
@@ -183,7 +220,7 @@ def _load_vec_dyn(
         if off < Int32(N):
             v = acc(mIn[row, off])
         vals.append(v)
-    return _reduce_vec(vals, vec_size)
+    return _reduce_vec(vals, vec_size, op)
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +229,7 @@ def _load_vec_dyn(
 # ---------------------------------------------------------------------------
 
 
-def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int):
+def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int, red: _Reduction):
     num_loads = _next_power_of_2(_ceil_div(N, vec_size))
 
     @cute.kernel
@@ -201,13 +238,13 @@ def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int):
         bx, _, _ = cute.arch.block_idx()
         row = bx * Int32(_MULTIROW_THREADS) + tx
         if row < num_outputs:
-            zero = acc(0.0)
+            zero = acc(red.identity)
             tree = []
             for load in cutlass.range_constexpr(num_loads):
                 val = _load_vec_static(
-                    mIn, row, load * vec_size, N, vec_size, acc, zero
+                    mIn, row, load * vec_size, N, vec_size, acc, zero, red.op
                 )
-                _streaming_push(tree, val, load, _MULTIROW_MAX_DEPTH)
+                _streaming_push(tree, val, load, _MULTIROW_MAX_DEPTH, red.op)
             mOut[row] = out_dt(tree[0])
 
     @cute.jit
@@ -225,7 +262,9 @@ def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int):
     return _launch
 
 
-def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
+def _make_looped(
+    in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams, red: _Reduction
+):
     wpr = p.num_warps  # warps_per_reduction == num_warps in launch_looped
     rows_per_block = p.rows_per_block
     total_warps = wpr * rows_per_block
@@ -259,7 +298,7 @@ def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
                 acc, cute.make_layout(total_warps), byte_alignment=8
             )
 
-        zero = acc(0.0)
+        zero = acc(red.identity)
         final_sum = zero
         for b in cutlass.range_constexpr(p.num_batches):
             batch_offset, remaining_c, lpw, warp_chunk = batches[b]
@@ -282,9 +321,10 @@ def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
                 v = zero
                 if Int32(load) < this_batch_loads:
                     v = _warp_butterfly(
-                        _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero)
+                        _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero, red.op),
+                        red.op,
                     )
-                _streaming_push(tree, v, load, p.depth)
+                _streaming_push(tree, v, load, p.depth, red.op)
             warp_acc = tree[0]
 
             if const_expr(wpr > 1):
@@ -295,11 +335,11 @@ def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
                 merged = zero
                 if lane < Int32(wpr):
                     merged = warp_writes[row_in_block * Int32(wpr) + lane]
-                warp_acc = _warp_butterfly(merged)
+                warp_acc = _warp_butterfly(merged, red.op)
                 if const_expr(b + 1 < p.num_batches):
                     cute.arch.barrier()
 
-            final_sum = final_sum + warp_acc
+            final_sum = red.op(final_sum, warp_acc)
 
         if row_active:
             if lane == Int32(0):
@@ -321,7 +361,9 @@ def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
     return _launch
 
 
-def _make_two_partial(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
+def _make_two_partial(
+    in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams, red: _Reduction
+):
     wpr = p.num_warps
     num_batches = p.num_batches
     wle = _WARP_SIZE * vec_size
@@ -373,16 +415,17 @@ def _make_two_partial(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreePar
             this_warp_elements = tail
         this_batch_loads = (this_warp_elements + Int32(wle - 1)) // Int32(wle)
 
-        zero = acc(0.0)
+        zero = acc(red.identity)
         tree = []
         for load in cutlass.range_constexpr(eff):
             base = warp_start + Int32(load * wle) + lane * Int32(vec_size)
             v = zero
             if Int32(load) < this_batch_loads:
                 v = _warp_butterfly(
-                    _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero)
+                    _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero, red.op),
+                    red.op,
                 )
-            _streaming_push(tree, v, load, p.depth)
+            _streaming_push(tree, v, load, p.depth, red.op)
         warp_acc = tree[0]
 
         if const_expr(wpr > 1):
@@ -393,7 +436,7 @@ def _make_two_partial(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreePar
             merged = zero
             if lane < Int32(wpr):
                 merged = warp_writes[lane]
-            warp_acc = _warp_butterfly(merged)
+            warp_acc = _warp_butterfly(merged, red.op)
 
         if lane == Int32(0):
             if warp_id == Int32(0):
@@ -417,7 +460,7 @@ def _make_two_partial(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreePar
     return _launch
 
 
-def _make_two_accum(acc, out_dt, num_batches: int):
+def _make_two_accum(acc, out_dt, num_batches: int, red: _Reduction):
     @cute.kernel
     def _kernel(mPartials: cute.Tensor, mOut: cute.Tensor, num_outputs: Int32):
         tx, _, _ = cute.arch.thread_idx()
@@ -433,7 +476,7 @@ def _make_two_accum(acc, out_dt, num_batches: int):
             # cute.compile blow up. Linear accumulation order matches the CUDA
             # kernel regardless of unroll.
             for b in cutlass.range(1, num_batches):
-                s = s + mPartials[base + b]
+                s = red.op(s, mPartials[base + b])
             mOut[row] = out_dt(s)
 
     @cute.jit
@@ -473,13 +516,15 @@ def _fake_1d_contig(dt):
 
 
 @instrumented_cutedsl_cache(
-    "aten::sum",
-    key_fn=lambda torch_dtype, N: f"multirow {torch_dtype} N={N}",
+    lambda red, *a, **k: f"aten::{red.name}",
+    key_fn=lambda red, torch_dtype, N: f"{red.name} multirow {torch_dtype} N={N}",
 )
-def _compile_multirow(torch_dtype: torch.dtype, N: int):
+def _compile_multirow(red: _Reduction, torch_dtype: torch.dtype, N: int):
     in_dt = _TORCH_TO_CUTE[torch_dtype]
     acc = _acc_for(in_dt)
-    launcher = _make_multirow(in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize))
+    launcher = _make_multirow(
+        in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize), red
+    )
     return cute.compile(
         launcher,
         _fake_2d(in_dt, N),
@@ -492,12 +537,13 @@ def _compile_multirow(torch_dtype: torch.dtype, N: int):
 
 
 @instrumented_cutedsl_cache(
-    "aten::sum",
-    key_fn=lambda torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
-        f"looped {torch_dtype} N={N} warps={num_warps} batches={num_batches}"
+    lambda red, *a, **k: f"aten::{red.name}",
+    key_fn=lambda red, torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
+        f"{red.name} looped {torch_dtype} N={N} warps={num_warps} batches={num_batches}"
     ),
 )
 def _compile_looped(
+    red: _Reduction,
     torch_dtype: torch.dtype,
     N: int,
     num_warps: int,
@@ -517,7 +563,9 @@ def _compile_looped(
         rows_per_block,
         effective_loads,
     )
-    launcher = _make_looped(in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize), p)
+    launcher = _make_looped(
+        in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize), p, red
+    )
     return cute.compile(
         launcher,
         _fake_2d(in_dt, N),
@@ -530,12 +578,14 @@ def _compile_looped(
 
 
 @instrumented_cutedsl_cache(
-    "aten::sum",
-    key_fn=lambda torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
-        f"two_partial {torch_dtype} N={N} warps={num_warps} batches={num_batches}"
+    lambda red, *a, **k: f"aten::{red.name}",
+    key_fn=lambda red, torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
+        f"{red.name} two_partial {torch_dtype} N={N} "
+        f"warps={num_warps} batches={num_batches}"
     ),
 )
 def _compile_two_partial(
+    red: _Reduction,
     torch_dtype: torch.dtype,
     N: int,
     num_warps: int,
@@ -554,7 +604,9 @@ def _compile_two_partial(
         1,
         effective_loads,
     )
-    launcher = _make_two_partial(in_dt, acc, acc, N, _vec_size(torch_dtype.itemsize), p)
+    launcher = _make_two_partial(
+        in_dt, acc, acc, N, _vec_size(torch_dtype.itemsize), p, red
+    )
     return cute.compile(
         launcher,
         _fake_2d(in_dt, N),
@@ -566,15 +618,15 @@ def _compile_two_partial(
 
 
 @instrumented_cutedsl_cache(
-    "aten::sum",
-    key_fn=lambda torch_dtype, num_batches: (
-        f"two_accum {torch_dtype} batches={num_batches}"
+    lambda red, *a, **k: f"aten::{red.name}",
+    key_fn=lambda red, torch_dtype, num_batches: (
+        f"{red.name} two_accum {torch_dtype} batches={num_batches}"
     ),
 )
-def _compile_two_accum(torch_dtype: torch.dtype, num_batches: int):
+def _compile_two_accum(red: _Reduction, torch_dtype: torch.dtype, num_batches: int):
     out_dt = _TORCH_TO_CUTE[torch_dtype]
     acc = _acc_for(out_dt)
-    launcher = _make_two_accum(acc, out_dt, num_batches)
+    launcher = _make_two_accum(acc, out_dt, num_batches, red)
     return cute.compile(
         launcher,
         _fake_1d_contig(acc),
@@ -586,8 +638,11 @@ def _compile_two_accum(torch_dtype: torch.dtype, num_batches: int):
     )
 
 
-def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
-    """Compute ``out[r] = sum(src[r, :])`` for every row ``r``.
+def _inner_tree_reduce_into(
+    out: torch.Tensor, src: torch.Tensor, red: _Reduction
+) -> None:
+    """Compute ``out[r] = reduce(src[r, :])`` for every row ``r`` in the
+    inner-tree order, where ``reduce`` is ``red`` (``sum`` or ``prod``).
 
     ``src`` is a 2D ``(M, N)`` view with inner-dim stride 1 (outer row stride
     may differ from N); ``out`` is a 1D ``(M,)`` view (its stride may differ
@@ -599,7 +654,7 @@ def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
     vec_size = _vec_size(dtype.itemsize)
 
     if n <= vec_size * _K_MULTIROW_MAX_LOADS:
-        compiled = _compile_multirow(dtype, n)
+        compiled = _compile_multirow(red, dtype, n)
         grid = _ceil_div(m, _MULTIROW_THREADS)
         compiled(src, out, m, grid)
         return
@@ -607,6 +662,7 @@ def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
     p = compute_inner_tree_params(n, m, vec_size)
     if p.num_batches <= _K_TWO_KERNEL_THRESHOLD:
         compiled = _compile_looped(
+            red,
             dtype,
             n,
             p.num_warps,
@@ -624,6 +680,7 @@ def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
         m * p.num_batches, dtype=_ACC_TORCH_DTYPE[dtype], device=src.device
     )
     c1 = _compile_two_partial(
+        red,
         dtype,
         n,
         p.num_warps,
@@ -633,5 +690,15 @@ def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
         p.effective_loads,
     )
     c1(src, partials, m * p.num_batches)
-    c2 = _compile_two_accum(dtype, p.num_batches)
+    c2 = _compile_two_accum(red, dtype, p.num_batches)
     c2(partials, out, m, _ceil_div(m, _ACCUM_THREADS))
+
+
+def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
+    """Row-wise inner-tree ``sum`` (see ``_inner_tree_reduce_into``)."""
+    _inner_tree_reduce_into(out, src, _SUM)
+
+
+def inner_tree_prod_into(out: torch.Tensor, src: torch.Tensor) -> None:
+    """Row-wise inner-tree ``prod`` (see ``_inner_tree_reduce_into``)."""
+    _inner_tree_reduce_into(out, src, _PROD)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192883
* #192995
* __->__ #192882

Extends the inner-tree reduction engine (shared `reductions` module) to
`aten::prod`, so `x.prod(dim=...)` is bit-for-bit deterministic in the same
inner-tree order as `sum` when `PYTORCH_SUM_INNER_TREE` is set. `prod` (and
`nansum`) were the flagged followups to the inner-tree `sum` work.

sum and prod share the entire inner-tree engine, tiling plan, and eligibility;
only two things differ, threaded through as a small `_Reduction(op, identity)`
descriptor:
- combiner: `+` (sum) vs `*` (prod)
- identity: `0.0` (sum) vs `1.0` (prod) -- pads ragged tails and initializes
  accumulators. Prod must pad with 1.0 (`x * 1 == x`); a 0.0 pad would collapse
  every row to 0.

`sum` keeps identical behavior via the `_SUM` defaults. The override registers
`prod.dim_int` / `prod.int_out`, reusing the reduction-agnostic eligibility
gate. fp32/fp64 are the bitwise-validated set; fp16/bf16 are functionally
supported (not part of the bitwise contract).

Compile instrumentation now labels each compile per-reduction (`aten::sum` vs
`aten::prod`) via a callable `op` label. Because the label is evaluated in the
instrumentation `finally` block, a failing label callback falls back to
`<op-label-error>` -- it never changes the wrapped compile's result or the
original exception.

Test Plan:
- `python test/python_native/test_sum_cutedsl.py` -- 22/22 pass.
  - prod matches ATen (product-appropriate tolerance) across the
    multirow/looped/two-kernel paths x fp32/fp64.
  - `test_prod_override_engaged` proves inner-tree prod differs bit-for-bit
    from the default ATen order (so the override actually ran).
  - `test_prod_low_precision_matches_aten` (fp16/bf16) spies on
    `inner_tree_prod_into` and asserts it was called -- proving the CuTeDSL
    kernel runs rather than silently falling back to ATen.
  - `out=` is bitwise-equal to the functional path; strided-outer and
    looped-partial-block confirm the 1.0 ragged-tail padding; determinism;
    int/complex fall through to ATen.
  - Sum regression: `test_bitwise` (27 shapes x 4 dtypes, SHA-pinned) and
    `test_cross_warp_order_sensitive_hash_sm100` hashes are unchanged.
- `python test/python_native/test_instrumentation.py` -- 35/35 pass, incl.
  callable-`op` label + label-failure-preserves-result/exception tests.