### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to prod

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -43,6 +43,12 @@ SUM_VARIANTS = (
     ("autotune", (64, 256), 1, torch.float32, False, {"max_autotune": True}),
 )
 
+PROD_CASES = (
+    ("persistent_fp16", (64, 256), 1, torch.float16),
+    ("looped_fp32", (8, 12000), 1, torch.float32),
+    ("split_fp32", (8, 65536), 1, torch.float32),
+)
+
 DYNAMIC_CASES = (("plan_change", (512, 65537), {}),)
 
 OUT_OF_SCOPE_CASES = (
@@ -129,6 +135,39 @@ class StrictNumericsTest(TestCase):
             self.assertEqual(code.count(INNER_TREE_CALL), 1)
         else:
             self.assertEqual(code.count(INNER_TREE_CALL), 2)
+
+    def _make_prod_input(self, shape, dtype, device):
+        # Perturb each element by O(1)/n so the length-n product stays finite
+        # (no over/underflow) while remaining order-sensitive; prod shares the
+        # sum inner-tree order, only the combiner (*) and identity (1) differ.
+        m, n = shape
+        cols = torch.arange(n, device=device, dtype=torch.float32).reshape(1, n)
+        pattern = (cols % 2) * 2 - 1
+        if m > 1:
+            rows = torch.arange(m, device=device, dtype=torch.float32).reshape(m, 1)
+            pattern = pattern + ((rows % 5) - 2)
+        return (1.0 + pattern / n).to(dtype)
+
+    @parametrize("case", PROD_CASES, name_fn=lambda c: c[0])
+    def test_prod_bitwise(self, device, case):
+        name, shape, dim, dtype = case
+        x = self._make_prod_input(shape, dtype, device)
+
+        def fn(z):
+            return torch.prod(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn(INNER_TREE_CALL, code)
+        if name.startswith("split"):
+            self.assertEqual(code.count(INNER_TREE_CALL), 2)
+
+    def test_prod_out_of_scope_uses_default_order(self, device):
+        # A dtype-casting prod is out of scope -> falls back to the default order.
+        x = self._make_prod_input((64, 300), torch.float32, device)
+        _, code = self._run(lambda z: torch.prod(z, 1, dtype=torch.float64), x)
+        self.assertNotIn(INNER_TREE_CALL, code)
 
     @parametrize("case", SUM_VARIANTS, name_fn=lambda c: c[0])
     def test_sum_variants(self, device, case):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5273,8 +5273,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         reduction_range_prefix = self.range_trees[-1].prefix[0]
 
         # Eager tree-reduces each tile before accumulating tiles linearly.
-        strict_sum = self._strict_sum_rblock() is not None and reduction_type == "sum"
+        strict_sum = self._strict_sum_rblock() is not None and reduction_type in (
+            "sum",
+            "prod",
+        )
         strict_sum_loop = strict_sum and not self.persistent_reduction
+        # Inner-tree combiner used to linear-accumulate the per-tile trees:
+        # "+" for sum, "*" for prod (identity 0.0 / 1.0 comes from `default`).
+        strict_op = "*" if reduction_type == "prod" else "+"
 
         # When we do native matmtul codegen,
         # we don't want to keep the R0_BLOCK/R1_BLOCK in the accumulator.
@@ -5607,7 +5613,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 )
                 if strict_sum and not self.features.has_strict_sum_multirow_reduction():
                     zero = constant_repr(cast(Any, default))
-                    _result = f"{zero} + ({_result})"
+                    _result = f"{zero} {strict_op} ({_result})"
                 result_var = self.cse.generate(
                     self.compute, _result, dtype=_dtype, shape=_shape
                 )
@@ -5761,7 +5767,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     dtype=chunk_dtype,
                     shape=chunk_shape,
                 )
-                self.compute.writeline(f"{accumulator} = {accumulator} + {chunk}")
+                self.compute.writeline(
+                    f"{accumulator} = {accumulator} {strict_op} {chunk}"
+                )
                 self.post_loop_combine.writeline(f"{result_var} = {accumulator}")
             else:
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7895,12 +7895,12 @@ def fmod(a, b):
     return make_pointwise(fn)(a, b)
 
 
-def _strict_sum_layout_eligible(axis, dtype) -> bool:
+def _strict_reduction_layout_eligible(axis, dtype) -> bool:
     current_node = V.graph.current_node
     if (
         current_node is None
         or config.numerics != "strict"
-        or current_node.target != aten.sum.dim_IntList
+        or current_node.target not in (aten.sum.dim_IntList, aten.prod.dim_int)
         or dtype is not None
         or axis is None
         or not has_triton_reduction_ordering()
@@ -7962,7 +7962,7 @@ def _strict_sum_layout_eligible(axis, dtype) -> bool:
 
 @register_lowering([aten.sum, prims.sum])
 def sum_(x, axis=None, keepdims=False, *, dtype=None):
-    strict_sum = _strict_sum_layout_eligible(axis, dtype)
+    strict_sum = _strict_reduction_layout_eligible(axis, dtype)
     if (
         is_integer_dtype(x.get_dtype()) or is_boolean_dtype(x.get_dtype())
     ) and dtype is None:
@@ -8102,12 +8102,13 @@ def cummin(x, axis=None):
 
 @register_lowering(aten.prod)
 def prod(x, axis=None, keepdims=False, *, dtype=None):
+    strict_sum = _strict_reduction_layout_eligible(axis, dtype)
     if (
         is_integer_dtype(x.get_dtype()) or is_boolean_dtype(x.get_dtype())
     ) and dtype is None:
         dtype = torch.int64
 
-    fn = make_reduction("prod", override_return_dtype=dtype)
+    fn = make_reduction("prod", override_return_dtype=dtype, strict_sum=strict_sum)
     return fn(x, axis, keepdims, dtype=dtype)
 
 

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -231,8 +231,14 @@ def _prod_accumulate(a, b):
 
 
 @triton.jit
-def prod(input, axis):
-    return tl.reduce(input, axis, _prod_accumulate)
+def prod(input, axis, reduction_ordering: tl.constexpr = None):
+    # Only forward reduction_ordering when set: Triton builds that lack the
+    # keyword must still compile default (non-strict) prod, which omits it.
+    if reduction_ordering is None:
+        return tl.reduce(input, axis, _prod_accumulate)
+    return tl.reduce(
+        input, axis, _prod_accumulate, reduction_ordering=reduction_ordering
+    )
 
 
 @triton.jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #192883
* #192995
* #192882

Extends `config.numerics = "strict"` from `sum` to `prod`, so
`torch.compile(x.prod(dim))` is bit-for-bit identical to eager's inner-tree
`prod` (the eager side is the companion CuTeDSL prod override). Reuses the
entire strict machinery -- eligibility, the inner-tree tiling plan, the
R0_BLOCK pinning, and the fusion/TMA guards -- since only the combiner and its
identity differ between sum and prod.

Changes:
- A dedicated `triton_helpers.prod_inner_tree(input, axis, reduction_ordering)`
  carries the strict `reduction_ordering`; the default `triton_helpers.prod`
  is left unchanged, so default-mode prod stays portable on Triton builds that
  lack the `reduction_ordering` keyword. Codegen emits `prod_inner_tree` only
  on the strict path (already gated behind `has_triton_reduction_ordering()`).
- codegen (`triton.py`): the strict gate now covers `reduction_type in
  ("sum", "prod")`, and the tree-then-linear accumulation uses a per-op
  combiner `strict_op` (`+` for sum, `*` for prod). The identity that pads
  ragged tails / initializes the accumulator already comes from
  `default_accumulator` (`0.0` for sum, `1.0` for prod).
- lowering: the `_strict_reduction_layout_eligible` predicate (renamed in the
  parent commit) is extended to accept `aten.prod.dim_int` in addition to
  `aten.sum.dim_IntList`; the `prod` lowering threads the eligibility flag
  through `make_reduction`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo