### PR TITLE
[CI] Split inductor_amx into 7 shards to stop timing out

### DIFF
--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -182,8 +182,9 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
         { include: [
-          { config: "inductor_amx", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
-          { config: "inductor_amx", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
         ]}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -182,9 +182,13 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       test-matrix: |
         { include: [
-          { config: "inductor_amx", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
-          { config: "inductor_amx", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
-          { config: "inductor_amx", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 1, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 2, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 3, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 4, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 5, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 6, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "inductor_amx", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
         ]}
       python-version: "3.10"
       compiler: gcc11


### PR DESCRIPTION
`inductor_amx` has been failing on main in roughly 80% of `inductor.yml` runs,
almost always as the only failing job in the workflow, and it is what fired the
"inductor is broken - 3 commits in a row" alert on 2026-08-11.

It is not a test regression. The shard no longer fits in its timeout.
`inductor-cpu-test` calls `_linux-test.yml` without passing `timeout-minutes`,
so it inherits the 240 minute default, and shard 1 has been consuming 80-90% of
that budget even on runs that pass:

| shard | conclusion | duration | % of 240min budget |
|---|---|---|---|
| 1 | failure | 217 min | 90% |
| 1 | success | 213 min | 89% |
| 1 | success | 207 min | 86% |
| 1 | success | 193 min | 80% |
| 2 | success | 186 min | 78% |
| 2 | success | 184 min | 77% |
| 2 | success | 173 min | 72% |
| 2 | success | 169 min | 70% |

With that little headroom any normal variance tips shard 1 over. The failure
signature is a timeout (`exit code 124` then SIGINT), not an assertion, and the
two tests that do report failures both pass when rerun in a new process.

Splitting 7 ways puts each shard near 58 minutes, about 24% of budget.

Sizing, after measuring the `Test` step in isolation rather than whole-job
wall clock: fixed per-shard overhead is only ~4 minutes (job 192min vs Test
step 188min), so the suite is ~375 minutes of real test work. 7 shards is
375/7 + 4 = ~58 min each.

I considered just raising `timeout-minutes`, but shard 2 is only ~20 minutes
behind shard 1, so that would leave both near the cliff and only delay a
recurrence as the suite grows. Resharding restores headroom for both.

Onset, for context:

| date | runs with an `inductor_amx` failure |
|---|---|
| 2026-08-05 | 0 / 8 |
| 2026-08-06 | 2 / 8 |
| 2026-08-07 | 0 / 8 |
| 2026-08-09 | 8 / 10 |

Separately worth flagging to whoever owns the alert: it auto-resolved 10 minutes
after firing while the breakage was ongoing. Because these jobs take 3.5-4 hours
to fail, completed-failure datapoints arrive too slowly to keep the alert's
window populated, so a timeout-shaped failure will be chronically
under-reported.

Real validation is post-merge: shard durations should drop to roughly 60
minutes and the job should stop hitting exit 124.

Authored with the assistance of an AI assistant.
