### PR TITLE
[Testcase Refactoring] Add hardware classification for test_micro_pipeline_tp.py

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -27,12 +27,15 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
-from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_device_type import (
+    Capability,
+    e4m3_type,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_LINUX,
-    parametrize,
     run_tests,
     TEST_WITH_ROCM,
     TEST_WITH_TORCHINDUCTOR,
@@ -40,7 +43,6 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import MLPModule
 from torch.testing._internal.distributed.fake_pg import FakeStore
-from torch.testing._internal.inductor_utils import HAS_GPU
 
 
 def _make_post_grad_fx(f, *inps):
@@ -63,15 +65,15 @@ def _fp8_all_gather(
     return torch.cat(chunks, dim=gather_dim).view(tensor.dtype)
 
 
-@instantiate_parametrized_tests
 class MicroPipelineTPTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         torch._inductor.config._micro_pipeline_tp = True
 
         self.rank = 0
         self.world_size = 2
-        torch.cuda.set_device("cuda:0")
 
         store = FakeStore()
         dist.init_process_group(
@@ -84,9 +86,15 @@ class MicroPipelineTPTest(TestCase):
     def tearDown(self):
         dist.destroy_process_group()
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def _init_device(self, device):
+        device_type = torch.device(device).type
+        torch.get_device_module(device_type).set_device(self.rank)
+        return device_type
+
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_find_all_gather_patterns(self):
+    def test_find_all_gather_patterns(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(
@@ -116,7 +124,7 @@ class MicroPipelineTPTest(TestCase):
             f = f_cat.narrow(1, 0, 32)
             return a, b, c, d, e, f
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device_type)
 
         gm = _make_post_grad_fx(func, inp)
         all_gathers = find_all_gather_patterns(gm.graph)
@@ -167,9 +175,10 @@ class MicroPipelineTPTest(TestCase):
             torch.ops.aten.slice.Tensor,
         )
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_find_reduce_scatter_patterns(self):
+    def test_find_reduce_scatter_patterns(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(
@@ -186,7 +195,7 @@ class MicroPipelineTPTest(TestCase):
             )
             return a, b, c
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device_type)
 
         gm = make_fx(func)(inp)
         reduce_scatters = find_reduce_scatter_patterns(gm.graph)
@@ -217,9 +226,10 @@ class MicroPipelineTPTest(TestCase):
         self.assertEqual(reduce_scatters[1].reduce_op, "avg")
         self.assertEqual(reduce_scatters[1].scatter_dim, 1)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_get_unexposed_collectives(self):
+    def test_get_unexposed_collectives(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(inp: torch.Tensor) -> torch.Tensor:
@@ -233,7 +243,7 @@ class MicroPipelineTPTest(TestCase):
             e = all_gather_single(d, gather_dim=0, group=group.group_name)
             return a, c, e
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device_type)
 
         gm = make_fx(func)(inp)
         overlappable_collectives = _get_unexposed_collectives(gm.graph)
@@ -242,57 +252,59 @@ class MicroPipelineTPTest(TestCase):
             ["all_gather_into_tensor", "reduce_scatter_tensor"],
         )
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @parametrize("A_dims", [2, 3])
-    @parametrize("gather_dim", [0, 1, 2])
-    @parametrize("return_A", [True, False])
+    @requires_capabilities(Capability.compile.inductor, Capability.lib.triton, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_all_gather_matmul(self, A_dims, gather_dim, return_A):
-        if gather_dim >= A_dims:
-            return
-
+    def test_fuse_all_gather_matmul(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
-        def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
-            A = all_gather_single(A_shard, gather_dim=gather_dim, group=group)
-            if return_A:
-                return A, A @ B
-            else:
-                return None, A @ B
+        for A_dims in [2, 3]:
+            for gather_dim in [0, 1, 2]:
+                for return_A in [True, False]:
+                    if gather_dim >= A_dims:
+                        continue
+                    with self.subTest(A_dims=A_dims, gather_dim=gather_dim, return_A=return_A):
+                        def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+                            A = all_gather_single(A_shard, gather_dim=gather_dim, group=group)
+                            if return_A:
+                                return A, A @ B
+                            else:
+                                return None, A @ B
 
-        if A_dims == 2:
-            A_shard_shape = [64, 32]
-        elif A_dims == 3:
-            A_shard_shape = [2, 64, 32]
-        else:
-            raise AssertionError(f"Invalid A_dims: {A_dims}")
+                        if A_dims == 2:
+                            A_shard_shape = [64, 32]
+                        elif A_dims == 3:
+                            A_shard_shape = [2, 64, 32]
+                        else:
+                            raise AssertionError(f"Invalid A_dims: {A_dims}")
 
-        A_shard_shape[gather_dim] //= self.world_size
-        A_shard = torch.rand(*A_shard_shape, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+                        A_shard_shape[gather_dim] //= self.world_size
+                        A_shard = torch.rand(*A_shard_shape, device=device_type)
+                        B = torch.rand(32, 16, device=device_type)
 
-        with _test_mode():
-            compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, A_shard, B)
+                        with _test_mode():
+                            compiled = torch.compile(func)
+                            code = run_and_get_triton_code(compiled, A_shard, B)
 
-            eager_stride = func(A_shard, B)[1].stride()
-            compiled_stride = compiled(A_shard, B)[1].stride()
-            self.assertEqual(eager_stride, compiled_stride)
+                            eager_stride = func(A_shard, B)[1].stride()
+                            compiled_stride = compiled(A_shard, B)[1].stride()
+                            self.assertEqual(eager_stride, compiled_stride)
 
-        if gather_dim == A_dims - 1:
-            # Gathering on the K dimension of the matmul -- fusion not supported.
-            self.assertNotIn("fused_all_gather_matmul", code)
-        else:
-            self.assertIn("fused_all_gather_matmul", code)
-            self.assertNotIn("all_gather_into_tensor", code)
-            self.assertEqual("return_A=True" in code, return_A)
+                        if gather_dim == A_dims - 1:
+                            # Gathering on the K dimension of the matmul -- fusion not supported.
+                            self.assertNotIn("fused_all_gather_matmul", code)
+                        else:
+                            self.assertIn("fused_all_gather_matmul", code)
+                            self.assertNotIn("all_gather_into_tensor", code)
+                            self.assertEqual("return_A=True" in code, return_A)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.lib.triton, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_all_gather_matmul_view_optimization(self):
+    def test_fuse_all_gather_matmul_view_optimization(self, device):
         """When batch=1 and gather_dim=1, _maybe_view_chunk_cat uses a view
         (no data movement), so the all_gather is optimized away entirely and
         there is no all_gather+matmul pattern to fuse."""
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -302,8 +314,8 @@ class MicroPipelineTPTest(TestCase):
         # batch=1: after all_gather, shape[0] == world_size == group_size,
         # so the view optimization in _maybe_view_chunk_cat applies.
         # Shard is [1, 32, 32], all_gather gives [2, 32, 32], view to [1, 64, 32].
-        A_shard = torch.rand(1, 32, 32, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A_shard = torch.rand(1, 32, 32, device=device_type)
+        B = torch.rand(32, 16, device=device_type)
 
         with _test_mode():
             compiled = torch.compile(func)
@@ -311,9 +323,10 @@ class MicroPipelineTPTest(TestCase):
 
         self.assertNotIn("fused_all_gather_matmul", code)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_all_gather_matmul_slice_cat(self):
+    def test_fuse_all_gather_matmul_slice_cat(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -328,11 +341,11 @@ class MicroPipelineTPTest(TestCase):
             )
             return A @ B
 
-        A_shard = torch.rand(64, 2048, device="cuda")
+        A_shard = torch.rand(64, 2048, device=device_type)
         torch._dynamo.decorators.mark_unbacked(
             A_shard, 0, hint_override=A_shard.shape[0]
         )
-        B = torch.rand(4096, 16, device="cuda")
+        B = torch.rand(4096, 16, device=device_type)
 
         gm = _make_post_grad_fx(func, A_shard, B)
         with _test_mode():
@@ -341,9 +354,10 @@ class MicroPipelineTPTest(TestCase):
         self.assertIn("fused_all_gather_matmul", str(gm.graph))
         self.assertNotIn("all_gather_into_tensor", str(gm.graph))
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_all_gather_matmul_slice_cat_trim(self):
+    def test_fuse_all_gather_matmul_slice_cat_trim(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -358,11 +372,11 @@ class MicroPipelineTPTest(TestCase):
             )
             return A.narrow(1, 0, 4096) @ B
 
-        A_shard = torch.rand(64, 2048, device="cuda")
+        A_shard = torch.rand(64, 2048, device=device_type)
         torch._dynamo.decorators.mark_unbacked(
             A_shard, 0, hint_override=A_shard.shape[0]
         )
-        B = torch.rand(4096, 16, device="cuda")
+        B = torch.rand(4096, 16, device=device_type)
 
         gm = _make_post_grad_fx(func, A_shard, B)
         with _test_mode():
@@ -371,109 +385,116 @@ class MicroPipelineTPTest(TestCase):
         self.assertIn("fused_all_gather_matmul", str(gm.graph))
         self.assertNotIn("all_gather_into_tensor", str(gm.graph))
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "Test requires FP8 support")
-    @parametrize("A_dims", [2, 3])
-    @parametrize("gather_dim", [0, 1, 2])
-    @parametrize("return_A", [True, False])
+    @requires_capabilities(
+        Capability.compile.inductor,
+        Capability.lib.triton,
+        Capability.distributed.backend,
+        Capability.dtype.fp8,
+    )
     @fresh_cache()
-    def test_fuse_all_gather_scaled_matmul(self, A_dims, gather_dim, return_A):
-        if gather_dim >= A_dims:
-            return
-
+    def test_fuse_all_gather_scaled_matmul(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
-        def func(
-            A_shard: torch.Tensor,
-            B: torch.Tensor,
-            A_scale: torch.Tensor,
-            B_scale: torch.Tensor,
-            out_dtype: torch.dtype | None,
-        ) -> torch.Tensor:
-            A = _fp8_all_gather(
-                A_shard, gather_dim=gather_dim, group_name=group.group_name
-            )
-            if len(A_shard.shape) > 2:
-                C = torch._scaled_mm(
-                    A.flatten(0, -2), B, A_scale, B_scale, out_dtype=out_dtype
-                )
-                C = C.view(*A.shape[:-1], -1)
-            else:
-                C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
+        for A_dims in [2, 3]:
+            for gather_dim in [0, 1, 2]:
+                for return_A in [True, False]:
+                    if gather_dim >= A_dims:
+                        continue
+                    with self.subTest(A_dims=A_dims, gather_dim=gather_dim, return_A=return_A):
+                        def func(
+                            A_shard: torch.Tensor,
+                            B: torch.Tensor,
+                            A_scale: torch.Tensor,
+                            B_scale: torch.Tensor,
+                            out_dtype: torch.dtype | None,
+                        ) -> torch.Tensor:
+                            A = _fp8_all_gather(
+                                A_shard, gather_dim=gather_dim, group_name=group.group_name
+                            )
+                            if len(A_shard.shape) > 2:
+                                C = torch._scaled_mm(
+                                    A.flatten(0, -2), B, A_scale, B_scale, out_dtype=out_dtype
+                                )
+                                C = C.view(*A.shape[:-1], -1)
+                            else:
+                                C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
 
-            if return_A:
-                return A, C
-            else:
-                return None, C
+                            if return_A:
+                                return A, C
+                            else:
+                                return None, C
 
-        if A_dims == 2:
-            A_shard_shape = [64, 32]
-        elif A_dims == 3:
-            A_shard_shape = [2, 64, 32]
-        else:
-            raise AssertionError(f"Invalid A_dims: {A_dims}")
+                        if A_dims == 2:
+                            A_shard_shape = [64, 32]
+                        elif A_dims == 3:
+                            A_shard_shape = [2, 64, 32]
+                        else:
+                            raise AssertionError(f"Invalid A_dims: {A_dims}")
 
-        A_shard_shape[gather_dim] //= self.world_size
-        A_shard = torch.rand(*A_shard_shape, device="cuda").to(e4m3_type)
-        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
-        A_scale = torch.tensor(0.1, device="cuda")
-        B_scale = torch.tensor(0.1, device="cuda")
+                        A_shard_shape[gather_dim] //= self.world_size
+                        A_shard = torch.rand(*A_shard_shape, device=device_type).to(e4m3_type)
+                        B = torch.rand(16, 32, device=device_type).to(e4m3_type).T
+                        A_scale = torch.tensor(0.1, device=device_type)
+                        B_scale = torch.tensor(0.1, device=device_type)
 
-        gm = _make_post_grad_fx(func, A_shard, B, A_scale, B_scale, torch.bfloat16)
-        with _test_mode():
-            micro_pipeline_tp_pass(gm.graph)
-        if gather_dim == A_dims - 1:
-            self.assertNotIn("fused_all_gather_scaled_matmul", str(gm.graph))
-            self.assertIn("all_gather_into_tensor", str(gm.graph))
-        else:
-            # Decomposing the matmul on the K dimension is not supported
-            self.assertIn("fused_all_gather_scaled_matmul", str(gm.graph))
-            self.assertNotIn("all_gather_into_tensor", str(gm.graph))
+                        gm = _make_post_grad_fx(func, A_shard, B, A_scale, B_scale, torch.bfloat16)
+                        with _test_mode():
+                            micro_pipeline_tp_pass(gm.graph)
+                        if gather_dim == A_dims - 1:
+                            self.assertNotIn("fused_all_gather_scaled_matmul", str(gm.graph))
+                            self.assertIn("all_gather_into_tensor", str(gm.graph))
+                        else:
+                            # Decomposing the matmul on the K dimension is not supported
+                            self.assertIn("fused_all_gather_scaled_matmul", str(gm.graph))
+                            self.assertNotIn("all_gather_into_tensor", str(gm.graph))
 
-        with _test_mode():
-            compiled = torch.compile(func)
-            code = run_and_get_triton_code(
-                compiled, A_shard, B, A_scale, B_scale, torch.bfloat16
-            )
-        if gather_dim == A_dims - 1:
-            self.assertNotIn("fused_all_gather_scaled_matmul", code)
-            self.assertIn("all_gather_into_tensor", code)
-        else:
-            # Decomposing the matmul on the K dimension is not supported
-            self.assertIn("fused_all_gather_scaled_matmul", code)
-            self.assertNotIn("all_gather_into_tensor", code)
+                        with _test_mode():
+                            compiled = torch.compile(func)
+                            code = run_and_get_triton_code(
+                                compiled, A_shard, B, A_scale, B_scale, torch.bfloat16
+                            )
+                        if gather_dim == A_dims - 1:
+                            self.assertNotIn("fused_all_gather_scaled_matmul", code)
+                            self.assertIn("all_gather_into_tensor", code)
+                        else:
+                            # Decomposing the matmul on the K dimension is not supported
+                            self.assertIn("fused_all_gather_scaled_matmul", code)
+                            self.assertNotIn("all_gather_into_tensor", code)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @parametrize("A_dims", [2, 3])
-    @parametrize("scatter_dim", [0, 1, 2])
+    @requires_capabilities(Capability.compile.inductor, Capability.lib.triton, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_matmul_reduce_scatter(self, A_dims, scatter_dim):
-        if scatter_dim >= A_dims:
-            return
-
+    def test_fuse_matmul_reduce_scatter(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
-        def func(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
-            return reduce_scatter_single(A @ B, "avg", scatter_dim, group)
+        for A_dims in [2, 3]:
+            for scatter_dim in [0, 1, 2]:
+                if scatter_dim >= A_dims:
+                    continue
+                with self.subTest(A_dims=A_dims, scatter_dim=scatter_dim):
+                    def func(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+                        return reduce_scatter_single(A @ B, "avg", scatter_dim, group)
 
-        if A_dims == 2:
-            A = torch.rand(64, 32, device="cuda")
-        elif A_dims == 3:
-            A = torch.rand(2, 64, 32, device="cuda")
-        else:
-            raise AssertionError(f"Invalid A_dims: {A_dims}")
-        B = torch.rand(32, 16, device="cuda")
+                    if A_dims == 2:
+                        A = torch.rand(64, 32, device=device_type)
+                    elif A_dims == 3:
+                        A = torch.rand(2, 64, 32, device=device_type)
+                    else:
+                        raise AssertionError(f"Invalid A_dims: {A_dims}")
+                    B = torch.rand(32, 16, device=device_type)
 
-        with _test_mode():
-            compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, A, B)
+                    with _test_mode():
+                        compiled = torch.compile(func)
+                        code = run_and_get_triton_code(compiled, A, B)
 
-        self.assertIn("fused_matmul_reduce_scatter", code)
-        self.assertNotIn("reduce_scatter_tensor", code)
+                    self.assertIn("fused_matmul_reduce_scatter", code)
+                    self.assertNotIn("reduce_scatter_tensor", code)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.compile.inductor, Capability.distributed.backend)
     @fresh_cache()
-    def test_fuse_matmul_reduce_scatter_slice_cat(self):
+    def test_fuse_matmul_reduce_scatter_slice_cat(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
         def func(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -488,8 +509,8 @@ class MicroPipelineTPTest(TestCase):
             )
             return reduce_scatter_tensor(C, "avg", 0, group)
 
-        A = torch.rand(64, 32, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A = torch.rand(64, 32, device=device_type)
+        B = torch.rand(32, 16, device=device_type)
         torch._dynamo.decorators.mark_unbacked(B, 1, hint_override=B.shape[1])
 
         gm = _make_post_grad_fx(func, A, B)
@@ -499,165 +520,178 @@ class MicroPipelineTPTest(TestCase):
         self.assertIn("fused_matmul_reduce_scatter", str(gm.graph))
         self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "Test requires FP8 support")
-    @parametrize("A_dims", [2, 3])
-    @parametrize("scatter_dim", [0, 1, 2])
+    @requires_capabilities(
+        Capability.compile.inductor,
+        Capability.lib.triton,
+        Capability.distributed.backend,
+        Capability.dtype.fp8,
+    )
     @fresh_cache()
-    def test_fuse_scaled_matmul_reduce_scatter(self, A_dims, scatter_dim):
-        if scatter_dim >= A_dims - 1:
-            return
-
+    def test_fuse_scaled_matmul_reduce_scatter(self, device):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
-        def func(
-            A: torch.Tensor,
-            B: torch.Tensor,
-            A_scale: torch.Tensor,
-            B_scale: torch.Tensor,
-            out_dtype: torch.dtype,
-        ) -> torch.Tensor:
-            if len(A.shape) > 2:
-                C = torch._scaled_mm(
-                    A.flatten(0, -2), B, A_scale, B_scale, out_dtype=out_dtype
-                )
-                C = C.view(*A.shape[:-1], B.shape[1])
-            else:
-                C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
-            return reduce_scatter_single(C, "avg", scatter_dim, group)
+        for A_dims in [2, 3]:
+            for scatter_dim in [0, 1, 2]:
+                if scatter_dim >= A_dims - 1:
+                    continue
+                with self.subTest(A_dims=A_dims, scatter_dim=scatter_dim):
+                    def func(
+                        A: torch.Tensor,
+                        B: torch.Tensor,
+                        A_scale: torch.Tensor,
+                        B_scale: torch.Tensor,
+                        out_dtype: torch.dtype,
+                    ) -> torch.Tensor:
+                        if len(A.shape) > 2:
+                            C = torch._scaled_mm(
+                                A.flatten(0, -2), B, A_scale, B_scale, out_dtype=out_dtype
+                            )
+                            C = C.view(*A.shape[:-1], B.shape[1])
+                        else:
+                            C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
+                        return reduce_scatter_single(C, "avg", scatter_dim, group)
 
-        if A_dims == 2:
-            A = torch.rand(64, 32, device="cuda").to(e4m3_type)
-        elif A_dims == 3:
-            A = torch.rand(2, 64, 32, device="cuda").to(e4m3_type)
-        else:
-            raise AssertionError(f"Invalid A_dims: {A_dims}")
-        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
-        A_scale = torch.tensor(0.1, device="cuda")
-        B_scale = torch.tensor(0.1, device="cuda")
+                    if A_dims == 2:
+                        A = torch.rand(64, 32, device=device_type).to(e4m3_type)
+                    elif A_dims == 3:
+                        A = torch.rand(2, 64, 32, device=device_type).to(e4m3_type)
+                    else:
+                        raise AssertionError(f"Invalid A_dims: {A_dims}")
+                    B = torch.rand(16, 32, device=device_type).to(e4m3_type).T
+                    A_scale = torch.tensor(0.1, device=device_type)
+                    B_scale = torch.tensor(0.1, device=device_type)
 
-        gm = _make_post_grad_fx(func, A, B, A_scale, B_scale, torch.bfloat16)
-        with _test_mode():
-            micro_pipeline_tp_pass(gm.graph)
-        self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
-        self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
+                    gm = _make_post_grad_fx(func, A, B, A_scale, B_scale, torch.bfloat16)
+                    with _test_mode():
+                        micro_pipeline_tp_pass(gm.graph)
+                    self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
+                    self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
-        with _test_mode():
-            compiled = torch.compile(func)
-            code = run_and_get_triton_code(
-                compiled, A, B, A_scale, B_scale, torch.bfloat16
-            )
-        self.assertIn("fused_scaled_matmul_reduce_scatter", code)
-        self.assertNotIn("reduce_scatter_tensor", code)
+                    with _test_mode():
+                        compiled = torch.compile(func)
+                        code = run_and_get_triton_code(
+                            compiled, A, B, A_scale, B_scale, torch.bfloat16
+                        )
+                    self.assertIn("fused_scaled_matmul_reduce_scatter", code)
+                    self.assertNotIn("reduce_scatter_tensor", code)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "Test requires FP8 support")
-    @parametrize("scatter_dim", [0, 1])
+    @requires_capabilities(
+        Capability.compile.inductor,
+        Capability.lib.triton,
+        Capability.distributed.backend,
+        Capability.dtype.fp8,
+    )
     @fresh_cache()
     def test_fuse_scaled_matmul_reduce_scatter_rowwise_scales_reshape_mm_reshape(
-        self, scatter_dim
+        self, device
     ):
+        device_type = self._init_device(device)
         group = dist.group.WORLD
 
-        def reshape_mm_reshape(
-            A: torch.Tensor,
-            B: torch.Tensor,
-            A_scale: torch.Tensor,
-            B_scale: torch.Tensor,
-            out_dtype: torch.dtype,
-        ) -> torch.Tensor:
-            """
-            Performs a scaled_mm followed by a reduce scatter,
-            following the reshape -> scaled_mm -> reshape pattern.
-            """
-            orig_shape = A.shape
+        for scatter_dim in [0, 1]:
+            with self.subTest(scatter_dim=scatter_dim):
+                def reshape_mm_reshape(
+                    A: torch.Tensor,
+                    B: torch.Tensor,
+                    A_scale: torch.Tensor,
+                    B_scale: torch.Tensor,
+                    out_dtype: torch.dtype,
+                ) -> torch.Tensor:
+                    """
+                    Performs a scaled_mm followed by a reduce scatter,
+                    following the reshape -> scaled_mm -> reshape pattern.
+                    """
+                    orig_shape = A.shape
 
-            # reshape tensor and scale together
-            A = A.reshape(-1, orig_shape[-1])
-            A_scale = A_scale.reshape(-1, A_scale.shape[-1])
-            A_scale = torch.reciprocal(A_scale)
+                    # reshape tensor and scale together
+                    A = A.reshape(-1, orig_shape[-1])
+                    A_scale = A_scale.reshape(-1, A_scale.shape[-1])
+                    A_scale = torch.reciprocal(A_scale)
 
-            C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
+                    C = torch._scaled_mm(A, B, A_scale, B_scale, out_dtype=out_dtype)
 
-            # reshape output to have same leading dims as original `A` tensor
-            C = C.view(*orig_shape[:-1], C.shape[-1])
-            return reduce_scatter_single(C, "sum", scatter_dim, group)
+                    # reshape output to have same leading dims as original `A` tensor
+                    C = C.view(*orig_shape[:-1], C.shape[-1])
+                    return reduce_scatter_single(C, "sum", scatter_dim, group)
 
-        A = torch.rand(2, 16, 32, device="cuda").to(e4m3_type)
-        B = torch.rand(64, 32, device="cuda").to(e4m3_type).T
+                A = torch.rand(2, 16, 32, device=device_type).to(e4m3_type)
+                B = torch.rand(64, 32, device=device_type).to(e4m3_type).T
 
-        # A_scale = rowwise scales
-        A_scale = torch.full((2, 16, 1), 0.1, device="cuda")
+                # A_scale = rowwise scales
+                A_scale = torch.full((2, 16, 1), 0.1, device=device_type)
 
-        # B_scale = rowwise scales transposed for A @ B^T
-        B_scale = torch.full((1, 64), 0.1, device="cuda")
+                # B_scale = rowwise scales transposed for A @ B^T
+                B_scale = torch.full((1, 64), 0.1, device=device_type)
 
-        gm = _make_post_grad_fx(
-            reshape_mm_reshape, A, B, A_scale, B_scale, torch.bfloat16
-        )
+                gm = _make_post_grad_fx(
+                    reshape_mm_reshape, A, B, A_scale, B_scale, torch.bfloat16
+                )
 
-        with _test_mode():
-            micro_pipeline_tp_pass(gm.graph)
+                with _test_mode():
+                    micro_pipeline_tp_pass(gm.graph)
 
-        self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
-        self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
+                self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
+                self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
-        if torch.cuda.get_device_capability() < (8, 9):
-            return
+                if torch.get_device_module(device_type).get_device_capability() < (8, 9):
+                    continue
 
-        with _test_mode():
-            compiled = torch.compile(reshape_mm_reshape)
-            code = run_and_get_triton_code(
-                compiled, A, B, A_scale, B_scale, torch.bfloat16
-            )
-        self.assertIn("fused_scaled_matmul_reduce_scatter", code)
-        self.assertNotIn("reduce_scatter_tensor", code)
+                with _test_mode():
+                    compiled = torch.compile(reshape_mm_reshape)
+                    code = run_and_get_triton_code(
+                        compiled, A, B, A_scale, B_scale, torch.bfloat16
+                    )
+                self.assertIn("fused_scaled_matmul_reduce_scatter", code)
+                self.assertNotIn("reduce_scatter_tensor", code)
 
+    @requires_capabilities(Capability.compile.inductor, Capability.lib.triton, Capability.distributed.backend)
     @unittest.skipIf(
         TEST_WITH_TORCHINDUCTOR or IS_LINUX or TEST_WITH_ROCM,
         "https://github.com/pytorch/pytorch/issues/153223",
     )
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/145924")
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @parametrize("shard_dim", [0, 1])
     @fresh_cache()
-    def test_dtensor_seq_par(self, shard_dim: int):
-        model: torch.nn.Module = MLPModule(device="cuda", bias=False)
-        device_mesh = DeviceMesh(
-            "cuda",
-            torch.arange(0, self.world_size),
-        )
-        parallelize_plan = {
-            "net1": ColwiseParallel(input_layouts=Shard(shard_dim)),
-            "net2": RowwiseParallel(output_layouts=Shard(shard_dim)),
-        }
-        model = parallelize_module(model, device_mesh, parallelize_plan)
-        if shard_dim == 0:
-            inp = torch.rand(8, 10, device="cuda")
-        elif shard_dim == 1:
-            inp = torch.rand(2, 8, 10, device="cuda")
-        else:
-            raise AssertionError("Invalid shard_dim")
+    def test_dtensor_seq_par(self, device):
+        device_type = self._init_device(device)
+        for shard_dim in [0, 1]:
+            with self.subTest(shard_dim=shard_dim):
+                model: torch.nn.Module = MLPModule(device=device_type, bias=False)
+                device_mesh = DeviceMesh(
+                    device_type,
+                    torch.arange(0, self.world_size),
+                )
+                parallelize_plan = {
+                    "net1": ColwiseParallel(input_layouts=Shard(shard_dim)),
+                    "net2": RowwiseParallel(output_layouts=Shard(shard_dim)),
+                }
+                model = parallelize_module(model, device_mesh, parallelize_plan)
+                if shard_dim == 0:
+                    inp = torch.rand(8, 10, device=device_type)
+                elif shard_dim == 1:
+                    inp = torch.rand(2, 8, 10, device=device_type)
+                else:
+                    raise AssertionError("Invalid shard_dim")
 
-        with _test_mode():
-            compiled = torch.compile(model)
-            code = run_and_get_triton_code(compiled, inp)
+                with _test_mode():
+                    compiled = torch.compile(model)
+                    code = run_and_get_triton_code(compiled, inp)
 
-        self.assertIn("fused_all_gather_matmul", code)
-        self.assertNotIn("all_gather_into_tensor", code)
-        self.assertIn("fused_matmul_reduce_scatter", code)
-        self.assertNotIn("reduce_scatter_tensor", code)
+                self.assertIn("fused_all_gather_matmul", code)
+                self.assertNotIn("all_gather_into_tensor", code)
+                self.assertIn("fused_matmul_reduce_scatter", code)
+                self.assertNotIn("reduce_scatter_tensor", code)
 
 
-@instantiate_parametrized_tests
 class MicroPipelineTP4GPUTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         torch._inductor.config._micro_pipeline_tp = True
 
         self.rank = 0
         self.world_size = 4
-        torch.cuda.set_device("cuda:0")
 
         store = FakeStore()
         dist.init_process_group(
@@ -670,12 +704,18 @@ class MicroPipelineTP4GPUTest(TestCase):
     def tearDown(self):
         dist.destroy_process_group()
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def _init_device(self, device):
+        device_type = torch.device(device).type
+        torch.get_device_module(device_type).set_device(self.rank)
+        return device_type
+
+    @requires_capabilities(Capability.compile.inductor, Capability.lib.triton, Capability.distributed.backend)
     @fresh_cache()
     @torch._inductor.config.patch(shape_padding=False)
-    def test_extra_collectives(self):
+    def test_extra_collectives(self, device):
+        device_type = self._init_device(device)
         device_mesh = DeviceMesh(
-            "cuda",
+            device_type,
             torch.arange(0, self.world_size).view(2, -1),
             mesh_dim_names=("tp", "other"),
         )
@@ -687,9 +727,9 @@ class MicroPipelineTP4GPUTest(TestCase):
             hidden = reduce_scatter_single(full_hidden, "avg", 0, (device_mesh, 1))
             return reduce_scatter_single(hidden @ w2.t(), "avg", 0, (device_mesh, 0))
 
-        inp = torch.rand(8, 10, device="cuda")
-        w1 = torch.rand(7, 10, device="cuda")
-        w2 = torch.rand(10, 7, device="cuda")
+        inp = torch.rand(8, 10, device=device_type)
+        w1 = torch.rand(7, 10, device=device_type)
+        w2 = torch.rand(10, 7, device=device_type)
 
         with _test_mode(group_names={device_mesh["tp"].get_group().group_name}):
             compiled = torch.compile(func)
@@ -700,6 +740,20 @@ class MicroPipelineTP4GPUTest(TestCase):
         self.assertIn("fused_matmul_reduce_scatter", code)
         self.assertIn("reduce_scatter_tensor", code)
 
+
+instantiate_device_type_tests(
+    MicroPipelineTPTest,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True
+)
+
+instantiate_device_type_tests(
+    MicroPipelineTP4GPUTest,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary:

1. Add hardware classification for `test_micro_pipeline_tp.py` and classify `MicroPipelineTPTest` and `MicroPipelineTP4GPUTest` as `ACCELERATOR`.
2. Add test classed instantiating.

## Changes:

1. Set `hw_classification = HardwareClassification.ACCELERATOR` on `MicroPipelineTPTest` and `MicroPipelineTP4GPUTest`, remove the skipping logic when `HAS_GPU` is not satisfied, use `instantiate_device_type_tests` to instantiate the test class on specific devices instead.
2. Inject `device` param into ACCELERATOR test class.
3. Replace test skip logic with capability-based test skip mechanism.
4. Move device initialization from `setUp` to test cases.

## Test Plan:
  `python test/distributed/tensor/parallel/test_micro_pipeline_tp.py`

This PR depends on the following PR:

- PR #194039 , which registers triton related capability.
- PR #192875 , which registers backend and inductor related capability.