### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -4,8 +4,12 @@ from torch._inductor import config, metrics
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import collect_defined_kernels
 from torch._inductor.wrapper_benchmark import get_kernel_category_by_source_code
-from torch.testing._internal.common_device_type import largeTensorTest
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    largeTensorTest,
+)
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 
 example_kernel = """
@@ -50,42 +54,53 @@ def triton_red_fused_add_sum_2(in_out_ptr0, in_ptr0, xnumel, rnumel, XBLOCK : tl
     tmp5 = tmp4 + tmp2
     tl.debug_barrier()
     tl.store(in_out_ptr0 + (x0), tmp5, xmask)
-""".replace("GPU_TYPE", GPU_TYPE)
+"""
+
+
+def replace_device_type(kernel_src, device):
+    device_type = torch.device(device).type
+    return kernel_src.replace("GPU_TYPE", device_type)
 
 
 class TestMetrics(TestCase):
-    def test_parse_proper_kernel_fn_code(self):
-        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_parse_proper_kernel_fn_code(self, device):
+        new_kernel = replace_device_type(example_kernel, device)
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(new_kernel)
         if not proper_kernel_fn_code.startswith("def "):
             raise AssertionError
 
-    def test_count_args(self):
-        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+    def test_count_args(self, device):
+        new_kernel = replace_device_type(example_kernel, device)
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(new_kernel)
         self.assertEqual(6, metrics._count_args(proper_kernel_fn_code))
 
-    def test_count_pattern(self):
-        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+    def test_count_pattern(self, device):
+        new_kernel = replace_device_type(example_kernel, device)
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(new_kernel)
         self.assertEqual(2, metrics._count_pattern(proper_kernel_fn_code, "tl.load"))
         self.assertEqual(1, metrics._count_pattern(proper_kernel_fn_code, "tl.store"))
         self.assertEqual(1, metrics._count_pattern(proper_kernel_fn_code, "for "))
 
-    def test_parse_reduction_hint(self):
-        kernel_category = get_kernel_category_by_source_code(example_kernel)
+    def test_parse_reduction_hint(self, device):
+        new_kernel = replace_device_type(example_kernel, device)
+        kernel_category = get_kernel_category_by_source_code(new_kernel)
         self.assertEqual("reduction", kernel_category)
         self.assertEqual(
-            "INNER", metrics._parse_reduction_hint(kernel_category, example_kernel)
+            "INNER", metrics._parse_reduction_hint(kernel_category, new_kernel)
         )
 
     @config.patch("fx_graph_remote_cache", False)
     @config.patch("partitioned_scatter_enabled", False)
-    def test_atomic_add(self):
+    def test_atomic_add(self, device):
         @torch.compile
         def f(lhs, index, rhs):
             return lhs.index_put_([index], rhs, accumulate=True)
 
-        lhs = torch.randn(1024, device=GPU_TYPE)
-        index = torch.randint(0, 1024, [32], device=GPU_TYPE, dtype=torch.int32)
-        rhs = torch.randn(32, device=GPU_TYPE)
+        lhs = torch.randn(1024, device=device)
+        index = torch.randint(0, 1024, [32], device=device, dtype=torch.int32)
+        rhs = torch.randn(32, device=device)
 
         kernel_list = []
         with collect_defined_kernels(kernel_list):
@@ -95,15 +110,15 @@ class TestMetrics(TestCase):
         kernel_code = kernel_list[0]
         self.assertEqual(metrics._count_pattern(kernel_code, "tl.atomic_add"), 1)
 
-    @largeTensorTest(25e7 * 2 * 4, device=GPU_TYPE, inductor=True)
+    @largeTensorTest(25e7 * 2 * 4, inductor=True)
     @config.patch("fx_graph_remote_cache", False)
     @config.patch("benchmark_kernel", True)
-    def test_kernel_args_num_gb(self):
+    def test_kernel_args_num_gb(self, device):
         @torch.compile
         def f(x):
             return x + 1
 
-        x = torch.randn(int(25e7), device=GPU_TYPE)
+        x = torch.randn(int(25e7), device=device)
         kernel_list = []
         with collect_defined_kernels(kernel_list):
             f(x)
@@ -115,6 +130,9 @@ class TestMetrics(TestCase):
         )
 
 
+instantiate_device_type_tests(TestMetrics, globals(), except_for="cpu", allow_xpu=True)
+
+
 if __name__ == "__main__":
-    if HAS_GPU:
+    if has_triton():
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_metrics.py
python test/inductor/test_metrics.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo