### PR TITLE
[Testcase Refactoring] Classify Dynamo decomposition tests by hardware

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -923,11 +923,7 @@ class TestDynamoDecompositionsCUDAOnly(TestCase):
         self.assertEqual(expected, actual)
 
 
-instantiate_device_type_tests(
-    TestDynamoDecompositionsNumerics,
-    globals(),
-    allow_xpu=True,
-)
+instantiate_device_type_tests(TestDynamoDecompositionsNumerics, globals())
 instantiate_device_type_tests(
     TestDynamoDecompositionsCUDAOnly,
     globals(),

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -4,10 +4,7 @@ import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    skipCPUIf,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -793,7 +790,6 @@ class TestDynamoDecompositionsNumerics(TestCase):
         actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual, atol=0, rtol=0)
 
-    @skipCPUIf(True, "accelerator fma numerics")
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_add_tensor_alpha_fma_matches_aten(self, device):
@@ -867,6 +863,26 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_add_scalar_alpha(self, device):
+        """Compiled add_ with scalar alpha matches eager."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device=device)
+        other = torch.randn(64, 64, device=device)
+
+        def fn(x, other):
+            return x.add_(other, alpha=2.3)
+
+        expected = fn(x.clone(), other)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)  # noqa: UNSPECIFIED_BACKEND
+        self.assertEqual(expected, actual)
+
+
+@xfailIfNoAcceleratorTriton
+class TestDynamoDecompositionsCUDAOnly(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_addcdiv_scalar_value_cuda(self, device):
         """Compiled addcdiv_ with scalar value matches eager on CUDA.
 
@@ -906,26 +922,16 @@ class TestDynamoDecompositionsNumerics(TestCase):
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
-    @skipIfCrossRef
-    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    def test_add_scalar_alpha(self, device):
-        """Compiled add_ with scalar alpha matches eager."""
-        torch.manual_seed(42)
-        x = torch.randn(64, 64, device=device)
-        other = torch.randn(64, 64, device=device)
-
-        def fn(x, other):
-            return x.add_(other, alpha=2.3)
-
-        expected = fn(x.clone(), other)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)  # noqa: UNSPECIFIED_BACKEND
-        self.assertEqual(expected, actual)
-
 
 instantiate_device_type_tests(
     TestDynamoDecompositionsNumerics,
     globals(),
     allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestDynamoDecompositionsCUDAOnly,
+    globals(),
+    only_for="cuda",
 )
 
 if __name__ == "__main__":

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -1,13 +1,15 @@
 # Owner(s): ["module: dynamo"]
 
-import unittest
-
 import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipCPUIf,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfCrossRef,
     TestCase,
@@ -22,6 +24,8 @@ class TestDynamoDecompositions(torch._dynamo.test_case.TestCase):
     into their constituent ops to avoid item() graph breaks.
     When False, the original ops are preserved.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfCrossRef
     def test_addcmul_inplace_decomposition_enabled(self):
@@ -611,6 +615,8 @@ class GraphModule(torch.nn.Module):
 class TestDynamoDecompositionsNumerics(TestCase):
     """Numerics tests for dynamo decompositions across devices."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_addcmul_tensor_value_numerics(self, device):
@@ -787,6 +793,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
         actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual, atol=0, rtol=0)
 
+    @skipCPUIf(True, "accelerator fma numerics")
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_add_tensor_alpha_fma_matches_aten(self, device):
@@ -860,7 +867,6 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcdiv_scalar_value_cuda(self, device):
         """Compiled addcdiv_ with scalar value matches eager on CUDA.
 
@@ -881,7 +887,6 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_addcdiv_tensor_value_cuda(self, device):
         """Compiled addcdiv_ with tensor value matches eager on CUDA.
 
@@ -917,7 +922,11 @@ class TestDynamoDecompositionsNumerics(TestCase):
         self.assertEqual(expected, actual)
 
 
-instantiate_device_type_tests(TestDynamoDecompositionsNumerics, globals())
+instantiate_device_type_tests(
+    TestDynamoDecompositionsNumerics,
+    globals(),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Classifies Dynamo decomposition tests with hardware metadata and keeps accelerator numerics coverage device-generic where applicable.

## Changes
- Add HardwareClassification coverage for Dynamo decomposition test classes.
- Replace CUDA-only skips with device-type test coverage for supported accelerators.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_dynamo_decompositions.py
python -m py_compile test/dynamo/test_dynamo_decompositions.py
git diff --check -- test/dynamo/test_dynamo_decompositions.py
```

### Environment
| Item | Version |
|------|---------|
| PyTorch | 2.14.0+gitee7bc39 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98