### PR TITLE
[inductor] Add lazy initialization hook for PrivateUse1 backends

### DIFF
--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -57,6 +57,60 @@ Define the initialization hook `_autoload` for backend initialization in [torch_
 
 ::::
 
+### Lazy Inductor Backend Initialization
+
+Integrating with torch.compile typically means registering device-specific codegen
+classes, decompositions, and passes with Inductor. Doing all of that inside `_autoload`
+would make every user pay the cost at `import torch`, even those who never compile.
+To defer it, define an `_inductor_backend_init` method on the device module class
+passed to `torch._register_device_module`: a no-arg callable that Inductor invokes at
+the first Inductor compilation, on every entry point (`torch.compile`, direct
+`compile_fx()`, and AOTInductor), and again on later compilations until it has
+registered the device. Until registration succeeds, backend-feature queries may
+invoke the hook multiple times within one compilation, so the hook must be safe
+and cheap to retry. Inductor looks it up with
+a plain attribute lookup, so it works the same whether the device module is a class
+(methods, as below) or a module object (attribute assignment).
+
+```python
+from torch._inductor.codegen.common import register_backend_for_device
+
+
+class MyDeviceModule:
+    # ... other device module APIs (is_available, device_count, ...)
+
+    @staticmethod
+    def _inductor_backend_init():
+        # Runs on the first inductor compile, not at import time.
+        from my_backend._inductor import MyCppWrapperCodegen, MyScheduling, MyWrapperCodegen
+
+        register_backend_for_device(
+            "my_device", MyScheduling, MyWrapperCodegen, MyCppWrapperCodegen
+        )
+        # May also register decompositions, device op overrides, and custom passes.
+
+
+torch.utils.rename_privateuse1_backend("my_device")
+torch._register_device_module("my_device", MyDeviceModule)
+```
+
+The hook must call `register_backend_for_device` itself; that registration is
+what stops Inductor from invoking the hook again on later compilations. Concurrent
+callers wait for an in-flight hook invocation to finish. Because the hook runs
+under Dynamo's compile lock, it must not wait on another thread that may import the
+same integration or invoke `torch.compile`, and it should not fork. If the hook
+raises, the exception propagates
+out of the compile, and the hook is invoked again on the next compile unless it
+registered the device before raising. Note that the hook is not gated on the
+compiled device: while the device is unregistered it fires on every Inductor
+compile, whichever device that graph targets. On the `compile_fx` paths, the hook
+runs before that compilation selects its decomposition table.
+
+Device modules that instead expose `Scheduling`, `PythonWrapperCodegen`, and
+`CppWrapperCodegen` attributes directly are still supported, but that form imports
+the codegen classes eagerly at `import torch`. A device that is already registered
+(for example eagerly from `_autoload`) skips the hook entirely.
+
 ## Result
 
 After setting up the entry point and backend, build and install your backend. Now, we can use the new accelerator without explicitly importing it.

--- a/test/inductor/test_device_backends.py
+++ b/test/inductor/test_device_backends.py
@@ -1,0 +1,392 @@
+# Owner(s): ["module: inductor"]
+import sys
+import threading
+import types
+from unittest import mock
+
+import torch
+import torch.fx
+from torch._inductor.codegen import common
+from torch._inductor.codegen.common import (
+    get_scheduling_for_device,
+    init_backend_registration,
+    register_backend_for_device,
+)
+from torch._inductor.test_case import TestCase
+
+
+class DeviceBackendInitTest(TestCase):
+    """
+    Tests the optional ``_inductor_backend_init`` hook: a no-arg callable on a
+    privateuse1 device module (the one registered via
+    ``torch._register_device_module``).  Inductor invokes it on each compile
+    while the device is unregistered (on the ``compile_fx`` paths, before the
+    decomposition table is selected); the hook must register the device via
+    ``register_backend_for_device`` itself, which is what stops the
+    re-invocation.
+    """
+
+    device = "fakedevice"
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Ensure the once-per-process built-in registration has run before
+        # snapshotting, so tearDown only removes what each test added.
+        common._init_builtin_backend_registration()
+        self._orig_codegen = dict(common.device_codegens)
+        self._orig_custom_passes = dict(common.custom_backend_passes)
+        self._orig_custom_configs = dict(common.custom_backend_codegen_configs)
+        common._privateuse1_backend_init_in_progress = False
+
+    def tearDown(self) -> None:
+        # Drop whatever the hooks registered, remove the fake device module
+        # from torch, and clear the in-progress flag so later tests start clean.
+        for registry, orig in [
+            (common.device_codegens, self._orig_codegen),
+            (common.custom_backend_passes, self._orig_custom_passes),
+            (common.custom_backend_codegen_configs, self._orig_custom_configs),
+        ]:
+            for device in [d for d in registry if d not in orig]:
+                del registry[device]
+        if hasattr(torch, self.device):
+            delattr(torch, self.device)
+        sys.modules.pop(f"torch.{self.device}", None)
+        common._privateuse1_backend_init_in_progress = False
+        super().tearDown()
+
+    def _install_device_module(self, **attrs) -> None:
+        # rename_privateuse1_backend() is once-per-process, so mock the name
+        # lookup instead of renaming for real.  Both references must be
+        # patched: the probe in common.py reads the C-level attribute, while
+        # backend_registration imported its own copy at module load.
+        setattr(torch, self.device, types.SimpleNamespace(**attrs))
+        for target in (
+            "torch._C._get_privateuse1_backend_name",
+            "torch.utils.backend_registration._get_privateuse1_backend_name",
+        ):
+            patcher = mock.patch(target, return_value=self.device)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _install_hook_registering_device(self) -> dict:
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+            register_backend_for_device(self.device, object, object)
+
+        self._install_device_module(_inductor_backend_init=hook)
+        return calls
+
+    # ------------------------------------------------------------------
+    # Hook semantics
+    # ------------------------------------------------------------------
+
+    def test_backend_init_called_once(self) -> None:
+        calls = self._install_hook_registering_device()
+        init_backend_registration()
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+        # The device is registered now, so the hook is not re-fired.
+        init_backend_registration()
+        self.assertEqual(calls["n"], 1)
+
+    def test_backend_init_takes_precedence_over_class_probe(self) -> None:
+        # When both the hook and the legacy class attributes are present,
+        # only the hook runs.
+        calls = {"n": 0}
+
+        class LegacyScheduling:
+            pass
+
+        class LegacyWrapper:
+            pass
+
+        class LegacyCppWrapper:
+            pass
+
+        class LegacyFxWrapper:
+            pass
+
+        def hook() -> None:
+            calls["n"] += 1
+            register_backend_for_device(self.device, object, object)
+
+        self._install_device_module(
+            _inductor_backend_init=hook,
+            Scheduling=LegacyScheduling,
+            PythonWrapperCodegen=LegacyWrapper,
+            CppWrapperCodegen=LegacyCppWrapper,
+            WrapperFxCodegen=LegacyFxWrapper,
+        )
+        init_backend_registration()
+        self.assertEqual(calls["n"], 1)
+        self.assertIs(get_scheduling_for_device(self.device), object)
+
+    def test_class_probe_fallback_without_hook(self) -> None:
+        # A device module without the hook still goes through the legacy
+        # four-class probe, which registers only when Scheduling,
+        # PythonWrapperCodegen and CppWrapperCodegen all resolve.
+        class Scheduling:
+            pass
+
+        class Wrapper:
+            pass
+
+        class CppWrapper:
+            pass
+
+        class FxWrapper:
+            pass
+
+        self._install_device_module(
+            Scheduling=Scheduling,
+            PythonWrapperCodegen=Wrapper,
+            CppWrapperCodegen=CppWrapper,
+            WrapperFxCodegen=FxWrapper,
+        )
+        init_backend_registration()
+        self.assertIs(get_scheduling_for_device(self.device), Scheduling)
+
+    def test_class_probe_skips_partial_modules(self) -> None:
+        # A module exposing only some of the four legacy classes registers
+        # nothing.
+        class Scheduling:
+            pass
+
+        self._install_device_module(Scheduling=Scheduling)
+        init_backend_registration()
+        self.assertIsNone(get_scheduling_for_device(self.device))
+
+    def test_backend_init_failure_propagates_and_retries(self) -> None:
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+        self._install_device_module(_inductor_backend_init=hook)
+        # The vendor's error propagates instead of being swallowed.
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            init_backend_registration()
+        # The hook registered nothing, so the next compile invokes it again.
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            init_backend_registration()
+        self.assertEqual(calls["n"], 2)
+        self.assertIsNone(get_scheduling_for_device(self.device))
+
+    def test_reentrant_hook_failure_does_not_block_retry(self) -> None:
+        # A hook that re-enters init_backend_registration and then raises
+        # must not leave the in-progress flag set, or every later compile
+        # would silently skip the hook.
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+            common.get_backend_features("cpu")
+            raise RuntimeError("boom")
+
+        self._install_device_module(_inductor_backend_init=hook)
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            init_backend_registration()
+        # The in-progress flag was reset, so the retry is not skipped.
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            init_backend_registration()
+        self.assertEqual(calls["n"], 2)
+        self.assertIsNone(get_scheduling_for_device(self.device))
+
+    def test_noop_hook_refires_while_unregistered(self) -> None:
+        # A hook that returns without registering leaves the device
+        # unregistered, so each compile invokes it again; registration is the
+        # signal that initialization is done.
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+
+        self._install_device_module(_inductor_backend_init=hook)
+        init_backend_registration()
+        init_backend_registration()
+        self.assertEqual(calls["n"], 2)
+        self.assertIsNone(get_scheduling_for_device(self.device))
+
+    def test_replaced_device_module_is_rediscovered(self) -> None:
+        # No permanent "fired" state: swapping in a new device module (A/B
+        # testing a new backend) is discovered once the old registration is
+        # dropped.
+        first = self._install_hook_registering_device()
+        init_backend_registration()
+        self.assertEqual(first["n"], 1)
+
+        for registry in (
+            common.device_codegens,
+            common.custom_backend_passes,
+            common.custom_backend_codegen_configs,
+        ):
+            del registry[self.device]
+
+        second = self._install_hook_registering_device()
+        init_backend_registration()
+        self.assertEqual(second["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_reentrant_hook_does_not_recurse(self) -> None:
+        # A vendor import may reach code that queries backend features, which
+        # re-enters init_backend_registration before the hook has registered
+        # the device; the compile lock is re-entrant and the in-progress flag
+        # prevents the hook from firing again.
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+            common.get_backend_features("cpu")
+            register_backend_for_device(self.device, object, object)
+
+        self._install_device_module(_inductor_backend_init=hook)
+        init_backend_registration()
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_concurrent_caller_waits_for_hook(self) -> None:
+        # A caller that reaches init_backend_registration while the hook is
+        # in flight must block until registration has finished, not return
+        # against a half-registered device. The hook re-enters first (the
+        # re-entrant call returns early via the in-progress flag); the second
+        # thread blocks on the compile lock until the first thread's hook
+        # finishes, then sees the registration.
+        hook_entered = threading.Event()
+        release_hook = threading.Event()
+        calls = {"n": 0}
+
+        def hook() -> None:
+            calls["n"] += 1
+            common.get_backend_features("cpu")
+            hook_entered.set()
+            release_hook.wait(timeout=10)
+            register_backend_for_device(self.device, object, object)
+
+        self._install_device_module(_inductor_backend_init=hook)
+
+        def caller() -> None:
+            init_backend_registration()
+
+        first = threading.Thread(target=caller)
+        first.start()
+        self.assertTrue(hook_entered.wait(timeout=10))
+        second = threading.Thread(target=caller)
+        second.start()
+        second.join(timeout=0.5)
+        self.assertTrue(second.is_alive())
+        release_hook.set()
+        first.join(timeout=10)
+        second.join(timeout=10)
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_backend_init_as_device_module_class_method(self) -> None:
+        # The documented form: a static method on the device module class
+        # registered via torch._register_device_module. The probe resolves it
+        # with a plain getattr, so no special support is needed.
+        calls = {"n": 0}
+
+        class DeviceModule:
+            @staticmethod
+            def _inductor_backend_init() -> None:
+                calls["n"] += 1
+                register_backend_for_device(
+                    DeviceBackendInitTest.device, object, object
+                )
+
+        # torch._register_device_module validates the device name, which needs
+        # the once-per-process rename, so emulate its two side effects (the
+        # attribute on torch and the sys.modules entry) directly.
+        setattr(torch, self.device, DeviceModule)
+        sys.modules[f"torch.{self.device}"] = DeviceModule
+        for target in (
+            "torch._C._get_privateuse1_backend_name",
+            "torch.utils.backend_registration._get_privateuse1_backend_name",
+        ):
+            patcher = mock.patch(target, return_value=self.device)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        init_backend_registration()
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    # ------------------------------------------------------------------
+    # Placement on the compile path
+    # ------------------------------------------------------------------
+
+    def test_init_fires_before_decomp_table(self) -> None:
+        # init_backend_registration must run at the top of _compile_fx_main,
+        # before the decomposition table is snapshotted: a vendor hook may
+        # register decompositions, and the first compile must see them.
+        order = []
+        compile_fx_mod = torch._inductor.compile_fx
+        real_init = compile_fx_mod.init_backend_registration
+        real_select_decomp = compile_fx_mod.select_decomp_table
+
+        def record_init() -> None:
+            order.append("init")
+            real_init()
+
+        def record_decomp():
+            order.append("decomp")
+            return real_select_decomp()
+
+        gm = torch.fx.symbolic_trace(lambda x: (x + 1,))
+        x = torch.randn(8)
+        with (
+            mock.patch.object(compile_fx_mod, "init_backend_registration", record_init),
+            mock.patch.object(compile_fx_mod, "select_decomp_table", record_decomp),
+        ):
+            compile_fx_mod.compile_fx(gm, [x])
+
+        self.assertEqual(order[0], "init")
+        self.assertLess(order.index("init"), order.index("decomp"))
+
+    def test_backend_init_fires_from_backend_features_query(self) -> None:
+        # use_triton_template queries backend features per lowered GEMM; an
+        # unregistered device is discovered from there too.
+        calls = self._install_hook_registering_device()
+        common.get_backend_features("cpu")
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_backend_init_fires_on_torch_compile(self) -> None:
+        calls = self._install_hook_registering_device()
+
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(8)
+        self.assertEqual(torch.compile(fn)(x), fn(x))
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_backend_init_fires_on_compile_fx(self) -> None:
+        calls = self._install_hook_registering_device()
+        gm = torch.fx.symbolic_trace(lambda x: (x + 1,))
+        torch._inductor.compile_fx.compile_fx(gm, [torch.randn(8)])
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+    def test_backend_init_fires_on_aot_compile(self) -> None:
+        calls = self._install_hook_registering_device()
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return (x + 1,)
+
+        x = torch.randn(8)
+        exported = torch.export.export(Model(), (x,))
+        torch._inductor.aot_compile(exported.module(), (x,))
+        self.assertEqual(calls["n"], 1)
+        self.assertIsNotNone(get_scheduling_for_device(self.device))
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -533,12 +533,15 @@ def get_custom_backend_config_for_device(device: str) -> ConfigModule | None:
     return custom_backend_codegen_configs.get(device)
 
 
+# Prevents a hook that re-enters init_backend_registration from firing itself again.
+_privateuse1_backend_init_in_progress = False
+
+
 @functools.cache
-def init_backend_registration() -> None:
-    """
-    Register the backend for different devices, including the scheduling
-    for kernel code generation and the host side wrapper code generation.
-    """
+def _init_builtin_backend_registration() -> None:
+    # The built-in devices are never unregistered, so this only needs to run
+    # once per process; the privateuse1 probe in init_backend_registration
+    # below re-runs on every call.
     from .cpp import CppScheduling
     from .cpp_wrapper_cpu import CppWrapperCpu
     from .cpp_wrapper_gpu import CppWrapperGpu
@@ -633,18 +636,48 @@ def init_backend_registration() -> None:
             WrapperFxCodegen,
         )
 
+
+def init_backend_registration() -> None:
+    """
+    Register the backend for different devices, including the scheduling
+    for kernel code generation and the host side wrapper code generation.
+    """
+    global _privateuse1_backend_init_in_progress
+    _init_builtin_backend_registration()
+
     private_backend = torch._C._get_privateuse1_backend_name()
     if (
         private_backend != "privateuseone"
         and get_scheduling_for_device(private_backend) is None
     ):
-        from torch.utils.backend_registration import _get_custom_mod_func
+        device_mod = getattr(torch, private_backend, None)
+        backend_init = getattr(device_mod, "_inductor_backend_init", None)
+        if backend_init is not None:
+            # Vendor hook: runs the full inductor integration and must call
+            # register_backend_for_device itself. Serialized on the compile
+            # lock so a concurrent first compile waits for the in-flight hook
+            # instead of observing a half-registered device.
+            from torch._dynamo.convert_frame import compile_lock
 
-        try:
-            device_scheduling = _get_custom_mod_func("Scheduling")
-            wrapper_codegen = _get_custom_mod_func("PythonWrapperCodegen")
-            cpp_wrapper_codegen = _get_custom_mod_func("CppWrapperCodegen")
-            fx_wrapper_codegen = _get_custom_mod_func("WrapperFxCodegen")
+            with compile_lock:
+                # Re-check under the lock: another thread may have finished
+                # registration while we waited, and a hook that re-enters
+                # this function (the lock is re-entrant) must not fire
+                # itself again.
+                if get_scheduling_for_device(private_backend) is not None:
+                    return
+                if _privateuse1_backend_init_in_progress:
+                    return
+                _privateuse1_backend_init_in_progress = True
+                try:
+                    backend_init()
+                finally:
+                    _privateuse1_backend_init_in_progress = False
+        else:
+            device_scheduling = getattr(device_mod, "Scheduling", None)
+            wrapper_codegen = getattr(device_mod, "PythonWrapperCodegen", None)
+            cpp_wrapper_codegen = getattr(device_mod, "CppWrapperCodegen", None)
+            fx_wrapper_codegen = getattr(device_mod, "WrapperFxCodegen", None)
             if device_scheduling and wrapper_codegen and cpp_wrapper_codegen:
                 register_backend_for_device(
                     private_backend,
@@ -653,8 +686,6 @@ def init_backend_registration() -> None:
                     cpp_wrapper_codegen,
                     fx_wrapper_codegen,
                 )
-        except RuntimeError:
-            pass
 
 
 def index_prevent_reordering(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -3325,6 +3325,12 @@ def _compile_fx_main(
 
         compiler_config_extra = create_compiler_config_extra(model_)
 
+        # Load device backends (privateuse1 vendors) before the decomposition
+        # table is snapshotted below: _inductor_backend_init may register
+        # decompositions, custom passes, and codegen backends, all of which are
+        # consumed from this point on.
+        init_backend_registration()
+
         decompositions = get_decomp_fn()
         inner_compile = functools.partial(inner_compile, get_decomp_fn=get_decomp_fn)
 

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -112,6 +112,13 @@ def rename_privateuse1_backend(backend_name: str) -> None:
     (5) ``set_rng_state(new_state: Tensor, device: Union[int, str, torch.device] = 'foo') -> None``
         Sets the random number generator state of the specified "foo" device.
 
+    Note(inductor): To defer the Inductor integration of the device out of import
+    time, BackendModule may define an optional ``_inductor_backend_init`` no-arg
+    callable. Inductor invokes it on each torch.compile / ``compile_fx()`` /
+    AOTInductor compilation until the device is registered; it must call
+    ``torch._inductor.codegen.common.register_backend_for_device`` itself. See
+    ``docs/source/accelerator/autoload.md`` for details.
+
     And there are some common funcs:
 
     (1) ``is_available() -> bool``


### PR DESCRIPTION
### Summary

Add an optional `_inductor_backend_init` hook to the registered PrivateUse1 device module. The hook allows an out-of-tree device extension to defer importing its full Inductor integration until Inductor initializes backend registration.

This reuses the existing device-module registration instead of introducing another entry-point group or global loader registry.

### Motivation

PyTorch already discovers out-of-tree device extensions through the `torch.backends` autoload mechanism and exposes the registered device module as `torch.<device>`.

Importing a vendor's complete Inductor integration from the autoload hook is too early for users who never use Inductor. Loading it from scheduling or wrapper-codegen resolvers is too late because decompositions, custom graph passes, and cache-key configuration may already have been consumed.

The new hook provides a deferred initialization point on the existing device module:

```python
class BackendModule:
    @staticmethod
    def _inductor_backend_init() -> None:
        import my_backend._inductor


torch.utils.rename_privateuse1_backend("foo")
torch._register_device_module("foo", BackendModule)
```

The imported integration must call `register_backend_for_device()` itself. It may also register decompositions, device-op overrides, custom passes, and backend-specific configuration.

If the hook is absent, the existing `Scheduling`, `PythonWrapperCodegen`, `CppWrapperCodegen`, and `WrapperFxCodegen` attribute probe remains unchanged. If the device codegen backend was registered eagerly, the hook is skipped.

Inductor invokes the hook while initializing backend registration whenever the PrivateUse1 device remains unregistered. The hook must call register_backend_for_device(); that registration prevents later invocations. The hook is not gated on the compiled graph's device. Exceptions propagate, and later backend-registration checks retry the hook while the device remains unregistered, potentially multiple times within one compilation.

### Ordering

On the `compile_fx` paths, `init_backend_registration()` runs before that compilation selects its decomposition table. This makes registrations available before custom post-grad passes, cache-key construction, and codegen, covering torch.compile, direct `compile_fx()`, and `AOTInductor`. Other flows may perform decomposition earlier.


### Test plan

```text
python test/inductor/test_device_backends.py
```


Related RFC: [DeviceInterface registry support for PrivateUse1 backends in torch.compile.](https://github.com/pytorch/pytorch/issues/189138)
---
> AI-Assisted: Author reviewed and validated all AI-generated content.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo