### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes.

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import HardwareClassification, serialTest
 from torch.utils._triton import has_triton
 
+
 try:
     import triton
     from triton import language as tl
@@ -59,18 +60,21 @@ class TestOperatorReorderForPeakMemory(TestCase):
 
     def setUp(self):
         super().setUp()
-
-        self.model = Foo().to(self.device_type)
-        M = 4096 if torch.version.hip is not None else 2048
-        self.inputs = torch.ones((M, 2), device=self.device_type)
         self.orig_reorder_method = memory.reorder_for_peak_memory
+
+    def _create_model_and_inputs(self, device):
+        model = Foo().to(device)
+        M = 4096 if torch.version.hip is not None else 2048
+        inputs = torch.ones((M, 2), device=device)
+        return model, inputs
 
     @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory(self, device):
-        outp_corr = self.model(self.inputs)
-        compiled_model = torch.compile(self.model)
-        code = run_and_get_triton_code(compiled_model, self.inputs)
+        model, inputs = self._create_model_and_inputs(device)
+        outp_corr = model(inputs)
+        compiled_model = torch.compile(model)
+        code = run_and_get_triton_code(compiled_model, inputs)
 
         call_str = (
             "def call(self, args):"
@@ -91,13 +95,14 @@ class TestOperatorReorderForPeakMemory(TestCase):
             .run(code)
         )
         # check for correctness
-        outp = compiled_model(self.inputs)
+        outp = compiled_model(inputs)
         self.assertTrue(same(outp, outp_corr))
 
     @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory_lpmf(self, device):
-        outp_corr = self.model(self.inputs)
+        model, inputs = self._create_model_and_inputs(device)
+        outp_corr = model(inputs)
 
         def reorder_with_only_lpmf(
             nodes,
@@ -125,9 +130,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
         with mock.patch.object(
             memory, "reorder_for_peak_memory", reorder_with_only_lpmf
         ):
-            compiled_model = torch.compile(self.model)
+            compiled_model = torch.compile(model)
 
-            code = run_and_get_triton_code(compiled_model, self.inputs)
+            code = run_and_get_triton_code(compiled_model, inputs)
             (
                 FileCheck()
                 .check(call_str)
@@ -141,13 +146,14 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 .run(code)
             )
             # check for correctness
-            outp = compiled_model(self.inputs)
+            outp = compiled_model(inputs)
             self.assertTrue(same(outp, outp_corr))
 
     @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory_bfs(self, device):
-        outp_corr = self.model(self.inputs)
+        model, inputs = self._create_model_and_inputs(device)
+        outp_corr = model(inputs)
 
         def reorder_with_only_bfs(
             nodes,
@@ -175,9 +181,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
         with mock.patch.object(
             memory, "reorder_for_peak_memory", reorder_with_only_bfs
         ):
-            compiled_model = torch.compile(self.model)
+            compiled_model = torch.compile(model)
 
-            code = run_and_get_triton_code(compiled_model, self.inputs)
+            code = run_and_get_triton_code(compiled_model, inputs)
 
             (
                 FileCheck()
@@ -192,13 +198,14 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 .run(code)
             )
             # check for correctness
-            outp = compiled_model(self.inputs)
+            outp = compiled_model(inputs)
             self.assertTrue(same(outp, outp_corr))
 
     @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
     def test_reorder_peak_memory_dfs(self, device):
-        outp_corr = self.model(self.inputs)
+        model, inputs = self._create_model_and_inputs(device)
+        outp_corr = model(inputs)
 
         def reorder_with_only_dfs(
             nodes,
@@ -226,9 +233,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
         with mock.patch.object(
             memory, "reorder_for_peak_memory", reorder_with_only_dfs
         ):
-            compiled_model = torch.compile(self.model)
+            compiled_model = torch.compile(model)
 
-            code = run_and_get_triton_code(compiled_model, self.inputs)
+            code = run_and_get_triton_code(compiled_model, inputs)
             (
                 FileCheck()
                 .check(call_str)
@@ -242,7 +249,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 .run(code)
             )
             # check for correctness
-            outp = compiled_model(self.inputs)
+            outp = compiled_model(inputs)
             self.assertTrue(same(outp, outp_corr))
 
     @config.patch("score_fusion_memory_threshold", 1)

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -8,9 +8,9 @@ from torch._dynamo.utils import same
 from torch._inductor import config, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
-from torch.testing._internal.common_utils import serialTest
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
-
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, serialTest
+from torch.utils._triton import has_triton
 
 try:
     import triton
@@ -54,18 +54,20 @@ class Foo(torch.nn.Module):
 # score_fusion_memory threshold will cause different fusion decisions and
 # generate a different wrapper. Override the threshold to make these tests
 # happy.
-@config.patch("score_fusion_memory_threshold", 1)
 class TestOperatorReorderForPeakMemory(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
 
-        self.model = Foo().to(GPU_TYPE)
+        self.model = Foo().to(self.device_type)
         M = 4096 if torch.version.hip is not None else 2048
-        self.inputs = torch.ones((M, 2), device=GPU_TYPE)
+        self.inputs = torch.ones((M, 2), device=self.device_type)
         self.orig_reorder_method = memory.reorder_for_peak_memory
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
-    def test_reorder_peak_memory(self):
+    def test_reorder_peak_memory(self, device):
         outp_corr = self.model(self.inputs)
         compiled_model = torch.compile(self.model)
         code = run_and_get_triton_code(compiled_model, self.inputs)
@@ -92,8 +94,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
         outp = compiled_model(self.inputs)
         self.assertTrue(same(outp, outp_corr))
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
-    def test_reorder_peak_memory_lpmf(self):
+    def test_reorder_peak_memory_lpmf(self, device):
         outp_corr = self.model(self.inputs)
 
         def reorder_with_only_lpmf(
@@ -141,8 +144,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
             outp = compiled_model(self.inputs)
             self.assertTrue(same(outp, outp_corr))
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
-    def test_reorder_peak_memory_bfs(self):
+    def test_reorder_peak_memory_bfs(self, device):
         outp_corr = self.model(self.inputs)
 
         def reorder_with_only_bfs(
@@ -191,8 +195,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
             outp = compiled_model(self.inputs)
             self.assertTrue(same(outp, outp_corr))
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "reorder_for_peak_memory", True)
-    def test_reorder_peak_memory_dfs(self):
+    def test_reorder_peak_memory_dfs(self, device):
         outp_corr = self.model(self.inputs)
 
         def reorder_with_only_dfs(
@@ -240,10 +245,11 @@ class TestOperatorReorderForPeakMemory(TestCase):
             outp = compiled_model(self.inputs)
             self.assertTrue(same(outp, outp_corr))
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @mock.patch.object(config, "allow_buffer_reuse", False)
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
     @config.patch("test_configs.track_memory_lifecycle", "assert")
-    def test_mutation_size_propagation(self):
+    def test_mutation_size_propagation(self, device):
         """
         This tests correct size propagation in the case of mutations.
         In this example, buf1 is a mutation of buf0; we should have:
@@ -300,8 +306,8 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 p = p @ e
             return p
 
-        a = [torch.randn(32, 32, device=GPU_TYPE) for _ in range(4)]
-        p = torch.ones(a[0].size(), dtype=torch.bfloat16, device=GPU_TYPE)
+        a = [torch.randn(32, 32, device=device) for _ in range(4)]
+        p = torch.ones(a[0].size(), dtype=torch.bfloat16, device=device)
 
         with mock.patch.object(
             memory,
@@ -320,23 +326,25 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 # succ nodes should be forwarded to pre mutation buffer
                 self.assertTrue(buffer_info[post][2] <= buffer_info[pre][2])
 
-    def test_fusing_reductions_increase_peak_memory(self):
+    @config.patch("score_fusion_memory_threshold", 1)
+    def test_fusing_reductions_increase_peak_memory(self, device):
         @torch.compile
         def f(a, b, c):
             return (a @ c).sum(dim=-1) + (b @ c).sum(dim=-1)
 
-        a = torch.randn(1024 * 32, 16, device=GPU_TYPE)
-        b = torch.randn(1024 * 32, 16, device=GPU_TYPE)
-        c = torch.randn(16, 1024 * 32, device=GPU_TYPE)
-        torch.get_device_module(GPU_TYPE).reset_peak_memory_stats()
+        a = torch.randn(1024 * 32, 16, device=device)
+        b = torch.randn(1024 * 32, 16, device=device)
+        c = torch.randn(16, 1024 * 32, device=device)
+        torch.get_device_module(device).reset_peak_memory_stats()
         f(a, b, c)
-        peak_mem = torch.get_device_module(GPU_TYPE).max_memory_allocated()
+        peak_mem = torch.get_device_module(device).max_memory_allocated()
 
         expected_bound = a.size(0) * c.size(1) * a.dtype.itemsize * 2
         self.assertLess(peak_mem, expected_bound)
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @serialTest()
-    def test_fusion_acc_large_reads(self):
+    def test_fusion_acc_large_reads(self, device):
         def f(x, y, z):
             res = torch.zeros_like(x[0])
             for _ in range(4):
@@ -345,11 +353,11 @@ class TestOperatorReorderForPeakMemory(TestCase):
             return res
 
         N = 128
-        x = torch.rand(N, N, dtype=torch.float32, device=GPU_TYPE)
-        y = torch.rand(N, N, dtype=torch.float32, device=GPU_TYPE)
+        x = torch.rand(N, N, dtype=torch.float32, device=device)
+        y = torch.rand(N, N, dtype=torch.float32, device=device)
         # Keep the add as pointwise so this test continues to exercise scheduler
         # fusion choices instead of addmm fusion.
-        z = torch.rand(1, N, dtype=torch.float32, device=GPU_TYPE).expand(N, N)
+        z = torch.rand(1, N, dtype=torch.float32, device=device).expand(N, N)
 
         from torch._inductor.choices import InductorChoices
         from torch._inductor.scheduler import BaseSchedulerNode, Scheduler
@@ -412,8 +420,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
                 .run(code)
             )
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
-    def test_multiple_mutations_of_buf(self):
+    def test_multiple_mutations_of_buf(self, device):
         @torch.compile()
         def foo(inp, inp2):
             inp = inp @ inp
@@ -426,8 +435,8 @@ class TestOperatorReorderForPeakMemory(TestCase):
 
             return out, out2, inp2 @ inp2
 
-        inp = torch.rand([256, 256], device=GPU_TYPE)
-        inp2 = torch.rand([256, 256], device=GPU_TYPE)
+        inp = torch.rand([256, 256], device=device)
+        inp2 = torch.rand([256, 256], device=device)
 
         def replace_foreach(gm):
             nodes = gm.find_nodes(
@@ -456,8 +465,9 @@ class TestOperatorReorderForPeakMemory(TestCase):
             code = run_and_get_triton_code(foo, inp, inp2)
             FileCheck().check("allocated=['buf0']").run(code)
 
+    @config.patch("score_fusion_memory_threshold", 1)
     @unittest.skipUnless(TRITON_AVAILABLE, "Triton is not available")
-    def test_torch_cond_ordering_consistency(self):
+    def test_torch_cond_ordering_consistency(self, device):
         small_sz, large_sz = 256, 1024
 
         class MultiCondModel(torch.nn.Module):
@@ -522,8 +532,8 @@ class TestOperatorReorderForPeakMemory(TestCase):
                     cond_order.append((f"cond_{cond_idx}", buf_size))
             return cond_order
 
-        model = MultiCondModel().to(GPU_TYPE)
-        x = torch.randn(10, device=GPU_TYPE)
+        model = MultiCondModel().to(device)
+        x = torch.randn(10, device=device)
 
         # Compile with base settings (no reordering)
         torch._dynamo.reset()
@@ -555,8 +565,13 @@ class TestOperatorReorderForPeakMemory(TestCase):
             )
 
 
+instantiate_device_type_tests(
+    TestOperatorReorderForPeakMemory, globals(), except_for="cpu", allow_xpu=True
+)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
+    if has_triton():
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_memory.py
python test/inductor/test_memory.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo