### PR TITLE
Map control_deps subgraph args by placeholder

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -688,6 +688,102 @@ class TestControlDeps(InductorTestCase):
         result, _ = run_and_get_code(torch.compile(fn), x)
         self.assertEqual(result, expected)
 
+    @config.patch(reorder_for_locality=False)
+    @requires_gpu()
+    def test_subgraph_placeholders_need_not_be_contiguous(self):
+        """Placeholders need not be a contiguous prefix of the subgraph.
+
+        fx allows a placeholder to appear after other nodes, and lowering a
+        subgraph can put nodes between its placeholders -- decomposing a
+        host-to-device transfer of one operand does exactly that.  ``args``
+        holds one entry per placeholder, so the mapping has to be by
+        placeholder order rather than by node position.
+        """
+
+        def fn(a, b):
+            x = a + 1
+            y = b * 2
+            return x - y
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            sub_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.sub.Tensor
+            )[0]
+            dep_node = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.add.Tensor
+            )[0]
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, {sub_node: OrderedSet([dep_node])}
+            )
+
+            cd_node = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )[0]
+            subgraph = getattr(graph.owning_module, cd_node.args[1].target)
+            placeholders = list(subgraph.graph.find_nodes(op="placeholder"))
+            if len(placeholders) != 2:
+                raise AssertionError(f"expected 2 placeholders, got {placeholders}")
+
+            # Put a node between the two placeholders.  It reads only the
+            # first, so every use stays dominated by its definition, and the
+            # body reads through it so it cannot be dropped as dead.  clone
+            # keeps the result identical to the un-mutated graph.
+            first, second = placeholders
+            with subgraph.graph.inserting_before(second):
+                cloned = subgraph.graph.call_function(
+                    torch.ops.aten.clone.default, (first,)
+                )
+            cloned.meta.update(first.meta)
+            first.replace_all_uses_with(cloned)
+            cloned.args = (first,)
+            subgraph.graph.lint()
+            subgraph.recompile()
+
+            positions = [
+                i for i, n in enumerate(subgraph.graph.nodes) if n.op == "placeholder"
+            ]
+            if positions == list(range(len(positions))):
+                raise AssertionError(
+                    f"placeholders still form a contiguous prefix: {positions}"
+                )
+            return graph
+
+        with torch._inductor.config.patch(post_grad_custom_post_pass=add_control_deps):
+            a = torch.rand([128, 64], device=GPU_TYPE)
+            b = torch.rand([128, 64], device=GPU_TYPE)
+            result = torch.compile(fn)(a, b)
+            torch.testing.assert_close(result, fn(a, b))
+
+    @requires_cuda_triton
+    def test_host_to_device_transfer_between_sync_passthroughs(self):
+        """The interleaving above, arrived at without touching the graph.
+
+        A CPU tensor and a CUDA tensor are both live across a stream sync, so
+        both are threaded through the sync's control_deps.  Lowering the CPU
+        one decomposes its transfer inside the subgraph, which leaves nodes
+        between the two placeholders.
+        """
+
+        def fn(x, w):
+            meta = torch.tensor(x.shape[-2], dtype=torch.long)
+            residual = x.sin()
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                out = x @ w
+            s.synchronize()
+            extra = meta.to(device=out.device, dtype=out.dtype)
+            return torch.cat((out, extra.expand(*out.shape[:-1], 1), residual), dim=-1)
+
+        x = torch.randn(8, 128, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        expected = fn(x, w)
+        with torch.no_grad():
+            result = torch.compile(fn, mode="reduce-overhead")(x, w)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result, expected)
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU_AND_TRITON:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9218,14 +9218,21 @@ def process_subgraph_nodes(graph_module: torch.fx.GraphModule, args: list[Any]):
     - Output nodes return their result
     - Other nodes are executed via V.graph.run_node
 
+    ``args`` holds one entry per placeholder, so placeholders are counted
+    separately from nodes.  fx does not require placeholders to be a
+    contiguous prefix of the graph, and a decomposition running over the
+    subgraph can leave ops between them; indexing ``args`` by node position
+    would then read past its end.
     """
     output = _MISSING
 
-    for i, node in enumerate(graph_module.graph.nodes):
+    placeholder_idx = 0
+    for node in graph_module.graph.nodes:
         if node.op == "placeholder":
             if node in V.graph.env:
                 raise AssertionError("expected: node not in V.graph.env")
-            V.graph.env[node] = args[i]
+            V.graph.env[node] = args[placeholder_idx]
+            placeholder_idx += 1
             continue
         elif node.op == "output":
             output_args, kwargs = V.graph.fetch_args_kwargs_from_env(node)


### PR DESCRIPTION
Not node index.

process_subgraph_nodes walks the subgraph with enumerate() and uses that index to read args:

    for i, node in enumerate(graph_module.graph.nodes):
        if node.op == "placeholder":
            V.graph.env[node] = args[i]

args has one entry per placeholder, so this is only correct while the placeholders occupy positions 0..N-1.  fx does not require that, and lowering a subgraph can put nodes between placeholders: when a control_deps threads both a CPU and a CUDA tensor through a stream sync, decomposing the host-to-device transfer of the CPU one expands in place and pushes the next placeholder later in the node order.  Reading args by node position then runs off the end:

    File "torch/_inductor/lowering.py", line 9228, in process_subgraph_nodes
        V.graph.env[node] = args[i]
    IndexError: list index out of range

Counting placeholders separately fixes it.  The graph in question passes graph.lint(), and find_nodes(op="placeholder") already yields them in the order args expects.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo