### PR TITLE
[MPS] Reject bool inputs to matmul family ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1001,11 +1001,20 @@ static void linalg_inv_ex_out_mps_impl(const Tensor& A, bool check_errors, const
   result.copy_(tmp);
 }
 
+// No matmul family Metal kernel is instantiated for Bool (see INSTANTIATE_MM_OPS
+// in LinearAlgebra.metal), so Bool inputs must be rejected before dispatch;
+// otherwise Metal fails to create the "..._bool" function state with an opaque
+// RuntimeError. See https://github.com/pytorch/pytorch/issues/191693
+static void check_matmul_dtype_supported(const Tensor& self, const char* name) {
+  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kBool, name, ": not implemented for 'Bool' on MPS");
+}
+
 static Tensor& mm_out_mps_impl(const Tensor& self, const Tensor& other, Tensor& output) {
   using namespace mps;
   static const bool is_macOS_15_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_15_0);
 
   using CachedGraph = MPSBinaryCachedGraph;
+  check_matmul_dtype_supported(self, "mm");
   TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
   TORCH_CHECK(self.dtype() == other.dtype(),
               "expected mat1 and mat2 to have the same dtype, but got: ",
@@ -1087,7 +1096,8 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
   TORCH_CHECK(batch2.is_mps());
   TORCH_CHECK(result.is_mps());
 
-  TORCH_CHECK(supportedFloatingOrComplexType(batch1) || c10::isIntegralType(batch1.scalar_type(), true),
+  check_matmul_dtype_supported(batch1, opType == ADDBMM_OP_TYPE ? "addbmm" : "baddbmm");
+  TORCH_CHECK(supportedFloatingOrComplexType(batch1) || c10::isIntegralType(batch1.scalar_type(), false),
               "MPS device does not support addbmm or baddbmm for this input type");
 
   TORCH_CHECK(batch1.dim() == 3, "batch1 must be a 3D tensor");
@@ -1205,6 +1215,7 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
                                   Tensor& output) {
   using namespace mps;
 
+  check_matmul_dtype_supported(self, "addmm");
   TORCH_CHECK(output.is_mps());
   TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
 
@@ -1453,6 +1464,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
               batch1.scalar_type(),
               " and ",
               batch2.scalar_type());
+  check_matmul_dtype_supported(batch1, "bmm");
   using namespace mps;
 
   // Matmul not supported if any output dimension size is larger than 2**32

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1196,6 +1196,19 @@ def sample_inputs_mm(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_arg((S, 0)), args=(make_arg(0, M),))
 
 
+def error_inputs_mm(op_info, device, **kwargs):
+    # bool matmul is not implemented on any backend (see gh-191693). CPU raises a
+    # plain RuntimeError from AT_DISPATCH; MPS raises NotImplementedError (a
+    # RuntimeError subclass) via TORCH_CHECK_NOT_IMPLEMENTED, so check the common
+    # base type and rely on the shared message substring.
+    make_arg = partial(make_tensor, device=device, dtype=torch.bool)
+    yield ErrorInput(
+        SampleInput(make_arg((S, M)), args=(make_arg((M, S)),)),
+        error_type=RuntimeError,
+        error_regex="not implemented for 'Bool'",
+    )
+
+
 def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
     alpha_val = kwargs.get('alpha', 2 + 3j if dtype.is_complex else 0.6 if dtype.is_floating_point else 2)
     beta_val = kwargs.get('beta', 1 + 2j if dtype.is_complex else 0.2 if dtype.is_floating_point else 3)
@@ -17843,6 +17856,7 @@ op_db: list[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_mm,
+           error_inputs_func=error_inputs_mm,
            skips=(
                # Issue with conj and torch dispatch, see https://github.com/pytorch/pytorch/issues/82479
                DecorateInfo(


### PR DESCRIPTION
Fixes #191693

torch.mm on MPS crashes on bool tensors with an opaque "Failed to
create function state object for: matmul_bool" RuntimeError, instead
of a clear dtype error like CPU's "addmm_impl_cpu_ not implemented
for 'Bool'".

Root cause: LinearAlgebra.metal only instantiates the matmul family
kernels (matmul, addmm, naive_bmm, naive_baddbmm, naive_addbmm) for
float/half/bfloat/complex and the real integral types (long, int,
short, char, uchar) - bool isn't among them. But use_metal_mm() and
the addbmm/baddbmm dtype check both route bool through
c10::isIntegralType(dtype, /*includeBool=*/true), so a bool tensor
builds the Metal function name "matmul_bool", which was never
compiled, and pipeline-state creation fails with an opaque error
instead of a clean rejection.

This picks up pytorch/pytorch#191783, which implemented an mm-only
version of this check and got review feedback from Isalia20: use
TORCH_CHECK_NOT_IMPLEMENTED instead of TORCH_CHECK, and a question
about whether the restriction was MPS-specific since CPU "has bool
matmul." I checked the CPU dispatch macros directly -
_AT_DISPATCH_ADDMM_TYPES (LinearAlgebra.cpp) and dot's dispatch
(Blas.cpp) both exclude kBool, and the mm OpInfo's CPU dtype list
omits bool too, so CPU already rejects bool matmul with the same
wording this PR uses. bmm/baddbmm/addbmm hit the identical bug via
the same dispatch path, so the check is extended to all five ops
rather than just mm, and the addbmm/baddbmm dtype check (which
incorrectly claimed bool was supported) is fixed too.

Test Plan:

Added error_inputs_mm to common_methods_invocations.py, wired into
the mm OpInfo, asserting bool inputs raise RuntimeError matching
"not implemented for 'Bool'" - RuntimeError rather than
NotImplementedError since that's the common base type across CPU's
plain RuntimeError and MPS's NotImplementedError.

python test/test_ops.py -k "test_errors_mm"

Written with AI assistance (Claude); reviewed before submission.