### PR TITLE
Fix mse loss fwad int target

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3831,10 +3831,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 for loss in (F.mse_loss, F.smooth_l1_loss):
                     xb = x.clone().requires_grad_()
                     out = loss(xb, target, reduction=reduction)
+                    grad = torch.autograd.grad(out.sum(), xb)[0]
                     if reduction == 'none':
-                        expected = torch.autograd.grad(out.sum(), xb)[0]
+                        expected = grad * v
                     else:
-                        expected = torch.autograd.grad(out, xb)[0]
+                        expected = (grad * v).sum()
                     with fwAD.dual_level():
                         dual = fwAD.make_dual(x, v)
                         tangent = fwAD.unpack_dual(loss(dual, target, reduction=reduction)).tangent

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3822,6 +3822,24 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             gradcheck(lambda self, target: nn.BCEWithLogitsLoss(reduction=reduction)(self, target),
                       (output, target), check_forward_ad=True)
 
+    def test_losses_have_correct_forward_grad_with_integral_target(self):
+        x = torch.tensor([0.5, 1.5, 0.25, 2.0, 1.0])
+        v = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])
+        for target in (torch.tensor([1, 0, 2, 0, 1]),
+                       torch.tensor([True, False, True, False, True])):
+            for reduction in ('sum', 'mean', 'none'):
+                for loss in (F.mse_loss, F.smooth_l1_loss):
+                    xb = x.clone().requires_grad_()
+                    out = loss(xb, target, reduction=reduction)
+                    if reduction == 'none':
+                        expected = torch.autograd.grad(out.sum(), xb)[0]
+                    else:
+                        expected = torch.autograd.grad(out, xb)[0]
+                    with fwAD.dual_level():
+                        dual = fwAD.make_dual(x, v)
+                        tangent = fwAD.unpack_dual(loss(dual, target, reduction=reduction)).tangent
+                    self.assertEqual(tangent, expected)
+
     def test_bce_with_logits_has_correct_grad_at_zero(self):
         output = torch.zeros(3, 1, requires_grad=True)
         target = torch.zeros(3, 1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2094,7 +2094,7 @@
 - name: mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   self: mse_loss_backward(grad, self, target, reduction)
   target: mse_loss_backward(grad, target, self, reduction)
-  result: apply_loss_reduction(mse_loss_backward(self_t.conj(), self_p, target_p, at::Reduction::None).conj() + mse_loss_backward(target_t.conj(), target_p, self_p, at::Reduction::None).conj(), reduction)
+  result: apply_loss_reduction(mse_loss_backward(self_t.conj(), self_p, target_p, at::Reduction::None).conj() + mse_loss_backward(target_t.conj(), target_p.to(self_p.scalar_type()), self_p, at::Reduction::None).conj(), reduction)
 
 - name: multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor
   self: multi_margin_loss_backward(grad, self, target, p, margin, weight, reduction)
@@ -2117,7 +2117,7 @@
 - name: smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean, float beta=1.0) -> Tensor
   self: smooth_l1_loss_backward(grad, self, target, reduction, beta)
   target: smooth_l1_loss_backward(grad, target, self, reduction, beta)
-  result: apply_loss_reduction(smooth_l1_loss_backward(self_t.conj(), self_p, target_p, at::Reduction::None, beta).conj() + smooth_l1_loss_backward(target_t.conj(), target_p, self_p, at::Reduction::None, beta).conj(), reduction)
+  result: apply_loss_reduction(smooth_l1_loss_backward(self_t.conj(), self_p, target_p, at::Reduction::None, beta).conj() + smooth_l1_loss_backward(target_t.conj(), target_p.to(self_p.scalar_type()), self_p, at::Reduction::None, beta).conj(), reduction)
 
 - name: huber_loss(Tensor self, Tensor target, int reduction=Mean, float delta=1.0) -> Tensor
   self: huber_loss_backward(grad, self, target, reduction, delta)


### PR DESCRIPTION

**Fixes** #192723

## Summary

`F.mse_loss` and `F.smooth_l1_loss` accept integral or boolean targets. The primal value and reverse-mode gradients are correct, but forward-mode AD raises a RuntimeError

## Root cause

The fwAD JVP formula passes the target primal in the "input" position of the loss backward kernel, so the gradient buffer is allocated via `zeros_like` in the target's dtype. With an integral/bool target this is a Long/Bool buffer, and the kernel's TensorIterator (`promote_inputs_to_common_dtype` + `enforce_safe_casting_to_output`) throws when writing a Float result into a Long output.

## Fix

Cast the target primal to the self primal's scalar type in the JVP formula (`target_p.to(self_p.scalar_type())`). This is a no-op for float targets and mirrors the forward pass's type promotion otherwise.

## Test Plan

Added `TestNN::test_losses_have_correct_forward_grad_with_integral_target`, covering `mse_loss` and `smooth_l1_loss` with integral and bool targets under all three reductions, comparing the fwAD tangent against the directional derivative computed from reverse mode.