### PR TITLE
[TEST] Refactor test/dynamo/test_misc.py with hw_classification

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -93,6 +93,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
@@ -203,6 +204,8 @@ class UserDefineSetAttr:
 
 
 class MiscTests(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_cache_entry(self):
         def f(x):
             return x + 1
@@ -284,61 +287,6 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val3, correct3))
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
-
-    @unittest.skipIf(not TEST_CUDA, "cuda needed")
-    def test_assume_32_bit_indexing(self):
-        @torch.compile(backend="inductor")
-        def func(a, b):
-            # Multiple concat operations
-            x = torch.concat([a, b], dim=0)
-            y = torch.concat([a, b], dim=1)
-
-            # Reshape to create indexing patterns
-            x_flat = x.reshape(-1)
-            y_flat = y.reshape(-1)
-
-            # Take the smaller one and expand
-            min_size = min(x_flat.shape[0], y_flat.shape[0])
-            x_trunc = x_flat[:min_size]
-            y_trunc = y_flat[:min_size]
-
-            # Combine and compute
-            result = (x_trunc + y_trunc) * 10
-
-            # Cumulative operations create complex indexing
-            cumsum = result.cumsum(dim=0)
-
-            return cumsum.sum()
-
-        a = torch.rand(100, 30, device="cuda")
-        b = torch.rand(100, 30, device="cuda")
-
-        torch._dynamo.decorators.mark_unbacked(a, 0)
-        torch._dynamo.decorators.mark_unbacked(a, 1)
-        torch._dynamo.decorators.mark_unbacked(b, 0)
-        torch._dynamo.decorators.mark_unbacked(b, 1)
-
-        source_code = run_and_get_code(func, a, b)[1]
-        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
-        self.assertTrue(
-            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-        )
-        # Check that 32-bit indexing is NOT used
-        self.assertFalse(
-            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
-            and ".to(tl.int64)" not in str(source_code)
-        )
-
-        torch._dynamo.reset()
-
-        with torch._inductor.config.patch(assume_32bit_indexing=True):
-            source_code = run_and_get_code(func, a, b)[1]
-            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
-            self.assertFalse(
-                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-            )
 
     def test_dynamo_side_effect(self):
         class GlobalContext:
@@ -1189,102 +1137,6 @@ graph():
         res = opt_f(x, True)
         self.assertEqual(res, torch.ones(5) + 1)
         self.assertTrue(res.offloading_activation)
-
-    @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-        "requires Hopper+ (SM >= 9.0) for TMA",
-    )
-    @unittest.skipIf(
-        not torch.utils._triton.has_triton()
-        or not hasattr(__import__("triton"), "set_allocator"),
-        "requires triton with set_allocator support",
-    )
-    def test_triton_set_allocator_no_graph_break(self):
-        """set_allocator inside torch.compile does not graph break and
-        replays correctly at runtime (including cache hits)."""
-        import triton
-        import triton.language as tl
-        from triton.runtime._allocation import NullAllocator
-
-        @triton.jit
-        def tma_copy_kernel(
-            x_ptr,
-            out_ptr,
-            M,
-            N,
-            stride_m,
-            stride_n,
-            BLOCK_M: tl.constexpr,
-            BLOCK_N: tl.constexpr,
-        ):
-            pid = tl.program_id(0)
-            desc = tl.make_tensor_descriptor(
-                x_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
-            out_desc = tl.make_tensor_descriptor(
-                out_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
-
-        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
-
-        def run_kernel(x):
-            out = torch.empty_like(x)
-            tma_copy_kernel[(M // BLOCK_M,)](
-                x,
-                out,
-                M,
-                N,
-                x.stride(0),
-                x.stride(1),
-                BLOCK_M=BLOCK_M,
-                BLOCK_N=BLOCK_N,
-            )
-            return out
-
-        x = torch.randn(M, N, device="cuda")
-
-        from contextlib import contextmanager
-
-        from triton.runtime._allocation import _allocator
-
-        @contextmanager
-        def triton_allocator(allocator):
-            prev = _allocator.get()
-            triton.set_allocator(allocator)
-            try:
-                yield
-            finally:
-                triton.set_allocator(prev)
-
-        def fn_with_set_allocator(x):
-            triton.set_allocator(
-                lambda size, alignment, stream: torch.empty(
-                    size, device="cuda", dtype=torch.int8
-                )
-            )
-            return run_kernel(x)
-
-        opt_fn = torch.compile(
-            fn_with_set_allocator, backend="aot_eager", fullgraph=True
-        )
-
-        # set_allocator inside compiled region does NOT graph break
-        with triton_allocator(NullAllocator()):
-            out = opt_fn(x)
-            self.assertEqual(out, x)
-
-            # Verify set_allocator replays on cache hit (not just tracing)
-            triton.set_allocator(NullAllocator())
-            out2 = opt_fn(x)
-            self.assertEqual(out2, x)
 
     def test_closure_recompiles(self):
         cnt = CompileCounter()
@@ -17483,11 +17335,249 @@ def forward(self, L_x_ : torch.Tensor):
         with self.assertRaises(RuntimeError):
             fn(torch.randn(3))
 
+    def test_scalar_isin_decomposition(self):
+        def f():
+            x = torch.tensor(0)
+            return torch.isin(x, x)
+
+        opt_f = torch.compile(f, backend="inductor", fullgraph=True)
+        ref = f()
+        res = opt_f()
+        self.assertEqual(ref, res)
+
+    def test_randint_no_graphbreak(self):
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def f(actions, n_act, epsilon=0.1):
+            actions_random = torch.randint_like(actions, n_act)
+
+            return actions_random
+
+        x = torch.ones([1], dtype=torch.int64)
+        y = torch.tensor(5)
+        f(x, y)
+
+    def test_full_graph_capture_scalar_outputs(self):
+        @torch.compile(fullgraph=True, backend="eager")
+        def foo(a):
+            return torch.randn(5) * a.item()
+
+        # We expect to no longer raise here
+        foo(torch.tensor(2.0))
+
+    def test_full_graph_capture_dynamic_output_shape_ops(self):
+        def fn(x):
+            nz = torch.nonzero(x)
+            squared = nz * nz
+            sliced = torch.ops.aten.slice.Tensor(squared, dim=1, start=-2, end=None)
+            view = sliced.unsqueeze(dim=0)
+            return view.squeeze(dim=0)
+
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        # we expect to no longer raise here
+        torch.compile(fn, fullgraph=True, backend="eager")(*example_inputs)
+
+    def test_dynamic_fill_diagonal_(self):
+        @torch.compile(dynamic=True, backend="eager")
+        def f(x):
+            x.fill_diagonal_(True)
+
+        x = torch.zeros(4, 4)
+        f(x)
+
+    def test_dynamic_float_scalar_tensor_coersion(self):
+        # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367
+        class Foo:
+            def __init__(self):
+                self.config = type(
+                    "Config", (), {"pad_val": 1123581321.0, "tolerance": 1e-6}
+                )
+
+            @torch.compile(fullgraph=True, backend="eager")
+            def forward(self, input):
+                outputs = torch.where(
+                    torch.abs(input - self.config.pad_val) < self.config.tolerance,
+                    torch.tensor(
+                        self.config.pad_val, dtype=input.dtype, device=input.device
+                    ),
+                    torch.tensor(
+                        self.config.pad_val + 1, dtype=input.dtype, device=input.device
+                    ),
+                )
+                return outputs
+
+        foo = Foo()
+        inputs = torch.randn(3, 4)
+        result = foo.forward(inputs)
+
+        original_pad_val = foo.config.pad_val
+        foo.config.pad_val += 1.0
+        result2 = foo.forward(inputs)
+
+        # Previously would crash with:
+        #   RuntimeError: value cannot be converted to type at::Half without overflow
+
 
 instantiate_parametrized_tests(MiscTests)
 
 
+class MiscTestsCUDA(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipIf(not TEST_CUDA, "cuda needed")
+    def test_assume_32_bit_indexing(self):
+        @torch.compile(backend="inductor")
+        def func(a, b):
+            # Multiple concat operations
+            x = torch.concat([a, b], dim=0)
+            y = torch.concat([a, b], dim=1)
+
+            # Reshape to create indexing patterns
+            x_flat = x.reshape(-1)
+            y_flat = y.reshape(-1)
+
+            # Take the smaller one and expand
+            min_size = min(x_flat.shape[0], y_flat.shape[0])
+            x_trunc = x_flat[:min_size]
+            y_trunc = y_flat[:min_size]
+
+            # Combine and compute
+            result = (x_trunc + y_trunc) * 10
+
+            # Cumulative operations create complex indexing
+            cumsum = result.cumsum(dim=0)
+
+            return cumsum.sum()
+
+        a = torch.rand(100, 30, device="cuda")
+        b = torch.rand(100, 30, device="cuda")
+
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 1)
+
+        source_code = run_and_get_code(func, a, b)[1]
+        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
+        self.assertTrue(
+            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+        )
+        # Check that 32-bit indexing is NOT used
+        self.assertFalse(
+            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
+            and ".to(tl.int64)" not in str(source_code)
+        )
+
+        torch._dynamo.reset()
+
+        with torch._inductor.config.patch(assume_32bit_indexing=True):
+            source_code = run_and_get_code(func, a, b)[1]
+            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
+            self.assertFalse(
+                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+            )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+        "requires Hopper+ (SM >= 9.0) for TMA",
+    )
+    @unittest.skipIf(
+        not torch.utils._triton.has_triton()
+        or not hasattr(__import__("triton"), "set_allocator"),
+        "requires triton with set_allocator support",
+    )
+    def test_triton_set_allocator_no_graph_break(self):
+        """set_allocator inside torch.compile does not graph break and
+        replays correctly at runtime (including cache hits)."""
+        import triton
+        import triton.language as tl
+        from triton.runtime._allocation import NullAllocator
+
+        @triton.jit
+        def tma_copy_kernel(
+            x_ptr,
+            out_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid = tl.program_id(0)
+            desc = tl.make_tensor_descriptor(
+                x_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
+            out_desc = tl.make_tensor_descriptor(
+                out_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
+
+        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
+
+        def run_kernel(x):
+            out = torch.empty_like(x)
+            tma_copy_kernel[(M // BLOCK_M,)](
+                x,
+                out,
+                M,
+                N,
+                x.stride(0),
+                x.stride(1),
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+            return out
+
+        x = torch.randn(M, N, device="cuda")
+
+        from contextlib import contextmanager
+
+        from triton.runtime._allocation import _allocator
+
+        @contextmanager
+        def triton_allocator(allocator):
+            prev = _allocator.get()
+            triton.set_allocator(allocator)
+            try:
+                yield
+            finally:
+                triton.set_allocator(prev)
+
+        def fn_with_set_allocator(x):
+            triton.set_allocator(
+                lambda size, alignment, stream: torch.empty(
+                    size, device="cuda", dtype=torch.int8
+                )
+            )
+            return run_kernel(x)
+
+        opt_fn = torch.compile(
+            fn_with_set_allocator, backend="aot_eager", fullgraph=True
+        )
+
+        # set_allocator inside compiled region does NOT graph break
+        with triton_allocator(NullAllocator()):
+            out = opt_fn(x)
+            self.assertEqual(out, x)
+
+            # Verify set_allocator replays on cache hit (not just tracing)
+            triton.set_allocator(NullAllocator())
+            out2 = opt_fn(x)
+            self.assertEqual(out2, x)
+
+
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize_pytree_module
     def test_tracing_pytree(self, pytree):
         def fn(xs):
@@ -17809,6 +17899,8 @@ class MiscTestsPyTree(torch._inductor.test_case.TestCase):
 
 
 class TestTracer(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_jit_save(self):
         def fn():
             class Foo(torch.nn.Module):
@@ -17838,6 +17930,8 @@ class TestTracer(JitTestCase):
 
 
 class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_autograd_function_with_matmul_folding_at_output(self):
         """
         When tensor folding occurs during matmul operation returned tensor is a view.
@@ -17902,6 +17996,8 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
 
 
 class MiscTestsDevice(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_rand(self, device):
         cnts = torch._dynamo.testing.CompileCounter()
         device = device
@@ -18123,87 +18219,6 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
 
         f(torch.tensor([30, 30], device=device), torch.tensor([68, 32], device=device))
 
-    def test_scalar_isin_decomposition(self):
-        def f():
-            x = torch.tensor(0)
-            return torch.isin(x, x)
-
-        opt_f = torch.compile(f, backend="inductor", fullgraph=True)
-        ref = f()
-        res = opt_f()
-        self.assertEqual(ref, res)
-
-    def test_randint_no_graphbreak(self):
-        @torch.compile(backend="aot_eager", fullgraph=True)
-        def f(actions, n_act, epsilon=0.1):
-            actions_random = torch.randint_like(actions, n_act)
-
-            return actions_random
-
-        x = torch.ones([1], dtype=torch.int64)
-        y = torch.tensor(5)
-        f(x, y)
-
-    def test_full_graph_capture_scalar_outputs(self):
-        @torch.compile(fullgraph=True, backend="eager")
-        def foo(a):
-            return torch.randn(5) * a.item()
-
-        # We expect to no longer raise here
-        foo(torch.tensor(2.0))
-
-    def test_full_graph_capture_dynamic_output_shape_ops(self):
-        def fn(x):
-            nz = torch.nonzero(x)
-            squared = nz * nz
-            sliced = torch.ops.aten.slice.Tensor(squared, dim=1, start=-2, end=None)
-            view = sliced.unsqueeze(dim=0)
-            return view.squeeze(dim=0)
-
-        example_inputs = (torch.randn(1, 1, 1, 1),)
-        # we expect to no longer raise here
-        torch.compile(fn, fullgraph=True, backend="eager")(*example_inputs)
-
-    def test_dynamic_fill_diagonal_(self):
-        @torch.compile(dynamic=True, backend="eager")
-        def f(x):
-            x.fill_diagonal_(True)
-
-        x = torch.zeros(4, 4)
-        f(x)
-
-    def test_dynamic_float_scalar_tensor_coersion(self):
-        # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367
-        class Foo:
-            def __init__(self):
-                self.config = type(
-                    "Config", (), {"pad_val": 1123581321.0, "tolerance": 1e-6}
-                )
-
-            @torch.compile(fullgraph=True, backend="eager")
-            def forward(self, input):
-                outputs = torch.where(
-                    torch.abs(input - self.config.pad_val) < self.config.tolerance,
-                    torch.tensor(
-                        self.config.pad_val, dtype=input.dtype, device=input.device
-                    ),
-                    torch.tensor(
-                        self.config.pad_val + 1, dtype=input.dtype, device=input.device
-                    ),
-                )
-                return outputs
-
-        foo = Foo()
-        inputs = torch.randn(3, 4)
-        result = foo.forward(inputs)
-
-        original_pad_val = foo.config.pad_val
-        foo.config.pad_val += 1.0
-        result2 = foo.forward(inputs)
-
-        # Previously would crash with:
-        #   RuntimeError: value cannot be converted to type at::Half without overflow
-
     def test_symbool_tensor_mul(self, device):
         def symbool_mul_fn(x_bool, sentinel):
             result = x_bool * sentinel
@@ -18339,6 +18354,8 @@ instantiate_device_type_tests(
 
 
 class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_tensorify_track_item_symint(self):
         def _random_resize(image: torch.Tensor):


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `MiscTests` (798 tests) — pure Dynamo tracing/compilation tests
- Split 2 CUDA-specific tests (`test_assume_32_bit_indexing`, `test_triton_set_allocator_no_graph_break`) into new `MiscTestsCUDA` class (`hw_classification = HardwareClassification.CUDA`)
- Move 6 device-independent self-only methods from `MiscTestsDevice` to `MiscTests` — they had no `device` parameter and tested device-irrelevant logic
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `MiscTestsDevice` (15 tests) — already uses `instantiate_device_type_tests`
- Add `hw_classification = HardwareClassification.GENERIC` to `MiscTestsPyTree` (12 tests), `TestTracer` (1 test), `TestCustomFunction` (2 tests), `DynamoOpPromotionTests` (5 tests) — no structural changes

## Test Plan

```
python test/dynamo/test_misc.py
Ran 864 tests in 92.186s — OK (skipped=11, expected failures=4)

python test/dynamo/test_misc.py --hw-classification GENERIC
Ran 847 tests in 97.245s — OK (skipped=11, expected failures=4)

python test/dynamo/test_misc.py --hw-classification CUDA
Ran 2 tests in 4.486s — OK

python test/dynamo/test_misc.py --hw-classification ACCELERATOR
Ran 15 tests in 3.710s — OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98