### PR TITLE
[TEST] Add hw_classification to test_ops_fwd_gradients.py

### DIFF
--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     run_tests,
     skipIfTorchInductor,
@@ -60,6 +61,8 @@ _fwd_grad_all = {
 
 @unMarkDynamoStrictTest
 class TestFwdGradients(TestGradients):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # Test that forward-over-reverse gradgrad is computed correctly
     @skipOps(
         _fwd_grad_all


### PR DESCRIPTION
## Summary

Adds `hw_classification = HardwareClassification.ACCELERATOR` to `TestFwdGradients` in `test/test_ops_fwd_gradients.py`, following #186918.

This change was drafted with help from an AI assistant; the commit includes an appropriate co-author trailer.

## Test plan

- `python test/test_ops_fwd_gradients.py -v --hw-classification GENERIC`
- `python test/test_ops_fwd_gradients.py -v --hw-classification ACCELERATOR`

Authored-with: AI assistant