### PR TITLE
[Testcase Refactoring] Migrate test_halide and test_helion_kernels to capability-based test skip

### DIFF
--- a/test/inductor/test_halide.py
+++ b/test/inductor/test_halide.py
@@ -14,9 +14,18 @@ from torch._inductor.codecache import HalideCodeCache
 from torch._inductor.runtime.hints import HalideInputSpec, HalideMeta
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import parallel_num_threads, run_and_get_code
-from torch.testing._internal.common_utils import IS_CI, IS_MACOS, IS_WINDOWS
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_CI,
+    IS_MACOS,
+    IS_WINDOWS,
+)
 from torch.testing._internal.inductor_utils import HAS_CPU
-from torch.utils._triton import has_triton
 
 
 if IS_WINDOWS and IS_CI:
@@ -69,7 +78,9 @@ def make_halide(cls):
 
 
 @unittest.skipUnless(HAS_HALIDE, "requires halide")
-class HalideTests(TestCase):
+class HalideTestsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_codecache(self):
         fn = HalideCodeCache.generate_halide(
             HalideMeta(
@@ -215,42 +226,6 @@ class HalideTests(TestCase):
         fn(a, b, c)
         self.assertEqual(c, a + b)
 
-    @unittest.skipUnless(has_triton(), "requires triton")
-    def test_random_consistency(self):
-        seed = 1234
-        shape = (3, 3)
-        dtype = torch.float32
-
-        for (rand_fn,) in itertools.product(
-            (
-                functools.partial(torch.rand, shape, dtype=dtype, device="cuda"),
-                functools.partial(torch.randn, shape, dtype=dtype, device="cuda"),
-                functools.partial(
-                    torch.randint,
-                    -1000,
-                    1000,
-                    size=shape,
-                    dtype=torch.int64,
-                    device="cuda",
-                ),
-            )
-        ):
-
-            @torch.compile(backend="inductor", options={"cuda_backend": "halide"})
-            def get_rand_halide():
-                return rand_fn()
-
-            @torch.compile(backend="inductor", options={"cuda_backend": "triton"})
-            def get_rand_triton():
-                return rand_fn()
-
-            torch.manual_seed(seed)
-            halide_output = get_rand_halide()
-            torch.manual_seed(seed)
-            triton_output = get_rand_triton()
-
-        self.assertEqual(halide_output, triton_output)
-
     def test_compile_options(self):
         @torch.compile(
             backend="inductor",
@@ -291,6 +266,50 @@ class HalideTests(TestCase):
 
         self.assertEqual(result, expected)
         self.assertEqual(x, expected)
+
+
+@unittest.skipUnless(HAS_HALIDE, "requires halide")
+class HalideTestsCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_random_consistency(self, device):
+        seed = 1234
+        shape = (3, 3)
+        dtype = torch.float32
+
+        for (rand_fn,) in itertools.product(
+            (
+                functools.partial(torch.rand, shape, dtype=dtype, device=device),
+                functools.partial(torch.randn, shape, dtype=dtype, device=device),
+                functools.partial(
+                    torch.randint,
+                    -1000,
+                    1000,
+                    size=shape,
+                    dtype=torch.int64,
+                    device=device,
+                ),
+            )
+        ):
+
+            @torch.compile(backend="inductor", options={"cuda_backend": "halide"})
+            def get_rand_halide():
+                return rand_fn()
+
+            @torch.compile(backend="inductor", options={"cuda_backend": "triton"})
+            def get_rand_triton():
+                return rand_fn()
+
+            torch.manual_seed(seed)
+            halide_output = get_rand_halide()
+            torch.manual_seed(seed)
+            triton_output = get_rand_triton()
+
+        self.assertEqual(halide_output, triton_output)
+
+
+instantiate_device_type_tests(HalideTestsCuda, globals(), only_for="cuda")
 
 
 if test_torchinductor.HAS_CPU and HAS_HALIDE:

--- a/test/inductor/test_halide.py
+++ b/test/inductor/test_halide.py
@@ -14,18 +14,14 @@ from torch._inductor.codecache import HalideCodeCache
 from torch._inductor.runtime.hints import HalideInputSpec, HalideMeta
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import parallel_num_threads, run_and_get_code
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_CI,
     IS_MACOS,
     IS_WINDOWS,
 )
-from torch.testing._internal.inductor_utils import HAS_CPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
 if IS_WINDOWS and IS_CI:
@@ -284,7 +280,7 @@ class HalideTestsCuda(TestCase):
         )
         self.assertIn("@hl.generator", code)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_random_consistency(self, device):
         seed = 1234
         shape = (3, 3)

--- a/test/inductor/test_halide.py
+++ b/test/inductor/test_halide.py
@@ -244,14 +244,6 @@ class HalideTestsGeneric(TestCase):
         )
         self.assertIn("@hl.generator", code)
 
-        if torch.cuda.is_available():
-            _, (code,) = run_and_get_code(
-                halide,
-                torch.randn(1024, 1024, device="cuda"),
-                torch.randn(1024, 1024, device="cuda"),
-            )
-            self.assertIn("@hl.generator", code)
-
     def test_inplace_add_broadcast_input_alias(self):
         @torch.compile(backend="inductor", options={"cpu_backend": "halide"})
         def fn(x, y):
@@ -271,6 +263,26 @@ class HalideTestsGeneric(TestCase):
 @unittest.skipUnless(HAS_HALIDE, "requires halide")
 class HalideTestsCuda(TestCase):
     hw_classification = HardwareClassification.CUDA
+
+    def test_compile_options(self, device):
+        @torch.compile(
+            backend="inductor",
+            options={
+                "cuda_backend": "halide",
+                "cpu_backend": "halide",
+                "halide.scheduler_cuda": "Anderson2021",
+                "halide.scheduler_cpu": "Adams2019",
+            },
+        )
+        def halide(a, b):
+            return torch.softmax(a, -1) + torch.softmax(b, -1)
+
+        _, (code,) = run_and_get_code(
+            halide,
+            torch.randn(1024, 1024, device=device),
+            torch.randn(1024, 1024, device=device),
+        )
+        self.assertIn("@hl.generator", code)
 
     @requires_capabilities(Capability.lib.triton)
     def test_random_consistency(self, device):

--- a/test/inductor/test_helion_kernels.py
+++ b/test/inductor/test_helion_kernels.py
@@ -1,13 +1,13 @@
 # Owner(s): ["module: inductor"]
 import torch
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import instantiate_parametrized_tests
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_HELION,
-    requires_helion,
-    requires_triton,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_HELION, requires_helion
 
 
 if HAS_HELION:
@@ -16,9 +16,11 @@ if HAS_HELION:
 
 
 class HelionTests(TestCase):
-    @requires_triton()
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
     @requires_helion()
-    def test_add_kernel(self):
+    def test_add_kernel(self, device):
         @helion.kernel(config=helion.Config(block_sizes=[1, 2]))
         def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             # match pytorch broadcasting rules
@@ -37,8 +39,8 @@ class HelionTests(TestCase):
         def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             return add(x, y)
 
-        x = torch.randn(4, 8, device=GPU_TYPE, dtype=torch.float16)
-        y = torch.randn(4, 8, device=GPU_TYPE, dtype=torch.float16)
+        x = torch.randn(4, 8, device=device, dtype=torch.float16)
+        y = torch.randn(4, 8, device=device, dtype=torch.float16)
 
         out = add(x, y)
         compiled_add = torch.compile(f, fullgraph=True, backend="inductor")
@@ -47,9 +49,9 @@ class HelionTests(TestCase):
         self.assertEqual(out, x + y)
         self.assertEqual(compiled_out, x + y)
 
-    @requires_triton()
+    @requires_capabilities(Capability.lib.triton)
     @requires_helion()
-    def test_softmax_view_reshape(self):
+    def test_softmax_view_reshape(self, device):
         @helion.kernel(config={"block_size": 1})
         def softmax(x: torch.Tensor) -> torch.Tensor:
             n, _m = x.size()
@@ -62,14 +64,16 @@ class HelionTests(TestCase):
                 out[tile_n, :] = exp / sum_exp
             return out
 
-        x = torch.randn([1024, 1024], device=GPU_TYPE, dtype=torch.float16)
+        x = torch.randn([1024, 1024], device=device, dtype=torch.float16)
         result = softmax(x)
         self.assertEqual(
             result, torch.nn.functional.softmax(x, dim=1), rtol=1e-2, atol=1e-1
         )
 
 
-instantiate_parametrized_tests(HelionTests)
+instantiate_device_type_tests(
+    HelionTests, globals(), except_for="cpu", allow_mps=True, allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_helion_kernels.py
+++ b/test/inductor/test_helion_kernels.py
@@ -1,13 +1,15 @@
 # Owner(s): ["module: inductor"]
+import unittest
+
 import torch
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
-from torch.testing._internal.inductor_utils import HAS_HELION, requires_helion
+from torch.testing._internal.inductor_utils import (
+    HAS_HELION,
+    HAS_TRITON,
+    requires_helion,
+)
 
 
 if HAS_HELION:
@@ -18,7 +20,7 @@ if HAS_HELION:
 class HelionTests(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_helion()
     def test_add_kernel(self, device):
         @helion.kernel(config=helion.Config(block_sizes=[1, 2]))
@@ -49,7 +51,7 @@ class HelionTests(TestCase):
         self.assertEqual(out, x + y)
         self.assertEqual(compiled_out, x + y)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_helion()
     def test_softmax_view_reshape(self, device):
         @helion.kernel(config={"block_size": 1})
@@ -71,9 +73,7 @@ class HelionTests(TestCase):
         )
 
 
-instantiate_device_type_tests(
-    HelionTests, globals(), except_for="cpu", allow_mps=True, allow_xpu=True
-)
+instantiate_device_type_tests(HelionTests, globals(), except_for="cpu", allow_xpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Split HalideTests into HalideTestsGeneric (GENERIC) and HalideTestsCuda (CUDA)
with proper hw_classification. Migrate test_helion_kernels from
instantiate_parametrized_tests to instantiate_device_type_tests with device
parameter.

### Changes

- Split HalideTests into HalideTestsGeneric + HalideTestsCuda, add
  hw_classification and instantiate_device_type_tests(only_for="cuda"); split
  test_compile_options into CPU-only (Generic) and CUDA (Cuda) variants
- Replace @requires_capabilities(Capability.lib.triton) with
  @unittest.skipIf(not HAS_TRITON) in both files; drop Capability/
  requires_capabilities imports
- Migrate test_helion_kernels from GPU_TYPE/instantiate_parametrized_tests to
  device parameter/instantiate_device_type_tests(except_for="cpu",
  allow_xpu=True)

### Motivation

The original tests used hardcoded GPU_TYPE and legacy skip decorators
(has_triton, requires_triton), which are not multi-backend friendly. The
refactoring adopts the device-parametric test pattern with HAS_TRITON guard.
Capability.lib.triton has been removed from common_device_type, so the guard
uses @unittest.skipIf(not HAS_TRITON) instead. allow_mps is omitted since the
original requires_triton (HAS_TRITON) is False on MPS.

### Test Plan
```bash
python test/inductor/test_halide.py
python test/inductor/test_helion_kernels.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper
@zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames
@chauhang @aakhundov @coconutruben @jataylo