### PR TITLE
[Testcase Refactoring] Add hardware classification for test_tp_transform.py

### DIFF
--- a/test/distributed/tensor/experimental/test_tp_transform.py
+++ b/test/distributed/tensor/experimental/test_tp_transform.py
@@ -10,6 +10,7 @@ from torch.distributed.tensor.parallel.style import (
     ParallelStyle,
     RowwiseParallel,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -52,7 +53,7 @@ class DummyModel(torch.nn.Module):
 
 
 class TensorParallelTest(DTensorTestBase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def setUp(self) -> None:
         super().setUp()
@@ -68,7 +69,7 @@ class TensorParallelTest(DTensorTestBase):
         self.assertDictEqual(expected_ops_count, actual_ops_count)
 
     @with_comms
-    def test_tp_transform_with_uncovered_op(self):
+    def test_tp_transform_with_uncovered_op(self, device):
         model = DummyModel().to(device=self.device_type)
         inputs = (torch.randn(7, 3, requires_grad=False).to(device=self.device_type),)
         with torch.no_grad():
@@ -97,7 +98,7 @@ class TensorParallelTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_tp_transform_e2e(self):
+    def test_tp_transform_e2e(self, device):
         torch.manual_seed(0)
         model = MLPListModule(2).to(device=self.device_type)
         inputs = (torch.randn((10, 12)).to(device=self.device_type),)
@@ -134,7 +135,7 @@ class TensorParallelTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_tp_transform_no_bias(self):
+    def test_tp_transform_no_bias(self, device):
         torch.manual_seed(0)
         model = MLPListModule(1, bias=False).to(device=self.device_type)
         inputs = (torch.randn((10, 12)).to(device=self.device_type),)
@@ -167,6 +168,8 @@ class TensorParallelTest(DTensorTestBase):
             },
         )
 
+
+instantiate_device_type_tests(TensorParallelTest, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/experimental/test_tp_transform.py
+++ b/test/distributed/tensor/experimental/test_tp_transform.py
@@ -10,7 +10,7 @@ from torch.distributed.tensor.parallel.style import (
     ParallelStyle,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -52,6 +52,8 @@ class DummyModel(torch.nn.Module):
 
 
 class TensorParallelTest(DTensorTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
 


### PR DESCRIPTION
## Summary:
  Add hardware classification for `test_tp_transform.py` and classify
  `TensorParallelTest` as `GENERIC`.

## Changes:
  Set `hw_classification = HardwareClassification.GENERIC` on
  `TensorParallelTest`.

## Test Plan:
  `python test/distributed/tensor/experimental/test_tp_transform.py -v --hw-classification GENERIC`