### PR TITLE
[TEST] Add hw_classification to test_compile.py and test_aot_autograd.py (dynamo)

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -33,7 +33,10 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import compare_equal_outs_and_grads
+from torch.testing._internal.common_utils import (
+    compare_equal_outs_and_grads,
+    HardwareClassification,
+)
 from torch.utils._sympy.symbol import make_symbol, SymT
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -59,6 +62,8 @@ lib.impl("maybe_dupe_op", maybe_dupe_op, "Meta")
 
 
 class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):
@@ -1912,6 +1917,8 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
 
 class AotAutogradFallbackTestsDevice(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     @patch.object(torch._dynamo.config, "capture_dynamic_output_shape_ops", True)

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter
-from torch.testing._internal.common_utils import munge_exc
+from torch.testing._internal.common_utils import HardwareClassification, munge_exc
 
 
 class ToyModel(torch.nn.Module):
@@ -23,6 +23,8 @@ class ToyModel(torch.nn.Module):
 
 
 class InPlaceCompilationTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_compilation(self):
         torch._dynamo.reset()
         model = ToyModel()
@@ -287,6 +289,8 @@ class InPlaceCompilationTests(TestCase):
 # The private variants of the below functions are extensively tested
 # So as long as the signatures match we're good
 class PublicTorchCompilerTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def check_signature(self, public_fn_name, private_fn_name, private_namespace):
         public_fn = getattr(torch.compiler, public_fn_name)
         private_fn = getattr(private_namespace, private_fn_name)
@@ -322,6 +326,8 @@ class PublicTorchCompilerTests(TestCase):
 
 
 class FullgraphTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_fullgraph_errors_on_frame_skip_with_dispatch_mode(self):
         from torch.utils._python_dispatch import TorchDispatchMode
 


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

**test/dynamo/test_compile.py:**
- Add `hw_classification = HardwareClassification.GENERIC` to `InPlaceCompilationTests` (20 tests) — dynamo in-place compilation, save/load, callbacks, error handling
- Add `hw_classification = HardwareClassification.GENERIC` to `PublicTorchCompilerTests` (1 test) — torch.compiler API signature validation
- Add `hw_classification = HardwareClassification.GENERIC` to `FullgraphTests` (6 tests) — fullgraph=True behavior and error messages

**test/dynamo/test_aot_autograd.py:**
- Add `hw_classification = HardwareClassification.GENERIC` to `AotAutogradFallbackTests` — CPU-only AOT autograd fallback tests
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `AotAutogradFallbackTestsDevice` — device-parameterized tests gated with `@onlyAccelerator`

All GENERIC classes exercise dynamo/AOT compilation logic with no device references. ACCELERATOR class is already restricted to accelerator devices via `@onlyAccelerator`. No structural changes or class splits needed.

Closes #192924

## Test Plan

```
python test/dynamo/test_compile.py -v
Ran 27 tests in 8.822s — OK

python test/dynamo/test_compile.py -v --hw-classification GENERIC
HW classification mode active (['GENERIC']): total=27, passed=27, unclassified=0, mismatched=0
Ran 27 tests in 3.288s — OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98