### PR TITLE
[Testcase Refactoring] Add hw_classification to test/distributed/elastic/events/lib_test.py

### DIFF
--- a/test/distributed/elastic/events/lib_test.py
+++ b/test/distributed/elastic/events/lib_test.py
@@ -20,10 +20,16 @@ from torch.distributed.elastic.events import (
     NodeState,
     RdzvEvent,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class EventLibTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def assert_event(self, actual_event, expected_event):
         self.assertEqual(actual_event.name, expected_event.name)
         self.assertEqual(actual_event.source, expected_event.source)
@@ -60,6 +66,8 @@ class EventLibTest(TestCase):
 
 
 class RdzvEventLibTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @patch("torch.distributed.elastic.events.record_rdzv_event")
     @patch("torch.distributed.elastic.events.get_logging_handler")
     def test_construct_and_record_rdzv_event(self, get_mock, record_mock):


### PR DESCRIPTION
**Summary**
Enable --hw-classification filtering for test/distributed/elastic/events/lib_test.py
by tagging both test classes (EventLibTest and RdzvEventLibTest) with a
HardwareClassification label. Both classes are pure logging/dataclass/mock
logic exercised via unittest.mock.patch over get_logging_handler and
record_rdzv_event (no device parameter, no accelerator APIs, no
@onlyCUDA/@onlyCPU/@skipXPU decorators), so they are classified GENERIC.

**Changes**
test/distributed/elastic/events/lib_test.py:
Merged HardwareClassification into the existing
from torch.testing._internal.common_utils import ... import (alphabetically,
split across multiple lines for the column limit). No other imports touched.
Added hw_classification = HardwareClassification.GENERIC as the first class
attribute of EventLibTest, immediately after the class definition and
before any method.
Added hw_classification = HardwareClassification.GENERIC as the first class
attribute of RdzvEventLibTest, immediately after the class definition and
before any method.
No test methods, helper methods (assert_event, assert_rdzv_event,
get_test_rdzv_event), or decorators were modified. The helper methods live
inside the tagged test classes and inherit the GENERIC classification
automatically; only test classes are tagged.
No tests were moved, renamed, or had decorators added/removed. The file was
already accelerator-unrelated (Strategy 1: plain TestCase, CPU-only logic);
the only missing piece for HardwareClassificationTestLoader to filter it was
the hw_classification attribute itself.
Motivation
Part of the test-case refactoring initiative (#185590) to tag test classes
with HardwareClassification so the suite can be filtered by hardware
category via --hw-classification. Without the tag, EventLibTest and
RdzvEventLibTest are "unclassified" and are excluded when
--hw-classification GENERIC is passed, even though they are logically
generic CPU-only logic that should run under that filter. This PR adds the
tag so both classes are correctly selectable.
The classification is metadata only: it filters tests when
--hw-classification is passed; normal discovery and execution are unchanged.

**Test Plan**
python test/distributed/elastic/events/lib_test.py -v --hw-classification GENERIC python test/distributed/elastic/events/lib_test.py
Both run OK (8/8 tests pass).

**Notes**
Part of the test case refactoring initiative tracked in #185590. No framework
dependency — this PR only adds the classification tag to two already-generic
test classes.

[@wjlFlyer](https://github.com/wjlFlyer)
[@pjyFight](https://github.com/pjyFight)
[@FuDdd](https://github.com/FuDdd)
[@fffrog](https://github.com/fffrog)
[@lyriexs666](https://github.com/lyriexs666)
[@jishuangfeng](https://github.com/jishuangfeng)
[@JiasenTian](https://github.com/JiasenTian)