### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_minifier_isolate.py
+++ b/test/inductor/test_minifier_isolate.py
@@ -1,18 +1,19 @@
 # Owner(s): ["module: inductor"]
 import unittest
 
+import torch
 import torch._inductor.config as inductor_config
 from torch._dynamo.test_minifier_common import MinifierTestBase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_JETSON,
     IS_MACOS,
     skipIfWindows,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE
-from torch.testing._internal.triton_utils import requires_gpu
-from torch.utils._triton import get_triton_version
+from torch.utils._triton import get_triton_version, has_triton
 
 
 skipIfRocmWithoutDebugAsserts = unittest.skipIf(
@@ -37,26 +38,41 @@ inner(torch.randn(2, 2).to("{device}"))
         # These must isolate because they crash the process
         self._run_full_test(run_code, "aot", expected_error, isolate=True)
 
+
+class MinifierIsolateTestsOnlyCPU(MinifierIsolateTests):
+    hw_classification = HardwareClassification.CPU
+
     @unittest.skipIf(IS_JETSON, "Fails on Jetson")
     @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "runtime_error")
     @skipIfWindows(
         msg="Build Failed: fatal error C1083: Cannot open include file: 'Python.h': No such file or directory"
     )
-    def test_after_aot_cpu_runtime_error(self):
-        self._test_after_aot_runtime_error("cpu", "")
+    def test_after_aot_cpu_runtime_error(self, device):
+        self._test_after_aot_runtime_error(device, "")
+
+
+class MinifierIsolateTestsACCELERATOR(MinifierIsolateTests):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @skipIfRocmWithoutDebugAsserts
-    @requires_gpu
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "runtime_error")
-    def test_after_aot_gpu_runtime_error(self):
+    def test_after_aot_gpu_runtime_error(self, device):
         # CUDA's __assertfail surfaces through PyTorch as "device-side assert";
         # ROCm's Triton AMD lowering prints the injected assertion text before trapping.
+        device_type = torch.device(device).type
         expected_error = (
             "injected assert fail"
-            if GPU_TYPE == "xpu" or TEST_WITH_ROCM
+            if device_type == "xpu" or TEST_WITH_ROCM
             else "device-side assert"
         )
-        self._test_after_aot_runtime_error(GPU_TYPE, expected_error)
+        self._test_after_aot_runtime_error(device, expected_error)
+
+
+instantiate_device_type_tests(MinifierIsolateTestsOnlyCPU, globals(), only_for="cpu")
+instantiate_device_type_tests(
+    MinifierIsolateTestsACCELERATOR, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_minifier_isolate.py
python test/inductor/test_minifier_isolate.py -v --hw-classification CPU
python test/inductor/test_minifier_isolate.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo