### PR TITLE
[Testcase Refactoring] Classify forward loss backward tests by hardware

### DIFF
--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -12,6 +12,7 @@ from torch._dynamo.testing import (
     normalize_gm,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -22,6 +23,8 @@ from torch.testing._internal.common_utils import (
 @torch._dynamo.config.patch(trace_autograd_ops=True)
 @skipIfTorchDynamo()
 class TestForwardLossBackward(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_backward_test(self, fn, mod, x, backend=None):
         """
         Shared utility for running backward tests.


### PR DESCRIPTION
## Summary
Classifies forward-loss-backward Dynamo tests with hardware metadata.

## Changes
- Add HardwareClassification coverage for the forward loss backward test class.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_fwd_loss_bwd.py
python -m py_compile test/dynamo/test_fwd_loss_bwd.py
npu-run-suite npu test_fwd_loss_bwd.py
```

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98