### PR TITLE
[TEST] Add hw_classification to test_aot_autograd.py

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -33,7 +33,10 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import compare_equal_outs_and_grads
+from torch.testing._internal.common_utils import (
+    compare_equal_outs_and_grads,
+    HardwareClassification,
+)
 from torch.utils._sympy.symbol import make_symbol, SymT
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -59,6 +62,8 @@ lib.impl("maybe_dupe_op", maybe_dupe_op, "Meta")
 
 
 class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):
@@ -1912,6 +1917,8 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
 
 class AotAutogradFallbackTestsDevice(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     @patch.object(torch._dynamo.config, "capture_dynamic_output_shape_ops", True)


### PR DESCRIPTION
## Summary
Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `AotAutogradFallbackTests` (54 CPU-only framework-level tests)
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `AotAutogradFallbackTestsDevice` (1 test with `@onlyAccelerator` and `instantiate_device_type_tests`)

## Test Plan

```
python test/dynamo/test_aot_autograd.py -v
Ran 56 tests in 46.206s -- OK (skipped=1, expected failures=1)

python test/dynamo/test_aot_autograd.py -v --hw-classification GENERIC
Ran 54 tests in 44.988s -- OK (expected failures=1)

python test/dynamo/test_aot_autograd.py -v --hw-classification ACCELERATOR
Ran 2 tests in 3.381s -- OK (skipped=1)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98