### PR TITLE
[Test] Move CUDA specific tests out ot TestProfilerTree class and add hw labels

### DIFF
--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_CROSSREF,
     TestCase,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.utils._pytree import tree_map
 
 
@@ -95,11 +96,11 @@ class ProfilerTree:
         """
 
         @functools.wraps(f)
-        def begin_unit_test_marker(self, replicates=3):
+        def begin_unit_test_marker(self, replicates=3, **kwargs):
             try:
                 for i in range(replicates):
                     self.tree_replicate = i
-                    out = f(self)
+                    out = f(self, **kwargs)
                     if self.tree_replicate is None:
                         break
                 return out
@@ -232,10 +233,7 @@ class ProfilerTree:
                     raise AssertionError(f"{parent_name} vs. {caller_name}")
 
 
-@unittest.skipIf(IS_ARM64, "Not working on ARM")
-class TestProfilerTree(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
+class _TestProfilerTreeBase(TestCase):
     def assertTreesMatch(self, actual: str, expected: str, allow_failure: bool = False):
         # Warning: Here be dragons
         #   Different platforms will have subtly different behavior for Python
@@ -277,6 +275,11 @@ class TestProfilerTree(TestCase):
                     print(msg.split("AssertionError:")[-1])
                 else:
                     raise
+
+
+@unittest.skipIf(IS_ARM64, "Not working on ARM")
+class TestProfilerTree(_TestProfilerTreeBase):
+    hw_classification = HardwareClassification.GENERIC
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
@@ -780,40 +783,15 @@ class TestProfilerTree(TestCase):
 
 
 @unittest.skipIf(IS_ARM64, "Not working on ARM")
-class TestProfilerTreeCUDA(TestCase):
+class TestProfilerTreeCUDA(_TestProfilerTreeBase):
     hw_classification = HardwareClassification.CUDA
 
-    # Kept in sync with TestProfilerTree.assertTreesMatch.
-    def assertTreesMatch(self, actual: str, expected: str, allow_failure: bool = False):
-        if not expecttest.ACCEPT:
-            actual = actual.ljust(len(expected))
-        self.maxDiff = None
-
-        replicate = getattr(self, "tree_replicate", None)
-        self.assertIsNotNone(
-            replicate, "Please annotate test with `@ProfilerTree.test`"
-        )
-
-        if replicate:
-            self.assertEqual(actual, expected)
-        else:
-            try:
-                self.assertExpectedInline(actual, expected, skip=1)
-            except AssertionError as e:
-                if allow_failure:
-                    self.tree_replicate = None
-                    msg = traceback.format_exception_only(type(e), e)[0]
-                    print(msg.split("AssertionError:")[-1])
-                else:
-                    raise
-
     @unittest.skip("https://github.com/pytorch/pytorch/issues/83606")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     @ProfilerTree.test
-    def test_profiler_experimental_tree_cuda(self):
+    def test_profiler_experimental_tree_cuda(self, device):
         with torch.profiler.profile(profile_memory=True) as p:
-            weight = torch.ones(1, device="cuda", requires_grad=True)
-            x = torch.ones(1, device="cuda")
+            weight = torch.ones(1, device=device, requires_grad=True)
+            x = torch.ones(1, device=device)
             y = torch.add(weight, x)
             loss = torch.pow(y, 2)
             loss.backward()
@@ -906,13 +884,12 @@ class TestProfilerTreeCUDA(TestCase):
         )
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/83606")
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     @ProfilerTree.test
-    def test_profiler_experimental_tree_cuda_with_stream(self):
+    def test_profiler_experimental_tree_cuda_with_stream(self, device):
         streams = [torch.cuda.Stream() for _ in range(3)]
         results = []
         with torch.profiler.profile(profile_memory=True) as p:
-            x = torch.ones((4, 4), device="cuda")
+            x = torch.ones((4, 4), device=device)
             for stream in streams:
                 with torch.cuda.stream(stream):
                     results.append(torch.tanh(x) - x)
@@ -966,18 +943,17 @@ class TestProfilerTreeCUDA(TestCase):
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."
     )
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     @ProfilerTree.test
-    def test_profiler_experimental_tree_cuda_detailed(self):
+    def test_profiler_experimental_tree_cuda_detailed(self, device):
         # Do lazy imports ahead of time to avoid it showing up in the tree
         import torch.nested._internal.nested_tensor
 
-        model = torch.nn.modules.Linear(1, 1, device="cuda")
+        model = torch.nn.modules.Linear(1, 1, device=device)
         model.train()
         opt = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
 
         def step():
-            x = torch.ones((1, 1), device="cuda")
+            x = torch.ones((1, 1), device=device)
             loss = model(x)
             loss.backward()
             opt.step()
@@ -1174,6 +1150,7 @@ class TestProfilerTreeCUDA(TestCase):
             allow_failure=ALLOW_CUDA_FAILURE,
         )
 
+instantiate_device_type_tests(TestProfilerTreeCUDA, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -12,6 +12,7 @@ import expecttest
 import torch
 from torch._C._profiler import _ExtraFields_PyCall, _ExtraFields_PyCCall
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_WINDOWS,
     run_tests,
@@ -233,6 +234,8 @@ class ProfilerTree:
 
 @unittest.skipIf(IS_ARM64, "Not working on ARM")
 class TestProfilerTree(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def assertTreesMatch(self, actual: str, expected: str, allow_failure: bool = False):
         # Warning: Here be dragons
         #   Different platforms will have subtly different behavior for Python
@@ -277,10 +280,6 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(
-        torch.cuda.is_available() or torch.xpu.is_available(),
-        "Test not working for CUDA and XPU",
-    )
     def test_profiler_experimental_tree(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile() as p:
@@ -335,10 +334,6 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(
-        torch.cuda.is_available() or torch.xpu.is_available(),
-        "Test not working for CUDA and XPU",
-    )
     def test_profiler_experimental_tree_with_record_function(self):
         with torch.profiler.profile() as p:
             with torch.autograd.profiler.record_function("Top level Annotation"):
@@ -388,10 +383,6 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(
-        torch.cuda.is_available() or torch.xpu.is_available(),
-        "Test not working for CUDA and XPU",
-    )
     def test_profiler_experimental_tree_with_memory(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile(profile_memory=True) as p:
@@ -786,6 +777,35 @@ class TestProfilerTree(TestCase):
                 torch/profiler/profiler.py(...): stop
                   ...""",
         )
+
+
+@unittest.skipIf(IS_ARM64, "Not working on ARM")
+class TestProfilerTreeCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    # Kept in sync with TestProfilerTree.assertTreesMatch.
+    def assertTreesMatch(self, actual: str, expected: str, allow_failure: bool = False):
+        if not expecttest.ACCEPT:
+            actual = actual.ljust(len(expected))
+        self.maxDiff = None
+
+        replicate = getattr(self, "tree_replicate", None)
+        self.assertIsNotNone(
+            replicate, "Please annotate test with `@ProfilerTree.test`"
+        )
+
+        if replicate:
+            self.assertEqual(actual, expected)
+        else:
+            try:
+                self.assertExpectedInline(actual, expected, skip=1)
+            except AssertionError as e:
+                if allow_failure:
+                    self.tree_replicate = None
+                    msg = traceback.format_exception_only(type(e), e)[0]
+                    print(msg.split("AssertionError:")[-1])
+                else:
+                    raise
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/83606")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -11,6 +11,7 @@ import expecttest
 
 import torch
 from torch._C._profiler import _ExtraFields_PyCall, _ExtraFields_PyCCall
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_ARM64,
@@ -20,7 +21,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_CROSSREF,
     TestCase,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.utils._pytree import tree_map
 
 
@@ -283,6 +283,10 @@ class TestProfilerTree(_TestProfilerTreeBase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile() as p:
@@ -337,6 +341,10 @@ class TestProfilerTree(_TestProfilerTreeBase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree_with_record_function(self):
         with torch.profiler.profile() as p:
             with torch.autograd.profiler.record_function("Top level Annotation"):
@@ -386,6 +394,10 @@ class TestProfilerTree(_TestProfilerTreeBase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree_with_memory(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile(profile_memory=True) as p:
@@ -1149,6 +1161,7 @@ class TestProfilerTreeCUDA(_TestProfilerTreeBase):
                     ...""",
             allow_failure=ALLOW_CUDA_FAILURE,
         )
+
 
 instantiate_device_type_tests(TestProfilerTreeCUDA, globals(), only_for="cuda")
 


### PR DESCRIPTION
## What changed
- Added a base class `_TestProfilerTreeBase` that owns shared method.
- Split the single mixed class into two: `TestProfilerTree` (S1, HardwareClassification.GENERIC) keeps the 7 CPU-only tests; new `TestProfilerTreeCUDA` holds the 3 genuinely CUDA-specific tests (`test_profiler_experimental_tree_cuda, _with_stream, _detailed`).
- Added `HardwareClassification` import and `hw_classification` attributes; `assertTreesMatch` is duplicated in the CUDA class (annotated "Kept in sync") since inheriting would double-collect the CPU tests.