### PR TITLE
[Test] Improve test reuse in test/quantization/jit/test_deprecated_jit_quant.py for out-of-tree backends

### DIFF
--- a/test/quantization/jit/test_deprecated_jit_quant.py
+++ b/test/quantization/jit/test_deprecated_jit_quant.py
@@ -113,43 +113,42 @@ class TestDeprecatedJitQuantized(JitTestCase):
                     cell, dtype=torch.float16
                 )
 
-    if "fbgemm" in torch.backends.quantized.supported_engines:
+    @skipIfNoFBGEMM
+    def test_quantization_modules(self):
+        K1, N1 = 2, 2
 
-        def test_quantization_modules(self):
-            K1, N1 = 2, 2
+        class FooBar(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = torch.nn.Linear(K1, N1).float()
 
-            class FooBar(torch.nn.Module):
-                def __init__(self) -> None:
-                    super().__init__()
-                    self.linear1 = torch.nn.Linear(K1, N1).float()
+            def forward(self, x):
+                x = self.linear1(x)
+                return x
 
-                def forward(self, x):
-                    x = self.linear1(x)
-                    return x
+        fb = FooBar()
+        fb.linear1.weight = torch.nn.Parameter(
+            torch.tensor([[-150, 100], [100, -150]], dtype=torch.float),
+            requires_grad=False,
+        )
+        fb.linear1.bias = torch.nn.Parameter(
+            torch.zeros_like(fb.linear1.bias), requires_grad=False
+        )
 
-            fb = FooBar()
-            fb.linear1.weight = torch.nn.Parameter(
-                torch.tensor([[-150, 100], [100, -150]], dtype=torch.float),
-                requires_grad=False,
-            )
-            fb.linear1.bias = torch.nn.Parameter(
-                torch.zeros_like(fb.linear1.bias), requires_grad=False
-            )
+        x = (torch.rand(1, K1).float() - 0.5) / 10.0
+        value = torch.tensor([[100, -150]], dtype=torch.float)
 
-            x = (torch.rand(1, K1).float() - 0.5) / 10.0
-            value = torch.tensor([[100, -150]], dtype=torch.float)
+        y_ref = fb(value)
 
-            y_ref = fb(value)
+        with self.assertRaisesRegex(
+            RuntimeError, "quantize_linear_modules function is no longer supported"
+        ):
+            fb_int8 = torch.jit.quantized.quantize_linear_modules(fb)
 
-            with self.assertRaisesRegex(
-                RuntimeError, "quantize_linear_modules function is no longer supported"
-            ):
-                fb_int8 = torch.jit.quantized.quantize_linear_modules(fb)
-
-            with self.assertRaisesRegex(
-                RuntimeError, "quantize_linear_modules function is no longer supported"
-            ):
-                fb_fp16 = torch.jit.quantized.quantize_linear_modules(fb, torch.float16)
+        with self.assertRaisesRegex(
+            RuntimeError, "quantize_linear_modules function is no longer supported"
+        ):
+            fb_fp16 = torch.jit.quantized.quantize_linear_modules(fb, torch.float16)
 
     @skipIfNoFBGEMM
     def test_erase_class_tensor_shapes(self):


### PR DESCRIPTION
Summary

Improve test reuse in test/quantization/jit/test_deprecated_jit_quant.py for out-of-tree backends by making the FBGEMM guard of `test_quantization_modules` consistent with the other tests in the file.

Changes

Replace the inline class-body guard:

```python
if "fbgemm" in torch.backends.quantized.supported_engines:

    def test_quantization_modules(self):
```

with the standard `@skipIfNoFBGEMM` decorator already used by `test_rnn_cell_quantized`, `test_rnn_quantized`, and `test_erase_class_tensor_shapes`.

No test semantics, test count, or execution logic are changed: `skipIfNoFBGEMM` skips the test with a clear reason when FBGEMM is not among `torch.backends.quantized.supported_engines`, instead of omitting the method at class definition time. This keeps test discovery consistent across backends.

Test Plan

```
python test/test_quantization.py TestDeprecatedJitQuantized -v
```
