### PR TITLE
Stop mse_loss/smooth_l1_loss mean/sum reductions from retaining the full elementwise-loss storage

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1535,6 +1535,13 @@ void TensorIteratorBase::build(TensorIteratorConfig& config) {
 // unconditionally returns a real Tensor (prior to output setting,
 // this function may return an undefined tensor.)
 void TensorIteratorBase::set_output_raw_strided(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides, TensorOptions options) {
+  if (operands_.empty()) {
+    // A structured kernel's meta function may declare its output without
+    // building this iterator when the impl does not use it (e.g. mse_loss
+    // with Mean/Sum reduction); there is no iterator state to synchronize.
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(num_outputs_ == 0);
+    return;
+  }
   auto& op = operands_[output_idx];
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(output_idx < num_outputs_);
   const auto& t = maybe_get_output(output_idx);

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -73,29 +73,46 @@ namespace {
 
 namespace at::meta {
 
+// For Mean/Sum reductions the result is 0-dim and the IMPL computes the
+// elementwise loss into its own temporary, so building *this* would allocate
+// a full broadcast-size output only to be shrunk by resize_({}), permanently
+// retaining the large storage (#185647). Validate the inputs with a throwaway
+// iterator instead and declare the 0-dim output directly.
+static void loss_reduction_meta(TensorIteratorBase& meta, const Tensor& input, const Tensor& target) {
+  Tensor unused;
+  auto iter = TensorIterator::borrowing_binary_op(unused, input, target);
+  auto options = iter.output().options();
+  const auto& out = meta.maybe_get_output(0);
+  if (out.defined()) {
+    TORCH_CHECK(canCast(iter.common_dtype(), out.scalar_type()),
+                "result type ", iter.common_dtype(),
+                " can't be cast to the desired output type ", out.scalar_type());
+    options = options.dtype(out.scalar_type());
+  }
+  meta.set_output_raw_strided(0, {}, {}, options);
+}
+
 TORCH_META_FUNC(smooth_l1_loss)
 (const Tensor& input, const Tensor& target, const int64_t reduction, double beta) {
   TORCH_CHECK(beta >= 0, "smooth_l1_loss does not support negative values for beta.")
-  // TODO: Reduce this extra TensorIterator construction for Reduction::Mean & Sum.
-  // We do another TensorIterator construction in the IMPL for the two cases.
-  build_borrowing_binary_op(maybe_get_output(), input, target);
   if (reduction == Reduction::None) {
+    build_borrowing_binary_op(maybe_get_output(), input, target);
     return;
   }
 
   TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
-  maybe_get_output().resize_({});
+  loss_reduction_meta(*this, input, target);
 }
 
 TORCH_META_FUNC(mse_loss)
 (const Tensor& input, const Tensor& target, const int64_t reduction) {
-  build_borrowing_binary_op(maybe_get_output(), input, target);
   if (reduction == Reduction::None) {
+    build_borrowing_binary_op(maybe_get_output(), input, target);
     return;
   }
 
   TORCH_INTERNAL_ASSERT(reduction == Reduction::Mean || reduction == Reduction::Sum);
-  maybe_get_output().resize_({});
+  loss_reduction_meta(*this, input, target);
 }
 
 } // namespace at::meta

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9066,6 +9066,45 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'Expected all tensors to be on the same device'):
             F.mse_loss(i, t)
 
+    @parametrize_test("loss_name", ["mse_loss", "smooth_l1_loss"])
+    @parametrize_test("reduction", ["mean", "sum"])
+    def test_loss_reduction_scalar_storage(self, device, loss_name, reduction):
+        # Regression test for #185647: the 0-dim result must not retain the
+        # full elementwise-loss buffer.
+        loss_fn = getattr(F, loss_name)
+        x = torch.rand(3, 16, 16, device=device)
+        y = torch.rand(3, 16, 16, device=device)
+        result = loss_fn(x, y, reduction=reduction)
+        self.assertEqual(result.untyped_storage().nbytes(), result.element_size())
+        unreduced = loss_fn(x, y, reduction='none')
+        expected = unreduced.mean() if reduction == 'mean' else unreduced.sum()
+        self.assertEqual(result, expected)
+        out = torch.empty((), device=device)
+        reduction_enum = torch.nn._reduction.get_enum(reduction)
+        loss_out = getattr(torch._C._nn, loss_name)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            loss_out(x, y, reduction_enum, out=out)
+        self.assertEqual(len(w), 0)
+        self.assertEqual(out.untyped_storage().nbytes(), out.element_size())
+        self.assertEqual(out, expected)
+        out_int = torch.empty((), device=device, dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "can't be cast to the desired output type"):
+            loss_out(x, y, reduction_enum, out=out_int)
+        out_f64 = torch.empty((), device=device, dtype=torch.float64)
+        loss_out(x, y, reduction_enum, out=out_f64)
+        self.assertEqual(out_f64.dtype, torch.float64)
+        self.assertEqual(out_f64.untyped_storage().nbytes(), out_f64.element_size())
+        self.assertEqual(out_f64, expected, exact_dtype=False)
+        out_full = torch.empty(3, 16, 16, device=device)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            loss_out(x, y, reduction_enum, out=out_full)
+        self.assertEqual(len(w), 1)
+        self.assertIn("resized", str(w[0].message))
+        self.assertEqual(out_full.dim(), 0)
+        self.assertEqual(out_full, expected)
+
     @onlyNativeDeviceTypes
     def test_Unfold_empty(self, device):
         inp = torch.randn(0, 3, 3, 4, device=device)


### PR DESCRIPTION
Fixes #185647

`mse_loss` and `smooth_l1_loss` with `reduction='mean'` or `'sum'` returned a
0-dim tensor whose storage still held the full broadcast-shape elementwise-loss
buffer (786 KB for a 3x256x256 input, instead of 4 bytes). The meta function
built the structured TensorIterator with the real output, which allocates the
full-size output, then shrank it with `resize_({})` - and `resize_` never
releases storage. The impl doesn't even use that iterator for mean/sum; it
builds its own temporary. The same path also grew a user-provided `out=` tensor
to full size and raised a spurious resize warning for a correctly-shaped 0-dim
`out=`.

The meta now only builds the structured iterator for `reduction='none'` (the
path that actually uses it). For mean/sum it validates the inputs with a
throwaway borrowing_binary_op (same broadcast/dtype/device checks as before),
replicates the `canCast` safe-casting check for `out=`, and declares the 0-dim
output directly. `TensorIteratorBase::set_output_raw_strided` gets an
early-return guard for this declare-without-build case, which previously
indexed an empty `operands_`.

Two user-visible edge-case deltas, both moving toward standard
structured-kernel behavior: a full-shape `out=` for a scalar result now gets
the standard out-resize deprecation warning (it was silently accepted before),
and a wrong-device `out=` error now comes from `resize_out` instead of the
iterator build, with different wording.

The new test in test/test_nn.py is device-generic, parametrized over both ops
and both reductions, and fails without the fix.