### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_minifier.py
+++ b/test/inductor/test_minifier.py
@@ -7,12 +7,17 @@ import torch._inductor.config as inductor_config
 from torch._dynamo.test_minifier_common import MinifierTestBase
 from torch._inductor import config
 from torch.export import load as export_load
-from torch.testing._internal.common_utils import IS_JETSON, IS_MACOS, TEST_WITH_ASAN
-from torch.testing._internal.inductor_utils import GPU_TYPE
-from torch.testing._internal.triton_utils import requires_gpu
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_JETSON,
+    IS_MACOS,
+    TEST_WITH_ASAN,
+)
+from torch.utils._triton import has_triton
 
 
-class MinifierTests(MinifierTestBase):
+class MinifierTestsBase(MinifierTestBase):
     # Test that compile and accuracy errors after aot can be repro'd (both CPU and CUDA)
     def _test_after_aot(self, device, expected_error):
         # NB: The program is intentionally quite simple, just enough to
@@ -28,146 +33,6 @@ def inner(x):
 inner(torch.randn(20, 20).to("{device}"))
 """
         self._run_full_test(run_code, "aot", expected_error, isolate=False)
-
-    @unittest.skipIf(IS_JETSON, "Fails on Jetson")
-    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "compile_error")
-    def test_after_aot_cpu_compile_error(self):
-        self._test_after_aot("cpu", "CppCompileError")
-
-    @unittest.skipIf(IS_JETSON, "Fails on Jetson")
-    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_after_aot_cpu_accuracy_error(self):
-        self._test_after_aot("cpu", "AccuracyError")
-
-    @requires_gpu
-    @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "compile_error")
-    def test_after_aot_gpu_compile_error(self):
-        self._test_after_aot(GPU_TYPE, "SyntaxError")
-
-    @requires_gpu
-    @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_after_aot_gpu_accuracy_error(self):
-        self._test_after_aot(GPU_TYPE, "AccuracyError")
-
-    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_constant_in_graph(self):
-        run_code = """\
-@torch.compile()
-def inner(x):
-    return torch.tensor(2) + torch.relu(x)
-
-inner(torch.randn(2))
-"""
-        self._run_full_test(run_code, "aot", "AccuracyError", isolate=False)
-
-    @requires_gpu
-    @patch.object(config, "joint_graph_constant_folding", False)
-    def test_rmse_improves_over_atol(self):
-        # From https://twitter.com/itsclivetime/status/1651135821045719041?s=20
-        run_code = """
-@torch.compile()
-def inner(x):
-    return x - torch.tensor(655, dtype=torch.half, device='GPU_TYPE') * 100
-
-inner(torch.tensor(655 * 100, dtype=torch.half, device='GPU_TYPE'))
-""".replace("GPU_TYPE", GPU_TYPE)
-
-        # If we disable RMSE against fp64, this triggers accuracy error,
-        # as the increased precision from torch.compile changes the result
-        # of 655 * 100
-        with dynamo_config.patch("same_two_models_use_fp64", False):
-            self._run_full_test(
-                run_code,
-                "aot",
-                "AccuracyError",
-                isolate=False,
-                # NB: need this to avoid refusing to minify when fp64 doesn't work
-                # (which it doesn't, due to the config patch above)
-                minifier_args=["--strict-accuracy"],
-            )
-
-        # But using fp64, we see that the intended semantics is the increased
-        # 655 * 100 precision, and so we report no problem
-        self._run_full_test(run_code, "aot", None, isolate=False)
-
-    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
-    @inductor_config.patch("cpp.inject_log1p_bug_TESTING_ONLY", "accuracy")
-    def test_accuracy_vs_strict_accuracy(self):
-        run_code = """
-@torch.compile()
-def inner(x):
-    y = torch.log1p(x)
-    b = y > 0
-    # Need to ensure suffix removal hits a boolean output
-    b = torch.logical_not(b)
-    b = torch.logical_not(b)
-    x = torch.relu(x)
-    return torch.where(b, x, x)
-
-inner(torch.randn(20))
-"""
-
-        # Strict accuracy gets hung up on the boolean mask difference, which
-        # will localize the error to sigmoid, even though it doesn't actually
-        # matter to the end result
-        res = self._run_full_test(
-            run_code,
-            "aot",
-            "AccuracyError",
-            isolate=False,
-            minifier_args=["--strict-accuracy"],
-        )
-        self.assertExpectedInline(
-            res.repro_module(),
-            """\
-class Repro(torch.nn.Module):
-    def __init__(self) -> None:
-        super().__init__()
-
-    def forward(self, arg0_1):
-        log1p = torch.ops.aten.log1p.default(arg0_1);  arg0_1 = None
-        return (log1p,)""",
-        )
-
-        # FP accuracy will refuse to promote the logical_not on the outputs,
-        # and so you'll get to the relu (unless the minifier somehow tries
-        # removing entire suffix except the log1p first!)
-        res = self._run_full_test(run_code, "aot", "AccuracyError", isolate=False)
-        self.assertExpectedInline(
-            res.repro_module(),
-            """\
-class Repro(torch.nn.Module):
-    def __init__(self) -> None:
-        super().__init__()
-
-    def forward(self, arg0_1):
-        relu = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
-        return (relu,)""",
-        )
-
-    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_offload_to_disk(self):
-        # Just a smoketest, this doesn't actually test that memory
-        # usage went down.  Test case is carefully constructed to hit
-        # delta debugging.
-        run_code = """\
-@torch.compile()
-def inner(x):
-    x = torch.sin(x)
-    x = torch.sin(x)
-    x = torch.cos(x)
-    x = torch.relu(x)
-    return x
-
-inner(torch.randn(20, 20))
-"""
-        self._run_full_test(
-            run_code,
-            "aot",
-            "AccuracyError",
-            isolate=False,
-            minifier_args=["--offload-to-disk"],
-        )
 
     # Test that compile errors in AOTInductor can be repro'd (both CPU and CUDA)
     def _test_aoti(self, device, expected_error):
@@ -256,13 +121,27 @@ def forward(self, linear_default):
     return pytree.tree_unflatten((relu_default,), self._out_spec)""",
         )
 
+
+class MinifierTestsOnlyCPU(MinifierTestsBase):
+    hw_classification = HardwareClassification.CPU
+
+    @unittest.skipIf(IS_JETSON, "Fails on Jetson")
+    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "compile_error")
+    def test_after_aot_cpu_compile_error(self, device):
+        self._test_after_aot(device, "CppCompileError")
+
+    @unittest.skipIf(IS_JETSON, "Fails on Jetson")
+    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
+    def test_after_aot_cpu_accuracy_error(self, device):
+        self._test_after_aot(device, "AccuracyError")
+
     @unittest.skipIf(IS_JETSON, "Fails on Jetson")
     @inductor_config.patch(
         "cpp.inject_relu_bug_TESTING_ONLY",
         "compile_error",
     )
-    def test_aoti_cpu_compile_error(self):
-        res = self._test_aoti("cpu", "CppCompileError")
+    def test_aoti_cpu_compile_error(self, device):
+        res = self._test_aoti(device, "CppCompileError")
         self._aoti_check_relu_repro(res)
 
     @unittest.skipIf(IS_JETSON, "Fails on Jetson")
@@ -270,39 +149,183 @@ def forward(self, linear_default):
         "cpp.inject_relu_bug_TESTING_ONLY",
         "compile_error",
     )
-    def test_aoti_cpu_compile_error_unflatten(self):
-        res = self._test_aoti_unflattened_inputs("cpu", "CppCompileError")
-        self._aoti_check_relu_repro(res)
-
-    @requires_gpu
-    @inductor_config.patch(
-        "triton.inject_relu_bug_TESTING_ONLY",
-        "compile_error",
-    )
-    def test_aoti_gpu_compile_error(self):
-        res = self._test_aoti(GPU_TYPE, "SyntaxError")
-        self._aoti_check_relu_repro(res)
-
-    @requires_gpu
-    @inductor_config.patch(
-        "triton.inject_relu_bug_TESTING_ONLY",
-        "compile_error",
-    )
-    def test_aoti_gpu_compile_error_unflatten(self):
-        res = self._test_aoti_unflattened_inputs(GPU_TYPE, "SyntaxError")
+    def test_aoti_cpu_compile_error_unflatten(self, device):
+        res = self._test_aoti_unflattened_inputs(device, "CppCompileError")
         self._aoti_check_relu_repro(res)
 
     @unittest.skipIf(IS_JETSON, "Fails on Jetson")
     @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_aoti_cpu_accuracy_error(self):
-        res = self._test_aoti("cpu", "AccuracyError")
+    def test_aoti_cpu_accuracy_error(self, device):
+        res = self._test_aoti(device, "AccuracyError")
         self._aoti_check_relu_repro(res)
 
-    @requires_gpu
+
+class MinifierTestsGeneric(MinifierTestsBase):
+    hw_classification = HardwareClassification.GENERIC
+
+    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
+    def test_constant_in_graph(self):
+        run_code = """\
+@torch.compile()
+def inner(x):
+    return torch.tensor(2) + torch.relu(x)
+
+inner(torch.randn(2))
+"""
+        self._run_full_test(run_code, "aot", "AccuracyError", isolate=False)
+
+    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
+    @inductor_config.patch("cpp.inject_log1p_bug_TESTING_ONLY", "accuracy")
+    def test_accuracy_vs_strict_accuracy(self):
+        run_code = """
+@torch.compile()
+def inner(x):
+    y = torch.log1p(x)
+    b = y > 0
+    # Need to ensure suffix removal hits a boolean output
+    b = torch.logical_not(b)
+    b = torch.logical_not(b)
+    x = torch.relu(x)
+    return torch.where(b, x, x)
+
+inner(torch.randn(20))
+"""
+
+        # Strict accuracy gets hung up on the boolean mask difference, which
+        # will localize the error to sigmoid, even though it doesn't actually
+        # matter to the end result
+        res = self._run_full_test(
+            run_code,
+            "aot",
+            "AccuracyError",
+            isolate=False,
+            minifier_args=["--strict-accuracy"],
+        )
+        self.assertExpectedInline(
+            res.repro_module(),
+            """\
+class Repro(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, arg0_1):
+        log1p = torch.ops.aten.log1p.default(arg0_1);  arg0_1 = None
+        return (log1p,)""",
+        )
+
+        # FP accuracy will refuse to promote the logical_not on the outputs,
+        # and so you'll get to the relu (unless the minifier somehow tries
+        # removing entire suffix except the log1p first!)
+        res = self._run_full_test(run_code, "aot", "AccuracyError", isolate=False)
+        self.assertExpectedInline(
+            res.repro_module(),
+            """\
+class Repro(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, arg0_1):
+        relu = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
+        return (relu,)""",
+        )
+
+    @inductor_config.patch("cpp.inject_relu_bug_TESTING_ONLY", "accuracy")
+    def test_offload_to_disk(self):
+        # Just a smoketest, this doesn't actually test that memory
+        # usage went down.  Test case is carefully constructed to hit
+        # delta debugging.
+        run_code = """\
+@torch.compile()
+def inner(x):
+    x = torch.sin(x)
+    x = torch.sin(x)
+    x = torch.cos(x)
+    x = torch.relu(x)
+    return x
+
+inner(torch.randn(20, 20))
+"""
+        self._run_full_test(
+            run_code,
+            "aot",
+            "AccuracyError",
+            isolate=False,
+            minifier_args=["--offload-to-disk"],
+        )
+
+
+class MinifierTestsACCELERATOR(MinifierTestsBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
+    @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "compile_error")
+    def test_after_aot_gpu_compile_error(self, device):
+        self._test_after_aot(device, "SyntaxError")
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "accuracy")
-    def test_aoti_gpu_accuracy_error(self):
-        res = self._test_aoti(GPU_TYPE, "AccuracyError")
+    def test_after_aot_gpu_accuracy_error(self, device):
+        self._test_after_aot(device, "AccuracyError")
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
+    @patch.object(config, "joint_graph_constant_folding", False)
+    def test_rmse_improves_over_atol(self, device):
+        # From https://twitter.com/itsclivetime/status/1651135821045719041?s=20
+        run_code = f"""
+@torch.compile()
+def inner(x):
+    return x - torch.tensor(655, dtype=torch.half, device='{device}') * 100
+
+inner(torch.tensor(655 * 100, dtype=torch.half, device='{device}'))
+"""
+
+        # If we disable RMSE against fp64, this triggers accuracy error,
+        # as the increased precision from torch.compile changes the result
+        # of 655 * 100
+        with dynamo_config.patch("same_two_models_use_fp64", False):
+            self._run_full_test(
+                run_code,
+                "aot",
+                "AccuracyError",
+                isolate=False,
+                # NB: need this to avoid refusing to minify when fp64 doesn't work
+                # (which it doesn't, due to the config patch above)
+                minifier_args=["--strict-accuracy"],
+            )
+
+        # But using fp64, we see that the intended semantics is the increased
+        # 655 * 100 precision, and so we report no problem
+        self._run_full_test(run_code, "aot", None, isolate=False)
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
+    @inductor_config.patch(
+        "triton.inject_relu_bug_TESTING_ONLY",
+        "compile_error",
+    )
+    def test_aoti_gpu_compile_error(self, device):
+        res = self._test_aoti(device, "SyntaxError")
         self._aoti_check_relu_repro(res)
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
+    @inductor_config.patch(
+        "triton.inject_relu_bug_TESTING_ONLY",
+        "compile_error",
+    )
+    def test_aoti_gpu_compile_error_unflatten(self, device):
+        res = self._test_aoti_unflattened_inputs(device, "SyntaxError")
+        self._aoti_check_relu_repro(res)
+
+    @unittest.skipUnless(has_triton(), "Triton not available")
+    @inductor_config.patch("triton.inject_relu_bug_TESTING_ONLY", "accuracy")
+    def test_aoti_gpu_accuracy_error(self, device):
+        res = self._test_aoti(device, "AccuracyError")
+        self._aoti_check_relu_repro(res)
+
+
+instantiate_device_type_tests(MinifierTestsOnlyCPU, globals(), only_for="cpu")
+instantiate_device_type_tests(
+    MinifierTestsACCELERATOR, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_minifier.py
python test/inductor/test_minifier.py -v --hw-classification CPU
python test/inductor/test_minifier.py -v --hw-classification GENERIC
python test/inductor/test_minifier.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo