### PR TITLE
[Test] Refactor test_comparison_utils.py with hw_classification

### DIFF
--- a/test/test_comparison_utils.py
+++ b/test/test_comparison_utils.py
@@ -4,10 +4,12 @@
 import unittest
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 class TestComparisonUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_all_equal_no_assert(self):
         t = torch.tensor([0.5])
         torch._assert_tensor_metadata(t, [1], [1], torch.float)


### PR DESCRIPTION
Add hw_classification = HardwareClassification.GENERIC to TestComparisonUtils. All tests verify torch._assert_tensor_metadata utility behavior (sizes, strides, dtype, device mismatch, layout) — comparison logic with no accelerator dependency.

cc: @mansiag05 @Vishal487 