### PR TITLE
Fix block_diag vmap batching rule crash on batch size 0

### DIFF
--- a/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
+++ b/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
@@ -588,6 +588,18 @@ Tensor block_diag_batching_rule(TensorList tensors) {
   // Implementing this as a dummy for loop for now, since I'm not sure how to do it any better.
   // I'm probably not accounting for potentially multiple batched dimensions?
   auto bdim = physical_tensors[0].size(0);
+  if (bdim == 0) {
+    // The loop below would give cat nothing. One block_diag call on
+    // per-sample-shaped zeros (sum keeps dtype) yields the right empty result.
+    std::vector<Tensor> inputs_for_batch;
+    inputs_for_batch.reserve(physical_tensors.size());
+    for (const auto& t : physical_tensors) {
+      inputs_for_batch.push_back(t.sum(0, /*keepdim=*/false, t.scalar_type()));
+    }
+    auto out = at::block_diag(inputs_for_batch);
+    auto result = out.unsqueeze(0).narrow(0, 0, 0);
+    return physical_views[0].getPhysicalToLogicalMap().apply(result);
+  }
   std::vector<Tensor> batched_outputs;
   batched_outputs.reserve(bdim);
   for (const auto& i : c10::irange(bdim)) {

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6608,6 +6608,28 @@ class TestVmapDeviceType(Namespace.TestVmapBase):
 
         check_vmap_fallback(self, test, torch._test_check_tensor)
 
+    def test_block_diag_batch_size_0(self, device):
+        # Regression test for #192024: batch size 0 crashed in at::cat.
+        def op(*tensors):
+            return torch.block_diag(*tensors)
+
+        x = torch.rand(0, 3, device=device)
+        y = torch.rand(0, 4, device=device)
+        self.assertEqual(vmap(op)(x, y).shape, (0, 2, 7))
+        self.assertEqual(vmap(op)(x).shape, (0, 1, 3))
+        self.assertEqual(vmap(op)(torch.rand(0, 2, 3, device=device)).shape, (0, 2, 3))
+        s0 = torch.rand(0, device=device)
+        self.assertEqual(vmap(op)(s0, s0.clone()).shape, (0, 2, 2))
+        unbatched = torch.rand(4, device=device)
+        self.assertEqual(vmap(op, in_dims=(0, None))(x, unbatched).shape, (0, 2, 7))
+        y64 = torch.rand(0, 4, device=device, dtype=torch.float64)
+        self.assertEqual(vmap(op)(x, y64).dtype, torch.float64)
+        xg = x.clone().requires_grad_()
+        result = vmap(op)(xg, y)
+        self.assertTrue(result.requires_grad)
+        result.sum().backward()
+        self.assertEqual(xg.grad, torch.zeros_like(xg))
+
 
 @markDynamoStrictTest
 class TestVmapNestedTensor(Namespace.TestVmapBase):


### PR DESCRIPTION
Fixes #192024

`torch.vmap(lambda *x: torch.block_diag(*x))` over inputs with a batch
dimension of 0 raised `ValueError: torch.cat(): expected a non-empty list of
Tensors`. The batching rule decomposes per batch index and concatenates the
per-sample outputs; with batch size 0 the loop never runs and `at::cat` gets
an empty list. Every other decomposing rule (e.g. cat, stack) handles batch
size 0.

The fix adds a bdim == 0 path to `block_diag_batching_rule`: it sums away the
empty batch dimension of each input (yielding per-sample-shaped zeros, with an
explicit dtype so bool/int inputs are not promoted), runs `at::block_diag`
once on those - reusing the op's own shape computation, dtype promotion, and
input validation - and narrows the unsqueezed result back to batch 0. Summing
and narrowing keep the result connected to the autograd graph, so a batch-0
result of inputs requiring grad still requires grad and backward produces
zero-sized grads, matching what vmap over `torch.cat` does at batch 0.

The issue's proposed fix (`return at::empty({0}, ...)`) returns a 1-D tensor
where the correct result is `(0, R, C)` and skips dtype promotion, so it was
not used.

The new test in test/functorch/test_vmap.py covers multi-input, single-input,
2-D/1-D/0-D per-sample shapes, mixed batched/unbatched inputs, dtype
promotion, and grad connectivity at batch 0; it fails without the fix.

cc @Chillee @samdow @kshitij12345