### PR TITLE
[Testcase Refactoring] Migrate test_inductor_annotations and test_inductor_utils to hw_classification and device-type tests

### DIFF
--- a/test/inductor/test_inductor_annotations.py
+++ b/test/inductor/test_inductor_annotations.py
@@ -3,32 +3,39 @@ import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class InductorAnnotationTestCase(TestCase):
-    def get_code(self):
+    hw_classification = HardwareClassification.CUDA
+
+    def get_code(self, device):
         def f(a, b):
             return a + b, a * b
 
-        a = torch.randn(5, device="cuda")
-        b = torch.randn(5, device="cuda")
+        a = torch.randn(5, device=device)
+        b = torch.randn(5, device=device)
         f_comp = torch.compile(f)
 
         _, code = run_and_get_code(f_comp, a, b)
         return code[0]
 
-    @requires_cuda_and_triton
-    def test_no_annotations(self):
-        code = self.get_code()
+    @requires_capabilities(Capability.lib.triton)
+    def test_no_annotations(self, device):
+        code = self.get_code(device)
 
         self.assertTrue("from torch.cuda import nvtx" not in code)
         self.assertTrue("training_annotation" not in code)
 
     @inductor_config.patch(annotate_training=True)
-    @requires_cuda_and_triton
-    def test_training_annotation(self):
-        code = self.get_code()
+    @requires_capabilities(Capability.lib.triton)
+    def test_training_annotation(self, device):
+        code = self.get_code(device)
 
         self.assertTrue("from torch.cuda import nvtx" in code)
         self.assertTrue(
@@ -37,6 +44,8 @@ class InductorAnnotationTestCase(TestCase):
         )
         self.assertTrue(code.count("nvtx._device_range_end(training_annotation)") >= 1)
 
+
+instantiate_device_type_tests(InductorAnnotationTestCase, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_inductor_annotations.py
+++ b/test/inductor/test_inductor_annotations.py
@@ -1,14 +1,13 @@
 # Owner(s): ["module: inductor"]
+import unittest
+
 import torch
 import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 class InductorAnnotationTestCase(TestCase):
@@ -25,7 +24,7 @@ class InductorAnnotationTestCase(TestCase):
         _, code = run_and_get_code(f_comp, a, b)
         return code[0]
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_no_annotations(self, device):
         code = self.get_code(device)
 
@@ -33,7 +32,7 @@ class InductorAnnotationTestCase(TestCase):
         self.assertTrue("training_annotation" not in code)
 
     @inductor_config.patch(annotate_training=True)
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_training_annotation(self, device):
         code = self.get_code(device)
 

--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -10,16 +10,15 @@ from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
 from torch.autograd import DeviceType
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+)
 from torch.utils._ordered_set import OrderedSet
 
 
 log = logging.getLogger(__name__)
-
-device_type = (
-    acc.type
-    if (acc := torch.accelerator.current_accelerator(check_available=True))
-    else "cpu"
-)
 
 
 class FakeKinetoEvent:
@@ -77,25 +76,8 @@ class FakeProfilerEvent:
         self.cpu_children = cpu_children or []
 
 
-class TestBench(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        x = torch.rand(1024, 10).to(device_type).half()
-        w = torch.rand(512, 10).to(device_type).half()
-        cls._bench_fn = staticmethod(
-            functools.partial(torch.nn.functional.linear, x, w)
-        )
-
-    def test_benchmarker(self):
-        res = benchmarker.benchmark_gpu(self._bench_fn)
-        log.warning("do_bench result: %s", res)
-        self.assertGreater(res, 0)
-
-    def test_do_bench_using_profiling(self):
-        res = do_bench_using_profiling(self._bench_fn)
-        log.warning("do_bench_using_profiling result: %s", res)
-        self.assertGreater(res, 0)
+class TestBenchGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_do_bench_profile_result_uses_linked_device_events(self):
         profiler_events = [
@@ -197,5 +179,40 @@ class TestBench(TestCase):
             )
 
 
+instantiate_parametrized_tests(TestBenchGeneric)
+
+
+class TestBenchAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        device = cls.get_primary_device()
+        x = torch.rand(1024, 10).to(device).half()
+        w = torch.rand(512, 10).to(device).half()
+        cls._bench_fn = staticmethod(
+            functools.partial(torch.nn.functional.linear, x, w)
+        )
+
+    def test_benchmarker(self, device):
+        res = benchmarker.benchmark_gpu(self._bench_fn)
+        log.warning("do_bench result: %s", res)
+        self.assertGreater(res, 0)
+
+    def test_do_bench_using_profiling(self, device):
+        res = do_bench_using_profiling(self._bench_fn)
+        log.warning("do_bench_using_profiling result: %s", res)
+        self.assertGreater(res, 0)
+
+
+instantiate_device_type_tests(
+    TestBenchAccelerator,
+    globals(),
+    allow_mps=True,
+    allow_xpu=True,
+)
+
+
 if __name__ == "__main__":
-    run_tests(device_type)
+    run_tests()

--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -184,15 +184,14 @@ class TestBenchGeneric(TestCase):
             )
 
 
-class TestBenchAccelerator(TestCase):
+class TestBenchCuda(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        device = cls.get_primary_device()
-        x = torch.rand(1024, 10).to(device).half()
-        w = torch.rand(512, 10).to(device).half()
+        x = torch.rand(1024, 10).to(cls.device_type).half()
+        w = torch.rand(512, 10).to(cls.device_type).half()
         cls._bench_fn = staticmethod(
             functools.partial(torch.nn.functional.linear, x, w)
         )
@@ -209,7 +208,7 @@ class TestBenchAccelerator(TestCase):
         self.assertGreater(res, 0)
 
 
-instantiate_device_type_tests(TestBenchAccelerator, globals(), only_for="cuda")
+instantiate_device_type_tests(TestBenchCuda, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -10,7 +10,11 @@ from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
 from torch.autograd import DeviceType
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -76,6 +80,7 @@ class FakeProfilerEvent:
         self.cpu_children = cpu_children or []
 
 
+@instantiate_parametrized_tests
 class TestBenchGeneric(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
@@ -179,11 +184,8 @@ class TestBenchGeneric(TestCase):
             )
 
 
-instantiate_parametrized_tests(TestBenchGeneric)
-
-
 class TestBenchAccelerator(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.CUDA
 
     @classmethod
     def setUpClass(cls):
@@ -195,23 +197,19 @@ class TestBenchAccelerator(TestCase):
             functools.partial(torch.nn.functional.linear, x, w)
         )
 
-    def test_benchmarker(self, device):
+    @requires_capabilities(Capability.lib.triton)
+    def test_benchmarker(self):
         res = benchmarker.benchmark_gpu(self._bench_fn)
         log.warning("do_bench result: %s", res)
         self.assertGreater(res, 0)
 
-    def test_do_bench_using_profiling(self, device):
+    def test_do_bench_using_profiling(self):
         res = do_bench_using_profiling(self._bench_fn)
         log.warning("do_bench_using_profiling result: %s", res)
         self.assertGreater(res, 0)
 
 
-instantiate_device_type_tests(
-    TestBenchAccelerator,
-    globals(),
-    allow_mps=True,
-    allow_xpu=True,
-)
+instantiate_device_type_tests(TestBenchAccelerator, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -2,24 +2,32 @@
 
 import functools
 import logging
+import unittest
 from unittest import mock
 
 import torch
-from torch._inductor import utils
+from torch._inductor import config, utils
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
 from torch.autograd import DeviceType
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.utils._ordered_set import OrderedSet
 
 
 log = logging.getLogger(__name__)
+
+
+class TestFallbackByDefault(TestCase):
+    def test_sym_size_uses_inductor_lowering_in_lite_mode(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        sym_size = graph.call_function(torch.ops.aten.sym_size.int, (x, 0))
+
+        with config.patch({"fallback_by_default": True}):
+            self.assertFalse(utils.should_fallback_by_default(sym_size))
 
 
 class FakeKinetoEvent:
@@ -192,7 +200,7 @@ class TestBenchCuda(TestCase):
             functools.partial(torch.nn.functional.linear, x, w)
         )
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_benchmarker(self):
         res = benchmarker.benchmark_gpu(self._bench_fn)
         log.warning("do_bench result: %s", res)

--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -15,10 +15,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     requires_capabilities,
 )
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    instantiate_parametrized_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.utils._ordered_set import OrderedSet
 
 
@@ -80,7 +77,6 @@ class FakeProfilerEvent:
         self.cpu_children = cpu_children or []
 
 
-@instantiate_parametrized_tests
 class TestBenchGeneric(TestCase):
     hw_classification = HardwareClassification.GENERIC
 


### PR DESCRIPTION
### Summary

Migrate test_inductor_annotations.py from requires_cuda_and_triton to instantiate_device_type_tests, and split test_inductor_utils.py into Generic and CUDA classes by HardwareClassification.

### Changes

- test_inductor_annotations.py: replace `@requires_cuda_and_triton` with `@unittest.skipIf(not HAS_TRITON, "requires triton")`, add device parameter, add hw_classification=CUDA, add instantiate_device_type_tests(only_for="cuda")
- test_inductor_utils.py: split TestBench into TestBenchGeneric (GENERIC, 3 mock tests) and TestBenchCuda (CUDA, 2 benchmark tests), restore TestFallbackByDefault (accidentally removed), use cls.device_type in setUpClass
- Guard test_benchmarker with `@unittest.skipIf(not HAS_TRITON, "requires triton")`
- Clean up imports: remove Capability/requires_capabilities, add HAS_TRITON

### Motivation

The original code used legacy patterns (requires_cuda_and_triton decorator, module-level device_type variable) that bypass the standard device-type test infrastructure. The split separates pure-logic tests (GENERIC) from CUDA-dependent benchmark tests, and uses standard instantiate_device_type_tests with explicit HAS_TRITON guard.

### Test Plan

```
python test/inductor/test_inductor_annotations.py
python test/inductor/test_inductor_utils.py
```