### PR TITLE
[Test] Refactor test_numba_integration.py with hw_classification

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -4,6 +4,7 @@ import unittest
 
 import torch
 import torch.testing._internal.common_utils as common
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.common_cuda import (
     TEST_CUDA,
     TEST_MULTIGPU,
@@ -20,6 +21,8 @@ if TEST_NUMBA_CUDA:
 
 
 class TestNumbaIntegration(common.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     def test_cuda_array_interface(self):


### PR DESCRIPTION
Add hw_classification = HardwareClassification.CUDA to TestNumbaIntegration. All 8 tests exercise the CUDA Array Interface protocol and numba.cuda interop — functionality that only exists on CUDA devices.

cc: @mansiag05 @vishalgoyal316 