### PR TITLE
[Testcase Refactoring] Decouple test_pg_wrapper.py from device-specific hardware

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_distributed import (
     with_dist_debug_levels,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_XPU,
@@ -54,7 +55,7 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
                 f"{list(tensor.shape)}" in err,
                 lambda msg: f"{msg}\nDid not find shapes {list(tensor.shape)} in error {err}",
             )
-            # For CUDA, only assert on device type, not index
+            # For accelerator, only assert on device type, not index
             if device_type in str(tensor.device):
                 self.assertTrue(
                     device_type in err,
@@ -258,6 +259,8 @@ if not TEST_WITH_DEV_DBG_ASAN:
     @requires_gloo()
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     class ProcessGroupNCCLWrapperTest(AbstractProcessGroupWrapperTest):
+        hw_classification = HardwareClassification.ACCELERATOR
+
         def setUp(self):
             super(AbstractProcessGroupWrapperTest, self).setUp()
             self._spawn_processes()
@@ -577,6 +580,72 @@ if not TEST_WITH_DEV_DBG_ASAN:
 
 @requires_gloo()
 class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def opts(self, threads=2, timeout=10.0):
+        opts = c10d.ProcessGroupGloo._Options()
+        opts._timeout = timeout
+        opts._devices = [create_device(interface=LOOPBACK)]
+        opts._threads = threads
+        return opts
+
+    def _create_wrapper_pg(self, with_new_group=False, timeout=10.0):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+        if with_new_group:
+            pg = c10d.new_group(backend="gloo")
+        else:
+            _pg = c10d.ProcessGroupGloo(
+                store, self.rank, self.world_size, self.opts(timeout=timeout)
+            )
+            pg = c10d._create_process_group_wrapper(
+                _pg,
+                "unused",
+                store,
+                self.rank,
+                self.world_size,
+                timeout=timeout,
+            )
+        return pg
+
+    # NOTE: these tests are separated by debug level instead of combined into
+    # one due to https://github.com/pytorch/pytorch/issues/55967, they can be
+    # combined after that is resolved.
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_collectives_op_mismatch_cuda_debug_mode(self):
+        pg = self._create_wrapper_pg(with_new_group=True)
+        self._test_collectives_op_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @with_dist_debug_levels(levels=["OFF"])
+    def test_collectives_op_mismatch_cuda(self):
+        pg = self._create_wrapper_pg(with_new_group=False)
+        self._test_collectives_op_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_collective_shape_mismatch_cuda_debug_mode(self):
+        pg = self._create_wrapper_pg(with_new_group=True)
+        self._test_collective_shape_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @with_dist_debug_levels(levels=["OFF"])
+    def test_collective_shape_mismatch_cuda(self):
+        pg = self._create_wrapper_pg(with_new_group=False)
+        self._test_collective_shape_mismatch(pg, use_accel=True)
+
+
+@requires_gloo()
+class ProcessGroupGlooWrapperTestOnCPU(AbstractProcessGroupWrapperTest):
+    hw_classification = HardwareClassification.GENERIC
+
     def opts(self, threads=2, timeout=10.0):
         opts = c10d.ProcessGroupGloo._Options()
         opts._timeout = timeout
@@ -631,33 +700,6 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def test_collective_shape_mismatch_debug_mode_off(self):
         pg = self._create_wrapper_pg(with_new_group=False)
         self._test_collective_shape_mismatch(pg)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["DETAIL"])
-    def test_collectives_op_mismatch_cuda_debug_mode(self):
-        pg = self._create_wrapper_pg(with_new_group=True)
-        self._test_collectives_op_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["OFF"])
-    def test_collectives_op_mismatch_cuda(self):
-        pg = self._create_wrapper_pg(with_new_group=False)
-        self._test_collectives_op_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["DETAIL"])
-    def test_collective_shape_mismatch_cuda_debug_mode(self):
-        pg = self._create_wrapper_pg(with_new_group=True)
-        self._test_collective_shape_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @with_dist_debug_levels(levels=["OFF"])
-    def test_collective_shape_mismatch_cuda(self):
-        pg = self._create_wrapper_pg(with_new_group=False)
-        self._test_collective_shape_mismatch(pg, use_accel=True)
 
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_reduce_scatter_tensor_coalesced_debug_mode(self):


### PR DESCRIPTION
## Summary

Extract 6 CPU-only Gloo tests into a new `ProcessGroupGlooWrapperTestOnCPU` class, separating accelerator-unrelated tests from accelerator-dependent ones. This enables these tests to run on CPU-only CI machines without requiring an accelerator.

## Changes

- **Create `ProcessGroupGlooWrapperTestOnCPU`** extending `MultiProcessTestCase` with `hw_classification = HardwareClassification.GENERIC`, containing the 6 CPU-only Gloo tests:
  - `test_collective_hang`
  - `test_collectives_op_mismatch_debug_mode`
  - `test_collectives_op_mismatch`
  - `test_collective_shape_mismatch_debug_mode`
  - `test_collective_shape_mismatch_debug_mode_off`
  - `test_reduce_scatter_tensor_coalesced_debug_mode`
- **Tag `ProcessGroupNCCLWrapperTest`** with `hw_classification = HardwareClassification.ACCELERATOR`
- **Tag `ProcessGroupGlooWrapperTest`** with `hw_classification = HardwareClassification.ACCELERATOR`
- **Add missing `@unittest.skipIf(TEST_XPU, ...)`** to `test_collective_shape_mismatch_cuda` to match its 3 sibling `_cuda` tests (fixes pre-existing inconsistency)
- **Update stale comment** `'For CUDA'` → `'For accelerator'` in `_validate_error`
- **Import `HardwareClassification`** from `common_utils`

## Test Plan

- Test count preserved: **21** (11 NCCL + 4 Gloo accelerator + 6 Gloo CPU-only)
- Verified: all 6 extracted tests pass on both **CPU** and **NPU** environments
- No regressions: 15 skipped tests skip for the same infrastructure reasons as before (no NCCL/XCCL backend on NPU; `skip_if_lt_x_gpu` doesn't check NPU)

cc @oncall: distributed