### PR TITLE
[autograd] Fix AD for logaddexp/logaddexp2 with a bool operand

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -4029,6 +4029,27 @@ class TestBinaryUfuncsDevice(TestCase):
     def test_logaddexp2(self, device, dtype):
         self._test_logaddexp(device, dtype, base2=True)
 
+    def test_logaddexp_bool_input_ad(self, device):
+        mask = torch.tensor([True, False, True], device=device)
+        x = torch.tensor([0.25, 0.5, 0.75], device=device)
+
+        for op, expected in (
+            (torch.logaddexp, torch.sigmoid(x - mask.float())),
+            (
+                torch.logaddexp2,
+                torch.exp2(x) / (torch.exp2(mask.float()) + torch.exp2(x)),
+            ),
+        ):
+            for op_call in (lambda m, v: op(m, v), lambda m, v: op(v, m)):
+                t = x.clone().requires_grad_()
+                op_call(mask, t).sum().backward()
+                self.assertEqual(t.grad, expected)
+
+                with fwAD.dual_level():
+                    dual = fwAD.make_dual(x, torch.ones_like(x))
+                    tangent = fwAD.unpack_dual(op_call(mask, dual)).tangent
+                self.assertEqual(tangent, expected)
+
     def test_add(self, device):
         dtypes = floating_and_complex_types()
         for dtype in dtypes:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -987,14 +987,14 @@
   result: auto_element_wise
 
 - name: logaddexp(Tensor self, Tensor other) -> Tensor
-  self: grad / (1 + exp(other - self)).conj()
-  other: grad / (1 + exp(self - other)).conj()
-  result: self_t / (1 + exp(other_p - self_p)) + other_t / (1 + exp(self_p - other_p))
+  self: grad / (1 + exp(other.to(grad.scalar_type()) - self.to(grad.scalar_type()))).conj()
+  other: grad / (1 + exp(self.to(grad.scalar_type()) - other.to(grad.scalar_type()))).conj()
+  result: self_t / (1 + exp(other_p.to(result.scalar_type()) - self_p.to(result.scalar_type()))) + other_t / (1 + exp(self_p.to(result.scalar_type()) - other_p.to(result.scalar_type())))
 
 - name: logaddexp2(Tensor self, Tensor other) -> Tensor
-  self: grad / (1 + pow(2, other - self))
-  other: grad / (1 + pow(2, self - other))
-  result: self_t / (1 + pow(2, other_p - self_p)) + other_t / (1 + pow(2, self_p - other_p))
+  self: grad / (1 + pow(2, other.to(grad.scalar_type()) - self.to(grad.scalar_type())))
+  other: grad / (1 + pow(2, self.to(grad.scalar_type()) - other.to(grad.scalar_type())))
+  result: self_t / (1 + pow(2, other_p.to(result.scalar_type()) - self_p.to(result.scalar_type()))) + other_t / (1 + pow(2, self_p.to(result.scalar_type()) - other_p.to(result.scalar_type())))
 
 # Note [Gradient formula for xlogy at x = 0, y <= 0]
 # x * log(y) is not defined at y <= 0, so we cannot even talk about differentiability


### PR DESCRIPTION
Fixes #192721

The reverse and forward mode derivative formulas subtract the input primals directlyby doing (exp(other - self)). ATen's sub_check bans subtraction when either operand is a bool tensor, so differentiating logaddexp(mask, x) fails in both modes even though the forward pass succeeds; an int8 operand works because it promotes to float.

The fix casts both primals to a floating scalar type before subtracting: grad.scalar_type() in the reverse formulas (mirrors the norm_backward formula) and result.scalar_type() in the forward formulas. No-op for the floating and complex dtypes logaddexp otherwise accepts, and handles a bool operand in either argument position.

Test Plan:
python test/test_binary_ufuncs.py -k logaddexp_bool_input_ad (passes successfully)