### PR TITLE
Fix backward for reductions with a complex dtype= on a real input

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -3803,7 +3803,7 @@ class CompiledAutograd0(torch.nn.Module):
         validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type='cpu'), 6, 0, None), [], True, 6)]);  getitem = None
         getitem_25 = validate_outputs[0];  validate_outputs = None
 
-        sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_25], [True], [unwrap_maybe_dynamic_int, unwrap_maybe_dynamic_int_1]);  getitem_25 = unwrap_maybe_dynamic_int = unwrap_maybe_dynamic_int_1 = None
+        sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_25], [True], 6, [unwrap_maybe_dynamic_int, unwrap_maybe_dynamic_int_1]);  getitem_25 = unwrap_maybe_dynamic_int = unwrap_maybe_dynamic_int_1 = None
         getitem_26 = sum_backward0[0];  sum_backward0 = None
         validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_26], [((None, None, device(type='cpu'), 6, 0, None), [unwrap_maybe_dynamic_int_2, unwrap_maybe_dynamic_int_3], True, 6)]);  getitem_26 = unwrap_maybe_dynamic_int_2 = unwrap_maybe_dynamic_int_3 = None
         getitem_27 = validate_outputs_1[0];  validate_outputs_1 = None
@@ -4064,7 +4064,7 @@ class CompiledAutograd0(torch.nn.Module):
         validate_outputs = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem], [((None, None, device(type='cpu'), 6, 0, None), [], False, 6)]);  getitem = None
         getitem_14 = validate_outputs[0];  validate_outputs = None
 
-        sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_14], [True], [unwrap_maybe_dynamic_int, unwrap_maybe_dynamic_int_1]);  getitem_14 = unwrap_maybe_dynamic_int = unwrap_maybe_dynamic_int_1 = None
+        sum_backward0 = torch__dynamo_compiled_autograd_ops_SumBackward0([getitem_14], [True], 6, [unwrap_maybe_dynamic_int, unwrap_maybe_dynamic_int_1]);  getitem_14 = unwrap_maybe_dynamic_int = unwrap_maybe_dynamic_int_1 = None
         getitem_15 = sum_backward0[0];  sum_backward0 = None
         validate_outputs_1 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_15], [((None, None, device(type='cpu'), 6, 0, None), [unwrap_maybe_dynamic_int_2, unwrap_maybe_dynamic_int_3], False, 6)]);  getitem_15 = unwrap_maybe_dynamic_int_2 = unwrap_maybe_dynamic_int_3 = None
         getitem_16 = validate_outputs_1[0];  validate_outputs_1 = None

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -14841,6 +14841,61 @@ class TestAutogradDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.autograd.grad(b, a)
 
+    _reduction_dtype_arg_ops = {
+        "sum": lambda t, d: t.sum(dtype=d),
+        "sum_dim": lambda t, d: t.sum(dim=0, dtype=d),
+        "nansum": lambda t, d: t.nansum(dim=0, dtype=d),
+        "mean": lambda t, d: t.mean(dtype=d),
+        "mean_dim": lambda t, d: t.mean(dim=0, dtype=d),
+        "prod": lambda t, d: t.prod(dtype=d),
+        "prod_dim": lambda t, d: t.prod(dim=0, dtype=d),
+        "cumsum": lambda t, d: t.cumsum(0, dtype=d),
+        "cumprod": lambda t, d: t.cumprod(0, dtype=d),
+    }
+
+    @parametrize("op_name", list(_reduction_dtype_arg_ops))
+    def test_reduction_complex_dtype_arg_backward(self, device, op_name):
+        # Regression test for #192719: a complex dtype= on a real input must
+        # produce a real grad instead of tripping autograd's dtype check.
+        if op_name == "nansum" and torch.device(device).type == "cpu":
+            self.skipTest("nansum CPU kernel does not support complex")
+        op = self._reduction_dtype_arg_ops[op_name]
+        # + 0.5 keeps prod/cumprod values away from zero and their backward
+        # away from the zero-input special case
+        x = torch.rand(3, 4, device=device, dtype=torch.float64) + 0.5
+        x.requires_grad_()
+        out = op(x, torch.complex128)
+        self.assertEqual(out.dtype, torch.complex128)
+        # warn_always so the TORCH_WARN_ONCE "discards the imaginary part"
+        # copy warning cannot be consumed by an earlier test in the process
+        with set_warn_always_context(True), warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            out.real.sum().backward()
+        self.assertFalse(any("imaginary part" in str(w.message) for w in ws))
+        self.assertEqual(x.grad.dtype, torch.float64)
+        ref = x.detach().clone().requires_grad_()
+        op(ref.to(torch.complex128), None).real.sum().backward()
+        self.assertEqual(x.grad, ref.grad)
+        gradcheck(
+            lambda t: torch.view_as_real(op(t, torch.complex128)),
+            (x.detach().clone().requires_grad_(),),
+        )
+
+    @parametrize("op_name", list(_reduction_dtype_arg_ops))
+    def test_reduction_widening_dtype_arg_backward(self, device, op_name):
+        # A real widening dtype= (float32 input, float64 out) must keep
+        # producing a float32 grad after the #192719 fix.
+        op = self._reduction_dtype_arg_ops[op_name]
+        x = torch.rand(3, 4, device=device, dtype=torch.float32) + 0.5
+        x.requires_grad_()
+        out = op(x, torch.float64)
+        self.assertEqual(out.dtype, torch.float64)
+        out.sum().backward()
+        self.assertEqual(x.grad.dtype, torch.float32)
+        ref = x.detach().clone().requires_grad_()
+        op(ref.to(torch.float64), None).sum().backward()
+        self.assertEqual(x.grad, ref.grad)
+
     def test_grad_unused_input_error_message(self, device):
         for unused_idx in [0, 1]:
             x = torch.randn(10, requires_grad=True, device=device)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -524,11 +524,11 @@
   result: logcumsumexp_jvp(self_p, self_t, dim)
 
 - name: cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
-  self: cumprod_backward(grad.to(self.scalar_type()), self, dim, result)
+  self: handle_r_to_c(self.scalar_type(), cumprod_backward(grad, self.to(grad.scalar_type()), dim, result))
   result: "cumprod_jvp(self_t, self_p, result, dim).to(dtype.has_value() ? *dtype : self_p.scalar_type())"
 
 - name: cumsum(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
-  self: cumsum_backward(grad.to(self.scalar_type()), dim)
+  self: cumsum_backward(handle_r_to_c(self.scalar_type(), grad), dim)
   result: auto_linear
 
 - name: cummax(Tensor self, int dim) -> (Tensor values, Tensor indices)
@@ -1156,15 +1156,15 @@
 - name: mean(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes()) / self.sym_numel()
+      self: handle_r_to_c(self.scalar_type(), grad).expand_symint(self.sym_sizes()) / self.sym_numel()
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) / self.sym_numel() when that is supported
-      self: (ones_like(self) * grad) / self.sym_numel()
+      self: (ones_like(self) * handle_r_to_c(self.scalar_type(), grad)) / self.sym_numel()
       result: auto_linear
 
 - name: mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
-  self: mean_backward(grad, self.sym_sizes(), dim, self.sym_numel(), keepdim)
+  self: mean_backward(handle_r_to_c(self.scalar_type(), grad), self.sym_sizes(), dim, self.sym_numel(), keepdim)
   result: auto_linear
 
 - name: median(Tensor self) -> Tensor
@@ -1423,11 +1423,11 @@
   result: auto_element_wise
 
 - name: prod(Tensor self, *, ScalarType? dtype=None) -> Tensor
-  self: prod_backward(grad, self.to(grad.scalar_type()), result)
+  self: handle_r_to_c(self.scalar_type(), prod_backward(grad, self.to(grad.scalar_type()), result))
   result: (prod_backward(at::ones({}, result.options()).expand_as(result), self_p.to(result.scalar_type()), result) * self_t.conj()).sum().conj()
 
 - name: prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
-  self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim)
+  self: handle_r_to_c(self.scalar_type(), prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim))
   result: (prod_backward(at::ones({}, result.options()).expand_as(result), self_p.to(result.scalar_type()), result, dim, keepdim) * self_t.conj()).sum(dim, keepdim).conj()
 
 - name: put(Tensor self, Tensor index, Tensor source, bool accumulate=False) -> Tensor
@@ -1714,24 +1714,24 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes())
+      self: handle_r_to_c(self.scalar_type(), grad).expand_symint(self.sym_sizes())
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) when that is supported
-      self: ones_like(self) * grad
+      self: ones_like(self) * handle_r_to_c(self.scalar_type(), grad)
       result: auto_linear
 
 - name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: sum_backward(grad, self.sym_sizes(), dim, keepdim)
+      self: sum_backward(handle_r_to_c(self.scalar_type(), grad), self.sym_sizes(), dim, keepdim)
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this function once semantics for nested tensor expand have been settled on
-      self: _nested_sum_backward(grad, self, dim, keepdim)
+      self: _nested_sum_backward(handle_r_to_c(self.scalar_type(), grad), self, dim, keepdim)
 
 - name: nansum(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
-  self: nansum_backward(grad.to(self.scalar_type()), self, dim, keepdim)
+  self: nansum_backward(handle_r_to_c(self.scalar_type(), grad), self, dim, keepdim)
   result: at::where(self_p.isnan(), 0, self_t).sum(dim, keepdim, dtype)
 
 # We never call _linalg_svd with compute_uv=False in an autograd context, so we don't even consider it here


### PR DESCRIPTION
Fixes #192719

`torch.sum(x, dtype=torch.complex128)` on a real `x` computed the forward but
failed in backward with the autograd engine's internal check
`isFloatingType(grad.scalar_type()) || (input_is_complex == grad_is_complex)`.
The engine deliberately refuses to pass a complex grad to a real input (to
avoid silently dropping imaginary parts), so backward formulas of ops with a
`dtype=` argument must cast the incoming grad back to the input's dtype
themselves. The formulas were inconsistent: cumsum and nansum cast via
`grad.to(self.scalar_type())` (which works but emits a spurious "Casting
complex values to real discards the imaginary part" warning on CPU), cumprod
cast the grad but then reintroduced complex values through `result`, and
sum/mean/prod did not cast at all - sum, mean, prod, and cumprod all raised.

This wraps the affected formulas in `handle_r_to_c` (the existing helper used
by 18 formulas in derivatives.yaml, which takes `at::real(grad)` for the
real-input/complex-grad case without the copy warning): sum, sum.dim_IntList
(incl. the nested-tensor variants), mean, mean.dim, prod, prod.dim_int,
cumprod, cumsum, and nansum. For prod/cumprod the whole backward call is
wrapped, since those compute internally with the complex `result`; cumprod's
input is now cast up to the grad dtype, matching prod's existing convention.
Grads now equal the cast-first reference `op(x.to(complex128))` backward
everywhere, and the cumsum CPU warning is gone.

Out of scope: nansum/nanmean and softmax/log_softmax on CPU fail earlier in
the *forward* (their CPU kernels have no complex support); nansum's backward
is fixed by this PR and verified on CUDA, where its forward works.

The new device-generic test parametrizes over the nine ops, checks grad
dtype/values against the cast-first reference, absence of the warning,
gradcheck, and that float widening (`dtype=float64` on float32 input) still
works. It fails without the fix for sum/mean/prod/cumprod.

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93 @anjali411 @dylanbespalko @mruberry @amjames @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @chauhang @aakhundov @coconutruben @jataylo