### PR TITLE
Fix FakeTensor output strides for native_batch_norm on noncontiguous CPU inputs

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3375,6 +3375,41 @@ class FakeTensorPropTest(TestCase):
         self.assertEqual(x.size(), y.size())
         self.assertEqual(x.stride(), y.stride())
 
+    def test_batch_norm_stride_match(self):
+        # Regression test for #192668: eager CPU batch_norm always returns a
+        # format-contiguous output while CUDA preserves the input layout; the
+        # fake output strides must match eager on both.
+        def check(x, op=torch.ops.aten.native_batch_norm.default):
+            C = x.shape[1]
+            w, b = torch.ones(C, device=x.device), torch.zeros(C, device=x.device)
+            m, v = torch.zeros(C, device=x.device), torch.ones(C, device=x.device)
+            args = (x, w, b, m, v, True, 0.1, 1e-5)
+            eager = op(*args)[0]
+            with FakeTensorMode() as mode:
+                fake_args = tuple(
+                    mode.from_tensor(a) if isinstance(a, torch.Tensor) else a
+                    for a in args
+                )
+                fake = op(*fake_args)[0]
+            self.assertEqual(eager.stride(), fake.stride())
+
+        def make_cases(device):
+            cl = torch.channels_last
+            return [
+                torch.randn(2, 3, 4, device=device).transpose(1, 2),
+                torch.randn(2, 4, 3, device=device),
+                torch.randn(2, 4, 8, 8, device=device).to(memory_format=cl),
+                torch.randn(8, 8, 4, 2, device=device).permute(3, 2, 0, 1),
+            ]
+
+        for x in make_cases("cpu"):
+            check(x)
+        x = torch.randn(2, 3, 4).transpose(1, 2)
+        check(x, op=torch.ops.aten._native_batch_norm_legit.default)
+        if RUN_CUDA:
+            for x in make_cases("cuda"):
+                check(x)
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_torch_load_with_fake_mode(self):
         model = torch.nn.Linear(5, 10)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2150,8 +2150,25 @@ def native_batch_norm_helper(
     if input.device.type == "cpu":
         save_mean = save_mean.to(dtype=input.dtype)
         save_rstd = save_rstd.to(dtype=input.dtype)
+        # batch_norm_cpu always allocates a format-contiguous output
+        # (Normalization.cpp), while other backends preserve the input layout
+        # via empty_like; without this the fake/meta output keeps arbitrary
+        # input strides that eager CPU does not produce (#192668).
+        if input.is_contiguous():
+            memory_format = torch.contiguous_format
+        elif input.is_contiguous(memory_format=torch.channels_last_3d):
+            memory_format = torch.channels_last_3d
+        elif input.is_contiguous(memory_format=torch.channels_last):
+            memory_format = torch.channels_last
+        else:
+            memory_format = utils.suggest_memory_format(input)
+        # copy=True because to() alone will not restride a noncontiguous
+        # tensor when the dtype already matches
+        output = output.to(dtype=input.dtype, memory_format=memory_format, copy=True)
+    else:
+        output = output.to(dtype=input.dtype)
     return (
-        output.to(dtype=input.dtype),
+        output,
         save_mean,
         save_rstd,
         new_running_mean,


### PR DESCRIPTION
Fixes #192668

Eager CPU `native_batch_norm` always allocates a format-contiguous output
(`batch_norm_cpu` uses `empty_like` with `suggest_memory_format`), but the
fake/meta path - the `native_batch_norm_helper` decomposition, since the op
has no meta kernel - computes the output with broadcasted elementwise
arithmetic, which preserves the input's strides. For a noncontiguous CPU
input the traced metadata is therefore wrong, and stride-consuming ops
downstream fail under torch.compile/export (e.g. `view(-1)`:
"Cannot view a tensor with shape ... and strides ..."). CUDA eager allocates
with plain `empty_like` and genuinely preserves the input layout, so the
current fake behavior is correct there - the divergence is CPU-only.

The fix pins the CPU output layout at the end of `native_batch_norm_helper`,
mirroring eager's memory-format rule (contiguous preferred, channels-last
kept for channels-last-contiguous inputs, `suggest_memory_format` otherwise).
The helper already branches on `input.device.type == "cpu"` twice for eager
CPU/CUDA differences (eval-mode save shapes, save-stat dtypes), so this
follows the established pattern in the same function; FakeTensors carry the
original device, which is why those branches work under fake. The
`.contiguous(...)` is a no-op for contiguous and channels-last inputs, so
common paths are unchanged, and CUDA/other devices are untouched. All three
`_native_batch_norm_legit*` variants go through the same helper and are fixed
together. Since Inductor traces through this decomposition, compiled CPU
graphs now also return eager-matching output strides.

The new test in test/test_fake_tensor.py compares fake vs eager output
strides for transposed, contiguous, channels-last, and arbitrarily permuted
inputs on CPU (plus the legit variant), and asserts CUDA still preserves
input strides. The reporter's compile repro (batch_norm + view on a
transposed input) was verified end-to-end on the eager backend and CPU
Inductor with values matching eager.

cc @eellison @aorenste @liangel-02