### PR TITLE
[Testcase Refactoring] Add hw_classification and split test_c10d_pypg

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -21,12 +21,16 @@ from torch.distributed.distributed_c10d import (
 )
 from torch.futures import Future
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def create_work(result):
@@ -213,6 +217,8 @@ class WindowProcessGroup(dist.ProcessGroup):
 
 # We cannot use parametrize as some tests are defined on the base class and use _get_process_group
 class AbstractDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._spawn_threads()
@@ -266,12 +272,16 @@ class AbstractDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest):
 
 
 class TestDDPWithWorkSubclass(AbstractDDPSingleRank, MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def use_wrapper(self):
         return False
 
 
 class TestDDPWithWorkWrapper(AbstractDDPSingleRank, MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def use_wrapper(self):
         return True
@@ -291,6 +301,8 @@ class BlockWork(dist._Work):
 
 
 class TestPyProcessGroup(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_attr_overrides(self):
         pg = DummyAttrProcessGroup(0, 1)
         self.assertEqual(pg.name(), "dummy-attr")
@@ -474,14 +486,18 @@ class TestPyProcessGroup(TestCase):
         self.assertEqual(dist._new_window(t, group=pg), "fake-window")
         self.assertIs(pg.new_window_tensor, t)
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
-    def test_block_current_stream(self) -> None:
-        torch.cuda.synchronize()
 
-        stream = torch.cuda.Stream()
+class TestPyProcessGroupDevice(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_block_current_stream(self, device) -> None:
+        device_module = torch.get_device_module(device)
+        device_module.synchronize()
+
+        stream = device_module.Stream()
         with stream:
             # nothing in queue so instantly resolves
-            event1 = torch.cuda.Event()
+            event1 = device_module.Event()
             event1.record()
             time.sleep(0.1)
             self.assertTrue(event1.query())
@@ -490,7 +506,7 @@ class TestPyProcessGroup(TestCase):
             work.block_current_stream()
 
             # stream is blocked so doesn't resolve
-            event = torch.cuda.Event()
+            event = device_module.Event()
             event.record()
             time.sleep(0.1)
             self.assertFalse(event.query())
@@ -501,13 +517,13 @@ class TestPyProcessGroup(TestCase):
             stream.synchronize()
             self.assertTrue(event.query())
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
-    def test_block_current_stream_use_after_free(self) -> None:
+    def test_block_current_stream_use_after_free(self, device) -> None:
         """
-        This tests that the CPU control tensor is not freed before the CUDA kernel executes.
+        This tests that the CPU control tensor is not freed before the device kernel executes.
         """
-        torch.cuda.synchronize()
-        stream = torch.cuda.Stream()
+        device_module = torch.get_device_module(device)
+        device_module.synchronize()
+        stream = device_module.Stream()
         with stream:
             a = BlockWork()
             a.block_current_stream()
@@ -521,7 +537,7 @@ class TestPyProcessGroup(TestCase):
             del b
 
             # a is still blocking so this doesn't resolve
-            event = torch.cuda.Event()
+            event = device_module.Event()
             event.record()
             time.sleep(0.1)
             self.assertFalse(event.query())
@@ -533,7 +549,12 @@ class TestPyProcessGroup(TestCase):
             self.assertTrue(event.query())
 
 
+instantiate_device_type_tests(TestPyProcessGroupDevice, globals(), only_for="cuda")
+
+
 class TestBatchSendRecv(MultiProcessTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._spawn_processes()


### PR DESCRIPTION
## Summary

`test/distributed/test_c10d_pypg.py` contains 6 test classes that were previously unclassified. This PR labels all 6 with `hw_classification`, splits the mixed `TestPyProcessGroup` class, and refactors the CUDA-specific stream tests to use device-agnostic APIs via `instantiate_device_type_tests`.

## Changes

### 1. hw_classification labels

- **GENERIC (5)**: `TestDDPWithWorkSubclass`, `TestDDPWithWorkWrapper`, `AbstractDDPSingleRank`, `TestPyProcessGroup` (14 CPU tests), `TestBatchSendRecv`.
- **CUDA (1)**: `TestPyProcessGroupDevice` (new), holding the 2 stream-blocking tests.

### 2. Refactoring of stream tests (addressing review feedback)

- Replaced `torch.cuda.synchronize`/`Stream`/`Event` with device-agnostic `torch.get_device_module(device).synchronize`/`Stream`/`Event`, so the test methods take a `device` parameter and use the device module API.
- Added `instantiate_device_type_tests(TestPyProcessGroupDevice, globals(), only_for="cuda")`. The `only_for="cuda"` is retained because `dist._Work.block_current_stream()` is a C++ method that only supports CUDA streams (raises `"Failed to create StreamBlock"` on other backends). The API layer is device-agnostic; the C++ limitation constrains the device range.
- Removed `@unittest.skipIf(not TEST_CUDA)` decorators (device range now expressed by `only_for="cuda"`) and the stale `TEST_CUDA` import.

### 3. AbstractDDPSingleRank label (addressing review feedback)

Added `hw_classification = HardwareClassification.GENERIC` to `AbstractDDPSingleRank` — its test methods are inherited and executed by `TestDDPWithWorkSubclass`/`Wrapper`, and the class is CPU-only.

No method bodies or decorators are changed (except the stream tests which were refactored). No HCCL or out-of-tree backend references are introduced.

## Motivation

PR #190991 established the convention that every `TestCase` subclass must carry a `hw_classification` attribute. The 6 classes in this file had no label, so they were invisible under hardware-classification filtering.

The stream tests used `torch.cuda.*` hardcoded APIs. Refactoring to `torch.get_device_module(device).*` makes the API layer device-agnostic, consistent with the capability decoupling direction. The `only_for="cuda"` constraint is a C++ limitation of `block_current_stream()`, not a Python-layer limitation.

## Dependencies

None.

## Test Plan

- `python -m py_compile test/distributed/test_c10d_pypg.py` passes.
- `lintrunner test/distributed/test_c10d_pypg.py` passes (No lint issues).
- Test count unchanged: 22 `def test_*` methods.
- CPU mode: `TestPyProcessGroup` (GENERIC) 14 passed; `TestPyProcessGroupDevice` (CUDA) correctly not generated.
- NPU mode: same results.
- No `hccl`/`ascend`/`npu`/`privateuse1` references (verified: 0 matches).

cc @fffrog @wjlFlyer @pjyFight @FuDdd @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
