### PR TITLE
[Testcase Refactoring] Add hardware classification to sparsity utility tests

### DIFF
--- a/test/ao/sparsity/test_sparsity_utils.py
+++ b/test/ao/sparsity/test_sparsity_utils.py
@@ -18,7 +18,11 @@ from torch.testing._internal.common_quantization import (
     SingleLayerLinearModel,
     TwoLayerLinearModel,
 )
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 logging.basicConfig(
@@ -37,6 +41,8 @@ model_list = [
 
 
 class TestSparsityUtilFunctions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_module_to_fqn(self):
         """
         Tests that module_to_fqn works as expected when compared to known good


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestSparsityUtilFunctions` contains eight tests for translating between modules, tensors, and fully qualified names. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestSparsityUtilFunctions`.
- Keep all eight test methods and their behavior unchanged.

## Self-test

Environment:

- Windows, Python 3.11.15
- PyTorch `2.14.0.dev20260810+cu130`
- CUDA 13.0 build
- NVIDIA GeForce RTX 4070 Laptop GPU

Commands:

```bash
python -m pytest -vv -ra test/ao/sparsity/test_sparsity_utils.py
python -m pytest -vv -ra test/ao/sparsity/test_sparsity_utils.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_sparsity_utils.py
```

Results:

- CPU-only environment (`CUDA_VISIBLE_DEVICES=-1`): 8 passed unfiltered; 8 passed with the `GENERIC` filter; 8 collected.
- CUDA-visible environment (`torch.cuda.is_available() == True`): 8 passed unfiltered; 8 passed with the `GENERIC` filter; 8 collected.
- The `GENERIC` filter reported `total=8, passed=8, unclassified=0, mismatched=0`.
- All command exit codes were 0, and the collected test set was unchanged.

The CUDA-visible run verifies compatibility with a CUDA-enabled build. The class does not create CUDA-specific variants because it is not instantiated by device type and does not exercise CUDA-specific behavior.

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.

<!-- self-test-logs:start -->
## Full self-test logs

<details>
<summary>CPU-only self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: False
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue8
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 8 items
Running 8 items in this shard

pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module PASSED [0.0126s] [ 12%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail PASSED [0.0029s] [ 25%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors PASSED [0.0065s] [ 37%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn PASSED [0.0054s] [ 50%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail PASSED [0.0045s] [ 62%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn PASSED [0.0040s] [ 75%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail PASSED [0.0030s] [ 87%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root PASSED [0.0033s] [100%]

============================== 8 passed in 1.29s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue8
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=8, passed=8, unclassified=0, mismatched=0
collected 8 items
Running 8 items in this shard

pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module PASSED [0.0113s] [ 12%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail PASSED [0.0031s] [ 25%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors PASSED [0.0061s] [ 37%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn PASSED [0.0052s] [ 50%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail PASSED [0.0039s] [ 62%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn PASSED [0.0042s] [ 75%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail PASSED [0.0034s] [ 87%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root PASSED [0.0032s] [100%]

============================== 8 passed in 1.27s ==============================
Running 8 items in this shard
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root

8 tests collected in 1.19s
CPU exit codes: unfiltered=0 generic=0 collect=0
```

</details>

<details>
<summary>CUDA-visible self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: True
GPU: NVIDIA GeForce RTX 4070 Laptop GPU
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue8
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 8 items
Running 8 items in this shard

pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module PASSED [0.0112s] [ 12%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail PASSED [0.0028s] [ 25%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors PASSED [0.0055s] [ 37%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn PASSED [0.0057s] [ 50%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail PASSED [0.0039s] [ 62%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn PASSED [0.0038s] [ 75%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail PASSED [0.0032s] [ 87%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root PASSED [0.0030s] [100%]

============================== 8 passed in 1.22s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue8
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=8, passed=8, unclassified=0, mismatched=0
collected 8 items
Running 8 items in this shard

pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module PASSED [0.0105s] [ 12%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail PASSED [0.0031s] [ 25%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors PASSED [0.0055s] [ 37%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn PASSED [0.0051s] [ 50%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail PASSED [0.0034s] [ 62%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn PASSED [0.0039s] [ 75%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail PASSED [0.0034s] [ 87%]
pytorch-issue8\test\ao\sparsity\test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root PASSED [0.0035s] [100%]

============================== 8 passed in 1.22s ==============================
Running 8 items in this shard
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_fqn_to_module_for_tensors
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_get_arg_info_from_tensor_fqn_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_fail
test/ao/sparsity/test_sparsity_utils.py::TestSparsityUtilFunctions::test_module_to_fqn_root

8 tests collected in 1.18s
CUDA exit codes: unfiltered=0 generic=0 collect=0
```

</details>
<!-- self-test-logs:end -->
