### PR TITLE
[Testcase Refactoring] Add hardware classification to nonuniform observer tests

### DIFF
--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -1,14 +1,20 @@
 # Owner(s): ["oncall: quantization"]
 
-from torch.ao.quantization.experimental.observer import APoTObserver
 import unittest
+
 import torch
+from torch.ao.quantization.experimental.observer import APoTObserver
+from torch.testing._internal.common_utils import HardwareClassification
+
 
 class TestNonUniformObserver(unittest.TestCase):
     """
         Test case 1: calculate_qparams
         Test that error is thrown when k == 0
     """
+
+    hw_classification = HardwareClassification.GENERIC
+
     def test_calculate_qparams_invalid(self):
         obs = APoTObserver(b=0, k=0)
         obs.min_val = torch.tensor([0.0])

--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -8,12 +8,12 @@ from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestNonUniformObserver(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """
         Test case 1: calculate_qparams
         Test that error is thrown when k == 0
     """
-
-    hw_classification = HardwareClassification.GENERIC
 
     def test_calculate_qparams_invalid(self):
         obs = APoTObserver(b=0, k=0)


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestNonUniformObserver` contains six tests for APoT observer parameter calculation and forward statistics. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. The tensors use the default device only as inputs to shared observer logic. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestNonUniformObserver`.
- Keep all six test methods and their behavior unchanged.

## Self-test

Environment:

- Windows, Python 3.11.15
- PyTorch `2.14.0.dev20260810+cu130`
- CUDA 13.0 build
- NVIDIA GeForce RTX 4070 Laptop GPU

The nightly wheel does not package the experimental quantization namespace. The current checkout's pure-Python `torch/ao/quantization` directory was therefore prepended to `torch.ao.quantization.__path__` before invoking pytest; the compiled PyTorch runtime remained the official nightly wheel.

Commands (the wrapper only extends the package search path before forwarding the remaining arguments to pytest):

```bash
python -c "import sys, pytest, torch.ao.quantization as q; q.__path__.insert(0, 'torch/ao/quantization'); sys.exit(pytest.main(sys.argv[1:]))" -vv -ra test/quantization/core/experimental/test_nonuniform_observer.py
python -c "import sys, pytest, torch.ao.quantization as q; q.__path__.insert(0, 'torch/ao/quantization'); sys.exit(pytest.main(sys.argv[1:]))" -vv -ra test/quantization/core/experimental/test_nonuniform_observer.py --hw-classification GENERIC
python -c "import sys, pytest, torch.ao.quantization as q; q.__path__.insert(0, 'torch/ao/quantization'); sys.exit(pytest.main(sys.argv[1:]))" --collect-only -q test/quantization/core/experimental/test_nonuniform_observer.py
```

Results:

- CPU-only environment (`CUDA_VISIBLE_DEVICES=-1`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- CUDA-visible environment (`torch.cuda.is_available() == True`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- The `GENERIC` filter reported `total=6, passed=6, unclassified=0, mismatched=0`.
- All command exit codes were 0, and the collected test set was unchanged.

The CUDA-visible run verifies compatibility with a CUDA-enabled build. The class does not create CUDA-specific variants because it is not instantiated by device type and does not exercise CUDA-specific behavior.

## Risks

Low. This change only adds test metadata. It does not modify observer behavior, test logic, device placement, or the collected test set.

<!-- self-test-logs:start -->
## Full self-test logs

<details>
<summary>CPU-only self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: False
source overlay: D:\project\pytorch\pytorch\torch\ao\quantization
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms PASSED [0.0020s] [ 16%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms PASSED [0.0012s] [ 33%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid PASSED [0.0003s] [ 50%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1 PASSED [0.0017s] [ 66%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed PASSED [0.0011s] [ 83%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_forward PASSED [0.0010s] [100%]

============================== 6 passed in 1.15s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms PASSED [0.0018s] [ 16%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms PASSED [0.0017s] [ 33%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid PASSED [0.0003s] [ 50%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1 PASSED [0.0014s] [ 66%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed PASSED [0.0010s] [ 83%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_forward PASSED [0.0012s] [100%]

============================== 6 passed in 1.16s ==============================
Running 6 items in this shard
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_forward

6 tests collected in 1.13s
CPU exit codes: unfiltered=0 generic=0 collect=0
```

</details>

<details>
<summary>CUDA-visible self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: True
GPU: NVIDIA GeForce RTX 4070 Laptop GPU
source overlay: D:\project\pytorch\pytorch\torch\ao\quantization
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms PASSED [0.0016s] [ 16%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms PASSED [0.0012s] [ 33%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid PASSED [0.0003s] [ 50%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1 PASSED [0.0014s] [ 66%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed PASSED [0.0009s] [ 83%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_forward PASSED [0.0011s] [100%]

============================== 6 passed in 1.13s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms PASSED [0.0018s] [ 16%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms PASSED [0.0017s] [ 33%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid PASSED [0.0003s] [ 50%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1 PASSED [0.0016s] [ 66%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed PASSED [0.0011s] [ 83%]
pytorch\test\quantization\core\experimental\test_nonuniform_observer.py::TestNonUniformObserver::test_forward PASSED [0.0011s] [100%]

============================== 6 passed in 1.17s ==============================
Running 6 items in this shard
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_2terms
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_3terms
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_invalid
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_k1
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_calculate_qparams_signed
test/quantization/core/experimental/test_nonuniform_observer.py::TestNonUniformObserver::test_forward

6 tests collected in 1.12s
CUDA exit codes: unfiltered=0 generic=0 collect=0
```

</details>
<!-- self-test-logs:end -->
