### PR TITLE
[Testcase Refactoring] Add hw_classification and split test_pg_wrapper

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -17,6 +16,7 @@ if not c10d.is_available():
 
 from test_c10d_common import LOOPBACK
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     create_device,
     MultiProcessTestCase,
@@ -27,14 +27,10 @@ from torch.testing._internal.common_distributed import (
     with_dist_debug_levels,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
-    TEST_XPU,
 )
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = c10d.get_default_backend_for_device(device_type)
 
 
 class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
@@ -54,7 +50,8 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
                 f"{list(tensor.shape)}" in err,
                 lambda msg: f"{msg}\nDid not find shapes {list(tensor.shape)} in error {err}",
             )
-            # For CUDA, only assert on device type, not index
+            # For accelerator tensors, only assert on device type, not index
+            device_type = tensor.device.type
             if device_type in str(tensor.device):
                 self.assertTrue(
                     device_type in err,
@@ -258,18 +255,27 @@ if not TEST_WITH_DEV_DBG_ASAN:
     @requires_gloo()
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     class ProcessGroupNCCLWrapperTest(AbstractProcessGroupWrapperTest):
+        hw_classification = HardwareClassification.CUDA
+
         def setUp(self):
-            super(AbstractProcessGroupWrapperTest, self).setUp()
-            self._spawn_processes()
-            # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
-            # that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
+            # Set before super().setUp() so spawned workers inherit the env var.
+            # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence
+            # tests that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
             os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
+            super().setUp()
 
         @property
         def world_size(self) -> int:
             return 2
 
-        def _create_wrapper_pg(self, with_new_group=False, timeout=10.0):
+        def _create_wrapper_pg(self, device, with_new_group=False, timeout=10.0):
+            # Persistent workers reuse the process across tests, so tear down any
+            # previously-initialized default group before re-initializing.
+            try:
+                c10d.destroy_process_group()
+            except (AssertionError, ValueError):
+                pass
+            backend = c10d.get_default_backend_for_device(device)
             store = c10d.FileStore(self.file_name, self.world_size)
             c10d.init_process_group(
                 backend=backend,
@@ -281,7 +287,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
             if with_new_group:
                 pg = c10d.new_group(backend=backend, timeout=timedelta(seconds=timeout))
             else:
-                if device_type == "xpu":
+                if torch.device(device).type == "xpu":
                     _pg = c10d.ProcessGroupXCCL(
                         store,
                         self.rank,
@@ -306,8 +312,8 @@ if not TEST_WITH_DEV_DBG_ASAN:
 
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
-        def test_collective_hang(self):
-            pg = self._create_wrapper_pg(timeout=2.0)
+        def test_collective_hang(self, device):
+            pg = self._create_wrapper_pg(device, timeout=2.0)
             self._test_collective_hang(pg)
 
         # NOTE: these tests are separated by debug level instead of combined into
@@ -316,37 +322,37 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_collectives_op_mismatch_debug_mode(self):
-            pg = self._create_wrapper_pg(with_new_group=True)
+        def test_collectives_op_mismatch_debug_mode(self, device):
+            pg = self._create_wrapper_pg(device, with_new_group=True)
             self._test_collectives_op_mismatch(pg, use_accel=True)
-            self._test_nccl_only_op_mismatch(pg)
+            self._test_nccl_only_op_mismatch(pg, device)
 
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["OFF"])
-        def test_collectives_op_mismatch(self):
-            pg = self._create_wrapper_pg(with_new_group=False)
+        def test_collectives_op_mismatch(self, device):
+            pg = self._create_wrapper_pg(device, with_new_group=False)
             self._test_collectives_op_mismatch(pg, use_accel=True)
-            self._test_nccl_only_op_mismatch(pg)
+            self._test_nccl_only_op_mismatch(pg, device)
 
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_collective_shape_mismatch_debug_mode_detail(self):
-            pg = self._create_wrapper_pg(with_new_group=True)
+        def test_collective_shape_mismatch_debug_mode_detail(self, device):
+            pg = self._create_wrapper_pg(device, with_new_group=True)
             self._test_collective_shape_mismatch(pg, use_accel=True)
-            self._test_nccl_only_shape_mismatch(pg)
+            self._test_nccl_only_shape_mismatch(pg, device)
 
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["OFF"])
-        def test_collective_shape_mismatch_debug_mode_off(self):
-            pg = self._create_wrapper_pg(with_new_group=False)
+        def test_collective_shape_mismatch_debug_mode_off(self, device):
+            pg = self._create_wrapper_pg(device, with_new_group=False)
             self._test_collective_shape_mismatch(pg, use_accel=True)
-            self._test_nccl_only_shape_mismatch(pg)
+            self._test_nccl_only_shape_mismatch(pg, device)
 
-        def _test_nccl_only_op_mismatch(self, wrapper_pg):
-            device = f"{device_type}:{self.rank}"
+        def _test_nccl_only_op_mismatch(self, wrapper_pg, device):
+            device = torch.device(f"{torch.device(device).type}:{self.rank}")
             with self.assertRaisesRegex(RuntimeError, ".*") as cm:
                 output = torch.zeros(4 + self.rank, device=device)
                 input = torch.ones(4 * self.world_size, device=device)
@@ -363,8 +369,8 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 tensor=input,
             )
 
-        def _test_nccl_only_shape_mismatch(self, wrapper_pg):
-            device = f"{device_type}:{self.rank}"
+        def _test_nccl_only_shape_mismatch(self, wrapper_pg, device):
+            device = torch.device(f"{torch.device(device).type}:{self.rank}")
             with self.assertRaisesRegex(RuntimeError, ".*") as cm:
                 output = torch.zeros(4 + self.rank, device=device)
                 input = torch.ones(4 * (self.world_size + 1), device=device)
@@ -393,13 +399,13 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_coalescing_manager_debug_mode_detail(self):
+        def test_coalescing_manager_debug_mode_detail(self, device):
             """
             Tests that coalescing manager w/TORCH_DISTRIBUTED_DEBUG
             does not crash: https://github.com/pytorch/pytorch/issues/109520
             """
             torch.accelerator.set_device_index(self.rank)
-            pg = self._create_wrapper_pg(with_new_group=True)
+            pg = self._create_wrapper_pg(device, with_new_group=True)
             dev = torch.accelerator.current_device_index()
             pg._start_coalescing(torch.device(dev))
             pg.allreduce([torch.ones(1, device=dev)])
@@ -408,10 +414,10 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_reduce_scatter_tensor_coalesced_debug_mode(self):
-            torch.cuda.set_device(self.rank)
-            pg = self._create_wrapper_pg(with_new_group=True)
-            dev = torch.cuda.current_device()
+        def test_reduce_scatter_tensor_coalesced_debug_mode(self, device):
+            torch.accelerator.set_device_index(self.rank)
+            pg = self._create_wrapper_pg(device, with_new_group=True)
+            dev = torch.accelerator.current_device_index()
 
             out_shapes = [(2, 2), (3, 3)]
             in_shapes = [(s[0] * self.world_size,) + s[1:] for s in out_shapes]
@@ -431,16 +437,16 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_allgather_into_tensor_coalesced_debug_mode(self):
+        def test_allgather_into_tensor_coalesced_debug_mode(self, device):
             """
             Tests that allgather_into_tensor_coalesced correctly invokes
             runCollectiveChecks in ProcessGroupWrapper. Previously this was the
             only collective missing the check.
             Regression test for https://github.com/pytorch/pytorch/pull/185123
             """
-            torch.cuda.set_device(self.rank)
-            pg = self._create_wrapper_pg(with_new_group=True)
-            dev = torch.cuda.current_device()
+            torch.accelerator.set_device_index(self.rank)
+            pg = self._create_wrapper_pg(device, with_new_group=True)
+            dev = torch.accelerator.current_device_index()
 
             in_shapes = [(2, 2), (3, 3)]
             out_shapes = [(s[0] * self.world_size,) + s[1:] for s in in_shapes]
@@ -463,14 +469,14 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_allgather_into_tensor_coalesced_op_mismatch_debug_mode(self):
+        def test_allgather_into_tensor_coalesced_op_mismatch_debug_mode(self, device):
             """
             Verify runCollectiveChecks detects a collective mismatch on the
             coalesced allgather path.
             Regression test for https://github.com/pytorch/pytorch/pull/185123
             """
-            torch.cuda.set_device(self.rank)
-            pg = self._create_wrapper_pg(with_new_group=True)
+            torch.accelerator.set_device_index(self.rank)
+            pg = self._create_wrapper_pg(device, with_new_group=True)
             self._test_allgather_into_tensor_coalesced_op_mismatch(pg, use_accel=True)
 
         @requires_nccl()
@@ -480,23 +486,23 @@ if not TEST_WITH_DEV_DBG_ASAN:
             "torch.distributed.distributed_c10d.is_gloo_available",
             lambda: False,
         )
-        def test_debug_level_detail_no_gloo(self):
+        def test_debug_level_detail_no_gloo(self, device):
             with self.assertRaisesRegex(
                 AssertionError, "ProcessGroupWrapper unsupported without GLOO backend"
             ):
-                self._create_wrapper_pg()
+                self._create_wrapper_pg(device)
 
         @requires_nccl()
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_wrapper_forwards_nccl_methods(self):
+        def test_wrapper_forwards_nccl_methods(self, device):
             """
             Tests that ProcessGroupWrapper correctly forwards NCCL-specific
             utility methods to the wrapped backend. See issue #173538.
             """
-            torch.cuda.set_device(self.rank)
-            device = torch.device(f"cuda:{self.rank}")
-            wrapper = self._create_wrapper_pg(with_new_group=False)
+            torch.accelerator.set_device_index(self.rank)
+            device = torch.device(f"{torch.device(device).type}:{self.rank}")
+            wrapper = self._create_wrapper_pg(device, with_new_group=False)
 
             # Verify we're testing the wrapper
             self.assertIsInstance(wrapper, _ProcessGroupWrapper)
@@ -530,17 +536,21 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @requires_nccl()
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
-        def test_wrapper_forwards_bound_device_id(self):
+        def test_wrapper_forwards_bound_device_id(self, device):
             """
             Tests that ProcessGroupWrapper propagates bound_device_id to the
             wrapped backend when init_process_group is called with device_id.
             See issue #178977.
             """
-            torch.cuda.set_device(self.rank)
-            device = torch.device(f"cuda:{self.rank}")
+            torch.accelerator.set_device_index(self.rank)
+            device = torch.device(f"{torch.device(device).type}:{self.rank}")
+            try:
+                c10d.destroy_process_group()
+            except (AssertionError, ValueError):
+                pass
             store = c10d.FileStore(self.file_name, self.world_size)
             c10d.init_process_group(
-                backend=backend,
+                backend=c10d.get_default_backend_for_device(device),
                 rank=self.rank,
                 world_size=self.world_size,
                 store=store,
@@ -557,7 +567,7 @@ if not TEST_WITH_DEV_DBG_ASAN:
             "torch.distributed.distributed_c10d.is_gloo_available",
             lambda: False,
         )
-        def test_new_group_no_gloo(self):
+        def test_new_group_no_gloo(self, device):
             def patched_isinstance(obj, clazz):
                 if clazz is _ProcessGroupWrapper:
                     raise NameError
@@ -568,15 +578,21 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 "torch.distributed.distributed_c10d.isinstance",
                 side_effect=patched_isinstance,
             ):
-                self._create_wrapper_pg(with_new_group=True)
+                self._create_wrapper_pg(device, with_new_group=True)
                 # nothing to assert, isinstance(pg, _ProcessGroupWrapper)
                 # should never be invoked since it is proceeded by
                 # Gloo availability check, this test will fail on
                 # an unexpected NameError if not.
 
+    instantiate_device_type_tests(
+        ProcessGroupNCCLWrapperTest, globals(), only_for="cuda"
+    )
+
 
 @requires_gloo()
 class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
+    hw_classification = HardwareClassification.GENERIC
+
     def opts(self, threads=2, timeout=10.0):
         opts = c10d.ProcessGroupGloo._Options()
         opts._timeout = timeout
@@ -585,6 +601,10 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
         return opts
 
     def _create_wrapper_pg(self, with_new_group=False, timeout=10.0):
+        try:
+            c10d.destroy_process_group()
+        except (AssertionError, ValueError):
+            pass
         store = c10d.FileStore(self.file_name, self.world_size)
         c10d.init_process_group(
             backend="gloo", rank=self.rank, world_size=self.world_size, store=store
@@ -631,33 +651,6 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def test_collective_shape_mismatch_debug_mode_off(self):
         pg = self._create_wrapper_pg(with_new_group=False)
         self._test_collective_shape_mismatch(pg)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["DETAIL"])
-    def test_collectives_op_mismatch_cuda_debug_mode(self):
-        pg = self._create_wrapper_pg(with_new_group=True)
-        self._test_collectives_op_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["OFF"])
-    def test_collectives_op_mismatch_cuda(self):
-        pg = self._create_wrapper_pg(with_new_group=False)
-        self._test_collectives_op_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
-    @with_dist_debug_levels(levels=["DETAIL"])
-    def test_collective_shape_mismatch_cuda_debug_mode(self):
-        pg = self._create_wrapper_pg(with_new_group=True)
-        self._test_collective_shape_mismatch(pg, use_accel=True)
-
-    @skip_if_lt_x_gpu(4)
-    @with_dist_debug_levels(levels=["OFF"])
-    def test_collective_shape_mismatch_cuda(self):
-        pg = self._create_wrapper_pg(with_new_group=False)
-        self._test_collective_shape_mismatch(pg, use_accel=True)
 
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_reduce_scatter_tensor_coalesced_debug_mode(self):
@@ -711,10 +704,71 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
         self._test_allgather_into_tensor_coalesced_op_mismatch(pg)
 
 
-if __name__ == "__main__":
-    if torch.cuda.is_initialized() or torch.xpu.is_initialized():
-        raise AssertionError(
-            "test_pg_wrapper must not have initialized CUDA/XPU context on main process"
-        )
+@requires_gloo()
+class ProcessGroupGlooWrapperTestCUDA(AbstractProcessGroupWrapperTest):
+    hw_classification = HardwareClassification.CUDA
 
+    def opts(self, threads=2, timeout=10.0):
+        opts = c10d.ProcessGroupGloo._Options()
+        opts._timeout = timeout
+        opts._devices = [create_device(interface=LOOPBACK)]
+        opts._threads = threads
+        return opts
+
+    def _create_wrapper_pg(self, device, with_new_group=False, timeout=10.0):
+        try:
+            c10d.destroy_process_group()
+        except (AssertionError, ValueError):
+            pass
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+        if with_new_group:
+            pg = c10d.new_group(backend="gloo")
+        else:
+            _pg = c10d.ProcessGroupGloo(
+                store, self.rank, self.world_size, self.opts(timeout=timeout)
+            )
+            pg = c10d._create_process_group_wrapper(
+                _pg,
+                "unused",
+                store,
+                self.rank,
+                self.world_size,
+                timeout=timeout,
+            )
+        return pg
+
+    @skip_if_lt_x_gpu(4)
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_collectives_op_mismatch_cuda_debug_mode(self, device):
+        pg = self._create_wrapper_pg(device, with_new_group=True)
+        self._test_collectives_op_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @with_dist_debug_levels(levels=["OFF"])
+    def test_collectives_op_mismatch_cuda(self, device):
+        pg = self._create_wrapper_pg(device, with_new_group=False)
+        self._test_collectives_op_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_collective_shape_mismatch_cuda_debug_mode(self, device):
+        pg = self._create_wrapper_pg(device, with_new_group=True)
+        self._test_collective_shape_mismatch(pg, use_accel=True)
+
+    @skip_if_lt_x_gpu(4)
+    @with_dist_debug_levels(levels=["OFF"])
+    def test_collective_shape_mismatch_cuda(self, device):
+        pg = self._create_wrapper_pg(device, with_new_group=False)
+        self._test_collective_shape_mismatch(pg, use_accel=True)
+
+
+instantiate_device_type_tests(
+    ProcessGroupGlooWrapperTestCUDA, globals(), only_for="cuda"
+)
+
+
+if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

`test/distributed/test_pg_wrapper.py` contains 3 test classes that were previously unclassified. This PR labels all 3 with `hw_classification`, splits the mixed `ProcessGroupGlooWrapperTest`, and refactors CUDA classes to use `instantiate_device_type_tests` with `device` parameters per the TEST_LINTER rule (PR #190173).

## Changes

### 1. hw_classification labels

- **CUDA (2)**: `ProcessGroupNCCLWrapperTest` and `ProcessGroupGlooWrapperTestCUDA`. Both use `instantiate_device_type_tests(only_for="cuda")` with `device` parameters.
- **GENERIC (1)**: `ProcessGroupGlooWrapperTest` (12 CPU gloo tests, no `instantiate_device_type_tests`).

### 2. Refactoring (addressing review feedback)

- **Removed module-level `device_type`/`backend` globals**. CUDA classes now receive a `device` parameter (injected by `instantiate_device_type_tests`) and resolve backend dynamically via `c10d.get_default_backend_for_device(device)`.
- **All `test_*` methods in CUDA classes accept a `device` parameter** and pass it to `_create_wrapper_pg` and helper methods.
- Replaced `torch.cuda.set_device`/`current_device` with `torch.accelerator.set_device_index`/`current_device_index`.
- Replaced hardcoded `device_type` references in `_test_nccl_only_*` helpers with the `device` parameter.
- Removed `@unittest.skipIf(TEST_XPU, ...)` from GlooCUDA methods (redundant with `only_for="cuda"`). Removed stale `TEST_XPU` import.
- Added `destroy_process_group` cleanup in `_create_wrapper_pg` to handle process reuse under `instantiate_device_type_tests`.

### 3. Gloo+CUDA classification

The gloo backend only supports CPU and CUDA tensors (per `ProcessGroupGloo.cpp`), so `ProcessGroupGlooWrapperTestCUDA` is correctly labeled `CUDA` (not `ACCELERATOR`).

No method bodies or test logic are changed. No HCCL or out-of-tree backend references are introduced.

## Motivation

PR #190991 established the convention that every `TestCase` subclass must carry a `hw_classification` attribute. PR #190173 (TEST_LINTER) requires that CUDA classes must use `instantiate_device_type_tests` with `only_for="cuda"` and every test method must accept a `device` parameter.

## Dependencies

None.

## Test Plan

- `python -m py_compile test/distributed/test_pg_wrapper.py` passes.
- `lintrunner test/distributed/test_pg_wrapper.py` passes (No lint issues).
- Test count unchanged: 25 `def test_*` methods.
- CPU mode: `ProcessGroupGlooWrapperTest` (GENERIC) 8 passed; CUDA classes correctly not generated (`only_for=cuda`).
- NPU mode: GENERIC passed; CUDA not generated.
- No `hccl`/`ascend`/`npu`/`privateuse1` references (verified: 0 matches).

cc @fffrog @wjlFlyer @pjyFight @FuDdd @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian
