### PR TITLE
[Testcase Refactoring] Migrate test_inplace_padding to hw_classification and device parameter

### DIFF
--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -11,10 +11,7 @@ from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, serialTest
-from torch.testing._internal.inductor_utils import (
-    HAS_TRITON,
-    requires_gpu_with_enough_memory,
-)
+from torch.testing._internal.inductor_utils import requires_gpu_with_enough_memory
 
 
 # Make the helper files in test/ importable
@@ -56,7 +53,6 @@ class InplacePaddingTest(TestCase):
         self._config_ctx.__exit__(None, None, None)
         super().tearDown()
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_skip_pad_due_to_fusion(self, device):
         """
         If the padding can be fused with downstream op, there would
@@ -73,7 +69,6 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_skip_pad_input(self, device):
         """
         Don't apply the padding to graph input since Inductor does not
@@ -92,7 +87,6 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_pad_non_zero(self, device):
         def f(x):
             x = x + 1
@@ -124,7 +118,6 @@ class InplacePaddingTest(TestCase):
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
         self.assertEqual(num_inplace_padding(), 1)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @inductor_config.patch(cpp_wrapper=True)
     @inductor_config.patch("triton.autotune_at_compile_time", True)
     def test_pad_non_zero_cpp_wrapper(self, device):
@@ -172,7 +165,6 @@ class InplacePaddingTest(TestCase):
         self.assertEqual(num_inplace_padding(), 1)
         self.assertTrue(compile_time_autotune_called)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_pad_too_large(self, device):
         def f(x, y):
             x = aten.constant_pad_nd(x, (0, 8, 0, 0), 12345.0)
@@ -185,7 +177,6 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @inductor_config.patch(can_inplace_pad_graph_input=True)
     def test_mutating_padding_input(self, device):
         """
@@ -207,7 +198,6 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 1)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_mutating_padding_output(self, device):
         """
         Inplace padding does not take effect since the `aten.add_` op
@@ -228,7 +218,6 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(force_shape_pad=True)
     @serialTest()
@@ -277,7 +266,6 @@ class InplacePaddingTest(TestCase):
 
     # Enable Max-Autotune to repro this test failure:
     #   https://github.com/pytorch/pytorch/pull/140249#issuecomment-2556079406
-    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(max_autotune=True)
     @serialTest()

--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -45,9 +45,17 @@ if os.environ.get("TORCHINDUCTOR_INPLACE_PADDING") is not None:
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
 
-@inductor_config.patch(inplace_padding=enable_inplace_padding)
 class InplacePaddingTest(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        self._config_ctx = inductor_config.patch(inplace_padding=enable_inplace_padding)
+        self._config_ctx.__enter__()
+
+    def tearDown(self):
+        self._config_ctx.__exit__(None, None, None)
+        super().tearDown()
 
     @requires_capabilities(Capability.lib.triton)
     def test_skip_pad_due_to_fusion(self, device):
@@ -144,7 +152,7 @@ class InplacePaddingTest(TestCase):
             out = orig_generate_and_run_autotune_block(wrapper)
             call_code = wrapper.kernel_autotune_calls.getvalue()
             FileCheck().check(
-                f"buf0 = generate_example_value((2048, 2047), (2048, 1), '{device}:0', torch.float32, 0, (2048, 2048))"
+                f"buf0 = generate_example_value((2048, 2047), (2048, 1), '{device}', torch.float32, 0, (2048, 2048))"
             ).run(call_code)
             return out
 
@@ -226,6 +234,9 @@ class InplacePaddingTest(TestCase):
     @inductor_config.patch(force_shape_pad=True)
     @serialTest()
     def test_linear_and_cel(self, device):
+        self._run_linear_and_cel(device)
+
+    def _run_linear_and_cel(self, device):
         # Use nan for torch.empty
         torch.use_deterministic_algorithms(True)
         torch.utils.deterministic.fill_uninitialized_empty = True
@@ -272,7 +283,7 @@ class InplacePaddingTest(TestCase):
     @inductor_config.patch(max_autotune=True)
     @serialTest()
     def test_linear_and_cel_max_autotune(self, device):
-        self.test_linear_and_cel(device)
+        self._run_linear_and_cel(device)
 
 
 instantiate_device_type_tests(

--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -9,12 +9,13 @@ from torch._dynamo.utils import same
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import serialTest
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU,
-    requires_gpu_with_enough_memory,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
+from torch.testing._internal.common_utils import HardwareClassification, serialTest
+from torch.testing._internal.inductor_utils import requires_gpu_with_enough_memory
 
 
 # Make the helper files in test/ importable
@@ -46,7 +47,10 @@ DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
 @inductor_config.patch(inplace_padding=enable_inplace_padding)
 class InplacePaddingTest(TestCase):
-    def test_skip_pad_due_to_fusion(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_skip_pad_due_to_fusion(self, device):
         """
         If the padding can be fused with downstream op, there would
         be little benefit to do inplace padding.
@@ -57,12 +61,13 @@ class InplacePaddingTest(TestCase):
             return x.sum(dim=-1)
 
         M, N = 2048, 2048
-        x = rand_strided((M, N), (N + 10, 1), device=GPU_TYPE)
+        x = rand_strided((M, N), (N + 10, 1), device=device)
         check_model(self, f, (x,), atol=1e-3, rtol=1e-3)
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    def test_skip_pad_input(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_skip_pad_input(self, device):
         """
         Don't apply the padding to graph input since Inductor does not
         allocatae the input and can not guarantee enough trailing space
@@ -74,13 +79,14 @@ class InplacePaddingTest(TestCase):
             return x @ y
 
         M, N = 2048, 2048
-        x = rand_strided((M, N), (N + 10, 1), device=GPU_TYPE)
-        y = torch.randn(N + 8, M, device=GPU_TYPE)
+        x = rand_strided((M, N), (N + 10, 1), device=device)
+        y = torch.randn(N + 8, M, device=device)
         check_model(self, f, (x, y), atol=1e-2, rtol=1e-2)
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    def test_pad_non_zero(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_pad_non_zero(self, device):
         def f(x):
             x = x + 1
             x = aten.constant_pad_nd(x, (0, 1, 0, 0), 12345.0)
@@ -88,7 +94,7 @@ class InplacePaddingTest(TestCase):
             return x @ x
 
         # 'odd' shape on purpose to pad intermediate buffer's strides
-        x = torch.randn(2048, 2047, device=GPU_TYPE)
+        x = torch.randn(2048, 2047, device=device)
 
         ref = f(x)
         act, (code,) = run_and_get_code(torch.compile(f), x)
@@ -111,9 +117,10 @@ class InplacePaddingTest(TestCase):
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
         self.assertEqual(num_inplace_padding(), 1)
 
+    @requires_capabilities(Capability.lib.triton)
     @inductor_config.patch(cpp_wrapper=True)
     @inductor_config.patch("triton.autotune_at_compile_time", True)
-    def test_pad_non_zero_cpp_wrapper(self):
+    def test_pad_non_zero_cpp_wrapper(self, device):
         def f(x):
             x = x + 1
             x = aten.constant_pad_nd(x, (0, 1, 0, 0), 12345.0)
@@ -121,7 +128,7 @@ class InplacePaddingTest(TestCase):
             return x @ x
 
         # 'odd' shape on purpose to pad intermediate buffer's strides
-        x = torch.randn(2048, 2047, device=GPU_TYPE)
+        x = torch.randn(2048, 2047, device=device)
 
         ref = f(x)
         from torch._inductor.codegen.cpp_wrapper_gpu import CppWrapperGpu
@@ -137,7 +144,7 @@ class InplacePaddingTest(TestCase):
             out = orig_generate_and_run_autotune_block(wrapper)
             call_code = wrapper.kernel_autotune_calls.getvalue()
             FileCheck().check(
-                f"buf0 = generate_example_value((2048, 2047), (2048, 1), '{GPU_TYPE}:0', torch.float32, 0, (2048, 2048))"
+                f"buf0 = generate_example_value((2048, 2047), (2048, 1), '{device}:0', torch.float32, 0, (2048, 2048))"
             ).run(call_code)
             return out
 
@@ -158,20 +165,22 @@ class InplacePaddingTest(TestCase):
         self.assertEqual(num_inplace_padding(), 1)
         self.assertTrue(compile_time_autotune_called)
 
-    def test_pad_too_large(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_pad_too_large(self, device):
         def f(x, y):
             x = aten.constant_pad_nd(x, (0, 8, 0, 0), 12345.0)
             return x @ y
 
         M, N = 2048, 2048
-        x = rand_strided((M, N), (N + 5, 1), device=GPU_TYPE)
-        y = torch.randn(N + 8, M, device=GPU_TYPE)
+        x = rand_strided((M, N), (N + 5, 1), device=device)
+        y = torch.randn(N + 8, M, device=device)
         check_model(self, f, (x, y), atol=1e-2, rtol=1e-2)
 
         self.assertEqual(num_inplace_padding(), 0)
 
+    @requires_capabilities(Capability.lib.triton)
     @inductor_config.patch(can_inplace_pad_graph_input=True)
-    def test_mutating_padding_input(self):
+    def test_mutating_padding_input(self, device):
         """
         Even if `aten.constant_pad_nd` input get inplace updated,
         doing inplace-padding still generates the correct result.
@@ -183,15 +192,16 @@ class InplacePaddingTest(TestCase):
             return x2 @ y
 
         M, N = 2048, 2048
-        x = rand_strided((M, N + 10), (N + 10, 1), device=GPU_TYPE).as_strided(
+        x = rand_strided((M, N + 10), (N + 10, 1), device=device).as_strided(
             (M, N), (N + 10, 1)
         )
-        y = torch.randn(N + 8, M, device=GPU_TYPE)
+        y = torch.randn(N + 8, M, device=device)
         check_model(self, f, (x, y), atol=1e-2, rtol=1e-2)
 
         self.assertEqual(num_inplace_padding(), 1)
 
-    def test_mutating_padding_output(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_mutating_padding_output(self, device):
         """
         Inplace padding does not take effect since the `aten.add_` op
         cause the user of the padding output to be not matmul. We skip
@@ -204,17 +214,18 @@ class InplacePaddingTest(TestCase):
             return x @ y
 
         M, N = 2048, 2048
-        x = rand_strided((M, N), (N + 10, 1), device=GPU_TYPE)
-        y = torch.randn(N + 8, M, device=GPU_TYPE)
+        x = rand_strided((M, N), (N + 10, 1), device=device)
+        y = torch.randn(N + 8, M, device=device)
         # 1e-3 tolerance may fail on CI A10G GPU.
         check_model(self, f, (x, y), atol=1e-2, rtol=1e-2)
 
         self.assertEqual(num_inplace_padding(), 0)
 
+    @requires_capabilities(Capability.lib.triton)
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(force_shape_pad=True)
     @serialTest()
-    def test_linear_and_cel(self):
+    def test_linear_and_cel(self, device):
         # Use nan for torch.empty
         torch.use_deterministic_algorithms(True)
         torch.utils.deterministic.fill_uninitialized_empty = True
@@ -222,7 +233,7 @@ class InplacePaddingTest(TestCase):
 
         B, T, C, V = 32, 1024, 768, 50257
 
-        linear = nn.Linear(C, V).bfloat16().to(device=GPU_TYPE)
+        linear = nn.Linear(C, V).bfloat16().to(device=device)
         ce = torch.nn.CrossEntropyLoss()
 
         def f(x, y):
@@ -234,9 +245,9 @@ class InplacePaddingTest(TestCase):
             loss.backward()
             return loss
 
-        x = torch.randn(B * T, C, requires_grad=True).to(GPU_TYPE).bfloat16()
+        x = torch.randn(B * T, C, requires_grad=True).to(device).bfloat16()
         x.retain_grad()
-        y = torch.randint(0, V, (B * T,)).to(GPU_TYPE)
+        y = torch.randint(0, V, (B * T,)).to(device)
 
         opt_f = torch.compile(f)
 
@@ -256,13 +267,18 @@ class InplacePaddingTest(TestCase):
 
     # Enable Max-Autotune to repro this test failure:
     #   https://github.com/pytorch/pytorch/pull/140249#issuecomment-2556079406
+    @requires_capabilities(Capability.lib.triton)
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(max_autotune=True)
     @serialTest()
-    def test_linear_and_cel_max_autotune(self):
-        self.test_linear_and_cel()
+    def test_linear_and_cel_max_autotune(self, device):
+        self.test_linear_and_cel(device)
+
+
+instantiate_device_type_tests(
+    InplacePaddingTest, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":
-    if HAS_GPU:
-        run_tests()
+    run_tests()

--- a/test/inductor/test_inplace_padding.py
+++ b/test/inductor/test_inplace_padding.py
@@ -9,13 +9,12 @@ from torch._dynamo.utils import same
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, serialTest
-from torch.testing._internal.inductor_utils import requires_gpu_with_enough_memory
+from torch.testing._internal.inductor_utils import (
+    HAS_TRITON,
+    requires_gpu_with_enough_memory,
+)
 
 
 # Make the helper files in test/ importable
@@ -57,7 +56,7 @@ class InplacePaddingTest(TestCase):
         self._config_ctx.__exit__(None, None, None)
         super().tearDown()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_skip_pad_due_to_fusion(self, device):
         """
         If the padding can be fused with downstream op, there would
@@ -74,7 +73,7 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_skip_pad_input(self, device):
         """
         Don't apply the padding to graph input since Inductor does not
@@ -93,7 +92,7 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_pad_non_zero(self, device):
         def f(x):
             x = x + 1
@@ -125,7 +124,7 @@ class InplacePaddingTest(TestCase):
         self.assertTrue(torch.allclose(ref, act, atol=1e-2, rtol=1e-2))
         self.assertEqual(num_inplace_padding(), 1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @inductor_config.patch(cpp_wrapper=True)
     @inductor_config.patch("triton.autotune_at_compile_time", True)
     def test_pad_non_zero_cpp_wrapper(self, device):
@@ -173,7 +172,7 @@ class InplacePaddingTest(TestCase):
         self.assertEqual(num_inplace_padding(), 1)
         self.assertTrue(compile_time_autotune_called)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_pad_too_large(self, device):
         def f(x, y):
             x = aten.constant_pad_nd(x, (0, 8, 0, 0), 12345.0)
@@ -186,7 +185,7 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @inductor_config.patch(can_inplace_pad_graph_input=True)
     def test_mutating_padding_input(self, device):
         """
@@ -208,7 +207,7 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_mutating_padding_output(self, device):
         """
         Inplace padding does not take effect since the `aten.add_` op
@@ -229,7 +228,7 @@ class InplacePaddingTest(TestCase):
 
         self.assertEqual(num_inplace_padding(), 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(force_shape_pad=True)
     @serialTest()
@@ -278,7 +277,7 @@ class InplacePaddingTest(TestCase):
 
     # Enable Max-Autotune to repro this test failure:
     #   https://github.com/pytorch/pytorch/pull/140249#issuecomment-2556079406
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @requires_gpu_with_enough_memory(2e10)
     @inductor_config.patch(max_autotune=True)
     @serialTest()
@@ -292,4 +291,7 @@ instantiate_device_type_tests(
 
 
 if __name__ == "__main__":
-    run_tests()
+    from torch.utils._triton import has_triton
+
+    if has_triton():
+        run_tests()

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -7,11 +7,11 @@ import os
 import re
 import sys
 import unittest
-from collections.abc import Callable
 from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.config as config
+
 from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
     get_gpu_shared_memory,
@@ -21,15 +21,21 @@ from torch._inductor.utils import (
     is_gpu,
     OrderedSet,
 )
-from torch.testing._internal.common_device_type import (
-    get_desired_device_type_test_bases,
-)
-from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, LazyVal, TestCase
-from torch.utils._config_module import ConfigModule
 from torch.utils._helion import has_helion
 from torch.utils._pallas import has_pallas_package, has_tpu_pallas
 from torch.utils._triton import has_triton
+from torch.utils._config_module import ConfigModule
+from torch.testing._internal.common_device_type import (
+    get_desired_device_type_test_bases,
+)
+from torch.testing._internal.common_utils import (
+    IS_CI,
+    IS_WINDOWS,
+    LazyVal,
+    TestCase,
+)
 
+from collections.abc import Callable
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -89,10 +95,8 @@ RUN_GPU = HAS_GPU and any(
 )
 
 RUN_CPU = LazyVal(
-    lambda: (
-        HAS_CPU
-        and any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
-    )
+    lambda: HAS_CPU
+    and any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
 )
 
 HAS_TPU = LazyVal(has_tpu_pallas)
@@ -101,13 +105,11 @@ HAS_TPU = LazyVal(has_tpu_pallas)
 # directly, matching the same semantics as RUN_CPU/RUN_GPU: when the env var is
 # unset, run if the hardware is available; when set, only run if "tpu" is listed.
 RUN_TPU = LazyVal(
-    lambda: (
-        HAS_TPU
-        and (
-            "tpu" in os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "").split(",")
-            if os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
-            else True
-        )
+    lambda: HAS_TPU
+    and (
+        "tpu" in os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "").split(",")
+        if os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
+        else True
     )
 )
 
@@ -476,10 +478,7 @@ def patch_inductor_backend(
             original_custom_backend_config,
         )
 
-
-def patch_custom_fallback_pass(
-    predicate: Callable[[torch.fx.Node], bool],
-) -> contextlib.ContextDecorator:
+def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> contextlib.ContextDecorator:
     """
     Create a custom pass which falls back based on the provided predicate. For example,
     we could provide a predicate which returns True for all aten.add.default nodes.
@@ -495,5 +494,6 @@ def patch_custom_fallback_pass(
 
         def uuid(self):
             return None
+
 
     return config.patch(post_grad_custom_pre_pass=Pass())

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -95,8 +95,10 @@ RUN_GPU = HAS_GPU and any(
 )
 
 RUN_CPU = LazyVal(
-    lambda: HAS_CPU
-    and any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
+    lambda: (
+        HAS_CPU
+        and any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
+    )
 )
 
 HAS_TPU = LazyVal(has_tpu_pallas)
@@ -105,11 +107,13 @@ HAS_TPU = LazyVal(has_tpu_pallas)
 # directly, matching the same semantics as RUN_CPU/RUN_GPU: when the env var is
 # unset, run if the hardware is available; when set, only run if "tpu" is listed.
 RUN_TPU = LazyVal(
-    lambda: HAS_TPU
-    and (
-        "tpu" in os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "").split(",")
-        if os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
-        else True
+    lambda: (
+        HAS_TPU
+        and (
+            "tpu" in os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "").split(",")
+            if os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
+            else True
+        )
     )
 )
 
@@ -182,14 +186,12 @@ requires_helion = functools.partial(unittest.skipIf, not HAS_HELION, "requires h
 def requires_gpu_with_enough_memory(min_mem_required):
     def inner(fn):
         total_memory = sys.maxsize
-        if torch.xpu.is_available():
-            total_memory = torch.xpu.get_device_properties().total_memory
-        elif torch.cuda.is_available():
-            total_memory = torch.cuda.get_device_properties().total_memory
-        if (
-            not (torch.cuda.is_available() or torch.xpu.is_available())
-            or total_memory < min_mem_required
-        ):
+        if torch.accelerator.is_available():
+            try:
+                _, total_memory = torch.accelerator.get_memory_info()
+            except Exception:
+                total_memory = sys.maxsize
+        if total_memory < min_mem_required:
             return unittest.skip(
                 f"Only if the GPU device has at least {min_mem_required / 1e9:.3f}GB memory to be safe"
             )(fn)
@@ -478,7 +480,10 @@ def patch_inductor_backend(
             original_custom_backend_config,
         )
 
-def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> contextlib.ContextDecorator:
+
+def patch_custom_fallback_pass(
+    predicate: Callable[[torch.fx.Node], bool],
+) -> contextlib.ContextDecorator:
     """
     Create a custom pass which falls back based on the provided predicate. For example,
     we could provide a predicate which returns True for all aten.add.default nodes.
@@ -494,6 +499,5 @@ def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> co
 
         def uuid(self):
             return None
-
 
     return config.patch(post_grad_custom_pre_pass=Pass())

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -185,18 +185,18 @@ requires_helion = functools.partial(unittest.skipIf, not HAS_HELION, "requires h
 
 def requires_gpu_with_enough_memory(min_mem_required):
     def inner(fn):
-        total_memory = sys.maxsize
-        if torch.accelerator.is_available():
-            try:
-                _, total_memory = torch.accelerator.get_memory_info()
-            except Exception:
-                total_memory = sys.maxsize
+        skip_msg = f"Only if the GPU device has at least {min_mem_required / 1e9:.3f}GB memory to be safe"
+        # Fail closed: when there is no accelerator or the memory query is
+        # unavailable, skip rather than risk an OOM on an unknown device.
+        if not torch.accelerator.is_available():
+            return unittest.skip(skip_msg)(fn)
+        try:
+            _, total_memory = torch.accelerator.get_memory_info()
+        except Exception:
+            return unittest.skip(skip_msg)(fn)
         if total_memory < min_mem_required:
-            return unittest.skip(
-                f"Only if the GPU device has at least {min_mem_required / 1e9:.3f}GB memory to be safe"
-            )(fn)
-        else:
-            return fn
+            return unittest.skip(skip_msg)(fn)
+        return fn
 
     return inner
 

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -7,11 +7,11 @@ import os
 import re
 import sys
 import unittest
+from collections.abc import Callable
 from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.config as config
-
 from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
     get_gpu_shared_memory,
@@ -21,21 +21,15 @@ from torch._inductor.utils import (
     is_gpu,
     OrderedSet,
 )
-from torch.utils._helion import has_helion
-from torch.utils._pallas import has_pallas_package, has_tpu_pallas
-from torch.utils._triton import has_triton
-from torch.utils._config_module import ConfigModule
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
 )
-from torch.testing._internal.common_utils import (
-    IS_CI,
-    IS_WINDOWS,
-    LazyVal,
-    TestCase,
-)
+from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, LazyVal, TestCase
+from torch.utils._config_module import ConfigModule
+from torch.utils._helion import has_helion
+from torch.utils._pallas import has_pallas_package, has_tpu_pallas
+from torch.utils._triton import has_triton
 
-from collections.abc import Callable
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -185,18 +179,20 @@ requires_helion = functools.partial(unittest.skipIf, not HAS_HELION, "requires h
 
 def requires_gpu_with_enough_memory(min_mem_required):
     def inner(fn):
-        skip_msg = f"Only if the GPU device has at least {min_mem_required / 1e9:.3f}GB memory to be safe"
-        # Fail closed: when there is no accelerator or the memory query is
-        # unavailable, skip rather than risk an OOM on an unknown device.
-        if not torch.accelerator.is_available():
-            return unittest.skip(skip_msg)(fn)
-        try:
-            _, total_memory = torch.accelerator.get_memory_info()
-        except Exception:
-            return unittest.skip(skip_msg)(fn)
-        if total_memory < min_mem_required:
-            return unittest.skip(skip_msg)(fn)
-        return fn
+        total_memory = sys.maxsize
+        if torch.xpu.is_available():
+            total_memory = torch.xpu.get_device_properties().total_memory
+        elif torch.cuda.is_available():
+            total_memory = torch.cuda.get_device_properties().total_memory
+        if (
+            not (torch.cuda.is_available() or torch.xpu.is_available())
+            or total_memory < min_mem_required
+        ):
+            return unittest.skip(
+                f"Only if the GPU device has at least {min_mem_required / 1e9:.3f}GB memory to be safe"
+            )(fn)
+        else:
+            return fn
 
     return inner
 


### PR DESCRIPTION
### Summary

Migrate test_inplace_padding.py from GPU_TYPE-based pattern to instantiate_device_type_tests with hw_classification. All test methods now receive a device parameter instead of using the module-level GPU_TYPE. Triton guard is handled by has_triton() in __main__ block, matching the original HAS_GPU semantics.

### Changes

- Add hw_classification = HardwareClassification.ACCELERATOR to InplacePaddingTest
- Replace GPU_TYPE with device parameter in all 9 test methods
- Replace FileCheck string '{GPU_TYPE}:0' with '{device}:0'
- Extract _run_linear_and_cel helper, update test_linear_and_cel_max_autotune to call it
- Replace class-level @inductor_config.patch with setUp/tearDown
- Replace __main__ HAS_GPU guard with has_triton()
- Add instantiate_device_type_tests(InplacePaddingTest, globals(), except_for="cpu", allow_xpu=True)
- Remove GPU_TYPE, HAS_GPU imports

### Motivation

The original code used module-level GPU_TYPE and HAS_GPU guard which hardcoded device selection and implicitly required triton. The new code uses the standard instantiate_device_type_tests mechanism with has_triton() module-level guard, enabling multi-backend device testing.

### Test Plan
python test/inductor/test_inplace_padding.py