### PR TITLE
[Testcase Refactoring] Split TestReinplacingPassCorrectness into Generic and Accelerator classes

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -13,21 +13,22 @@ from torch._higher_order_ops.auto_functionalize import (
 )
 from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_LINUX,
     parametrize,
     subtest,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.logging_utils import logs_to_string
+from torch.utils._triton import has_triton
 
 
 aten = torch.ops.aten
 
 
 const = torch.tensor(0.0)
-device = GPU_TYPE
 
 
 def num_reinplacing_failures():
@@ -49,7 +50,7 @@ def sin_cos(x: torch.Tensor, out_sin: torch.Tensor, out_cos: torch.Tensor) -> No
     out_cos.copy_(x.cos())
 
 
-if HAS_GPU:
+if has_triton():
     import triton  # @manual
     import triton.language as tl  # @manual
 
@@ -83,12 +84,43 @@ def boo(x: torch.Tensor) -> None:
     x.sin_()
 
 
-class TestReinplacingPassCorrectness(InductorTestCase):
+class TestReinplacingPassCorrectnessGeneric(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_generalized_scatter(self):
+        # This is an integration test for the reinplacing pass.
+        def fn(x_1):
+            a = torch.ones([2, 3])
+            c = torch.ones(2)
+            a[:, 0].copy_(c)
+
+            d = a.clone()
+            e = torch.ops.aten.as_strided.default(d, [2], [3], 0)
+            f = e.clone()
+
+            g = torch.zeros(2)
+            e.copy_(g)
+
+            h = torch.zeros(2, 3)
+            h[:, 0].copy_(f)
+
+            add_1 = d + h
+            return add_1
+
+        x = torch.randn(2, 3)
+        expected = fn(x)
+        result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
+        self.assertEqual(result, expected)
+
+
+class TestReinplacingPassCorrectnessAccelerator(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         ReinplaceCounters.clear()
         return super().setUp()
 
-    def _test(self, f):
+    def _test(self, device, f):
         nf = torch.compile(f)
         inp = (
             torch.randn(4, device=device),
@@ -98,15 +130,15 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(f(*inp), nf(*inp2))
         self.assertEqual(inp, inp2)
 
-    def test_dont_modify_live(self):
+    def test_dont_modify_live(self, device):
         def f(x, y):
             x = x.cos()
             x2 = x.index_put((y,), const)
             return x2, x
 
-        self._test(f)
+        self._test(device, f)
 
-    def test_dont_modify_view_of_live(self):
+    def test_dont_modify_view_of_live(self, device):
         def f(x, y):
             x = x.cos()
             x2 = aten.alias(x)
@@ -114,30 +146,30 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             y = x2 + x.cos()
             return y
 
-        self._test(f)
+        self._test(device, f)
 
-    def test_dont_modify_input(self):
+    def test_dont_modify_input(self, device):
         def f(x, y):
             return x.index_put((y,), const)
 
-        self._test(f)
+        self._test(device, f)
 
-    def test_should_modify_inner(self):
+    def test_should_modify_inner(self, device):
         def f(x, y):
             x = x.cos()
             x = x.index_put((y,), const)
             return x
 
-        self._test(f)
+        self._test(device, f)
 
-    def test_should_modify_input(self):
+    def test_should_modify_input(self, device):
         def f(x, y):
             x = x.index_put_((y,), const)
             return x
 
-        self._test(f)
+        self._test(device, f)
 
-    def test_view_index_put_should_reinplace_copy_to_base(self):
+    def test_view_index_put_should_reinplace_copy_to_base(self, device):
         def f(input_pos, val, cache):
             cache_view = aten.reshape.default(cache, [4, -1])
             val_view = aten.reshape.default(val, [-1])
@@ -167,7 +199,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(actual_cache, expected_cache)
 
-    def test_view_index_put_keeps_copy_when_later_view_is_live(self):
+    def test_view_index_put_keeps_copy_when_later_view_is_live(self, device):
         def f(input_pos, val, cache):
             cache_view = aten.reshape.default(cache, [4, -1])
             live_view = aten.select.int(cache, 0, 0)
@@ -191,7 +223,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertIn(aten.copy_.default, targets)
         self.assertNotIn(aten.index_put_.default, targets)
 
-    def test_view_index_put_rejects_non_inverse_copy_back_view(self):
+    def test_view_index_put_rejects_non_inverse_copy_back_view(self, device):
         def f(input_pos, val, cache):
             cache_view = aten.transpose.int(cache, 0, 1)
             updated = aten.index_put.default(cache_view, [input_pos], val)
@@ -220,7 +252,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(actual_cache, expected_cache)
 
-    def test_counters_functionalize_old(self):
+    def test_counters_functionalize_old(self, device):
         ReinplaceCounters.clear()
 
         def f(x):
@@ -240,7 +272,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(num_reinplacing_failures(), 1)
         self.assertEqual(miss_inplaced_bytes(), 12)
 
-    def test_counters_functionalize_v2(self):
+    def test_counters_functionalize_v2(self, device):
         ReinplaceCounters.clear()
 
         def f(x):
@@ -280,7 +312,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             raise AssertionError
         return counter
 
-    def test_view_inplaced_functionalize_v2(self):
+    def test_view_inplaced_functionalize_v2(self, device):
         def f(arg0_1):
             torch.ops.aten.select.int(arg0_1, 0, 0)
             auto_functionalized = auto_functionalized_v2(
@@ -302,7 +334,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 0)
 
     # introduce a view another_view that is used `after` the copy
-    def test_view_inplaced2_functionalize_v2(self):
+    def test_view_inplaced2_functionalize_v2(self, device):
         def f(arg0_1):
             _select = torch.ops.aten.select.int(arg0_1, 0, 0)
             another_view = arg0_1[2]
@@ -325,7 +357,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 0)
 
     # introduce a view another_view that is used `before` the copy
-    def test_views_not_inplaced_functionalize_v2(self):
+    def test_views_not_inplaced_functionalize_v2(self, device):
         def f(arg0_1):
             _select = torch.ops.aten.select.int(arg0_1, 0, 0)
             another_view = arg0_1[2]
@@ -349,7 +381,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
     # a view over input without copy node, inplace not allowed
-    def test_views_not_inplaced2_functionalize_v2(self):
+    def test_views_not_inplaced2_functionalize_v2(self, device):
         def f(arg0_1):
             _select = torch.ops.aten.select.int(arg0_1, 0, 0)
             _another_view = arg0_1[2]
@@ -371,7 +403,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
     # no copy nodes, view over local, with a use for another view
-    def test_views_not_inplaced3_functionalize_v2(self):
+    def test_views_not_inplaced3_functionalize_v2(self, device):
         def f(arg0_1):
             a = torch.ones(10)
             another_view = a[2]
@@ -392,7 +424,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
-    def test_multi_output_intermediate(self):
+    def test_multi_output_intermediate(self, device):
         for requires_grad in [False, True]:
             for enable_v2 in [False, True]:
                 with inductor_config.patch(
@@ -412,7 +444,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
                     self.assertEqual(res2, x.cos())
                     self.assertEqual(num_reinplacing_failures(), 0)
 
-    def test_multiple_mutations(self):
+    def test_multiple_mutations(self, device):
         ReinplaceCounters.clear()
 
         def f(x, out):
@@ -428,7 +460,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(result, out)
         self.assertEqual(num_reinplacing_failures(), 0)
 
-    def test_multiple_intermediate(self):
+    def test_multiple_intermediate(self, device):
         ReinplaceCounters.clear()
 
         def f(x):
@@ -443,7 +475,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(result, x.sin().sin().sin())
         self.assertEqual(num_reinplacing_failures(), 0)
 
-    def test_lists_functionalize_v2(self):
+    def test_lists_functionalize_v2(self, device):
         with inductor_config.patch({"enable_auto_functionalized_v2": True}):
 
             @torch.library.custom_op("mylib::mutate_op", mutates_args={"y"})
@@ -470,7 +502,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             self.assertEqual(miss_inplaced_bytes(), 0)
             self.assertEqual(post_grad_graphs.count("aten.clone"), 0)
 
-    def test_lists_old_functionalize(self):
+    def test_lists_old_functionalize(self, device):
         with inductor_config.patch({"enable_auto_functionalized_v2": False}):
 
             @torch.library.custom_op("mylib::mutate_op", mutates_args={"y"})
@@ -499,31 +531,6 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             # Both list inputs failed to reinplace. So we should have emitted clones for them.
             self.assertEqual(post_grad_graphs.count("aten.clone"), 2)
 
-    def test_generalized_scatter(self):
-        # This is an integration test for the reinplacing pass.
-        def fn(x_1):
-            a = torch.ones([2, 3])
-            c = torch.ones(2)
-            a[:, 0].copy_(c)
-
-            d = a.clone()
-            e = torch.ops.aten.as_strided.default(d, [2], [3], 0)
-            f = e.clone()
-
-            g = torch.zeros(2)
-            e.copy_(g)
-
-            h = torch.zeros(2, 3)
-            h[:, 0].copy_(f)
-
-            add_1 = d + h
-            return add_1
-
-        x = torch.randn(2, 3)
-        expected = fn(x)
-        result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
-        self.assertEqual(result, expected)
-
     @parametrize(
         "factory_op",
         [
@@ -538,7 +545,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             subtest(sin_triton, name="sin_triton"),
         ],
     )
-    def test_partitioner_recomputes_factory(self, factory_op, sin_op):
+    def test_partitioner_recomputes_factory(self, device, factory_op, sin_op):
         class MySin(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x):
@@ -562,7 +569,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         f(x)
         self.assertEqual(num_reinplacing_failures(), 0)
 
-    def test_with_effects_reinplace(self):
+    def test_with_effects_reinplace(self, device):
         """Test that the reinplace pass correctly handles with_effects wrapped ops.
 
         When an effectful op is wrapped with with_effects, the reinplace pass should:
@@ -665,7 +672,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             if my_add_functional._opoverload in inplaceable_ops:
                 del inplaceable_ops[my_add_functional._opoverload]
 
-    def test_with_effects_reinplace_multiple_mutated_args(self):
+    def test_with_effects_reinplace_multiple_mutated_args(self, device):
         """Test reinplace pass with multiple mutated args in with_effects wrapped ops.
 
         This tests the case where an effectful op mutates multiple tensors,
@@ -767,7 +774,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             if my_swap_functional._opoverload in inplaceable_ops:
                 del inplaceable_ops[my_swap_functional._opoverload]
 
-    def test_with_effects_reinplace_list_arg(self):
+    def test_with_effects_reinplace_list_arg(self, device):
         """Test reinplace pass with list arguments in with_effects wrapped ops.
 
         This tests the case where the mutated argument is a list of tensors,
@@ -868,9 +875,14 @@ class TestReinplacingPassCorrectness(InductorTestCase):
                 del inplaceable_ops[my_wait_functional._opoverload]
 
 
-instantiate_parametrized_tests(TestReinplacingPassCorrectness)
+instantiate_device_type_tests(
+    TestReinplacingPassCorrectnessAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU:
+    if IS_LINUX and HAS_TRITON:
         run_tests(needs="filelock")


### PR DESCRIPTION
### Summary

Split TestReinplacingPassCorrectness into two classes by hw_classification:
a Generic class for CPU-only logic tests and an Accelerator class for
GPU-dependent tests using instantiate_device_type_tests.

### Changes

- Split into TestReinplacingPassCorrectnessGeneric (GENERIC, 1 method)
  and TestReinplacingPassCorrectnessAccelerator (ACCELERATOR, 24 methods)
- Replace module-level GPU_TYPE variable with device parameter
- Change __main__ guard from HAS_GPU to HAS_TRITON as entry valve
- Change if HAS_GPU guard to if has_triton() for triton kernel definitions
- Update _test helper signature to accept device parameter
- Remove instantiate_parametrized_tests, add instantiate_device_type_tests
  with except_for="cpu", allow_xpu=True

### Motivation

The original code used a module-level GPU_TYPE variable and HAS_GPU guard
that hardcoded device selection. The split separates pure-logic tests
(GENERIC) from device-dependent tests, and uses __main__-level HAS_TRITON
guard as the entry valve.

### Test Plan
python test/inductor/test_inplacing_pass.py