### PR TITLE
[Testcase Refactoring] Refactor test_c10d_fault_tolerance with instantiate_device_type_tests and hw-classification

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -161,21 +161,22 @@ class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
     )
     def test_work_explicit_timeout_includes_prelaunch_stall(self, device):
         rank_device = self._rank_device(device)
+        dev_mod = torch.get_device_module(self.device_type)
         self._create_reconfigured_pg("ft_work_timeout", 1300, rank_device)
         dist.all_reduce(torch.ones(1, device=rank_device))
-        torch.cuda.synchronize()
-        torch.cuda._sleep(int(500 * get_cycles_per_ms()))
+        torch.accelerator.synchronize()
+        dev_mod._sleep(int(500 * get_cycles_per_ms()))
         work = dist.all_reduce(torch.ones(4, device=rank_device), async_op=True)
 
         with self.assertRaisesRegex(dist.DistBackendError, "timed out"):
             work.wait(timeout=timedelta(milliseconds=50))
 
-        self.assertFalse(torch.cuda.current_stream().query())
+        self.assertFalse(dev_mod.current_stream().query())
         self.assertTrue(work.is_completed())
         self.assertEqual(
             WorkResult(work.get_future_result().wait()), WorkResult.TIMEOUT
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
     @requires_capabilities(
         Capability.collective.reconfigure, Capability.collective.work_result
@@ -184,7 +185,7 @@ class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
         rank_device = self._rank_device(device)
         self._create_reconfigured_pg("ft_work_error", 1301, rank_device)
         dist.all_reduce(torch.ones(1, device=rank_device))
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         if self.rank == 0:
             work = dist.all_reduce(torch.ones(1, device=rank_device), async_op=True)

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -35,11 +35,11 @@ class AbstractFaultToleranceTest:
     def world_size(self):
         return 3
 
-    @property
-    def device(self):
-        if self.device_type == "cpu":
-            return "cpu"
-        return f"{self.device_type}:{self.rank}"
+    def _rank_device(self, device):
+        dev = torch.device(device)
+        if dev.type == "cpu":
+            return dev
+        return torch.device(dev.type, self.rank)
 
     @property
     def backend_name(self):
@@ -55,14 +55,6 @@ class AbstractFaultToleranceTest:
             self.skipTest("fault tolerance tests require at least 3 accelerators")
         self._spawn_processes()
 
-    def run_test(self, test_name, parent_pipe):
-        # Workers run the test method directly via run_test, skipping setUpClass.
-        # Re-invoke it so class-level setup applies in the worker like in the main
-        # process (e.g. PrivateUse1TestBase resolving device_type from the
-        # "privateuse1" placeholder to the real backend name).
-        type(self).setUpClass()
-        super().run_test(test_name, parent_pipe)
-
     def tearDown(self):
         if dist.is_initialized():
             dist.destroy_process_group()
@@ -75,7 +67,7 @@ class AbstractFaultToleranceTest:
     def _create_store(self):
         return dist.FileStore(self.file_name, self.world_size)
 
-    def _init_reconfigurable_pg(self):
+    def _init_reconfigurable_pg(self, rank_device):
         self.store = self._create_store()
         if self.device_type != "cpu":
             torch.accelerator.set_device_index(self.rank)
@@ -88,7 +80,7 @@ class AbstractFaultToleranceTest:
             enable_reconfigure=True,
         )
         self.pg = c10d._get_default_group()
-        self.backend = dist.get_backend_impl(self.pg, torch.device(self.device))
+        self.backend = dist.get_backend_impl(self.pg, rank_device)
         self.assertTrue(dist._supports_reconfigure())
         self.assertTrue(self.backend.supports_reconfigure)
 
@@ -113,38 +105,45 @@ class AbstractFaultToleranceTest:
         )
         work.wait()
 
-    def _create_reconfigured_pg(self, name, uuid):
-        self._init_reconfigurable_pg()
+    def _create_reconfigured_pg(self, name, uuid, rank_device):
+        self._init_reconfigurable_pg(rank_device)
         handles = self._collect_handles(f"{name}_init")
         self._reconfigure(uuid, handles)
         self.assertEqual(dist.get_world_size(), self.world_size)
         self.assertEqual(dist.get_rank(), self.rank)
         return self._collect_handles(f"{name}_post")
 
-    def _assert_all_reduce_sum(self, expected_value):
-        tensor = torch.full((4,), dist.get_rank() + 1.0, device=self.device)
+    def _assert_all_reduce_sum(self, expected_value, rank_device):
+        tensor = torch.full((4,), dist.get_rank() + 1.0, device=rank_device)
         dist.all_reduce(tensor)
         expected = torch.full((4,), expected_value, dtype=tensor.dtype)
         self.assertEqual(tensor.cpu(), expected)
 
-    @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_basic(self):
-        self._create_reconfigured_pg("ft_basic", 100)
+
+class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_then_all_reduce(self):
-        self._create_reconfigured_pg("ft_all_reduce", 200)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+    def test_reconfigure_basic(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_basic", 100, rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_then_send_recv(self):
-        self._create_reconfigured_pg("ft_send_recv", 300)
+    def test_reconfigure_then_all_reduce(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_all_reduce", 200, rank_device)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
+
+    @requires_capabilities(Capability.collective.reconfigure)
+    def test_reconfigure_then_send_recv(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_send_recv", 300, rank_device)
 
         rank = dist.get_rank()
         send_rank = (rank + 1) % self.world_size
         recv_rank = (rank - 1 + self.world_size) % self.world_size
-        send_tensor = torch.full((4,), rank + 1.0, device=self.device)
-        recv_tensor = torch.zeros(4, device=self.device)
+        send_tensor = torch.full((4,), rank + 1.0, device=rank_device)
+        recv_tensor = torch.zeros(4, device=rank_device)
 
         if rank % 2 == 0:
             send_work = self.backend.send([send_tensor], send_rank, 0)
@@ -160,12 +159,13 @@ class AbstractFaultToleranceTest:
     @requires_capabilities(
         Capability.collective.reconfigure, Capability.collective.work_result
     )
-    def test_work_explicit_timeout_includes_prelaunch_stall(self):
-        self._create_reconfigured_pg("ft_work_timeout", 1300)
-        dist.all_reduce(torch.ones(1, device=self.device))
+    def test_work_explicit_timeout_includes_prelaunch_stall(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_work_timeout", 1300, rank_device)
+        dist.all_reduce(torch.ones(1, device=rank_device))
         torch.cuda.synchronize()
         torch.cuda._sleep(int(500 * get_cycles_per_ms()))
-        work = dist.all_reduce(torch.ones(4, device=self.device), async_op=True)
+        work = dist.all_reduce(torch.ones(4, device=rank_device), async_op=True)
 
         with self.assertRaisesRegex(dist.DistBackendError, "timed out"):
             work.wait(timeout=timedelta(milliseconds=50))
@@ -180,13 +180,14 @@ class AbstractFaultToleranceTest:
     @requires_capabilities(
         Capability.collective.reconfigure, Capability.collective.work_result
     )
-    def test_work_reports_communicator_error(self):
-        self._create_reconfigured_pg("ft_work_error", 1301)
-        dist.all_reduce(torch.ones(1, device=self.device))
+    def test_work_reports_communicator_error(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_work_error", 1301, rank_device)
+        dist.all_reduce(torch.ones(1, device=rank_device))
         torch.cuda.synchronize()
 
         if self.rank == 0:
-            work = dist.all_reduce(torch.ones(1, device=self.device), async_op=True)
+            work = dist.all_reduce(torch.ones(1, device=rank_device), async_op=True)
             time.sleep(0.5)
             self.backend.abort()
             self.assertTrue(work.is_completed())
@@ -202,8 +203,9 @@ class AbstractFaultToleranceTest:
             time.sleep(1)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_shrink_exclude_last_rank(self):
-        handles = self._create_reconfigured_pg("ft_shrink_last", 400)
+    def test_shrink_exclude_last_rank(self, device):
+        rank_device = self._rank_device(device)
+        handles = self._create_reconfigured_pg("ft_shrink_last", 400, rank_device)
         excluded_rank = self.world_size - 1
         if self.rank == excluded_rank:
             self._store_barrier("ft_shrink_last_done")
@@ -212,9 +214,9 @@ class AbstractFaultToleranceTest:
         self._reconfigure(401, handles[:excluded_rank])
         self.assertEqual(dist.get_world_size(), self.world_size - 1)
         self.assertEqual(dist.get_rank(), self.rank)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size)), rank_device)
 
-        tensor = torch.zeros(4, device=self.device)
+        tensor = torch.zeros(4, device=rank_device)
         if dist.get_rank() == 0:
             tensor.fill_(42.0)
         dist.broadcast(tensor, group_src=0)
@@ -222,8 +224,9 @@ class AbstractFaultToleranceTest:
         self._store_barrier("ft_shrink_last_done")
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_shrink_exclude_middle_rank(self):
-        handles = self._create_reconfigured_pg("ft_shrink_middle", 500)
+    def test_shrink_exclude_middle_rank(self, device):
+        rank_device = self._rank_device(device)
+        handles = self._create_reconfigured_pg("ft_shrink_middle", 500, rank_device)
         excluded_rank = self.world_size // 2
         if self.rank == excluded_rank:
             self._store_barrier("ft_shrink_middle_done")
@@ -237,12 +240,13 @@ class AbstractFaultToleranceTest:
         expected_rank = self.rank if self.rank < excluded_rank else self.rank - 1
         self.assertEqual(dist.get_world_size(), self.world_size - 1)
         self.assertEqual(dist.get_rank(), expected_rank)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size)), rank_device)
         self._store_barrier("ft_shrink_middle_done")
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_scale_down_up(self):
-        self._init_reconfigurable_pg()
+    def test_reconfigure_scale_down_up(self, device):
+        rank_device = self._rank_device(device)
+        self._init_reconfigurable_pg(rank_device)
         # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
         self._reconfigure(600 + self.rank, [dist._get_reconfigure_handle()])
         self.assertEqual(dist.get_world_size(), 1)
@@ -259,25 +263,28 @@ class AbstractFaultToleranceTest:
         self._store_barrier("ft_scale_down_up_done")
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_single_to_all(self):
-        self._init_reconfigurable_pg()
+    def test_reconfigure_single_to_all(self, device):
+        rank_device = self._rank_device(device)
+        self._init_reconfigurable_pg(rank_device)
         # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
         self._reconfigure(700 + self.rank, [dist._get_reconfigure_handle()])
 
         handles = self._collect_handles("ft_single_to_all")
         self._reconfigure(703, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_identity(self):
-        self._create_reconfigured_pg("ft_identity", 800)
+    def test_reconfigure_identity(self, device):
+        rank_device = self._rank_device(device)
+        self._create_reconfigured_pg("ft_identity", 800, rank_device)
         handles = self._collect_handles("ft_identity_again")
         self._reconfigure(801, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_late_join(self):
-        self._init_reconfigurable_pg()
+    def test_reconfigure_late_join(self, device):
+        rank_device = self._rank_device(device)
+        self._init_reconfigurable_pg(rank_device)
         handles = self._collect_handles("ft_late_join_initial")
         initial_world_size = self.world_size // 2
         if self.rank < initial_world_size:
@@ -285,11 +292,12 @@ class AbstractFaultToleranceTest:
 
         handles = self._collect_handles("ft_late_join_all")
         self._reconfigure(901, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_merge_split(self):
-        self._init_reconfigurable_pg()
+    def test_reconfigure_merge_split(self, device):
+        rank_device = self._rank_device(device)
+        self._init_reconfigurable_pg(rank_device)
         handles = self._collect_handles("ft_merge_split_initial")
         split = self.world_size // 2
         if self.rank < split:
@@ -299,14 +307,15 @@ class AbstractFaultToleranceTest:
 
         handles = self._collect_handles("ft_merge_split_all")
         self._reconfigure(1002, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_after_abort(self):
+    def test_reconfigure_after_abort(self, device):
+        rank_device = self._rank_device(device)
         # Port of torchcomms' ReconfigureTest.test_reconfigure_after_abort:
         # abort() (a revoke in reconfigurable mode) must be recoverable by a
         # reconfigure() with a fresh uuid.
-        self._create_reconfigured_pg("ft_abort", 1200)
+        self._create_reconfigured_pg("ft_abort", 1200, rank_device)
         self.backend.abort()
 
         from torch._C._distributed_c10d import ErrorType
@@ -317,18 +326,19 @@ class AbstractFaultToleranceTest:
 
         handles = self._collect_handles("ft_abort_recover")
         self._reconfigure(1201, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_after_timeout(self):
+    def test_reconfigure_after_timeout(self, device):
+        rank_device = self._rank_device(device)
         from torch._C._distributed_c10d import ErrorType
 
-        self._create_reconfigured_pg("ft_timeout", 1300)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._create_reconfigured_pg("ft_timeout", 1300, rank_device)
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
         self.backend.set_timeout(timedelta(milliseconds=50))
 
         if self.rank == 1:
-            tensor = torch.ones(4, device=self.device)
+            tensor = torch.ones(4, device=rank_device)
             work = dist.all_reduce(tensor, async_op=True)
             try:
                 work.wait()
@@ -351,11 +361,12 @@ class AbstractFaultToleranceTest:
 
         handles = self._collect_handles("ft_timeout_recover")
         self._reconfigure(1301, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
     @requires_capabilities(Capability.collective.reconfigure)
-    def test_reconfigure_rejects_reused_uuid(self):
-        self._init_reconfigurable_pg()
+    def test_reconfigure_rejects_reused_uuid(self, device):
+        rank_device = self._rank_device(device)
+        self._init_reconfigurable_pg(rank_device)
         if self.backend_name != "nccl2":
             uuid = 1100 + self.rank
             self._reconfigure(uuid, [dist._get_reconfigure_handle()])
@@ -375,12 +386,13 @@ class AbstractFaultToleranceTest:
                 timeout=timedelta(milliseconds=500),
             ).wait()
         self._store_barrier("ft_reused_uuid_rejected")
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
-    def test_reconfigure_timeout_is_retryable(self):
+    def test_reconfigure_timeout_is_retryable(self, device):
+        rank_device = self._rank_device(device)
         if self.backend_name != "nccl2":
             self.skipTest("nonblocking NCCL initialization behavior")
-        self._init_reconfigurable_pg()
+        self._init_reconfigurable_pg(rank_device)
         handles = self._collect_handles("ft_timeout_retry_initial")
 
         if self.rank == 0:
@@ -394,11 +406,7 @@ class AbstractFaultToleranceTest:
 
         handles = self._collect_handles("ft_timeout_retry_current")
         self._reconfigure(1401, handles)
-        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
-
-
-class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+        self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)), rank_device)
 
 
 instantiate_device_type_tests(FaultToleranceTest, globals(), except_for=["hpu", "xpu"])

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -3,8 +3,6 @@
 import os
 import sys
 import time
-import unittest
-from dataclasses import dataclass
 from datetime import timedelta
 
 import torch
@@ -17,27 +15,19 @@ if not dist.is_available():
 
 import torch.distributed.distributed_c10d as c10d
 from torch._C._distributed_c10d import WorkResult
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
+    HardwareClassification,
     run_tests,
-    TEST_CUDA,
     TEST_WITH_ROCM,
     TestCase,
 )
-
-
-@dataclass(frozen=True)
-class FaultToleranceBackend:
-    name: str
-    device_type: str
-    supports_work_result: bool = False
-
-
-FAULT_TOLERANCE_BACKENDS = [
-    FaultToleranceBackend("gloo", "cpu"),
-    FaultToleranceBackend("nccl2", "cuda", supports_work_result=True),
-]
 
 
 class AbstractFaultToleranceTest:
@@ -47,13 +37,31 @@ class AbstractFaultToleranceTest:
 
     @property
     def device(self):
+        if self.device_type == "cpu":
+            return "cpu"
+        return f"{self.device_type}:{self.rank}"
+
+    @property
+    def backend_name(self):
         if self.device_type == "cuda":
-            return f"cuda:{self.rank}"
-        return self.device_type
+            return "nccl2"
+        return dist.get_default_backend_for_device(self.device_type)
 
     def setUp(self):
         super().setUp()
+        if self.device_type == "cuda" and TEST_WITH_ROCM:
+            self.skipTest("nccl2 reconfigure is not supported with RCCL")
+        if self.device_type != "cpu" and torch.accelerator.device_count() < 3:
+            self.skipTest("fault tolerance tests require at least 3 accelerators")
         self._spawn_processes()
+
+    def run_test(self, test_name, parent_pipe):
+        # Workers run the test method directly via run_test, skipping setUpClass.
+        # Re-invoke it so class-level setup applies in the worker like in the main
+        # process (e.g. PrivateUse1TestBase resolving device_type from the
+        # "privateuse1" placeholder to the real backend name).
+        type(self).setUpClass()
+        super().run_test(test_name, parent_pipe)
 
     def tearDown(self):
         if dist.is_initialized():
@@ -69,8 +77,8 @@ class AbstractFaultToleranceTest:
 
     def _init_reconfigurable_pg(self):
         self.store = self._create_store()
-        if self.device_type == "cuda":
-            torch.cuda.set_device(self.rank)
+        if self.device_type != "cpu":
+            torch.accelerator.set_device_index(self.rank)
         dist.init_process_group(
             self.backend_name,
             world_size=self.world_size,
@@ -119,13 +127,16 @@ class AbstractFaultToleranceTest:
         expected = torch.full((4,), expected_value, dtype=tensor.dtype)
         self.assertEqual(tensor.cpu(), expected)
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_basic(self):
         self._create_reconfigured_pg("ft_basic", 100)
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_then_all_reduce(self):
         self._create_reconfigured_pg("ft_all_reduce", 200)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_then_send_recv(self):
         self._create_reconfigured_pg("ft_send_recv", 300)
 
@@ -146,9 +157,10 @@ class AbstractFaultToleranceTest:
         recv_work.wait()
         self.assertEqual(recv_tensor.cpu(), torch.full((4,), recv_rank + 1.0))
 
+    @requires_capabilities(
+        Capability.collective.reconfigure, Capability.collective.work_result
+    )
     def test_work_explicit_timeout_includes_prelaunch_stall(self):
-        if not self.supports_work_result:
-            self.skipTest(f"{self.backend_name} does not report work results")
         self._create_reconfigured_pg("ft_work_timeout", 1300)
         dist.all_reduce(torch.ones(1, device=self.device))
         torch.cuda.synchronize()
@@ -165,9 +177,10 @@ class AbstractFaultToleranceTest:
         )
         torch.cuda.synchronize()
 
+    @requires_capabilities(
+        Capability.collective.reconfigure, Capability.collective.work_result
+    )
     def test_work_reports_communicator_error(self):
-        if not self.supports_work_result:
-            self.skipTest(f"{self.backend_name} does not report work results")
         self._create_reconfigured_pg("ft_work_error", 1301)
         dist.all_reduce(torch.ones(1, device=self.device))
         torch.cuda.synchronize()
@@ -188,6 +201,7 @@ class AbstractFaultToleranceTest:
         else:
             time.sleep(1)
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_shrink_exclude_last_rank(self):
         handles = self._create_reconfigured_pg("ft_shrink_last", 400)
         excluded_rank = self.world_size - 1
@@ -207,6 +221,7 @@ class AbstractFaultToleranceTest:
         self.assertEqual(tensor.cpu(), torch.full((4,), 42.0))
         self._store_barrier("ft_shrink_last_done")
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_shrink_exclude_middle_rank(self):
         handles = self._create_reconfigured_pg("ft_shrink_middle", 500)
         excluded_rank = self.world_size // 2
@@ -225,6 +240,7 @@ class AbstractFaultToleranceTest:
         self._assert_all_reduce_sum(sum(range(1, self.world_size)))
         self._store_barrier("ft_shrink_middle_done")
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_scale_down_up(self):
         self._init_reconfigurable_pg()
         # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
@@ -242,6 +258,7 @@ class AbstractFaultToleranceTest:
         self.assertEqual(dist.get_rank(), 0)
         self._store_barrier("ft_scale_down_up_done")
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_single_to_all(self):
         self._init_reconfigurable_pg()
         # Each rank shrinks to its own disjoint group, so each needs a unique uuid.
@@ -251,12 +268,14 @@ class AbstractFaultToleranceTest:
         self._reconfigure(703, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_identity(self):
         self._create_reconfigured_pg("ft_identity", 800)
         handles = self._collect_handles("ft_identity_again")
         self._reconfigure(801, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_late_join(self):
         self._init_reconfigurable_pg()
         handles = self._collect_handles("ft_late_join_initial")
@@ -268,6 +287,7 @@ class AbstractFaultToleranceTest:
         self._reconfigure(901, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_merge_split(self):
         self._init_reconfigurable_pg()
         handles = self._collect_handles("ft_merge_split_initial")
@@ -281,6 +301,7 @@ class AbstractFaultToleranceTest:
         self._reconfigure(1002, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_after_abort(self):
         # Port of torchcomms' ReconfigureTest.test_reconfigure_after_abort:
         # abort() (a revoke in reconfigurable mode) must be recoverable by a
@@ -298,6 +319,7 @@ class AbstractFaultToleranceTest:
         self._reconfigure(1201, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_after_timeout(self):
         from torch._C._distributed_c10d import ErrorType
 
@@ -331,6 +353,7 @@ class AbstractFaultToleranceTest:
         self._reconfigure(1301, handles)
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @requires_capabilities(Capability.collective.reconfigure)
     def test_reconfigure_rejects_reused_uuid(self):
         self._init_reconfigurable_pg()
         if self.backend_name != "nccl2":
@@ -374,38 +397,16 @@ class AbstractFaultToleranceTest:
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
 
-def _make_fault_tolerance_test_class(backend):
-    class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
-        pass
-
-    FaultToleranceTest.backend_name = backend.name
-    FaultToleranceTest.device_type = backend.device_type
-    FaultToleranceTest.supports_work_result = backend.supports_work_result
-    FaultToleranceTest.__name__ = f"{backend.name.capitalize()}FaultToleranceTest"
-    FaultToleranceTest.__qualname__ = FaultToleranceTest.__name__
-    cls = unittest.skipIf(
-        not dist.is_backend_available(backend.name),
-        f"{backend.name} backend is not available",
-    )(FaultToleranceTest)
-    if backend.device_type == "cuda":
-        cls = unittest.skipIf(
-            not TEST_CUDA or torch.cuda.device_count() < 3,
-            "fault tolerance CUDA tests require at least 3 GPUs",
-        )(cls)
-    if backend.name == "nccl2":
-        cls = unittest.skipIf(
-            TEST_WITH_ROCM,
-            "nccl2 reconfigure is not supported with RCCL",
-        )(cls)
-    return cls
+class FaultToleranceTest(AbstractFaultToleranceTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
 
-for backend in FAULT_TOLERANCE_BACKENDS:
-    class_name = f"{backend.name.capitalize()}FaultToleranceTest"
-    globals()[class_name] = _make_fault_tolerance_test_class(backend)
+instantiate_device_type_tests(FaultToleranceTest, globals(), except_for=["hpu", "xpu"])
 
 
 class ReconfigureContractTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_reconfigure_rejects_multiple_backends(self) -> None:
         pg = dist.ProcessGroup(0, 1)
         pg._register_backend(torch.device("cpu"), dist.ProcessGroup.BackendType.GLOO)
@@ -423,6 +424,8 @@ class ReconfigureContractTest(TestCase):
 class BackendCapabilityContractTest(TestCase):
     """Ensures base-Backend bindings are safe to call on any backend (e.g. Gloo)
     without throwing, so hasattr-based capability detection stays valid."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_error_returns_success_on_base_backend(self) -> None:
         from torch._C._distributed_c10d import Backend as C10DBackend, ErrorType

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -349,6 +349,12 @@ class Capability:
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
 
+    class collective:
+        """Collective communication capabilities (reconfigure, etc.)."""
+
+        reconfigure = "collective.reconfigure"
+        work_result = "collective.work_result"
+
 
 class DeviceTypeTestBase(TestCase):
     device_type: str = "generic_device_type"
@@ -788,11 +794,17 @@ class CPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
+        import torch.distributed as dist
+
         return {
             Capability.dtype.fp8: lambda: True,
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: True,
             Capability.attention.mem_efficient_attention: lambda: False,
+            # gloo (the default CPU backend) supports reconfigure; it is built
+            # whenever distributed is built. gloo does not report WorkResult.
+            Capability.collective.reconfigure: lambda: dist.is_available(),
+            Capability.collective.work_result: lambda: False,
         }
 
 
@@ -810,6 +822,7 @@ class CUDATestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
+        import torch.distributed as dist
         from torch.testing._internal.common_cuda import (
             PLATFORM_SUPPORTS_FLASH_ATTENTION,
             PLATFORM_SUPPORTS_FP8,
@@ -817,11 +830,18 @@ class CUDATestBase(DeviceTypeTestBase):
             SM80OrLater,
         )
 
+        def nccl2_available():
+            return dist.is_available() and dist.is_backend_available("nccl2")
+
         return {
             Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
             Capability.dtype.bf16: lambda: SM80OrLater,
             Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
             Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            # nccl2 is the reconfigure-capable CUDA backend (default "nccl" is
+            # not) and is the only backend that reports WorkResult.
+            Capability.collective.reconfigure: nccl2_available,
+            Capability.collective.work_result: nccl2_available,
         }
 
     @classmethod


### PR DESCRIPTION
## Summary
Refactor `test_c10d_fault_tolerance` to use `instantiate_device_type_tests` + `hw-classification`, and gate reconfigure support through the #190846 capability framework (stacks on #190846). Each test method is decorated with `@requires_capabilities`, so a variant whose backend lacks reconfigure skips at run time, while the original `assertTrue` contract is preserved as a second layer.

## Changes

**`torch/testing/_internal/common_device_type.py`** (extends #190846's framework):
- Add `Capability.collective.{reconfigure, work_result}` to the `Capability` namespace.
- `CPUTestBase._capabilities`: declare `reconfigure = dist.is_available()` (gloo, the default CPU backend, supports reconfigure and is built whenever distributed is) and `work_result = False` (gloo does not report `WorkResult`).
- `CUDATestBase._capabilities`: declare both `reconfigure` and `work_result` via a nested `nccl2_available()` helper (`dist.is_available() and dist.is_backend_available("nccl2")`) — nccl2 is the reconfigure-capable CUDA backend (the default `"nccl"` is not) and the only backend that reports `WorkResult`.

**`test/distributed/test_c10d_fault_tolerance.py`**:
- Replace the `_make_fault_tolerance_test_class` factory + `globals()` registration loop with `instantiate_device_type_tests(FaultToleranceTest, globals(), except_for=["hpu", "xpu"])`; classify the reconfigure collective tests as `HardwareClassification.ACCELERATOR`.
- Decorate each test method with `@requires_capabilities`: the 13 reconfigure tests declare `Capability.collective.reconfigure`; the 2 work-result tests declare both `reconfigure` and `work_result`. A variant whose device base reports the capability as missing/unsupported raises `SkipTest` at run time, before `_init_reconfigurable_pg`.
- The `assertTrue(dist._supports_reconfigure())` / `assertTrue(backend.supports_reconfigure)` contract in `_init_reconfigurable_pg` is **preserved** as a second layer: it catches a backend that lacks reconfigure even if a variant reaches init (e.g. if an OOT base later declares the capability before the backend actually supports it).
- Override `MultiProcessTestCase.run_test` to re-invoke `type(self).setUpClass()` before the parent's `run_test`. Workers run the test method directly via `run_test`, skipping `setUpClass`, so `PrivateUse1TestBase` would never translate the `"privateuse1"` device_type token to the real backend name in the worker; the override makes class-level device setup apply in the worker like in the main process. `device`/`backend_name`/`setUp` then read `self.device_type` directly (no `_resolved_device_type` shim).
- Generalize the device setup: `set_device` → `torch.accelerator.set_device_index(self.rank)` (was cuda-only); the 3-device gate uses `torch.accelerator.device_count()`.
- The 15 test method bodies and per-test PG lifecycle are unchanged; the two pure-logic contract classes (`ReconfigureContractTest`, `BackendCapabilityContractTest`) are labeled `GENERIC` and not instantiated.

## Motivation
Part of the test case refactoring initiative (#185590) to label tests by hardware classification and generate per-device variants via `instantiate_device_type_tests`, so reconfigure (fault-tolerance) collective behavior is exercised across reconfigure-capable accelerator backends rather than hand-rolled per-backend.

## Notes
- **Depends on #190846** (the capability-based test-skip framework). This PR extends that framework with the `collective.reconfigure` / `collective.work_result` capabilities and is the first consumer.
