### PR TITLE
[Testcase Refactoring] Migrate test_kernel_optimization to hw_classification and device parameter

### DIFF
--- a/test/inductor/test_kernel_optimization.py
+++ b/test/inductor/test_kernel_optimization.py
@@ -4,8 +4,8 @@ import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import serialTest
-from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, serialTest
 
 
 class _TestEinsumtoPointwise(torch.nn.Module):
@@ -29,6 +29,8 @@ class _TestEinsumtoPointwise(torch.nn.Module):
 
 
 class TestKernelOptimization(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
             return False
@@ -54,10 +56,9 @@ class TestKernelOptimization(TestCase):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
         self.assertTrue(
-            self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
+            self.compare_dict_tensors(ref_grad, res_grad, rtol, atol=atol)
         )
 
-    @requires_gpu()
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
             "einsum_to_pointwise_pass": {},
@@ -65,16 +66,16 @@ class TestKernelOptimization(TestCase):
         post_grad_fusion_options={},
     )
     @serialTest()  # Needs slightly more memory on GPUs
-    def test_einsum_to_pointwise(self):
+    def test_einsum_to_pointwise(self, device):
         counters.clear()
-        module = _TestEinsumtoPointwise().to(GPU_TYPE)
+        module = _TestEinsumtoPointwise().to(device)
         input = [
-            torch.randn(4096, 9, 512, device=GPU_TYPE, requires_grad=True),
-            torch.randn(9, 512, 96, device=GPU_TYPE, requires_grad=True),
-            torch.randn(9, 96, device=GPU_TYPE, requires_grad=True),
-            torch.randn(4096, 9, 160, device=GPU_TYPE, requires_grad=True),
-            torch.randn(4096, 9, 160, 96, device=GPU_TYPE, requires_grad=True),
-            torch.randn(4096, 9, 96, device=GPU_TYPE, requires_grad=True),
+            torch.randn(4096, 9, 512, device=device, requires_grad=True),
+            torch.randn(9, 512, 96, device=device, requires_grad=True),
+            torch.randn(9, 96, device=device, requires_grad=True),
+            torch.randn(4096, 9, 160, device=device, requires_grad=True),
+            torch.randn(4096, 9, 160, 96, device=device, requires_grad=True),
+            torch.randn(4096, 9, 96, device=device, requires_grad=True),
         ]
         traced = torch.compile(module)
         ref = module(*input)
@@ -89,6 +90,11 @@ class TestKernelOptimization(TestCase):
             1,
         )
         counters.clear()
+
+
+instantiate_device_type_tests(
+    TestKernelOptimization, globals(), except_for="cpu", allow_mps=True, allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_kernel_optimization.py
+++ b/test/inductor/test_kernel_optimization.py
@@ -1,15 +1,14 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, serialTest
+from torch.testing._internal.inductor_utils import HAS_MPS, HAS_TRITON
 
 
 class _TestEinsumtoPointwise(torch.nn.Module):
@@ -32,7 +31,7 @@ class _TestEinsumtoPointwise(torch.nn.Module):
         return add1 + add2
 
 
-class TestKernelOptimization(TestCase):
+class TestKernelOptimizationAccelerator(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
@@ -61,7 +60,7 @@ class TestKernelOptimization(TestCase):
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
         self.assertTrue(self.compare_dict_tensors(ref_grad, res_grad, rtol, atol=atol))
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not (HAS_MPS or HAS_TRITON), "requires triton")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
             "einsum_to_pointwise_pass": {},
@@ -96,7 +95,11 @@ class TestKernelOptimization(TestCase):
 
 
 instantiate_device_type_tests(
-    TestKernelOptimization, globals(), except_for="cpu", allow_mps=True, allow_xpu=True
+    TestKernelOptimizationAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
 )
 
 

--- a/test/inductor/test_kernel_optimization.py
+++ b/test/inductor/test_kernel_optimization.py
@@ -4,7 +4,11 @@ import torch
 import torch._inductor
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import HardwareClassification, serialTest
 
 
@@ -55,10 +59,9 @@ class TestKernelOptimization(TestCase):
     def compare_gradients(self, module, traced, rtol=1e-3, atol=1e-3):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
-        self.assertTrue(
-            self.compare_dict_tensors(ref_grad, res_grad, rtol, atol=atol)
-        )
+        self.assertTrue(self.compare_dict_tensors(ref_grad, res_grad, rtol, atol=atol))
 
+    @requires_capabilities(Capability.lib.triton)
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
             "einsum_to_pointwise_pass": {},


### PR DESCRIPTION
### Summary

Migrate test_kernel_optimization.py from GPU_TYPE-based pattern to instantiate_device_type_tests with hw_classification = ACCELERATOR. The test class is renamed to TestKernelOptimizationAccelerator and its single test method now receives a device parameter instead of using the module-level GPU_TYPE.

### Changes

- Rename TestKernelOptimization to TestKernelOptimizationAccelerator and add hw_classification = HardwareClassification.ACCELERATOR
- Replace @requires_gpu() with instantiate_device_type_tests (except_for="cpu", allow_mps=True, allow_xpu=True)
- Replace GPU_TYPE with device parameter in test_einsum_to_pointwise
- Replace the triton guard with @unittest.skipIf(not (HAS_MPS or HAS_TRITON), "requires triton"), matching the original @requires_gpu() semantics (HAS_GPU or HAS_MPS)
- Clean up imports: drop GPU_TYPE, requires_gpu, Capability, requires_capabilities; add HAS_MPS, HAS_TRITON

### Motivation

The original code used module-level GPU_TYPE and @requires_gpu() which hardcoded device selection. The new code uses the standard instantiate_device_type_tests mechanism. The triton requirement is preserved via @unittest.skipIf(not (HAS_MPS or HAS_TRITON)), the standard replacement for @requires_gpu() from inductor_utils (skipIf(not (HAS_GPU or HAS_MPS))).

### Test Plan

```
python test/inductor/test_kernel_optimization.py
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo