### PR TITLE
Sort same-file read items by storage offset to improve read locality

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -876,8 +876,9 @@ class FileSystemReader(StorageReader):
 
         for relative_path, reqs in per_file.items():
             new_path = self.fs.concat_path(self.path, relative_path)
+            # Sort requests by physical offset to improve read locality and minimize seeks.
+            reqs.sort(key=lambda req: self.storage_data[req.storage_index].offset)
             with self.fs.create_stream(new_path, "rb") as stream:
-                # TODO sort by offset and cache the reading
                 for req in reqs:
                     item_md = self.storage_data[req.storage_index]
                     file_slice = self._slice_file(stream, item_md)


### PR DESCRIPTION
> Why
> 
> Reading requests for items within the same file were executed in logical plan order, which can cause backward seeks within a single file and fragmented I/O. This is especially harmful for large distributed checkpoint restores where physical layout differs from logical load order.
> 
> What
> 
> - Sorts each file's ReadItem list by the physical storage offset before opening the file stream in FileSystemReader.read_data. This makes per-file reads progress in increasing file-offset order, improving kernel/file-system readahead and reducing random seeks.
> 
> Tests / Validation
> 
> - Run lintrunner -a and the targeted checkpoint tests locally or in CI.
> - Targeted pytest commands:
>   - python -m pytest -q test/distributed/checkpoint/test_file_system_checkpoint.py -q
>   - python -m pytest -q test/distributed/checkpoint/test_file_system_checkpoint_cpu.py -q
> - Recommended additional unit test: tests/distributed/test_filesystem_reader.py::test_read_items_sorted_by_offset_per_file (constructs a LoadPlan with two ReadItems in reverse logical order and asserts the reader processes them in offset order).
> 
> Notes
> 
> - This is a small, self-contained change that addresses the root cause (out-of-order intra-file reads). It should be safe for fsspec and other FileSystem implementations; tie-breaking for identical offsets is stable (Python sort). If deterministic tie-breaking is required, consider sorting by (offset, storage_index).
> - lintrunner/pytest were not available in the interactive session that prepared this branch; please run the Test Plan in CI or locally.
> 
> AI disclosure
> 
> > This PR description was generated with assistance from an AI (Copilot App). Please review the changes before merging.