### PR TITLE
[Testcase Refactoring] Classify guard manager tests by hardware

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -16,7 +16,12 @@ from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch._library.fake_class_registry import FakeScriptObject
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     set_default_dtype,
     TEST_WITH_ASAN,
     TEST_WITH_TSAN,
@@ -78,6 +83,8 @@ def less_match_verbose_code_parts(expected):
 
 
 class GuardManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_cpp_shape_guard_missing_windows_compiler_falls_back(self):
         from torch._inductor.codecache import CppCodeCache
         from torch._inductor.cpp_builder import check_compiler_exist_windows
@@ -307,22 +314,6 @@ user_stack=None)
         self.assertTrue(guard(foo))
         self.assertTrue(guard(int))
         self.assertFalse(guard(float))
-
-    def test_default_device_guard(self):
-        root = RootGuardManager()
-        foo = 1
-        guard = guards.DEFAULT_DEVICE(root, ["cpu device"], None)
-        self.assertTrue(guard(foo))
-
-        if not torch.accelerator.is_available():
-            self.skipTest("Accelerator is not available")
-
-        try:
-            device = torch.accelerator.current_accelerator()
-            torch.set_default_device(device)
-            self.assertFalse(guard(foo))
-        finally:
-            torch.set_default_device(None)
 
     def test_length_check_guard(self):
         root = RootGuardManager()
@@ -588,19 +579,6 @@ user_stack=None)
         del x
         self.assertFalse(guard(weakref_x()))
 
-    def test_call_function_no_args_guard(self):
-        if not torch.accelerator.is_available():
-            self.skipTest("Accelerator is not available")
-
-        root = RootGuardManager()
-        device = torch.accelerator.current_accelerator()
-        # Use device.index which is device-agnostic (works on all accelerators)
-        x = device.index if device.index is not None else 0
-        guard = guards.EQUALS_MATCH(root, x, [0], None)
-        self.assertTrue(guard(0))
-        self.assertFalse(guard(1))
-        self.assertFalse(guard(2))
-
     def test_guard_manager_leaf_guard(self):
         guard_manager = RootGuardManager()
         guard_manager.add_type_match_guard(id_type(5), ["type(x) == int"], None)
@@ -789,9 +767,11 @@ user_stack=None)
         ).getitem_manager("global_pair", "", global_pair, default_mgr_enum)
 
         gpair_mgr.add_lambda_guard(
-            lambda x: isinstance(x, Pair)
-            and isinstance(x.x, torch.Tensor)
-            and isinstance(x.y, int),
+            lambda x: (
+                isinstance(x, Pair)
+                and isinstance(x.x, torch.Tensor)
+                and isinstance(x.y, int)
+            ),
             "global guard fail",
             None,
         )
@@ -1118,7 +1098,40 @@ user_stack=None)
             opt_fn(x, foo, bar)
 
 
+class GuardManagerAcceleratorTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_default_device_guard(self, device):
+        root = RootGuardManager()
+        foo = 1
+        guard = guards.DEFAULT_DEVICE(root, ["cpu device"], None)
+        self.assertTrue(guard(foo))
+
+        try:
+            torch.set_default_device(device)
+            self.assertFalse(guard(foo))
+        finally:
+            torch.set_default_device(None)
+
+    @onlyAccelerator
+    def test_call_function_no_args_guard(self, device):
+        root = RootGuardManager()
+        device = torch.device(device)
+        # Use device.index which is device-agnostic (works on all accelerators)
+        x = device.index if device.index is not None else 0
+        guard = guards.EQUALS_MATCH(root, x, [0], None)
+        self.assertTrue(guard(0))
+        self.assertFalse(guard(1))
+        self.assertFalse(guard(2))
+
+
+instantiate_device_type_tests(GuardManagerAcceleratorTests, globals())
+
+
 class TypePropagationTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(skip_tensor_guards_with_matching_dict_tags=True)
     def test_basic_types(self):
         class Foo:
@@ -1180,6 +1193,8 @@ class TypePropagationTests(torch._dynamo.test_case.TestCase):
 
 
 class DuplicateGuardTest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_duplicate_guard(self):
         class Foo:
             def __init__(self):
@@ -1215,6 +1230,8 @@ class DuplicateGuardTest(torch._dynamo.test_case.TestCase):
 
 
 class RecursiveDictTagTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.use_recursive_dict_tags_for_guards
@@ -1617,6 +1634,8 @@ class RecursiveDictGuardTests(RecursiveDictTagTests):
 
 
 class SourceCloneTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_clone_identity_transform(self):
         """Identity transform should produce a source with the same name."""
         from torch._dynamo.source import AttrSource, GetItemSource, LocalSource
@@ -1731,6 +1750,8 @@ class SourceCloneTests(torch._dynamo.test_case.TestCase):
 
 class GuardCheckSpecTests(torch._dynamo.test_case.TestCase):
     """Tests for the GuardCheckSpec get_metadata_fn/eval_fn handlers on GuardBuilder."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _get_handler(self, name):
         from torch._dynamo.guards import GUARD_VALUE_DISPATCH

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -16,10 +16,7 @@ from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch._library.fake_class_registry import FakeScriptObject
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     set_default_dtype,
@@ -1101,7 +1098,6 @@ user_stack=None)
 class GuardManagerAcceleratorTests(torch._dynamo.test_case.TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @onlyAccelerator
     def test_default_device_guard(self, device):
         root = RootGuardManager()
         foo = 1
@@ -1114,7 +1110,6 @@ class GuardManagerAcceleratorTests(torch._dynamo.test_case.TestCase):
         finally:
             torch.set_default_device(None)
 
-    @onlyAccelerator
     def test_call_function_no_args_guard(self, device):
         root = RootGuardManager()
         device = torch.device(device)
@@ -1126,7 +1121,13 @@ class GuardManagerAcceleratorTests(torch._dynamo.test_case.TestCase):
         self.assertFalse(guard(2))
 
 
-instantiate_device_type_tests(GuardManagerAcceleratorTests, globals())
+instantiate_device_type_tests(
+    GuardManagerAcceleratorTests,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 class TypePropagationTests(torch._dynamo.test_case.TestCase):
@@ -1230,8 +1231,6 @@ class DuplicateGuardTest(torch._dynamo.test_case.TestCase):
 
 
 class RecursiveDictTagTests(torch._dynamo.test_case.TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.use_recursive_dict_tags_for_guards
@@ -1243,6 +1242,8 @@ class RecursiveDictTagTests(torch._dynamo.test_case.TestCase):
 
 
 class TagSafetyChecks(RecursiveDictTagTests):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.use_recursive_dict_tags_for_guards
@@ -1519,6 +1520,8 @@ class TagSafetyChecks(RecursiveDictTagTests):
 
 
 class RecursiveDictGuardTests(RecursiveDictTagTests):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_disabling(self):
         class Mod(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
## Summary
Classifies Dynamo guard manager tests with hardware metadata and separates accelerator-only default device coverage.

## Changes
- Add HardwareClassification coverage for guard manager test classes.
- Move accelerator-only default device and no-arg guard coverage into an accelerator-instantiated test class.
- Use the instantiated device for accelerator-specific guard checks.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_guard_manager.py
python -m py_compile test/dynamo/test_guard_manager.py
npu-run-suite npu ./test_guard_manager.py
```


### Environment
| Item | Version |
|------|---------|
| PyTorch | 2.14.0+gitee7bc39 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98