### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard_compile.py

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -47,10 +47,10 @@ class Mod(torch.nn.Module):
         return self.encoder(x)
 
 
+@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompileCompute(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_disable_compiling_hooks(self):
         """Verify that dynamo never traces into FSDP hooks in forward or backward."""
@@ -79,7 +79,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         torch._dynamo.trace_rules.check = orig_trace_rules_check
         self.assertEqual(trace_rules_check_count, 0)
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_compiled_autograd_fsdp2_backward(self):
         """
@@ -128,7 +127,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         #   graph break 2: post_backward (from RegisterPostBackwardFunction)
         self.assertEqual(backend_count, 2)
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_compile_optimizer_uneven_shard(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/176667
@@ -162,7 +160,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         model(x).sum().backward()
         torch.compile(opt.step)()
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(4)
     def test_tp_mixed_precision_dtensor_spec_dtype(self):
         torch._dynamo.reset()
@@ -226,10 +223,10 @@ class TestFullyShardCompileCompute(FSDPTest):
             dist.barrier()
 
 
+@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompile(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_dynamo_trace_use_training_state(self):
         torch._dynamo.reset()
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
@@ -267,7 +264,6 @@ class TestFullyShardCompile(FSDPTest):
         self.assertEqual(cnt.op_count, 1)
         self.assertEqual(len(cnt.graphs), 1)
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_trace_fsdp_copy_(self):
         @torch.library.custom_op("mylib::add_one_out", mutates_args={"out"})
         def add_one_out(x: torch.Tensor, out: torch.Tensor) -> None:
@@ -286,7 +282,6 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
-    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_dynamo_recompiles_on_fsdp_layers(self):
         m = Mod()
         for name, child in m.encoder.named_children():

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -2,7 +2,6 @@
 
 
 import copy
-import unittest
 
 import torch
 import torch._dynamo.compiled_autograd as compiled_autograd
@@ -21,10 +20,14 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
 from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype, MLP
-from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 device_type = torch.device(get_devtype())
@@ -45,7 +48,9 @@ class Mod(torch.nn.Module):
 
 
 class TestFullyShardCompileCompute(FSDPTest):
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_disable_compiling_hooks(self):
         """Verify that dynamo never traces into FSDP hooks in forward or backward."""
@@ -74,7 +79,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         torch._dynamo.trace_rules.check = orig_trace_rules_check
         self.assertEqual(trace_rules_check_count, 0)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_compiled_autograd_fsdp2_backward(self):
         """
@@ -123,7 +128,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         #   graph break 2: post_backward (from RegisterPostBackwardFunction)
         self.assertEqual(backend_count, 2)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_compile_optimizer_uneven_shard(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/176667
@@ -157,7 +162,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         model(x).sum().backward()
         torch.compile(opt.step)()
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(4)
     def test_tp_mixed_precision_dtensor_spec_dtype(self):
         torch._dynamo.reset()
@@ -221,8 +226,10 @@ class TestFullyShardCompileCompute(FSDPTest):
             dist.barrier()
 
 
-@unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
 class TestFullyShardCompile(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilities(Capability.lib.triton)
     def test_dynamo_trace_use_training_state(self):
         torch._dynamo.reset()
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
@@ -260,6 +267,7 @@ class TestFullyShardCompile(FSDPTest):
         self.assertEqual(cnt.op_count, 1)
         self.assertEqual(len(cnt.graphs), 1)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_trace_fsdp_copy_(self):
         @torch.library.custom_op("mylib::add_one_out", mutates_args={"out"})
         def add_one_out(x: torch.Tensor, out: torch.Tensor) -> None:
@@ -278,6 +286,7 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
+    @requires_capabilities(Capability.lib.triton)
     def test_dynamo_recompiles_on_fsdp_layers(self):
         m = Mod()
         for name, child in m.encoder.named_children():
@@ -287,6 +296,21 @@ class TestFullyShardCompile(FSDPTest):
         m = FSDP(m, sharding_strategy=ShardingStrategy.FULL_SHARD, use_orig_params=True)
         inp = torch.randn(32, 784, device=device_type)
         m(inp)
+
+
+instantiate_device_type_tests(
+    TestFullyShardCompileCompute,
+    globals(),
+    except_for=["cpu", "hpu", "privateuse1"],
+    allow_xpu=True,
+)
+
+instantiate_device_type_tests(
+    TestFullyShardCompile,
+    globals(),
+    except_for=["cpu", "hpu", "privateuse1"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -2,6 +2,7 @@
 
 
 import copy
+import unittest
 
 import torch
 import torch._dynamo.compiled_autograd as compiled_autograd
@@ -20,14 +21,11 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
 from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype, MLP
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
+from torch.utils._triton import has_triton
 
 
 device_type = torch.device(get_devtype())
@@ -47,10 +45,10 @@ class Mod(torch.nn.Module):
         return self.encoder(x)
 
 
+@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompileCompute(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_disable_compiling_hooks(self, device):
         """Verify that dynamo never traces into FSDP hooks in forward or backward."""
@@ -79,7 +77,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         torch._dynamo.trace_rules.check = orig_trace_rules_check
         self.assertEqual(trace_rules_check_count, 0)
 
-    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_compiled_autograd_fsdp2_backward(self, device):
         """
@@ -128,7 +125,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         #   graph break 2: post_backward (from RegisterPostBackwardFunction)
         self.assertEqual(backend_count, 2)
 
-    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
     def test_compile_optimizer_uneven_shard(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/176667
@@ -162,7 +158,6 @@ class TestFullyShardCompileCompute(FSDPTest):
         model(x).sum().backward()
         torch.compile(opt.step)()
 
-    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(4)
     def test_tp_mixed_precision_dtensor_spec_dtype(self, device):
         torch._dynamo.reset()
@@ -226,10 +221,10 @@ class TestFullyShardCompileCompute(FSDPTest):
             dist.barrier()
 
 
+@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompile(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
     def test_dynamo_trace_use_training_state(self, device):
         torch._dynamo.reset()
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
@@ -267,7 +262,6 @@ class TestFullyShardCompile(FSDPTest):
         self.assertEqual(cnt.op_count, 1)
         self.assertEqual(len(cnt.graphs), 1)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_trace_fsdp_copy_(self, device):
         @torch.library.custom_op("mylib::add_one_out", mutates_args={"out"})
         def add_one_out(x: torch.Tensor, out: torch.Tensor) -> None:
@@ -286,7 +280,6 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_dynamo_recompiles_on_fsdp_layers(self, device):
         m = Mod()
         for name, child in m.encoder.named_children():

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -2,6 +2,7 @@
 
 
 import copy
+import unittest
 
 import torch
 import torch._dynamo.compiled_autograd as compiled_autograd
@@ -21,13 +22,12 @@ from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype, MLP
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
+from torch.utils._triton import has_triton
 
 
 device_type = torch.device(get_devtype())
@@ -50,7 +50,7 @@ class Mod(torch.nn.Module):
 class TestFullyShardCompileCompute(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_disable_compiling_hooks(self):
         """Verify that dynamo never traces into FSDP hooks in forward or backward."""
@@ -79,7 +79,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         torch._dynamo.trace_rules.check = orig_trace_rules_check
         self.assertEqual(trace_rules_check_count, 0)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_compiled_autograd_fsdp2_backward(self):
         """
@@ -128,7 +128,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         #   graph break 2: post_backward (from RegisterPostBackwardFunction)
         self.assertEqual(backend_count, 2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(2)
     def test_compile_optimizer_uneven_shard(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/176667
@@ -162,7 +162,7 @@ class TestFullyShardCompileCompute(FSDPTest):
         model(x).sum().backward()
         torch.compile(opt.step)()
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     @skip_if_lt_x_gpu(4)
     def test_tp_mixed_precision_dtensor_spec_dtype(self):
         torch._dynamo.reset()
@@ -229,7 +229,7 @@ class TestFullyShardCompileCompute(FSDPTest):
 class TestFullyShardCompile(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_dynamo_trace_use_training_state(self):
         torch._dynamo.reset()
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
@@ -267,7 +267,7 @@ class TestFullyShardCompile(FSDPTest):
         self.assertEqual(cnt.op_count, 1)
         self.assertEqual(len(cnt.graphs), 1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_trace_fsdp_copy_(self):
         @torch.library.custom_op("mylib::add_one_out", mutates_args={"out"})
         def add_one_out(x: torch.Tensor, out: torch.Tensor) -> None:
@@ -286,7 +286,7 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Triton is not available")
     def test_dynamo_recompiles_on_fsdp_layers(self):
         m = Mod()
         for name, child in m.encoder.named_children():

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -2,7 +2,6 @@
 
 
 import copy
-import unittest
 
 import torch
 import torch._dynamo.compiled_autograd as compiled_autograd
@@ -22,12 +21,13 @@ from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
+    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype, MLP
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
-from torch.utils._triton import has_triton
 
 
 device_type = torch.device(get_devtype())
@@ -47,12 +47,12 @@ class Mod(torch.nn.Module):
         return self.encoder(x)
 
 
-@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompileCompute(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
-    def test_disable_compiling_hooks(self):
+    def test_disable_compiling_hooks(self, device):
         """Verify that dynamo never traces into FSDP hooks in forward or backward."""
         torch._dynamo.reset()
         trace_rules_check_count = 0
@@ -79,8 +79,9 @@ class TestFullyShardCompileCompute(FSDPTest):
         torch._dynamo.trace_rules.check = orig_trace_rules_check
         self.assertEqual(trace_rules_check_count, 0)
 
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
-    def test_compiled_autograd_fsdp2_backward(self):
+    def test_compiled_autograd_fsdp2_backward(self, device):
         """
         Verify that compiled autograd with FSDP2 backward does not crash and
         that FSDP hooks cause graph breaks (due to _dynamo_disable).
@@ -127,8 +128,9 @@ class TestFullyShardCompileCompute(FSDPTest):
         #   graph break 2: post_backward (from RegisterPostBackwardFunction)
         self.assertEqual(backend_count, 2)
 
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(2)
-    def test_compile_optimizer_uneven_shard(self):
+    def test_compile_optimizer_uneven_shard(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/176667
         # When a param dim is not divisible by world_size, FSDP2 creates
         # param._local_tensor as a narrow view of an N-D padded tensor, while
@@ -160,8 +162,9 @@ class TestFullyShardCompileCompute(FSDPTest):
         model(x).sum().backward()
         torch.compile(opt.step)()
 
+    @requires_capabilities(Capability.lib.triton)
     @skip_if_lt_x_gpu(4)
-    def test_tp_mixed_precision_dtensor_spec_dtype(self):
+    def test_tp_mixed_precision_dtensor_spec_dtype(self, device):
         torch._dynamo.reset()
         if self.world_size % 2 != 0:
             self.skipTest(f"Expects even world size but got {self.world_size}")
@@ -223,11 +226,11 @@ class TestFullyShardCompileCompute(FSDPTest):
             dist.barrier()
 
 
-@unittest.skipIf(not has_triton(), "Triton is not available")
 class TestFullyShardCompile(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_dynamo_trace_use_training_state(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_dynamo_trace_use_training_state(self, device):
         torch._dynamo.reset()
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
         param_group = FSDPParamGroup(
@@ -264,7 +267,8 @@ class TestFullyShardCompile(FSDPTest):
         self.assertEqual(cnt.op_count, 1)
         self.assertEqual(len(cnt.graphs), 1)
 
-    def test_trace_fsdp_copy_(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_trace_fsdp_copy_(self, device):
         @torch.library.custom_op("mylib::add_one_out", mutates_args={"out"})
         def add_one_out(x: torch.Tensor, out: torch.Tensor) -> None:
             torch.add(x, 1, out=out)
@@ -282,7 +286,8 @@ class TestFullyShardCompile(FSDPTest):
         torch.compile(f, backend="aot_eager")(x)
         self.assertEqual(x, ref_x)
 
-    def test_dynamo_recompiles_on_fsdp_layers(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_dynamo_recompiles_on_fsdp_layers(self, device):
         m = Mod()
         for name, child in m.encoder.named_children():
             if isinstance(child, torch.nn.Linear):


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the fully_shard compile test classes
and instantiates them via instantiate_device_type_tests with
except_for=["cpu", "hpu", "privateuse1"] and allow_xpu=True, so they are
discovered per device type under the hardware-classification selection.

Each test method now takes a `device` parameter, so the framework injects the
device on which the instantiated variant runs.

The legacy `@unittest.skipIf(not HAS_GPU, ...)` gates are replaced with
class-level `@unittest.skipIf(not has_triton(), "Triton is not available")`.
The HAS_GPU check was a hardware-brand check that implicitly assumed "has GPU
implies has Triton"; these tests actually depend on a Triton-capable Inductor
backend, which is now checked directly at the class level.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_compile.py --hw-classification ACCELERATOR