### PR TITLE
Shrink multi_head_attention_forward grad OpInfo sample

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10091,7 +10091,8 @@ def sample_inputs_multi_head_attention_forward(opinfo, device, dtype, requires_g
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
     if requires_grad:
-        # backward tests would take too long to complete, causing the job timeout.
+        # Keep the grad sample small (no mask/biases): composite-compliance
+        # forward-AD cost grows as ~4^(num tensors) and times out otherwise.
         bsz = 2
         is_batcheds = (True,)
         use_separate_proj_weights = (False,)
@@ -10100,7 +10101,7 @@ def sample_inputs_multi_head_attention_forward(opinfo, device, dtype, requires_g
         tgt_lens = (XS,)
         heads = (2,)
         dropouts = (0.5,)
-        mask_types = ("2d",)
+        mask_types = (None,)
     else:
         bsz = 2
         is_batcheds = (False, True)
@@ -10140,11 +10141,14 @@ def sample_inputs_multi_head_attention_forward(opinfo, device, dtype, requires_g
             k_proj_weight = None
             v_proj_weight = None
 
-        bias_k = make_input(emb_size)
-        bias_v = make_input(emb_size)
-        in_proj_bias = make_input(emb_size * 3)
         out_proj_weight = make_input(emb_size, emb_size)
-        out_proj_bias = make_input(emb_size)
+        if requires_grad:
+            bias_k = bias_v = in_proj_bias = out_proj_bias = None
+        else:
+            bias_k = make_input(emb_size)
+            bias_v = make_input(emb_size)
+            in_proj_bias = make_input(emb_size * 3)
+            out_proj_bias = make_input(emb_size)
         sample_args = (
             k, v, emb_size, num_heads, in_proj_weight,
             in_proj_bias, bias_k, bias_v, False,


### PR DESCRIPTION
The composite-compliance forward-AD check
(composite_compliance.check_forward_ad_formula) wraps every differentiable tensor argument in a tensor subclass at two nesting levels (args x tangent args), so it's cost grows as ~4^(num tensor args). The requires_grad OpInfo sample for
nn.functional.multi_head_attention_forward carried 10 tensor args (q, k, v, in_proj_weight, in/out proj biases, bias_k, bias_v, and a 2d attn_mask), giving ~4^10 = 1.048.576 forward executions for a single sample. On slow integrated GPUs this ran for over 7 hours

Fix: reduce the requires_grad sample to 5 differentiable tensors by dropping the attention mask (mask_types ("2d",) -> (None,)) and keeping the in/out projection biases and bias_k/bias_v as None. This cuts the forward-AD cost to ~4^5 = 1.024 executions while still exercising the biassless MHA forward-AD path.

Fixes: https://github.com/intel/torch-xpu-ops/issues/4835