### PR TITLE
[Testcase Refactoring] 1. Remove the whitelist for instantiate_device_type_tests. 2. Add proper hw_classification attribute to test classes.

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -14,15 +14,20 @@ from torch.fx.experimental.symbolic_shapes import (
     StatelessSymbolicContext,
 )
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+    skipMPS,
+)
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     parametrize,
     run_tests,
     TEST_XPU,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils._triton import has_triton
 
 
 default_atol = {
@@ -116,10 +121,14 @@ ts_list = [
 
 
 class TestDecomp(NNTestCase):
-    _do_cuda_memory_leak_check = GPU_TYPE == "cuda"
-    _do_cuda_non_default_stream = GPU_TYPE == "cuda"
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    _do_cuda_memory_leak_check = True
+    _do_cuda_non_default_stream = True
+
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize("dtype", [torch.float, torch.bfloat16])
     def test_simple_mm(self, device, dtype):
         fudge = 10
@@ -136,7 +145,9 @@ class TestDecomp(NNTestCase):
             run_comp_nocomp(torch_mm, t1, t2, rtol=rtol, atol=atol)
             run_comp_nocomp(torch_addmm, tadd, t1, t2, rtol=rtol, atol=atol)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize(
         "dtype",
         [torch.float, torch.float16, torch.bfloat16]
@@ -146,8 +157,6 @@ class TestDecomp(NNTestCase):
     @parametrize("m", [256, 4096])
     @parametrize("k,n", [(2, 3), (3, 4), (4, 4)])
     def test_small_mm_pointwise(self, device, dtype, m, k, n):
-        if device == "cpu":
-            self.skipTest("small-dim mm pointwise is GPU-only")
         from torch._dynamo.utils import counters
 
         counters.clear()
@@ -162,11 +171,11 @@ class TestDecomp(NNTestCase):
             run_comp_nocomp(torch_mm, t1, t2, rtol=rtol, atol=atol)
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @config.patch(shape_padding=True)
     def test_small_mm_pointwise_skips_padding(self, device):
-        if device == "cpu":
-            self.skipTest("small-dim mm pointwise is GPU-only")
         from unittest import mock
 
         from torch._dynamo.utils import counters
@@ -183,7 +192,9 @@ class TestDecomp(NNTestCase):
         self.assertEqual(should_pad.call_count, 0)
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize(
         "dtype",
         [torch.float, torch.float16, torch.bfloat16]
@@ -194,8 +205,6 @@ class TestDecomp(NNTestCase):
     @parametrize("k,n", [(2, 3), (3, 4), (4, 4)])
     @parametrize("transpose", ["lhs", "rhs", "both"])
     def test_small_mm_pointwise_transposed(self, device, dtype, m, k, n, transpose):
-        if device == "cpu":
-            self.skipTest("small-dim mm pointwise is GPU-only")
         from torch._dynamo.utils import counters
 
         counters.clear()
@@ -229,10 +238,10 @@ class TestDecomp(NNTestCase):
             run_comp_nocomp(fn, t1, t2, rtol=rtol, atol=atol)
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 1)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     def test_small_mm_no_pointwise_for_large_dims(self, device):
-        if device == "cpu":
-            self.skipTest("GPU-only test")
         from torch._dynamo.utils import counters
 
         counters.clear()
@@ -245,11 +254,11 @@ class TestDecomp(NNTestCase):
         torch.compile(fn)(a, b)
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 0)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @config.patch(max_autotune_gemm=True)
     def test_small_mm_no_pointwise_under_max_autotune(self, device):
-        if device == "cpu":
-            self.skipTest("GPU-only test")
         from torch._dynamo.utils import counters
 
         counters.clear()
@@ -262,7 +271,9 @@ class TestDecomp(NNTestCase):
         torch.compile(fn)(a, b)
         self.assertEqual(counters["inductor"]["decompose_mm_pointwise"], 0)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize(
         "dtype",
         [torch.float, torch.bfloat16] if SM80OrLater or TEST_XPU else [torch.float],
@@ -288,7 +299,9 @@ class TestDecomp(NNTestCase):
                         torch_baddbmm, tadd, t1, t2, alpha, beta, rtol=rtol, atol=atol
                     )
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @config.patch(coordinate_descent_tuning=True)
     def test_bmm_batch2_last_dim_size_is_one(self, device):
         fudge = 3
@@ -311,11 +324,10 @@ class TestDecomp(NNTestCase):
         self.assertIsNot(out, NotImplemented)
         self.assertEqual(expected, out)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     def test_bmm_outer_product_k_is_one_with_unbacked_k(self, device):
-        if device == "cpu":
-            self.skipTest("unbacked symints require GPU fake tensors")
-
         shape_env = ShapeEnv()
         with FakeTensorMode(shape_env=shape_env):
             b, m, n = [shape_env.create_unbacked_symint() for _ in range(3)]
@@ -378,12 +390,14 @@ class TestDecomp(NNTestCase):
             self.assertIsNot(out, NotImplemented)
             self.assertEqual(expected, out, exact_stride=True)
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize("dtype", [torch.float, torch.bfloat16, torch.int])
     def test_some(self, device, dtype):
         # this Pytorch data type is not fully supported on cuda today
         # - unfortunately we can't skipIf because we don't see the actual params in skipIf
-        if device.startswith(GPU_TYPE) and dtype == torch.int:
+        if dtype == torch.int:
             return
 
         run_comp_nocomp(
@@ -397,13 +411,15 @@ class TestDecomp(NNTestCase):
             init_tensor([[1], [2], [3], [4]], dtype=dtype, device=device),
         )
 
-    @unittest.skipIf(not HAS_GPU, "GPU tests require triton")
+    @skipMPS
+    @onlyAccelerator
+    @unittest.skipUnless(has_triton(), "Triton not available")
     @parametrize("dtype", [torch.float, torch.bfloat16, torch.int])
     @parametrize("bs", [1, 2, 4, 10])
     def test_some_batched(self, device, dtype, bs):
         # this Pytorch data type is not fully supported on cuda today
         # - unfortunately we can't skipIf because we don't see the actual params in skipIf
-        if device.startswith(GPU_TYPE) and dtype == torch.int:
+        if dtype == torch.int:
             return
 
         run_comp_nocomp(
@@ -416,6 +432,10 @@ class TestDecomp(NNTestCase):
             init_tensor([[[1, 2, 3, 4]]] * bs, dtype=dtype, device=device),
             init_tensor([[[1], [2], [3], [4]]] * bs, dtype=dtype, device=device),
         )
+
+
+class TestDecompOnlyCPU(NNTestCase):
+    hw_classification = HardwareClassification.CPU
 
     @parametrize("dtype", [torch.float, torch.bfloat16])
     def test_dynamic_shape_mm(self, device, dtype):
@@ -423,10 +443,6 @@ class TestDecomp(NNTestCase):
 
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env)
-
-        # Only test decomp for cpu to match fake tensors from dynamo
-        if device != "cpu":
-            return
 
         for t_size in ts_list:
             ((a1_0, a1_1, a2_0, a2_1)) = t_size
@@ -483,10 +499,9 @@ class TestDecomp(NNTestCase):
                 self.assertTrue(r_expr_types[1] == og_t2_expr_types[1])
 
 
-device_types = ("cpu", GPU_TYPE)
-instantiate_device_type_tests(
-    TestDecomp, globals(), only_for=device_types, allow_xpu=True
-)
+instantiate_device_type_tests(TestDecomp, globals(), allow_mps=True, allow_xpu=True)
+instantiate_device_type_tests(TestDecompOnlyCPU, globals(), only_for="cpu")
+
 
 if __name__ == "__main__":
     # We don't support torch.compile() on Windows


### PR DESCRIPTION
## Summary
1. Remove the whitelist for instantiate_device_type_tests. 
2. Add proper hw_classification attribute to test classes.  

## Changes
- Remove the `only_for` parameter from `instantiate_device_type_tests`.
- Added `hw_classification` attribute to classes

## Test Plan
python test/inductor/test_mmdecomp.py
python test/inductor/test_mmdecomp.py -v --hw-classification ACCELERATOR
python test/inductor/test_mmdecomp.py -v --hw-classification CPU


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo