### PR TITLE
[inductor] Rename strict_sum -> strict_reduction

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -884,8 +884,8 @@ class MixOrderReductionTest(TestBase):
         mock_node_1.get_device.return_value.type = "cuda"
         mock_node_1.is_reduction.return_value = True
         mock_node_2.is_reduction.return_value = True
-        mock_node_1.has_strict_sum.return_value = False
-        mock_node_2.has_strict_sum.return_value = False
+        mock_node_1.has_strict_reduction.return_value = False
+        mock_node_2.has_strict_reduction.return_value = False
 
         from torch._inductor.utils import OrderedSet
 
@@ -955,8 +955,8 @@ class MixOrderReductionTest(TestBase):
         mock_node_1.get_device.return_value.type = "cuda"
         mock_node_1.is_reduction.return_value = True
         mock_node_2.is_reduction.return_value = True
-        mock_node_1.has_strict_sum.return_value = False
-        mock_node_2.has_strict_sum.return_value = False
+        mock_node_1.has_strict_reduction.return_value = False
+        mock_node_2.has_strict_reduction.return_value = False
 
         from torch._inductor.utils import OrderedSet
 

--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -271,7 +271,7 @@ class StrictNumericsTest(TestCase):
         return fn, args, result_index, cfg, expected_metrics, kernel_count
 
     @parametrize("kind", FUSION_CASES)
-    def test_fusion_preserves_strict_sum(self, device, kind):
+    def test_fusion_preserves_strict_reduction(self, device, kind):
         fn, args, index, cfg, expected_metrics, kernel_count = self._make_fusion_case(
             kind, device
         )
@@ -292,7 +292,7 @@ class StrictNumericsTest(TestCase):
         elif kind == "multi_output":
             self.assertEqual(eager[0], result[0])
 
-    def test_combo_kernel_preserves_strict_sum_blocks(self, device):
+    def test_combo_kernel_preserves_strict_reduction_blocks(self, device):
         args = (
             torch.randn(8, 12000, device=device),
             torch.randn(8, 12000, device=device),
@@ -316,7 +316,7 @@ class StrictNumericsTest(TestCase):
 
     @unittest.skipIf(not SM90OrLater, "requires TMA support")
     @parametrize("kind", ("multirow", "split"))
-    def test_tma_preserves_strict_sum(self, device, kind):
+    def test_tma_preserves_strict_reduction(self, device, kind):
         if kind == "multirow":
             x = torch.randn(64, 5, device=device)
         else:

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -449,8 +449,8 @@ class InductorChoices:
         if not config.triton.persistent_reductions:
             return False
         reduction_hint = features.get_reduction_hint()
-        rblock = features.strict_sum_rblock()
-        if rblock is not None and not features.has_strict_sum_multirow_reduction():
+        rblock = features.strict_reduction_rblock()
+        if rblock is not None and not features.has_strict_multirow_reduction():
             if not (
                 V.graph.sizevars.statically_known_geq(rblock, features.reduction_numel)
             ):

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -146,22 +146,22 @@ class SIMDKernelFeatures:
         return [n for n in self.scheduler_nodes() if n.is_reduction()]
 
     @cache_on_self
-    def strict_sum_reductions(self) -> tuple[ir.Reduction, ...]:
+    def strict_reductions(self) -> tuple[ir.Reduction, ...]:
         return tuple(
             node.node.data
             for node in self.reduction_nodes()
             if isinstance(node.node, ir.ComputedBuffer)
             and isinstance(node.node.data, ir.Reduction)
-            and node.node.data.strict_sum_rblock is not None
+            and node.node.data.strict_reduction_rblock is not None
         )
 
-    def has_strict_sum_multirow_reduction(self) -> bool:
-        return any(r.strict_sum_multirow for r in self.strict_sum_reductions())
+    def has_strict_multirow_reduction(self) -> bool:
+        return any(r.strict_reduction_multirow for r in self.strict_reductions())
 
     @cache_on_self
-    def strict_sum_rblock(self) -> int | None:
+    def strict_reduction_rblock(self) -> int | None:
         rblocks = OrderedSet(
-            reduction.strict_sum_rblock for reduction in self.strict_sum_reductions()
+            reduction.strict_reduction_rblock for reduction in self.strict_reductions()
         )
         if not rblocks:
             return None

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2963,8 +2963,7 @@ class TMACompatibilityChecker:
         # XBLOCK=1 after the initial TMA probe. Their output store must therefore
         # use the scalar fallback rather than a 16-byte tensor descriptor.
         if self.for_store and (
-            self.kernel.no_x_dim
-            or self.kernel.features.has_strict_sum_multirow_reduction()
+            self.kernel.no_x_dim or self.kernel.features.has_strict_multirow_reduction()
         ):
             log.debug(
                 "%s stores with XBLOCK=1 cannot transfer 16 bytes.",
@@ -3096,7 +3095,7 @@ class TMACompatibilityChecker:
             )
 
         if (
-            self.kernel.features.strict_sum_rblock() == 1
+            self.kernel.features.strict_reduction_rblock() == 1
             and innermost_block_symt in TritonSymbols.reduction_types
         ):
             log.debug(
@@ -3654,7 +3653,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return triton_type(dtype)
 
     def should_use_cooperative_reduction(self) -> bool:
-        if self._strict_sum_rblock() is not None:
+        if self._strict_reduction_rblock() is not None:
             return False
         return self.inside_reduction and V.choices.should_use_cooperative_reduction(
             V.graph.get_current_device_or_throw(),
@@ -3772,10 +3771,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         )
 
     @cache_on_self
-    def _strict_sum_rblock(self) -> int | None:
+    def _strict_reduction_rblock(self) -> int | None:
         if self.num_reduction_dims != 1:
             return None
-        return self.features.strict_sum_rblock()
+        return self.features.strict_reduction_rblock()
 
     def want_no_x_dim(self):
         return (
@@ -5273,8 +5272,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         reduction_range_prefix = self.range_trees[-1].prefix[0]
 
         # Eager tree-reduces each tile before accumulating tiles linearly.
-        strict_sum = self._strict_sum_rblock() is not None and reduction_type == "sum"
-        strict_sum_loop = strict_sum and not self.persistent_reduction
+        strict_reduction = (
+            self._strict_reduction_rblock() is not None and reduction_type == "sum"
+        )
+        strict_reduction_loop = strict_reduction and not self.persistent_reduction
 
         # When we do native matmtul codegen,
         # we don't want to keep the R0_BLOCK/R1_BLOCK in the accumulator.
@@ -5363,7 +5364,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             else:
                 reduction_ordering = (
                     ", reduction_ordering=tl.constexpr(tl.ReductionOrdering.INNER_TREE)"
-                    if strict_sum
+                    if strict_reduction
                     else ""
                 )
                 result, shape = self.reduction_resize_and_shape(  # type: ignore[assignment]
@@ -5605,7 +5606,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 _result, _dtype, _shape = final_reduction(
                     self.compute, masked_value, masked_value.dtype
                 )
-                if strict_sum and not self.features.has_strict_sum_multirow_reduction():
+                if (
+                    strict_reduction
+                    and not self.features.has_strict_multirow_reduction()
+                ):
                     zero = constant_repr(cast(Any, default))
                     _result = f"{zero} + ({_result})"
                 result_var = self.cse.generate(
@@ -5639,7 +5643,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     self.body.writeline(
                         f"{accumulator} = tl.full({dense_size_str}, {default}, {acc_type})"
                     )
-                elif strict_sum_loop:
+                elif strict_reduction_loop:
                     accumulator.shape = tuple(result_shape)
                     result_size_str = f"[{', '.join(result_shape)}]"
                     self.body.writeline(
@@ -5744,7 +5748,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     dim,
                     dtype,
                 )
-            elif strict_sum_loop:
+            elif strict_reduction_loop:
                 zero = cast(str, default)
                 masked = self.cse.generate(
                     self.compute,
@@ -7051,8 +7055,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["native_matmul_persistent_rblock"] = rblock
         if self.add_persistent_rblock:
             out["add_persistent_rblock"] = True
-        if (rblock := self._strict_sum_rblock()) is not None:
-            out["strict_sum_rblock"] = rblock
+        if (rblock := self._strict_reduction_rblock()) is not None:
+            out["strict_reduction_rblock"] = rblock
         if (
             config.benchmark_kernel
             or config.profile_bandwidth
@@ -7475,7 +7479,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return math.prod(rblocks) if rblocks else None
 
     def _get_persistent_reduction_block(self, rnumel) -> int:
-        if (rblock := self._strict_sum_rblock()) is not None:
+        if (rblock := self._strict_reduction_rblock()) is not None:
             if V.graph.sizevars.statically_known_geq(rblock, rnumel):
                 return rblock
             raise AssertionError(
@@ -7500,7 +7504,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # bound anyway so taking the hit of non-coalesced loads is okay.
         if (
             kernel_features.contains_op("sort")
-            or kernel_features.has_strict_sum_multirow_reduction()
+            or kernel_features.has_strict_multirow_reduction()
         ):
             kernel_kwargs["override_persistent_reduction"] = True
             kernel_kwargs["override_cooperative_reduction"] = False

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1406,8 +1406,8 @@ class Reduction(Loops):
     src_dtype: torch.dtype
     reduction_hint: ReductionHint
     # Exact eager tile; rblock 1 is the split final stage.
-    strict_sum_multirow: bool = False
-    strict_sum_rblock: int | None = None
+    strict_reduction_multirow: bool = False
+    strict_reduction_rblock: int | None = None
 
     def __str__(self) -> str:
         return self._to_str(("ranges", "reduction_ranges", "reduction_type"))
@@ -1469,8 +1469,8 @@ class Reduction(Loops):
             reduction_type=self.reduction_type,
             src_dtype=self.src_dtype,
             reduction_hint=ReductionHint.DEFAULT,
-            strict_sum_multirow=self.strict_sum_multirow,
-            strict_sum_rblock=self.strict_sum_rblock,
+            strict_reduction_multirow=self.strict_reduction_multirow,
+            strict_reduction_rblock=self.strict_reduction_rblock,
         )
 
     @staticmethod
@@ -1760,7 +1760,7 @@ class Reduction(Loops):
         reduction_hint: ReductionHint = ReductionHint.DEFAULT,
         input_node: IRNode | None = None,
         *,
-        strict_sum: bool = False,
+        strict_reduction: bool = False,
     ) -> TensorBox:
         """
         Create a reduction node. May split the reduction to multiple layers to expose
@@ -1808,9 +1808,9 @@ class Reduction(Loops):
             )
 
         strict_split = None
-        strict_sum_multirow = False
-        strict_sum_rblock = None
-        if strict_sum and reduction_hint in (
+        strict_reduction_multirow = False
+        strict_reduction_rblock = None
+        if strict_reduction and reduction_hint in (
             ReductionHint.DEFAULT,
             ReductionHint.INNER,
         ):
@@ -1835,30 +1835,30 @@ class Reduction(Loops):
                 )
                 if indexing_safe:
                     strict_split = 1
-                    strict_sum_multirow = (
+                    strict_reduction_multirow = (
                         guarded_reduction_numel
                         <= vector_size * inner_tree_plan._K_MULTIROW_MAX_LOADS
                     )
-                    if strict_sum_multirow:
+                    if strict_reduction_multirow:
                         num_loads = ceildiv(guarded_reduction_numel, vector_size)
                         num_loads = 1 << (num_loads - 1).bit_length()
-                        strict_sum_rblock = num_loads * vector_size
+                        strict_reduction_rblock = num_loads * vector_size
                     else:
                         params = inner_tree_plan.compute_inner_tree_params(
                             guarded_reduction_numel,
                             1,
                             vector_size,
                         )
-                        strict_sum_rblock = params.batch_total_elements
+                        strict_reduction_rblock = params.batch_total_elements
                         if (
                             params.num_batches > inner_tree_plan._K_TWO_KERNEL_THRESHOLD
-                            and guarded_reduction_numel % strict_sum_rblock == 0
+                            and guarded_reduction_numel % strict_reduction_rblock == 0
                         ):
                             strict_split = params.num_batches
-        strict_sum = strict_split is not None
+        strict_reduction = strict_split is not None
 
-        if strict_sum_multirow:
-            if strict_sum_rblock is None:
+        if strict_reduction_multirow:
+            if strict_reduction_rblock is None:
                 raise AssertionError("strict multirow sum requires a reduction block")
             actual_reduction_numel = reduction_numel
             original_inner_fn = inner_fn
@@ -1878,10 +1878,10 @@ class Reduction(Loops):
                 return ops.masked(mask, body, default)
 
             inner_fn = cast(Callable[..., Any], padded_inner_fn)
-            reduction_ranges = [sympy.Integer(strict_sum_rblock)]
-            reduction_numel = sympy.Integer(strict_sum_rblock)
+            reduction_ranges = [sympy.Integer(strict_reduction_rblock)]
+            reduction_numel = sympy.Integer(strict_reduction_rblock)
 
-        if reduction_numel == 1 and not strict_sum:
+        if reduction_numel == 1 and not strict_reduction:
             # this reduction is actually a pointwise op
             if reduction_type in ("argmin", "argmax"):
 
@@ -1903,7 +1903,7 @@ class Reduction(Loops):
             and int(reduction_numel) < config.unroll_reductions_threshold
             and (sympy_product(ranges) != 1 or is_gpu(device.type))
             and reduction_type != "dot"
-            and not strict_sum
+            and not strict_reduction
         ):
             # When native matmul, don't unroll the dot reduction.
 
@@ -1987,7 +1987,7 @@ class Reduction(Loops):
                 split,
                 reduction_hint,
                 input_node,
-                strict_sum=strict_sum,
+                strict_reduction=strict_reduction,
             )
 
             # Find the reduction that get split
@@ -2042,8 +2042,8 @@ class Reduction(Loops):
                 reduction_type=reduction_type,
                 src_dtype=src_dtype,
                 reduction_hint=reduction_hint,
-                strict_sum_multirow=strict_sum_multirow,
-                strict_sum_rblock=strict_sum_rblock,
+                strict_reduction_multirow=strict_reduction_multirow,
+                strict_reduction_rblock=strict_reduction_rblock,
             )
         )
         return out
@@ -2230,7 +2230,7 @@ class Reduction(Loops):
         reduction_type: ReductionType,
         split: _IntLike,
         reduction_hint: ReductionHint,
-        strict_sum: bool = False,
+        strict_reduction: bool = False,
     ) -> TensorBox:
         """
         Break a large reduction up into multiple smaller reductions
@@ -2253,7 +2253,7 @@ class Reduction(Loops):
             new_reduction_ranges,
             reduction_type,
             reduction_hint,
-            strict_sum=strict_sum,
+            strict_reduction=strict_reduction,
         )
         intermediate.realize()
         intermediate_loader = intermediate.make_loader()
@@ -2282,7 +2282,7 @@ class Reduction(Loops):
                 reduction_type=reduction_type,
                 src_dtype=src_dtype,
                 reduction_hint=reduction_hint,
-                strict_sum_rblock=1 if strict_sum else None,
+                strict_reduction_rblock=1 if strict_reduction else None,
             )
         )
 
@@ -2300,7 +2300,7 @@ class Reduction(Loops):
         reduction_hint: ReductionHint,
         input_node: IRNode | None = None,
         *,
-        strict_sum: bool = False,
+        strict_reduction: bool = False,
     ) -> TensorBox:
         """
         Break a large reduction up into multiple smaller reductions
@@ -2332,7 +2332,7 @@ class Reduction(Loops):
             reduction_type,
             split,
             reduction_hint,
-            strict_sum,
+            strict_reduction,
         )
 
     @classmethod
@@ -5566,8 +5566,8 @@ class ComputedBuffer(OperationBuffer):
                 reduction_type=old_data.reduction_type,
                 src_dtype=old_data.src_dtype,
                 reduction_hint=old_data.reduction_hint,
-                strict_sum_multirow=old_data.strict_sum_multirow,
-                strict_sum_rblock=old_data.strict_sum_rblock,
+                strict_reduction_multirow=old_data.strict_reduction_multirow,
+                strict_reduction_rblock=old_data.strict_reduction_rblock,
             )
             self.data = new_data
             # this layout does not matter since we skip tl.store

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7347,7 +7347,7 @@ def make_reduction(
     reduction_type: ReductionType,
     override_return_dtype=None,
     *,
-    strict_sum: bool = False,
+    strict_reduction: bool = False,
 ) -> Callable[..., TensorBox]:
     def inner(x, axis=None, keepdims=False, *, dtype=None) -> TensorBox:
         # For argmax/argmin on boolean tensors, cast to int32 first to ensure
@@ -7368,7 +7368,7 @@ def make_reduction(
         result = Reduction.create(
             reduction_type=reduction_type,
             input_node=x,
-            strict_sum=strict_sum,
+            strict_reduction=strict_reduction,
             **kwargs,
         )
         if isinstance(
@@ -7895,7 +7895,7 @@ def fmod(a, b):
     return make_pointwise(fn)(a, b)
 
 
-def _strict_sum_layout_eligible(axis, dtype) -> bool:
+def _strict_reduction_layout_eligible(axis, dtype) -> bool:
     current_node = V.graph.current_node
     if (
         current_node is None
@@ -7962,13 +7962,15 @@ def _strict_sum_layout_eligible(axis, dtype) -> bool:
 
 @register_lowering([aten.sum, prims.sum])
 def sum_(x, axis=None, keepdims=False, *, dtype=None):
-    strict_sum = _strict_sum_layout_eligible(axis, dtype)
+    strict_reduction = _strict_reduction_layout_eligible(axis, dtype)
     if (
         is_integer_dtype(x.get_dtype()) or is_boolean_dtype(x.get_dtype())
     ) and dtype is None:
         dtype = torch.int64
 
-    fn = make_reduction("sum", override_return_dtype=dtype, strict_sum=strict_sum)
+    fn = make_reduction(
+        "sum", override_return_dtype=dtype, strict_reduction=strict_reduction
+    )
     return fn(x, axis, keepdims, dtype=dtype)
 
 

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -330,7 +330,7 @@ class InductorMeta(typing.TypedDict, total=False):
     native_matmul_persistent_rblock: int
     add_persistent_rblock: bool
     max_persistent_rblock: int
-    strict_sum_rblock: int
+    strict_reduction_rblock: int
     kernel_num_gb: float
     kernel_flop: int
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -839,7 +839,7 @@ class CachingAutotuner(KernelInterface):
         """Whether ``_dynamic_scale_rblock`` should attempt occupancy-
         driven rblock halving for this autotuner.
         """
-        if "strict_sum_rblock" in self.inductor_meta:
+        if "strict_reduction_rblock" in self.inductor_meta:
             # Strict numerics: don't scale/tune R0_BLOCK for reductions (it shifts the order).
             return False
         return _could_dynamic_scale_rblock(
@@ -2283,7 +2283,7 @@ class CachingAutotuner(KernelInterface):
         # Deterministic mode (and strict numerics) forbid tuning RBLOCK / num_warps for
         # reductions because those knobs shift numerics.
         if (
-            self.deterministic_mode or "strict_sum_rblock" in self.inductor_meta
+            self.deterministic_mode or "strict_reduction_rblock" in self.inductor_meta
         ) and self.heuristic_type in (
             HeuristicType.REDUCTION,
             HeuristicType.PERSISTENT_REDUCTION,
@@ -4571,7 +4571,7 @@ def _reduction_configs(
         triton_meta=triton_meta,
         num_dynamic=num_dynamic,
     )
-    r0 = inductor_meta.get("strict_sum_rblock")
+    r0 = inductor_meta.get("strict_reduction_rblock")
     if r0 is not None:
         configs = copy.deepcopy(configs)
         for triton_config in configs:
@@ -4741,7 +4741,7 @@ def reduction(
 
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
     configs = filter_reduction_configs_for_determinism(inductor_meta, configs)
-    strict_rblock = inductor_meta.get("strict_sum_rblock")
+    strict_rblock = inductor_meta.get("strict_reduction_rblock")
     if strict_rblock is not None and any(
         triton_config.kwargs.get("R0_BLOCK", strict_rblock) != strict_rblock
         for triton_config in configs

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -369,7 +369,7 @@ class MixOrderReduction:
             return False
         if not node1.is_reduction() or not node2.is_reduction():
             return False
-        if node1.has_strict_sum() or node2.has_strict_sum():
+        if node1.has_strict_reduction() or node2.has_strict_reduction():
             return False
 
         if (node1.ancestors & node2.get_operation_names()) or (
@@ -555,8 +555,8 @@ class NestedReduction:
             config.triton.nested_reduction
             and not V.graph.cpp_wrapper
             and _is_gpu_triton_backend(outer_node, grouped_node)
-            and not outer_node.has_strict_sum()
-            and not grouped_node.has_strict_sum()
+            and not outer_node.has_strict_reduction()
+            and not grouped_node.has_strict_reduction()
         )
 
     @classmethod
@@ -1470,12 +1470,12 @@ class BaseSchedulerNode:
         return [self]
 
     @cache_on_self
-    def has_strict_sum(self) -> bool:
+    def has_strict_reduction(self) -> bool:
         return any(
             isinstance(node, SchedulerNode)
             and isinstance(node.node, ComputedBuffer)
             and isinstance(node.node.data, ir.Reduction)
-            and node.node.data.strict_sum_rblock is not None
+            and node.node.data.strict_reduction_rblock is not None
             for node in self.get_nodes()
         )
 
@@ -3033,7 +3033,7 @@ class FusedMixOrderReductions(FusedSchedulerNode):
         )
 
     def can_fuse_with(self, other: BaseSchedulerNode):
-        if self.has_strict_sum() or other.has_strict_sum():
+        if self.has_strict_reduction() or other.has_strict_reduction():
             return False
         # Limit tl.load() count in the fused RSPLIT loop to avoid register
         # spills. See https://github.com/pytorch/pytorch/issues/179423
@@ -3554,7 +3554,9 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
         filtered_nodes = [x for x in filtered_nodes if x not in template_nodes]
 
         # Keep strict sums standalone so their planned R0_BLOCK cannot change.
-        filtered_nodes = [node for node in filtered_nodes if not node.has_strict_sum()]
+        filtered_nodes = [
+            node for node in filtered_nodes if not node.has_strict_reduction()
+        ]
 
         # Filter out reduction nodes if combo_kernels_pointwise_only is enabled
         if config.combo_kernels_pointwise_only:
@@ -8116,12 +8118,12 @@ class Scheduler:
 
         why = WhyNoFuse(node1, node2)
 
-        if node1.is_template() and node2.has_strict_sum():
+        if node1.is_template() and node2.has_strict_reduction():
             why("template fusion does not preserve strict sum ordering")
             return False
 
         if (
-            (node1.has_strict_sum() or node2.has_strict_sum())
+            (node1.has_strict_reduction() or node2.has_strict_reduction())
             and node1.is_reduction()
             and node2.is_reduction()
         ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #192883
* __->__ #192995
* #192882

The strict-numerics INNER_TREE machinery was introduced for `sum` and named
`strict_sum` throughout, but it is reduction-generic. Rename the `strict_sum*`
identifiers to `strict_reduction*` so the names match the behavior before `prod`
(and future reductions) build on them. Pure mechanical rename, no behavior
change.

- `strict_sum_reductions` -> `strict_reductions` and
  `has_strict_sum_multirow_reduction` -> `has_strict_multirow_reduction` to
  avoid redundant doubles.
- Also updates the matching prose ("strict sum" -> "strict reduction") in
  comments, assertion/error messages, and the `test_strict_numerics` module
  docstring.

Test Plan:
- `python test/inductor/test_strict_numerics.py -k bitwise` -- sum + prod
  bitwise (9/9) unchanged; behavior-preserving.
- lintrunner clean.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo