### PR TITLE
Add current_device_idx_expr to XPUDeviceOpOverrides

### DIFF
--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -21,6 +21,9 @@ class XPUDeviceOpOverrides(DeviceOpOverrides):
     def device_guard(self, device_idx: DeviceIdx) -> str:
         return f"torch.xpu._DeviceGuard({device_idx})"
 
+    def current_device_idx_expr(self) -> str:
+        return "torch.xpu.current_device()"
+
     def current_stream(self) -> str:
         return "torch.xpu.current_stream()"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #192996

# Motivation
https://github.com/pytorch/pytorch/pull/187870 introduces `current_device_idx_expr` but forgot to add it on XPU, which result in a XPU CI failure: https://github.com/pytorch/pytorch/issues/192994

# Additional Context
With this PR, https://github.com/pytorch/pytorch/issues/192994 passed
<img width="1263" height="190" alt="image" src="https://github.com/user-attachments/assets/5069561a-7aac-4d6b-b1cc-e0565b1d2e9a" />

Fix https://github.com/pytorch/pytorch/issues/192994


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo