### PR TITLE
[Testcase Refactoring] Add hardware classification to APoT quantizer tests

### DIFF
--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -10,6 +10,8 @@ import unittest
 import random
 
 class TestQuantizer(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     r""" Tests quantize_APoT result on random 1-dim tensor
         and hardcoded values for b, k by comparing to uniform quantization
         (non-uniform quantization reduces to uniform for k = 1)
@@ -18,8 +20,6 @@ class TestQuantizer(unittest.TestCase):
         * b: 8
         * k: 1
     """
-
-    hw_classification = HardwareClassification.GENERIC
 
     def test_quantize_APoT_rand_k1(self):
         # generate random size of tensor2quantize between 1 -> 20

--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -5,6 +5,7 @@ from torch import quantize_per_tensor
 from torch.ao.quantization.observer import MinMaxObserver
 from torch.ao.quantization.experimental.observer import APoTObserver
 from torch.ao.quantization.experimental.quantizer import APoTQuantizer, quantize_APoT, dequantize_APoT
+from torch.testing._internal.common_utils import HardwareClassification
 import unittest
 import random
 
@@ -17,6 +18,9 @@ class TestQuantizer(unittest.TestCase):
         * b: 8
         * k: 1
     """
+
+    hw_classification = HardwareClassification.GENERIC
+
     def test_quantize_APoT_rand_k1(self):
         # generate random size of tensor2quantize between 1 -> 20
         size = random.randint(1, 20)


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so test selection can distinguish device-agnostic framework tests from accelerator-specific tests.

`TestQuantizer` contains six APoT quantization and dequantization tests. The class does not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. All tensors are intentionally created on the default device to validate shared quantization logic. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestQuantizer`.
- Keep all six test methods, assertions, and collected test names unchanged.

## Self-test

Environment:

- Windows, Python 3.11.15
- PyTorch `2.14.0.dev20260810+cu130`
- CUDA 13.0 build
- NVIDIA GeForce RTX 4070 Laptop GPU

Commands:

```bash
python -m pytest -vv -ra test/quantization/core/experimental/test_quantizer.py
python -m pytest -vv -ra test/quantization/core/experimental/test_quantizer.py --hw-classification GENERIC
python -m pytest --collect-only -q test/quantization/core/experimental/test_quantizer.py
```

Results:

- CPU-only environment (`CUDA_VISIBLE_DEVICES=-1`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- CUDA-visible environment (`torch.cuda.is_available() == True`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- The `GENERIC` filter reported `total=6, passed=6, unclassified=0, mismatched=0`.
- `git diff --check` passed.
- All command exit codes were 0, and the collected test set was unchanged.

The CUDA-visible run verifies compatibility with a CUDA-enabled build. The class does not create CUDA-specific variants because it is not instantiated by device type and does not exercise CUDA-specific behavior.

The installed nightly wheel omits the experimental quantization Python package. For these local runs, that package path was resolved from the checkout while the compiled runtime came from the nightly wheel.

## Risks

Low. The change only imports the hardware classification enum and adds class-level test metadata; test logic and product code are unchanged.

<details>
<summary>CPU-only self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: False
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue12
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_dim PASSED [0.0170s] [ 16%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4 PASSED [0.0021s] [ 33%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6 PASSED [1.6994s] [ 50%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_q_apot_alpha PASSED [0.0003s] [ 66%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_k2 PASSED [0.0018s] [ 83%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1 PASSED [0.0685s] [100%]

============================== 6 passed in 2.96s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue12
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_dim PASSED [0.0164s] [ 16%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4 PASSED [0.0022s] [ 33%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6 PASSED [1.7018s] [ 50%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_q_apot_alpha PASSED [0.0002s] [ 66%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_k2 PASSED [0.0021s] [ 83%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1 PASSED [0.0688s] [100%]

============================== 6 passed in 2.92s ==============================
Running 6 items in this shard
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_dim
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_q_apot_alpha
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_quantize_APoT_k2
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1

6 tests collected in 1.12s
CPU exit codes: unfiltered=0 generic=0 collect=0
```

</details>

<details>
<summary>CUDA-visible self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: True
GPU: NVIDIA GeForce RTX 4070 Laptop GPU
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue12
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_dim PASSED [0.0164s] [ 16%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4 PASSED [0.0022s] [ 33%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6 PASSED [1.6926s] [ 50%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_q_apot_alpha PASSED [0.0002s] [ 66%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_k2 PASSED [0.0021s] [ 83%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1 PASSED [0.0680s] [100%]

============================== 6 passed in 2.90s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue12
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_dim PASSED [0.0168s] [ 16%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4 PASSED [0.0022s] [ 33%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6 PASSED [1.6789s] [ 50%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_q_apot_alpha PASSED [0.0002s] [ 66%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_k2 PASSED [0.0017s] [ 83%]
pytorch-issue12\test\quantization\core\experimental\test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1 PASSED [0.0701s] [100%]

============================== 6 passed in 2.89s ==============================
Running 6 items in this shard
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_dim
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b4
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_dequantize_quantize_rand_b6
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_q_apot_alpha
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_quantize_APoT_k2
test/quantization/core/experimental/test_quantizer.py::TestQuantizer::test_quantize_APoT_rand_k1

6 tests collected in 1.12s
CUDA exit codes: unfiltered=0 generic=0 collect=0
```

</details>
