### PR TITLE
[Testcase Refactoring] Add hardware classification to quantization utility tests

### DIFF
--- a/test/quantization/core/test_utils.py
+++ b/test/quantization/core/test_utils.py
@@ -1,13 +1,22 @@
 # Owner(s): ["oncall: quantization"]
 
 import torch
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
-from torch.ao.quantization.utils import get_fqn_to_example_inputs
 from torch.ao.nn.quantized.modules.utils import _quantize_weight
-from torch.ao.quantization import MovingAverageMinMaxObserver, MovingAveragePerChannelMinMaxObserver
+from torch.ao.quantization import (
+    MovingAverageMinMaxObserver,
+    MovingAveragePerChannelMinMaxObserver,
+)
+from torch.ao.quantization.utils import get_fqn_to_example_inputs
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class TestUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _test_get_fqn_to_example_inputs(self, M, example_inputs, expected_fqn_to_dim):
         m = M().eval()
         fqn_to_example_inputs = get_fqn_to_example_inputs(m, example_inputs)
@@ -52,14 +61,14 @@ class TestUtils(TestCase):
             "linear2": (2,),
             "sub": (2,),
             "sub.linear1": (2,),
-            "sub.linear2": (2,)
+            "sub.linear2": (2,),
         }
         example_inputs = (torch.rand(1, 5),)
         self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)
 
     def test_get_fqn_to_example_inputs_default_kwargs(self):
-        """ Test that we can get example inputs for functions with default keyword arguments
-        """
+        """Test that we can get example inputs for functions with default keyword arguments"""
+
         class Sub(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -93,14 +102,14 @@ class TestUtils(TestCase):
             # third arg is `key2`, override by callsite
             "sub": (2, 1, 2),
             "sub.linear1": (2,),
-            "sub.linear2": (2,)
+            "sub.linear2": (2,),
         }
         example_inputs = (torch.rand(1, 5),)
         self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)
 
     def test_get_fqn_to_example_inputs_complex_args(self):
-        """ Test that we can record complex example inputs such as lists and dicts
-        """
+        """Test that we can record complex example inputs such as lists and dicts"""
+
         class Sub(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -138,8 +147,7 @@ class TestUtils(TestCase):
             raise AssertionError("Expected '3' in fqn_to_example_inputs['sub'][2]")
 
     def test_quantize_weight_clamping_per_tensor(self):
-        """ Test quant_{min, max} from per tensor observer is honored by `_quantize_weight` method
-        """
+        """Test quant_{min, max} from per tensor observer is honored by `_quantize_weight` method"""
         fp_min, fp_max = -1000.0, 1000.0
         q8_min, q8_max = -10, 10
 
@@ -183,8 +191,7 @@ class TestUtils(TestCase):
             )
 
     def test_quantize_weight_clamping_per_channel(self):
-        """ Test quant_{min, max} from per channel observer is honored by `_quantize_weight` method
-        """
+        """Test quant_{min, max} from per channel observer is honored by `_quantize_weight` method"""
         fp_min, fp_max = -1000.0, 1000.0
         q8_min, q8_max = -10, 10
 
@@ -229,11 +236,11 @@ class TestUtils(TestCase):
             )
 
     def test_uint4_int4_dtype(self):
-
         def up_size(size):
             return (*size[:-1], size[-1] * 2)
 
         for dtype in [torch.uint4, torch.int4]:
+
             class UInt4OrInt4Tensor(torch.Tensor):
                 @staticmethod
                 def __new__(cls, elem, **kwargs):
@@ -242,7 +249,9 @@ class TestUtils(TestCase):
                     if kwargs.get("requires_grad", False):
                         raise AssertionError("Expected requires_grad to be False")
                     kwargs["requires_grad"] = False
-                    return torch.Tensor._make_wrapper_subclass(cls, up_size(elem.shape), dtype=dtype, **kwargs)
+                    return torch.Tensor._make_wrapper_subclass(
+                        cls, up_size(elem.shape), dtype=dtype, **kwargs
+                    )
 
                 def __init__(self, elem):
                     self.elem = elem
@@ -252,13 +261,19 @@ class TestUtils(TestCase):
                     pass
 
             # make sure it runs
-            x = UInt4OrInt4Tensor(torch.tensor([
-                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-            ], dtype=torch.uint8))
+            x = UInt4OrInt4Tensor(
+                torch.tensor(
+                    [
+                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                    ],
+                    dtype=torch.uint8,
+                )
+            )
             if x.dtype != dtype:
                 raise AssertionError(f"Expected dtype {dtype}, got {x.dtype}")
+
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/quantization/core/test_utils.py
+++ b/test/quantization/core/test_utils.py
@@ -1,17 +1,14 @@
 # Owner(s): ["oncall: quantization"]
 
 import torch
-from torch.ao.nn.quantized.modules.utils import _quantize_weight
-from torch.ao.quantization import (
-    MovingAverageMinMaxObserver,
-    MovingAveragePerChannelMinMaxObserver,
-)
-from torch.ao.quantization.utils import get_fqn_to_example_inputs
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     raise_on_run_directly,
     TestCase,
 )
+from torch.ao.quantization.utils import get_fqn_to_example_inputs
+from torch.ao.nn.quantized.modules.utils import _quantize_weight
+from torch.ao.quantization import MovingAverageMinMaxObserver, MovingAveragePerChannelMinMaxObserver
 
 
 class TestUtils(TestCase):
@@ -61,14 +58,14 @@ class TestUtils(TestCase):
             "linear2": (2,),
             "sub": (2,),
             "sub.linear1": (2,),
-            "sub.linear2": (2,),
+            "sub.linear2": (2,)
         }
         example_inputs = (torch.rand(1, 5),)
         self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)
 
     def test_get_fqn_to_example_inputs_default_kwargs(self):
-        """Test that we can get example inputs for functions with default keyword arguments"""
-
+        """ Test that we can get example inputs for functions with default keyword arguments
+        """
         class Sub(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -102,14 +99,14 @@ class TestUtils(TestCase):
             # third arg is `key2`, override by callsite
             "sub": (2, 1, 2),
             "sub.linear1": (2,),
-            "sub.linear2": (2,),
+            "sub.linear2": (2,)
         }
         example_inputs = (torch.rand(1, 5),)
         self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)
 
     def test_get_fqn_to_example_inputs_complex_args(self):
-        """Test that we can record complex example inputs such as lists and dicts"""
-
+        """ Test that we can record complex example inputs such as lists and dicts
+        """
         class Sub(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -147,7 +144,8 @@ class TestUtils(TestCase):
             raise AssertionError("Expected '3' in fqn_to_example_inputs['sub'][2]")
 
     def test_quantize_weight_clamping_per_tensor(self):
-        """Test quant_{min, max} from per tensor observer is honored by `_quantize_weight` method"""
+        """ Test quant_{min, max} from per tensor observer is honored by `_quantize_weight` method
+        """
         fp_min, fp_max = -1000.0, 1000.0
         q8_min, q8_max = -10, 10
 
@@ -191,7 +189,8 @@ class TestUtils(TestCase):
             )
 
     def test_quantize_weight_clamping_per_channel(self):
-        """Test quant_{min, max} from per channel observer is honored by `_quantize_weight` method"""
+        """ Test quant_{min, max} from per channel observer is honored by `_quantize_weight` method
+        """
         fp_min, fp_max = -1000.0, 1000.0
         q8_min, q8_max = -10, 10
 
@@ -236,11 +235,11 @@ class TestUtils(TestCase):
             )
 
     def test_uint4_int4_dtype(self):
+
         def up_size(size):
             return (*size[:-1], size[-1] * 2)
 
         for dtype in [torch.uint4, torch.int4]:
-
             class UInt4OrInt4Tensor(torch.Tensor):
                 @staticmethod
                 def __new__(cls, elem, **kwargs):
@@ -249,9 +248,7 @@ class TestUtils(TestCase):
                     if kwargs.get("requires_grad", False):
                         raise AssertionError("Expected requires_grad to be False")
                     kwargs["requires_grad"] = False
-                    return torch.Tensor._make_wrapper_subclass(
-                        cls, up_size(elem.shape), dtype=dtype, **kwargs
-                    )
+                    return torch.Tensor._make_wrapper_subclass(cls, up_size(elem.shape), dtype=dtype, **kwargs)
 
                 def __init__(self, elem):
                     self.elem = elem
@@ -261,19 +258,13 @@ class TestUtils(TestCase):
                     pass
 
             # make sure it runs
-            x = UInt4OrInt4Tensor(
-                torch.tensor(
-                    [
-                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
-                    ],
-                    dtype=torch.uint8,
-                )
-            )
+            x = UInt4OrInt4Tensor(torch.tensor([
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+            ], dtype=torch.uint8))
             if x.dtype != dtype:
                 raise AssertionError(f"Expected dtype {dtype}, got {x.dtype}")
-
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so test selection can distinguish device-agnostic framework tests from accelerator-specific tests.

`TestUtils` contains six quantization utility tests covering FQN input capture, weight clamping, and low-bit wrapper dtypes. The class does not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Its tensors and modules intentionally use the default device to validate shared framework logic. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestUtils`.
- Keep all six test methods, assertions, and collected test names unchanged.

## Self-test

Environment:

- Windows, Python 3.11.15
- PyTorch `2.14.0.dev20260810+cu130`
- CUDA 13.0 build
- NVIDIA GeForce RTX 4070 Laptop GPU

Commands:

```bash
python -m pytest -vv -ra test/quantization/core/test_utils.py
python -m pytest -vv -ra test/quantization/core/test_utils.py --hw-classification GENERIC
python -m pytest --collect-only -q test/quantization/core/test_utils.py
```

Results:

- CPU-only environment (`CUDA_VISIBLE_DEVICES=-1`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- CUDA-visible environment (`torch.cuda.is_available() == True`): 6 passed unfiltered; 6 passed with the `GENERIC` filter; 6 collected.
- The `GENERIC` filter reported `total=6, passed=6, unclassified=0, mismatched=0`.
- Repository lint and `git diff --check` passed.
- All command exit codes were 0, and the collected test set was unchanged.

The CUDA-visible run verifies compatibility with a CUDA-enabled build. The class does not create CUDA-specific variants because it is not instantiated by device type and does not exercise CUDA-specific behavior.

## Risks

Low. The change only adds test metadata; test logic and product code are unchanged.

<details>
<summary>CPU-only self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: False
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue14
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args PASSED [0.0081s] [ 16%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs PASSED [0.0028s] [ 33%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple PASSED [0.0034s] [ 50%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel PASSED [0.0034s] [ 66%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor PASSED [0.0025s] [ 83%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_uint4_int4_dtype PASSED [0.0019s] [100%]

============================== 6 passed in 1.18s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue14
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args PASSED [0.0078s] [ 16%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs PASSED [0.0027s] [ 33%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple PASSED [0.0033s] [ 50%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel PASSED [0.0034s] [ 66%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor PASSED [0.0023s] [ 83%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_uint4_int4_dtype PASSED [0.0018s] [100%]

============================== 6 passed in 1.18s ==============================
Running 6 items in this shard
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple
test/quantization/core/test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel
test/quantization/core/test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor
test/quantization/core/test_utils.py::TestUtils::test_uint4_int4_dtype

6 tests collected in 1.13s
CPU exit codes: unfiltered=0 generic=0 collect=0
```

</details>

<details>
<summary>CUDA-visible self-test log</summary>

```text
torch: 2.14.0.dev20260810+cu130
CUDA build: 13.0
CUDA available: True
GPU: NVIDIA GeForce RTX 4070 Laptop GPU
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue14
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... collected 6 items
Running 6 items in this shard

pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args PASSED [0.0084s] [ 16%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs PASSED [0.0028s] [ 33%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple PASSED [0.0035s] [ 50%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel PASSED [0.0034s] [ 66%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor PASSED [0.0026s] [ 83%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_uint4_int4_dtype PASSED [0.0019s] [100%]

============================== 6 passed in 1.16s ==============================
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- D:\project\pytorch\.venv-pytorch-nightly\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: D:\project\pytorch\pytorch-issue14
configfile: pytest.ini
plugins: hypothesis-6.165.3
collecting ... HW classification mode active (['GENERIC']): total=6, passed=6, unclassified=0, mismatched=0
collected 6 items
Running 6 items in this shard

pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args PASSED [0.0080s] [ 16%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs PASSED [0.0037s] [ 33%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple PASSED [0.0025s] [ 50%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel PASSED [0.0032s] [ 66%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor PASSED [0.0030s] [ 83%]
pytorch-issue14\test\quantization\core\test_utils.py::TestUtils::test_uint4_int4_dtype PASSED [0.0022s] [100%]

============================== 6 passed in 1.19s ==============================
Running 6 items in this shard
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_complex_args
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_default_kwargs
test/quantization/core/test_utils.py::TestUtils::test_get_fqn_to_example_inputs_simple
test/quantization/core/test_utils.py::TestUtils::test_quantize_weight_clamping_per_channel
test/quantization/core/test_utils.py::TestUtils::test_quantize_weight_clamping_per_tensor
test/quantization/core/test_utils.py::TestUtils::test_uint4_int4_dtype

6 tests collected in 1.15s
CUDA exit codes: unfiltered=0 generic=0 collect=0
```

</details>

