### PR TITLE
[RAWTHROW][1a] Allow-by-rule policy; delete six exclude patterns

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -583,29 +583,25 @@ include_patterns = [
     '**/*.h',
 ]
 exclude_patterns = [
-    # Pre-existing violations; burn down over time.
+    # Vendored upstream code - permanent, not debt.
+    'third_party/concurrentqueue/**',
+    # Pre-existing violations; burn down over time. Nothing may be added here.
     'aten/src/**',
     'c10/core/**',
-    'c10/cuda/**',
     'c10/test/**',
     'c10/util/**',
-    'c10/xpu/**',
     'test/cpp/**',
     'test/cpp_extensions/**',
-    'third_party/concurrentqueue/**',
     'tools/autograd/**',
     'torch/csrc/*.cpp',
     'torch/csrc/*.h',
-    'torch/csrc/api/**',
     'torch/csrc/autograd/**',
     'torch/csrc/cuda/**',
     'torch/csrc/distributed/**',
     'torch/csrc/dynamo/**',
     'torch/csrc/export/**',
-    'torch/csrc/fx/**',
     'torch/csrc/inductor/**',
     'torch/csrc/jit/**',
-    'torch/csrc/lazy/**',
     'torch/csrc/multiprocessing/**',
     'torch/csrc/profiler/**',
     'torch/csrc/stable/**',
@@ -614,7 +610,6 @@ exclude_patterns = [
     'torch/csrc/xpu/**',
     'torch/headeronly/**',
     'torch/lib/**',
-    'torch/nativert/**',
 ]
 command = [
     'python3',

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -35,6 +35,24 @@ LINTER_CODE = "RAWTHROW"
 
 MARKER = "@allow-raw-throw"
 
+# pybind11's exception types are that library's own protocol for reaching the
+# interpreter. No TORCH_CHECK stands in for them.
+PYBIND_NAMESPACES = ("py::", "pybind11::")
+
+# Typed exceptions that are control flow rather than error reporting: each one
+# is caught by name in the subsystem that throws it, so a TORCH_CHECK would
+# break the code that handles it. Add a name here only with that justification,
+# never because converting a site looked awkward. Names are matched exactly as
+# written at the throw, so a type thrown both qualified and unqualified needs
+# both spellings.
+ALLOWED_EXCEPTION_TYPES = frozenset(
+    {
+        "PythonError",  # torch/csrc/fx/node.cpp, caught in the same file
+        "WorkerException",  # torch/csrc/api dataloader, carries a worker's error
+        "c10::AcceleratorError",  # carries the device error code alongside the message
+    }
+)
+
 
 class LintSeverity(str, Enum):
     ERROR = "error"
@@ -66,6 +84,8 @@ _RAW_STRING_PREFIXES = frozenset({"R", "LR", "uR", "UR", "u8R"})
 _IDENT_CHARS = re.compile(r"\w")
 _NUMBER_CHARS = re.compile(r"[\w']")
 _THROW = re.compile(r"\bthrow\b")
+_QUALIFIED_NAME = re.compile(r"(?:[A-Za-z_]\w*::)*[A-Za-z_]\w*")
+_BARE_IDENTIFIER = re.compile(r"[A-Za-z_]\w*")
 _MARKER_LINE = re.compile(rf"{re.escape(MARKER)}(?P<rest>.*)")
 
 
@@ -196,9 +216,56 @@ def find_throws(code: str) -> list[Throw]:
             elif ch in ";," and depth == 0:
                 break
             i += 1
-        expression = " ".join(code[match.end() : i].split())
+        expression = _unwrap(" ".join(code[match.end() : i].split()))
         throws.append(Throw(code.count("\n", 0, match.start()) + 1, expression))
     return throws
+
+
+def _unwrap(expression: str) -> str:
+    """Drop the parentheses clang-format adds around a wrapped throw operand."""
+    while expression.startswith("("):
+        depth = 0
+        for end, char in enumerate(expression):
+            depth += (char == "(") - (char == ")")
+            if depth == 0:
+                break
+        if depth or end != len(expression) - 1:
+            break
+        expression = expression[1:-1].strip()
+    return expression
+
+
+def is_allowed(expression: str) -> bool:
+    """Whether this throw is correct as written and needs no annotation.
+
+    Everything else has to become a TORCH_CHECK, or be added to
+    ALLOWED_EXCEPTION_TYPES with a justification, or carry a per-site marker.
+    """
+    if not expression:
+        return True  # bare `throw;` re-raises the exception already in flight
+    # `throw std::move(e)` is deliberately not allowed. It reads like a rethrow,
+    # but every occurrence in this repo constructs a fresh exception and moves
+    # it to avoid a copy, so the type still has to be judged on its merits.
+    thrown = expression.removeprefix("::")
+    if thrown.startswith(PYBIND_NAMESPACES):
+        return True
+    match = _QUALIFIED_NAME.match(thrown)
+    if match is None or match.group(0) not in ALLOWED_EXCEPTION_TYPES:
+        return False
+    # An allowed name still has to be a constructor call, so that a variable
+    # that happens to share the name is not allowed along with it.
+    return thrown[match.end() :].lstrip().startswith(("(", "{"))
+
+
+def display(expression: str) -> str:
+    """The thrown expression, for a diagnostic. Arguments are elided because by
+    this point string literals in them have been blanked out."""
+    prefix = "::" if expression.startswith("::") else ""
+    thrown = expression.removeprefix("::")
+    match = _QUALIFIED_NAME.match(thrown)
+    if match and "(" in thrown:
+        return f"{prefix}{match.group(0)}(...)"
+    return expression
 
 
 def replacement_macro(path: str) -> str:
@@ -213,17 +280,15 @@ def replacement_macro(path: str) -> str:
 
 
 def describe(path: str, expression: str) -> str:
-    if not expression:
+    if _BARE_IDENTIFIER.fullmatch(expression):
         return (
-            "`throw;` re-raises the exception being handled. If the try/catch "
-            f"cannot be restructured away, put `// {MARKER}: <reason>` on the "
-            "line immediately above it."
+            f"`throw {expression};` throws a copy of `{expression}` with its "
+            "static type, so a derived exception would be sliced. Write "
+            "`throw;` to re-raise the original."
         )
     macro = replacement_macro(path)
-    if len(expression) > 80:
-        expression = expression[:77] + "..."
     lines = [
-        f"`throw {expression}` is a raw throw. Use {macro} instead.",
+        f"`throw {display(expression)}` is a raw throw. Use {macro} instead.",
     ]
     if macro == "TORCH_CHECK":
         lines.append(
@@ -233,8 +298,11 @@ def describe(path: str, expression: str) -> str:
             "See c10/util/Exception.h for the full list."
         )
     lines.append(
-        f"If this throw is correct and must stay, put `// {MARKER}: <reason>` "
-        "on the line immediately above it."
+        "If this exception is typed control flow that something catches by "
+        "name, add it to ALLOWED_EXCEPTION_TYPES in "
+        "tools/linter/adapters/raw_throw_linter.py with a reason. If this one "
+        f"site is correct, put `// {MARKER}: <reason>` on the line immediately "
+        "above it."
     )
     return " ".join(lines)
 
@@ -256,7 +324,9 @@ def check_source(path: str, text: str) -> list[LintMessage]:
         )
 
     throws = find_throws(code)
-    throw_lines = {throw.line for throw in throws}
+    first_on_line: dict[int, Throw] = {}
+    for throw in throws:
+        first_on_line.setdefault(throw.line, throw)
 
     # A marker licenses exactly one throw: the first one on the line below it.
     # A marker sharing a line with a throw licenses nothing - otherwise a
@@ -267,8 +337,8 @@ def check_source(path: str, text: str) -> list[LintMessage]:
         marker = _MARKER_LINE.search(comment)
         if marker is None:
             continue
-        target = lineno + 1
-        if lineno in throw_lines or target not in throw_lines:
+        target = first_on_line.get(lineno + 1)
+        if lineno in first_on_line or target is None:
             messages.append(
                 message(
                     lineno,
@@ -278,22 +348,33 @@ def check_source(path: str, text: str) -> list[LintMessage]:
                     "file-level opt-out and it cannot trail the throw itself.",
                 )
             )
-            continue
-        licensed.add(target)
-        rest = marker.group("rest").strip()
-        if not (rest.startswith(":") and rest[1:].strip()):
+        elif is_allowed(target.expression):
             messages.append(
                 message(
                     lineno,
-                    "allow-raw-throw-without-reason",
-                    f"`{MARKER}` must state why the throw is correct, as "
-                    f"`// {MARKER}: <reason>`.",
+                    "redundant-allow-raw-throw",
+                    f"`throw {display(target.expression)}` is allowed already, "
+                    f"so this `{MARKER}` suppresses nothing. Remove it.",
                 )
             )
+        else:
+            licensed.add(lineno + 1)
+            rest = marker.group("rest").strip()
+            if not (rest.startswith(":") and rest[1:].strip()):
+                messages.append(
+                    message(
+                        lineno,
+                        "allow-raw-throw-without-reason",
+                        f"`{MARKER}` must state why the throw is correct, as "
+                        f"`// {MARKER}: <reason>`.",
+                    )
+                )
 
     for throw in throws:
         if throw.line in licensed:
             licensed.discard(throw.line)
+            continue
+        if is_allowed(throw.expression):
             continue
         messages.append(
             message(throw.line, "raw throw statement", describe(path, throw.expression))

--- a/tools/test/test_raw_throw_linter.py
+++ b/tools/test/test_raw_throw_linter.py
@@ -118,7 +118,7 @@ class TestFindThrows(unittest.TestCase):
         throws = find_throws(code_of(source))
         self.assertEqual(len(throws), 1)
         self.assertEqual(throws[0].line, 1)
-        self.assertEqual(throws[0].expression, "( ErrorReport(loc) << what)")
+        self.assertEqual(throws[0].expression, "ErrorReport(loc) << what")
 
     def test_bare_rethrow(self) -> None:
         throws = find_throws(code_of("throw;\n"))
@@ -132,24 +132,72 @@ class TestFindThrows(unittest.TestCase):
 
 
 class TestBuckets(unittest.TestCase):
-    """Every kind of throw is flagged at this stage; the allow-by-rule policy
-    for typed exceptions is a separate change."""
-
-    def test_all_shapes_are_flagged(self) -> None:
+    def test_flagged(self) -> None:
         for expression in (
             "std::runtime_error(x)",
             "std::invalid_argument(x)",
             "std::out_of_range(x)",
+            "std::logic_error(x)",
+            # python_error is typed, but TORCH_CHECK_PYTHON replaces it.
             "python_error()",
-            "py::value_error(x)",
+            # A torch error type is not automatically allowed either.
             "c10::Error(x, y)",
+            # Not in ALLOWED_EXCEPTION_TYPES, so it must be justified first.
             "ErrorReport(loc) << x",
+            "TypeError(x)",
+            # Throws a sliced copy rather than re-raising.
+            "e",
+            # Reads like a rethrow, but the operand is a fresh exception.
             "std::move(e)",
-            "",
+            # Not a rethrow either, and neither name is allowed.
+            "MyError<int>(x)",
+            "factory.make()",
         ):
             source = f"throw {expression};\n"
             with self.subTest(expression=expression):
                 self.assertEqual(names(source), ["raw throw statement"])
+
+    def test_allowed(self) -> None:
+        for expression in (
+            "",  # bare `throw;`
+            "py::value_error(x)",
+            "pybind11::index_error(x)",
+            "::py::key_error(x)",
+            "PythonError()",
+            "WorkerException(e)",
+            "c10::AcceleratorError(x, y, z)",
+            "c10::AcceleratorError{x}",
+        ):
+            source = f"throw {expression};\n"
+            with self.subTest(expression=expression):
+                self.assertEqual(names(source), [])
+
+    def test_a_variable_named_like_an_allowed_type_is_still_flagged(self) -> None:
+        self.assertEqual(names("throw PythonError;\n"), ["raw throw statement"])
+
+    def test_a_namespace_ending_in_py_is_not_pybind(self) -> None:
+        for expression in ("foo::py::value_error(x)", "pyxx::value_error(x)"):
+            with self.subTest(expression=expression):
+                self.assertEqual(
+                    names(f"throw {expression};\n"), ["raw throw statement"]
+                )
+
+    def test_sliced_rethrow_is_told_to_use_bare_throw(self) -> None:
+        (message,) = check_source(PATH, "throw e;\n")
+        self.assertIn("throw;", message.description or "")
+        self.assertNotIn("TORCH_CHECK", message.description or "")
+
+    def test_only_a_bare_variable_gets_the_slicing_advice(self) -> None:
+        for expression in ("MyError<int>(x)", "factory.make()", "Foo()"):
+            with self.subTest(expression=expression):
+                (message,) = check_source(PATH, f"throw {expression};\n")
+                self.assertNotIn("sliced", message.description or "")
+
+    def test_arguments_are_elided_from_the_diagnostic(self) -> None:
+        # By this point string literals have been blanked, so printing them back
+        # would show `throw Foo( )`.
+        (message,) = check_source(PATH, 'throw Foo("some message", x);\n')
+        self.assertIn("`throw Foo(...)`", message.description or "")
 
     def test_word_throw_in_comment_or_string_is_not_flagged(self) -> None:
         source = (
@@ -163,16 +211,24 @@ class TestBuckets(unittest.TestCase):
 
 class TestAllowMarker(unittest.TestCase):
     def test_marker_on_preceding_line_allows_the_throw(self) -> None:
-        source = "// @allow-raw-throw: rethrow keeps the original error\nthrow;\n"
+        source = "// @allow-raw-throw: PyErr is already set here\nthrow Foo();\n"
         self.assertEqual(names(source), [])
 
     def test_marker_without_reason_is_rejected(self) -> None:
-        source = "// @allow-raw-throw\nthrow;\n"
+        source = "// @allow-raw-throw\nthrow Foo();\n"
         self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
 
     def test_marker_with_empty_reason_is_rejected(self) -> None:
-        source = "// @allow-raw-throw:   \nthrow;\n"
+        source = "// @allow-raw-throw:   \nthrow Foo();\n"
         self.assertEqual(names(source), ["allow-raw-throw-without-reason"])
+
+    def test_marker_above_an_allowed_throw_is_redundant(self) -> None:
+        source = "// @allow-raw-throw: reason\nthrow py::value_error(x);\n"
+        self.assertEqual(names(source), ["redundant-allow-raw-throw"])
+
+    def test_redundant_marker_is_not_also_reported_as_reasonless(self) -> None:
+        source = "// @allow-raw-throw\nthrow py::value_error(x);\n"
+        self.assertEqual(names(source), ["redundant-allow-raw-throw"])
 
     def test_trailing_marker_does_not_allow_the_throw(self) -> None:
         source = "throw Foo(); // @allow-raw-throw: nope\n"
@@ -212,6 +268,10 @@ class TestAllowMarker(unittest.TestCase):
         source = "\f\n// @allow-raw-throw: reason\nthrow Foo();\n"
         self.assertEqual(names(source), [])
 
+    def test_marker_licenses_the_flagged_throw_not_the_allowed_one(self) -> None:
+        allowed, marker = "throw py::value_error(x);", "// @allow-raw-throw: reason"
+        self.assertEqual(names(f"{allowed}\n{marker}\nthrow Foo();\n"), [])
+
     def test_marker_above_a_wrapped_throw(self) -> None:
         source = "// @allow-raw-throw: reason\nthrow(\n    Foo());\n"
         self.assertEqual(names(source), [])
@@ -230,10 +290,6 @@ class TestReplacementMacro(unittest.TestCase):
         for path, macro in cases.items():
             with self.subTest(path=path):
                 self.assertEqual(replacement_macro(path), macro)
-
-    def test_bare_rethrow_is_not_told_to_use_a_check_macro(self) -> None:
-        (message,) = check_source(PATH, "throw;\n")
-        self.assertNotIn("TORCH_CHECK", message.description or "")
 
     def test_description_names_the_macro(self) -> None:
         (message,) = check_source("torch/headeronly/util/Foo.h", "throw Foo();\n")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193005
* #192848

## Author Notes

Allow some exception types from TS and pybind that get properly converted. So we don't have to lint dead code or code that already works fine.

## Agent Notes

Written by Claude Code:

> Phase 0 made RAWTHROW able to see what it was looking at. This teaches it which
> throws are actually wrong, and cashes that in by deleting the first six
> exclude_patterns entries.
>
> Three kinds of throw are correct as written and are no longer reported:
>
> - bare `throw;`, which re-raises the exception already in flight;
> - `throw py::*` and `throw pybind11::*`, that library's own protocol for
>   reaching the interpreter, with no TORCH_CHECK equivalent;
> - typed exceptions named in ALLOWED_EXCEPTION_TYPES, currently `PythonError`,
>   `WorkerException` and `c10::AcceleratorError`.
>
> That last one is a fixed list rather than the more obvious rule "anything that
> is not a std:: type is fine". The open rule is tempting because it needs no
> maintenance, but it means the linter can never again catch someone inventing a
> bespoke exception class instead of using TORCH_CHECK - and it is not
> hypothetical: it would have quietly blessed the three `throw TypeError(...)` in
> tools/autograd/templates/python_variable_methods.cpp and the two
> `throw AttributeError(...)` in torch/csrc/jit, which are `c10::TypeError` and
> `c10::AttributeError`, i.e. exactly the conversions to TORCH_CHECK_TYPE this
> project exists to make. The list grows one name at a time, each with a written
> reason, in the PR that needs it. `py::` stays a namespace rule because that set
> of types belongs to pybind11, not to us.
>
> `throw std::move(e)` is deliberately *not* allowed, though it looks like a
> rethrow and reads like one. All seven occurrences in the repo construct a fresh
> exception object and move it only to avoid a copy - three are `python_error`,
> three are `NCCLException`, one is `c10::Error`. Allowing the `std::move` wrapper
> would have exempted them from the rules that apply to those types everywhere
> else, including the `python_error` conversion coming in the next PR. All seven
> are in directories that stay excluded here, so each is judged by the phase that
> owns it.
>
> Two smaller rules come with it. `throw e;` is now reported rather than treated
> as a rethrow: it throws a copy with the static type, so a derived exception is
> sliced, and the diagnostic says to write `throw;` instead. And a marker sitting
> above a throw the rules already allow is reported as
> `redundant-allow-raw-throw`, so suppressions cannot quietly accumulate while the
> exclude list shrinks. Diagnostics now elide constructor arguments, because by
> the time the linter sees an expression its string literals have been blanked and
> printing them back showed things like `throw Foo( )`.
>
> exclude_patterns is split into a permanent block and a burn-down block.
> `third_party/concurrentqueue/**` moves to the permanent one - it is vendored, so
> it is not debt and should stop looking like it. Deleted from the burn-down
> block, all six now clean:
>
>     c10/cuda/**            1 site,  c10::AcceleratorError
>     c10/xpu/**             1 site,  bare throw;
>     torch/csrc/api/**      2 sites, WorkerException
>     torch/csrc/fx/**      11 sites, PythonError
>     torch/csrc/lazy/**     1 site,  bare throw;
>     torch/nativert/**      2 sites, bare throw;
>
> `c10/core/**` was expected to be a seventh, but its only two sites are the
> `throw e;` in CPUAllocator.cpp, which needs a code change, so it moves to the
> long-tail phase rather than being smuggled in here.
>
> No C++ is touched, by design: this PR is the proof that phase 0's linter works
> on real code, so it should be readable as config plus rules and nothing else.
>
> Test Plan:
>
> ```
> PYTHONPATH=$(pwd) python -m pytest tools/test/test_raw_throw_linter.py -q
> ```
>
> 46 passed, 35 subtests passed. The new cases are an allowed/flagged matrix over
> every shape in the repo, the sliced-rethrow diagnostic and the shapes that must
> *not* get that advice (`throw MyError<int>(x)`, `throw factory.make()`), a
> variable that shares a name with an allowed type, a namespace merely ending in
> `py`, and the redundant-marker rule including that it does not double-report a
> reasonless marker.
>
> ```
> spin lint
> ```
>
> Clean. Note that lintrunner only looks at files git knows about, so this was run
> after `git add`; before staging it passes vacuously on new files.
>
> Six directories now linted, and the whole repo for the record:
>
> ```
> python tools/linter/adapters/raw_throw_linter.py \
>     $(git ls-files 'c10/cuda/*' 'c10/xpu/*' 'torch/csrc/api/*' 'torch/csrc/fx/*' \
>                    'torch/csrc/lazy/*' 'torch/nativert/*' | grep -E '\.(cpp|h)$')
> python tools/linter/adapters/raw_throw_linter.py $(git ls-files '*.cpp' '*.h') \
>     | python -c 'import json,sys,collections; print(collections.Counter(json.loads(l)["name"] for l in sys.stdin))'
> ```
>
> The first prints nothing. The second reports 1310 raw throws, down from phase
> 0's 1461. The 153 sites the rules now allow are 72 bare `throw;`, 67 `py::*`, 11
> `PythonError`, 2 `WorkerException` and 1 `c10::AcceleratorError`; 151 of them
> were previously reported, the other 2 having been suppressed by a marker
> already. Those 2 are the `py::value_error` in torch/csrc/dynamo/guards.cpp,
> which now show up as the 2 redundant markers. The 27 orphaned markers are
> unchanged. Every one of these lives in a directory that is still excluded.
>
> No build was run because no C++ changed.