### PR TITLE
[CI][ROCm] Stream test results during the run via OIDC

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -176,6 +176,17 @@ jobs:
           env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
           env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
 
+      # Creds for the in-run test-result upload (tools/testing/upload_artifacts.py).
+      # Soft-fail so a credential hiccup never reddens the test job; the job just
+      # falls back to the end-of-run backfill.
+      - name: Configure AWS credentials for in-run test-result upload
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        continue-on-error: true
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_rocm-test-results-write
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
       - name: Test
         id: test
         env:
@@ -239,6 +250,9 @@ jobs:
             -e BRANCH \
             -e SHA1 \
             -e AWS_DEFAULT_REGION \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
             -e IN_WHEEL_TEST \
             -e SHARD_NUMBER \
             -e TEST_CONFIG \


### PR DESCRIPTION
ROCm test jobs skip S3 (no instance profile), so per-test JSONs only reach tests.all_test_runs via the end-of-run backfill -- 8-11 min after the whole run completes, which recently let a trunk regression slip past autorevert. The streaming uploader (tools/testing/upload_artifacts.py) already runs on ROCm; it just fails silently with no S3 write creds.

Mint a scoped OIDC role before the Test step and forward the creds into the test container so the in-run upload succeeds, matching the CUDA/CPU fleet. Depends on the gha_workflow_rocm-test-results-write role (pytorch-gha-infra) being applied first. continue-on-error keeps a cred hiccup from reddening tests -- it just falls back to the backfill.

Authored with Claude Code.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang