### PR TITLE
[DCP][BugFix] sort checkpoint reads by offset

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -3,6 +3,7 @@
 import sys
 import tempfile
 from typing import Any, IO
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
@@ -15,6 +16,7 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed.checkpoint import (
+    DefaultLoadPlanner,
     FileSystemReader,
     FileSystemWriter,
     load,
@@ -128,6 +130,48 @@ class BlobState:
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
+    def test_read_data_sorts_items_by_storage_offset(self) -> None:
+        with tempfile.TemporaryDirectory() as path:
+            expected = {
+                "first": torch.arange(8),
+                "second": torch.arange(4),
+            }
+            save(
+                expected,
+                storage_writer=FileSystemWriter(path),
+            )
+
+            actual = {key: torch.empty_like(value) for key, value in expected.items()}
+            reader = FileSystemReader(path)
+            metadata = reader.read_metadata()
+            planner = DefaultLoadPlanner()
+            planner.set_up_planner(actual, metadata, is_coordinator=True)
+            reader.set_up_storage_reader(metadata, is_coordinator=True)
+            plan = planner.create_local_plan()
+
+            relative_paths = {
+                reader.storage_data[item.storage_index].relative_path
+                for item in plan.items
+            }
+            self.assertEqual(len(relative_paths), 1)
+            plan.items.sort(
+                key=lambda item: reader.storage_data[item.storage_index].offset,
+                reverse=True,
+            )
+            planned_offsets = [
+                reader.storage_data[item.storage_index].offset for item in plan.items
+            ]
+            self.assertGreater(planned_offsets[0], planned_offsets[-1])
+
+            with patch.object(
+                reader, "_slice_file", wraps=reader._slice_file
+            ) as slice_file:
+                reader.read_data(plan, planner).wait()
+
+            read_offsets = [call.args[1].offset for call in slice_file.call_args_list]
+            self.assertEqual(read_offsets, sorted(planned_offsets))
+            self.assertEqual(actual, expected)
+
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
         with tempfile.TemporaryDirectory() as path:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -868,19 +868,19 @@ class FileSystemReader(StorageReader):
 
     def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
         # group requests by file
-        per_file: dict[str, list[tuple[int, ReadItem, _StorageInfo]]] = {}
-        for read_item in plan.items:
+        per_file: dict[str, list[tuple[int, int, ReadItem, _StorageInfo]]] = {}
+        for plan_index, read_item in enumerate(plan.items):
             item_md: _StorageInfo = self.storage_data[read_item.storage_index]
             per_file.setdefault(item_md.relative_path, []).append(
-                (item_md.offset, read_item, item_md)
+                (item_md.offset, plan_index, read_item, item_md)
             )
 
         for relative_path, reqs in per_file.items():
             new_path = self.fs.concat_path(self.path, relative_path)
-            reqs.sort(key=lambda entry: entry[0])
+            reqs.sort(key=lambda entry: (entry[0], entry[1]))
             with self.fs.create_stream(new_path, "rb") as stream:
                 # TODO cache the reading
-                for _, req, item_md in reqs:
+                for _, _, req, item_md in reqs:
                     file_slice = self._slice_file(stream, item_md)
                     transform_from = self.transforms.transform_load_stream(
                         req,

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -868,18 +868,19 @@ class FileSystemReader(StorageReader):
 
     def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
         # group requests by file
-        per_file: dict[str, list[ReadItem]] = {}
+        per_file: dict[str, list[tuple[int, ReadItem, _StorageInfo]]] = {}
         for read_item in plan.items:
             item_md: _StorageInfo = self.storage_data[read_item.storage_index]
-            path = item_md.relative_path
-            per_file.setdefault(path, []).append(read_item)
+            per_file.setdefault(item_md.relative_path, []).append(
+                (item_md.offset, read_item, item_md)
+            )
 
         for relative_path, reqs in per_file.items():
             new_path = self.fs.concat_path(self.path, relative_path)
+            reqs.sort(key=lambda entry: entry[0])
             with self.fs.create_stream(new_path, "rb") as stream:
-                # TODO sort by offset and cache the reading
-                for req in reqs:
-                    item_md = self.storage_data[req.storage_index]
+                # TODO cache the reading
+                for _, req, item_md in reqs:
                     file_slice = self._slice_file(stream, item_md)
                     transform_from = self.transforms.transform_load_stream(
                         req,

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -868,19 +868,19 @@ class FileSystemReader(StorageReader):
 
     def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
         # group requests by file
-        per_file: dict[str, list[tuple[int, int, ReadItem, _StorageInfo]]] = {}
-        for plan_index, read_item in enumerate(plan.items):
+        per_file: dict[str, list[tuple[int, ReadItem, _StorageInfo]]] = {}
+        for read_item in plan.items:
             item_md: _StorageInfo = self.storage_data[read_item.storage_index]
             per_file.setdefault(item_md.relative_path, []).append(
-                (item_md.offset, plan_index, read_item, item_md)
+                (item_md.offset, read_item, item_md)
             )
 
         for relative_path, reqs in per_file.items():
             new_path = self.fs.concat_path(self.path, relative_path)
-            reqs.sort(key=lambda entry: (entry[0], entry[1]))
+            reqs.sort(key=lambda entry: entry[0])
             with self.fs.create_stream(new_path, "rb") as stream:
                 # TODO cache the reading
-                for _, _, req, item_md in reqs:
+                for _, req, item_md in reqs:
                     file_slice = self._slice_file(stream, item_md)
                     transform_from = self.transforms.transform_load_stream(
                         req,


### PR DESCRIPTION
checkpoint reads can currently go backwards. this sorts file reqs by storage offset before read

python test/distributed/checkpoint/test_file_system_checkpoint_cpu.py - 17 passed

Fixes #192926