### PR TITLE
[DOCS] Fixed parameter type mismatch in docs. see torch/csrc/cuda/CUDAPluggableAllocator.cpp

### DIFF
--- a/docs/source/notes/cuda.md
+++ b/docs/source/notes/cuda.md
@@ -722,14 +722,14 @@ traces all the memory operations.
 #include <iostream>
 // Compile with g++ alloc.cc -o alloc.so -I/usr/local/cuda/include -shared -fPIC
 extern "C" {
-void* my_malloc(ssize_t size, int device, cudaStream_t stream) {
+void* my_malloc(size_t size, int device, cudaStream_t stream) {
    void *ptr;
    cudaMalloc(&ptr, size);
    std::cout<<"alloc "<<ptr<<size<<std::endl;
    return ptr;
 }
 
-void my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
+void my_free(void* ptr, size_t size, int device, cudaStream_t stream) {
    std::cout<<"free "<<ptr<< " "<<stream<<std::endl;
    cudaFree(ptr);
 }


### PR DESCRIPTION
Fixed parameter type mismatch in docs. see torch/csrc/cuda/CUDAPluggableAllocator.cpp

These parameters were (sensibly) defined as size_t's in torch/csrc/cuda/CUDAPluggableAllocator.cpp and it looks like someone accidentally typed them as ssize_t's here.