### PR TITLE
[Testcase Refactoring] [quantization] Annotate TestFakeQuantize with hw_classification = GENERIC

### DIFF
--- a/test/quantization/core/experimental/test_fake_quantize.py
+++ b/test/quantization/core/experimental/test_fake_quantize.py
@@ -1,20 +1,29 @@
 # Owner(s): ["oncall: quantization"]
 
-import torch
 import unittest
-from torch.ao.quantization.experimental.observer import APoTObserver
-from torch.ao.quantization.experimental.quantizer import quantize_APoT, dequantize_APoT
+
+import torch
 from torch.ao.quantization.experimental.fake_quantize import APoTFakeQuantize
-from torch.ao.quantization.experimental.fake_quantize_function import fake_quantize_function
+from torch.ao.quantization.experimental.fake_quantize_function import (
+    fake_quantize_function,
+)
+from torch.ao.quantization.experimental.observer import APoTObserver
+from torch.ao.quantization.experimental.quantizer import dequantize_APoT, quantize_APoT
+from torch.testing._internal.common_utils import HardwareClassification
+
+
 forward_helper = fake_quantize_function.forward
 backward = fake_quantize_function.backward
 from torch.autograd import gradcheck
+
 
 class TestFakeQuantize(unittest.TestCase):
     r""" Tests fake quantize calculate_qparams() method
          by comparing with result from observer calculate_qparams.
          Uses hard-coded values: alpha=1.0, b=4, k=2.
     """
+    hw_classification = HardwareClassification.GENERIC
+
     def test_fake_calc_qparams(self):
         apot_fake = APoTFakeQuantize(b=4, k=2)
         apot_fake.activation_post_process.min_val = torch.tensor([0.0])


### PR DESCRIPTION
## Summary

Annotate the `TestFakeQuantize` test class in `test/quantization/core/experimental/test_fake_quantize.py` with `hw_classification = HardwareClassification.GENERIC`.

This test file does **not** require device-decoupling changes. This PR only adds the metadata class attribute so that the upstream CI can schedule this test class via the `--hw-classification` flag, aligned with the upstream device-agnostic test infrastructure.

## Why no decoupling changes are needed

The 4 test cases in `TestFakeQuantize` (inheriting native `unittest.TestCase`) were reviewed case by case and have **no hardware coupling**:

1. No device-specific decorators such as `@onlyCUDA` / `@deviceCountAtLeast`.
2. No pytest `is_cuda` parameterization.
3. No `.cuda()` calls or `torch.cuda.*` CUDA-specific APIs.
4. No `device` parameter, and no `instantiate_device_type_tests` registration.
5. All tensors are created on CPU by default; the tests verify the pure logic of `APoTFakeQuantize` (`calculate_qparams`, forward, and `torch.autograd.gradcheck` backward).
6. The underlying `torch.ao.quantization.experimental` APoT module is a CPU-only implementation (`Tensor.apply_()` only supports CPU tensors, plus numpy conversions) and is not designed for device acceleration.

Therefore this test class belongs to `HardwareClassification.GENERIC` (device-agnostic framework-internal logic / pure semantic validation) and should remain running on CPU. Forcing device parameterization would add unnecessary accelerator dependencies and conflict with the `GENERIC` semantics.

## Changes

- `test/quantization/core/experimental/test_fake_quantize.py`
  - Add `from torch.testing._internal.common_utils import HardwareClassification`.
  - Annotate `TestFakeQuantize` with `hw_classification = HardwareClassification.GENERIC`.
  - Imports are sorted per isort rules (no other changes).
  - No test semantics changed, no test cases added or removed (metadata-only change).

## Validation (CPU / CUDA)

- **CPU**: `pytest test_fake_quantize.py --collect-only -q` reports **4 tests collected** both before and after the change (identical test count and names).
- **CUDA**: this test relies on the CPU-only `Tensor.apply_()` and numpy conversions and is not runnable on CUDA (unchanged from upstream; this PR does not alter its device behavior).
- **Lint**: `py_compile`, `ruff check`, and `isort --check-only` all pass locally.

## Risk

None. This is a metadata-only change that does not affect test logic or compatibility.