### PR TITLE
[Testcase Refactoring] [quantization] Annotate TestModelNumericsEager with hw_classification = GENERIC

### DIFF
--- a/test/quantization/eager/test_model_numerics.py
+++ b/test/quantization/eager/test_model_numerics.py
@@ -10,9 +10,12 @@ from torch.testing._internal.common_quantized import (
     override_quantized_engine,
     supported_qengines,
 )
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestModelNumericsEager(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_float_quant_compare_per_tensor(self):
         for qengine in supported_qengines:
             with override_quantized_engine(qengine):


### PR DESCRIPTION
## Summary

Annotate the `TestModelNumericsEager` test class in `test/quantization/eager/test_model_numerics.py` with `hw_classification = HardwareClassification.GENERIC`.

This test file does **not** require device-decoupling changes. This PR only adds the metadata class attribute so that the upstream CI can schedule this test class via the `--hw-classification` flag, aligned with the upstream device-agnostic test infrastructure.

## Why no decoupling changes are needed

The 4 test cases in `TestModelNumericsEager` (inheriting `QuantizationTestCase`) were reviewed case by case and have **no hardware coupling**:

1. No device-specific decorators such as `@onlyCUDA` / `@deviceCountAtLeast`.
2. No pytest `is_cuda` parameterization.
3. No `.cuda()` calls or `torch.cuda.*` CUDA-specific APIs.
4. No `device` parameter, and no `instantiate_device_type_tests` registration.
5. All tensors are created on CPU by default; the tests compare the numerics (SQNR) between the floating-point model and the quantized model using CPU quantization engines (fbgemm/qnnpack/onednn/x86).
6. `supported_qengines` is a list of CPU quantization engines and is unrelated to GPU/NPU accelerators.

Therefore this test class belongs to `HardwareClassification.GENERIC` (device-agnostic framework-internal logic / CPU quantization engine numerics validation) and should remain running on CPU. Forcing device parameterization would add unnecessary accelerator dependencies and conflict with the `GENERIC` semantics.

## Changes

- `test/quantization/eager/test_model_numerics.py`
  - Add `from torch.testing._internal.common_utils import HardwareClassification`.
  - Annotate `TestModelNumericsEager` with `hw_classification = HardwareClassification.GENERIC`.
  - No test semantics changed, no test cases added or removed (metadata-only change).

## Validation (CPU / CUDA)

- **CPU**: `pytest test_model_numerics.py --collect-only -q --noconftest` reports **4 tests collected** both before and after the change (identical test count and names).
- **CUDA**: this test relies on CPU quantization engines (fbgemm/qnnpack) and is not runnable on CUDA (unchanged from upstream; this PR does not alter its device behavior).

## Risk

None. This is a metadata-only change that does not affect test logic or compatibility.