### PR TITLE
[BugFix] release tracked fake tensors

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -18105,6 +18105,15 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
     )
     @torch._functorch.config.patch(fake_tensor_propagate_real_tensors=True)
     def test_interpolate_propagate_real_tensors(self, device):
+        real_tensor_refs = []
+        from_tensor = torch._subclasses.FakeTensorMode.from_tensor
+
+        def record_real_tensor(mode, tensor, **kwargs):
+            fake = from_tensor(mode, tensor, **kwargs)
+            if mode.propagate_real_tensors and fake.real_tensor is not None:
+                real_tensor_refs.append(weakref.ref(fake.real_tensor))
+            return fake
+
         @torch.compile(backend="eager", fullgraph=True)
         def f(mask, box):
             # u0, u1 = mask.tolist()
@@ -18114,7 +18123,18 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
                 mask, (h, w), mode="bilinear", align_corners=False
             )
 
-        f(torch.tensor([30, 30], device=device), torch.tensor([68, 32], device=device))
+        with mock.patch.object(
+            torch._subclasses.FakeTensorMode, "from_tensor", record_real_tensor
+        ):
+            f(
+                torch.tensor([30, 30], device=device),
+                torch.tensor([68, 32], device=device),
+            )
+
+        self.assertTrue(real_tensor_refs)
+        torch._dynamo.reset()
+        gc.collect()
+        self.assertTrue(all(ref() is None for ref in real_tensor_refs))
 
     def test_scalar_isin_decomposition(self):
         def f():

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -99,7 +99,6 @@ from torch.testing._internal.common_utils import (
     recover_orig_fp32_precision,
     scoped_load_inline,
     set_default_dtype,
-    skipCUDAMemoryLeakCheckIf,
     skipIfHpu,
     skipIfNNModuleInlined,
     skipIfWindows,
@@ -18101,10 +18100,6 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
             res = opt_func(a)
             self.assertIsInstance(res, torch.Tensor)
 
-    # Known CUDA memory leak: under propagate_real_tensors, a data-dependent
-    # .tolist() retains the real input tensor (via FakeTensor.real_tensor held by
-    # a TrackedFake) past torch._dynamo.reset(). See #190093.
-    @skipCUDAMemoryLeakCheckIf(True)
     @torch._dynamo.config.patch(
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -919,9 +919,8 @@ inline_invoke_subgraph: bool = False
 # Single-use subgraphs add overhead without deduplication benefit.
 inline_single_use_invoke_subgraph: bool = True
 
-# Clear WeakIdRef entries from TracingContext.tensor_to_context and
-# MetaTensorDescriber.lookup_tensor at the end of compile. These weakrefs
-# can block torch.utils.swap_tensors from working after compile.
+# Clear compile-context references, including ShapeEnv tracked fakes, at the
+# end of compile. These can retain tensors or block torch.utils.swap_tensors.
 # - None (default): clear for registered backends (inductor, eager, etc.),
 #   don't clear for custom backends (to support standalone_compile, etc.)
 # - True: always clear regardless of backend

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -228,7 +228,7 @@ def clear_compile_context_weakrefs(
     tracer_output: DynamoTracerOutput | None,
     compiler_fn: CompilerFn,
 ) -> None:
-    """Clear WeakIdRef entries that can block swap_tensors after compile."""
+    """Clear compile-context references that can retain tensors after compile."""
     should_clear = config.invalidate_compile_context_weakrefs
     if should_clear is None:
         should_clear = _is_registered_backend(innermost_backend(compiler_fn))
@@ -244,6 +244,7 @@ def clear_compile_context_weakrefs(
     _clear_fake_mode_weakrefs(tc.fake_mode)
     if hasattr(output_graph, "_old_fake_mode"):
         _clear_fake_mode_weakrefs(output_graph._old_fake_mode)
+    output_graph.shape_env.tracked_fakes = None
 
 
 class Tracker:

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -244,7 +244,7 @@ def clear_compile_context_weakrefs(
     _clear_fake_mode_weakrefs(tc.fake_mode)
     if hasattr(output_graph, "_old_fake_mode"):
         _clear_fake_mode_weakrefs(output_graph._old_fake_mode)
-    output_graph.shape_env.tracked_fakes = None
+    output_graph.tracked_fakes.clear()
 
 
 class Tracker:


### PR DESCRIPTION
ShapeEnv.tracked_fakes can hold CUDA tensors after compile. this clears it and removes the leak-check skip from the currenet regression

Testing:
- PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 python test/dynamo/test_misc.py MiscTestsDeviceCUDA.test_interpolate_propagate_real_tensors_cuda
  - passed

Closes #190093

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98