### PR TITLE
[CPU][BugFix] support uint8 trilinear interpolation

### DIFF
--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -1617,7 +1617,7 @@ void upsample_separable_1d(
   unsigned int weights_precision = 0;
 
   if (input_scalar_type == at::kByte) {
-    // This is a special branch to provide uint8 dtype support for bilinear, bicubic and lanczos modes only
+    // This is a special branch to provide uint8 dtype support for bilinear, trilinear, bicubic and lanczos modes only
     TORCH_INTERNAL_ASSERT(F::interp_size == 2 || F::interp_size == 4 || F::interp_size == 6);
     int unused = 0;
     std::tie(indices_weights, unused, weights_precision) =
@@ -1669,8 +1669,8 @@ void upsample_separable_1d(
 
 // Generic separable upsampling interpolation kernel for N-d case with anti-aliasing.
 // It also supports antialias=False iff
-// (dtype == uint8 and mode in ("bilinear", "bicubic")): this is used as
-// fallback in these settings when AVX isn't supported.
+// (dtype == uint8 and mode in ("bilinear", "trilinear", "bicubic")). This is
+// used as fallback for bilinear and bicubic when AVX isn't supported.
 template <int out_ndims, typename scale_type, class F>
 void upsample_separable_Nd_kernel_impl(
     const Tensor& output,
@@ -1950,6 +1950,11 @@ void upsample_trilinear3d_kernel_impl(
     std::optional<double> scales_d,
     std::optional<double> scales_h,
     std::optional<double> scales_w) {
+  if (input.dtype() == at::kByte) {
+    return upsample_separable_Nd_kernel_impl<3, scale_t, HelperInterpLinear>(
+      output, input, align_corners, {scales_d, scales_h, scales_w},
+      /*antialias=*/false);
+  }
   if ((_use_channels_last_kernel_3d(output, input))) {
     AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, input.scalar_type(), "upsample_trilinear3d_channels_last", [&] {
       upsample_linear_channels_last<scalar_t, scale_t>(output, input, align_corners, {scales_d, scales_h, scales_w});

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -569,6 +569,9 @@ comprehensive_failures = {
         "nn.functional.interpolate", "bicubic", dtypes=(torch.uint8,)
     ),  # off by one error
     xfail(
+        "nn.functional.interpolate", "trilinear", dtypes=(torch.uint8,)
+    ),  # native CPU uses separable fixed-point rounding
+    xfail(
         "nn.functional.upsample_bilinear", "", dtypes=(torch.uint8,)
     ),  # off by one error
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10287,6 +10287,55 @@ class TestNNDeviceType(NNTestCase):
             gradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
             gradgradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
 
+    @onlyCPU
+    @parametrize_test("align_corners", [True, False])
+    @parametrize_test(
+        "input_shape, output_size, memory_format",
+        [
+            ((1, 1, 2, 3, 4), (3, 5, 7), torch.contiguous_format),
+            ((2, 5, 4, 3, 2), (3, 1, 5), torch.channels_last_3d),
+        ],
+    )
+    def test_upsamplingTrilinear3d_uint8(
+        self, device, align_corners, input_shape, output_size, memory_format
+    ):
+        input_uint8 = torch.arange(
+            math.prod(input_shape), dtype=torch.uint8, device=device
+        ).reshape(input_shape)
+        input_uint8 = input_uint8.contiguous(memory_format=memory_format)
+
+        expected = F.interpolate(
+            input_uint8.float(),
+            size=output_size,
+            mode="trilinear",
+            align_corners=align_corners,
+        ).add(0.5).clamp(0, 255).to(torch.uint8)
+        actual = F.interpolate(
+            input_uint8,
+            size=output_size,
+            mode="trilinear",
+            align_corners=align_corners,
+        )
+
+        self.assertTrue(actual.is_contiguous(memory_format=memory_format))
+        self.assertEqual(actual, expected, rtol=0, atol=1)
+
+    @onlyCPU
+    def test_upsamplingTrilinear3d_uint8_rounds_half_up(self, device):
+        input_uint8 = torch.tensor([0, 1], dtype=torch.uint8, device=device).reshape(
+            1, 1, 1, 1, 2
+        )
+        actual = F.interpolate(
+            input_uint8,
+            size=(1, 1, 3),
+            mode="trilinear",
+            align_corners=True,
+        )
+        expected = torch.tensor([0, 1, 1], dtype=torch.uint8, device=device).reshape(
+            1, 1, 1, 1, 3
+        )
+        self.assertEqual(actual, expected)
+
     @onlyCUDA
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('40GB')

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5063,6 +5063,11 @@ def interpolate(  # noqa: F811
         For ``uint8`` inputs, it already performs saturating cast operation. So, no manual `clamp` operation is needed.
 
     .. note::
+        On CPU, ``uint8`` trilinear interpolation uses fixed-point separable
+        interpolation. Each spatial pass rounds to nearest with halfway values
+        rounded upward and saturates the result to ``[0, 255]``.
+
+    .. note::
         Mode ``mode='lanczos'`` uses a Lanczos-3 windowed sinc filter (6 taps) and requires
         ``antialias=True``. It only supports 4-D input (i.e. 2D spatial) and CPU. With ``antialias=True``
         and ``align_corners=False``, the result matches PIL's ``Image.LANCZOS`` resampling filter.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16432,7 +16432,9 @@ op_db: list[OpInfo] = [
            supports_autograd=True,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           dtypes=floating_types_and(torch.half, torch.bfloat16),
+           dtypes=floating_types_and(torch.uint8, torch.half, torch.bfloat16),
+           dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
+           dtypesIfHpu=floating_types_and(torch.half, torch.bfloat16),
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            sample_inputs_func=partial(sample_inputs_interpolate, 'trilinear'),
            skips=(
@@ -16440,8 +16442,6 @@ op_db: list[OpInfo] = [
                # INTERNAL ASSERT FAILED at "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":185,
                # please report a bug to PyTorch.
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
-               # torch.uint8 - Failed to create function state object for: upsample_bicubic2d_uchar
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            ),
            supports_out=False),
     OpInfo('nn.functional.interpolate',


### PR DESCRIPTION
trilinear interpolation currentyl reject uint8. changes made are so it routes through the existing fixed-point path and as per issue request: dcouments its saturating rounding behavior.

Testing:
- python test/test_nn.py -k test_upsamplingTrilinear3d_uint8 - 5 passed
- python test/test_decomp.py -k trilinear -v - 8 passed
- python test/test_ops.py TestCommonCPU.test_dtypes_nn_functional_interpolate_trilinear_cpu - passed

Closes #191907

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01