### PR TITLE
Sort per-file read requests by storage offset

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -876,8 +876,8 @@ class FileSystemReader(StorageReader):
 
         for relative_path, reqs in per_file.items():
             new_path = self.fs.concat_path(self.path, relative_path)
+            reqs.sort(key=lambda req: self.storage_data[req.storage_index].offset)
             with self.fs.create_stream(new_path, "rb") as stream:
-                # TODO sort by offset and cache the reading
                 for req in reqs:
                     item_md = self.storage_data[req.storage_index]
                     file_slice = self._slice_file(stream, item_md)


### PR DESCRIPTION
When processing per-file read requests in FileSystemReader, sort the requests by the corresponding storage_data offset before opening the file stream. This ensures reads occur in storage order (reducing seeks and enabling more efficient caching) and removes a stale TODO about sorting/caching. Change is in torch/distributed/checkpoint/filesystem.py where per-file reqs are prepared for streaming. To close #192926.