### PR TITLE
[c10d] Replace Backend's per-capability virtuals with a capability bitset

### DIFF
--- a/docs/source/accelerator/distributed.md
+++ b/docs/source/accelerator/distributed.md
@@ -79,12 +79,32 @@ See [`Backend.hpp`][Backend.hpp] for the full list of virtual methods and their 
 
 ### Optional Capabilities
 
-Backends can advertise optional capabilities by overriding the following methods:
+Backends advertise optional capabilities by overriding `capabilities()`, which
+returns the set of `BackendCapability` bits the backend supports. Any bit left
+out of the returned set is unsupported.
 
-| Method                    | Default  | Description                                           |
-| :---                      | :---     | :---                                                  |
-| `supportsSplitting()`     | `false`  | Process group splitting support                       |
-| `supportsCoalescing()`    | `false`  | Coalesced collective operations                       |
+| Capability                            | Description                            |
+| :---                                  | :---                                   |
+| `BackendCapability::Splitting`        | Process group splitting support        |
+| `BackendCapability::Coalescing`       | Coalesced collective operations        |
+| `BackendCapability::TimeEstimation`   | Collective time estimation             |
+| `BackendCapability::Shrinking`        | Communicator shrinking                 |
+| `BackendCapability::Reconfigure`      | Fault-tolerant reconfiguration         |
+| `BackendCapability::Window`           | One-sided (RMA) windows                |
+| `BackendCapability::AbortHooks`       | Hooks run before the backend aborts    |
+| `BackendCapability::CompletionHooks`  | Hooks run when an operation completes  |
+
+```cpp
+c10d::BackendCapabilities capabilities() const override {
+  return {
+      c10d::BackendCapability::Splitting,
+      c10d::BackendCapability::Coalescing};
+}
+```
+
+Build the set from a braced list rather than combining bits one at a time:
+`std::bitset` cannot be mutated in a constant expression until C++23, so only
+the braced form folds at compile time.
 
 ## Implementation
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/distributed/c10d/ProcessGroupOCCL.hpp
@@ -59,10 +59,6 @@ class OPENREG_EXPORT ProcessGroupOCCL : public Backend {
     return std::string(OCCL_BACKEND_NAME);
   }
 
-  bool supportsSplitting() const override {
-    return false;
-  }
-
   c10::intrusive_ptr<Backend::Options> getBackendOptions() override {
     return c10::static_intrusive_pointer_cast<Backend::Options>(options_);
   }

--- a/test/distributed/test_c10d_pybackend.py
+++ b/test/distributed/test_c10d_pybackend.py
@@ -311,6 +311,24 @@ def create_process_group(backend):
 
 
 class TestPyBackend(TestCase):
+    def test_partial_capability_overrides(self) -> None:
+        # A Python backend need not define every capability property. The ones
+        # it leaves out must fall back to the C++ default rather than resolving
+        # to Backend's own binding, which would call back in and recurse.
+        class PartialBackend(C10DBackend):
+            @property
+            def supports_reconfigure(self):
+                return True
+
+        backend = PartialBackend(0, 1)
+        group = create_process_group(backend)
+
+        self.assertTrue(backend.supports_reconfigure)
+        self.assertTrue(group.supports_reconfigure)
+        self.assertFalse(group.supports_window)
+        for attr in ("supports_splitting", "supports_coalescing"):
+            self.assertFalse(getattr(backend, attr))
+
     def test_attr_overrides(self) -> None:
         backend = RecordingBackend(0, 1)
         group = create_process_group(backend)

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -502,12 +502,19 @@ if not TEST_WITH_DEV_DBG_ASAN:
             self.assertIsInstance(wrapper, _ProcessGroupWrapper)
             unwrapped = wrapper.wrapped_pg
 
-            # Verify wrapper forwards property/method calls to wrapped backend
+            # Verify wrapper forwards property/method calls to wrapped backend.
+            # These all come from the wrapped backend's capabilities() bitset,
+            # so the wrapper cannot forward a subset of them by accident.
             self.assertEqual(wrapper.supports_splitting, unwrapped.supports_splitting)
             self.assertEqual(wrapper.supports_coalescing, unwrapped.supports_coalescing)
             self.assertEqual(
                 wrapper._supports_time_estimate, unwrapped._supports_time_estimate
             )
+            self.assertEqual(wrapper.supports_shrinking, unwrapped.supports_shrinking)
+            self.assertEqual(
+                wrapper.supports_reconfigure, unwrapped.supports_reconfigure
+            )
+            self.assertEqual(wrapper.supports_window, unwrapped.supports_window)
             self.assertEqual(
                 wrapper.supports_tensor_alloc(device),
                 unwrapped.supports_tensor_alloc(device),
@@ -608,6 +615,20 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def test_collective_hang(self):
         pg = self._create_wrapper_pg(timeout=2.0)
         self._test_collective_hang(pg)
+
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_wrapper_forwards_capabilities(self):
+        """
+        Gloo advertises reconfigure support, so this catches a wrapper that
+        forwards only some of the wrapped backend's capabilities. See #173538.
+        """
+        wrapper = self._create_wrapper_pg(with_new_group=False)
+        unwrapped = wrapper.wrapped_pg
+
+        self.assertTrue(unwrapped.supports_reconfigure)
+        self.assertEqual(wrapper.supports_reconfigure, unwrapped.supports_reconfigure)
+        self.assertEqual(wrapper.supports_splitting, unwrapped.supports_splitting)
+        self.assertEqual(wrapper.supports_window, unwrapped.supports_window)
 
     # NOTE: these tests are separated by debug level instead of combined into
     # one due to https://github.com/pytorch/pytorch/issues/55967, they can be

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <bitset>
+#include <cstddef>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -29,6 +32,12 @@
 // interface. Downstream backends can guard their overrides with #ifdef.
 #define C10D_BACKEND_HAS_WINDOW 1
 
+// Feature macro: when defined, c10d::Backend (and ProcessGroup) advertise
+// their static capabilities through a single virtual, capabilities(), rather
+// than one virtual per capability. Downstream backends can guard their
+// overrides with #ifdef to build against both old and new c10d headers.
+#define C10D_BACKEND_HAS_CAPABILITIES 1
+
 // Feature macro: when defined, c10d::Backend exposes abort-hook registration
 // and c10d::ProcessGroup additionally exposes pre/post collective hooks (see
 // Hooks.hpp). Downstream backends can guard their overrides with #ifdef.
@@ -47,6 +56,85 @@ enum class ErrorType {
   // TODO, do we need to distinguish between remote timeout or remote COMM
   // errors?
   REMOTE_ERROR = 3
+};
+
+// A static, backend-wide capability. These describe what a backend can do at
+// all Values are bit positions; COUNT must stay
+// last so it always equals the number of capabilities.
+enum class BackendCapability : size_t {
+  Splitting,
+  Coalescing,
+  TimeEstimation,
+  Shrinking,
+  Reconfigure,
+  Window,
+  AbortHooks,
+  CompletionHooks,
+  // Add new capability here
+  COUNT,
+  // DO NOT EDIT BEYOND COUNT
+};
+
+inline constexpr size_t kNumBackendCapabilities =
+    static_cast<size_t>(BackendCapability::COUNT);
+static_assert(
+    kNumBackendCapabilities <= 64,
+    "capability sets are assembled through a 64-bit mask");
+
+// The set of capabilities a backend advertises. Backends report all of them at
+// once via a single Backend::capabilities() virtual: the capability list grows
+// over time, and one virtual per capability costs every backend a vtable slot
+// while making each query an indirect call that cannot be folded.
+//
+// std::bitset's mutating members (set / operator|= / test) are not constexpr
+// until C++23, but its unsigned-long-long constructor and const operator[]
+// are. Compile-time sets are therefore assembled as a raw mask and handed to
+// the bitset once, and always read back through operator[].
+class BackendCapabilities {
+ public:
+  constexpr BackendCapabilities() = default;
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr BackendCapabilities(BackendCapability cap) : bits_(maskOf({cap})) {}
+
+  constexpr BackendCapabilities(std::initializer_list<BackendCapability> caps)
+      : bits_(maskOf(caps)) {}
+
+  constexpr bool has(BackendCapability cap) const {
+    return bits_[static_cast<size_t>(cap)];
+  }
+
+  BackendCapabilities& set(BackendCapability cap, bool value) {
+    bits_.set(static_cast<size_t>(cap), value);
+    return *this;
+  }
+
+  BackendCapabilities& operator|=(BackendCapabilities other) {
+    bits_ |= other.bits_;
+    return *this;
+  }
+
+  // Masking is useful for wrappers that only forward a subset of the wrapped
+  // backend's capabilities.
+  BackendCapabilities operator&(BackendCapabilities other) const {
+    return BackendCapabilities(bits_ & other.bits_);
+  }
+
+ private:
+  using Bits = std::bitset<kNumBackendCapabilities>;
+
+  explicit constexpr BackendCapabilities(Bits bits) : bits_(bits) {}
+
+  static constexpr unsigned long long maskOf(
+      std::initializer_list<BackendCapability> caps) {
+    unsigned long long mask = 0;
+    for (auto cap : caps) {
+      mask |= 1ULL << static_cast<size_t>(cap);
+    }
+    return mask;
+  }
+
+  Bits bits_;
 };
 
 namespace {
@@ -154,19 +242,27 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     use_pg_for_symm_mem_rendezvous_ = value;
   }
 
-  virtual bool supportsSplitting() const {
-    return false;
+  // Advertise this backend's static capabilities. Subclasses override this
+  // single method instead of one accessor per capability; the supportsX()
+  // accessors below are non-virtual views onto the returned set.
+  virtual BackendCapabilities capabilities() const {
+    return {};
   }
 
-  virtual bool supportsCoalescing() const {
-    return false;
+  bool supportsSplitting() const {
+    return capabilities().has(BackendCapability::Splitting);
   }
 
-  // Experimental collective time-estimation API. Backends that return true
-  // must simulate collectives issued between startTimeEstimate() and
-  // endTimeEstimate(), which returns the estimated duration in microseconds.
-  virtual bool supportsTimeEstimation() const {
-    return false;
+  bool supportsCoalescing() const {
+    return capabilities().has(BackendCapability::Coalescing);
+  }
+
+  // Experimental collective time-estimation API. Backends advertising
+  // BackendCapability::TimeEstimation must simulate collectives issued between
+  // startTimeEstimate() and endTimeEstimate(), which returns the estimated
+  // duration in microseconds.
+  bool supportsTimeEstimation() const {
+    return capabilities().has(BackendCapability::TimeEstimation);
   }
 
   virtual void startTimeEstimate() {
@@ -183,8 +279,8 @@ class TORCH_API Backend : public torch::CustomClassHolder {
             "Backend ", getBackendName(), " does not support time estimation"));
   }
 
-  virtual bool supportsShrinking() const {
-    return false;
+  bool supportsShrinking() const {
+    return capabilities().has(BackendCapability::Shrinking);
   }
 
   // Shrink the backend by excluding specified ranks. Backends that support
@@ -218,12 +314,13 @@ class TORCH_API Backend : public torch::CustomClassHolder {
 
   // Fault Tolerance / Reconfigure API
   //
-  // Backends that support dynamic membership override these.
-  // supportsReconfigure advertises support; get_reconfigure_handle returns an
-  // opaque handle that peers exchange out-of-band; reconfigure (re)initializes
-  // the communicator with a new set of peers.
-  virtual bool supportsReconfigure() const {
-    return false;
+  // Backends that support dynamic membership advertise
+  // BackendCapability::Reconfigure and override these.
+  // get_reconfigure_handle returns an opaque handle that peers exchange
+  // out-of-band; reconfigure (re)initializes the communicator with a new set
+  // of peers.
+  bool supportsReconfigure() const {
+    return capabilities().has(BackendCapability::Reconfigure);
   }
 
   virtual ReconfigureHandle get_reconfigure_handle() const {
@@ -245,12 +342,13 @@ class TORCH_API Backend : public torch::CustomClassHolder {
 
   // Window & One-sided (RMA) API
   //
-  // Backends that support one-sided operations advertise it via supportsWindow
-  // and return a concrete c10d::Window from new_window. The optional tensor, if
-  // provided, is registered with the new window. new_window is collective: all
-  // ranks in the backend must call it in the same order.
-  virtual bool supportsWindow() const {
-    return false;
+  // Backends that support one-sided operations advertise
+  // BackendCapability::Window and return a concrete c10d::Window from
+  // new_window. The optional tensor, if provided, is registered with the new
+  // window. new_window is collective: all ranks in the backend must call it in
+  // the same order.
+  bool supportsWindow() const {
+    return capabilities().has(BackendCapability::Window);
   }
 
   virtual c10::intrusive_ptr<Window> new_window(
@@ -265,10 +363,11 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   // Abort hooks are invoked before the backend aborts on a timeout or error,
   // letting users capture debug information. Hooks are keyed by an opaque
   // hook_id so they can be individually unregistered. Backends that implement
-  // them must advertise it via supportsAbortHooks, so a caller can tell "this
-  // backend has no abort hooks" from a registration that genuinely failed.
-  virtual bool supportsAbortHooks() const {
-    return false;
+  // them must advertise BackendCapability::AbortHooks, so a caller can tell
+  // "this backend has no abort hooks" from a registration that genuinely
+  // failed.
+  bool supportsAbortHooks() const {
+    return capabilities().has(BackendCapability::AbortHooks);
   }
 
   virtual void registerAbortHook(int64_t /* hook_id */, AbortHook /* hook */) {
@@ -296,10 +395,10 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   // collect its work queue. Same hook_id keying and same capability query as
   // the abort hooks above; see Hooks.hpp for what is reported and the threading
   // contract. A backend without them leaves its consumers to poll, so
-  // supportsCompletionHooks is what lets a caller choose a fallback rather than
-  // catch a throw.
-  virtual bool supportsCompletionHooks() const {
-    return false;
+  // BackendCapability::CompletionHooks is what lets a caller choose a fallback
+  // rather than catch a throw.
+  bool supportsCompletionHooks() const {
+    return capabilities().has(BackendCapability::CompletionHooks);
   }
 
   virtual void registerCompletionHook(

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -82,8 +82,8 @@ class FakeProcessGroup : public Backend {
     // Backend base class emits for unsupported backends.
   }
 
-  bool supportsSplitting() const override {
-    return true;
+  BackendCapabilities capabilities() const override {
+    return {BackendCapability::Splitting};
   }
 
   // Create a sub-group from a subset of the parent's ranks. The fake backend

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -1077,13 +1077,18 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     getDefaultBackend()->setUsePgForSymmMemRendezvous(value);
   }
 
+  // Capabilities of the default backend; see Backend.hpp for semantics.
+  virtual BackendCapabilities capabilities() const {
+    return getDefaultBackend()->capabilities();
+  }
+
   // Fault Tolerance / Reconfigure API. Forwards to the default backend; see
   // Backend.hpp for semantics.
-  virtual bool supportsReconfigure() const {
+  bool supportsReconfigure() const {
     TORCH_CHECK(
         !hasMultipleBackends(),
         "ProcessGroup reconfigure APIs do not support process groups with multiple backends.");
-    return getDefaultBackend()->supportsReconfigure();
+    return capabilities().has(BackendCapability::Reconfigure);
   }
 
   virtual ReconfigureHandle get_reconfigure_handle() const {
@@ -1102,8 +1107,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
   // Window & One-sided (RMA) API. Forwards to the default backend; see
   // Backend.hpp and Window.hpp for semantics.
-  virtual bool supportsWindow() const {
-    return getDefaultBackend()->supportsWindow();
+  bool supportsWindow() const {
+    return capabilities().has(BackendCapability::Window);
   }
 
   virtual c10::intrusive_ptr<Window> new_window(
@@ -1117,8 +1122,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // opaque hook_id so they can be individually unregistered. Registration is
   // expected to happen at setup time, not concurrently with collectives. See
   // Hooks.hpp.
-  virtual bool supportsAbortHooks() const {
-    return getDefaultBackend()->supportsAbortHooks();
+  bool supportsAbortHooks() const {
+    return capabilities().has(BackendCapability::AbortHooks);
   }
 
   virtual void registerAbortHook(int64_t hook_id, AbortHook hook) {
@@ -1132,8 +1137,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // Completion hooks forward to the default backend for the same reason abort
   // hooks do: completion is detected inside the backend, not by the dispatcher
   // kernels that fire the pre/post hooks below.
-  virtual bool supportsCompletionHooks() const {
-    return getDefaultBackend()->supportsCompletionHooks();
+  bool supportsCompletionHooks() const {
+    return capabilities().has(BackendCapability::CompletionHooks);
   }
 
   virtual void registerCompletionHook(int64_t hook_id, CompletionHook hook) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -271,12 +271,8 @@ class TORCH_API ProcessGroupGloo : public Backend {
     return std::string(GLOO_BACKEND_NAME);
   }
 
-  bool supportsSplitting() const override {
-    return true;
-  }
-
-  bool supportsReconfigure() const override {
-    return true;
+  BackendCapabilities capabilities() const override {
+    return {BackendCapability::Splitting, BackendCapability::Reconfigure};
   }
 
   // Helper functions to create a new device object.

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -824,20 +824,16 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     return std::string(NCCL_BACKEND_NAME);
   }
 
-  bool supportsSplitting() const override {
-    return true;
-  }
-
-  bool supportsCoalescing() const override {
-    return true;
-  }
-
-  bool supportsTimeEstimation() const override {
+  BackendCapabilities capabilities() const override {
+    BackendCapabilities caps = {
+        BackendCapability::Splitting, BackendCapability::Coalescing};
 #ifdef NCCL_SIM_INFO_INITIALIZER
-    return true;
-#else
-    return false;
+    caps |= BackendCapability::TimeEstimation;
 #endif
+#ifdef NCCL_HAS_COMM_SHRINK
+    caps |= BackendCapability::Shrinking;
+#endif
+    return caps;
   }
 
   void setTimeout(std::chrono::milliseconds timeout) override {
@@ -1022,14 +1018,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   bool isInitialized();
 
   ErrorType getError() override;
-
-  bool supportsShrinking() const override {
-#ifdef NCCL_HAS_COMM_SHRINK
-    return true;
-#else
-    return false;
-#endif
-  }
 
   // Backend-style shrink override that returns a Backend instance.
   c10::intrusive_ptr<Backend> shrink(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -586,16 +586,8 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::endCoalescing() {
   return backend_->endCoalescing();
 }
 
-bool ProcessGroupWrapper::supportsSplitting() const {
-  return backend_->supportsSplitting();
-}
-
-bool ProcessGroupWrapper::supportsCoalescing() const {
-  return backend_->supportsCoalescing();
-}
-
-bool ProcessGroupWrapper::supportsTimeEstimation() const {
-  return backend_->supportsTimeEstimation();
+BackendCapabilities ProcessGroupWrapper::capabilities() const {
+  return backend_->capabilities();
 }
 
 void ProcessGroupWrapper::startTimeEstimate() {
@@ -604,10 +596,6 @@ void ProcessGroupWrapper::startTimeEstimate() {
 
 float ProcessGroupWrapper::endTimeEstimate() {
   return backend_->endTimeEstimate();
-}
-
-bool ProcessGroupWrapper::supportsShrinking() const {
-  return backend_->supportsShrinking();
 }
 
 c10::intrusive_ptr<Backend> ProcessGroupWrapper::shrink(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -147,12 +147,9 @@ class TORCH_API ProcessGroupWrapper : public Backend {
       const int& size) override;
 
   // Forward methods to wrapped backend
-  bool supportsSplitting() const override;
-  bool supportsCoalescing() const override;
-  bool supportsTimeEstimation() const override;
+  BackendCapabilities capabilities() const override;
   void startTimeEstimate() override;
   float endTimeEstimate() override;
-  bool supportsShrinking() const override;
   c10::intrusive_ptr<Backend> shrink(
       const std::vector<int64_t>& ranks_to_exclude,
       int shrink_flags = 0,

--- a/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
+++ b/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
@@ -80,6 +80,20 @@ class LazyBackend : public Backend {
     primary_->setGroupUid(pg_uid);
   }
 
+  // Only the capabilities this wrapper actually routes to the primary are
+  // forwarded; the rest (shrinking, abort hooks) fall back to the base default
+  // even when the primary supports them.
+  BackendCapabilities capabilities() const override {
+    constexpr BackendCapabilities kForwarded = {
+        BackendCapability::Coalescing,
+        BackendCapability::TimeEstimation,
+        BackendCapability::Window,
+        BackendCapability::Reconfigure,
+        BackendCapability::Splitting,
+        BackendCapability::CompletionHooks};
+    return primary_->capabilities() & kForwarded;
+  }
+
   // ---- P2P: dispatched to per-peer 2-rank pair comms ----
   c10::intrusive_ptr<Work> send(
       std::vector<at::Tensor>& tensors,
@@ -101,9 +115,6 @@ class LazyBackend : public Backend {
   }
 
   // Batched P2P stays on the primary (multiple peers per group).
-  bool supportsCoalescing() const override {
-    return primary_->supportsCoalescing();
-  }
   void startCoalescing() override {
     primary_->startCoalescing();
     coalescing_active_ = true;
@@ -113,9 +124,6 @@ class LazyBackend : public Backend {
     return primary_->endCoalescing();
   }
 
-  bool supportsTimeEstimation() const override {
-    return primary_->supportsTimeEstimation();
-  }
   void startTimeEstimate() override {
     primary_->startTimeEstimate();
   }
@@ -224,9 +232,6 @@ class LazyBackend : public Backend {
   }
 
   // ---- Windows / memory: forwarded to the primary comm ----
-  bool supportsWindow() const override {
-    return primary_->supportsWindow();
-  }
   c10::intrusive_ptr<Window> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override {
     return primary_->new_window(tensor);
@@ -324,9 +329,6 @@ class LazyBackend : public Backend {
       channel->unregisterAbortHook(hook_id);
     }
   }
-  bool supportsCompletionHooks() const override {
-    return primary_->supportsCompletionHooks();
-  }
   void registerCompletionHook(int64_t hook_id, CompletionHook hook) override {
     completion_hooks_.emplace(hook_id, hook);
     primary_->registerCompletionHook(hook_id, hook);
@@ -346,9 +348,6 @@ class LazyBackend : public Backend {
 
   // Reconfigure: the primary reconfigures in place; stale pair comms (built
   // for the previous membership) are aborted and rebuilt lazily on demand.
-  bool supportsReconfigure() const override {
-    return primary_->supportsReconfigure();
-  }
   ReconfigureHandle get_reconfigure_handle() const override {
     return primary_->get_reconfigure_handle();
   }
@@ -365,9 +364,6 @@ class LazyBackend : public Backend {
   }
 
   // ---- Splitting: split the collective (primary) comm only ----
-  bool supportsSplitting() const override {
-    return primary_->supportsSplitting();
-  }
   // Split just the primary comm; the child is a bare backend for the subgroup.
   // We deliberately don't split the P2P pair comms: like a reconfigure, they
   // encode the parent membership's global ranks and can't be carried into the

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -227,26 +227,8 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
       int srcRank,
       int tag) override;
 
-  bool supportsCoalescing() const override {
-    return true;
-  }
-  bool supportsTimeEstimation() const override {
-#ifdef NCCL_SIM_INFO_INITIALIZER
-    return true;
-#else
-    return false;
-#endif
-  }
-  bool supportsSplitting() const override {
-    return true;
-  }
-  bool supportsShrinking() const override {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
-    return true;
-#else
-    return false;
-#endif
-  }
+  // Out of line: the window capability needs a runtime ncclGetVersion check.
+  ::c10d::BackendCapabilities capabilities() const override;
   void startCoalescing() override;
   c10::intrusive_ptr<::c10d::Work> endCoalescing() override;
   void startTimeEstimate() override;
@@ -295,13 +277,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // current communicator generation (if any) and bootstraps a fresh ncclComm
   // over the surviving/new members. Implemented in
   // ReconfigureNCCL.cpp.
-  bool supportsReconfigure() const override {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
-    return true;
-#else
-    return false;
-#endif
-  }
   ::c10d::ReconfigureHandle get_reconfigure_handle() const override;
   c10::intrusive_ptr<::c10d::Work> reconfigure(
       const ::c10d::ReconfigureOptions& opts) override;
@@ -312,7 +287,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // registers each mempool segment with the communicator and WindowNCCL
   // lazily upgrades the segment to a collective NCCL_WIN_COLL_SYMMETRIC
   // window on first use. Requires NCCL 2.29+ at runtime.
-  bool supportsWindow() const override;
   c10::intrusive_ptr<::c10d::Window> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
 
@@ -339,15 +313,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // if it is not one already. Collective: all ranks must call it together.
   ncclResult_t ensureSegmentWindow(const void* ptr);
 
-  bool supportsAbortHooks() const override {
-    return true;
-  }
   void registerAbortHook(int64_t hook_id, ::c10d::AbortHook hook) override;
   void unregisterAbortHook(int64_t hook_id) override;
 
-  bool supportsCompletionHooks() const override {
-    return true;
-  }
   void registerCompletionHook(int64_t hook_id, ::c10d::CompletionHook hook)
       override;
   void unregisterCompletionHook(int64_t hook_id) override;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -382,14 +382,31 @@ c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
   return window;
 }
 
-bool ProcessGroupNCCL::supportsWindow() const {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0) && !defined(USE_ROCM)
-  int runtime_version = 0;
-  return ncclGetVersion(&runtime_version) == ncclSuccess &&
-      runtime_version >= NCCL_VERSION(2, 29, 0);
-#else
-  return false;
+::c10d::BackendCapabilities ProcessGroupNCCL::capabilities() const {
+  ::c10d::BackendCapabilities caps = {
+      ::c10d::BackendCapability::Coalescing,
+      ::c10d::BackendCapability::Splitting,
+      ::c10d::BackendCapability::AbortHooks,
+      ::c10d::BackendCapability::CompletionHooks};
+#ifdef NCCL_SIM_INFO_INITIALIZER
+  caps |= ::c10d::BackendCapability::TimeEstimation;
 #endif
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+  caps |= ::c10d::BackendCapability::Shrinking;
+#endif
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
+  caps |= ::c10d::BackendCapability::Reconfigure;
+#endif
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0) && !defined(USE_ROCM)
+  // Windows additionally need the runtime NCCL to be new enough, not just the
+  // headers we compiled against.
+  int runtime_version = 0;
+  caps.set(
+      ::c10d::BackendCapability::Window,
+      ncclGetVersion(&runtime_version) == ncclSuccess &&
+          runtime_version >= NCCL_VERSION(2, 29, 0));
+#endif
+  return caps;
 }
 
 // ---------------------------------------------------------------------------

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLLazy.hpp
@@ -36,8 +36,12 @@ class TORCH_API ProcessGroupNCCLLazy
     return std::string(kBackendName);
   }
 
-  bool supportsReconfigure() const override {
-    return false;
+  // Reconfigure is deliberately dropped: the wrapper would otherwise forward
+  // the primary's support, but the pair comms cannot be carried across one.
+  ::c10d::BackendCapabilities capabilities() const override {
+    auto caps = ::c10d::LazyBackend<ProcessGroupNCCL>::capabilities();
+    caps.set(::c10d::BackendCapability::Reconfigure, false);
+    return caps;
   }
 
   ::c10d::ReconfigureHandle get_reconfigure_handle() const override {

--- a/torch/csrc/distributed/c10d/py/PyBackend.hpp
+++ b/torch/csrc/distributed/c10d/py/PyBackend.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <iterator>
+#include <utility>
+
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/py/PyProcessGroup.hpp>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -361,35 +364,29 @@ class PyBackend : public Backend {
   // These are bound as def_property_readonly, so Python subclasses override
   // them with @property. get_override won't find @property descriptors, so
   // we use py::getattr to access them through normal Python attribute
-  // resolution, which handles both @property and regular methods.
+  // resolution, which handles both @property and regular methods. Each
+  // capability keeps its own Python property; only the C++ side is bundled.
 
-  bool supportsSplitting() const override {
-    return getPropertyOverride(
-        "supports_splitting", Backend::supportsSplitting());
-  }
-
-  bool supportsCoalescing() const override {
-    return getPropertyOverride(
-        "supports_coalescing", Backend::supportsCoalescing());
-  }
-
-  bool supportsTimeEstimation() const override {
-    return getPropertyOverride(
-        "_supports_time_estimate", Backend::supportsTimeEstimation());
-  }
-
-  bool supportsShrinking() const override {
-    return getPropertyOverride(
-        "supports_shrinking", Backend::supportsShrinking());
-  }
-
-  bool supportsReconfigure() const override {
-    return getPropertyOverride(
-        "supports_reconfigure", Backend::supportsReconfigure());
-  }
-
-  bool supportsWindow() const override {
-    return getPropertyOverride("supports_window", Backend::supportsWindow());
+  BackendCapabilities capabilities() const override {
+    static constexpr std::pair<BackendCapability, const char*> kProperties[] = {
+        {BackendCapability::Splitting, "supports_splitting"},
+        {BackendCapability::Coalescing, "supports_coalescing"},
+        {BackendCapability::TimeEstimation, "_supports_time_estimate"},
+        {BackendCapability::Shrinking, "supports_shrinking"},
+        {BackendCapability::Reconfigure, "supports_reconfigure"},
+        {BackendCapability::Window, "supports_window"},
+        {BackendCapability::AbortHooks, "supports_abort_hooks"},
+        {BackendCapability::CompletionHooks, "supports_completion_hooks"},
+    };
+    static_assert(
+        std::size(kProperties) == kNumBackendCapabilities,
+        "every BackendCapability needs a Python property name here");
+    pybind11::gil_scoped_acquire gil;
+    BackendCapabilities caps = Backend::capabilities();
+    for (const auto& [cap, name] : kProperties) {
+      caps.set(cap, getPropertyOverride(name, caps.has(cap)));
+    }
+    return caps;
   }
 
   bool supportsTensorAlloc(c10::DeviceIndex deviceIdx) override {
@@ -519,13 +516,22 @@ class PyBackend : public Backend {
     pybind11::gil_scoped_acquire gil;
     auto self = pybind11::cast(this);
     auto cls = pybind11::type::of(self);
-    if (pybind11::hasattr(cls, name)) {
-      auto attr = cls.attr(name);
-      if (!pybind11::isinstance<pybind11::cpp_function>(attr)) {
-        return pybind11::getattr(self, name).cast<bool>();
-      }
+    if (!pybind11::hasattr(cls, name)) {
+      return defaultValue;
     }
-    return defaultValue;
+    auto attr = cls.attr(name);
+    if (pybind11::isinstance<pybind11::cpp_function>(attr)) {
+      return defaultValue;
+    }
+    // If the attribute resolves to the very same object Backend itself binds,
+    // the subclass did not override it and we merely inherited the C++
+    // def_property_readonly. Reading it would call straight back into this
+    // Backend and recurse until the stack runs out.
+    auto base = pybind11::type::of<Backend>();
+    if (pybind11::hasattr(base, name) && attr.is(base.attr(name))) {
+      return defaultValue;
+    }
+    return pybind11::getattr(self, name).cast<bool>();
   }
 };
 


### PR DESCRIPTION
`c10d::Backend` advertised six static capabilities (splitting, coalescing, time estimation, shrinking, reconfigure, window) through one `const` virtual each. The set only grows, and every addition requires a new virtual flag. Replace them with a single `capabilities()` virtual returning a bitset that can carry all info in one container.

## Design notes:

The `supportsX()` names survive as non-virtual inline accessors over the bitset. This is what keeps the change small: all ~30 call sites and every pybind11 binding are untouched, because `def_property_readonly` takes a pointer-to-member and does not care that the target stopped being virtual. The diff is confined to the definitions.

`BackendCapabilities` wraps `std::bitset<BackendCapability::COUNT>`. A raw `uint64_t` wrapper was the other candidate and has direct precedent in `c10::DispatchKeySet`, which solves this same problem the same way. Both generate identical code -- `supportsWindow()` is a load plus a single-bit extract, and a `capabilities()` override folds to one immediate -- so the standard type won on familiarity. The catch is that std::bitset's mutating members (`set`, `operator|=`, `test`) are not constexpr until C++23 and libstdc++ has not shipped that yet, while its unsigned-long-long constructor and const `operator[]` are constexpr today. Compile-time sets are therefore assembled as a raw mask and handed to the bitset once, and always read back through `operator[]`; the header says so, because the natural-looking alternative silently fails to compile.

`supportsTensorAlloc(DeviceIndex)` deliberately stays a virtual. It is parameterized by device, so it is a per-device query rather than a static capability and does not belong in the set.

The `COUNT` sentinel gives a compile-time capability count, which lets PyBackend static_assert that its capability-to-Python-property table is exhaustive: adding a capability without wiring up its property is now a build failure instead of a silent False.

Two behavioural consequences fall out of bundling.

ProcessGroupWrapper forwarded only four of the six, silently dropping reconfigure and window under TORCH_DISTRIBUTED_DEBUG=DETAIL -- exactly the class of bug its own header warns about (#173538). With one method to forward, partial forwarding is no longer expressible. LazyBackend's partial forwarding, by contrast, is intentional (it does not route time estimation or shrinking to the primary), so it is preserved explicitly as a mask rather than silently widened.

This also fixes an unrelated crash that the refactor forced into the open. PyBackend::getPropertyOverride asked `hasattr(cls, name)` to decide whether a Python subclass overrode a capability. When the subclass did not define it, that lookup resolved to the property inherited from Backend's own pybind11 binding; reading it re-entered PyBackend and recursed until the stack ran out. This reproduces on an unmodified tree, but only for capabilities a subclass omits, so it stayed latent -- both in-tree Python backends define all six. Reading the whole set on every query would have turned it from a rare edge case into a crash for essentially any partially-specified Python backend, so it had to be fixed here. The fix is to treat an attribute that is identity-equal to Backend's own bound property as "not overridden".

Note for Python backend authors: querying any one capability now evaluates all six properties, so an exception from an unrelated capability property surfaces from an unrelated query. Caching the bitset on first read would avoid this and is consistent with capabilities being fixed for a backend's lifetime, but it would change the contract to read-once, so it is left out.

Out-of-tree backends overriding a `supportsX()` with `override` get a clean compile error. One written without `override` would silently shadow instead, so a C10D_BACKEND_HAS_CAPABILITIES feature macro is provided for #ifdef guards, matching the existing convention in that header.

Review in this order: Backend.hpp for the new type and the accessors, then ProcessGroup.hpp which gets the same treatment for its own two forwarding virtuals, then the backends (Gloo, NCCL, nccl2, Fake) which are mechanical, then ProcessGroupWrapper and LazyBackend for the forwarding semantics, and finally PyBackend.hpp for the trampoline and the recursion fix.

Test Plan:

Built and tested on 2x GB200 (aarch64, CUDA 13, NCCL 2.29.7):

```
pip install -e . -v --no-build-isolation
```

```
python -m pytest -q test/distributed/test_c10d_pybackend.py
python -m pytest -q test/distributed/test_c10d_pypg.py
python -m pytest -q test/distributed/test_fake_pg.py
python -m pytest -q test/distributed/test_pg_wrapper.py
python -m pytest -q test/distributed/test_c10d_window.py
python -m pytest -q test/distributed/test_c10d_fault_tolerance.py
python -m pytest -q test/inductor/test_comm_analysis.py
```

___

Authored with the assistance of Claude Code.