### PR TITLE
Use STD_TORCH_CHECK in the vec quant, float and half headers (#193025)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -11,6 +11,7 @@
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
 #include <c10/util/quint8.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include <array>
 #include <cmath>
@@ -77,7 +78,7 @@ inline __m256i pack_saturate_and_clamp<int32_t>(
     int32_t /*min_val*/,
     int32_t /*max_val*/) {
   // This function is for linkage only, will not be used
-  TORCH_CHECK(false, "pack_saturate_and_clamp<int32_t> is not supported");
+  STD_TORCH_CHECK(false, "pack_saturate_and_clamp<int32_t> is not supported");
 }
 
 template <>

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include <limits>
 
@@ -1478,7 +1479,7 @@ inline void transpose_mxn<BFloat16>(
     int M,
     int N) {
   // load from src
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       M <= 32 && N <= 32, "transpose_mxn<BFloat16> expects M, N <= 32.");
   __m512i r[32];
   int i;
@@ -1536,7 +1537,8 @@ inline void transpose_mxn<Half>(
     int64_t ld_dst,
     int M,
     int N) {
-  TORCH_CHECK(M <= 32 && N <= 32, "transpose_mxn<Half> expects M, N <= 32.");
+  STD_TORCH_CHECK(
+      M <= 32 && N <= 32, "transpose_mxn<Half> expects M, N <= 32.");
   // load from src
   __m512i r[32];
   int i;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/util/irange.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include <limits>
 #if defined(CPU_CAPABILITY_AVX512)
@@ -792,7 +793,7 @@ inline void transpose_block(
     at::vec::VectorizedN<float, 16>& input,
     int M = 16,
     int N = 16) {
-  TORCH_CHECK(M <= 16 && N <= 16, "transpose_block expects M, N <= 16.");
+  STD_TORCH_CHECK(M <= 16 && N <= 16, "transpose_block expects M, N <= 16.");
   // unpacking and interleaving 32-bit elements
   __m512 temp[16];
   int i;
@@ -857,7 +858,8 @@ inline void transpose_mxn_16x16(
     int64_t ld_dst,
     int M,
     int N) {
-  TORCH_CHECK(M <= 16 && N <= 16, "transpose_mxn<float> expects M, N <= 16.");
+  STD_TORCH_CHECK(
+      M <= 16 && N <= 16, "transpose_mxn<float> expects M, N <= 16.");
   // load from src to registers
   at::vec::VectorizedN<float, 16> input;
   int i;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -11,6 +11,7 @@
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
 #include <c10/util/quint8.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include <array>
 #include <cmath>
@@ -78,7 +79,7 @@ inline __m512i pack_saturate_and_clamp<int32_t>(
     int32_t min_val [[maybe_unused]],
     int32_t max_val [[maybe_unused]]) {
   // This function is for linkage only, will not be used
-  TORCH_CHECK(false, "pack_saturate_and_clamp<int32_t> is not supported");
+  STD_TORCH_CHECK(false, "pack_saturate_and_clamp<int32_t> is not supported");
   return __m512i{};
 }
 

--- a/aten/src/ATen/cpu/vec/vec_half.h
+++ b/aten/src/ATen/cpu/vec/vec_half.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/cpu/vec/intrinsics.h>
-#include <c10/util/Exception.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include <torch/headeronly/cpu/vec/vec_half.h>
 
@@ -65,7 +65,7 @@ static inline void transpose_pad_2x32_block(
     _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst + 32), d1);
   }
 #else
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       false,
       "transpose_pad_2x32_block is only supported when avx512 is supported")
 #endif
@@ -110,7 +110,8 @@ static inline void pack_vnni2(
     }
   }
 #else
-  TORCH_CHECK(false, "pack_vnni2 is only supported when avx512 is supported")
+  STD_TORCH_CHECK(
+      false, "pack_vnni2 is only supported when avx512 is supported")
 #endif
 }
 

--- a/aten/src/ATen/cpu/vec/vec_quant.h
+++ b/aten/src/ATen/cpu/vec/vec_quant.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/cpu/vec/intrinsics.h>
-#include <c10/util/Exception.h>
+#include <torch/headeronly/util/Exception.h>
 
 namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
@@ -99,7 +99,7 @@ static inline void transpose_pad_4x64_block(
     _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst + 64 * 3), r3);
   }
 #else
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       false,
       "transpose_pad_4x64_block is only supported when AVX-512 is supported")
 #endif
@@ -145,7 +145,8 @@ static inline void pack_vnni4(
     }
   }
 #else
-  TORCH_CHECK(false, "pack_vnni4 is only supported when AVX-512 is supported")
+  STD_TORCH_CHECK(
+      false, "pack_vnni4 is only supported when AVX-512 is supported")
 #endif
 }
 
@@ -206,7 +207,7 @@ static inline void transpose_vnni4_pad_4x16_block(
         reinterpret_cast<__m128i*>(dst + ld_dst * 3), mask, r3);
   }
 #else
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       false,
       "transpose_vnni4_pad_4x16_block is only supported when AVX-512 is supported")
 #endif
@@ -222,7 +223,7 @@ static inline void transpose_pack_vnni4(
     int64_t K,
     int64_t N) {
 #if defined(CPU_CAPABILITY_AVX512)
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       N % 16 == 0, "N needs to be multiple of 16 for transpose_pack_vnni4");
   int64_t bk = 0;
   int64_t _K = K / 4 * 4;
@@ -244,7 +245,7 @@ static inline void transpose_pack_vnni4(
     }
   }
 #else
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       false, "transpose_pack_vnni4 is only supported when AVX-512 is supported")
 #endif
 }


### PR DESCRIPTION
Summary:

Second of three changes converting ATen's vec headers off TORCH_CHECK, so
ExecuTorch can stop defining STANDALONE_TORCH_HEADER. That flag gives
TORCH_CHECK two different expansions, which leaves a binary linking both
libtorch and ExecuTorch with two definitions of every header-inline function
that uses it.

13 sites across vec_quant.h, vec_half.h, vec512_float.h, vec512_bfloat16.h and
the two qint headers. All are unsupported-configuration or bad-shape
rejections, so the only behavioural difference is the exception type:
std::runtime_error instead of c10::Error, both of which surface as
RuntimeError in Python.

vec_quant.h and vec_half.h included c10/util/Exception.h for nothing but
TORCH_CHECK, so those become the torch/headeronly include. The rest were
picking TORCH_CHECK up transitively and now include it directly.

STD_TORCH_CHECK was suggested by janeyx99 in review of
https://github.com/pytorch/pytorch/pull/192264, an earlier attempt at the
same ODR problem that tried to make c10::Error itself header-only. That PR
was dismissed; this series takes the suggested approach instead.

Test Plan:
- ATen CPU, the AVX2 kernels and ExecuTorch's optimized kernels build
  unchanged.
- Also compiled with -DCPU_CAPABILITY_AVX512, which is where most of these
  paths live; every translation unit compiles. That configuration was compiled
  but not linked.

Differential Revision: D115044091


