### PR TITLE
[inductor] Remove dead fast path and double copy in eager_force_stride

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -348,6 +348,23 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
     def test_mul_complex(self):
         prims.mul(torch.randn(2), 1 + 1j)
 
+    def test_inductor_force_stride_order_eager_single_copy(self):
+        import torch._inductor.inductor_prims
+        from torch.profiler import ProfilerActivity, profile
+
+        x = torch.randn(4, 8)
+        for stride in (x.stride(), (1, 4)):
+            out = torch.ops.prims.inductor_force_stride_order.default(x, stride)
+            self.assertEqual(out.stride(), stride)
+            self.assertEqual(out, x)
+            # functional op: the output may not alias the input even when strides match
+            self.assertNotEqual(out.data_ptr(), x.data_ptr())
+
+        with profile(activities=[ProfilerActivity.CPU]) as prof:
+            torch.ops.prims.inductor_force_stride_order.default(x, x.stride())
+        ops = {e.key for e in prof.key_averages()}
+        self.assertNotIn("aten::clone", ops)
+
     def test_clone_complex(self):
         with torch._dispatch.python.enable_python_dispatcher():
             x = torch.randn(4, dtype=torch.complex64, device='meta').conj()

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -7,7 +7,7 @@ import unittest
 import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (parametrize, run_tests, TestCase, TEST_SCIPY,
-                                                  set_default_dtype)
+                                                  set_default_dtype, skipIfTorchDynamo)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -348,6 +348,7 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
     def test_mul_complex(self):
         prims.mul(torch.randn(2), 1 + 1j)
 
+    @skipIfTorchDynamo("tests the eager impl of the prim; dynamo/inductor take the lowering")
     def test_inductor_force_stride_order_eager_single_copy(self):
         import torch._inductor.inductor_prims
         from torch.profiler import ProfilerActivity, profile
@@ -362,8 +363,11 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
 
         with profile(activities=[ProfilerActivity.CPU]) as prof:
             torch.ops.prims.inductor_force_stride_order.default(x, x.stride())
-        ops = {e.key for e in prof.key_averages()}
-        self.assertNotIn("aten::clone", ops)
+        counts = {e.key: e.count for e in prof.key_averages()}
+        self.assertNotIn("aten::clone", counts)
+        # 2, not 1: _prim_impl runs impl_aten a second time for meta validation,
+        # so one dispatch executes the impl twice, each doing a single copy_
+        self.assertEqual(counts.get("aten::copy_", 0), 2)
 
     def test_clone_complex(self):
         with torch._dispatch.python.enable_python_dispatcher():

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -49,12 +49,7 @@ def eager_force_stride(input_tensor: Tensor, stride) -> Tensor:
     # A copy is mandatory even when input_tensor already has the requested
     # stride: the op is registered as a functional custom op, so returning
     # the input would trip the library-level aliasing check.
-    new_tensor = torch.empty_strided(
-        input_tensor.shape,
-        stride,
-        dtype=input_tensor.dtype,
-        device=input_tensor.device,
-    )
+    new_tensor = input_tensor.new_empty_strided(input_tensor.shape, stride)
     new_tensor.copy_(input_tensor)
     return new_tensor
 
@@ -198,7 +193,11 @@ rand_eager_offsets = _prims._make_prim(
 force_stride_order = make_prim(
     "inductor_force_stride_order(Tensor input, SymInt[] stride) -> Tensor",
     eager_force_stride,
-    doc="Force the stride order for input tensor. No-op if the input tensor already has the stride. Do a copy otherwise",
+    doc=(
+        "Force the stride order for input tensor. The eager impl always "
+        "copies (the op is functional); the inductor lowering is a no-op "
+        "when the strides already match"
+    ),
 )
 _unsafe_index_put_ = make_prim(
     "_unsafe_index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)",

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -46,11 +46,14 @@ def make_prim(
 
 
 def eager_force_stride(input_tensor: Tensor, stride) -> Tensor:
-    if input_tensor.stride() == stride:
-        return input_tensor
-    new_tensor = input_tensor.clone().as_strided(
+    # A copy is mandatory even when input_tensor already has the requested
+    # stride: the op is registered as a functional custom op, so returning
+    # the input would trip the library-level aliasing check.
+    new_tensor = torch.empty_strided(
         input_tensor.shape,
         stride,
+        dtype=input_tensor.dtype,
+        device=input_tensor.device,
     )
     new_tensor.copy_(input_tensor)
     return new_tensor


### PR DESCRIPTION
The eager implementation of `prims.inductor_force_stride_order` (inserted by the post-grad `micro_pipeline_tp_pass` and by freezing) carries a stride-match fast path that is dead code, and its fallback pays two full copies per call. This PR removes the fast path and reduces the copy to a single one.

### Dead (and unfixable) fast path

`eager_force_stride` intended to return the input unchanged when it already has the requested stride:

- It never fires: through the dispatcher the `SymInt[]` argument is materialized as a Python `list`, while `Tensor.stride()` is a `tuple`, so the comparison is always `False`.
- It also must not fire: the op is registered as a functional custom op (via `torch.library.custom_op` in `_make_prim`), so an output that aliases the input trips the library-level aliasing check (`_c_check_aliasing_constraint`) at runtime. "Repairing" the comparison would make the op raise instead of getting faster.
- No caller can bypass this: the only references to `eager_force_stride` are its definition and the `make_prim` wiring, so every path to the impl goes through the dispatcher and the fast path is unreachable everywhere.

Keeping it around is a trap for the next person to touch this function, so remove it and document the constraint in a comment.

### Double copy

The fallback did `clone()` (a full copy into the *source* layout) followed by `copy_()` through an `as_strided` view (a second full copy that overwrites everything the clone wrote — the cloned data is never read). Replace it with `empty_strided()` + a single `copy_()`.

Under `torch.compile` none of this runs (the op has its own inductor lowering). The eager impl runs when a post-grad graph executes eagerly, e.g. minifier/accuracy repros, or consuming `micro_pipeline_tp_pass` output outside inductor. Measured with the CPU profiler, one eager dispatch goes from `aten::clone` ×2 + `aten::copy_` ×4 to `aten::copy_` ×2 (each op appears twice because `_prim_impl` also runs the ATen impl once inside its meta-validation call).

### Test

`test/test_prims.py::TestPrimsBasic::test_inductor_force_stride_order_eager_single_copy` checks values and strides for matching and non-matching target strides, asserts the output never aliases the input (pinning the functional contract), and asserts via the profiler that no `aten::clone` is issued. The profiler assertion fails on the previous implementation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @shunting314
