### PR TITLE
[TEST] Refactor test_importer.py with hw_classification

### DIFF
--- a/test/package/test_importer.py
+++ b/test/package/test_importer.py
@@ -10,7 +10,7 @@ from torch.package import (
     PackageImporter,
     sys_importer,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -22,6 +22,8 @@ except ImportError:
 
 class TestImporter(PackageTestCase):
     """Tests for Importer and derived classes."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_sys_importer(self):
         import package_a


### PR DESCRIPTION
## Summary
- Annotate `TestImporter` with `hw_classification = HardwareClassification.GENERIC`
- Package importer tests are device-agnostic (no device-type instantiation)

## Test plan
- `python test/package/test_importer.py -v`

Authored with an AI assistant.