### PR TITLE
Fix pre-existing bugs in the fused/foreach optimizer tests

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1044,19 +1044,17 @@ class TestOptimRenewed(TestCase):
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
             params = [torch.ones(numel, device=device, dtype=dtype)]
-            params[0].grad = torch.rand_like(params[0])
-            grads = (params[0].grad[0].item(), params[0].grad[-1].item())
+            params[0].grad = torch.ones_like(params[0])
             optimizer = optim_cls(params, foreach=True, **optim_input.kwargs)
             optimizer.step()
 
-            # A size-1 param stepped with the same config and grad gives the expected
-            # value for one element. Distinct grads mean a 32-bit index overflow shows
-            # up whether it drops the tail or reads the wrong grad for it.
-            for idx, grad in zip((0, -1), grads):
-                ref = torch.ones(1, device=device, dtype=dtype)
-                ref.grad = torch.full_like(ref, grad)
-                optim_cls([ref], foreach=True, **optim_input.kwargs).step()
-                self.assertEqual(params[0][idx], ref[0])
+            # Every element saw the same param and grad, so they must all agree.
+            # Compare with a size 1 param for reference.
+            self.assertEqual(params[0].min(), params[0].max())
+            ref = torch.ones(1, device=device, dtype=dtype)
+            ref.grad = torch.ones_like(ref)
+            optim_cls([ref], foreach=True, **optim_input.kwargs).step()
+            self.assertEqual(params[0][0], ref[0])
 
     @onlyCUDA
     @optims(
@@ -1269,19 +1267,17 @@ class TestOptimRenewed(TestCase):
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
             params = [torch.ones(2**32, device=device, dtype=dtype)]
-            params[0].grad = torch.rand_like(params[0])
-            grads = (params[0].grad[0].item(), params[0].grad[-1].item())
+            params[0].grad = torch.ones_like(params[0])
             optimizer = optim_cls(params, fused=True, **optim_input.kwargs)
             optimizer.step()
 
-            # A size-1 param stepped with the same config and grad gives the expected
-            # value for one element. Distinct grads mean a 32-bit index overflow shows
-            # up whether it drops the tail or reads the wrong grad for it.
-            for idx, grad in zip((0, -1), grads):
-                ref = torch.ones(1, device=device, dtype=dtype)
-                ref.grad = torch.full_like(ref, grad)
-                optim_cls([ref], fused=True, **optim_input.kwargs).step()
-                self.assertEqual(params[0][idx], ref[0])
+            # Every element saw the same param and grad, so they must all agree; a
+            # size-1 param pins what that shared value should be.
+            self.assertEqual(params[0].min(), params[0].max())
+            ref = torch.ones(1, device=device, dtype=dtype)
+            ref.grad = torch.ones_like(ref)
+            optim_cls([ref], fused=True, **optim_input.kwargs).step()
+            self.assertEqual(params[0][0], ref[0])
 
     @skipMPS  # MPS fused optimizer does not properly handle found_inf
     @onlyAccelerator

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1025,15 +1025,6 @@ class TestOptimRenewed(TestCase):
             finally:
                 torch.set_default_dtype(old_default_dtype)
 
-    def _assert_large_tensor_matches_ref(self, optim_cls, param, optim_input, impl):
-        # A size-1 param stepped with the same config gives the expected value for
-        # every element, so a 32-bit index overflow shows up as the tail diverging.
-        ref = torch.ones(1, device=param.device, dtype=param.dtype)
-        ref.grad = torch.ones_like(ref)
-        optim_cls([ref], **{impl: True}, **optim_input.kwargs).step()
-        self.assertEqual(param[0], ref[0])
-        self.assertEqual(param[-1], ref[0])
-
     @onlyCUDA
     @largeTensorTest("72GB", "cuda")
     @serialTest()
@@ -1043,21 +1034,29 @@ class TestOptimRenewed(TestCase):
     )
     def test_foreach_large_tensor(self, device, dtype, optim_info):
         optim_cls = optim_info.optim_cls
-        if optim_cls.__name__ == "Adafactor":
-            # Adafactor scales by p.norm(2) / sqrt(p.numel()) computed in the param
-            # dtype. At 2**32 elements sqrt(numel) is 65536, just past the fp16 max
-            # of 65504, so the norm is inf and every param goes nan. Pre-existing:
-            # this test passed only because it asserted nothing.
-            self.skipTest("Adafactor overflows the fp16 norm at 2**32 elements")
+        # 2**32 is the uint32 wrap point: a numel narrowed to 32 bits becomes 0 and the
+        # kernel silently does nothing. Adafactor can't use it because it reduces over
+        # the whole param and update in the param dtype (p.norm(2), update.norm(2)),
+        # and at 2**32 unit-magnitude elements both norms are 65536, past the fp16 max
+        # of 65504, so they go inf and every param lands on nan. The backoff still
+        # clears INT32_MAX, so it keeps signed-overflow coverage but loses wrap-to-zero.
+        numel = 2**32 - 2**23 if optim_cls.__name__ == "Adafactor" else 2**32
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
-            params = [torch.ones(2**32, device=device, dtype=dtype)]
-            params[0].grad = torch.ones_like(params[0])
+            params = [torch.ones(numel, device=device, dtype=dtype)]
+            params[0].grad = torch.rand_like(params[0])
+            grads = (params[0].grad[0].item(), params[0].grad[-1].item())
             optimizer = optim_cls(params, foreach=True, **optim_input.kwargs)
             optimizer.step()
-            self._assert_large_tensor_matches_ref(
-                optim_cls, params[0], optim_input, "foreach"
-            )
+
+            # A size-1 param stepped with the same config and grad gives the expected
+            # value for one element. Distinct grads mean a 32-bit index overflow shows
+            # up whether it drops the tail or reads the wrong grad for it.
+            for idx, grad in zip((0, -1), grads):
+                ref = torch.ones(1, device=device, dtype=dtype)
+                ref.grad = torch.full_like(ref, grad)
+                optim_cls([ref], foreach=True, **optim_input.kwargs).step()
+                self.assertEqual(params[0][idx], ref[0])
 
     @onlyCUDA
     @optims(
@@ -1270,12 +1269,19 @@ class TestOptimRenewed(TestCase):
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
             params = [torch.ones(2**32, device=device, dtype=dtype)]
-            params[0].grad = torch.ones_like(params[0])
+            params[0].grad = torch.rand_like(params[0])
+            grads = (params[0].grad[0].item(), params[0].grad[-1].item())
             optimizer = optim_cls(params, fused=True, **optim_input.kwargs)
             optimizer.step()
-            self._assert_large_tensor_matches_ref(
-                optim_cls, params[0], optim_input, "fused"
-            )
+
+            # A size-1 param stepped with the same config and grad gives the expected
+            # value for one element. Distinct grads mean a 32-bit index overflow shows
+            # up whether it drops the tail or reads the wrong grad for it.
+            for idx, grad in zip((0, -1), grads):
+                ref = torch.ones(1, device=device, dtype=dtype)
+                ref.grad = torch.full_like(ref, grad)
+                optim_cls([ref], fused=True, **optim_input.kwargs).step()
+                self.assertEqual(params[0][idx], ref[0])
 
     @skipMPS  # MPS fused optimizer does not properly handle found_inf
     @onlyAccelerator

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1025,6 +1025,15 @@ class TestOptimRenewed(TestCase):
             finally:
                 torch.set_default_dtype(old_default_dtype)
 
+    def _assert_large_tensor_matches_ref(self, optim_cls, param, optim_input, impl):
+        # A size-1 param stepped with the same config gives the expected value for
+        # every element, so a 32-bit index overflow shows up as the tail diverging.
+        ref = torch.ones(1, device=param.device, dtype=param.dtype)
+        ref.grad = torch.ones_like(ref)
+        optim_cls([ref], **{impl: True}, **optim_input.kwargs).step()
+        self.assertEqual(param[0], ref[0])
+        self.assertEqual(param[-1], ref[0])
+
     @onlyCUDA
     @largeTensorTest("72GB", "cuda")
     @serialTest()
@@ -1034,12 +1043,21 @@ class TestOptimRenewed(TestCase):
     )
     def test_foreach_large_tensor(self, device, dtype, optim_info):
         optim_cls = optim_info.optim_cls
+        if optim_cls.__name__ == "Adafactor":
+            # Adafactor scales by p.norm(2) / sqrt(p.numel()) computed in the param
+            # dtype. At 2**32 elements sqrt(numel) is 65536, just past the fp16 max
+            # of 65504, so the norm is inf and every param goes nan. Pre-existing:
+            # this test passed only because it asserted nothing.
+            self.skipTest("Adafactor overflows the fp16 norm at 2**32 elements")
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
             params = [torch.ones(2**32, device=device, dtype=dtype)]
-            params[0].grad = torch.zeros_like(params[0])
+            params[0].grad = torch.ones_like(params[0])
             optimizer = optim_cls(params, foreach=True, **optim_input.kwargs)
             optimizer.step()
+            self._assert_large_tensor_matches_ref(
+                optim_cls, params[0], optim_input, "foreach"
+            )
 
     @onlyCUDA
     @optims(
@@ -1244,7 +1262,7 @@ class TestOptimRenewed(TestCase):
         dtypes=[torch.float16],
     )
     def test_fused_large_tensor(self, device, dtype, optim_info):
-        if device not in optim_info.supports_fused_on:
+        if _get_device_type(device) not in optim_info.supports_fused_on:
             self.skipTest(
                 f"{device} is not supported for fused on {optim_info.optim_cls.__name__}"
             )
@@ -1252,9 +1270,12 @@ class TestOptimRenewed(TestCase):
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
             params = [torch.ones(2**32, device=device, dtype=dtype)]
-            params[0].grad = torch.zeros_like(params[0])
+            params[0].grad = torch.ones_like(params[0])
             optimizer = optim_cls(params, fused=True, **optim_input.kwargs)
             optimizer.step()
+            self._assert_large_tensor_matches_ref(
+                optim_cls, params[0], optim_input, "fused"
+            )
 
     @skipMPS  # MPS fused optimizer does not properly handle found_inf
     @onlyAccelerator
@@ -2382,7 +2403,7 @@ class TestOptimRenewed(TestCase):
         for optim_input in optim_inputs:
             inpts, models, optimizers = [], [], []
             for dev in ("cpu", _get_device_type(device)):
-                kwargs = optim_input.kwargs
+                kwargs = deepcopy(optim_input.kwargs)
                 kwargs["fused"] = True
                 inpt = torch.tensor(
                     [0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=dtype, device=dev
@@ -2410,7 +2431,7 @@ class TestOptimRenewed(TestCase):
                 inpts.append(inpt)
                 models.append(model)
                 optimizers.append(optimizer)
-        self._compare_between(inpts, models, optimizers)
+            self._compare_between(inpts, models, optimizers)
 
     @onlyCUDA
     @optims(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1034,12 +1034,18 @@ class TestOptimRenewed(TestCase):
     )
     def test_foreach_large_tensor(self, device, dtype, optim_info):
         optim_cls = optim_info.optim_cls
-        # 2**32 is the uint32 wrap point: a numel narrowed to 32 bits becomes 0 and the
-        # kernel silently does nothing. Adafactor can't use it because it reduces over
-        # the whole param and update in the param dtype (p.norm(2), update.norm(2)),
-        # and at 2**32 unit-magnitude elements both norms are 65536, past the fp16 max
-        # of 65504, so they go inf and every param lands on nan. The backoff still
-        # clears INT32_MAX, so it keeps signed-overflow coverage but loses wrap-to-zero.
+        # Why 2**32? 2 reasons.
+        # 1. if numel gets narrowed to 32 bits for uint32, it becomes 0, and the
+        # kernel silently does nothing
+        # 2. if it gets narrowed to int32 (much smaller max), it will be negative
+        # and the kernel may also silently do nothing
+        # This test makes sure that we do not hit either of these by accident.
+        #
+        # However, we use a smaller number for Adafactor as it reduces over the whole
+        # param and update in the param dtype (p.norm(2), update.norm(2)), and at 2**32
+        # unit-magnitude elements both norms are 65536, past the fp16 max of 65504, so
+        # they become inf and every param ends up nan. The smaller value will prevent
+        # situation 2 only, but that's better than skipping the test.
         numel = 2**32 - 2**23 if optim_cls.__name__ == "Adafactor" else 2**32
         optim_inputs = optim_info.optim_inputs_func(device=device)
         for optim_input in optim_inputs:
@@ -1271,8 +1277,8 @@ class TestOptimRenewed(TestCase):
             optimizer = optim_cls(params, fused=True, **optim_input.kwargs)
             optimizer.step()
 
-            # Every element saw the same param and grad, so they must all agree; a
-            # size-1 param pins what that shared value should be.
+            # Every element saw the same param and grad, so they must all agree.
+            # Compare with a size 1 param for reference.
             self.assertEqual(params[0].min(), params[0].max())
             ref = torch.ones(1, device=device, dtype=dtype)
             ref.grad = torch.ones_like(ref)


### PR DESCRIPTION
This PR hardens a few optim tests:
1. it makes the large tensor tests actually test something
2. it fixes pre-existing bad indent and a typo'd device filter

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #193030

**Claude description of what happened in detail:**

test_fused_cpu_matches_device called _compare_between outside its optim_input
loop, so only the last configuration was ever compared, and it aliased
optim_input.kwargs instead of copying it. Move the call inside the loop and
deepcopy the kwargs.

test_fused_large_tensor checked `device` rather than _get_device_type(device)
against supports_fused_on. Device-generic tests get "cuda:0", which is never in
that set, so the test has been unconditionally skipping on CUDA.

Both large-tensor tests used zero grads and asserted nothing, so they only
checked that a 2**32-element step does not crash. Give them nonzero grads and
assert that every element agrees, then that the shared value matches a size-1
param stepped with the same config. Since every element starts identical and
sees an identical grad, min == max covers the whole tensor rather than a
sampled index, and the size-1 param supplies the expected value.

Adafactor needs a smaller tensor: it reduces over the whole param and update in
the param dtype, and at 2**32 unit-magnitude elements those norms exceed the
fp16 max and everything goes nan. 2**32 - 2**23 still clears INT32_MAX.

Test Plan:

```
(pytorch-3.13) ➜  pytorch git:(fix-191763) ✗ python test/test_optim.py -k large_tensor -k test_fused_cpu_matches_device                             
/home/janeyx/.conda/envs/pytorch-3.13/lib/python3.13/site-packages/hypothesis/entry_points.py:23: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
/home/janeyx/repos/pytorch/torch/testing/_internal/common_device_type.py:783: UserWarning: PyTorch was compiled without cuDNN/MIOpen support. To use cuDNN/MIOpen, rebuild PyTorch making sure the library is visible to the build system.
  cls.no_cudnn = not torch.backends.cudnn.is_acceptable(t)
/home/janeyx/repos/pytorch/torch/testing/_internal/common_device_type.py:783: UserWarning: PyTorch was compiled without cuDNN/MIOpen support. To use cuDNN/MIOpen, rebuild PyTorch making sure the library is visible to the build system.
  cls.no_cudnn = not torch.backends.cudnn.is_acceptable(t)
ssssssssssssssssssssssssssss..........s.........................
----------------------------------------------------------------------
Ran 64 tests in 81.392s

OK (skipped=29)
```

Authored with assistance from Claude Code.