### PR TITLE
Fix b200 smoke test mlir helper failure

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -277,6 +277,16 @@ class TestFlexGemmRuntimeImport(TestCase):
 
 @instantiate_parametrized_tests
 class TestFlexGemmRuntimeHelpers(TestCase):
+    def test_clamp_codegen_uses_public_cutlass_api(self):
+        from torch._inductor.kernel.flex_gemm.fx_cutedsl_codegen import (
+            FlexGemmCuteDSLOpOverrides,
+        )
+
+        self.assertEqual(
+            FlexGemmCuteDSLOpOverrides.clamp("x", "lower", "upper"),
+            "cutlass.min(cutlass.max(x, lower), upper)",
+        )
+
     @parametrize(
         "reduction_type",
         get_args(ReductionType),
@@ -6352,14 +6362,14 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         )
 
         self.assertTrue(torch.isnan(actual).all())
-        check = FileCheck().check("cutlass_math.")
+        check = FileCheck()
         match case:
             case "clamp":
-                check = check.check("max").check("cutlass_math.min")
+                check = check.check("cutlass.max").check("cutlass.min")
             case "clamp_min":
-                check = check.check("max")
+                check = check.check("cutlass.max")
             case "clamp_max":
-                check = check.check("min")
+                check = check.check("cutlass.min")
         check.check_not("operator.ne").run(code)
 
     @skipIfNoCuteDSL

--- a/torch/_inductor/kernel/flex_gemm/fx_cutedsl_codegen.py
+++ b/torch/_inductor/kernel/flex_gemm/fx_cutedsl_codegen.py
@@ -157,7 +157,7 @@ class FlexGemmCuteDSLOpOverrides(GemmEpilogueCuteDSLOpOverrides):
         return GemmEpilogueCuteDSLOpOverrides._apply_binary_op(
             x,
             min,
-            "cutlass_math.max({a}, {b}, propagate_nan=True)",
+            "cutlass.max({a}, {b})",
             Max,
         )
 
@@ -166,7 +166,7 @@ class FlexGemmCuteDSLOpOverrides(GemmEpilogueCuteDSLOpOverrides):
         return GemmEpilogueCuteDSLOpOverrides._apply_binary_op(
             x,
             max,
-            "cutlass_math.min({a}, {b}, propagate_nan=True)",
+            "cutlass.min({a}, {b})",
             Min,
         )
 
@@ -1132,7 +1132,6 @@ class FlexGemmEpilogueEmitter:
             "import cutlass.cute as cute\n"
             "import operator\n"
             "from cutlass._mlir.dialects import math as mlir_math\n"
-            "from cutlass._mlir_helpers import math as cutlass_math\n"
             "from torch._inductor.codegen.cutedsl._inline_asm import (\n"
             "    inline_asm_elementwise_intrinsic,\n"
             ")\n\n"


### PR DESCRIPTION
b200 smoke tests install an older cutlass DSL package which has a different import name, this is a semantics-preserving change to make flex gemm backwards compatible

> AI-assisted analysis:
>
> The B200 smoke tests install CUTLASS DSL 4.5.2, but FlexGEMM clamp codegen imports `cutlass._mlir_helpers`, which exists only in newer packages. Generated kernels therefore fail before compilation.
>
> This switches clamp codegen to the public `cutlass.min` and `cutlass.max` APIs. In 4.5.2 these lower to the same NaN-propagating MLIR operations, preserving semantics.
>
> A CPU codegen regression locks in the public spelling, while the existing GB200 tests cover `clamp`, `clamp_min`, `clamp_max`, and NaN propagation.
>
> Test Plan:
>
> ```text
> spin quicklint
> git diff --check
> ```
>
> The focused CPU regression and all three GB200 clamp variants passed with CUTLASS DSL 4.5.2.
>
> Prepared with assistance from Codex.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo