### PR TITLE
Revert "[cuBLAS][cuBLASLt] Thread-local cuBLAS(Lt) workspace maps (#180283)"

### DIFF
--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -3,8 +3,7 @@
 
 #include <cstdint>
 #include <map>
-#include <unordered_map>
-#include <utility>
+#include <shared_mutex>
 
 #include <cuda_runtime_api.h>
 #include <cusparse.h>
@@ -26,7 +25,6 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/cuda/CUDAFunctions.h>
-#include <c10/util/hash.h>
 
 namespace c10 {
 struct Allocator;
@@ -90,18 +88,16 @@ TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API void clearCublasWorkspacesForStream(cudaStream_t stream);
+struct WorkspaceMapWithMutex {
+  std::map<std::tuple<void*, void*>, std::pair<at::DataPtr, size_t>> map;
+  std::shared_mutex mutex;
+};
 
-// Thread-local workspace map keyed by (device, stream).
-// No mutex is needed because cuBLAS handles are unique per thread
-// (guaranteed by DeviceThreadHandlePool), so each thread's workspace
-// map is only ever accessed by that thread.
-using WorkspaceMap = std::unordered_map<std::pair<int, void*>, std::pair<at::DataPtr, size_t>, c10::hash<std::pair<int, void*>>>;
-
-TORCH_CUDA_CPP_API WorkspaceMap& cublas_stream_to_workspace();
-TORCH_CUDA_CPP_API WorkspaceMap& cublaslt_stream_to_workspace();
+TORCH_CUDA_CPP_API WorkspaceMapWithMutex& cublas_handle_stream_to_workspace();
+TORCH_CUDA_CPP_API WorkspaceMapWithMutex& cublaslt_handle_stream_to_workspace();
+TORCH_CUDA_CPP_API size_t getChosenWorkspaceSize();
 TORCH_CUDA_CPP_API size_t getCUDABlasLtWorkspaceSize();
 TORCH_CUDA_CPP_API void* getCUDABlasLtWorkspace();
-TORCH_CUDA_CPP_API size_t getChosenWorkspaceSize();
 TORCH_CUDA_CPP_API void setChosenWorkspaceSize(size_t size);
 TORCH_CUDA_CPP_API void setCUDABlasLtWorkspaceSize(size_t size);
 TORCH_CUDA_CPP_API void resetChosenWorkspaceSize();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -8,8 +8,9 @@
 #include <map>
 #include <memory>
 #include <regex>
+#include <shared_mutex>
 #include <string>
-#include <utility>
+#include <tuple>
 
 #if defined(USE_ROCM)
 #include <rocblas/rocblas.h>
@@ -120,29 +121,45 @@ using CuBlasPoolType = DeviceThreadHandlePool<cublasHandle_t, createCublasHandle
 
 } // namespace
 
-WorkspaceMap& cublas_stream_to_workspace() {
-  thread_local WorkspaceMap instance;
+WorkspaceMapWithMutex& cublas_handle_stream_to_workspace() {
+  static auto& instance = *new WorkspaceMapWithMutex;
   return instance;
 }
 
-WorkspaceMap& cublaslt_stream_to_workspace() {
-  thread_local WorkspaceMap instance;
+WorkspaceMapWithMutex& cublaslt_handle_stream_to_workspace() {
+  static auto& instance = *new WorkspaceMapWithMutex;
   return instance;
 }
 
 void clearCublasWorkspaces() {
-  cublas_stream_to_workspace().clear();
-  cublaslt_stream_to_workspace().clear();
+  {
+    auto& workspace = cublas_handle_stream_to_workspace();
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    workspace.map.clear();
+  }
+  {
+    auto& workspace = cublaslt_handle_stream_to_workspace();
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    workspace.map.clear();
+  }
 }
 
 void clearCublasWorkspacesForStream(cudaStream_t stream) {
   void* stream_ptr = static_cast<void*>(stream);
-  std::erase_if(cublas_stream_to_workspace(), [stream_ptr](const auto& entry) {
-    return entry.first.second == stream_ptr;
-  });
-  std::erase_if(cublaslt_stream_to_workspace(), [stream_ptr](const auto& entry) {
-    return entry.first.second == stream_ptr;
-  });
+  {
+    auto& workspace = cublas_handle_stream_to_workspace();
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    std::erase_if(workspace.map, [stream_ptr](const auto& entry) {
+      return std::get<1>(entry.first) == stream_ptr;
+    });
+  }
+  {
+    auto& workspace = cublaslt_handle_stream_to_workspace();
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    std::erase_if(workspace.map, [stream_ptr](const auto& entry) {
+      return std::get<1>(entry.first) == stream_ptr;
+    });
+  }
 }
 
 size_t parseChosenWorkspaceSize() {
@@ -295,59 +312,96 @@ at::DataPtr getNewCUDABlasLtWorkspace() {
   return c10::cuda::CUDACachingAllocator::get()->allocate(getCUDABlasLtWorkspaceSize());
 }
 
-void setCublasWorkspace(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
-  c10::DeviceIndex device = stream.device_index();
+void setWorkspaceForHandle(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
   cudaStream_t _stream = stream;
-  auto key = std::make_pair(static_cast<int>(device), static_cast<void *>(_stream));
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
 
-  auto& workspace_map = cublas_stream_to_workspace();
+  auto& workspace = cublas_handle_stream_to_workspace();
 
   size_t workspace_size = getChosenWorkspaceSize();
 
-  auto workspace_it = workspace_map.find(key);
-  if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
-    TORCH_CUDABLAS_CHECK(cublasSetWorkspace(
-        handle, workspace_it->second.first.get(), workspace_size));
-    return;
+  // Fast path: check if workspace already exists and is large enough
+  {
+    std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+    auto workspace_it = workspace.map.find(key);
+    if (workspace_it != workspace.map.end() && workspace_it->second.second >= workspace_size) {
+      TORCH_CUDABLAS_CHECK(cublasSetWorkspace(
+          handle, workspace_it->second.first.get(), workspace_size));
+      return;
+    }
   }
 
-  auto [it, _] = workspace_map.insert_or_assign(
-      key, std::make_pair(getNewWorkspace(), workspace_size));
-  TORCH_CUDABLAS_CHECK(
-      cublasSetWorkspace(handle, it->second.first.get(), workspace_size));
+  // Slow path: allocate workspace outside the lock
+  auto new_workspace = getNewWorkspace();
+
+  // Insert with lock, replacing any undersized entry
+  {
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    workspace.map.insert_or_assign(key, std::make_pair(std::move(new_workspace), workspace_size));
+    auto workspace_it = workspace.map.find(key);
+    TORCH_CUDABLAS_CHECK(
+        cublasSetWorkspace(handle, workspace_it->second.first.get(), workspace_size));
+  }
 }
 
 void* getCUDABlasLtWorkspace() {
-  c10::DeviceIndex device = c10::cuda::current_device();
-  auto stream = c10::cuda::getCurrentCUDAStream();
-  cudaStream_t _stream = stream;
-  auto key = std::make_pair(static_cast<int>(device), static_cast<void *>(_stream));
 #ifndef USE_ROCM
   if (unified_cublas_and_lt_workspaces()) {
-    auto& workspace_map = at::cuda::cublas_stream_to_workspace();
-    size_t workspace_size = getChosenWorkspaceSize();
-    auto workspace_it = workspace_map.find(key);
-    if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
+    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle(/*setup=*/false);
+    auto stream = c10::cuda::getCurrentCUDAStream();
+    cudaStream_t _stream = stream;
+    auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+    auto& workspace = at::cuda::cublas_handle_stream_to_workspace();
+    {
+      std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.find(key);
+      if (workspace_it != workspace.map.end()) {
+        return workspace_it->second.first.mutable_get();
+      }
+    }
+    // First use for this handle+stream pair — allocate and insert directly.
+    // No need to call cublasSetWorkspace; Lt passes workspace explicitly.
+    auto new_workspace = getNewWorkspace();
+    {
+      std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.try_emplace(key, std::make_pair(std::move(new_workspace), getChosenWorkspaceSize())).first;
       return workspace_it->second.first.mutable_get();
     }
-    auto [it, _] = workspace_map.insert_or_assign(
-        key, std::make_pair(getNewWorkspace(), workspace_size));
-    return it->second.first.mutable_get();
   }
 #endif
-  auto& workspace_map = cublaslt_stream_to_workspace();
+  cublasLtHandle_t handle = getCurrentCUDABlasLtHandle();
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t _stream = stream;
+  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+
+  auto& workspace = cublaslt_handle_stream_to_workspace();
+
   size_t workspace_size = getCUDABlasLtWorkspaceSize();
-  auto workspace_it = workspace_map.find(key);
-  if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
+
+  // Fast path: check if workspace already exists and is large enough
+  {
+    std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+    auto workspace_it = workspace.map.find(key);
+    if (workspace_it != workspace.map.end() && workspace_it->second.second >= workspace_size) {
+      return workspace_it->second.first.mutable_get();
+    }
+  }
+
+  // Slow path: allocate workspace outside the lock
+  auto new_workspace = getNewCUDABlasLtWorkspace();
+
+  // Insert with lock, replacing any undersized entry
+  {
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    workspace.map.insert_or_assign(key, std::make_pair(std::move(new_workspace), workspace_size));
+    auto workspace_it = workspace.map.find(key);
     return workspace_it->second.first.mutable_get();
   }
-  auto [it, _] = workspace_map.insert_or_assign(
-      key, std::make_pair(getNewCUDABlasLtWorkspace(), workspace_size));
-  return it->second.first.mutable_get();
 }
 
 cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
-  c10::DeviceIndex device = c10::cuda::current_device();
+  c10::DeviceIndex device = 0;
+  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
 
 #if !defined(USE_ROCM)
   CUcontext pctx = nullptr;
@@ -389,7 +443,7 @@ cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
   // will allocate memory dynamically (even if they're cheap) outside
   // PyTorch's CUDA caching allocator. It's possible that CCA used up
   // all the memory and cublas's cudaMallocAsync will return OOM
-  setCublasWorkspace(handle, stream);
+  setWorkspaceForHandle(handle, stream);
 
 #if !defined(USE_ROCM)
   // On CUDA >= 11, and architecture >= Ampere, cuBLAS can use TF32 to speedup
@@ -415,7 +469,8 @@ cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
 
 cublasLtHandle_t getCurrentCUDABlasLtHandle() {
 #ifdef USE_ROCM
-  c10::DeviceIndex device = c10::cuda::current_device();
+  c10::DeviceIndex device = 0;
+  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
 
   // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.

--- a/aten/src/ATen/test/cuda_cublas_handle_pool_test.cpp
+++ b/aten/src/ATen/test/cuda_cublas_handle_pool_test.cpp
@@ -8,39 +8,35 @@
 #include <thread>
 #include <vector>
 
-// Test that concurrent threads can independently use cuBLAS handles
-// and workspaces without interference.
-// With thread_local workspaces, each thread has its own workspace map
-// so there is no shared state to race on.
+// Test concurrent access to getCurrentCUDABlasHandle and getCUDABlasLtWorkspace
+// to verify that the data race fix is working correctly
 
-TEST(CUDABlasHandlePoolTest, ConcurrentHandleAndWorkspaceAccess) {
+TEST(CUDABlasHandlePoolTest, ConcurrentGetAndClearWorkspaces) {
   if (!at::cuda::is_available()) {
     return;
   }
 
-  constexpr int num_threads = 20;
+  constexpr int num_accessor_threads = 15;
+  constexpr int num_clear_threads = 5;
   constexpr int iterations_per_thread = 50;
 
+  std::atomic<bool> stop{false};
   std::atomic<int> error_count{0};
   std::vector<std::thread> threads;
-  threads.reserve(num_threads);
+  threads.reserve(num_accessor_threads + num_clear_threads);
 
-  for (int i = 0; i < num_threads; ++i) {
-    threads.emplace_back([&error_count]() {
+  // Launch accessor threads
+  for (int i = 0; i < num_accessor_threads; ++i) {
+    threads.emplace_back([&stop, &error_count]() {
       try {
         at::cuda::CUDAGuard device_guard(0);
 
-        for (int j = 0; j < iterations_per_thread; ++j) {
+        while (!stop.load(std::memory_order_relaxed)) {
           const auto handle = at::cuda::getCurrentCUDABlasHandle();
           const auto workspace = at::cuda::getCUDABlasLtWorkspace();
 
           if (handle == nullptr || workspace == nullptr) {
             error_count++;
-          }
-
-          // Clearing workspaces on this thread should not affect other threads
-          if (j % 10 == 0) {
-            at::cuda::clearCublasWorkspaces();
           }
         }
       } catch (const std::exception&) {
@@ -48,6 +44,24 @@ TEST(CUDABlasHandlePoolTest, ConcurrentHandleAndWorkspaceAccess) {
       }
     });
   }
+
+  // Launch threads that clear workspaces
+  for (int i = 0; i < num_clear_threads; ++i) {
+    threads.emplace_back([&error_count]() {
+      try {
+        for (int j = 0; j < iterations_per_thread; ++j) {
+          at::cuda::clearCublasWorkspaces();
+          std::this_thread::yield();
+        }
+      } catch (const std::exception&) {
+        error_count++;
+      }
+    });
+  }
+
+  // Let them run for a bit
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  stop.store(true, std::memory_order_relaxed);
 
   for (auto& thread : threads) {
     thread.join();

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -119,7 +119,7 @@ hipBLAS workspaces
 For each combination of hipBLAS handle and HIP stream, a hipBLAS workspace will be allocated if that
 handle and stream combination executes a hipBLAS kernel that requires a workspace.  In order to
 avoid repeatedly allocating workspaces, these workspaces are not deallocated unless
-``torch.cuda._clear_cublas_workspaces()`` is called; note that it's the same function for CUDA or
+``torch._C._cuda_clearCublasWorkspaces()`` is called; note that it's the same function for CUDA or
 HIP. The workspace size per allocation can be specified via the environment variable
 ``HIPBLAS_WORKSPACE_CONFIG`` with the format ``:[SIZE]:[COUNT]``.  As an example, the environment
 variable ``HIPBLAS_WORKSPACE_CONFIG=:4096:2:16:8`` specifies a total size of ``2 * 4096 + 8 * 16

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -38,7 +38,7 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 def get_cur_mem(rank, result, prefix):
     """Collect memory allocated values in a result dict in MB"""
     if TEST_CUDA:
-        torch.cuda._clear_cublas_workspaces()
+        torch._C._cuda_clearCublasWorkspaces()
     result[prefix] = round(torch.accelerator.memory_allocated() / 1024 / 1024)
 
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2142,7 +2142,7 @@ if HAS_CUDA_AND_TRITON:
         @blas_library_context("cublas")
         @unittest.mock.patch.dict(os.environ, {"TORCH_DISABLE_ADDR2LINE": "0"})
         def test_workspace_allocation_error(self):
-            torch.cuda._clear_cublas_workspaces()
+            torch._C._cuda_clearCublasWorkspaces()
 
             prev = torch._inductor.cudagraph_trees.clear_cublas_manager
 
@@ -2182,7 +2182,7 @@ if HAS_CUDA_AND_TRITON:
                 self.assertTrue(thrown)
 
             finally:
-                torch.cuda._clear_cublas_workspaces()
+                torch._C._cuda_clearCublasWorkspaces()
                 torch._inductor.cudagraph_trees.clear_cublas_manager = prev
                 torch._inductor.cudagraph_trees.get_container(
                     self.device_idx

--- a/test/inductor/test_custom_op_autotune.py
+++ b/test/inductor/test_custom_op_autotune.py
@@ -1458,7 +1458,7 @@ class TestCustomOpAutoTune(TestCase):
 
         # Clear everything first
         torch.cuda.synchronize()
-        torch.cuda._clear_cublas_workspaces()
+        torch._C._cuda_clearCublasWorkspaces()
 
         # Create test tensors and establish baseline with some mm activity
         a = torch.randn(256, 256, device=self.device, dtype=self.dtype)
@@ -1503,7 +1503,7 @@ class TestCustomOpAutoTune(TestCase):
 
         # Clear everything first
         torch.cuda.synchronize()
-        torch.cuda._clear_cublas_workspaces()
+        torch._C._cuda_clearCublasWorkspaces()
 
         # Create test tensors
         a = torch.randn(256, 256, device=self.device, dtype=self.dtype)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2408,12 +2408,12 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         torch._dynamo.reset()
         gc.collect()
         if torch.cuda.is_available():
-            torch.cuda._clear_cublas_workspaces()
+            torch._C._cuda_clearCublasWorkspaces()
         torch.accelerator.empty_cache()
         torch._dynamo.reset()
         gc.collect()
         if torch.cuda.is_available():
-            torch.cuda._clear_cublas_workspaces()
+            torch._C._cuda_clearCublasWorkspaces()
         torch.accelerator.empty_cache()
 
     @supported_platform

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -969,7 +969,7 @@ print(t.is_pinned())
                 default_workspace_size = 4096 * 8 * 1024
 
         def check_workspace_size(inp):
-            torch.cuda._clear_cublas_workspaces()
+            torch._C._cuda_clearCublasWorkspaces()
             start = torch.cuda.memory_stats()["active_bytes.all.allocated"]
             with torch.no_grad():
                 torch.matmul(inp, inp)
@@ -994,58 +994,7 @@ print(t.is_pinned())
         torch._C._cuda_resetCublasWorkspaceSize()
         self.assertLess(abs(check_workspace_size(a) - default_workspace_size), 524288)
 
-        torch.cuda._clear_cublas_workspaces()
-
-    @serialTest()
-    def test_clear_cublas_workspaces_uses_zero_size_cuda_dummy(self):
-        expected_device = torch.device("cuda", torch.cuda.current_device())
-        dummy_metadata = []
-
-        def metadata(tensor):
-            return (
-                tensor.device,
-                tensor.numel(),
-                tensor.untyped_storage().nbytes(),
-                tensor.data_ptr(),
-                torch.autograd.is_multithreading_enabled(),
-            )
-
-        class RecordDevice(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, dummy):
-                dummy_metadata.append(metadata(dummy))
-                return dummy
-
-            @staticmethod
-            def backward(ctx, grad):
-                dummy_metadata.append(metadata(grad))
-                return None
-
-        torch.cuda._clear_cublas_workspaces()
-        stats = torch.cuda.memory_stats()
-        allocator_stats = {
-            key: stats[key]
-            for key in (
-                "allocation.all.allocated",
-                "allocated_bytes.all.allocated",
-                "segment.all.allocated",
-            )
-        }
-        with (
-            torch.device("cpu"),
-            torch.autograd.set_multithreading_enabled(False),
-            patch.object(torch.cuda, "_ClearCublasWorkspaces", RecordDevice),
-            patch.object(torch.cuda, "device_count", side_effect=AssertionError),
-            patch.object(torch.cuda, "device", side_effect=AssertionError),
-        ):
-            torch.cuda._clear_cublas_workspaces()
-
-        self.assertEqual(
-            dummy_metadata,
-            [(expected_device, 0, 0, 0, True), (expected_device, 0, 0, 0, True)],
-        )
-        stats = torch.cuda.memory_stats()
-        self.assertEqual({key: stats[key] for key in allocator_stats}, allocator_stats)
+        torch._C._cuda_clearCublasWorkspaces()
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @unittest.skipIf(IS_FBCODE, "not enabled by default on fbcode")
@@ -1151,37 +1100,32 @@ print(t.is_pinned())
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @setBlasBackendsToDefaultFinally
-    @parametrize("backend", ("cublas", "cublaslt"))
-    def test_cublas_workspace_lazy_reallocation(self, backend):
-        torch.backends.cuda.preferred_blas_library(backend)
-        small_size = 1024
-        bigger_size = 64 * 1024 * 1024
-        if backend == "cublaslt":
-            torch.backends.cuda.cublas_workspace_size(small_size)
-        torch.backends.cuda.blas_workspace_size(small_size, backend=backend)
-        torch.cuda._clear_cublas_workspaces()
+    def test_cublas_workspace_lazy_reallocation(self):
+        torch.backends.cuda.preferred_blas_library("cublas")
+
+        original_size = torch.backends.cuda.cublas_workspace_size()
+        torch._C._cuda_clearCublasWorkspaces()
 
         # Trigger initial allocation with matmul
         a = torch.randn(7, 7, device="cuda", requires_grad=False)
         with torch.no_grad():
             torch.matmul(a, a)
 
-        mem_after_first = torch.cuda.memory_stats()["active_bytes.all.current"]
+        mem_after_first = torch.cuda.memory_stats()["active_bytes.all.allocated"]
 
         # Increase workspace size
-        if backend == "cublaslt":
-            torch.backends.cuda.cublas_workspace_size(bigger_size)
-        torch.backends.cuda.blas_workspace_size(bigger_size, backend=backend)
+        bigger_size = original_size + 32 * 1024 * 1024  # +32 MiB
+        torch.backends.cuda.cublas_workspace_size(bigger_size)
 
         # No immediate memory change (lazy reallocation)
-        mem_after_set = torch.cuda.memory_stats()["active_bytes.all.current"]
+        mem_after_set = torch.cuda.memory_stats()["active_bytes.all.allocated"]
         self.assertEqual(mem_after_first, mem_after_set)
 
         # Next matmul triggers reallocation
         with torch.no_grad():
             torch.matmul(a, a)
 
-        mem_after_realloc = torch.cuda.memory_stats()["active_bytes.all.current"]
+        mem_after_realloc = torch.cuda.memory_stats()["active_bytes.all.allocated"]
         self.assertGreater(mem_after_realloc, mem_after_first)
 
     @recover_orig_fp32_precision
@@ -6436,7 +6380,7 @@ class TestCudaAllocator(TestCase):
     def test_memory_plots_free_segment_stack(self):
         for context in ["alloc", "all", "state"]:
             try:
-                torch.cuda._clear_cublas_workspaces()
+                torch._C._cuda_clearCublasWorkspaces()
                 torch.cuda.memory.empty_cache()
                 torch.cuda.memory._record_memory_history(context=context)
                 x = torch.rand(3, 4, device="cuda")
@@ -6455,7 +6399,7 @@ class TestCudaAllocator(TestCase):
     def test_memory_plots_metadata(self):
         for context in ["alloc", "all", "state"]:
             try:
-                torch.cuda._clear_cublas_workspaces()
+                torch._C._cuda_clearCublasWorkspaces()
                 torch.cuda.memory.empty_cache()
                 torch.cuda.memory._set_memory_metadata("metadata test")
                 torch.cuda.memory._record_memory_history(context=context)
@@ -6521,7 +6465,7 @@ class TestCudaAllocator(TestCase):
     )
     def test_memory_snapshot_script(self):
         try:
-            torch.cuda._clear_cublas_workspaces()
+            torch._C._cuda_clearCublasWorkspaces()
             torch.cuda.memory.empty_cache()
             torch.cuda.memory._record_memory_history("state", stacks="python")
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4200,7 +4200,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         # for higher dim input sizes.
         # See https://github.com/pytorch/pytorch/issues/141112
         B, D, max_seq_len = 64, 512, 100
-        torch.cuda._clear_cublas_workspaces()
+        torch._C._cuda_clearCublasWorkspaces()
         m = torch.nn.Linear(D, D, device=device)
         nt = torch.nested.as_nested_tensor(
             [

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -262,7 +262,6 @@ manual_torch_name_rule_map: dict[
     "torch.Tensor#_make_wrapper_subclass": SkipFunctionVariable,
     "torch.Tensor#__init__": SkipFunctionVariable,
     "torch.Tensor#split": TorchInGraphFunctionVariable,
-    "torch.cuda._clear_cublas_workspaces": SkipFunctionVariable,
     "torch.cuda.set_device": SkipFunctionVariable,
     "torch.cuda.current_device": TorchInGraphFunctionVariable,
     "torch.autograd.grad": TorchInGraphFunctionVariable,

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -177,7 +177,7 @@ def clear_cublass_cache() -> None:
     it will be allocated to the cudagraph private pool and accounted for in the allocator for the duration of the
     program. There is no overhead to this on replay since cudagraphs removes allocation overhead.
     """
-    torch.cuda._clear_cublas_workspaces()
+    torch._C._cuda_clearCublasWorkspaces()
 
 
 @contextlib.contextmanager

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1368,62 +1368,6 @@ def current_solver_handle():
     return torch._C._cuda_getCurrentSolverHandle()
 
 
-_ClearCublasWorkspaces = None
-
-
-def _clear_cublas_workspaces() -> None:
-    r"""Clear cuBLAS workspaces on this thread and current CUDA device's autograd worker."""
-    if not hasattr(torch._C, "_cuda_clearCublasWorkspaces"):
-        return
-
-    torch._C._cuda_clearCublasWorkspaces()
-    if not is_initialized():
-        return
-
-    global _ClearCublasWorkspaces
-    if _ClearCublasWorkspaces is None:
-        from torch.autograd import Function
-
-        class ClearCublasWorkspaces(Function):
-            @staticmethod
-            def forward(ctx, dummy):
-                return dummy
-
-            @staticmethod
-            def backward(ctx: Any, *grad_outputs: Any) -> Any:
-                torch._C._cuda_clearCublasWorkspaces()
-                return None
-
-        _ClearCublasWorkspaces = ClearCublasWorkspaces
-
-    # This synthetic backward is internal cleanup; keep it out of compiled
-    # autograd to avoid tracing it while still routing through the CUDA worker.
-    compiled_autograd = getattr(
-        getattr(torch._C, "_dynamo", None), "compiled_autograd", None
-    )
-    set_autograd_compiler = (
-        getattr(compiled_autograd, "set_autograd_compiler", None)
-        if compiled_autograd is not None
-        else None
-    )
-    prior_compiler = prior_dynamic = None
-    if set_autograd_compiler is not None:
-        prior_compiler, prior_dynamic = set_autograd_compiler(None, False)
-
-    try:
-        with (
-            torch.autograd.set_multithreading_enabled(True),
-            torch.inference_mode(False),
-            torch.enable_grad(),
-        ):
-            dummy = torch.empty(0, device="cuda", requires_grad=True)
-            output = _ClearCublasWorkspaces.apply(dummy)
-            output.backward(output.detach())
-    finally:
-        if set_autograd_compiler is not None:
-            set_autograd_compiler(prior_compiler, prior_dynamic)
-
-
 def set_sync_debug_mode(debug_mode: int | str) -> None:
     r"""Set the debug mode for cuda synchronizing operations.
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2649,7 +2649,7 @@ def setBlasBackendsToDefaultFinally(fn):
             if torch.backends.cuda.is_built():
                 torch._C._cuda_resetCublasWorkspaceSize()
                 torch._C._cuda_resetCublasLtWorkspaceSize()
-                torch.cuda._clear_cublas_workspaces()
+                torch._C._cuda_clearCublasWorkspaces()
     return _fn
 
 def setSdpaBackendsToDefaultFinally(fn):
@@ -3089,7 +3089,7 @@ class CudaMemoryLeakCheck:
             #   because the driver will always have some bytes in use (context size?)
             if caching_allocator_mem_allocated > 0:
                 gc.collect()
-                torch.cuda._clear_cublas_workspaces()
+                torch._C._cuda_clearCublasWorkspaces()
                 torch.cuda.empty_cache()
                 break
 
@@ -3107,17 +3107,17 @@ class CudaMemoryLeakCheck:
 
         self.testcase.before_cuda_memory_leak_check()
         gc.collect()
-        num_devices = torch.cuda.device_count()
-        torch.cuda._clear_cublas_workspaces()
+        torch._C._cuda_clearCublasWorkspaces()
         torch.cuda.empty_cache()
 
         # Compares caching allocator before/after statistics
         # An increase in allocated memory is a discrepancy indicating a possible
         #   memory leak
         discrepancy_detected = False
-        # avoid counting cublasWorkspace allocations
-        torch.cuda._clear_cublas_workspaces()
+        num_devices = torch.cuda.device_count()
         for i in range(num_devices):
+            # avoid counting cublasWorkspace allocations
+            torch._C._cuda_clearCublasWorkspaces()
             caching_allocator_mem_allocated = torch.cuda.memory_allocated(i)
 
             if caching_allocator_mem_allocated > self.caching_allocator_befores[i]:


### PR DESCRIPTION
This reverts commit 6d926a6fe8211749001c108506bf806da03fa133.

Reverted https://github.com/pytorch/pytorch/pull/180283 on behalf of https://github.com/eqy due to see #192061, needs additional handling for multithreaded graph-capture ([comment](https://github.com/pytorch/pytorch/pull/180283#issuecomment-5254900294))

(cherry picked from commit 6065eb33863342d46deb70055c7ef055ecaa58ea)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98