### PR TITLE
[DO NOT LAND] Mock test: drive a manywheel build through test-infra's remote BuildKit action

### DIFF
--- a/.github/workflows/test-remote-buildkit-action.yml
+++ b/.github/workflows/test-remote-buildkit-action.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - huydhn/test-remote-buildkit-action
+  pull_request:
+    paths:
+      - .github/workflows/test-remote-buildkit-action.yml
 
 env:
   DOCKER_BUILDKIT: 1
@@ -23,7 +26,7 @@ permissions:
 jobs:
   # One cheap target out of build-manywheel-images.yml's 14-entry matrix.
   manywheel-cpu:
-    runs-on: mt-rel-l-x86iavx512-8-64
+    runs-on: mt-l-x86iavx512-16-128
     container:
       image: ghcr.io/actions/actions-runner:latest
     defaults:

--- a/.github/workflows/test-remote-buildkit-action.yml
+++ b/.github/workflows/test-remote-buildkit-action.yml
@@ -1,0 +1,47 @@
+name: Test remote BuildKit composite action
+
+# Throwaway check that pytorch/test-infra's docker-build-remote-buildkit action
+# works when called from this repo. Scoped to its own branch so it cannot run
+# anywhere else; delete the branch (and this file) once the action has landed.
+on:
+  push:
+    branches:
+      - huydhn/test-remote-buildkit-action
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: mt-l-x86iavx512-16-128
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    # The actions-runner container defaults `run:` to sh.
+    defaults:
+      run:
+        shell: bash
+    timeout-minutes: 30
+    steps:
+      - name: Write a trivial build context
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/ctx"
+          cat > "${RUNNER_TEMP}/ctx/Dockerfile" <<'EOF'
+          FROM alpine:3.20
+          ARG GREETING=hello
+          RUN echo "${GREETING} from remote buildkit" > /greeting
+          EOF
+
+      # No checkout: the runner fetches the action from GitHub, and the build
+      # context is generated above.
+      - name: Build with the remote BuildKit action
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+        with:
+          context: ${{ runner.temp }}/ctx
+          tags: ghcr.io/pytorch/pytorch-buildkit-action-check:${{ github.sha }}
+          build-args: |
+            GREETING=pytorch-ci
+          # Build only. Pushing would need either GHCR_PAT or an ECR repository
+          # on role/arc's allowlist; test-infra's own smoke test covers --push.
+          push: false

--- a/.github/workflows/test-remote-buildkit-action.yml
+++ b/.github/workflows/test-remote-buildkit-action.yml
@@ -1,47 +1,49 @@
 name: Test remote BuildKit composite action
 
 # Throwaway check that pytorch/test-infra's docker-build-remote-buildkit action
-# works when called from this repo. Scoped to its own branch so it cannot run
-# anywhere else; delete the branch (and this file) once the action has landed.
+# can drive a real manywheel image build, the way binary-docker-build does today
+# with its vendored copy of build_with_remote_buildkit.sh. Scoped to its own
+# branch so it cannot run anywhere else; delete the branch and this file once the
+# action has landed.
 on:
   push:
     branches:
       - huydhn/test-remote-buildkit-action
+
+env:
+  DOCKER_BUILDKIT: 1
+  # Build only. WITH_PUSH=false makes .ci/docker/manywheel/build.sh drop the
+  # --push, so nothing reaches Docker Hub or ECR from this mock.
+  WITH_PUSH: false
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  build:
-    runs-on: mt-l-x86iavx512-16-128
+  # One cheap target out of build-manywheel-images.yml's 14-entry matrix.
+  manywheel-cpu:
+    runs-on: mt-rel-l-x86iavx512-8-64
     container:
       image: ghcr.io/actions/actions-runner:latest
-    # The actions-runner container defaults `run:` to sh.
     defaults:
       run:
         shell: bash
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
-      - name: Write a trivial build context
-        run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/ctx"
-          cat > "${RUNNER_TEMP}/ctx/Dockerfile" <<'EOF'
-          FROM alpine:3.20
-          ARG GREETING=hello
-          RUN echo "${GREETING} from remote buildkit" > /greeting
-          EOF
-
-      # No checkout: the runner fetches the action from GitHub, and the build
-      # context is generated above.
-      - name: Build with the remote BuildKit action
-        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
-          context: ${{ runner.temp }}/ctx
-          tags: ghcr.io/pytorch/pytorch-buildkit-action-check:${{ github.sha }}
-          build-args: |
-            GREETING=pytorch-ci
-          # Build only. Pushing would need either GHCR_PAT or an ECR repository
-          # on role/arc's allowlist; test-infra's own smoke test covers --push.
-          push: false
+          submodules: false
+
+      - name: Avoid git's dubious-ownership error
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      # The same build that binary-docker-build runs, but driven through the
+      # shared action instead of the vendored helper script.
+      - name: Build manylinux2_28-builder:cpu on remote BuildKit
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+        env:
+          REMOTE_BUILDKIT: "1"
+        with:
+          command: .ci/docker/manywheel/build.sh manylinux2_28-builder:cpu


### PR DESCRIPTION
Do not land. Throwaway PR validating pytorch/test-infra#8487, which adds a reusable `docker-build-remote-buildkit` composite action.

The workflow here runs the same `.ci/docker/manywheel/build.sh manylinux2_28-builder:cpu` that `binary-docker-build` runs today, but routes it through the shared action instead of this repo's vendored copy of `build_with_remote_buildkit.sh`. `WITH_PUSH=false`, so the image is built and discarded — nothing reaches Docker Hub or ECR.

If the action lands, `binary-docker-build`, `docker-builds.yml` and `docker-release.yml` could drop their vendored script and share one implementation of the builder registration plus the cold-pool retry. The action is pinned to its PR branch here, which is another reason this must not land.