### PR TITLE
[SDPA] Support mixed head dimensions with FA4

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -289,6 +289,14 @@ void Context::setSDPUseFA3(bool e) {
   enabled_fa3SDP = e;
 }
 
+bool Context::userEnabledFA4SDP() const {
+  return enabled_fa4SDP;
+}
+
+void Context::setSDPUseFA4(bool e) {
+  enabled_fa4SDP = e;
+}
+
 bool Context::userEnabledMemEfficientSDP() const {
   return enabled_mem_efficientSDP;
 }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -282,6 +282,9 @@ class TORCH_API Context {
   void setSDPUseFA3(bool /*e*/);
   bool userEnabledFA3SDP() const;
 
+  void setSDPUseFA4(bool /*e*/);
+  bool userEnabledFA4SDP() const;
+
   void setSDPUseMemEfficient(bool /*e*/);
   bool userEnabledMemEfficientSDP() const;
 
@@ -488,6 +491,7 @@ class TORCH_API Context {
       at::SDPBackend::overrideable};
   bool enabled_flashSDP = true;
   bool enabled_fa3SDP = false;
+  bool enabled_fa4SDP = false;
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;
   bool enabled_cudnnSDP = true;

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -829,7 +829,7 @@ Tensor scaled_dot_product_attention(
     case SDPBackend::flash_attention: {
       if(query_device_type == DeviceType::CUDA ||
          query_device_type == DeviceType::XPU) {
-        c10::SymInt og_size = query_.sym_size(-1);
+        c10::SymInt og_size = value.sym_size(-1);
         int alignment_size = (query_device_type == DeviceType::XPU) ? 1 : 8;
         Tensor query_padded = pad_last_dim(query_, alignment_size);
         Tensor key_padded = pad_last_dim(key, alignment_size);

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -191,27 +191,92 @@ inline int aotriton_max_hdim() {
 // check_head_dim_size_flash because it changes the backend selection logic for
 // FA, which can break certain workloads that rely on the behavior of rejecting
 // FA for hdim_qk != hdim_vo
+bool check_fa4_constraints(sdp_params const& params, bool debug) {
+#if USE_ROCM_ATTENTION
+  return true;
+#else
+  if (!at::globalContext().userEnabledFA4SDP()) {
+    return true;
+  }
+
+  const auto* dprop = at::cuda::getCurrentDeviceProperties();
+  if (dprop->major != 9 && dprop->major != 10) {
+    if (debug) {
+      TORCH_WARN("FA4 requires compute capability 9.0 or 10.0.");
+    }
+    return false;
+  }
+  if (params.dropout != 0.0) {
+    if (debug) {
+      TORCH_WARN("FA4 does not support dropout.");
+    }
+    return false;
+  }
+  return true;
+#endif
+}
+
+#if !USE_ROCM_ATTENTION
+bool check_head_dim_size_fa4(sdp_params const& params) {
+  const auto query_size_last = params.query.sym_size(-1);
+  const auto key_size_last = params.key.sym_size(-1);
+  const auto value_size_last = params.value.sym_size(-1);
+  if (query_size_last != key_size_last) {
+    return false;
+  }
+
+  const auto* dprop = at::cuda::getCurrentDeviceProperties();
+  if (dprop->major == 9) {
+    return query_size_last > 0 && query_size_last <= 256 &&
+        value_size_last > 0 && value_size_last <= 256;
+  }
+  if (dprop->major == 10) {
+    const bool standard_head_dims = query_size_last > 0 &&
+        query_size_last <= 128 && value_size_last > 0 &&
+        value_size_last <= 128;
+    const bool deepseek_head_dims =
+        query_size_last == 192 && value_size_last == 128;
+    const bool head_dim_256 =
+        query_size_last == 256 && value_size_last == 256;
+    return standard_head_dims || deepseek_head_dims || head_dim_256;
+  }
+  return false;
+}
+#endif
+
 template<bool caller_is_meff = false>
 bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
+  const auto query_size_last = params.query.sym_size(-1);
+  const auto key_size_last = params.key.sym_size(-1);
+  const auto value_size_last = params.value.sym_size(-1);
+  bool supported_head_dim;
 #if USE_ROCM_ATTENTION
   if (at::cuda::device_count() == 0) {
     return false;
   }
   const auto max_size = c10::SymInt(aotriton_max_hdim());
+  supported_head_dim =
+      query_size_last == key_size_last && query_size_last == value_size_last &&
+      query_size_last <= max_size;
 #else
-  // All head_dim sizes must be equal and less than 256
-  const auto max_size = c10::SymInt(256);
+  supported_head_dim = at::globalContext().userEnabledFA4SDP()
+      ? check_head_dim_size_fa4(params)
+      : query_size_last == key_size_last &&
+          query_size_last == value_size_last && query_size_last <= 256;
 #endif
-  const auto query_size_last = params.query.sym_size(-1);
-  const auto key_size_last = params.key.sym_size(-1);
-  const auto value_size_last = params.value.sym_size(-1);
-  bool same_head_dim_size =
-      query_size_last == key_size_last && query_size_last == value_size_last;
-  if (!(same_head_dim_size && (query_size_last <= max_size))) {
+  if (!supported_head_dim) {
     if (debug) {
+#if USE_ROCM_ATTENTION
+      const char* requirement = caller_is_meff
+          ? "Efficient attention on ROCM requires q,k,v to have the same last dimension and to be less than or equal to 256."
+          : "Flash attention requires q,k,v to have the same last dimension and to be less than or equal to 256.";
+#else
+      const char* requirement = at::globalContext().userEnabledFA4SDP()
+          ? "FA4 does not support the provided head dimensions."
+          : "Flash attention requires q,k,v to have the same last dimension and to be less than or equal to 256.";
+#endif
       TORCH_WARN(
-          caller_is_meff ? "Efficient attention on ROCM" : "Flash attention",
-          " requires q,k,v to have the same last dimension and to be less than or equal to 256.",
+          requirement,
           " Got Query.size(-1): ",
           query_size_last,
           ", Key.size(-1): ",
@@ -1020,6 +1085,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_all_tensors_on_device,
       check_tensor_shapes,
       check_for_attn_mask,
+      check_fa4_constraints,
       check_head_dim_size_flash<false /*caller_is_meff*/>,
       check_flash_attention_hardware_support,
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89_or_120,

--- a/test/nn/attention/test_fa4.py
+++ b/test/nn/attention/test_fa4.py
@@ -4,12 +4,16 @@ import importlib
 import unittest
 from unittest.mock import patch
 
-from _fa_test_common import FlashAttentionTestMixin, SdpaShape
+from _fa_test_common import flash_vs_math, FlashAttentionTestMixin, SdpaShape
 
 import torch
 import torch.nn.functional as F
-from torch.backends.cuda import SDPBackend
-from torch.nn.attention import activate_flash_attention_impl, sdpa_kernel
+from torch.backends.cuda import can_use_flash_attention, SDPAParams, SDPBackend
+from torch.nn.attention import (
+    activate_flash_attention_impl,
+    restore_flash_attention_impl,
+    sdpa_kernel,
+)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -83,6 +87,74 @@ class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_fa4_kernel_called(self, device, dtype):
         self._test_kernel_called(device, dtype)
+
+    @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
+    def test_mixed_head_dims(self, device):
+        q = (
+            torch.randn(1, 128, 2, 192, dtype=torch.float16, device=device)
+            .transpose(1, 2)
+            .requires_grad_()
+        )
+        k = torch.randn_like(q, memory_format=torch.preserve_format).requires_grad_()
+        v = (
+            torch.randn(1, 128, 2, 128, dtype=torch.float16, device=device)
+            .transpose(1, 2)
+            .requires_grad_()
+        )
+
+        out, _, _ = flash_vs_math(self, q, k, v, is_causal=True)
+        self.assertEqual(out.shape, v.shape)
+        self.assertTrue(out.transpose(1, 2).is_contiguous())
+
+        grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+        for grad, expected in zip(grads, (q, k, v)):
+            self.assertEqual(grad.shape, expected.shape)
+            self.assertTrue(torch.isfinite(grad).all())
+
+        def sdpa(q, k, v):
+            return F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+        with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+            compiled_out = torch.compile(sdpa, fullgraph=True)(q, k, v)
+        self.assertEqual(compiled_out.shape, out.shape)
+        self.assertEqual(compiled_out.stride(), out.stride())
+        self.assertEqual(compiled_out, out)
+
+    @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
+    def test_mixed_head_dims_with_expanded_query(self, device):
+        q = torch.randn(1, 1, 128, 192, dtype=torch.float16, device=device).expand(
+            2, 4, -1, -1
+        )
+        k = torch.randn(1, 1, 128, 192, dtype=torch.float16, device=device).expand(
+            2, 4, -1, -1
+        )
+        v = torch.randn(1, 1, 128, 128, dtype=torch.float16, device=device).expand(
+            2, 4, -1, -1
+        )
+
+        out, _, _ = flash_vs_math(self, q, k, v, is_causal=True)
+        self.assertEqual(out.shape, v.shape)
+        self.assertEqual(out.stride(-1), 1)
+
+    @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
+    def test_head_dim_selection_uses_fa4_contract(self, device):
+        q = torch.empty(1, 1, 128, 192, dtype=torch.float16, device=device)
+        k = torch.empty_like(q)
+        v = torch.empty(1, 1, 128, 128, dtype=torch.float16, device=device)
+        params = SDPAParams(q, k, v, None, 0.0, True, False)
+        self.assertTrue(can_use_flash_attention(params))
+        dropout_params = SDPAParams(q, k, v, None, 0.1, True, False)
+        self.assertFalse(can_use_flash_attention(dropout_params))
+
+        if torch.cuda.get_device_capability(device)[0] == 10:
+            unsupported_params = SDPAParams(q, k, q, None, 0.0, True, False)
+            self.assertFalse(can_use_flash_attention(unsupported_params))
+
+        restore_flash_attention_impl()
+        try:
+            self.assertFalse(can_use_flash_attention(params))
+        finally:
+            activate_flash_attention_impl("FA4")
 
     @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
     def test_multiple_activate(self):

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2202,6 +2202,32 @@ class TestMeta(TestCase):
         self.assertEqual(cpu_output_dtype, meta_output_dtype)
         self.assertEqual(cpu_logsumexp_dtype, meta_logsumexp_dtype)
 
+    def test_flash_attention_mixed_head_dim_metadata(self):
+        q_bshd = torch.empty(1, 128, 2, 192, device="meta", dtype=torch.float16)
+        k_bshd = torch.empty_like(q_bshd)
+        v_bshd = torch.empty(1, 128, 2, 128, device="meta", dtype=torch.float16)
+        q, k, v = (tensor.transpose(1, 2) for tensor in (q_bshd, k_bshd, v_bshd))
+
+        output = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[0]
+        self.assertEqual(output.shape, v.shape)
+        self.assertEqual(output.stride(), v.stride())
+
+        expanded_q = q[:1, :1].expand(2, 4, -1, -1)
+        expanded_k = k[:1, :1].expand(2, 4, -1, -1)
+        expanded_v = v[:1, :1].expand(2, 4, -1, -1)
+        output = torch.ops.aten._scaled_dot_product_flash_attention(
+            expanded_q, expanded_k, expanded_v
+        )[0]
+        self.assertEqual(output.shape, expanded_v.shape)
+        self.assertEqual(output.stride(), (16384, 32768, 128, 1))
+
+        output = torch.ops.aten._flash_attention_forward(
+            q_bshd, k_bshd, v_bshd, None, None, 128, 128, 0.0, False, False
+        )[0]
+        self.assertEqual(output.shape, v_bshd.shape)
+        self.assertEqual(output.stride(), v_bshd.stride())
+
+
 class TestMetaKernelConv(TestCase):
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_convolution_backward_meta_kernel_channels_last(self):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock, ANY
 import math
 import itertools
 import torch.optim as optim
+from torch.backends.cuda import can_use_flash_attention, SDPAParams
 from torch.testing._internal.common_device_type import expectedFailureMPS, instantiate_device_type_tests, onlyCUDA, largeTensorTest
 import torch.utils.cpp_extension
 from torch.testing._internal.common_nn import NNTestCase
@@ -3604,6 +3605,13 @@ class TestSDPACudaOnly(NNTestCase):
         else:
             with self.assertRaisesRegex(RuntimeError, "No available kernel."):
                 test()
+
+    def test_flash_attention_rejects_different_dk_dv(self, device):
+        q = torch.empty(1, 1, 128, 192, dtype=torch.float16, device=device)
+        k = torch.empty_like(q)
+        v = torch.empty(1, 1, 128, 128, dtype=torch.float16, device=device)
+        params = SDPAParams(q, k, v, None, 0.0, True, False)
+        self.assertFalse(can_use_flash_attention(params))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     def test_fused_attention_different_dk_dv(self, device):

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1209,6 +1209,8 @@ def _get_flash_sdp_enabled() -> _bool: ...  # THPModule_userEnabledFusedSDP
 def _set_sdp_use_flash(arg: _bool) -> None: ...  # THPModule_setSDPUseFlash
 def _get_fa3_sdp_enabled() -> _bool: ...  # THPModule_userEnabledFA3SDP
 def _set_sdp_use_fa3(arg: _bool) -> None: ...  # THPModule_setSDPUseFA3
+def _get_fa4_sdp_enabled() -> _bool: ...  # THPModule_userEnabledFA4SDP
+def _set_sdp_use_fa4(arg: _bool) -> None: ...  # THPModule_setSDPUseFA4
 def _get_mem_efficient_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP
 def _set_sdp_use_mem_efficient(
     arg: _bool,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6264,6 +6264,28 @@ def meta_scatter_(self, dim, index, src_or_value, reduce=None):
     return self
 
 
+def alloc_with_matching_layout(
+    query: Tensor,
+    res_shape: tuple[int, ...],
+):
+    """Allocate a result with the query's dimension order."""
+    if tuple(query.shape) == res_shape:
+        return torch.empty_like(query)
+
+    fill_order = sorted(
+        range(query.dim()),
+        key=lambda idx: query.stride()[idx] if query.stride()[idx] else math.inf,
+    )
+    strides = [0] * len(fill_order)
+    stride = 1
+    for idx in fill_order:
+        strides[idx] = stride
+        stride *= res_shape[idx]
+    return torch.empty_strided(
+        res_shape, strides, dtype=query.dtype, device=query.device
+    )
+
+
 @register_meta([aten._scaled_dot_product_flash_attention.default])
 def meta__scaled_dot_product_flash_attention(
     query: Tensor,
@@ -6280,7 +6302,7 @@ def meta__scaled_dot_product_flash_attention(
     head_dim = query.size(3)
     max_seqlen_batch_k = key.size(2)
 
-    attention = torch.empty_like(query)
+    attention = alloc_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
     logsumexp = torch.empty(
         (batch_size, num_heads, max_seqlen_batch_q),
         dtype=torch.float,
@@ -6353,28 +6375,6 @@ def meta__scaled_dot_product_flash_attention_quantized(
         return_debug_mask,
         scale,
     )
-
-
-def alloc_with_matching_layout(
-    query: Tensor,
-    res_shape: tuple[int, ...],
-):
-    if query.shape == res_shape:
-        res = torch.empty_like(query)
-    else:
-        dim_order = sorted(
-            [0, 1, 2, 3], key=lambda idx: query.stride()[idx], reverse=True
-        )
-        strides = [0] * len(dim_order)
-        stride = 1
-        for idx in reversed(dim_order):
-            strides[idx] = stride
-            stride *= res_shape[idx]
-        res = torch.empty_strided(
-            res_shape, strides, dtype=query.dtype, device=query.device
-        )
-
-    return res
 
 
 @register_meta([aten._scaled_dot_product_cudnn_attention])
@@ -6824,7 +6824,7 @@ def meta__flash_attention_forward(
     head_dim = query.size(-1)
 
     # Cuda Path
-    attention = torch.empty_like(query)
+    attention = alloc_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
     if cum_seq_q is None:
         logsumexp = torch.empty(
             (batch_size, num_heads, max_seqlen_batch_q),

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1031,6 +1031,25 @@ static PyObject* THPModule_userEnabledFA3SDP(
   else
     Py_RETURN_FALSE;
 }
+static PyObject* THPModule_setSDPUseFA4(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      PyBool_Check(arg),
+      "set_sdp_use_fa4 expects a bool, "
+      "but got ",
+      THPUtils_typename(arg));
+  at::globalContext().setSDPUseFA4(Py_IsTrue(arg));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+static PyObject* THPModule_userEnabledFA4SDP(
+    PyObject* _unused,
+    PyObject* noargs) {
+  if (at::globalContext().userEnabledFA4SDP())
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+}
 static PyObject* THPModule_setSDPUseMemEfficient(
     PyObject* _unused,
     PyObject* arg) {
@@ -2092,6 +2111,8 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
     {"_set_sdp_use_flash", THPModule_setSDPUseFlash, METH_O, nullptr},
     {"_get_fa3_sdp_enabled", THPModule_userEnabledFA3SDP, METH_NOARGS, nullptr},
     {"_set_sdp_use_fa3", THPModule_setSDPUseFA3, METH_O, nullptr},
+    {"_get_fa4_sdp_enabled", THPModule_userEnabledFA4SDP, METH_NOARGS, nullptr},
+    {"_set_sdp_use_fa4", THPModule_setSDPUseFA4, METH_O, nullptr},
     {"_get_mem_efficient_sdp_enabled",
      userEnabledMemEfficientSDP,
      METH_NOARGS,

--- a/torch/nn/attention/_fa4.py
+++ b/torch/nn/attention/_fa4.py
@@ -10,6 +10,7 @@ from typing import Any, TYPE_CHECKING
 from typing_extensions import TypeVarTuple, Unpack
 
 from . import _registry
+from ._utils import _empty_with_matching_layout
 
 
 if TYPE_CHECKING:
@@ -33,6 +34,7 @@ class _FA4Handle:
 
     def remove(self) -> None:
         self.library = None
+        torch._C._set_sdp_use_fa4(False)
 
 
 @cache
@@ -53,7 +55,9 @@ def register_flash_attention_fa4(
     global _FA4_MODULE_PATH
     _ = _fa4_import_module(module_path)
     _FA4_MODULE_PATH = module_path
-    return _FA4Handle(_fa4_register_kernels())
+    handle = _FA4Handle(_fa4_register_kernels())
+    torch._C._set_sdp_use_fa4(True)
+    return handle
 
 
 @cache
@@ -447,10 +451,7 @@ def _fa4_scaled_dot_product_flash_attention_forward_impl(
         raise RuntimeError(f"FA4 SDPA forward unsupported: {error}")
     q, k, v = _transpose_dense(query, key, value)
 
-    # Pre-allocate output with query's strides (BHSD layout), then create
-    # a BSHD view for the kernel. This ensures the returned output has
-    # the same memory layout as the input query.
-    out_bhsd = torch.empty_like(query)
+    out_bhsd = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
     out_bshd = out_bhsd.transpose(1, 2)
 
     max_q_flash = q.size(1)

--- a/torch/nn/attention/_utils.py
+++ b/torch/nn/attention/_utils.py
@@ -9,6 +9,25 @@ import torch
 __all__: list[str] = []
 
 
+def _empty_with_matching_layout(
+    query: torch.Tensor, shape: tuple[int, ...]
+) -> torch.Tensor:
+    """Allocate an output with the query's dimension order."""
+    if tuple(query.shape) == shape:
+        return torch.empty_like(query)
+
+    fill_order = sorted(
+        range(query.dim()),
+        key=lambda idx: query.stride()[idx] if query.stride()[idx] else math.inf,
+    )
+    strides = [0] * len(fill_order)
+    stride = 1
+    for idx in fill_order:
+        strides[idx] = stride
+        stride *= shape[idx]
+    return torch.empty_strided(shape, strides, dtype=query.dtype, device=query.device)
+
+
 def _input_requires_grad(*tensors: torch.Tensor) -> bool:
     """Returns True if any of the tensors requires grad"""
     return any(t.requires_grad for t in tensors)

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -11,6 +11,8 @@ from typing import Any, NamedTuple
 
 import torch
 
+from ._utils import _empty_with_matching_layout
+
 
 log = logging.getLogger(__name__)
 
@@ -187,8 +189,7 @@ def _varlen_attn_fake(
     """
     window_size = _normalize_window_size(window_size)
 
-    # Output has same shape as query
-    output = torch.empty_like(query)
+    output = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
 
     # For varlen path: logsumexp shape is (num_heads, total_q)
     total_q = query.size(0)


### PR DESCRIPTION
Human Note

FA4 has different constraints than FA2. This one speicfically is for enabling DSv3 style mla training. Follows the same pattern for communciating FA3 is being used; set in context and update sdp utils to use this info


Agent note
PyTorch's generic Flash SDPA selector required Q, K, and V to have equal head dimensions before
calling an activated Flash implementation. This preserves FA2's contract, but prevents FA4 from
running supported shapes such as DeepSeek's Q/K=192, V=128. The FA4 SDPA adapter and meta kernels
also allocated output using Q's head dimension even though attention output follows V.

This change tracks FA4 activation in the existing SDPA context, following the FA3 precedent, and
applies FA4's architecture-specific head-dimension and no-dropout constraints only while FA4 is
active. The default FA2/FA3 and ROCm selection rules remain unchanged. Eager, fake, and meta outputs
now use V's head dimension while preserving Q's dimension order, and Flash output is unpadded to V's
original dimension.

On a B200, forced Flash SDPA now dispatches the exact DeepSeek shape `(B,H,S,Dqk,Dv) =
(4,128,4096,192,128)` to FA4 forward and backward kernels with the expected output and gradient
shapes. The broader FA4 test file, mixed-dimension metadata tests, default-selector regressions, and
varlen tests pass locally.

This PR is draft until the Human Note section contains the author's own review and rationale, as
required by `AI_POLICY.md`.

Test Plan:

```bash
cd ~/meta/pytorch && source ~/.venvs/dev/bin/activate && source ~/dotfiles/scripts/_build_setup.sh -b200 && CCACHE_NOHASHDIR=true uv pip install -e . --no-build-isolation -v
cd ~/meta/pytorch && gpu-run 0 -- env PYTHONPATH=$PWD/test/nn/attention:$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/dev/bin/python -m pytest test/nn/attention/test_fa4.py -q
# 82 passed

cd ~/meta/pytorch && env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/dev/bin/python -m pytest test/test_meta.py -k flash_attention_mixed_head_dim_metadata -q
# 2 passed

cd ~/meta/pytorch && gpu-run 0 -- env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/dev/bin/python -m pytest test/test_transformers.py -k "flash_attention_rejects_different_dk_dv or fused_attention_different_dk_dv or invalid_fused_inputs_head_dim" -q
# 5 passed, 3 skipped

cd ~/meta/pytorch && env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/dev/bin/python -m pytest test/test_varlen_attention.py -q
# 353 passed, 74 skipped, 8 xfailed, 9 subtests passed

cd ~/meta/pytorch && lintrunner --skip CLANGTIDY aten/src/ATen/Context.cpp aten/src/ATen/Context.h aten/src/ATen/native/transformers/attention.cpp aten/src/ATen/native/transformers/cuda/sdp_utils.cpp test/nn/attention/test_fa4.py test/test_meta.py test/test_transformers.py torch/_C/__init__.pyi.in torch/_meta_registrations.py torch/csrc/Module.cpp torch/nn/attention/_fa4.py torch/nn/attention/_utils.py torch/nn/attention/varlen.py
# No lint issues
```

The unfiltered lintrunner invocation reports two pre-existing clang-tidy findings in untouched code:
`aten/src/ATen/Context.cpp:689` and `torch/csrc/Module.cpp:269`.


cc @liangel-02 @howardzhang-cv