### PR TITLE
Fix exp2 derivatives overflowing to inf near the float64 max

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13773,6 +13773,18 @@ class TestAutogradDeviceType(TestCase):
                 gradgradcheck(fn, (input, 0, idx, src, "prod"))
 
     @skipIfMPS  # the test doesn't work on MPS as double types are not supported
+    @skipMeta
+    def test_exp2_backward_no_spurious_overflow(self, device):
+        # 2 ** 1024 overflows float64, but ln(2) ** k * 2 ** 1024 does not, so
+        # the derivatives must not be recovered from the (infinite) result.
+        x = torch.tensor(1024.0, device=device, dtype=torch.float64, requires_grad=True)
+        (g1,) = torch.autograd.grad(torch.exp2(x), x, create_graph=True)
+        (g2,) = torch.autograd.grad(g1, x)
+        ln2 = math.log(2.0)
+        self.assertEqual(g1, math.ldexp(ln2, 1024))
+        self.assertEqual(g2, math.ldexp(ln2 * ln2, 1024))
+
+    @skipIfMPS  # the test doesn't work on MPS as double types are not supported
     def test_parameter_resize(self, device):
         asd = torch.nn.Parameter(torch.ones(16, dtype=torch.double, device=device))
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -655,7 +655,7 @@
   result: auto_element_wise
 
 - name: exp2(Tensor self) -> Tensor
-  self: grad * result.conj() * M_LN2
+  self: grad * exp2(self - 1).conj() * (2 * M_LN2)
   result: auto_element_wise
 
 - name: expm1(Tensor self) -> Tensor


### PR DESCRIPTION
### Changes
torch's exp2 derivative was computed using: `grad * result.conj() * M_LN2` in derivatives.yaml

2**x overflows float64 at x=1024, but the first derivative stays finite until ~1024.53 and the second derivative stays finite until ~1025.06. Currently, since inf is at x = 1024, multiplying by M_LN2 propagates the inf.

The fix is:
`self: grad * exp2(self - 1).conj() * (2 * M_LN2)`

Fixes #192408

### Test Plan:

  New regression test asserting both derivatives at x = 1024. The expected
  values are built with math.ldexp so that computing the reference does not
  itself overflow:

  ```
  python test/test_autograd.py -k exp2
  ```

  Existing exp2 coverage, including OpInfo gradcheck/gradgradcheck:

  ```
  python test/test_ops_gradients.py -k exp2
  python test/test_ops_fwd_gradients.py -k exp2
  python test/test_unary_ufuncs.py -k exp2
  python test/test_ops.py -k exp2
  ```
