### PR TITLE
Add sync_cache_decision_cross_ranks (#193043)

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -3918,6 +3918,153 @@ class TestSyncDecisionCrossRanks(MultiProcessTestCase):
             compiled(x, w, group_size, group_name)
 
 
+class TestCompileSyncPgCrossRanks(MultiProcessTestCase):
+    """
+    The compile time sync runs on a gloo process group over CPU, so unlike the rest of
+    TestSyncDecisionCrossRanks these need no accelerator.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _init_process_group(self, timeout: datetime.timedelta | None = None) -> None:
+        store = torch.distributed.FileStore(self.file_name, self.world_size)
+        torch.distributed.init_process_group(
+            backend="gloo",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            timeout=timeout,
+        )
+
+    def test_sync_cache_decision_cross_ranks(self):
+        # A cache hit on one rank and a miss on another leaves only the missing rank
+        # inside _sync_decision_cross_ranks, which desyncs the process group. The hit
+        # must be discarded unless every rank hit.
+        from torch._dynamo.utils import counters
+        from torch._functorch._aot_autograd.autograd_cache import (
+            sync_cache_decision_cross_ranks,
+        )
+
+        self._init_process_group()
+
+        with torch._functorch.config.patch(_sync_cache_decision_cross_ranks=True):
+            self.assertTrue(sync_cache_decision_cross_ranks(True))
+            self.assertFalse(sync_cache_decision_cross_ranks(False))
+
+            counters.clear()
+            # Rank 0 hits, rank 1 misses.
+            self.assertFalse(sync_cache_decision_cross_ranks(self.rank == 0))
+            self.assertEqual(
+                counters["aot_autograd"]["autograd_cache_cross_rank_miss"],
+                1 if self.rank == 0 else 0,
+            )
+
+        # Disabled by default, so a lone hit survives and no collective is issued.
+        self.assertEqual(
+            sync_cache_decision_cross_ranks(self.rank == 0), self.rank == 0
+        )
+
+    @torch._functorch.config.patch(
+        enable_autograd_cache=True, _sync_cache_decision_cross_ranks=True
+    )
+    @torch._inductor.config.patch(fx_graph_cache=True, compile_threads=1)
+    def test_cross_rank_miss_recompiles_and_saves(self):
+        # End to end through aot_module_simplified, rank 0 warm and rank 1 cold: rank 1
+        # reaches the partitioner's collective alone while rank 0 sails past on its hit.
+        # Rejecting that hit is only half of it, the rejected rank also has to populate
+        # aot_config.cache_info or its recompile is never saved and the next compile
+        # diverges all over again.
+        from torch._dynamo.utils import counters
+        from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
+
+        self._init_process_group()
+        torch._C._distributed_c10d._register_process_group(
+            "default", torch.distributed.group.WORLD
+        )
+        expected = torch.full((4, 4), self.world_size + 1.0)
+
+        def fn(x):
+            return _functional_collectives.all_reduce(x, "sum", "default") + 1
+
+        def compile_and_run():
+            counters.clear()
+            torch._dynamo.reset()
+            self.assertEqual(torch.compile(fn)(torch.ones(4, 4)), expected)
+
+        # Each rank gets its own cache dir, so the clear below only cools rank 1.
+        with fresh_inductor_cache():
+            compile_and_run()
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+            if self.rank == 1:
+                AOTAutogradCache.clear()
+
+            compile_and_run()
+            self.assertEqual(
+                counters["aot_autograd"]["autograd_cache_cross_rank_miss"],
+                1 if self.rank == 0 else 0,
+            )
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+            # Both ranks are warm again, so the hit survives the sync and is usable.
+            compile_and_run()
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+            self.assertEqual(
+                counters["aot_autograd"]["autograd_cache_cross_rank_miss"], 0
+            )
+
+    def test_compile_sync_pg_built_for_partitioner_sync_alone(self):
+        # _sync_decision_cross_ranks builds the pg lazily on the partitioner path, which
+        # a partial cache hit leaves to the ranks that missed. Building a group on a
+        # subset of ranks hangs and desyncs _world.group_count, so it has to happen here,
+        # where every rank is, even though the decision itself passes straight through.
+        from torch._dynamo import distributed as dynamo_distributed
+        from torch._functorch._aot_autograd.autograd_cache import (
+            sync_cache_decision_cross_ranks,
+        )
+
+        self._init_process_group()
+        self.assertIsNone(dynamo_distributed._COMPILE_SYNC_PG)
+
+        with torch._functorch.config.patch(_sync_decision_cross_ranks=True):
+            # A build without gloo has nothing to prime, and priming must not be what
+            # surfaces that: the partitioner still raises, and only for the graphs it
+            # syncs, rather than every compile that gets here.
+            with mock.patch.object(c10d, "is_gloo_available", return_value=False):
+                self.assertTrue(sync_cache_decision_cross_ranks(True))
+            self.assertIsNone(dynamo_distributed._COMPILE_SYNC_PG)
+
+            self.assertTrue(sync_cache_decision_cross_ranks(True))
+            self.assertFalse(sync_cache_decision_cross_ranks(False))
+
+        self.assertIsNotNone(dynamo_distributed._COMPILE_SYNC_PG)
+
+    def test_compile_sync_pg_without_gloo(self):
+        from torch._dynamo.distributed import get_compile_sync_pg
+
+        self._init_process_group()
+
+        with mock.patch.object(c10d, "is_gloo_available", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "requires the gloo backend"):
+                get_compile_sync_pg()
+
+    def test_compile_sync_pg_inherits_default_timeout(self):
+        from torch._dynamo.distributed import get_compile_sync_pg
+
+        timeout = datetime.timedelta(seconds=120)
+        self._init_process_group(timeout=timeout)
+
+        pg = get_compile_sync_pg()
+        device = torch.device(c10d.distributed_c10d._get_object_coll_device(pg))
+        self.assertEqual(pg._get_backend(device).options._timeout, timeout)
+
+
 class TestNodeGroupNameResolution(torch._dynamo.test_case.TestCase):
     """Unit tests for Node-typed group_name handling in bucketing.
 

--- a/torch/_dynamo/distributed.py
+++ b/torch/_dynamo/distributed.py
@@ -14,6 +14,7 @@ is properly initialized, making it safe to import and use this module even in
 non-distributed scenarios.
 """
 
+import torch
 import torch.distributed as dist
 
 from . import config
@@ -21,6 +22,7 @@ from . import config
 
 _COMPILE_PG: dist.ProcessGroup | None = None
 _GUARD_PG: dist.ProcessGroup | None = None
+_COMPILE_SYNC_PG: dist.ProcessGroup | None = None
 
 
 def get_compile_pg() -> dist.ProcessGroup | None:
@@ -31,7 +33,6 @@ def get_compile_pg() -> dist.ProcessGroup | None:
     ):
         global _COMPILE_PG
         if _COMPILE_PG is None:
-            # , timeout=datetime.timedelta(seconds=2)
             compile_pg = dist.distributed_c10d._new_group_with_tag(
                 pg_tag="pt2_compile_pg"
             )
@@ -54,5 +55,52 @@ def get_guard_pg() -> dist.ProcessGroup | None:
                 raise AssertionError("Guard process group must include all ranks")
             _GUARD_PG = guard_pg
         return _GUARD_PG
+
+    return None
+
+
+# NB: Like get_guard_pg, this is only called when the caller explicitly asked for
+# compile time synchronization.
+def get_compile_sync_pg() -> dist.ProcessGroup | None:
+    """
+    Process group for collectives issued from inside the compiler itself, e.g. the
+    partitioner's cross rank decision sync.
+
+    These must not share a process group with the model's runtime collectives: ranks
+    reach a given compile at different times, so a rank that has already resumed
+    execution can otherwise match one of its runtime ops against another rank's
+    compile time op. We thus require gloo as the backend. Gloo keeps the traffic off
+    the accelerator as well, so a compile time collective can't interleave with
+    an in flight NCCL op.
+    """
+    if dist.is_available() and dist.is_initialized():
+        global _COMPILE_SYNC_PG
+        if _COMPILE_SYNC_PG is None:
+            if not dist.is_gloo_available():
+                # No fallback: per above, the accelerator backend would let a compile
+                # time collective match a runtime one.
+                raise RuntimeError(
+                    "Compile time cross rank synchronization requires the gloo "
+                    "backend, which this build of PyTorch does not have. Either "
+                    "build with gloo, or turn off "
+                    "torch._functorch.config._sync_decision_cross_ranks and "
+                    "torch._functorch.config._sync_cache_decision_cross_ranks."
+                )
+            # Left to itself, _new_group_with_tag picks the global default_pg_timeout
+            # constant rather than the timeout init_process_group was configured with.
+            default_pg = dist.distributed_c10d._get_default_group()
+            coll_device = dist.distributed_c10d._get_object_coll_device(default_pg)
+            default_backend = default_pg._get_backend(torch.device(coll_device))
+            compile_sync_pg = dist.distributed_c10d._new_group_with_tag(
+                backend="gloo",
+                timeout=default_backend.options._timeout,
+                pg_tag="pt2_compile_sync_pg",
+            )
+            if compile_sync_pg == dist.GroupMember.NON_GROUP_MEMBER:
+                raise AssertionError(
+                    "Compile sync process group must include all ranks"
+                )
+            _COMPILE_SYNC_PG = compile_sync_pg
+        return _COMPILE_SYNC_PG
 
     return None

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -143,6 +143,76 @@ def should_bundle_autograd_cache() -> bool:
     return config.bundled_autograd_cache or torch._dynamo.config.caching_precompile
 
 
+def sync_cache_decision_cross_ranks(local_hit: bool) -> bool:
+    """
+    Whether every rank hit AOTAutogradCache. The caller has to drop a lone hit.
+
+    Compilation itself issues collectives (see config._sync_decision_cross_ranks and the
+    inductor pass that reorders collectives), and only the ranks that actually compile
+    reach them, so the hit/miss decision has to be unanimous. Every rank that could
+    reach one of those collectives should call this.
+
+    The outcome is synchronized rather than the cache key: a key only says which entries
+    are candidates, while the hit is decided afterwards by evaluating each candidate's
+    dynamic shape guards against rank local hints, which can diverge for equal keys.
+
+    No attempt to skip collective free graphs: the partitioner can gate on the joint
+    graph, but this sees the Dynamo graph, where a DTensor collective is still just a
+    redistribute() call. Gating here would no-op the feature for the TP/SP jobs it is
+    for, and a 4 byte gloo all_reduce is nothing next to a compile.
+    """
+    dist = torch.distributed
+    if not (dist.is_available() and dist.is_initialized()):
+        return local_hit
+    if dist.get_world_size() < 2:
+        return local_hit
+
+    from torch._dynamo.distributed import get_compile_sync_pg
+
+    if not config._sync_cache_decision_cross_ranks:
+        # Nothing to decide, but _sync_decision_cross_ranks builds this same group lazily
+        # on the partitioner path, which a partial cache hit leaves to the ranks that
+        # missed: a subset of ranks building a group hangs in the rendezvous, and worse,
+        # advances _world.group_count only on those ranks, which is the salt every later
+        # group name is derived from. Build it here instead, where every rank is. Skipped
+        # without gloo so such a build keeps failing where it did before, in the
+        # partitioner and only for the graphs it actually syncs.
+        if config._sync_decision_cross_ranks and dist.is_gloo_available():
+            get_compile_sync_pg()
+        return local_hit
+
+    pg = get_compile_sync_pg()
+    if pg is None:
+        return local_hit
+
+    from torch._subclasses.fake_tensor import unset_fake_temporarily
+    from torch.utils._mode_utils import no_dispatch
+
+    with no_dispatch(), unset_fake_temporarily():
+        decision = torch.tensor(
+            [local_hit],
+            dtype=torch.int32,
+            device=dist.distributed_c10d._get_object_coll_device(pg),
+        )
+        dist.all_reduce(decision, op=dist.ReduceOp.MIN, group=pg)
+        all_ranks_hit = bool(decision.item())
+
+    if all_ranks_hit:
+        return True
+
+    # The collective only carries whether every rank hit, so each rank reports its
+    # own decision here: grep for local_hit=False to find the ranks that missed.
+    log.info(
+        "AOTAutograd cache cross rank miss: rank=%d local_hit=%s",
+        dist.get_rank(),
+        local_hit,
+    )
+
+    if local_hit:
+        counters["aot_autograd"]["autograd_cache_cross_rank_miss"] += 1
+    return False
+
+
 def check_node_safe(node: Node) -> None:
     """
     Checks that the node only uses supported operators. We are starting with very
@@ -1079,17 +1149,59 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         debug_lines: list[str] = []
         cache_event_time = time.time_ns()
         cache_state = None
+        result: tuple[GenericAOTAutogradResult[Any, Any], bytes] | None = None
+
+        # Most often this is BypassAOTAutogradCache, but
+        # if there's ever different reason we can't cache,
+        # we still never want to hard throw an exception, since
+        # we can always fallback to a cache bypass.
+        # As an example, if the user calls autograd via
+        # standalone inductor, we will sometimes get a GraphModule
+        # that doesn't actually have a `.graph` on it. Instead
+        # of checking every single case, we safely catch the exception
+        # in those cases.
+        def record_bypass(e: Exception) -> None:
+            nonlocal cache_key, cache_state, cache_event_time
+            cache_key = None
+            counters["aot_autograd"]["autograd_cache_bypass"] += 1
+            log.info("Bypassing autograd cache due to: %s", e)
+            cache_state = "bypass"
+            cache_event_time = time.time_ns()
+            cache_info["cache_bypass_reason"] = str(e)
+            cache_info["cache_bypass_exception_type"] = type(e).__name__
+            cache_info["cache_bypass_traceback"] = traceback.format_exc().split("\n")
+            # TODO: this gets logged implicitly by cache_bypass_reason,
+            # and here we explicitly log it into tlparse.
+            # We may want to log this as an extra column in Scuba, though.
+            cache_info["cache_bypass_hard_exception"] = not isinstance(
+                e, BypassAOTAutogradCache
+            )
+            if remote:
+                log_cache_bypass("bypass_aot_autograd", str(e))
+            if config.strict_autograd_cache or torch._dynamo.config.strict_precompile:
+                raise e
+
         try:
             cache_key, debug_lines = autograd_cache_key(
                 mod, args, aot_config, compiler_config_extra, act_input_paths
             )
-            result: tuple[GenericAOTAutogradResult[Any, Any], bytes] | None = (
-                AOTAutogradCache._lookup(
-                    cache_key, local, remote, args, cache_info, aot_config
-                )
+            result = AOTAutogradCache._lookup(
+                cache_key, local, remote, args, cache_info, aot_config
             )
-            if result is not None:
-                (entry, pickled_content) = result
+        except Exception as e:
+            record_bypass(e)
+
+        # Outside the try so bypassing ranks reach it too, and before the load rather
+        # than after: the load ends in _check_guards, which installs the entry's guards
+        # into the ShapeEnv (see [Note: Caching guards generated by AOTAutograd and
+        # Inductor]). Dropping the callable does not undo that, so a rank rejected post
+        # load would recompile under constraints the cleanly missing ranks never saw.
+        if not sync_cache_decision_cross_ranks(result is not None):
+            result = None
+
+        if result is not None:
+            (entry, pickled_content) = result
+            try:
                 fx_config = create_fx_config(compiler_config_extra, compile_region_name)
                 compiled_fn = entry.wrap_post_compile(args, aot_config, fx_config)
                 # Make the compiled_fn serializable, where the serialize function just
@@ -1097,6 +1209,33 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 compiled_fn = SerializableCompiledFunction(
                     compiled_fn, lambda: pickle.loads(pickled_content)
                 )
+            # Count missing the FXGraphCache as a miss not a bypass, which is what
+            # leaving cache_state unset gets us from the tail below.
+            except FXGraphCacheMiss as e:
+                if (
+                    config.strict_autograd_cache
+                    or torch._dynamo.config.strict_precompile
+                ):
+                    raise e
+            except Exception as e:
+                record_bypass(e)
+
+            # Unanimous above, so every rank reaches this backstop. It catches the one
+            # asymmetry the first sync cannot see: an entry that loaded here but whose
+            # FXGraphCache missed on another rank. FXGraphCacheMiss is raised before
+            # _check_guards, so this does leave the ShapeEnv lopsided and only buys
+            # lockstep recompiling instead of a hang, which is enough for a window that
+            # needs the two caches to disagree with each other.
+            if not sync_cache_decision_cross_ranks(compiled_fn is not None):
+                compiled_fn = None
+
+            # Reported only once the hit is final, so a rank whose hit was rejected falls
+            # through to the miss tail instead: no autograd_cache_hit, no time saved in
+            # cache_info, and no ephemeral timeout bump for time it is about to spend
+            # compiling anyway. cache_status_detailed, which _lookup already put in
+            # cache_info, is deliberately left alone: it describes what the lookup found,
+            # which is true either way.
+            if compiled_fn is not None:
                 log.info("AOTAutograd cache hit for key %s", cache_key)
 
                 counters["aot_autograd"]["autograd_cache_hit"] += 1
@@ -1123,45 +1262,12 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 ) != 0:
                     cache_info["ephemeral_timeout_increase"] = ephemeral_increase
 
-            if compiled_fn is None:
-                log.info("AOTAutograd cache miss for key %s", cache_key)
-                counters["aot_autograd"]["autograd_cache_miss"] += 1
-                cache_state = "miss"
-                cache_event_time = time.time_ns()
-        # Count missing the FXGraphCache as a miss not a bypass
-        except FXGraphCacheMiss as e:
+        if compiled_fn is None and cache_state is None:
+            log.info("AOTAutograd cache miss for key %s", cache_key)
             counters["aot_autograd"]["autograd_cache_miss"] += 1
             cache_state = "miss"
-            if config.strict_autograd_cache or torch._dynamo.config.strict_precompile:
-                raise e
-        # Most often this is BypassAOTAutogradCache, but
-        # if there's ever different reason we can't cache,
-        # we still never want to hard throw an exception, since
-        # we can always fallback to a cache bypass.
-        # As an example, if the user calls autograd via
-        # standalone inductor, we will sometimes get a GraphModule
-        # that doesn't actually have a `.graph` on it. Instead
-        # of checking every single case, we safely catch the exception
-        # in those cases.
-        except Exception as e:
-            cache_key = None
-            counters["aot_autograd"]["autograd_cache_bypass"] += 1
-            log.info("Bypassing autograd cache due to: %s", e)
-            cache_state = "bypass"
             cache_event_time = time.time_ns()
-            cache_info["cache_bypass_reason"] = str(e)
-            cache_info["cache_bypass_exception_type"] = type(e).__name__
-            cache_info["cache_bypass_traceback"] = traceback.format_exc().split("\n")
-            # TODO: this gets logged implicitly by cache_bypass_reason,
-            # and here we explicitly log it into tlparse.
-            # We may want to log this as an extra column in Scuba, though.
-            cache_info["cache_bypass_hard_exception"] = not isinstance(
-                e, BypassAOTAutogradCache
-            )
-            if remote:
-                log_cache_bypass("bypass_aot_autograd", str(e))
-            if config.strict_autograd_cache or torch._dynamo.config.strict_precompile:
-                raise e
+
         if compiled_fn is None:
             # Set the cache key so we can save a cache result later
             symints = AOTAutogradCache._filter_backed_symints(args)

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -421,7 +421,25 @@ guess_tangent_strides_as_outputs = not is_fbcode()
 
 # This is a temporary config to ensure all ranks take the same decision in the partitioner
 # it will ultimately be removed once we share size_hints across ranks through compiler collectives
+# Only the ranks that actually compile reach the partitioner, so with AOTAutogradCache on
+# this needs _sync_cache_decision_cross_ranks below to keep hits unanimous. Without it a
+# partial cache hit hangs the ranks that missed, as it did before that config existed.
 _sync_decision_cross_ranks = False
+
+# Compilation itself issues collectives, for example, when _sync_decision_cross_ranks is
+# set, those collectives only run on the ranks that actually compile, so a cache hit on
+# one rank and a miss on another desyncs the process group and hangs. This config makes
+# the outcome uniform: after every rank has consulted AOTAutogradCache, the hits are discarded
+# unless *all* ranks hit.
+# Synchronizing the outcome rather than the cache key is deliberate. A key only covers
+# whether an entry exists; a rank can find its entry and still miss because the entry's
+# dynamic shape guards do not hold for that rank's hints (`guard_miss`).
+# Precondition: every rank has to reach AOTAutogradCache.try_load for the same compiles,
+# since that is where the collective is issued. try_load runs only for a
+# SerializableAOTDispatchCompiler backend with local or remote caching on, so a rank that
+# differs on enable_autograd_cache, force_disable_caches, or the remote cache JustKnob
+# never joins the all_reduce and hangs the ranks that did.
+_sync_cache_decision_cross_ranks = False
 
 # By default apply inlined saved_tensors_hooks only for "donated" buffers.
 # "donated" buffers are invisible to the user, they are intermediates of the forward graph.

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3870,6 +3870,7 @@ def _sync_decision_cross_ranks(
     joint_graph: torch.fx.Graph, saved_values: list[torch.fx.Node]
 ) -> list[torch.fx.Node]:
     # use the same policy across different GPUs
+    from torch._dynamo.distributed import get_compile_sync_pg
     from torch._subclasses.fake_tensor import unset_fake_temporarily
 
     def has_collectives(joint_graph: torch.fx.Graph) -> bool:
@@ -3887,6 +3888,11 @@ def _sync_decision_cross_ranks(
         and has_collectives(joint_graph)
     ):
         return saved_values
+
+    pg = get_compile_sync_pg()
+    if pg is None:
+        raise AssertionError("Compile sync process group must be available here")
+    coll_device = torch.distributed.distributed_c10d._get_object_coll_device(pg)
 
     canonical = _canonical_node_names(joint_graph)
     reverse_canonical = {v: k for k, v in canonical.items()}
@@ -3908,10 +3914,9 @@ def _sync_decision_cross_ranks(
             for n in sorted(joint_graph.nodes, key=lambda n: canonical[n])
         )
         inputs = hashlib.sha256(node_str.encode("utf-8")).hexdigest()
-        all_inputs = [None for _ in range(torch.distributed.get_world_size())]
+        all_inputs = [None for _ in range(pg.size())]
         with no_dispatch(), unset_fake_temporarily():
-            # TODO: maybe use a different process group?
-            torch.distributed.all_gather_object(all_inputs, inputs)
+            torch.distributed.all_gather_object(all_inputs, inputs, group=pg)
             for rank, x in enumerate(all_inputs):
                 if all_inputs[0] != x:
                     log.debug(
@@ -3926,10 +3931,10 @@ def _sync_decision_cross_ranks(
             # Communicate saved values using canonical names so that
             # node names (which may differ across ranks) don't matter.
             objects = [[canonical[x] for x in saved_values]]
-            saved_ops_names_all_ranks: list[list[str]] = [
-                [] for _ in range(torch.distributed.get_world_size())
-            ]
-            torch.distributed.all_gather_object(saved_ops_names_all_ranks, objects[0])
+            saved_ops_names_all_ranks: list[list[str]] = [[] for _ in range(pg.size())]
+            torch.distributed.all_gather_object(
+                saved_ops_names_all_ranks, objects[0], group=pg
+            )
             saved_sizes: list[int] = []
             saved_ops_with_sizes: dict[str, int] = {}
 
@@ -3941,17 +3946,16 @@ def _sync_decision_cross_ranks(
                 for node in saved_nodes:
                     size_of_node = _size_of(node)
                     saved_size += size_of_node
-                    if idx == torch.distributed.get_rank():
+                    if idx == pg.rank():
                         saved_ops_with_sizes[node.name] = size_of_node
                 saved_ops_with_sizes["total size"] = saved_size
                 saved_sizes.append(saved_size)
 
-            saved_sizes_tensor = torch.tensor(
-                saved_sizes,
-                device=torch.distributed.distributed_c10d._get_object_coll_device(),
-            )
+            saved_sizes_tensor = torch.tensor(saved_sizes, device=coll_device)
             torch.distributed.all_reduce(
-                saved_sizes_tensor, op=torch.distributed.distributed_c10d.ReduceOp.MAX
+                saved_sizes_tensor,
+                op=torch.distributed.distributed_c10d.ReduceOp.MAX,
+                group=pg,
             )
 
             picked_rank_idx = int(torch.argmin(saved_sizes_tensor).item())


### PR DESCRIPTION
Summary:

This diff introduces `sync_cache_decision_cross_ranks`. This mechanism make sure that all ranks have the same aot_autograd cache hit/miss results. This is important because during compilation process, there are some steps running collectives (e.g., `sync_decision_cross_ranks`), if some rank hit aot_autograd cache while other ranks do not. Then only ranks missed the cache will run the collective, which leads to a hang. With this flag on, we ensure unanimous decisions across all ranks.

Another change in this PR is that we introduced a global `_COMPILE_SYNC_PG` whose backend is gloo. Both `sync_cache_decision_cross_ranks` and `_sync_decision_cross_ranks` are using this pg. It's better than previous implementation with NCCL pg which is likely interleave with an in flight NCCL op from training execution.

Test Plan:
f1125112932

It's working:
 {F1993930398}

Differential Revision: D114838651




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98