### PR TITLE
[inductor] Report cudagraph skip when no graph partition is cudagraphable

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -4656,7 +4656,10 @@ if HAS_CUDA_AND_TRITON:
             self.assertIsNotNone(self.get_manager())
 
         @torch._inductor.config.patch("triton.slow_path_cudagraph_asserts", True)
+        @torch._inductor.config.patch("triton.cudagraph_or_error", True)
         def test_kernel_free_allocation_uses_cudagraph_pool(self):
+            counters.clear()
+
             def fn(x):
                 return torch.empty_like(x)
 
@@ -4677,6 +4680,7 @@ if HAS_CUDA_AND_TRITON:
                 self.assertFalse(
                     any("CUDA Graph is empty" in str(w.message) for w in caught)
                 )
+                self.assertEqual(counters["inductor"]["cudagraph_skips"], 0)
 
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_forward_backward(self):
@@ -6038,6 +6042,56 @@ if HAS_CUDA_AND_TRITON:
 
             with self.assertRaises(RuntimeError):
                 f(torch.tensor(1, device="cuda"))
+
+        @config.patch(implicit_fallbacks=True)
+        @torch._inductor.config.patch("graph_partition", True)
+        def test_graph_partition_cudagraph_or_error(self):
+            # With no cudagraphable partition, cudagraphify is never reached, so
+            # the skip has to be reported before returning early.
+            @torch.library.custom_op(
+                "mylib::cudagraph_unsafe_mul",
+                mutates_args=(),
+                tags=(torch._C.Tag.cudagraph_unsafe,),
+            )
+            def cudagraph_unsafe_mul(x: torch.Tensor) -> torch.Tensor:
+                return x * 2.0
+
+            @cudagraph_unsafe_mul.register_fake
+            def _(x):
+                return torch.empty_like(x)
+
+            def f(x):
+                return cudagraph_unsafe_mul(x)
+
+            msg = "skipping cudagraphs as no graph partition is cudagraphable"
+
+            with torch._inductor.config.patch("triton.cudagraph_or_error", True):
+                f_error = torch.compile(f, mode="reduce-overhead")
+
+                # Match the branch-specific message: an unrelated RuntimeError or
+                # another skip path would pass a broader assertion.
+                with self.assertRaisesRegex(RuntimeError, msg):
+                    f_error(torch.randn(4, device="cuda"))
+
+            torch._dynamo.reset()
+            counters.clear()
+            torch._dynamo.utils.clear_compilation_metrics()
+            log_stream, ctx = logs_to_string(
+                "torch._inductor.cudagraph_utils", "cudagraphs"
+            )
+            with ctx():
+                f_report = torch.compile(f, mode="reduce-overhead")
+                f_report(torch.randn(4, device="cuda"))
+
+            FileCheck().check(msg).run(log_stream.getvalue())
+            self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
+            self.assertIn(
+                msg,
+                [
+                    metric.cudagraph_skip_reason
+                    for metric in torch._dynamo.utils.get_compilation_metrics()
+                ],
+            )
 
         @config.patch(implicit_fallbacks=True)
         @torch._inductor.config.patch("graph_partition", True)

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -362,6 +362,16 @@ def cudagraph_partition_post_compile(
         # cudagraphify is not called if there are no partitions
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
+
+        if any(is_gpu(device) for device in compiled_graph.device_types):
+            if cudagraph_fail_reasons:
+                log_cudagraph_skip_and_bump_counter(
+                    f"skipping cudagraphs due to {cudagraph_fail_reasons}"
+                )
+            else:
+                log_cudagraph_skip_and_bump_counter(
+                    "skipping cudagraphs as no graph partition is cudagraphable"
+                )
         return
 
     if compiled_graph.current_callable is None:


### PR DESCRIPTION
Fixes #176611

### Problem

`cudagraph_partition_post_compile` bails out early when there are cudagraph fail
reasons, or when `partition_maps` is `None` or empty, but it never called
`log_cudagraph_skip_and_bump_counter` on that path:

```python
if (
    cudagraph_fail_reasons
    or compiled_graph.partition_maps is None
    or len(compiled_graph.partition_maps) == 0
):
    BoxedBool.disable(cudagraphs)
    maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
    return
```

That helper is what raises under `triton.cudagraph_or_error`, so whenever
`graph_partition` is enabled — the default outside fbcode — a graph that is
never captured was accepted silently. `cudagraph_or_error=True` did not fire,
`counters["inductor"]["cudagraph_skips"]` stayed at zero, and no skip reason
reached the metrics context.

The non-partitioned path, `cudagraph_post_compile`, already reports the skip,
so the two paths disagreed on whether a skipped graph is worth reporting.

### Fix

Report the skip before returning, mirroring the non-partitioned path: prefer
`disabled_cudagraphs_reason` because it carries a stack trace, fall back to the
fail reasons, and otherwise report that no partition was cudagraphable.

### Note on the patch suggested in the issue

The issue proposes chaining three independent `if` statements. That form calls
`len(compiled_graph.partition_maps)` inside the branch that just established
`partition_maps` may be `None`, and it can bump `cudagraph_skips` up to three
times for a single skipped graph. The `if`/`elif`/`else` used here keeps the
counter at one increment per skip and evaluates nothing the enclosing guard has
not already ruled out.

### On the test

The new test asserts on the message rather than using a bare `assertRaises`.
When the custom op cannot be lowered, inductor raises
`MissingOperatorWithoutDecomp: missing lowering`, which satisfies a bare
`assertRaises(RuntimeError)` and lets the test pass while the bug is still
present. Matching the message keeps the test honest.

### Testing

```
python test/inductor/test_cudagraph_trees.py -k test_graph_partition_cudagraph_or_error
```

Fails without the fix (`AssertionError: RuntimeError not raised`), passes with
it. The repro from the issue raises
`RuntimeError: skipping cudagraphs as no graph partition is cudagraphable` with
the fix, and silently does nothing without it.

```
python test/inductor/test_cudagraph_trees.py
```

245 tests, OK (skipped=3).

This change bumps `cudagraph_skips` on a path that previously did not, so the
suites that assert on that counter were run as well:

```
python test/inductor/test_compiled_autograd.py -k cudagraph
python test/dynamo/test_compiler_bisector.py -k cudagraph
python test/functorch/test_control_flow.py -k cudagraph
```

6, 1 and 8 tests respectively, all OK.

Run on 2x H100 NVL, CUDA 12.8, sm_90.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @BoyuanFeng @eellison @mcarilli @ezyang
