### PR TITLE
[TEST] Refactor tests with hw_classification

### DIFF
--- a/test/package/test_glob_group.py
+++ b/test/package/test_glob_group.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 
 from torch.package import GlobGroup
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -14,6 +14,8 @@ except ImportError:
 
 
 class TestGlobGroup(PackageTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def assertMatchesGlob(self, glob: GlobGroup, candidates: Iterable[str]):
         for candidate in candidates:
             self.assertTrue(glob.matches(candidate))

--- a/test/package/test_importer.py
+++ b/test/package/test_importer.py
@@ -10,7 +10,7 @@ from torch.package import (
     PackageImporter,
     sys_importer,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -22,6 +22,8 @@ except ImportError:
 
 class TestImporter(PackageTestCase):
     """Tests for Importer and derived classes."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_sys_importer(self):
         import package_a

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -20,6 +20,7 @@ from torch.profiler._trace_validator import (
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -248,6 +249,8 @@ class TestTraceValidatorRules(TestCase):
     These tests verify rule logic using hand-crafted event dictionaries.
     No profiling or device operations — runs on any machine.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     # --- _check_nccl_metadata ---
 
@@ -571,6 +574,8 @@ class TestTraceValidatorE2EAgnostic(_TraceValidatorE2EMixin, TestCase):
     Instantiated per device type via ``instantiate_device_type_tests``.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     _trace_dir: str = ""
     _payloads: dict = {}
 
@@ -629,6 +634,8 @@ class TestTraceValidatorE2ECUDA(_TraceValidatorE2EMixin, TestCase):
     They use CUDA-specific profiling payloads including multi-stream
     and CUDA event synchronization.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     _trace_dir: str = ""
     _payloads: dict = {}

--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     run_tests,
     skipIfTorchInductor,
@@ -60,6 +61,8 @@ _fwd_grad_all = {
 
 @unMarkDynamoStrictTest
 class TestFwdGradients(TestGradients):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # Test that forward-over-reverse gradgrad is computed correctly
     @skipOps(
         _fwd_grad_all

--- a/test/test_ops_gradients.py
+++ b/test/test_ops_gradients.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TestCase,
     TestGradients,
@@ -52,6 +53,8 @@ _bwd_grad_all = {
 
 @unMarkDynamoStrictTest
 class TestBwdGradients(TestGradients):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # Tests that gradients are computed correctly
     @skipOps(
         _bwd_grad_all

--- a/test/test_throughput_benchmark.py
+++ b/test/test_throughput_benchmark.py
@@ -1,7 +1,12 @@
 # Owner(s): ["module: unknown"]
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TemporaryFileName, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TemporaryFileName,
+    TestCase,
+)
 from torch.utils import ThroughputBenchmark
 
 
@@ -35,6 +40,8 @@ class TwoLayerNetModule(torch.nn.Module):
 
 
 class TestThroughputBenchmark(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def linear_test(self, Module, profiler_output_path=""):
         D_in = 10
         H = 5
@@ -78,6 +85,10 @@ class TestThroughputBenchmark(TestCase):
     def test_profiling(self):
         with TemporaryFileName() as fname:
             self.linear_test(TwoLayerNetModule, profiler_output_path=fname)
+
+
+class TestThroughputBenchmarkCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
 
     def linear_with_compile_test(self, Module, dtype):
         from contextlib import nullcontext


### PR DESCRIPTION
## Summary

Apply hardware classification following #186918 guidelines across six test files.

**`test/package/test_glob_group.py`**
- **TestGlobGroup**: `GENERIC` — pure Python string/pattern logic, no device

**`test/package/test_importer.py`**
- **TestImporter**: `GENERIC` — device-agnostic package importer tests

**`test/test_ops_fwd_gradients.py`**
- **TestFwdGradients**: `ACCELERATOR` — uses `instantiate_device_type_tests`

**`test/test_ops_gradients.py`**
- **TestBwdGradients**: `ACCELERATOR` — uses `instantiate_device_type_tests`

**`test/test_throughput_benchmark.py`**
- **TestThroughputBenchmark**: `GENERIC` — script/module/profiling API tests
- **TestThroughputBenchmarkCPU**: `CPU` — hardcodes `torch.amp.autocast("cpu")`, cpp_wrapper, freezing

**`test/profiler/test_trace_validator.py`**
- **TestTraceValidatorRules**: `GENERIC` — synthetic JSON event rules, no device
- **TestTraceValidatorE2EAgnostic**: `ACCELERATOR` — E2E tests via `instantiate_device_type_tests`
- **TestTraceValidatorE2ECUDA**: `CUDA` — CUDA-specific profiler events (streams, sync, NCCL)

cc @mansiag05 @RiyaP2508

## Test plan

```
lintrunner -a test/package/test_glob_group.py test/package/test_importer.py \
  test/test_ops_gradients.py test/test_ops_fwd_gradients.py \
  test/test_throughput_benchmark.py test/profiler/test_trace_validator.py
# ok No lint issues.

python test/package/test_glob_group.py -v
python test/package/test_importer.py -v

python test/test_ops_fwd_gradients.py -v --hw-classification GENERIC
python test/test_ops_fwd_gradients.py -v --hw-classification ACCELERATOR

python test/test_ops_gradients.py -v --hw-classification GENERIC
python test/test_ops_gradients.py -v --hw-classification ACCELERATOR

python test/test_throughput_benchmark.py -v
python test/test_throughput_benchmark.py --hw-classification GENERIC -v
python test/test_throughput_benchmark.py --hw-classification CPU -v

python test/profiler/test_trace_validator.py -v
python test/profiler/test_trace_validator.py --hw-classification GENERIC -v
python test/profiler/test_trace_validator.py --hw-classification ACCELERATOR -v
python test/profiler/test_trace_validator.py --hw-classification CUDA -v
```

Authored with an AI assistant.