### PR TITLE
Fix nn.functional.threshold OpInfo reference for NumPy >= 2.5

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17510,10 +17510,13 @@ op_db: list[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
+        # NumPy >= 2.5 raises instead of wrapping when an out-of-range Python int is
+        # written into an unsigned result, so keep value representable in dtype.
+        # 247 is what -9 already wrapped to for uint8, so the numerics are unchanged.
         sample_kwargs=lambda device, dtype, input: ({'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9},
+                                                    'value': -9 if dtype.is_signed else 247},
                                                     {'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9}),
+                                                    'value': -9 if dtype.is_signed else 247}),
         # TODO(whc) should not need sample_inputs_func, but without it
         # kwargs aren't being hooked up properly
         sample_inputs_func=sample_inputs_threshold,


### PR DESCRIPTION
Fixes #189267

### Root cause

The `nn.functional.threshold` OpInfo passes `value=-9` to its NumPy reference for every dtype it covers, including `uint8`. Through NumPy 2.4, `np.where(x <= threshold, -9, x).astype(np.uint8)` silently wrapped `-9` to `247`, which is what `torch.nn.functional.threshold` produces for that input, so the comparison passed.

[NumPy 2.5 stopped truncating out-of-range Python integers](https://numpy.org/devdocs/release/2.5.0-notes.html#numpy-where-no-longer-truncates-python-integers) and raises `OverflowError` instead, so these fail on `uint8` for both `nn.functional.threshold` and `_refs.nn.functional.threshold`:

```
test_reference_numerics_small_nn_functional_threshold_cpu_uint8
test_reference_numerics_small__refs_nn_functional_threshold_cpu_uint8
test_reference_numerics_normal_nn_functional_threshold_cpu_uint8
test_reference_numerics_normal__refs_nn_functional_threshold_cpu_uint8

OverflowError: Python integer -9 out of bounds for uint8
```

This is currently breaking ROCm nightly wheel CI across several GPU architectures and release branches 2.9-2.11, as reported in the issue.

### Fix

This OpInfo exists to exercise `threshold`, not NumPy's integer wrap-around (as @rgommers noted on the issue), so the fix keeps `value` representable in the sample dtype instead of depending on the truncation.

Unsigned dtypes use `247` directly, which is exactly what `-9` already wrapped to for `uint8`. The values actually compared are therefore unchanged, making this a pure test-fixture fix with no change in coverage, and `247` stays outside `make_tensor`'s `uint8` sample range so it still reads as a distinct sentinel. An arbitrary small in-range value such as `9` would also silence the error, but it can collide with the generated data and would quietly weaken the assertion.

Branching on `dtype.is_signed` rather than `dtype == torch.uint8` also covers `torch.bool`, which `dtypesIfMPS` adds; `-9` and `247` both map to `True` there, so MPS behaviour is unchanged.

### Test plan

Before the change, with `numpy 2.5.2`:

```
python -m pytest test/test_unary_ufuncs.py -k "nn_functional_threshold and uint8"
# 4 failed, 16 passed, 2 skipped
# OverflowError: Python integer -9 out of bounds for uint8
```

After the change:

```
python -m pytest test/test_unary_ufuncs.py -k "nn_functional_threshold"
# 202 passed, 4 skipped

python -m pytest test/test_ops.py -k "nn_functional_threshold and cpu"
# 52 passed, 13 skipped

python -m pytest test/test_mps.py -k "nn_functional_threshold"
# 11 passed
```

---

This change was prepared with assistance from an AI coding assistant (Claude Code). I reviewed the diff and the test results before submitting.
