### PR TITLE
[inductor] bmm template specialised for a batch-broadcast left operand (#193049)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -30,6 +30,7 @@ from torch._inductor.codecache import WritableTempFile
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.package import package_aoti
 from torch._inductor.runtime.runtime_utils import cache_dir
+from torch._inductor.select_algorithm import TritonTemplate
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import (
     is_big_gpu,
@@ -243,6 +244,55 @@ def get_triton_grid_info(kernel, total_elements, src_code):
         return int(grid_match.group(1)), expected_grids
     else:
         return None, expected_grids
+
+
+# copy_tests() only copies test_* methods onto the concrete device classes, so
+# helpers shared by the bmm_shared_a tests have to live at module level.
+def _skip_unless_bmm_shared_a_runnable(test):
+    # Any Triton-capable accelerator can run the template; it is only ever
+    # offered under max-autotune.
+    if test.device != GPU_TYPE:
+        raise unittest.SkipTest("requires an accelerator")
+    if not is_big_gpu():
+        raise unittest.SkipTest("requires modern GPU to run max-autotune")
+
+
+def _bmm_shared_a_model():
+    class Model(torch.nn.Module):
+        def forward(self, a, b):
+            # Broadcasting a over the batch is what gives mat1 the zero batch
+            # stride the template keys on.
+            return torch.bmm(a.expand(b.shape[0], -1, -1), b)
+
+    return Model()
+
+
+def _record_bmm_shared_a_choices(example_inputs, model=None, **config_overrides):
+    """Compile through AOTI and return the configs offered to the autotuner.
+
+    Which candidate ultimately wins is a timing outcome and not stable enough to
+    assert on; whether the template was offered at all is the behaviour the
+    eligibility rules actually control.
+    """
+    offered = []
+    maybe_append_choice = TritonTemplate.maybe_append_choice
+
+    def record(template, choices, **kwargs):
+        if template.name == "bmm_shared_a":
+            offered.append(kwargs)
+        return maybe_append_choice(template, choices, **kwargs)
+
+    patches = {"max_autotune": True, "bmm_shared_a": True, **config_overrides}
+    with (
+        patch.object(TritonTemplate, "maybe_append_choice", record),
+        config.patch(patches),
+        torch.no_grad(),
+    ):
+        torch._dynamo.reset()
+        torch._export.aot_compile(
+            model if model is not None else _bmm_shared_a_model(), example_inputs
+        )
+    return offered
 
 
 class AOTInductorTestsTemplate:
@@ -9343,6 +9393,70 @@ torch._inductor.aoti_load_package("{model_path}")
         }
         with config.patch({"combo_kernels": True}):
             self.check_model(Model(), example_inputs, dynamic_shapes=dynamic_shapes)
+
+    def test_bmm_shared_a_numerics(self):
+        _skip_unless_bmm_shared_a_runnable(self)
+        # Autotuning only times candidates, it does not check them, so a template
+        # config that miscompiles can win and silently return garbage. Comparing
+        # against eager after a real AOTI compile is what catches that.
+        example_inputs = (
+            torch.randn(1, 64, 64, device=self.device, dtype=torch.float16),
+            torch.randn(128, 64, 32, device=self.device, dtype=torch.float16),
+        )
+        with config.patch({"max_autotune": True, "bmm_shared_a": True}):
+            self.check_model(_bmm_shared_a_model(), example_inputs)
+
+    def test_bmm_shared_a_offered_when_eligible(self):
+        _skip_unless_bmm_shared_a_runnable(self)
+        example_inputs = (
+            torch.randn(1, 64, 64, device=self.device, dtype=torch.float16),
+            torch.randn(128, 64, 32, device=self.device, dtype=torch.float16),
+        )
+        offered = _record_bmm_shared_a_choices(example_inputs)
+        self.assertTrue(offered, "bmm_shared_a was not offered to the autotuner")
+        # BLOCK_Q batches share one A tile, so the accumulator is
+        # BLOCK_M x BLOCK_N x BLOCK_Q floats; the config space is bounded to keep
+        # that in registers.
+        for cfg in offered:
+            self.assertLessEqual(64, cfg["BLOCK_N"] * cfg["BLOCK_Q"])
+            self.assertLessEqual(cfg["BLOCK_N"] * cfg["BLOCK_Q"], 256)
+            self.assertLessEqual(
+                cfg["BLOCK_M"] * cfg["BLOCK_N"] * cfg["BLOCK_Q"], 64 * 256
+            )
+
+    def test_bmm_shared_a_not_offered_when_disabled(self):
+        _skip_unless_bmm_shared_a_runnable(self)
+        example_inputs = (
+            torch.randn(1, 64, 64, device=self.device, dtype=torch.float16),
+            torch.randn(128, 64, 32, device=self.device, dtype=torch.float16),
+        )
+        offered = _record_bmm_shared_a_choices(example_inputs, bmm_shared_a=False)
+        self.assertEqual(offered, [])
+
+    def test_bmm_shared_a_not_offered_for_small_batch(self):
+        _skip_unless_bmm_shared_a_runnable(self)
+        # Below the profitability gate: with few batches the grouping only costs
+        # parallelism, so the template must decline.
+        example_inputs = (
+            torch.randn(1, 64, 64, device=self.device, dtype=torch.float16),
+            torch.randn(8, 64, 32, device=self.device, dtype=torch.float16),
+        )
+        offered = _record_bmm_shared_a_choices(example_inputs)
+        self.assertEqual(offered, [])
+
+    def test_bmm_shared_a_not_offered_without_broadcast(self):
+        _skip_unless_bmm_shared_a_runnable(self)
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.bmm(a, b)
+
+        example_inputs = (
+            torch.randn(128, 64, 64, device=self.device, dtype=torch.float16),
+            torch.randn(128, 64, 32, device=self.device, dtype=torch.float16),
+        )
+        offered = _record_bmm_shared_a_choices(example_inputs, model=Model())
+        self.assertEqual(offered, [])
 
 
 class AOTInductorLoggingTest(LoggingTestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -653,6 +653,14 @@ max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON,CPP"
 ).upper()
 
+# Opt-in for the shared-A bmm template (see kernel/bmm.py), off by default. The
+# template is only ever an extra autotune choice, so leaving it off keeps the
+# stock bmm choices and changes nothing else.
+bmm_shared_a: bool = Config(
+    default=False,
+    env_name_force="TORCHINDUCTOR_BMM_SHARED_A_TEMPLATE_ENABLED",
+)
+
 
 # Configures the maximum number of NVIDIA Universal GEMM (NVGEMM) configs to profile
 # in max_autotune. Default 10: a sweep over GDN2/attn/MoE + FLUX shapes (bf16 and

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import itertools
 import logging
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,7 @@ from ..utils import (
 from ..virtualized import ops, V
 from .mm_common import (
     _is_static_problem,
+    acc_type,
     is_batch_stride_largest_or_zero,
     mm_args,
     use_native_matmul,
@@ -54,6 +56,12 @@ def bmm_grid(b, m, n, meta, *, cdiv, max):
     return (tiles, grid_y, grid_z)
 
 
+@SymbolicGridFn
+def bmm_shared_a_grid(b, m, n, meta, *, cdiv, max):
+    tiles = cdiv(m, meta["BLOCK_M"]) * cdiv(n, meta["BLOCK_N"])
+    return (tiles, cdiv(b, meta["BLOCK_Q"]), 1)
+
+
 # We define each template kernel in a separate file which is the name of the input to load_kernel_template
 # (e.g. triton_bmm for templates/triton_bmm.py.jinja).
 # If you are adding a new template, please follow that pattern and add a new file with your implementation in the templates folder.
@@ -63,6 +71,67 @@ bmm_template = TritonTemplate(
     source=load_kernel_template("triton_bmm"),
     cache_codegen_enabled_for_template=True,
 )
+
+# Specialisation for a left operand shared across the batch, i.e. an expanded A
+# whose batch stride is zero. The stock template re-fetches the same A tile once
+# per batch; this one reuses it across BLOCK_Q batches. See the jinja source.
+bmm_shared_a_template = TritonTemplate(
+    name="bmm_shared_a",
+    grid=bmm_shared_a_grid,
+    source=load_kernel_template("triton_bmm_shared_a"),
+)
+
+
+def _use_bmm_shared_a(mat1, mat2, layout) -> bool:
+    """Whether A is one matrix broadcast over the batch.
+
+    Only worth it when there are enough batches to group: with a handful of
+    batches the grouping just costs parallelism.
+    """
+    if not inductor_config.bmm_shared_a:
+        return False
+    sizevars = V.graph.sizevars
+    if not sizevars.statically_known_equals(mat1.get_stride()[0], 0):
+        return False
+    # Batch size only gates profitability, so a hint is enough: requiring it to
+    # be statically known would silently skip every model compiled with a
+    # dynamic batch, which is most of them.
+    batch_hint = sizevars.optimization_hint(mat2.get_size()[0], fallback=1)
+    if batch_hint < 64:
+        log.info("bmm_shared_a: declined, batch hint %s < 64", batch_hint)
+        return False
+    return True
+
+
+def _bmm_shared_a_configs(dtype):
+    """Hand-tuned config space for the shared-A template.
+
+    BLOCK_Q batches share one A tile and are laid side by side in the dot, so
+    BLOCK_N * BLOCK_Q is the real dot width and the accumulator is
+    BLOCK_M x BLOCK_N x BLOCK_Q floats; the bound below keeps that in registers.
+    """
+    acc = acc_type(dtype)
+    allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+
+    for block_m, block_n, block_k, block_q, warps, stages in itertools.product(
+        (64, 128), (32, 64), (32, 64), (2, 4, 8), (4, 8), (1, 2, 3)
+    ):
+        if not 64 <= block_n * block_q <= 256:
+            continue
+        if block_m * block_n * block_q > 64 * 256:
+            continue
+        yield {
+            "BLOCK_M": block_m,
+            "BLOCK_N": block_n,
+            "BLOCK_K": block_k,
+            "BLOCK_Q": block_q,
+            "GROUP_M": 8,
+            "ACC_TYPE": acc,
+            "ALLOW_TF32": allow_tf32,
+            "num_stages": stages,
+            "num_warps": warps,
+        }
+
 
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(
@@ -239,6 +308,27 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
             kwarg_overrides=kwarg_overrides,
         )
     )
+
+    # The shared-A specialisation carries an extra BLOCK_Q dimension that the
+    # shared mm config heuristics do not know about, so its choices are added
+    # directly here. They autotune against aten and the stock template as usual.
+    if use_triton_template(layout, check_max_autotune=False) and _use_bmm_shared_a(
+        mat1, mat2, layout
+    ):
+        log.info(
+            "bmm_shared_a: offering specialised choices for bmm batch=%s m=%s n=%s k=%s",
+            mat2.get_size()[0],
+            m,
+            n,
+            k,
+        )
+        for config in _bmm_shared_a_configs(mat1.get_dtype()):
+            bmm_shared_a_template.maybe_append_choice(
+                choices,
+                input_nodes=(mat1, mat2),
+                layout=layout,
+                **config,
+            )
     _, is_nonzero = _is_static_problem(layout)
     batch_stride_largest_or_zero = is_batch_stride_largest_or_zero(mat1, mat2, layout)
     if (

--- a/torch/_inductor/kernel/templates/triton_bmm_shared_a.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmm_shared_a.py.jinja
@@ -1,0 +1,84 @@
+{{def_kernel("A", "B")}}
+    M = {{size("A", -2)}}
+    N = {{size("B", -1)}}
+    K = {{size("A", -1)}}
+    BATCH = {{size("B", 0)}}
+
+    stride_am = {{stride("A", 1)}}
+    stride_ak = {{stride("A", 2)}}
+
+    stride_bq = {{stride("B", 0)}}
+    stride_bk = {{stride("B", 1)}}
+    stride_bn = {{stride("B", 2)}}
+
+    # A is shared across the batch (its batch stride is zero), so one A tile is
+    # reused by BLOCK_Q batches instead of being re-fetched per batch. The right
+    # operand is loaded as [BLOCK_K, BLOCK_Q, BLOCK_N] -- three separate index
+    # vectors, so the innermost dimension stays unit-stride and the load still
+    # vectorises -- and flattened into a single [BLOCK_K, BLOCK_Q*BLOCK_N] dot.
+    # Writing the same gather as one div/mod index vector instead scalarises the
+    # load and is ~4x slower.
+    pid = tl.program_id(0).to(INDEX_DTYPE)
+    qid = tl.program_id(1).to(INDEX_DTYPE)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)
+    if ((stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1)) and (M >= BLOCK_M and K > 1):
+        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    else:
+        ram = rm % M
+    if ((stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1)) and (N >= BLOCK_N and K > 1):
+        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    else:
+        rbn = rn % N
+
+    rk = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
+    rq = qid * BLOCK_Q + tl.arange(0, BLOCK_Q).to(INDEX_DTYPE)
+    # Clamp so a partial trailing batch block still forms legal addresses; those
+    # lanes are masked off at the store.
+    rq_safe = tl.minimum(rq, BATCH - 1)
+
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None, None] * stride_bk + rq_safe[None, :, None] * stride_bq + rbn[None, None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_Q * BLOCK_N), dtype=ACC_TYPE)
+    # Peel the K remainder so the main loop loads unmasked. The stock bmm
+    # template guards every iteration whenever K % BLOCK_K != 0, which for these
+    # shapes is every one of them.
+    k_full = (K // BLOCK_K) * BLOCK_K
+    for _k in range(0, k_full, BLOCK_K):
+        a = tl.load(A)
+        b = tl.reshape(tl.load(B), (BLOCK_K, BLOCK_Q * BLOCK_N))
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+        A += BLOCK_K * stride_ak
+        B += BLOCK_K * stride_bk
+    if k_full < K:
+        k_mask = rk < (K - k_full)
+        a = tl.load(A, mask=k_mask[None, :], other=0.)
+        b = tl.reshape(tl.load(B, mask=k_mask[:, None, None], other=0.), (BLOCK_K, BLOCK_Q * BLOCK_N))
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+
+    # rematerialize rm to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
+    rj = tl.arange(0, BLOCK_Q * BLOCK_N).to(INDEX_DTYPE)
+    # The accumulator is [BLOCK_M, BLOCK_Q*BLOCK_N]; column j is batch
+    # qid*BLOCK_Q + j // BLOCK_N, output column pid_n*BLOCK_N + j % BLOCK_N. The
+    # div/mod is paid once per program here rather than inside the K loop.
+    idx_m = rm[:, None]
+    idx_q = (qid * BLOCK_Q + rj // BLOCK_N)[None, :]
+    idx_n = (pid_n * BLOCK_N + rj % BLOCK_N)[None, :]
+    mask = (idx_m < M) & (idx_n < N) & (idx_q < BATCH)
+
+    # inductor generates a suffix
+    {{store_output(("idx_q", "idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_Q * BLOCK_N"))}}


### PR DESCRIPTION
Summary:

Create a new triton template when the left operand in bmm has a zero batch stride i.e [M, K] x [B, K, N]. 

`bmm_shared_a` reuses one A tile
across `BLOCK_Q` batches instead, loading B as `[BLOCK_K, BLOCK_Q, BLOCK_N]` from
three separate index vectors and flattening it into a single
`[BLOCK_K, BLOCK_Q*BLOCK_N]` dot, so the innermost dimension stays unit-stride.
Writing the same gather with one div/mod index vector scalarises the load and
costs 3.4x, which is why the index arithmetic is shaped the way it is. The K
remainder is peeled so the main loop loads unmasked.

**The template is off by default.** `inductor_config.bmm_shared_a` defaults to
False and is forced on with `TORCHINDUCTOR_BMM_SHARED_A_TEMPLATE_ENABLED=1` (or
by setting `torch._inductor.config.bmm_shared_a` in process). Nothing changes
for anyone who does not opt in: the template is only ever an *extra* autotune
choice, so leaving it off means the stock bmm choices are the only ones offered,
and turning it off later is a one-variable revert rather than a code change.

When it is enabled, the template is offered to the autotuner alongside the stock
template and `aten.bmm`, gated on `_use_bmm_shared_a`: a statically-known zero
batch stride plus a batch-size *hint* of at least 64. The hint matters --
requiring the batch to be statically known would silently skip every model
compiled with a dynamic batch, which is most of them. Because it competes in the
autotuner rather than replacing anything, a shape where it loses simply does not
select it.

The config space includes `num_stages=1`. Pipelining usually wins, but this
kernel is SMEM-limited rather than register-limited and the stage buffers are
what fill shared memory: dropping the double-buffer halves SMEM (73728 -> 40960
bytes) and lets the autotuner take 8 warps at 128 registers instead of 4 at 255.
Widening any other axis was measured and lost -- BLOCK_M=32 with BLOCK_Q=16,
num_stages 4-5, GROUP_M=1, and a 928-config microbenchmark sweep over BLOCK_K=128
and BLOCK_M=256 -- so the box is deliberately narrow.

 {F1993976799}

Q: Does cuBLAS/rocBLAS already optimizes the shared-left-operand bmm?

A: cuBLAS/rocBLAS support it, but don't optimize it — so the diff is justified.

The API supports it trivially: batch stride 0 on the broadcast operand. PyTorch already does this — `aten.bmm` hands cuBLAS the zero stride with no materialized copy. It's in your autotune set and loses, 163 vs 205 TFLOP/s.
No library kernel exploits the sharing. Strided-batched pins one CTA per (m_tile, n_tile, batch), so the shared operand can never be fused across batches into a wider mma. Confirmed in vendored CUTLASS: zero batch stride is first-class (Int<0>), but the batch axis isn't even in the tile swizzle.

Test Plan:
**Unit test**
```
buck2 test mode/opt -c fbcode.nvcc_arch=h100a   fbcode//caffe2/test/inductor:test_aot_inductor -- --regex 'bmm_shared_a'
```

https://www.internalfb.com/intern/testinfra/testconsole/testrun/30399297510327241/

-------
**E2E tests**


Correctness and head-to-head autotuning against the stock template and
`aten.bmm`, on an H100 devgpu. The template is off by default, so the A/B below
is the same binary run twice with only the env var changed.

On the
`batch=3072 M=448 K=931 N=160` shape:

| | time | throughput | rel err |
| --- | --- | --- | --- |
| flag unset (default bmm template) | 2.521 ms | 163 TFLOP/s | 5.43e-04 |
| flag set (shared-a bmm template) | 1.997 ms | 205 TFLOP/s | 5.08e-04 |


E2E benchmark on model <redacted> (H100, batch 2048, fp16), measured with the
template unconditionally enabled, which is equivalent to setting the flag: the
template is selected for the `3072x448x931x160` chain and `num_stages=1` wins the
autotune outright, taking 124us/iter off that kernel
(2110.8 -> 1986.8 us). `Accuracy: True` on every run.

Reviewed By: eellison

Differential Revision: D115608139




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo