### PR TITLE
[fx] Shallow-copy `from_node` provenance in `NodeSource` instead of deepcopy (#193051)

### DIFF
--- a/test/fx/test_fx_traceback.py
+++ b/test/fx/test_fx_traceback.py
@@ -1,16 +1,56 @@
 # Owner(s): ["module: fx"]
 
 import torch
-from torch._inductor.compile_fx import aot_export_module
+from torch._functorch.aot_autograd import aot_export_module
 from torch.export import default_decompositions
 from torch.fx.traceback import get_graph_provenance_json, NodeSource, NodeSourceAction
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
 
 
 CREATE_STR = NodeSourceAction.CREATE.name.lower()
 
 
 class TestFXNodeSource(TestCase):
+    def test_node_source_shallow_copies_provenance_list(self):
+        ancestor = NodeSource(
+            node=None,
+            pass_name="ancestor_pass",
+            action=NodeSourceAction.CREATE,
+        )
+        original_provenance = [ancestor]
+        node = torch.fx.Graph().placeholder("x")
+        node.meta["from_node"] = original_provenance
+
+        node_source = NodeSource(
+            node=node,
+            pass_name="current_pass",
+            action=NodeSourceAction.CREATE,
+        )
+        original_provenance.append(
+            NodeSource(
+                node=None,
+                pass_name="later_pass",
+                action=NodeSourceAction.CREATE,
+            )
+        )
+
+        self.assertIsNot(node_source.from_node, original_provenance)
+        self.assertEqual(node_source.from_node, [ancestor])
+        self.assertIs(node_source.from_node[0], ancestor)
+        self.assertEqual(
+            node_source.to_dict()["from_node"],
+            [
+                {
+                    "name": "",
+                    "target": "",
+                    "graph_id": -1,
+                    "pass_name": "ancestor_pass",
+                    "action": CREATE_STR,
+                    "from_node": [],
+                }
+            ],
+        )
+
     def test_node_source(self):
         node_source = NodeSource(
             node=None, pass_name="test_pass", action=NodeSourceAction.CREATE
@@ -283,7 +323,4 @@ class TestFXNodeSource(TestCase):
 
 
 if __name__ == "__main__":
-    raise RuntimeError(
-        "This test is not currently used and should be "
-        "enabled in discover_tests.py if required."
-    )
+    raise_on_run_directly("test/test_fx.py")

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -52,6 +52,7 @@ from fx.test_fx_const_fold import TestConstFold  # noqa: F401
 from fx.test_fx_param_shape_control_flow import (  # noqa: F401
     TestConstParamShapeInControlFlow,
 )
+from fx.test_fx_traceback import TestFXNodeSource  # noqa: F401
 
 from fx.test_gradual_type import (  # noqa: F401  # noqa: F401
     AnnotationsTest,

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -126,11 +126,9 @@ class NodeSource:
             self.node_info = self.NodeInfo(
                 name=node.name, target=str(node.target), graph_id=id(node.graph)
             )
-            self.from_node = (
-                copy.deepcopy(node.meta["from_node"])
-                if "from_node" in node.meta
-                else []
-            )
+            # NodeSource records are immutable after construction, so share them
+            # while copying the outer list to preserve its snapshot semantics.
+            self.from_node = list(node.meta.get("from_node", ()))
         else:
             self.node_info = None
             self.from_node = []


### PR DESCRIPTION
Summary:

`NodeSource.__init__` recursively deep-copies `node.meta["from_node"]` whenever a pass-retraced node is created. Because each provenance list contains earlier `NodeSource` records, repeated pass replay copies an increasingly large provenance tree and can make this path approximately quadratic in pass depth.

Copy only the outer list with `list(...)`. This preserves snapshot semantics for callers that later append to the original list while sharing the existing provenance records. Those records are treated as immutable after construction; existing code already aliases or shallow-copies them.

The regression test makes the contract explicit: the captured outer list is distinct, later mutations to the original list are not observed, existing `NodeSource` entries remain shared by identity, and `to_dict()` serialization is unchanged. This is a targeted complexity reduction; it does not change graph structure, node metadata contents, or serialization format.

In a representative U55 workflow targeting ExecuTorch, this reduced warm end-to-end model export/lowering time by ~15% (406s → 342s, not insignificant).

Differential Revision: D109215317


