### PR TITLE
[inductor] Assert static-input alignment at runtime instead of guarding

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -722,6 +722,113 @@ class CudaReproTests(TestCase):
                 for param in model_opt.parameters():
                     param.add_(1.0)
 
+    @config.patch(
+        {
+            "triton.cudagraph_trees": False,
+            "triton.cudagraphs": True,
+            "size_asserts": False,
+        }
+    )
+    def test_cudagraphs_static_input_address_check_no_size_asserts(self):
+        class Repro(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(8, 8))
+
+            def forward(self, x):
+                return x @ self.weight
+
+        model = Repro().to(device_type)
+        model_opt = torch.compile(model, backend="inductor")
+        x = torch.randn(8, 8, device=device_type)
+
+        for _ in range(3):
+            model_opt(x)
+
+        with torch.no_grad():
+            model.weight.set_(model.weight.clone())
+
+        with self.assertRaisesRegex(AssertionError, "static input data pointer"):
+            model_opt(x)
+
+    def test_static_input_alignment_assert(self):
+        # Inductor bakes example-input alignment into codegen and skips the
+        # runtime clone-if-misaligned fixup for static inputs. Unguarded static
+        # inputs (params) may legally change address without recompiling; if one
+        # is swapped to a misaligned address, a runtime assert must raise a clear
+        # error rather than run an alignment-assuming kernel on a misaligned
+        # pointer.
+        class Repro(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(64, 64))
+
+            def forward(self, x):
+                return (x + self.weight).relu()
+
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("inductor")
+        model = Repro().to(device_type)
+        fn = torch.compile(model, backend=cnt)
+        x = torch.randn(64, 64, device=device_type)
+
+        fn(x)
+        self.assertEqual(cnt.frame_count, 1)
+
+        # aligned address change: no recompile, correct numerics
+        with torch.no_grad():
+            model.weight.data = torch.randn(64, 64, device=device_type)
+        out = fn(x)
+        torch.cuda.synchronize()
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(out, (x + model.weight).relu())
+
+        # misaligned address change: runtime assert fires, no recompile
+        base = torch.randn(64 * 64 + 4, device=device_type)
+        misaligned = base[1 : 1 + 64 * 64].view(64, 64)
+        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
+        with torch.no_grad():
+            model.weight.data = misaligned
+        with self.assertRaisesRegex(RuntimeError, "not 16-byte aligned"):
+            fn(x)
+        self.assertEqual(cnt.frame_count, 1)
+
+    @config.patch({"triton.cudagraphs": True, "triton.cudagraph_trees": True})
+    def test_static_input_alignment_assert_cudagraph_trees(self):
+        # cudagraph_trees re-records (rather than recompiles) when a static
+        # input's address changes; a misaligned re-record would run an
+        # alignment-assuming kernel on a misaligned pointer, so the alignment
+        # assert must fire on the trees path too.
+        class Repro(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(64, 64))
+
+            def forward(self, x):
+                return (x + self.weight).relu()
+
+        model = Repro().to(device_type)
+        fn = torch.compile(model, backend="inductor")
+        x = torch.randn(64, 64, device=device_type)
+
+        for _ in range(3):
+            fn(x)
+
+        # aligned address change: trees re-records, no error, correct numerics
+        with torch.no_grad():
+            model.weight.data = torch.randn(64, 64, device=device_type)
+        out = fn(x)
+        torch.cuda.synchronize()
+        self.assertEqual(out, (x + model.weight).relu())
+
+        # misaligned address change: alignment assert fires before re-record
+        base = torch.randn(64 * 64 + 4, device=device_type)
+        misaligned = base[1 : 1 + 64 * 64].view(64, 64)
+        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
+        with torch.no_grad():
+            model.weight.data = misaligned
+        with self.assertRaisesRegex(RuntimeError, "not 16-byte aligned"):
+            fn(x)
+
     # https://github.com/pytorch/torchdynamo/issues/1850
     def test_inductor_output_aliases_intermediate(self):
         def foo(x):

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2246,6 +2246,11 @@ def _tensors_data_ptrs_at_indices_equal(
     ptrs: list[_int | None],
     indices: list[_int],
 ) -> _bool: ...
+def _tensors_aligned_at_indices(
+    tensors: list[Tensor | _int],
+    indices: list[_int],
+    alignment: _int,
+) -> _bool: ...
 def _construct_CUDA_Tensor_From_Storage_And_Metadata(
     metadata: dict,
     storage: Storage,

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1367,6 +1367,27 @@ def mark_static(t: Any, index: int | list[Any] | tuple[Any] | None = None) -> No
             mark_static(t, i)
 
 
+# Note: [Static input do-not-copy contract]
+# The underlying semantics of a "static address" tensor is that it is
+# weight-like (large, long-lived, reused across calls), so the compiled
+# artifact must never fall back to copying it per call. Everything else is a
+# downstream approximation of that invariant:
+# - cudagraphs skips copying static inputs into graph-owned memory, and when
+#   an unguarded static's address changes (legal: one artifact serves many
+#   module instances under inline_inbuilt_nn_modules, see #126822) it
+#   re-records a new cudagraph keyed on the pointers rather than copying.
+# - Non-trees cudagraph replay asserts pointer equality instead
+#   (cudagraphify_impl in compile_fx.py).
+# - Inductor bakes the example's 16-byte alignment into generated code and
+#   exempts static inputs from the runtime clone-if-misaligned fixup
+#   (get_input_idxs_to_check), since cloning a weight per call is unacceptable.
+#   Because the fixup is skipped, a runtime assert (assert_static_inputs_aligned)
+#   instead raises if an unguarded static that was aligned at compile time is
+#   swapped to a misaligned address, rather than silently running an
+#   alignment-assuming kernel on a misaligned pointer.
+# All nn.Module params/buffers are auto-marked unguarded-static (#130391);
+# guard=True pins the exact data_ptr with a guard (used by the optimizer
+# capture) and recompiles on any address change.
 @forbid_in_graph
 def mark_static_address(t: Any, guard: bool = False) -> None:
     """

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2145,10 +2145,10 @@ def get_input_idxs_to_check(
         with maybe_get_suppress_shape_guards_ctx():
             # suppress guards so that tensor_is_aligned and should_assume_input_aligned
             # do not add guards on input's storage offset
-            #
-            # Static inputs are address-stable, so compile-time alignment
-            # holds for every call and cloning would break the address
-            # cudagraphs recorded; see Note: [static_input_idxs semantics].
+            # Static inputs are weight-like and must not be cloned per call;
+            # get_static_input_idxs_to_assert_aligned instead asserts at runtime
+            # that a static aligned here stays aligned. See Note: [Static input
+            # do-not-copy contract] in torch/_dynamo/decorators.py.
             if i in static_input_idxs and tensor_is_aligned(input):
                 continue
             if not should_assume_input_aligned(input):
@@ -2340,8 +2340,35 @@ def cudagraphify_impl(
         copy_indices = [
             idx for idx in range(len(static_inputs)) if idx not in static_input_idxs
         ]
+        # Replaying with a static input whose address moved is an IMA or silent
+        # corruption, so verify addresses even without size_asserts. This is a
+        # single C++ call over only the static indices, negligible vs replay.
+        static_tensor_input_idxs = [
+            idx
+            for idx in static_input_idxs
+            if isinstance(static_inputs[idx], torch.Tensor)
+        ]
+        static_input_data_ptrs: list[int | None] = [
+            x.data_ptr() if isinstance(x, torch.Tensor) else None for x in static_inputs
+        ]
 
         def run(new_inputs: list[InputType]) -> Callable[[list[InputType]], Any]:
+            if not torch._C._tensors_data_ptrs_at_indices_equal(
+                new_inputs,  # type: ignore[arg-type]
+                static_input_data_ptrs,
+                static_tensor_input_idxs,
+            ):
+                mismatch = [
+                    idx
+                    for idx in static_tensor_input_idxs
+                    if new_inputs[idx].data_ptr() != static_input_data_ptrs[idx]  # type: ignore[union-attr]
+                ]
+                raise AssertionError(
+                    f"static input data pointer changed at indices {mismatch}; "
+                    f"replaying the cudagraph would access freed or unrelated memory. "
+                    f"Static inputs (parameters and mark_static_address tensors) must "
+                    f"keep the same address as when the graph was recorded."
+                )
             for idx in copy_indices:
                 expanded_dims = inps_expanded_dims[idx]
                 src = new_inputs[idx]

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -49,8 +49,10 @@ from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
 from torch._inductor.utils import (
     _unstable_customized_partition_wrapper,
     align_inputs_from_check_idxs,
+    assert_static_inputs_aligned,
     BoxedBool,
     CUDAGraphWrapperMetadata,
+    get_static_input_idxs_to_assert_aligned,
     GraphPartitionMap,
     InputType,
     is_gpu,
@@ -466,6 +468,24 @@ def maybe_realign_inputs(
                 # uses the Sequence[InputType] boxed alias, so re-tag it here.
                 compiled_graph.current_callable = cast("_BoxedCallable", new_callable)
 
+    # Static inputs are exempt from the clone-if-misaligned fixup, so assert their
+    # alignment held: an unguarded static may be swapped to a misaligned address,
+    # which would run an alignment-assuming kernel on a misaligned pointer. This
+    # runs on every path -- including cudagraph_trees, which re-records (rather
+    # than recompiles) on an address change and would otherwise record a kernel
+    # over the new misaligned pointer. Non-trees cudagraphify_impl additionally
+    # asserts pointer equality. See Note: [Static input do-not-copy contract] in
+    # torch/_dynamo/decorators.py.
+    if compiled_graph.alignment_assert_idxs:
+        if compiled_graph.current_callable is None:
+            raise AssertionError("compiled_graph.current_callable must not be None")
+        new_callable = assert_static_inputs_aligned(
+            compiled_graph.current_callable,
+            compiled_graph.alignment_assert_idxs,
+        )
+        if new_callable is not compiled_graph.current_callable:
+            compiled_graph.current_callable = cast("_BoxedCallable", new_callable)
+
 
 class CompiledFxGraphConstants:
     """Wrapper class that unwraps constants from a compiled fx graph. This
@@ -557,6 +577,7 @@ class CompiledFxGraph(OutputCode):
     compile_region_name: str | None
     fx_kwargs: _CompileFxKwargs
     inputs_to_check: Sequence[int]
+    alignment_assert_idxs: Sequence[int]
 
     _boxed_call: bool | None = None
     _triton_bundle: TritonBundle | None = None
@@ -648,6 +669,9 @@ class CompiledFxGraph(OutputCode):
         storage_mutation_info = get_input_storage_mutation_info(gm)
         self.fx_kwargs = {}
         self.inputs_to_check = ()
+        self.alignment_assert_idxs = get_static_input_idxs_to_assert_aligned(
+            example_inputs, static_input_idxs
+        )
 
         cudagraph_info = None
         if cudagraphs:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3720,6 +3720,65 @@ def align_inputs_from_check_idxs(
     return run
 
 
+def get_static_input_idxs_to_assert_aligned(
+    inputs: Sequence[InputType],
+    static_input_idxs: Sequence[int],
+) -> list[int]:
+    # Inductor bakes each example input's 16-byte alignment into codegen and
+    # exempts static inputs from the runtime clone-if-misaligned fixup (see
+    # get_input_idxs_to_check), since cloning a weight per call is unacceptable.
+    # A static input's address may legally change between calls (one artifact
+    # serves many module instances under inline_inbuilt_nn_modules, #126822), so
+    # for a static whose example was aligned we assert at runtime that it stays
+    # aligned; a misaligned swap must raise rather than silently run an
+    # alignment-assuming kernel on a misaligned pointer. A static whose example
+    # was already misaligned got unaligned codegen and needs no assert.
+    # See Note: [Static input do-not-copy contract] in torch/_dynamo/decorators.py.
+    static = OrderedSet(static_input_idxs)
+    result = []
+    for i in static:
+        inp = inputs[i]
+        if not isinstance(inp, torch.Tensor) or not is_gpu(inp.device.type):
+            continue
+        with maybe_get_suppress_shape_guards_ctx():
+            if tensor_is_aligned(inp):
+                result.append(i)
+    return result
+
+
+def assert_static_inputs_aligned(
+    model: Callable[[list[InputType]], _T],
+    alignment_assert_idxs: Sequence[int],
+) -> Callable[[list[InputType]], _T]:
+    if len(alignment_assert_idxs) == 0:
+        return model
+
+    idxs = list(alignment_assert_idxs)
+
+    def run(new_inputs: list[InputType]) -> Any:
+        if not torch._C._tensors_aligned_at_indices(
+            new_inputs,  # type: ignore[arg-type]
+            idxs,
+            GPU_ALIGN_BYTES,
+        ):
+            misaligned = [
+                i
+                for i in idxs
+                if new_inputs[i].data_ptr() % GPU_ALIGN_BYTES != 0  # type: ignore[union-attr]
+            ]
+            raise RuntimeError(
+                f"static input at indices {misaligned} is not {GPU_ALIGN_BYTES}-byte "
+                f"aligned, but inductor compiled assuming alignment. Static inputs "
+                f"(parameters and mark_static_address tensors) that were aligned at "
+                f"compile time must stay aligned across calls; pad or realign the "
+                f"tensor so its data_ptr is a multiple of {GPU_ALIGN_BYTES}. See "
+                f"Note: [Static input do-not-copy contract]."
+            )
+        return model(new_inputs)
+
+    return run
+
+
 def clone_preserve_strides(x: torch.Tensor) -> torch.Tensor:
     if 0 in x.size():
         # Short-circuits if the shape has no elements

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1488,6 +1488,18 @@ static void registerCudaPluggableAllocator(PyObject* module) {
       });
 
   m.def(
+      "_tensors_aligned_at_indices",
+      [](py::list& tensors, py::list& indices, int64_t alignment) {
+        for (auto index : indices) {
+          auto t = tensors[index].cast<at::Tensor>();
+          if (reinterpret_cast<int64_t>(t.data_ptr()) % alignment != 0) {
+            return false;
+          }
+        }
+        return true;
+      });
+
+  m.def(
       "_construct_CUDA_Tensor_From_Storage_And_Metadata",
       [](py::dict& metadata, c10::Storage s) {
         auto dtype_arg = metadata["dtype"].ptr();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #193054

Static inputs (nn.Module params/buffers, auto-marked unguarded via #130391,
and user mark_static_address tensors) are exempt from Inductor's runtime
clone-if-misaligned fixup in get_input_idxs_to_check, because cloning a
weight on every call is unacceptable. Inductor bakes the example input's
16-byte alignment into the generated Triton, so if an unguarded static that
was aligned at compile time is later swapped to a misaligned address -- which
is legal without recompiling, since one artifact serves many module instances
under inline_inbuilt_nn_modules (#126822) -- the alignment-assuming kernel
runs on a misaligned pointer and silently IMAs or corrupts, even without
cudagraphs.

The fix asserts, at runtime, that a static input aligned at compile time
stays aligned. CompiledFxGraph gains an alignment_assert_idxs field computed
in __init__ from example_inputs + static_input_idxs (mirroring inputs_to_check,
so it serializes through FxGraphCache with no extra plumbing), and
maybe_realign_inputs wraps current_callable with assert_static_inputs_aligned.
The wrap is unconditional (outside the `if not ran_cudagraphs` branch) so it
also covers cudagraph_trees, which re-records rather than recompiles on an
address change and would otherwise record a kernel over the new misaligned
pointer. The check is a single batched C++ call
(torch._C._tensors_aligned_at_indices) over just the static indices,
negligible against a kernel launch. Statics that were already misaligned at
compile time got unaligned codegen and are excluded.

An earlier version of this change enforced alignment with a dynamo
TENSOR_ALIGNMENT leaf guard, which recompiled on misalignment and only
covered the forward. The runtime assert is preferred: it gives uniform
forward/backward coverage, preserves cudagraph re-record without a full
recompile, and treats a misaligned static as the user error it is (raise a
clear message) rather than a recompile trigger. The non-trees cudagraph
data-pointer equality assert in cudagraphify_impl is retained.

Test Plan:

```
python test/inductor/test_cuda_repro.py CudaReproTests.test_static_input_alignment_assert
python test/inductor/test_cuda_repro.py CudaReproTests.test_static_input_alignment_assert_cudagraph_trees
python test/inductor/test_cuda_repro.py CudaReproTests.test_cudagraphs_static_input_address_check_no_size_asserts
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98