### PR TITLE
[distributed] Continue socket fallback after constructor errors

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -13,6 +13,7 @@ import socket
 import sys
 import unittest
 from contextlib import closing
+from unittest import mock
 
 from torch.distributed import DistNetworkError, DistStoreError
 from torch.distributed.elastic.utils.distributed import (
@@ -51,6 +52,21 @@ if IS_WINDOWS or IS_MACOS:
 
 
 class DistributedUtilTest(TestCase):
+    @mock.patch("torch.distributed.elastic.utils.distributed.socket.getaddrinfo")
+    @mock.patch("torch.distributed.elastic.utils.distributed.socket.socket")
+    def test_get_socket_with_port_continues_after_socket_creation_failure(
+        self, socket_mock, getaddrinfo_mock
+    ):
+        first_addr = (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", 0))
+        second_addr = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))
+        getaddrinfo_mock.return_value = [first_addr, second_addr]
+        usable_socket = mock.Mock()
+        socket_mock.side_effect = [OSError("unsupported address family"), usable_socket]
+
+        self.assertIs(get_socket_with_port(), usable_socket)
+        usable_socket.bind.assert_called_once_with(("localhost", 0))
+        usable_socket.listen.assert_called_once_with(0)
+
     def test_create_store_single_server(self):
         store = create_c10d_store(is_server=True, server_addr=socket.gethostname())
         self.assertIsNotNone(store)

--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -8,11 +8,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import datetime
+import socket
 from multiprocessing.pool import ThreadPool
 from unittest import mock
 
 import torch.distributed as dist
 import torch.distributed.elastic.utils.store as store_util
+from torch.distributed.elastic.utils import get_socket_with_port
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.testing._internal.common_utils import run_tests, TestCase
 
@@ -251,6 +253,21 @@ class StoreUtilTest(TestCase):
 
 
 class UtilTest(TestCase):
+    @mock.patch("torch.distributed.elastic.utils.api.socket.getaddrinfo")
+    @mock.patch("torch.distributed.elastic.utils.api.socket.socket")
+    def test_get_socket_with_port_continues_after_socket_creation_failure(
+        self, socket_mock, getaddrinfo_mock
+    ):
+        first_addr = (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", 0))
+        second_addr = (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))
+        getaddrinfo_mock.return_value = [first_addr, second_addr]
+        usable_socket = mock.Mock()
+        socket_mock.side_effect = [OSError("unsupported address family"), usable_socket]
+
+        self.assertIs(get_socket_with_port(), usable_socket)
+        usable_socket.bind.assert_called_once_with(("localhost", 0))
+        usable_socket.listen.assert_called_once_with(0)
+
     def test_get_logger_different(self):
         logger1 = get_logger("name1")
         logger2 = get_logger("name2")

--- a/torch/distributed/elastic/utils/api.py
+++ b/torch/distributed/elastic/utils/api.py
@@ -33,7 +33,10 @@ def get_socket_with_port() -> socket.socket:
     )
     for addr in addrs:
         family, type, proto, _, _ = addr
-        s = socket.socket(family, type, proto)
+        try:
+            s = socket.socket(family, type, proto)
+        except OSError:
+            continue
         try:
             s.bind(("localhost", 0))
             s.listen(0)

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -167,7 +167,11 @@ def get_socket_with_port() -> socket.socket:
     )
     for addr in addrs:
         family, type, proto, _, _ = addr
-        s = socket.socket(family, type, proto)
+        try:
+            s = socket.socket(family, type, proto)
+        except OSError as e:
+            logger.warning("Socket creation attempt failed.", exc_info=e)
+            continue
         try:
             s.bind(("localhost", 0))
             s.listen(0)


### PR DESCRIPTION
## Summary

get_socket_with_port() iterates every address returned by getaddrinfo(), but both implementations created each socket outside the existing OSError handler. A constructor failure for one address family therefore prevented fallback to later usable addresses.

This change catches socket-construction errors per address and continues the existing traversal. The distributed helper preserves its warning behavior. No port-selection or bind/listen semantics change.

## Tests

Added focused regression coverage for both implementations. Each test provides two addresses, makes socket construction fail for the first, and verifies that the second socket is bound, listened on, and returned.

Local focused module verification passed for both source implementations. The standard test files require a built PyTorch checkout; this sparse source checkout used the installed PyTorch test harness plus direct source-module verification.

## Scope

- 	orch/distributed/elastic/utils/api.py`n- 	orch/distributed/elastic/utils/distributed.py`n- their two existing focused test modules