### PR TITLE
Fix IndexError in produce_guards for jagged NestedTensor batch dim (#193059)

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -8252,6 +8252,30 @@ torch.cuda.synchronize()
 
     @dtypes(torch.float32)
     @skipIfTorchDynamo("Test compiles internally")
+    def test_compile_jagged_recompile_on_outer_batch_dim(self, device, dtype):
+        # Recompiling on a changed batch size makes the outer dim symbolic, and
+        # jagged NJT records no source for it, which used to break guard issuing.
+        def make_nt(batch):
+            return torch.nested.nested_tensor(
+                [
+                    torch.randn(2 + (i % 3), 3, device=device, dtype=dtype)
+                    for i in range(batch)
+                ],
+                layout=torch.jagged,
+            )
+
+        def f(nt):
+            if nt.size(0) == 8:
+                return nt.values().sum() * 3
+            return nt.values().sum()
+
+        compiled_f = torch.compile(f, fullgraph=True)
+        nt8, nt16 = make_nt(8), make_nt(16)
+        self.assertEqual(compiled_f(nt8), f(nt8))
+        self.assertEqual(compiled_f(nt16), f(nt16))
+
+    @dtypes(torch.float32)
+    @skipIfTorchDynamo("Test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     def test_compile_padded_dense_conversion_preserves_metadata_cache(
         self, device, dtype

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6696,7 +6696,7 @@ class ShapeEnv:
                 if any(
                     is_dim(source)
                     for s in expr.free_symbols
-                    for source in symbol_to_source[s]
+                    for source in symbol_to_source.get(s, ())
                 ):
                     if self.dim_constraints is None:
                         raise AssertionError("dim_constraints must not be None")
@@ -6713,7 +6713,14 @@ class ShapeEnv:
                 # a constraint
                 if not is_trivial and len(expr.free_symbols) == 1:
                     symbol = next(iter(expr.free_symbols))
-                    source = symbol_to_source[symbol][0]
+                    # Subclasses opting out of outer size/stride tracking leave their
+                    # outer dims out of symbol_to_source; fall back as _print_Symbol does.
+                    sources = symbol_to_source.get(symbol) or self.var_to_sources.get(
+                        symbol
+                    )
+                    if not sources:
+                        return
+                    source = sources[0]
                     constraints = symbol_to_constraints[symbol]
                     for c in constraints:
                         if isinstance(c, StrictMinMaxConstraint):


### PR DESCRIPTION
Summary:

`ShapeEnv.produce_guards_verbose` raises `IndexError: list index out of range`
when it issues a guard whose only free symbol has no entry in the local
`symbol_to_source` map. Jagged `NestedTensor` reliably produces such symbols, so
a model taking an NJT as a compiled input whose batch size varies dies at
compile time on the first recompile.

pytorch#184053 set `track_outer_size_stride=False` for `NestedTensor` and
replaced full outer size/stride tracking with a helper that records a source
only when the symbol's value is a `SingletonInt`. That covers the ragged
dimension; the outer batch dimension is an ordinary backed `SymInt` and gets no
entry. Both failure sites below predate that change: it did not introduce the
fragility, it created the condition that makes it reachable.

`symbol_to_source` is a `defaultdict(list)`, which yields two distinct failures
from the same missing entry. First, `symbol_to_source[symbol][0]` indexes an
empty list and raises `IndexError`, when the guard expression has exactly one
free symbol. Second, the `is_dim` membership test a few lines earlier reads
`symbol_to_source[s]` on the defaultdict, which inserts an empty list for every
free symbol of every guard; the later value-range loop then walks those entries
and raises `AssertionError: sources must not be empty for symbol sNN`.

This makes two changes. The membership test now reads through `.get(s, ())` so
the defaultdict is no longer populated as a side effect, which is what fixes the
`AssertionError`. At the single-free-symbol site, it falls back to
`var_to_sources` when `symbol_to_source` has no entry, mirroring
`_ShapeGuardPrinter._print_Symbol`, and returns early when neither map has a
source.

Returning early is provably lossless. `symbol_to_constraints` has exactly one
mutation site, four lines after the corresponding `symbol_to_source[s].append`
inside `track_symint`, so a symbol with no source can never carry a constraint
to report, and the enclosing `if` is the last statement in the `try`. Reviewers
should still weigh that early return, since it becomes wrong if code is later
appended after that block; the alternative is wrapping the loop in `if sources:`
at the cost of reindenting it.

The `var_to_sources` fallback is strictly more conservative than skipping
outright, and that map is demonstrably populated in this case: `printer.doprint`
runs immediately before the failure and would itself raise if the symbol were in
neither map.

This diff was authored with the assistance of an AI coding assistant.

Test Plan:
Added a regression test to `test_nestedtensor.py` and verified it locally: it
fails without the change and passes with it. The failure is the signature this
diff addresses:

  File "torch/fx/experimental/symbolic_shapes.py", line 6716, in issue_guard
    source = symbol_to_source[symbol][0]
  IndexError: list index out of range

The existing `test_compile_jagged_mean_omits_outer_size_stride_guards` invokes
its function once, which never produces a guard on the outer batch dimension,
and no test in the file compiled an NJT with a changing outer batch size. The
new test calls twice at different batch sizes, which forces the recompile that
makes that dimension symbolic, and compares the compiled result against eager.

The full `caffe2/test:nested` suite was also run locally.

Reviewed By: poojasethi

Differential Revision: D115466062
