### PR TITLE
Fall back to 'triage review' instead of blocking when all labels are filtered

### DIFF
--- a/.claude/skills/triaging-issues/scripts/validate_labels.py
+++ b/.claude/skills/triaging-issues/scripts/validate_labels.py
@@ -206,12 +206,17 @@ def main():
             )
 
         if not clean_labels:
-            debug_log("No valid labels remain after filtering, blocking")
+            # Blocking here would abandon triage entirely: the model retries, gets
+            # blocked again, and gives up, so the issue keeps no status label and the
+            # post-hook that stamps 'bot-triaged' never runs. Fall back to flagging it
+            # for a human, matching what the forbidden-label branch above already does.
+            debug_log("No valid labels remain after filtering, using 'triage review'")
+            clean_labels = ["triage review"]
             print(
-                "All requested labels were invalid. No labels to apply.",
+                "All requested labels were filtered out. "
+                "Applying 'triage review' for human attention.",
                 file=sys.stderr,
             )
-            sys.exit(2)
 
         existing_labels = fetch_existing_labels(owner, repo, issue_number)
         debug_log(f"Existing labels on issue: {existing_labels}")


### PR DESCRIPTION
Fixes #193045

### Problem

`validate_labels.py` is a `PreToolUse` hook that sanitizes the labels the triage bot proposes. When filtering removed *every* proposed label it called `sys.exit(2)`, blocking the tool call. The model then retries, gets blocked again, and abandons triage — so no status label is applied, and because no mutation lands, the `add_bot_triaged.py` post-hook never fires either. The issue ends up with no `bot-triaged` marker, invisible to every "what did the bot do" query.

### Root cause

Only the **non-existent-label** filter can reach that state.

An all-forbidden proposal is already rescued a few lines earlier:

```python
if forbidden:
    if not clean_labels:
        clean_labels = ["triage review"]
```

`triage review` is present in `labels.json`, so it survives the later non-existent filter and the call reaches `exit(0)`. An all-forbidden proposal therefore *cannot* reach the `exit(2)`. The same empty-`clean_labels` state was recovered in one branch and fatal in the other.

(This corrects the mechanism given in the issue body, per discussion with @bobrenjc93 on the issue. The user-visible bug is unchanged.)

### Fix

Apply that same fallback at the second site. Reaching it means the bot proposed label names that don't exist, i.e. its judgement on the issue was unreliable — so a human should look. `triaged` would silently mark a bad decision as done. This also keeps the two branches consistent.

`sys.exit(2)` is retained for genuine hook failures (malformed JSON, missing `issue_number`, `gh` errors), which are the errors it was meant for.

### Test plan

The hook reads a tool call on stdin and signals its decision through the exit code, so each path can be driven directly. From `.claude/skills/triaging-issues/scripts`:

| Case | Before | After |
|---|---|---|
| All labels non-existent | **exit 2, blocked** | exit 0, `triage review` applied |
| All labels forbidden | exit 0, `triage review` | unchanged |
| A valid label present | exit 0 | unchanged, no spurious `triage review` |
| No labels requested | exit 0 | unchanged |
| Malformed JSON | exit 2 | unchanged |
| Missing `issue_number` | exit 2 | unchanged |

```
# all proposed labels non-existent -- the reported bug
echo '{"tool_input":{"owner":"pytorch","repo":"pytorch","issue_number":193045,"labels":["module: totally-made-up"]}}' | python3 validate_labels.py; echo "exit=$?"

# all proposed labels forbidden -- pre-existing fallback, must be unchanged
echo '{"tool_input":{"owner":"pytorch","repo":"pytorch","issue_number":193045,"labels":["actionable","needs design"]}}' | python3 validate_labels.py; echo "exit=$?"

# a valid label -- must not gain a spurious 'triage review'
echo '{"tool_input":{"owner":"pytorch","repo":"pytorch","issue_number":189267,"labels":["module: nn"]}}' | python3 validate_labels.py; echo "exit=$?"

# genuine hook failures must still block
echo 'not json' | python3 validate_labels.py; echo "exit=$?"
echo '{"tool_input":{"labels":["module: nn"]}}' | python3 validate_labels.py; echo "exit=$?"
```

`lintrunner` reports no findings against the changed file, and it is unchanged under `ruff format`.

---

This change was prepared with assistance from an AI coding assistant (Claude Code). I reviewed the diff and the test results before submitting.
