### PR TITLE
[Testcase Refactoring] Classify graph region tracker tests by hardware

### DIFF
--- a/test/dynamo/test_graph_region_tracker.py
+++ b/test/dynamo/test_graph_region_tracker.py
@@ -5,11 +5,16 @@ import torch
 import torch.fx
 from torch._dynamo.test_case import TestCase
 from torch._dynamo.testing import extract_graph_and_tracker
-from torch.testing._internal.common_utils import recover_orig_fp32_precision
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    recover_orig_fp32_precision,
+)
 from torch.utils._pytree import tree_map
 
 
 class GraphRegionTrackerTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.exit_stack = contextlib.ExitStack()


### PR DESCRIPTION
## Summary
Classifies Dynamo graph region tracker tests with generic hardware metadata.

## Changes
- Add HardwareClassification coverage for the graph region tracker test class.

## Test plan
```bash
python -m ruff format --check test/dynamo/test_graph_region_tracker.py
python -m py_compile test/dynamo/test_graph_region_tracker.py
npu-run-suite npu ./test_guard_serialization.py
```

### Environment
| Item | Version |
|------|---------|
| CANN | 9.1.0 |
| PyTorch | 2.14.0+gitee7bc39 |
| torch_npu | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98