### PR TITLE
[Testcase Refactoring] Add HardwareClassification.GENERIC to test_nested_graph_breaks.py

### DIFF
--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -6,6 +6,7 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch.utils._pytree as python_pytree
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 try:
@@ -31,6 +32,8 @@ class CustomizedCtxManager:
 
 
 class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_single_graph_break(self):
         # NOTE marking f1, f2, f3 as global
         # prevents them from being freevars


### PR DESCRIPTION
## Summary

Classify `NestedGraphBreakTests` in `test/dynamo/test_nested_graph_breaks.py` as device-generic by adding `HardwareClassification.GENERIC`. 

## Changes

- **test/dynamo/test_nested_graph_breaks.py**:
  - Import `HardwareClassification` from `torch.testing._internal.common_utils`
  - Add `hw_classification = HardwareClassification.GENERIC` to the `NestedGraphBreakTests` class

## Test Plan

`python pytorch/test/dynamo/test_nested_graph_breaks.py --hw-classification GENERIC -v`
- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
