### PR TITLE
[Testcase Refactoring] Add hw_classification to elastic multiprocessing tail_log_test.py

### DIFF
--- a/test/distributed/elastic/multiprocessing/tail_log_test.py
+++ b/test/distributed/elastic/multiprocessing/tail_log_test.py
@@ -12,13 +12,17 @@ import shutil
 import sys
 import tempfile
 import time
-import unittest
 from concurrent.futures import wait
 from concurrent.futures._base import ALL_COMPLETED
 from concurrent.futures.thread import ThreadPoolExecutor
 from unittest import mock
 
 from torch.distributed.elastic.multiprocessing.tail_log import TailLog
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def write(max: int, sleep: float, file: str):
@@ -28,7 +32,9 @@ def write(max: int, sleep: float, file: str):
             time.sleep(sleep)
 
 
-class TailLogTest(unittest.TestCase):
+class TailLogTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")
@@ -262,3 +268,7 @@ class TailLogTest(unittest.TestCase):
         tail.stop()
 
         mock_logger.exception.assert_called_once()
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to
`TailLogTest` in
`test/distributed/elastic/multiprocessing/tail_log_test.py`, switch
from `unittest.TestCase` to `TestCase`, and add a `run_tests()` entry
point.

## Changes

- **Import `HardwareClassification`, `run_tests`, `TestCase`** from
  `common_utils`.  Remove `import unittest`.
- **Switch `TailLogTest` from `unittest.TestCase` to `TestCase`**.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `TailLogTest`.  All seven tests exercise pure CPU log tailing,
  custom prefix, and custom filter logic without any device
  dependency.
- **Add `if __name__ == "__main__": run_tests()`** at the end.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/multiprocessing/tail_log_test.py` —
  TODO: confirm all seven tests pass on CPU.