### PR TITLE
[Testcase Refactoring]Add hw_classification to elastic multiprocessing test_api.py

### DIFF
--- a/test/distributed/elastic/multiprocessing/test_api.py
+++ b/test/distributed/elastic/multiprocessing/test_api.py
@@ -16,10 +16,16 @@ from torch.distributed.elastic.multiprocessing.api import (
     PContext,
     SignalException,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class SignalHandlingTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Save original environment variable if it exists


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to
`SignalHandlingTest` in
`test/distributed/elastic/multiprocessing/test_api.py`.

## Changes

- **Import `HardwareClassification`** from `common_utils`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to
  `SignalHandlingTest`.  All seven tests exercise pure CPU signal
  handling logic (`PContext.start`, signal registration, invalid
  signals, Windows signals, non-main thread) using `@patch` and
  `MagicMock` without any device dependency.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/multiprocessing/test_api.py` —
  TODO: confirm all seven tests pass on CPU.