### PR TITLE
[Testcase Refactoring] Migrate test_layout_optim to instantiate_device_type_tests

### DIFF
--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -9,11 +9,7 @@ from torch._dynamo.utils import same
 from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_cuda import tf32_off
-from torch.testing._internal.common_device_type import (
-    Capability,
-    instantiate_device_type_tests,
-    requires_capabilities,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
 
 
@@ -124,14 +120,12 @@ class TestLayoutOptim(TestCase):
     def verify_accuracy_for_train(self, model_class, device, **kwargs):
         self.verify_accuracy(model_class, device, is_train=True, **kwargs)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_2conv_with_graph_break(self, device):
         """
         Make sure graph break does not cause any accuracy issue.
         """
         self.verify_accuracy_for_infer(Model2Conv, device)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_3conv_with_graph_break(self, device):
         class Model(nn.Module):
             def __init__(
@@ -191,11 +185,9 @@ class TestLayoutOptim(TestCase):
         # Note that if the output is channels last, the view op will fail.
         opt_out.view(5, -1)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_keep_output_layout_infer(self, device):
         self._run_keep_output_layout_infer(device)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_keep_output_layout_with_freezing(self, device):
         with config.patch(
             {
@@ -204,11 +196,9 @@ class TestLayoutOptim(TestCase):
         ):
             self._run_keep_output_layout_infer(device)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_training_acc(self, device):
         self.verify_accuracy_for_train(Model2Conv, device)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_mutate_view(self, device):
         """
         The GraphModule passed to GraphLowering init method is like:
@@ -227,7 +217,6 @@ class TestLayoutOptim(TestCase):
         f(x)
         self.assertTrue(torch.equal(x, torch.ones(2, 3).to(device) * 2))
 
-    @requires_capabilities(Capability.lib.triton)
     def test_mutate_base(self, device):
         """
         The GraphModule passed to GraphLowering init method is like:
@@ -247,7 +236,6 @@ class TestLayoutOptim(TestCase):
         y = f(x)
         self.assertTrue(torch.equal(y, torch.ones(3, 2).to(device) * 2))
 
-    @requires_capabilities(Capability.lib.triton)
     @tf32_off()
     def test_mutate_base_for_conv_output(self, device):
         class Model(nn.Module):
@@ -266,7 +254,6 @@ class TestLayoutOptim(TestCase):
 
         self.verify_accuracy_for_infer(Model, device)
 
-    @requires_capabilities(Capability.lib.triton)
     @tf32_off()
     def test_mutate_view_for_conv_output(self, device):
         class Model(nn.Module):
@@ -285,7 +272,6 @@ class TestLayoutOptim(TestCase):
 
         self.verify_accuracy_for_infer(Model, device)
 
-    @requires_capabilities(Capability.lib.triton)
     def test_dynamic_shape_specialization(self, device):
         """
         Previously in aot_autograd.py we compare strides of FakeTensor
@@ -308,7 +294,6 @@ class TestLayoutOptim(TestCase):
             # Trigger the compiling of the backward graph
             actual.sum().backward()
 
-    @requires_capabilities(Capability.lib.triton)
     def test_nll_loss_backward(self, device):
         """
         Repro for issue https://github.com/pytorch/pytorch/issues/120759
@@ -360,4 +345,7 @@ instantiate_device_type_tests(TestLayoutOptim, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":
-    run_tests()
+    from torch.utils._triton import has_triton
+
+    if has_triton():
+        run_tests()

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -9,8 +9,12 @@ from torch._dynamo.utils import same
 from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_cuda import tf32_off
-from torch.testing._internal.common_utils import skipIfXpu
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 USE_DDP_WRAPPER = os.environ.get("USE_DDP_WRAPPER", "1") == "1"
@@ -34,8 +38,9 @@ class Model2Conv(nn.Module):
         return (torch.rand(2, 3, 16, 16),)
 
 
-@skipIfXpu(msg="ccl doesn't currently work on the XPU stack")
 class TestLayoutOptim(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -47,10 +52,7 @@ class TestLayoutOptim(TestCase):
         for retry_no in range(tot_retry):
             try:
                 port = random.randint(10000, 60000)
-                if GPU_TYPE == "cuda":
-                    backend = "nccl"
-                elif GPU_TYPE == "xpu":
-                    backend = "ccl"
+                backend = dist.get_default_backend_for_device(cls.device_type)
                 dist.init_process_group(
                     backend=backend,
                     init_method=f"tcp://localhost:{port}",
@@ -65,7 +67,7 @@ class TestLayoutOptim(TestCase):
                     continue
 
     def verify_accuracy(
-        self, model_class, use_ddp_wrapper=USE_DDP_WRAPPER, is_train=False
+        self, model_class, device, use_ddp_wrapper=USE_DDP_WRAPPER, is_train=False
     ):
         # there are 2 potential ways to introduce graph breaks
         # 1. manually
@@ -91,8 +93,8 @@ class TestLayoutOptim(TestCase):
                 return m
 
         manual_graph_break = not use_ddp_wrapper
-        mod = model_class(manual_graph_break=manual_graph_break).to(GPU_TYPE)
-        inp = [t.to(GPU_TYPE) for t in mod.get_example_inputs()]
+        mod = model_class(manual_graph_break=manual_graph_break).to(device)
+        inp = [t.to(device) for t in mod.get_example_inputs()]
         expected_out = wrap_mod(mod)(*inp)
 
         fp64_mod = copy.deepcopy(mod).to(torch.float64)
@@ -116,19 +118,21 @@ class TestLayoutOptim(TestCase):
             print(f"Expected sum {expected_sum}, actual sum {actual_sum}")
             self.assertTrue(same(expected_out, actual_out, fp64_ref=fp64_out))
 
-    def verify_accuracy_for_infer(self, *args, **kwargs):
-        self.verify_accuracy(*args, **kwargs, is_train=False)
+    def verify_accuracy_for_infer(self, model_class, device, **kwargs):
+        self.verify_accuracy(model_class, device, is_train=False, **kwargs)
 
-    def verify_accuracy_for_train(self, *args, **kwargs):
-        self.verify_accuracy(*args, **kwargs, is_train=True)
+    def verify_accuracy_for_train(self, model_class, device, **kwargs):
+        self.verify_accuracy(model_class, device, is_train=True, **kwargs)
 
-    def test_2conv_with_graph_break(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_2conv_with_graph_break(self, device):
         """
         Make sure graph break does not cause any accuracy issue.
         """
-        self.verify_accuracy_for_infer(Model2Conv)
+        self.verify_accuracy_for_infer(Model2Conv, device)
 
-    def test_3conv_with_graph_break(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_3conv_with_graph_break(self, device):
         class Model(nn.Module):
             def __init__(
                 self, dim=512, patch_size=7, kernel_size=7, manual_graph_break=False
@@ -155,10 +159,9 @@ class TestLayoutOptim(TestCase):
             def get_example_inputs(self):
                 return (torch.randn(2, 3, 16, 16),)
 
-        self.verify_accuracy_for_infer(Model)
+        self.verify_accuracy_for_infer(Model, device)
 
-    @torch.no_grad()
-    def test_keep_output_layout_infer(self):
+    def _run_keep_output_layout_infer(self, device):
         class Model(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -173,8 +176,8 @@ class TestLayoutOptim(TestCase):
             def get_example_inputs(self):
                 return (torch.randn(2, 3, 5, 5),)
 
-        mod = Model().to(GPU_TYPE)
-        inp = [t.to(GPU_TYPE) for t in mod.get_example_inputs()]
+        mod = Model().to(device)
+        inp = [t.to(device) for t in mod.get_example_inputs()]
         out = mod(*inp)
 
         opt_mod = torch.compile(mod)
@@ -187,18 +190,26 @@ class TestLayoutOptim(TestCase):
         # Note that if the output is channels last, the view op will fail.
         opt_out.view(5, -1)
 
-    def test_keep_output_layout_with_freezing(self):
+    @requires_capabilities(Capability.lib.triton)
+    @torch.no_grad()
+    def test_keep_output_layout_infer(self, device):
+        self._run_keep_output_layout_infer(device)
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_keep_output_layout_with_freezing(self, device):
         with config.patch(
             {
                 "freezing": True,
             }
         ):
-            self.test_keep_output_layout_infer()
+            self._run_keep_output_layout_infer(device)
 
-    def test_training_acc(self):
-        self.verify_accuracy_for_train(Model2Conv)
+    @requires_capabilities(Capability.lib.triton)
+    def test_training_acc(self, device):
+        self.verify_accuracy_for_train(Model2Conv, device)
 
-    def test_mutate_view(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_mutate_view(self, device):
         """
         The GraphModule passed to GraphLowering init method is like:
         https://gist.github.com/shunting314/07228313fd017e2267101ff32edc6d64
@@ -212,11 +223,12 @@ class TestLayoutOptim(TestCase):
             y = x.view(3, 2)
             y.mul_(2)
 
-        x = torch.ones(2, 3).to(GPU_TYPE)
+        x = torch.ones(2, 3).to(device)
         f(x)
-        self.assertTrue(torch.equal(x, torch.ones(2, 3).to(GPU_TYPE) * 2))
+        self.assertTrue(torch.equal(x, torch.ones(2, 3).to(device) * 2))
 
-    def test_mutate_base(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_mutate_base(self, device):
         """
         The GraphModule passed to GraphLowering init method is like:
         https://gist.github.com/shunting314/fd60fe11d1f844c6db76aba7b06811bc
@@ -231,12 +243,13 @@ class TestLayoutOptim(TestCase):
             x.mul_(2)
             return y
 
-        x = torch.ones(2, 3).to(GPU_TYPE)
+        x = torch.ones(2, 3).to(device)
         y = f(x)
-        self.assertTrue(torch.equal(y, torch.ones(3, 2).to(GPU_TYPE) * 2))
+        self.assertTrue(torch.equal(y, torch.ones(3, 2).to(device) * 2))
 
+    @requires_capabilities(Capability.lib.triton)
     @tf32_off()
-    def test_mutate_base_for_conv_output(self):
+    def test_mutate_base_for_conv_output(self, device):
         class Model(nn.Module):
             def __init__(self, manual_graph_break=False):
                 super().__init__()
@@ -251,10 +264,11 @@ class TestLayoutOptim(TestCase):
             def get_example_inputs(self):
                 return (torch.rand(2, 3, 16, 16),)
 
-        self.verify_accuracy_for_infer(Model)
+        self.verify_accuracy_for_infer(Model, device)
 
+    @requires_capabilities(Capability.lib.triton)
     @tf32_off()
-    def test_mutate_view_for_conv_output(self):
+    def test_mutate_view_for_conv_output(self, device):
         class Model(nn.Module):
             def __init__(self, manual_graph_break=False):
                 super().__init__()
@@ -269,9 +283,10 @@ class TestLayoutOptim(TestCase):
             def get_example_inputs(self):
                 return (torch.rand(2, 3, 16, 16),)
 
-        self.verify_accuracy_for_infer(Model)
+        self.verify_accuracy_for_infer(Model, device)
 
-    def test_dynamic_shape_specialization(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_dynamic_shape_specialization(self, device):
         """
         Previously in aot_autograd.py we compare strides of FakeTensor
         with real tensor. That cause dynamic dimensions of the FakeTensor
@@ -285,19 +300,20 @@ class TestLayoutOptim(TestCase):
             return z
 
         for size in [4, 8, 16]:
-            a = torch.randn(2, size, requires_grad=True).to(GPU_TYPE)
-            b = torch.randn(2, size).to(GPU_TYPE)
+            a = torch.randn(2, size, requires_grad=True).to(device)
+            b = torch.randn(2, size).to(device)
             actual = torch.compile(f, dynamic=True)(a, b)
             self.assertTrue(torch.allclose(f(a, b), actual))
 
             # Trigger the compiling of the backward graph
             actual.sum().backward()
 
-    def test_nll_loss_backward(self):
+    @requires_capabilities(Capability.lib.triton)
+    def test_nll_loss_backward(self, device):
         """
         Repro for issue https://github.com/pytorch/pytorch/issues/120759
 
-        The CUDA implementation of aten.nll_loss2d_backward.default requires
+        The accelerator implementation of aten.nll_loss2d_backward.default requires
         the self tensor (whose layout will be used to create grad_input)
         to be contiguous. Layout optimization may change the self tensor's layout
         and cause failure. We fix that by adding layout constraints to the
@@ -318,7 +334,6 @@ class TestLayoutOptim(TestCase):
                 loss = torch.nn.functional.cross_entropy(logits, targets)
                 return loss
 
-        device = GPU_TYPE
         batch_size = 48
         seq_len = 144
         input_dim = 39
@@ -341,6 +356,8 @@ class TestLayoutOptim(TestCase):
         self.assertTrue(torch.allclose(ref, loss))
 
 
+instantiate_device_type_tests(TestLayoutOptim, globals(), except_for="cpu")
+
+
 if __name__ == "__main__":
-    if HAS_GPU:
-        run_tests()
+    run_tests()

--- a/test/inductor/test_layout_optim.py
+++ b/test/inductor/test_layout_optim.py
@@ -161,6 +161,7 @@ class TestLayoutOptim(TestCase):
 
         self.verify_accuracy_for_infer(Model, device)
 
+    @torch.no_grad()
     def _run_keep_output_layout_infer(self, device):
         class Model(nn.Module):
             def __init__(self) -> None:
@@ -191,7 +192,6 @@ class TestLayoutOptim(TestCase):
         opt_out.view(5, -1)
 
     @requires_capabilities(Capability.lib.triton)
-    @torch.no_grad()
     def test_keep_output_layout_infer(self, device):
         self._run_keep_output_layout_infer(device)
 


### PR DESCRIPTION
### Summary

Refactored test/inductor/test_layout_optim.py to use capability-based device type tests via `instantiate_device_type_tests`, replacing hardcoded `GPU_TYPE`/`HAS_GPU`/`skipIfXpu` guards.

### Changes

- Replaced `GPU_TYPE`/`HAS_GPU`/`skipIfXpu` imports with `Capability`, `instantiate_device_type_tests`, `requires_capabilities`, and `HardwareClassification`
- Added `hw_classification = HardwareClassification.ACCELERATOR` and `device` parameter to all test methods
- Replaced hardcoded `GPU_TYPE == "cuda"/"xpu"` backend selection with `dist.get_default_backend_for_device(cls.device_type)`
- Added `@requires_capabilities(Capability.lib.triton)` to all test methods and used `instantiate_device_type_tests(..., except_for="cpu")`
- Removed `if HAS_GPU: run_tests()` guard at module entry point

### Motivation

The original code hardcoded `GPU_TYPE` for device selection and backend assignment, preventing multi-backend support. The refactored version uses capability-based guards and `instantiate_device_type_tests` for proper device abstraction.

### Test Plan
```
python test/inductor/test_layout_optim.py
```

### Dependencies
Depends on: PR #190846, PR #194039 (`Capability.lib.triton` capability registration)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
