### PR TITLE
[Testcase Refactoring]Add hw_classification to elastic rendezvous api_test.py

### DIFF
--- a/test/distributed/elastic/rendezvous/api_test.py
+++ b/test/distributed/elastic/rendezvous/api_test.py
@@ -7,7 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, cast, SupportsInt
-from unittest import TestCase
 
 from torch.distributed.elastic.rendezvous import (
     RendezvousHandler,
@@ -15,9 +14,16 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousInfo,
     RendezvousParameters,
 )
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class RendezvousParametersTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self._backend = "dummy_backend"
@@ -227,6 +233,8 @@ class _DummyRendezvousHandler(RendezvousHandler):
 
 
 class RendezvousHandlerRegistryTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self._params = RendezvousParameters(
@@ -289,3 +297,7 @@ class RendezvousHandlerRegistryTest(TestCase):
             self._params.backend = "dummy_backend_2"
 
             self._registry.create_handler(self._params)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to both test
classes in `test/distributed/elastic/rendezvous/api_test.py`, switch
from `unittest.TestCase` to `TestCase`, and add a `run_tests()` entry
point.

## Changes

- **Import `HardwareClassification`, `run_tests`, `TestCase`** from
  `common_utils`.  Remove `import unittest`.
- **Switch `RendezvousParametersTest` and
  `RendezvousHandlerRegistryTest`** from `unittest.TestCase` to
  `TestCase`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to both
  classes.  All 22 tests exercise pure CPU rendezvous parameter
  validation, boolean/integer type coercion, and backend registry
  logic without any device dependency.
- **Add `if __name__ == "__main__": run_tests()`** at the end.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/rendezvous/api_test.py` —
  TODO: confirm all 22 tests pass on CPU.