### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes.

### DIFF
--- a/test/inductor/test_move_constructors_to_gpu.py
+++ b/test/inductor/test_move_constructors_to_gpu.py
@@ -1,87 +1,78 @@
 # Owner(s): ["module: inductor"]
 
-import functools
 import unittest
 
 import torch
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU_AND_TRITON,
-    HAS_MULTIGPU,
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.utils._triton import has_triton
+
+
+def _has_multigpu():
+    if torch.accelerator.is_available():
+        return torch.accelerator.device_count() > 1
+    return False
+
+
+requires_multigpu = unittest.skipIf(
+    not _has_multigpu(), "requires multiple accelerator devices"
 )
 
 
-requires_multigpu = functools.partial(
-    unittest.skipIf, not HAS_MULTIGPU, f"requires multiple {GPU_TYPE} devices"
-)
+def _check_fn(test_case, func, expect_cpu, *args):
+    out_eager = func(*args)
 
+    out_compiled, code = run_and_get_code(torch.compile(func), *args)
+    test_case.assertEqual(out_eager, out_compiled)
 
-aten = torch.ops.aten
+    if len(code) != 1:
+        raise AssertionError
+    if expect_cpu:
+        FileCheck().check("cpp_fused").run(code[0])
+    else:
+        FileCheck().check_not("cpp_fused").run(code[0])
 
 
 class TestMoveConstructorsToGpu(TestCase):
-    def _check_fn(self, func, expect_cpu, *args):
-        out_eager = func(*args)
+    hw_classification = HardwareClassification.ACCELERATOR
 
-        out_compiled, code = run_and_get_code(torch.compile(func), *args)
-        self.assertEqual(out_eager, out_compiled)
-
-        if len(code) != 1:
-            raise AssertionError
-        if expect_cpu:
-            FileCheck().check("cpp_fused").run(code[0])
-        else:
-            FileCheck().check_not("cpp_fused").run(code[0])
-
-    def test_simple(self):
+    def test_simple(self, device):
         def foo(x):
             return x[torch.arange(x.shape[0])]
 
-        inp = torch.rand(32, 77, 512, device=GPU_TYPE)
+        inp = torch.rand(32, 77, 512, device=device)
 
-        self._check_fn(foo, False, inp)
+        _check_fn(self, foo, False, inp)
 
-    def test_output_failure(self):
+    def test_output_failure(self, device):
         def foo(x):
             tmp1 = torch.arange(x.shape[0])
             return tmp1, x[tmp1]
 
-        inp = torch.rand(32, 77, 512, device=GPU_TYPE)
+        inp = torch.rand(32, 77, 512, device=device)
 
-        self._check_fn(foo, True, inp)
+        _check_fn(self, foo, True, inp)
 
-    def test_non_convertable_op_failure(self):
+    def test_non_convertable_op_failure(self, device):
         def foo(x):
             y = torch.arange(x.shape[0])
-            return x + y, torch.ones([4], device=GPU_TYPE)
+            return x + y, torch.ones([4], device=device)
 
         inp = torch.rand([100])
 
-        self._check_fn(foo, True, inp)
+        _check_fn(self, foo, True, inp)
 
-    def test_multiple_constructors(self):
-        def foo(x):
-            tmp1 = torch.arange(x.shape[0])
-            o1 = x[tmp1]
-            tmp2 = torch.arange(x.shape[1]).view([1, x.shape[1]])
-            o2 = x[tmp2]
-            return o1, o2, o1 + o2
-
-        inp = torch.rand([200, 200])
-        self._check_fn(foo, True, inp)
-
-    def test_sets_equiv(self):
+    def test_sets_equiv(self, device):
         @torch.compile()
         def foo(x):
             c1 = torch.ones([4], dtype=torch.long)
             c2 = torch.arange(-1, 3)
             return x[c1 + c2], c2 - 4 * 2
 
-        inp = torch.rand([4]).to(GPU_TYPE)
+        inp = torch.rand([4]).to(device)
         _, code = run_and_get_code(foo, inp)
         FileCheck().check_not("triton.jit").run(code[0])
 
@@ -94,28 +85,23 @@ class TestMoveConstructorsToGpu(TestCase):
         _, code = run_and_get_code(foo, inp)
         FileCheck().check_not("triton.jit").run(code[0])
 
-    @requires_multigpu()
+    @requires_multigpu
     @unittest.skip("https://github.com/pytorch/pytorch/issues/139520")
-    def test_multi_gpu(self):
+    def test_multi_gpu(self, device):
+        device_type = torch.device(device).type
+
         def foo(x):
             return (
                 x[torch.arange(x.shape[0])],
-                torch.ones([4], device=f"{GPU_TYPE}:0"),
-                torch.ones([4], device=f"{GPU_TYPE}:1"),
+                torch.ones([4], device=f"{device_type}:0"),
+                torch.ones([4], device=f"{device_type}:1"),
             )
 
         # nyi, multi-gpu
-        inp = torch.rand([100], device=GPU_TYPE)
-        self._check_fn(foo, True, inp)
+        inp = torch.rand([100], device=device)
+        _check_fn(self, foo, True, inp)
 
-    def test_no_gpu(self):
-        def foo(x):
-            return x[torch.arange(x.shape[0])]
-
-        inp = torch.rand([100])
-        self._check_fn(foo, True, inp)
-
-    def test_random_constructor_not_moved(self):
+    def test_random_constructor_not_moved(self, device):
         from torch._inductor import config
 
         for random_fn in [torch.randn, torch.rand]:
@@ -126,7 +112,7 @@ class TestMoveConstructorsToGpu(TestCase):
                 indices = torch.tensor([0, 2], dtype=torch.long).to(x.device)
                 return torch.index_add(x, 0, indices, values)
 
-            inp = torch.randn(4, 8, device=GPU_TYPE)
+            inp = torch.randn(4, 8, device=device)
 
             with config.patch(fallback_random=True):
                 torch.manual_seed(0)
@@ -138,6 +124,33 @@ class TestMoveConstructorsToGpu(TestCase):
             self.assertEqual(out_eager, out_compiled)
 
 
+class TestMoveConstructorsGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_multiple_constructors(self):
+        def foo(x):
+            tmp1 = torch.arange(x.shape[0])
+            o1 = x[tmp1]
+            tmp2 = torch.arange(x.shape[1]).view([1, x.shape[1]])
+            o2 = x[tmp2]
+            return o1, o2, o1 + o2
+
+        inp = torch.rand([200, 200])
+        _check_fn(self, foo, True, inp)
+
+    def test_no_gpu(self):
+        def foo(x):
+            return x[torch.arange(x.shape[0])]
+
+        inp = torch.rand([100])
+        _check_fn(self, foo, True, inp)
+
+
+instantiate_device_type_tests(
+    TestMoveConstructorsToGpu, globals(), except_for="cpu", allow_xpu=True
+)
+
+
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU_AND_TRITON:
+    if IS_LINUX and has_triton():
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_move_constructors_to_gpu.py
python test/inductor/test_move_constructors_to_gpu.py -v --hw-classification GENERIC
python test/inductor/test_move_constructors_to_gpu.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo