### PR TITLE
[Testcase Refactoring] Migrate test_flex_decoding to capability-based skip mechanism

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -29,20 +29,22 @@ from torch.testing._internal.common_cuda import (
     with_tf32_off,
 )
 from torch.testing._internal.common_device_type import (
+    Capability,
     E4M3_MAX_POS,
     e4m3_type,
-    flex_attention_supported_platform as supported_platform,
     instantiate_device_type_tests,
-    IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED as TEST_ON_CPU,
-    IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED as TEST_ON_CUDA,
-    IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED as TEST_ON_XPU,
     largeTensorTest,
+    requires_capabilities,
     skipCPUIf,
     skipCUDAIf,
     skipXPUIf,
 )
 from torch.testing._internal.common_quantized import _snr
-from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_CI,
+    IS_WINDOWS,
+)
 from torch.utils._triton import has_triton_tma_device
 
 
@@ -104,12 +106,8 @@ device_configs = {
     ),
 }
 
-test_device = ("cpu",)
-if TEST_ON_CUDA:
-    test_device = ("cuda", "cpu") if TEST_ON_CPU else ("cuda",)
-elif TEST_ON_XPU:
+if torch.xpu.is_available():
     torch._C._set_onednn_allow_tf32(True)
-    test_device = ("xpu",)
 
 torch_config_string = torch.__config__.show()
 LONG_COMPILATION_ON_CPU = False
@@ -126,7 +124,11 @@ class parametrize_device_dtype(common_utils.parametrize):
         self.dtypes_attr = dtypes_attr
 
     def _parametrize_test(self, test, generic_cls, device_cls):
-        dtypes = getattr(device_configs[device_cls.device_type], self.dtypes_attr)
+        config = device_configs.get(
+            device_cls.device_type,
+            DeviceConfig(dtypes=[torch.float32], dtypes_fast=[torch.float32]),
+        )
+        dtypes = getattr(config, self.dtypes_attr)
         for idx, dtype in enumerate(dtypes):
             values = [dtype]
             test_name = self._get_subtest_name(idx, values)
@@ -352,6 +354,8 @@ def batch_reserve(paged_attention: PagedAttention, target_seq_len: Tensor):
 
 
 class TestFlexDecoding(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         self.test_inference_only = False
@@ -806,7 +810,7 @@ class TestFlexDecoding(InductorTestCase):
             compiled_out,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @expectedFailure  # tl.dot does not support embedding size less than 16
     @skip_on_cpu
     @parametrize_device_dtype("dtypes_fast")
@@ -837,7 +841,7 @@ class TestFlexDecoding(InductorTestCase):
 
         output.backward(backward_grad)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
@@ -855,7 +859,7 @@ class TestFlexDecoding(InductorTestCase):
             score_mod, dtype, Q_H=Hq, KV_H=Hkv, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
@@ -899,7 +903,7 @@ class TestFlexDecoding(InductorTestCase):
             device=device,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("BLOCK_SIZE", test_block_size)
@@ -938,7 +942,7 @@ class TestFlexDecoding(InductorTestCase):
             kernel_options=kernel_options,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("k_s", test_input_strides)
     @common_utils.parametrize("v_s", test_input_strides)
@@ -1001,7 +1005,7 @@ class TestFlexDecoding(InductorTestCase):
             ref_out, paged_compiled_out, atol=tolerance.atol, rtol=tolerance.rtol
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
     @common_utils.parametrize("batch_dims", test_Bq_Bkv)
@@ -1032,7 +1036,7 @@ class TestFlexDecoding(InductorTestCase):
             score_mod, dtype, Bq, Hq, 1, D, Bkv, Hkv, S, D, block_mask, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     def test_skip_odd_keys(self, device, dtype: torch.dtype):
         def score_mod(score, b, h, q, kv):
@@ -1041,7 +1045,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(score_mod, dtype, device=device)
         self.run_test_with_paged_attention(score_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     def test_function_composition(self, device, dtype: torch.dtype):
         def score_mod_1(score, b, h, m, n):
@@ -1056,7 +1060,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(composed_score_mod, dtype, device=device)
         self.run_test_with_paged_attention(composed_score_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     def test_captured_buffers(self, device, dtype: torch.dtype):
         head_offset = torch.rand(Hq, device=device, dtype=dtype)
@@ -1067,7 +1071,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(score_mod, dtype, device=device)
         self.run_test_with_paged_attention(score_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     def test_captured_buffers_all_dims(self, device, dtype: torch.dtype):
         head_scale = torch.randn(Hq, device=device)
@@ -1085,7 +1089,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(all_bias, dtype, device=device)
         self.run_test_with_paged_attention(all_bias, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_seq_masking(self, device, dtype):
         seq_idx = torch.zeros(S, device=device, dtype=torch.bool)
@@ -1097,7 +1101,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(seq_mask_mod, dtype, device=device)
         self.run_test_with_paged_attention(seq_mask_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_non_divisible_offset_mask(self, device):
         KV_S = S - 3
         offset_tensor = torch.tensor(S // 2 - 3, device=device, dtype=torch.int32)
@@ -1108,7 +1112,7 @@ class TestFlexDecoding(InductorTestCase):
         block_mask = create_block_mask(mask_mod, B, 1, 1, KV_S, device=device)
         self.run_test(KV_S=KV_S, block_mask=block_mask, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_non_divisible_offset_mask_with_captured_buffer(self, device):
         KV_S = S - 3
         offset_kv = torch.randn(KV_S, device=device, dtype=torch.bfloat16)
@@ -1125,7 +1129,7 @@ class TestFlexDecoding(InductorTestCase):
             KV_S=KV_S, block_mask=block_mask, score_mod=score_mod, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_non_divisible_multi_token_offset_mask(self, device):
         KV_S = S - 3
         Q_S = 3
@@ -1137,7 +1141,7 @@ class TestFlexDecoding(InductorTestCase):
         block_mask = create_block_mask(mask_mod, B, 1, Q_S, KV_S, device=device)
         self.run_test(Q_S=Q_S, KV_S=KV_S, block_mask=block_mask, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_non_divisible_multi_token_offset_mask_with_captured_buffer(self, device):
         KV_S = S - 3
@@ -1161,7 +1165,7 @@ class TestFlexDecoding(InductorTestCase):
             device=device,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_load_from_bias_seq_only(self, device, dtype):
         bias = torch.randn(1, S, device=device, dtype=dtype)
@@ -1172,7 +1176,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(bias_mod, dtype, device=device)
         self.run_test_with_paged_attention(bias_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_load_from_bias_seq_batch(self, device, dtype):
         bias = torch.randn(B, 1, S, device=device, dtype=dtype)
@@ -1183,7 +1187,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(bias_mod, dtype, device=device)
         self.run_test_with_paged_attention(bias_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_load_from_bias_head_seq_batch(self, device, dtype):
         bias = torch.randn(
@@ -1201,7 +1205,7 @@ class TestFlexDecoding(InductorTestCase):
         self.run_test(bias_mod, dtype, device=device)
         self.run_test_with_paged_attention(bias_mod, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @common_utils.parametrize("score_mod", test_score_mods)
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("head_dims", [(D, D // 2), (D // 2, D)])
@@ -1215,7 +1219,7 @@ class TestFlexDecoding(InductorTestCase):
             score_mod, dtype, B, Hq, 1, qk_d, B, Hkv, S, V_D=v_d, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("head_dims", test_Hq_Hkv)
@@ -1252,7 +1256,7 @@ class TestFlexDecoding(InductorTestCase):
             score_mod, dtype, Q_H=Hq, KV_H=Hkv, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_subgraph_respect_decompostion(self, device, dtype):
         from torch._decomp import core_aten_decompositions
@@ -1303,7 +1307,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     return sub""",
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_silu_on_score(self, device, dtype):
         def silu_score(score, b, h, q, kv):
@@ -1312,7 +1316,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(silu_score, dtype, device=device)
         self.run_test_with_paged_attention(silu_score, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_padded_dense_causal(self, device, dtype):
         seq_len = torch.arange(B, device=device, dtype=torch.int32) + 1
@@ -1330,7 +1334,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(causal_njt, dtype, device=device)
         self.run_test_with_paged_attention(causal_njt, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_captured_scale(self, device, dtype):
         scale = torch.ones((), device=device, dtype=torch.int32)
@@ -1341,7 +1345,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(score_mod_scale, dtype, device=device)
         self.run_test_with_paged_attention(score_mod_scale, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_recompile_changed_score_mod(self, device, dtype):
         scale = torch.ones((), device=device, dtype=torch.int32)
@@ -1360,7 +1364,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(score_mod_scale, dtype, device=device)
         self.run_test_with_paged_attention(score_mod_scale, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @common_utils.parametrize("head_dim", [17, 24, 94, 121])
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.serialTest()
@@ -1380,7 +1384,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             device=device,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @expectedFailure  # If we capture a tensor then we can perform a reduction on it, and that shouldn't be allowed
     @parametrize_device_dtype("dtypes_fast")
     def test_captured_reduction(self, device, dtype):
@@ -1391,7 +1395,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
         self.run_test(score_mod_scale, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_multiple_score_mod_calls(self, device):
         query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device=device)
         keys = [
@@ -1418,7 +1422,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         tolerance = Tolerances(atol=2e-1, rtol=2e-1)
         torch.testing.assert_close(out, out2, atol=tolerance.atol, rtol=tolerance.rtol)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_multiple_score_mod_calls2(self, device):
         query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device=device)
         keys = [
@@ -1447,7 +1451,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         out2 = torch.compile(f)(query, *keys, *values)
         self.assertTrue((out - out2).abs().mean() < 1e-2)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_multiple_score_mod_calls_paged_attention(self, device):
         query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device=device)
         keys = [
@@ -1528,7 +1532,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             eager_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_multiple_score_mod_calls_paged_attention2(self, device):
         query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device=device)
         keys = [
@@ -1635,7 +1639,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             eager_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes")
     def test_njt_causal(self, device, dtype):
         offsets = torch.tensor(
@@ -1658,7 +1662,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(causal_njt, dtype, device=device)
         self.run_test_with_paged_attention(causal_njt, dtype, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_mixed_dtypes(self, device):
         dtype_high = torch.float16 if PLATFORM_SUPPORTS_FP8 else torch.float32
@@ -1677,7 +1681,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.assertEqual(out.shape, query.shape)
         self.assertEqual(out.dtype, query.dtype)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     @unittest.skipUnless(PLATFORM_SUPPORTS_FP8, "FP8 is not supported on this platform")
     def test_mixed_dtypes_sqnr_per_tensor(self, device):
@@ -1715,7 +1719,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         _, _, sqnr = _snr(out_ref, out)
         self.assertGreater(sqnr, 10)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     @unittest.skipUnless(PLATFORM_SUPPORTS_FP8, "FP8 is not supported on this platform")
     def test_mixed_dtypes_sqnr_per_head(self, device):
@@ -1758,7 +1762,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         _, _, sqnr = _snr(out_ref, out)
         self.assertGreater(sqnr, 10)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_mixed_dtype_backwards(self, device):
         dtype_high = torch.float16 if PLATFORM_SUPPORTS_FP8 else torch.float32
@@ -1794,7 +1798,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             ).mean()
             out_mixed.backward()
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skipCUDAIf(True, "Not supported on CUDA")
     @skipXPUIf(True, "Not supported on XPU")
     @parametrize_device_dtype("dtypes")
@@ -1811,7 +1815,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             kernel_options={"PARTITION_SIZE": partition_size},
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @patch.object(torch._inductor.config, "max_autotune", True)
     def test_max_autotune(self, device):
         def score_mod(score, b, h, m, n):
@@ -1833,45 +1837,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             device=device,
         )
 
-    @supported_platform
-    @unittest.skip("OOMs in CI")
-    @unittest.skipIf(not TEST_ON_CUDA or torch.version.hip, "requires CUDA")
-    @largeTensorTest("16GB", inductor=True)
-    def test_large_kv_decode_int64_pointer_math(self, device):
-        H, D = 1, 128
-        Q_S = 1
-        dtype = torch.bfloat16
-        tail = 128
-        KV_S = torch.iinfo(torch.int32).max // D + tail + 1
-        self.assertGreater((KV_S - tail) * D, torch.iinfo(torch.int32).max)
-
-        q = torch.randn(1, H, Q_S, D, device=device, dtype=dtype)
-        k = torch.empty(1, H, KV_S, D, device=device, dtype=dtype)
-        v = torch.empty(1, H, KV_S, D, device=device, dtype=dtype)
-        k[:, :, -tail:, :] = torch.randn(1, H, tail, D, device=device, dtype=dtype)
-        v[:, :, -tail:, :] = torch.randn(1, H, tail, D, device=device, dtype=dtype)
-
-        def mask_mod(b, h, q_idx, kv_idx):
-            return kv_idx >= (KV_S - tail)
-
-        block_mask = create_block_mask(mask_mod, 1, 1, Q_S, KV_S, device=device)
-        compiled = torch.compile(flex_attention, fullgraph=True)
-        out = compiled(
-            q,
-            k,
-            v,
-            block_mask=block_mask,
-            kernel_options={"BACKEND": "TRITON_DECODE"},
-        )
-
-        k_tail = k[:, :, -tail:, :].to(torch.float32)
-        v_tail = v[:, :, -tail:, :].to(torch.float32)
-        scores = (q.to(torch.float32) @ k_tail.transpose(-2, -1)) * (D**-0.5)
-        ref = (torch.softmax(scores, dim=-1) @ v_tail).to(dtype)
-
-        torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
-
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @patch.object(torch._inductor.config, "max_autotune", True)
     def test_max_autotune_with_captured(self, device):
         head_scale = torch.randn(Hq, device=device)
@@ -1889,7 +1855,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.run_test(bias_mod, device=device)
         self.run_test_with_paged_attention(bias_mod, device=device)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_fully_masked_out_rows_0_check_gqa(self, device):
         # Ensure fully masked out rows won't cause NaNs.
         query = torch.randn(
@@ -1944,7 +1910,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             )
         self.assertEqual(out[:, :, M:, :].sum(), 0)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_no_mask_vs_sdpa(self, device):
         score_mod = _generate_windowed(1000)
         attention = functools.partial(flex_attention, score_mod=score_mod)
@@ -1959,7 +1925,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             attention, sdpa_attention, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_full_mask_vs_sdpa(self, device):
         def mask_mod(b, h, q, kv):
             return q + 1000 >= kv
@@ -1980,7 +1946,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             attention, sdpa_attention, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_partial_block_vs_sdpa(self, device):
         def mask_mod(b, h, q, kv):
             return q + 1000 >= kv
@@ -1997,7 +1963,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             attention, sdpa_attention, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_no_mask_vs_sdpa_paged_attention(self, device):
         score_mod = _generate_windowed(1000)
 
@@ -2007,7 +1973,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             score_mod, None, sdpa_mask, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_full_mask_vs_sdpa_paged_attention(self, device):
         def mask_mod(b, h, q, kv):
             return q + 1000 >= kv
@@ -2018,7 +1984,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             score_mod, mask_mod, sdpa_mask, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_windowed_partial_block_vs_sdpa_paged_attention(self, device):
         def mask_mod(b, h, q, kv):
             return q + 1000 >= kv
@@ -2029,7 +1995,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             None, mask_mod, sdpa_mask, Q_H=16, KV_H=16, Q_S=8, device=device
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("score_mod", [_identity, _causal])
@@ -2083,7 +2049,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             rtol=tolerance.rtol,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_not_pw_of_two(self, device):
         query = torch.randn(1, 12, 1, 16, device=device)
@@ -2093,7 +2059,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         flex_compiled = torch.compile(flex_attention)
         flex_compiled(query, key, value, enable_gqa=True)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_logsumexp_only_return(self, device):
         make_q = functools.partial(
@@ -2125,7 +2091,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             code[0]
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_non_sparse_mulitple_block_size(self, device):
         def generate_causal_offset(offset: torch.Tensor):
             def causal_offset_mask(b, h, q_idx, kv_idx):
@@ -2170,7 +2136,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             device=device,
         )
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_do_not_trigger_dynamic_shapes_on_empty_block_mask(self, device):
         torch._dynamo.reset()
         H = Hq
@@ -2191,7 +2157,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             else:
                 self.assertEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @common_utils.parametrize("q_seq_len", [4, 8, 16, 23, 64])
     def test_multi_block_m(self, q_seq_len, device):
         def mask_mod(b, h, q_idx, kv_idx):
@@ -2230,7 +2196,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         out = flex_attention_compiled(q, k, v, **kwargs)
         torch.testing.assert_close(eager, out, atol=5e-3, rtol=5e-3)
 
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     def test_larger_block_mask_bug(self, device, dtype):
         def mask_mod(b, h, q_idx, kv_idx):
@@ -2259,7 +2225,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("score_mod", test_score_mods)
-    @supported_platform
+    @requires_capabilities(Capability.attention.flex_attention)
     def test_decode_at_different_input_position(
         self, device, dtype: torch.dtype, score_mod: Callable
     ):
@@ -2405,9 +2371,52 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             self._check_equal(golden_outs, ref_outs, paged_out, fudge_factor, "Out")
 
 
-instantiate_device_type_tests(
-    TestFlexDecoding, globals(), only_for=test_device, allow_xpu=True
-)
+instantiate_device_type_tests(TestFlexDecoding, globals(), allow_xpu=True)
+
+
+class TestFlexDecodingCUDA(InductorTestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_capabilities(Capability.attention.flex_attention)
+    @unittest.skip("OOMs in CI")
+    @skipCUDAIf(torch.version.hip is not None, "requires non-HIP CUDA")
+    @largeTensorTest("16GB", inductor=True)
+    def test_large_kv_decode_int64_pointer_math(self, device):
+        H, D = 1, 128
+        Q_S = 1
+        dtype = torch.bfloat16
+        tail = 128
+        KV_S = torch.iinfo(torch.int32).max // D + tail + 1
+        self.assertGreater((KV_S - tail) * D, torch.iinfo(torch.int32).max)
+
+        q = torch.randn(1, H, Q_S, D, device=device, dtype=dtype)
+        k = torch.empty(1, H, KV_S, D, device=device, dtype=dtype)
+        v = torch.empty(1, H, KV_S, D, device=device, dtype=dtype)
+        k[:, :, -tail:, :] = torch.randn(1, H, tail, D, device=device, dtype=dtype)
+        v[:, :, -tail:, :] = torch.randn(1, H, tail, D, device=device, dtype=dtype)
+
+        def mask_mod(b, h, q_idx, kv_idx):
+            return kv_idx >= (KV_S - tail)
+
+        block_mask = create_block_mask(mask_mod, 1, 1, Q_S, KV_S, device=device)
+        compiled = torch.compile(flex_attention, fullgraph=True)
+        out = compiled(
+            q,
+            k,
+            v,
+            block_mask=block_mask,
+            kernel_options={"BACKEND": "TRITON_DECODE"},
+        )
+
+        k_tail = k[:, :, -tail:, :].to(torch.float32)
+        v_tail = v[:, :, -tail:, :].to(torch.float32)
+        scores = (q.to(torch.float32) @ k_tail.transpose(-2, -1)) * (D**-0.5)
+        ref = (torch.softmax(scores, dim=-1) @ v_tail).to(dtype)
+
+        torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+
+
+instantiate_device_type_tests(TestFlexDecodingCUDA, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -25,7 +25,6 @@ from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_FP8,
     with_tf32_off,
 )
 from torch.testing._internal.common_device_type import (
@@ -104,6 +103,10 @@ device_configs = {
         ),
         dtypes_fast=[torch.float32],
     ),
+    "default": DeviceConfig(
+        dtypes=[torch.float32, torch.bfloat16, torch.float16],
+        dtypes_fast=[torch.float16],
+    ),
 }
 
 if torch.xpu.is_available():
@@ -124,10 +127,7 @@ class parametrize_device_dtype(common_utils.parametrize):
         self.dtypes_attr = dtypes_attr
 
     def _parametrize_test(self, test, generic_cls, device_cls):
-        config = device_configs.get(
-            device_cls.device_type,
-            DeviceConfig(dtypes=[torch.float32], dtypes_fast=[torch.float32]),
-        )
+        config = device_configs.get(device_cls.device_type, device_configs["default"])
         dtypes = getattr(config, self.dtypes_attr)
         for idx, dtype in enumerate(dtypes):
             values = [dtype]
@@ -1665,8 +1665,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_mixed_dtypes(self, device):
-        dtype_high = torch.float16 if PLATFORM_SUPPORTS_FP8 else torch.float32
-        dtype_low = e4m3_type if PLATFORM_SUPPORTS_FP8 else torch.float16
+        fp8_supported = type(self).get_capabilities().get(Capability.dtype.fp8, False)
+        dtype_high = torch.float16 if fp8_supported else torch.float32
+        dtype_low = e4m3_type if fp8_supported else torch.float16
         query = torch.randn((1, 1, 8, 64), dtype=dtype_high, device=device)
         key = torch.randn((1, 1, 1024, 64), dtype=dtype_high, device=device).to(
             dtype_low
@@ -1683,7 +1684,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
-    @unittest.skipUnless(PLATFORM_SUPPORTS_FP8, "FP8 is not supported on this platform")
+    @requires_capabilities(Capability.dtype.fp8)
     def test_mixed_dtypes_sqnr_per_tensor(self, device):
         query_ref = torch.testing.make_tensor(
             (1, 1, 8, 64), dtype=torch.bfloat16, device=device
@@ -1721,7 +1722,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
-    @unittest.skipUnless(PLATFORM_SUPPORTS_FP8, "FP8 is not supported on this platform")
+    @requires_capabilities(Capability.dtype.fp8)
     def test_mixed_dtypes_sqnr_per_head(self, device):
         query_ref = torch.testing.make_tensor(
             (1, 4, 8, 64), dtype=torch.bfloat16, device=device
@@ -1765,8 +1766,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @requires_capabilities(Capability.attention.flex_attention)
     @skip_on_cpu
     def test_mixed_dtype_backwards(self, device):
-        dtype_high = torch.float16 if PLATFORM_SUPPORTS_FP8 else torch.float32
-        dtype_low = e4m3_type if PLATFORM_SUPPORTS_FP8 else torch.float16
+        fp8_supported = type(self).get_capabilities().get(Capability.dtype.fp8, False)
+        dtype_high = torch.float16 if fp8_supported else torch.float32
+        dtype_low = e4m3_type if fp8_supported else torch.float16
         q = torch.testing.make_tensor(
             (1, 1, 8, 64),
             dtype=dtype_high,
@@ -2371,10 +2373,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             self._check_equal(golden_outs, ref_outs, paged_out, fudge_factor, "Out")
 
 
-instantiate_device_type_tests(TestFlexDecoding, globals(), allow_xpu=True)
-
-
-class TestFlexDecodingCUDA(InductorTestCase):
+class TestFlexDecodingLargeKV(InductorTestCase):
     hw_classification = HardwareClassification.CUDA
 
     @requires_capabilities(Capability.attention.flex_attention)
@@ -2416,7 +2415,8 @@ class TestFlexDecodingCUDA(InductorTestCase):
         torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
 
 
-instantiate_device_type_tests(TestFlexDecodingCUDA, globals(), only_for="cuda")
+instantiate_device_type_tests(TestFlexDecoding, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestFlexDecodingLargeKV, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -23,10 +23,7 @@ from torch.nn.attention.flex_attention import (
 )
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16,
-    with_tf32_off,
-)
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_BF16, with_tf32_off
 from torch.testing._internal.common_device_type import (
     Capability,
     E4M3_MAX_POS,
@@ -108,9 +105,6 @@ device_configs = {
         dtypes_fast=[torch.float16],
     ),
 }
-
-if torch.xpu.is_available():
-    torch._C._set_onednn_allow_tf32(True)
 
 torch_config_string = torch.__config__.show()
 LONG_COMPILATION_ON_CPU = False
@@ -355,6 +349,12 @@ def batch_reserve(paged_attention: PagedAttention, target_seq_len: Tensor):
 
 class TestFlexDecoding(InductorTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if cls.device_type == "xpu":
+            torch._C._set_onednn_allow_tf32(True)
 
     def setUp(self):
         super().setUp()
@@ -1801,23 +1801,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             out_mixed.backward()
 
     @requires_capabilities(Capability.attention.flex_attention)
-    @skipCUDAIf(True, "Not supported on CUDA")
-    @skipXPUIf(True, "Not supported on XPU")
-    @parametrize_device_dtype("dtypes")
-    @common_utils.parametrize("partition_size", [64, 128, 256, 1024])
-    def test_flash_decoding_partition_size(self, device, dtype, partition_size):
-        def score_mod(score, b, h, m, n):
-            return score * 2
-
-        self.run_test_with_paged_attention(
-            score_mod,
-            dtype,
-            KV_S=64,
-            device=device,
-            kernel_options={"PARTITION_SIZE": partition_size},
-        )
-
-    @requires_capabilities(Capability.attention.flex_attention)
     @patch.object(torch._inductor.config, "max_autotune", True)
     def test_max_autotune(self, device):
         def score_mod(score, b, h, m, n):
@@ -2225,9 +2208,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         out = flex_attention_compiled(q, k, v, block_mask=mask_2)
         torch.testing.assert_close(eager, out, atol=5e-3, rtol=5e-3)
 
+    @requires_capabilities(Capability.attention.flex_attention)
     @parametrize_device_dtype("dtypes_fast")
     @common_utils.parametrize("score_mod", test_score_mods)
-    @requires_capabilities(Capability.attention.flex_attention)
     def test_decode_at_different_input_position(
         self, device, dtype: torch.dtype, score_mod: Callable
     ):
@@ -2415,8 +2398,28 @@ class TestFlexDecodingLargeKV(InductorTestCase):
         torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
 
 
+class TestFlexDecodingCpuPartition(TestFlexDecoding):
+    hw_classification = HardwareClassification.CPU
+
+    @requires_capabilities(Capability.attention.flex_attention)
+    @parametrize_device_dtype("dtypes")
+    @common_utils.parametrize("partition_size", [64, 128, 256, 1024])
+    def test_flash_decoding_partition_size(self, device, dtype, partition_size):
+        def score_mod(score, b, h, m, n):
+            return score * 2
+
+        self.run_test_with_paged_attention(
+            score_mod,
+            dtype,
+            KV_S=64,
+            device=device,
+            kernel_options={"PARTITION_SIZE": partition_size},
+        )
+
+
 instantiate_device_type_tests(TestFlexDecoding, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestFlexDecodingLargeKV, globals(), only_for="cuda")
+instantiate_device_type_tests(TestFlexDecodingCpuPartition, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests


### PR DESCRIPTION
### Summary

Replaced legacy flex_attention platform flags and the `supported_platform` decorator with `@requires_capabilities(Capability.attention.flex_attention)`, and split device-specific tests (CUDA-only, CPU-only) into separate classes instantiated with `only_for=...`.

### Changes

- Replaced imports of `flex_attention_supported_platform`, `IS_FLEX_ATTENTION_CPU/CUDA/XPU_PLATFORM_SUPPORTED`, and `HardwareClassification` with `Capability` and `requires_capabilities`
- Replaced all `@supported_platform` decorators with `@requires_capabilities(Capability.attention.flex_attention)`
- Extracted `test_large_kv_decode_int64_pointer_math` into `TestFlexDecodingLargeKV` with `only_for="cuda"`
- Extracted `test_flash_decoding_partition_size` into `TestFlexDecodingCpuPartition` with `only_for="cpu"` (removed redundant `@skipCUDAIf(True)`/`@skipXPUIf(True)`)
- Moved the XPU TF32 setup from a module-level side effect into `TestFlexDecoding.setUpClass` gated by `cls.device_type == "xpu"`
- Removed `hw_classification` and `setUp` CPU platform guard (now handled by capability check)
- Added fallback `DeviceConfig` in `parametrize_device_dtype` for unconfigured device types
- Removed `only_for` from `TestFlexDecoding` instantiation

### Motivation

The original code used hardcoded boolean flags (`IS_FLEX_ATTENTION_*`) and a composite `supported_platform` skip decorator, making it difficult to extend to new accelerator backends. The capability-based approach allows each device test base to declare flex_attention support independently.

### Test Plan
python test/inductor/test_flex_decoding.py

### Dependencies

Depends on: PR #194039 (register `Capability.attention.flex_attention` and `Capability.attention.fused_attention` capabilities). This PR must be landed after #194039 is merged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo