### PR TITLE
[Testcase Refactoring] Add hw_classification to elastic rendezvous c10d_rendezvous_backend_test.py

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
 
 class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
     hw_classification = HardwareClassification.GENERIC
+
     _store: ClassVar[TCPStore]
 
     @classmethod
@@ -55,6 +56,7 @@ class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
 
 class FileStoreBackendTest(TestCase, RendezvousBackendTestMixin):
     hw_classification = HardwareClassification.GENERIC
+
     _store: ClassVar[FileStore]
 
     def setUp(self) -> None:

--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -12,7 +12,7 @@ from base64 import b64encode
 from collections.abc import Callable
 from datetime import timedelta
 from typing import cast, ClassVar
-from unittest import mock, TestCase
+from unittest import mock
 
 from rendezvous_backend_test import RendezvousBackendTestMixin
 
@@ -27,9 +27,15 @@ from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import (
     create_backend,
 )
 from torch.distributed.elastic.utils.distributed import get_free_port
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
+    hw_classification = HardwareClassification.GENERIC
     _store: ClassVar[TCPStore]
 
     @classmethod
@@ -48,6 +54,7 @@ class TCPStoreBackendTest(TestCase, RendezvousBackendTestMixin):
 
 
 class FileStoreBackendTest(TestCase, RendezvousBackendTestMixin):
+    hw_classification = HardwareClassification.GENERIC
     _store: ClassVar[FileStore]
 
     def setUp(self) -> None:
@@ -69,6 +76,8 @@ class FileStoreBackendTest(TestCase, RendezvousBackendTestMixin):
 
 
 class CreateBackendTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         # For testing, the default parameters used are for tcp. If a test
@@ -288,3 +297,7 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to all three
test classes in
`test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py`,
switch from `unittest.TestCase` to `TestCase`, and add a `run_tests()`
entry point.

## Changes

- **Import `HardwareClassification`, `run_tests`, `TestCase`** from
  `common_utils`.  Remove `TestCase` from the `unittest` import.
- **Switch `TCPStoreBackendTest`, `FileStoreBackendTest`, and
  `CreateBackendTest`** from `unittest.TestCase` to `TestCase`.
- **Add `hw_classification = HardwareClassification.GENERIC`** to all
  three classes.  The 14 tests exercise pure CPU C10d store backend
  creation (TCP/File), parameter validation, store type/timeout
  handling, and error conditions — all without any device dependency.
- **Add `if __name__ == "__main__": run_tests()`** at the end.

## Not changed

- No test logic or assertions are modified.

## Test plan

- `python test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` —
  TODO: confirm all 14 tests pass on CPU.