### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_native_matmul.py
+++ b/test/inductor/test_native_matmul.py
@@ -10,14 +10,17 @@ from torch._inductor import config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing import FileCheck
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 
 aten = torch.ops.aten
 
 
-@inductor_config.patch({"triton.native_matmul": True})
 class TestTritonDotReduction(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _check_equal(
         self, f: Callable, example_inputs: tuple[torch.Tensor], tol: float = 1e-4
     ):
@@ -41,50 +44,54 @@ class TestTritonDotReduction(TestCase):
             "tl.dot", dot_count, exactly=True
         ).run(code)
 
-    def test_matmul(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_matmul(self, device):
         def f(x, y):
             z = x @ y
             return z
 
         M, K, N = 128, 128, 128
-        x = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((M, K), (K, 1), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
 
-    def test_mm_1d_expand(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_mm_1d_expand(self, device):
         def f(x, y, M, K):
             z = x[:, None].expand(M, K) @ y
             return z
 
         M, K, N = 128, 128, 128
-        x = rand_strided((M,), (1,), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((M,), (1,), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y, M, K))
         self._check_code(f, (x, y, M, K), 1, 1)
 
-    def test_mm_2_expand(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_mm_2_expand(self, device):
         def f(x, y, M, K):
             z = x[:, None].expand(M, K) @ y
             return z
 
         M, K, N = 128, 128, 128
-        x = rand_strided((1,), (0,), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((1,), (0,), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y, M, K))
         self._check_code(f, (x, y, M, K), 1, 1)
 
-    def test_matmul_fp16(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_matmul_fp16(self, device):
         def f(x, y):
             z = x @ y.to(x.dtype)
             return z
 
         M, K, N = 128, 128, 128
-        x = rand_strided((M, K), (K, 1), dtype=torch.float16, device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), dtype=torch.float32, device=GPU_TYPE)
+        x = rand_strided((M, K), (K, 1), dtype=torch.float16, device=device)
+        y = rand_strided((K, N), (N, 1), dtype=torch.float32, device=device)
 
         # _check_equal calls torch._dynamo.utils.same with kwarg tol=1e-4.
         # For fp16 dtype, torch.allclose() defaults to atol=1e-3 rtol=1e-5,
@@ -93,59 +100,64 @@ class TestTritonDotReduction(TestCase):
         self._check_equal(f, (x, y), tol=1e-3)
         self._check_code(f, (x, y), 1, 1)
 
-    def test_reduction_mask_zeroout(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_reduction_mask_zeroout(self, device):
         def f(x, y):
             return (x + 1) @ (y - 2)
 
         M, K, N = 62, 62, 62
-        x = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((M, K), (K, 1), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
 
-    def test_3mm_add(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_3mm_add(self, device):
         def f(x, y, z, w, r, t):
             return x @ y + z @ w + r @ t
 
         M, K, N = 128, 128, 128
-        x = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
-        w = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        z = rand_strided((K, N), (N, 1), device=GPU_TYPE)
-        r = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        t = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((M, K), (K, 1), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
+        w = rand_strided((M, K), (K, 1), device=device)
+        z = rand_strided((K, N), (N, 1), device=device)
+        r = rand_strided((M, K), (K, 1), device=device)
+        t = rand_strided((K, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y, z, w, r, t))
         self._check_code(f, (x, y, z, w, r, t), 1, 3)
 
-    def test_mm_complex(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_mm_complex(self, device):
         def f(x, y, z, w):
             return x[z] @ y + w + 3
 
         M, K, N = 128, 128, 128
-        x = rand_strided((M, K), (K, 1), device=GPU_TYPE)
-        y = rand_strided((K, N), (N, 1), device=GPU_TYPE)
+        x = rand_strided((M, K), (K, 1), device=device)
+        y = rand_strided((K, N), (N, 1), device=device)
 
-        z = torch.randint(M, (M, K), dtype=torch.long, device=GPU_TYPE)
-        w = rand_strided((M, N), (N, 1), device=GPU_TYPE)
+        z = torch.randint(M, (M, K), dtype=torch.long, device=device)
+        w = rand_strided((M, N), (N, 1), device=device)
 
         self._check_equal(f, (x, y, z, w))
         self._check_code(f, (x, y, z, w), 1, 1)
 
-    def test_batchmatmul(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_batchmatmul(self, device):
         def f(x, y):
             z = torch.bmm(x, y)
             return z
 
         B, M, K, N = 256, 128, 128, 128
-        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        x = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=device)
 
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
 
-    def test_bmm_vertical_fusion(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_vertical_fusion(self, device):
         def f(x, y):
             z = torch.bmm(x, y)
             w = torch.nn.functional.relu(z)
@@ -153,28 +165,30 @@ class TestTritonDotReduction(TestCase):
             return v
 
         B, M, K, N = 128, 16, 128, 16
-        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        x = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=device)
 
         self._check_equal(f, (x, y))
         self._check_code(f, (x, y), 1, 1)
 
-    def test_bmm_horizontal_fusion(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_horizontal_fusion(self, device):
         def f(x, y, z, w):
             bmm1 = torch.bmm(x, y)
             bmm2 = torch.bmm(z, w)
             return bmm1 - bmm2 + bmm1 * bmm2
 
         B, M, K, N = 128, 16, 128, 16
-        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
-        z = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        w = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        x = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=device)
+        z = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        w = rand_strided((B, K, N), (K * N, N, 1), device=device)
 
         self._check_equal(f, (x, y, z, w))
         self._check_code(f, (x, y, z, w), 1, 2)
 
-    def test_bmm_fusion_complex1(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_fusion_complex1(self, device):
         # Out[O[b,i],j] += Input[I[b,i],r] * Weight[W[b],r,j] * Val[b,i]
         def f(inp, weight, val, I_idx, W_idx, O_idx, out):
             x = inp[I_idx]  # [B,I,R]
@@ -188,20 +202,21 @@ class TestTritonDotReduction(TestCase):
         N_w = 64
         N_out = 128
 
-        inp = rand_strided((N_in, R), (R, 1), device=GPU_TYPE)
-        weight = rand_strided((N_w, R, J), (R * J, J, 1), device=GPU_TYPE)
-        val = rand_strided((B, I), (I, 1), device=GPU_TYPE)
+        inp = rand_strided((N_in, R), (R, 1), device=device)
+        weight = rand_strided((N_w, R, J), (R * J, J, 1), device=device)
+        val = rand_strided((B, I), (I, 1), device=device)
 
-        I_idx = torch.randint(0, N_in, (B, I), device=GPU_TYPE, dtype=torch.int64)
-        W_idx = torch.randint(0, N_w, (B,), device=GPU_TYPE, dtype=torch.int64)
-        O_idx = torch.randint(0, N_out, (B, I), device=GPU_TYPE, dtype=torch.int64)
+        I_idx = torch.randint(0, N_in, (B, I), device=device, dtype=torch.int64)
+        W_idx = torch.randint(0, N_w, (B,), device=device, dtype=torch.int64)
+        O_idx = torch.randint(0, N_out, (B, I), device=device, dtype=torch.int64)
 
-        out = torch.zeros((N_out, J), device=GPU_TYPE)
+        out = torch.zeros((N_out, J), device=device)
 
         self._check_equal(f, (inp, weight, val, I_idx, W_idx, O_idx, out))
         self._check_code(f, (inp, weight, val, I_idx, W_idx, O_idx, out), 1, 1)
 
-    def test_bmm_fusion_complex2(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_fusion_complex2(self, device):
         # out[Ai[g],m,n] += Av[g,m,k,p] * B[Ak[g,p],k,n]
         def f(Av, B, Ai, Ak, out):
             Bg = B[Ak]  # [G,P,K,N]
@@ -213,25 +228,26 @@ class TestTritonDotReduction(TestCase):
         NB = 128
         NA = 128
 
-        Av = rand_strided((G, M, K, P), (M * K * P, K * P, P, 1), device=GPU_TYPE)
-        B = rand_strided((NB, K, N), (K * N, N, 1), device=GPU_TYPE)
+        Av = rand_strided((G, M, K, P), (M * K * P, K * P, P, 1), device=device)
+        B = rand_strided((NB, K, N), (K * N, N, 1), device=device)
 
-        Ai = torch.randint(0, NA, (G,), device=GPU_TYPE, dtype=torch.int64)
-        Ak = torch.randint(0, NB, (G, P), device=GPU_TYPE, dtype=torch.int64)
+        Ai = torch.randint(0, NA, (G,), device=device, dtype=torch.int64)
+        Ak = torch.randint(0, NB, (G, P), device=device, dtype=torch.int64)
 
-        out = torch.zeros((NA, M, N), device=GPU_TYPE)
+        out = torch.zeros((NA, M, N), device=device)
 
         self._check_equal(f, (Av, B, Ai, Ak, out))
         self._check_code(f, (Av, B, Ai, Ak, out), 1, 1)
 
-    def test_bmm_large_batch_reversed_pid(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_large_batch_reversed_pid(self, device):
         def f(x, y):
             z = torch.bmm(x, y)
             return z
 
         B, M, K, N = 65537, 16, 16, 16
-        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        x = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=device)
 
         f = torch.compile(f)
         code = run_and_get_triton_code(f, x, y)
@@ -240,14 +256,15 @@ class TestTritonDotReduction(TestCase):
             "yoffset = tl.program_id(1)"
         ).check("xoffset = tl.program_id(2)").run(code)
 
-    def test_bmm_no_z_broadcast(self):
+    @inductor_config.patch({"triton.native_matmul": True})
+    def test_bmm_no_z_broadcast(self, device):
         def f(x, y):
             z = torch.bmm(x, y)
             return z
 
         B, M, K, N = 128, 16, 128, 16
-        x = rand_strided((B, M, K), (M * K, K, 1), device=GPU_TYPE)
-        y = rand_strided((B, K, N), (K * N, N, 1), device=GPU_TYPE)
+        x = rand_strided((B, M, K), (M * K, K, 1), device=device)
+        y = rand_strided((B, K, N), (K * N, N, 1), device=device)
 
         f = torch.compile(f)
         code = run_and_get_triton_code(f, x, y)
@@ -259,9 +276,11 @@ class TestTritonDotReduction(TestCase):
         ).check("tl.arange(0, R0_BLOCK)[None, None, None, :]").run(code)
 
 
-if HAS_GPU:
-    torch.set_default_device(GPU_TYPE)
+instantiate_device_type_tests(
+    TestTritonDotReduction, globals(), except_for="cpu", allow_xpu=True
+)
+
 
 if __name__ == "__main__":
-    if HAS_GPU:
+    if has_triton():
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_native_matmul.py
python test/inductor/test_native_matmul.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo