### PR TITLE
[Testcase Refactoring] Add distributed capability registration to PrivateUse1TestBase

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -883,6 +883,27 @@ class PrivateUse1TestBase(DeviceTypeTestBase):
     bypass_device_restrictions = False
 
     @classmethod
+    def _capabilities(cls):
+        capabilities = super()._capabilities()
+        device_type = torch._C._get_privateuse1_backend_name()
+        capabilities.update(
+            {
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                },
+            }
+        )
+        return capabilities
+
+    @classmethod
     def get_primary_device(cls):
         return cls.primary_device
 


### PR DESCRIPTION
## Summary

Add `_capabilities()` override to `PrivateUse1TestBase` declaring
`Capability.distributed.backend`, `dtensor`, and `fsdp` capabilities,
enabling `@requires_capabilities(Capability.distributed.backend)` to gate
tests on PrivateUse1 backends.

## Changes

- Added `_capabilities()` method to `PrivateUse1TestBase` in
  `torch/testing/_internal/common_device_type.py`
- Declares `distributed.backend`, `distributed.dtensor`,
  `distributed.fsdp` capabilities via `_distributed_backend_available(device_type)`

## Motivation

PR #191919 added the `Capability` mechanism to `CPUTestBase`, `CUDATestBase`,
and `XPUTestBase`, but did not cover `PrivateUse1TestBase`. Without this
override, tests using `@requires_capabilities(Capability.distributed.backend)`
are silently skipped on PrivateUse1 backends (e.g., NPU), even when the
distributed backend (HCCL) is available.

## Depends on

This PR relies on #191919 for the `Capability` mechanism.

## Test plan

- Verified on NPU (Ascend 910B3, torch_npu 2.13.0, CANN 9.1.0-beta.1):
  `@requires_capabilities(Capability.distributed.backend)` correctly allows
  tests to run on PrivateUse1 backends after this patch.
- Without this patch: tests using `@requires_capabilities(Capability.distributed.backend)`
  are skipped on PrivateUse1 backends.