### PR TITLE
[Testcase Refactoring] Add HardwareClassification to test_hf_storage.py

### DIFF
--- a/test/distributed/checkpoint/test_hf_storage.py
+++ b/test/distributed/checkpoint/test_hf_storage.py
@@ -35,10 +35,16 @@ from torch.distributed.checkpoint.planner import (
 )
 from torch.distributed.checkpoint.planner_helpers import _create_write_item_for_tensor
 from torch.distributed.checkpoint.storage import WriteResult
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestHfStorage(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_write_data_hf(self) -> None:
         mock_module = MagicMock()
         mock_module.save.return_value = b""


### PR DESCRIPTION
## Summary

Tags `TestHfStorage` in `test/distributed/checkpoint/test_hf_storage.py` with
`hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/checkpoint/test_hf_storage.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `TestHfStorage`.

## Context

`TestHfStorage` is a plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so this class is classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `python test/distributed/checkpoint/test_hf_storage.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian