### PR TITLE
[Testcase Refactoring] Refactor test_ctx_manager.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -16,19 +16,19 @@ from torch._dynamo.testing import (
 )
 from torch._dynamo.utils import counters
 from torch.nn import functional as F
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
-    onlyCUDA,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
+    skipIfXpu,
 )
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 try:
     from . import test_functions
@@ -90,6 +90,8 @@ def customized_ctx_manager_with_graph_break(mode):
 
 
 class CtxManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_no_grad(self):
         def fn1(a, b):
             x = a + 1
@@ -260,67 +262,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(a, b)
         self.assertTrue(same(ref, res))
-
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Can't run fused SDPA on this platform",
-    )
-    def test_autocast_sdpa(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, query, key, value):
-                with torch.autocast("cpu"):
-                    with torch.autocast(device_type, dtype=torch.float32):
-                        out = F.scaled_dot_product_attention(
-                            query, key, value, None, 0.0, True
-                        )
-                return out
-
-        dtype = torch.float32
-        seq_len_q = 1
-        seq_len_k = 1
-        head_dim = 8
-        query = torch.ones(
-            1,
-            8,
-            seq_len_q,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-        key = torch.ones(
-            1,
-            8,
-            seq_len_k,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-        value = torch.ones(
-            1,
-            8,
-            seq_len_k,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-
-        module = MyModule()
-        real = module(query, key, value)
-        real_device = real.device
-        real_dtype = real.dtype
-
-        opt_mod = torch.compile(module, backend="inductor")
-        compiled = opt_mod(query, key, value)
-
-        self.assertEqual(compiled.device, real_device)
-        self.assertEqual(compiled.dtype, real_dtype)
-
-        self.assertEqual(compiled.device.type, device_type)
-        self.assertEqual(compiled.device.index, 0)
-        self.assertEqual(compiled.dtype, torch.float32)
 
     def test_autocast_cpu(self):
         class MyModule(torch.nn.Module):
@@ -1103,37 +1044,6 @@ class GraphModule(torch.nn.Module):
         opt_fn(x, y, z).sum().backward()
 
         self.assertEqual(cnts.frame_count, 2)
-
-    def _graph_break_inlining_autocast_test_helper(self, device):
-        def gn(x, y):
-            with torch.autocast(device_type=device, dtype=torch.bfloat16):
-                z = torch.mm(x, y)
-                torch._dynamo.graph_break()
-                return torch.sin(z)
-
-        def fn(x, y):
-            z = torch.mm(x, y)
-            z = z + gn(x, y)
-            return z
-
-        x = torch.rand(3, 3).to(device)
-        y = torch.rand(3, 3).to(device)
-        opt_fn = torch.compile(backend="eager")(fn)
-        ref = fn(x, y)
-        res = opt_fn(x, y)
-        self.assertEqual(ref, res)
-
-    def test_graph_break_inlining_autocast(self):
-        for device in ["cuda", "cpu", "xpu"]:
-            if device == "cuda" and not (
-                torch.cuda.is_available() and torch.cuda.is_bf16_supported()
-            ):
-                continue
-            if device == "xpu" and not (
-                torch.xpu.is_available() and torch.xpu.is_bf16_supported()
-            ):
-                continue
-            self._graph_break_inlining_autocast_test_helper(device)
 
     def test_disable_saved_tensors_hooks(self):
         def fn(z):
@@ -2083,9 +1993,7 @@ class GraphModule(torch.nn.Module):
         ):
             ContextWrappingVariable(target_values={"key": "val"})
 
-
-class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
-    def test_cuda_use_mem_pool_fx_cse_preserves_distinct_contexts(self):
+    def test_fx_cse_preserves_distinct_custom_meta_contexts(self):
         from torch._functorch.compile_utils import fx_graph_cse
 
         graph = torch.fx.Graph()
@@ -2104,12 +2012,16 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         ]
         self.assertEqual(len(add_nodes), 2)
 
-    def _check_cuda_use_mem_pool(self, backend=None):
+
+class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def _check_cuda_use_mem_pool(self, device, backend=None):
         torch.cuda.empty_cache()
 
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda") + 1
+                return torch.ones(16, device=device) + 1
 
         pool = torch.cuda.MemPool()
         opt_fn = (
@@ -2119,16 +2031,14 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         )
         res = opt_fn(pool)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 2.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 2.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_use_mem_pool_context_manager(self):
-        self._check_cuda_use_mem_pool(backend="eager")
+    def test_cuda_use_mem_pool_context_manager(self, device):
+        self._check_cuda_use_mem_pool(device, backend="eager")
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_mem_pool_id(self):
+    def test_cuda_mem_pool_id(self, device):
         def fn(pool):
             return pool.id
 
@@ -2136,15 +2046,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(opt_fn(pool), pool.id)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_context_manager_inductor(self):
-        self._check_cuda_use_mem_pool()
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_context_manager_inductor(self, device):
+        self._check_cuda_use_mem_pool(device)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_cpp_wrapper_unsupported(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_cpp_wrapper_unsupported(self, device):
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda")
+                return torch.ones(16, device=device)
 
         pool = torch.cuda.MemPool()
         with (
@@ -2162,8 +2072,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         ):
             torch.compile(fn, backend="inductor", fullgraph=True)(pool)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_realize_at_boundary_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_realize_at_boundary_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, inp):
@@ -2172,15 +2082,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
             return x + 1
 
         pool = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 3.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_fallback_alloc_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_fallback_alloc_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, inp):
@@ -2188,15 +2098,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return torch.histc(inp, bins=4, min=0, max=4)
 
         pool = torch.cuda.MemPool()
-        inp = torch.arange(16, device="cuda", dtype=torch.float32) % 4
+        inp = torch.arange(16, device=device, dtype=torch.float32) % 4
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((4,), 4.0, device="cuda"))
+        self.assertEqual(res, torch.full((4,), 4.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_foreach_alloc_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_foreach_alloc_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, xs):
@@ -2205,18 +2115,18 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         pool = torch.cuda.MemPool()
         xs = [
-            torch.ones(64, device="cuda"),
-            torch.full((64,), 2.0, device="cuda"),
+            torch.ones(64, device=device),
+            torch.full((64,), 2.0, device=device),
         ]
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, xs)
         torch.cuda.synchronize()
-        self.assertEqual(res[0], torch.full((64,), 2.0, device="cuda"))
-        self.assertEqual(res[1], torch.full((64,), 3.0, device="cuda"))
+        self.assertEqual(res[0], torch.full((64,), 2.0, device=device))
+        self.assertEqual(res[1], torch.full((64,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_forced_extern_multi_template_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_forced_extern_multi_template_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, x, y):
@@ -2224,8 +2134,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return x @ y
 
         pool = torch.cuda.MemPool()
-        x = torch.randn(32, 32, device="cuda")
-        y = torch.randn(32, 32, device="cuda")
+        x = torch.randn(32, 32, device=device)
+        y = torch.randn(32, 32, device=device)
         with torch._inductor.config.patch(
             {
                 "test_configs.force_extern_kernel_in_multi_template": True,
@@ -2243,8 +2153,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_nested_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_nested_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(outer_pool, inner_pool, inp):
@@ -2257,20 +2167,20 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         outer_pool = torch.cuda.MemPool()
         inner_pool = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         outer, inner = torch.compile(fn, backend="inductor", fullgraph=True)(
             outer_pool, inner_pool, inp
         )
         torch.cuda.synchronize()
-        self.assertEqual(outer, torch.full((16,), 5.0, device="cuda"))
-        self.assertEqual(inner, torch.full((16,), 3.0, device="cuda"))
+        self.assertEqual(outer, torch.full((16,), 5.0, device=device))
+        self.assertEqual(inner, torch.full((16,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(outer_pool.id)), 0)
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(inner_pool.id)), 0)
         self.assertEqual(outer_pool.use_count(), 1)
         self.assertEqual(inner_pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_distinct_pools_not_cse_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_distinct_pools_not_cse_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool_a, pool_b, inp):
@@ -2282,17 +2192,17 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         pool_a = torch.cuda.MemPool()
         pool_b = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool_a, pool_b, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 4.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 4.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool_a.id)), 0)
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool_b.id)), 0)
         self.assertEqual(pool_a.use_count(), 1)
         self.assertEqual(pool_b.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_reduce_overhead_cudagraph_asserts_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_reduce_overhead_cudagraph_asserts_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, x, w):
@@ -2300,8 +2210,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return (x @ w).relu()
 
         pool = torch.cuda.MemPool()
-        x = torch.randn(64, 64, device="cuda")
-        w = torch.randn(64, 64, device="cuda")
+        x = torch.randn(64, 64, device=device)
+        w = torch.randn(64, 64, device=device)
         with torch._inductor.config.patch({"triton.slow_path_cudagraph_asserts": True}):
             opt_fn = torch.compile(
                 fn, backend="inductor", mode="reduce-overhead", fullgraph=True
@@ -2314,8 +2224,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_stream_order_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_stream_order_inductor(self, device):
         from torch._inductor.utils import run_and_get_code
 
         torch.cuda.empty_cache()
@@ -2330,7 +2240,7 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 with torch.cuda.use_mem_pool(pool):
                     return inp + 2
 
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         stream = torch.cuda.Stream()
         for fn in (pool_outer, stream_outer):
             with self.subTest(fn=fn.__name__):
@@ -2355,47 +2265,46 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 stream_enter = source.index("with stream")
                 self.assertLess(mempool_enter, stream_enter)
 
-    @requires_cuda_and_triton
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(torch.cuda.device_count() < 2, "requires multiple cuda devices")
-    def test_cuda_use_mem_pool_device_none_resolves_at_entry_inductor(self):
+    def test_cuda_use_mem_pool_device_none_resolves_at_entry_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda:0")
+                return torch.ones(16, device=device)
 
         with torch.cuda.device(1):
             pool = torch.cuda.MemPool()
             res = torch.compile(fn, backend="inductor", fullgraph=True)(pool)
         torch.cuda.synchronize(0)
         torch.cuda.synchronize(1)
-        self.assertEqual(res, torch.ones(16, device="cuda:0"))
+        self.assertEqual(res, torch.ones(16, device=device))
         self.assertEqual(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_use_mem_pool_invalid_signatures(self):
+    def test_cuda_use_mem_pool_invalid_signatures(self, device):
         pool = torch.cuda.MemPool()
 
-        def missing(_pool):
+        def missing(_pool, device):
             with torch.cuda.use_mem_pool():
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def too_many(pool):
+        def too_many(pool, device):
             with torch.cuda.use_mem_pool(pool, None, None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def unexpected_kwarg(pool):
+        def unexpected_kwarg(pool, device):
             with torch.cuda.use_mem_pool(pool, foo=None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def duplicate_pool(pool):
+        def duplicate_pool(pool, device):
             with torch.cuda.use_mem_pool(pool, pool=pool):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def duplicate_device(pool):
+        def duplicate_device(pool, device):
             with torch.cuda.use_mem_pool(pool, None, device=None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
         cases = [
             (missing, "missing 1 required positional argument: 'pool'"),
@@ -2412,380 +2321,21 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 self.subTest(msg=msg),
                 self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg),
             ):
-                torch.compile(fn, backend="eager", fullgraph=True)(pool)
+                torch.compile(fn, backend="eager", fullgraph=True)(pool, device)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager1(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """9""")
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_across_graph_break(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            print("foo")
-
-            tcs = torch.cuda.stream(s)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with tcs:
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 9)
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager2(self):
-        def fn(x, s):
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            with torch.cuda.stream(current_stream):
-                x = torch.relu(x)
-
-            s2 = torch.cuda.Stream()
-            s2.wait_stream(current_stream)
-            with torch.cuda.stream(s2):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s2)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        s = torch.cuda.Stream()
-        ref = fn(x, s)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x, s)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 18)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_method(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            new_stream = torch.cuda.Stream()
-            cur_stream = torch.cuda.current_stream()
-            new_stream.wait_stream(cur_stream)
-
-            with torch.cuda.stream(new_stream):
-                x = torch.sin(x)
-                x = torch.add(x, 3)
-
-            cur_stream.wait_stream(new_stream)
-
-            x = torch.add(x, 4)
-            cur_stream.query()
-            cur_stream.synchronize()
-
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 5)
-            new_stream.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """15""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_constant(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream is not None:
-                return x + 1
-            return x - 1
-
-        def fn2(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream != "const_str":
-                return x + 1
-            return x - 1
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        opt_fn2 = torch.compile(fn2, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        res2 = opt_fn2(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(ref, res2)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_stream(self):
-        def fn(x, s0, s1):
-            if s0 == s1:
-                return x + 1
-            else:
-                return x - 1
-
-        s0 = torch.cuda.Stream()
-        s1 = torch.cuda.Stream()
-        x = torch.randn(2, 2)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref0, res0)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref1, res1)
-
-        torch._dynamo.reset()
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref1, res1)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref0, res0)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_reconstruct(self):
-        def fn(x):
-            e = torch.cuda.Event()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            return x, e
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref[0], res[0])
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 3)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_across_graph_break(self):
-        def fn(x):
-            e = torch.cuda.Event()
-            e.record()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            print("foo")
-
-            torch.cuda.current_stream().wait_event(e)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x, e
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref[0], res[0])
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 10)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_created_outside_of_graph(self):
-        user_stream = torch.cuda.Stream()
-        event = torch.cuda.Event()
-        foo = torch.empty((2, 2), device="cuda")
-
-        def func(foo):
-            event.wait()
-            return foo + 1, event
-
-        x = torch.randn((1024, 1024), device="cuda")
-        cnts = torch._dynamo.testing.CompileCounter()
-
-        def run_iters(fn, compile=False):
-            if compile:
-                fn = torch.compile(fn, backend=cnts)
-            for _ in range(10):
-                with torch.cuda.stream(user_stream):
-                    torch.mm(x, x, out=foo)
-                    event.record()
-                out = fn(foo)
-                torch.cuda.current_stream().synchronize()
-            return out
-
-        ref = run_iters(func, compile=False)
-        res = run_iters(func, compile=True)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 4)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_method_create_stream_outside_of_compile(self):
-        def fn(x, cur_stream, new_stream):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            x = torch.add(x, 3)
-
-            event = cur_stream.record_event()
-            event.query()
-
-            new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 4)
-
-            new_event = torch.cuda.Event()
-            new_event.record(new_stream)
-
-            new_event.wait(cur_stream)
-            x = torch.add(x, 5)
-
-            new_event.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        cur_stream = torch.cuda.current_stream()
-        new_stream = torch.cuda.Stream()
-        ref = fn(x, cur_stream, new_stream)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x, cur_stream, new_stream)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """16""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_method(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            new_stream = torch.cuda.Stream()
-
-            x = torch.add(x, 3)
-
-            event = cur_stream.record_event()
-            event.query()
-
-            new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 4)
-
-            new_event = torch.Event()
-            new_event.record(new_stream)
-
-            new_event.wait(cur_stream)
-            x = torch.add(x, 5)
-
-            new_event.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """17""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_device(self):
+    def test_cuda_device(self, device):
         def fn(x):
             with torch.cuda.device(x.device.index - 1):
                 x = torch.sin(x + 1)
             return x
 
-        x = torch.randn((2, 2), device="cuda")
+        x = torch.randn((2, 2), device=device)
         ref = fn(x)
         opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda__exchange_device_args(self):
+    def test_cuda__exchange_device_args(self, device):
         @torch.compile(backend="eager", fullgraph=True)
         def fn(args, kwargs):
             torch.cuda._exchange_device(*args, **kwargs)
@@ -2795,96 +2345,14 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
             self.assertRaises(torch._dynamo.exc.Unsupported, fn, args, kwargs)
             self.assertEqual(torch.cuda.current_device(), initial_dev)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast(self):
-        if not torch.cuda.is_bf16_supported():
-            raise unittest.SkipTest("requires bf16")
-
+    def test_autocast_device(self, device):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
+                a_float32 = torch.rand((8, 8), device=device)
+                b_float32 = torch.rand((8, 8), device=device)
+                d_float32 = torch.rand((8, 8), device=device)
 
-                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-                    e_float16 = torch.mm(a_float32, b_float32)
-                    f_float16 = torch.mm(d_float32, e_float16)
-                return f_float16
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.type, "cuda")
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.bfloat16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_amp_autocast(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
-                    c_float64 = torch.mm(a_float32, b_float32)
-                return c_float64
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.type, "cuda")
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.float64)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_float64(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
-                    e_float64 = torch.mm(a_float32, b_float32)
-                    f_float64 = torch.mm(d_float32, e_float64)
-                return f_float64
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.float64)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_device(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast("cuda"):
+                with torch.autocast(torch.device(device).type):
                     e_float64 = torch.mm(a_float32, b_float32)
                     f_float64 = torch.mm(d_float32, e_float64)
                 return f_float64
@@ -2902,73 +2370,10 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float16)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_arguments_binding(self):
-        def f1(x):
-            with torch.autocast(device_type="cuda", enabled=False):
-                x = torch.sin(x + 1)
-            return x
-
-        def f2(x):
-            with torch.autocast(device_type="cpu", enabled=False):
-                x = torch.cos(x + 1)
-            return x
-
-        x = torch.rand([2, 3])
-        ref1 = f1(x)
-        ref2 = f2(x)
-        opt_f1 = torch.compile(backend="eager")(f1)
-        opt_f2 = torch.compile(backend="eager")(f2)
-        res1 = opt_f1(x)
-        res2 = opt_f2(x)
-        self.assertTrue(same(ref1, res1))
-        self.assertTrue(same(ref2, res2))
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_decorator(self):
-        def autocast_func(orig_func):
-            @torch.amp.autocast(device_type="cuda", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def autocast_func_cuda(orig_func):
-            @torch.autocast(device_type="cuda", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def autocast_func_cpu(orig_func):
-            @torch.autocast(device_type="cpu", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def mm(a, b):
-            return torch.mm(a, b)
-
-        mm_float16 = autocast_func(mm)
-        mm_float16_cuda = autocast_func_cuda(mm)
-        mm_float16_cpu = autocast_func_cpu(mm)
-
-        def fn(a, b):
-            return mm_float16(a, b), mm_float16_cuda(a, b), mm_float16_cpu(a, b)
-
-        a_float32 = torch.rand((8, 8), device="cuda")
-        b_float32 = torch.rand((8, 8), device="cuda")
-
-        ref = fn(a_float32, b_float32)
-        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
-        res = opt_fn(a_float32, b_float32)
-        self.assertTrue(same(ref, res))
-        self.assertTrue(res[0].dtype == torch.float16)
-        self.assertTrue(res[1].dtype == torch.float16)
-
 
 class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_stream_context_manager1(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -3293,7 +2698,7 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
             with new_stream:
                 x = torch.add(x, 4)
 
-            new_event = torch.Event()
+            new_event = torch.Event(device=device)
             new_event.record(new_stream)
 
             new_event.wait(cur_stream)
@@ -3328,11 +2733,8 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
-    @onlyCUDA
+    @requires_capabilities(Capability.dtype.bf16)
     def test_autocast_bf16(self, device):
-        if not torch.cuda.is_bf16_supported():
-            raise unittest.SkipTest("requires bf16")
-
         device_type = torch.device(device).type
 
         class MyModule(torch.nn.Module):
@@ -3361,7 +2763,7 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.dtype, torch.bfloat16)
 
     # autocast with float64 not support on XPU
-    @onlyCUDA
+    @skipIfXpu
     def test_amp_autocast(self, device):
         device_type = torch.device(device).type
 
@@ -3388,7 +2790,7 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
 
-    @onlyCUDA
+    @skipIfXpu
     def test_autocast_float64(self, device):
         device_type = torch.device(device).type
 
@@ -3509,8 +2911,93 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertTrue(res[0].dtype == torch.float16)
         self.assertTrue(res[1].dtype == torch.float16)
 
+    @requires_capabilities(Capability.attention.flash_attention)
+    def test_autocast_sdpa(self, device):
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, query, key, value):
+                with torch.autocast("cpu"):
+                    with torch.autocast(device_type, dtype=torch.float32):
+                        out = F.scaled_dot_product_attention(
+                            query, key, value, None, 0.0, True
+                        )
+                return out
+
+        dtype = torch.float32
+        seq_len_q = 1
+        seq_len_k = 1
+        head_dim = 8
+        query = torch.ones(
+            1,
+            8,
+            seq_len_q,
+            head_dim,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        key = torch.ones(
+            1,
+            8,
+            seq_len_k,
+            head_dim,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        value = torch.ones(
+            1,
+            8,
+            seq_len_k,
+            head_dim,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+
+        module = MyModule()
+        real = module(query, key, value)
+        real_device = real.device
+        real_dtype = real.dtype
+
+        opt_mod = torch.compile(module, backend="inductor")
+        compiled = opt_mod(query, key, value)
+
+        self.assertEqual(compiled.device, real_device)
+        self.assertEqual(compiled.dtype, real_dtype)
+
+        self.assertEqual(compiled.device.type, device_type)
+        self.assertEqual(compiled.device.index, 0)
+        self.assertEqual(compiled.dtype, torch.float32)
+
+    def _graph_break_inlining_autocast_test_helper(self, device):
+        def gn(x, y):
+            with torch.autocast(device_type=torch.device(device).type, dtype=torch.bfloat16):
+                z = torch.mm(x, y)
+                torch._dynamo.graph_break()
+                return torch.sin(z)
+
+        def fn(x, y):
+            z = torch.mm(x, y)
+            z = z + gn(x, y)
+            return z
+
+        x = torch.rand(3, 3).to(device)
+        y = torch.rand(3, 3).to(device)
+        opt_fn = torch.compile(backend="eager")(fn)
+        ref = fn(x, y)
+        res = opt_fn(x, y)
+        self.assertEqual(ref, res)
+
+    @requires_capabilities(Capability.dtype.bf16)
+    def test_graph_break_inlining_autocast(self, device):
+        self._graph_break_inlining_autocast_test_helper(device)
+
 
 class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.enable_trace_contextlib
@@ -4475,6 +3962,7 @@ instantiate_parametrized_tests(ContextlibContextManagerTests)
 instantiate_device_type_tests(
     CtxManagerTestsDevice, globals(), except_for=("cpu",), allow_xpu=True
 )
+instantiate_device_type_tests(CUDACtxManagerTests, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR decouples test/dynamo/test_ctx_manager.py from specific hardware accelerators by splitting tests into hardware-classified classes (GENERIC, ACCELERATOR, CUDA) and replacing hardcoded CUDA APIs with device-parameterized equivalents. 

## Changes

- Classified test classes by hardware dependency:
   - CtxManagerTests: Marked as `HardwareClassification.GENERIC` (device-generic tests with instantiate_parametrized_tests)
   - CtxManagerTestsDevice: New `HardwareClassification.ACCELERATOR` class with `instantiate_device_type_tests` for device-generic stream/event/autocast/device-context tests
   - CUDACtxManagerTests: Retained as `HardwareClassification.CUDA` for CUDA-specific tests with `instantiate_device_type_tests(CUDACtxManagerTests, globals(), only_for="cuda")` (cuda_use_mem_pool, cuda_device, cuda._exchange_device_args, autocast_device)
- Replaced hardcoded CUDA APIs with device-agnostic equivalents and remove CUDA test cases that have the same content as the device test cases:
   - APIs:
      - `torch.cuda.Stream()` → `torch.Stream(device=device)`
      - `torch.cuda.current_stream()` → `torch.accelerator.current_stream()`
      - `torch.cuda.device()` → `device_mod.device() via torch.get_device_module(device)`
      - `torch.cuda.Event()` → `torch.Event(device=device)`
   - test cases:

| Removed CUDA test cases | corresponding ACCELERATOR test cases |
| ----------- | ----------- |
| test_cuda_stream_context_manager1 | test_stream_context_manager1  |
| test_cuda_stream_across_graph_break | test_stream_across_graph_break  | 
| test_cuda_stream_context_manager2 | test_stream_context_manager2 |
| test_cuda_stream_method | test_stream_method |
| test_cuda_stream_compared_with_constant | test_stream_compared_with_constant |
| test_cuda_stream_compared_with_stream | test_stream_compared_with_stream |
| test_cuda_event_reconstruct | test_event_reconstruct |
| test_cuda_event_across_graph_break | test_event_across_graph_break |
| test_cuda_event_created_outside_of_graph | test_event_created_outside_of_graph |
| test_cuda_event_method_create_stream_outside_of_compile | test_event_method_create_stream_outside_of_compile |
| test_cuda_event_method | test_event_method |
| test_autocast | test_autocast_bf16 |
| test_cuda_amp_autocast | test_amp_autocast |
| test_autocast_float64 (CUDACtxManagerTests) | test_autocast_float64 (CtxManagerTestsDevice) |
| test_autocast_arguments_binding (CUDACtxManagerTests) | test_autocast_arguments_binding (CtxManagerTestsDevice) |
| test_autocast_decorator (CUDACtxManagerTests) | test_autocast_decorator (CtxManagerTestsDevice) |

- Removed global `device_type` variable that hardcoded accelerator type at import time
- Modernized skip/capability decorators:
   - Replaced manual `torch.cuda.is_bf16_supported()` checks with `@requires_capabilities(Capability.dtype.bf16)`
   - Replaced `PLATFORM_SUPPORTS_FLASH_ATTENTION` skip with `@requires_capabilities(Capability.attention.flash_attention)`
   - Replaced `requires_cuda_and_triton` with `@unittest.skipIf(not HAS_TRITON, "requires triton")`
   - Added `@skipIfXpu` for float64 autocast tests (XPU does not support float64 autocast)
- Consolidated duplicate test code:
   - Removed duplicate `CtxManagerTestsDevice` class definition that was previously at file end
   - Moved `test_autocast_sdpa` and `test_graph_break_inlining_autocast` from `CtxManagerTests` (GENERIC) to `CtxManagerTestsDevice` (ACCELERATOR) with proper device parameterization
   - Moved `test_fx_cse_preserves_distinct_custom_meta_contexts` from `CUDACtxManagerTests` to `CtxManagerTests` (GENERIC) since it tests FX CSE logic, not CUDA behavior
- Updated imports:
   - Added `Capability`, `requires_capabilities`, `HardwareClassification` from `common_device_type` and `common_utils`
   - Removed unused `PLATFORM_SUPPORTS_FLASH_ATTENTION`, `onlyCUDA`, `skipIf` and `requires_cuda_and_triton` imports

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
