### PR TITLE
[cuda][graphs] Preserve graph data for batch memory operation nodes

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -15,7 +15,7 @@ from torch.cuda._graph_annotations import (
     resolve_and_remap,
     resolve_pending_annotations,
 )
-from torch.cuda._utils import _check_cuda_bindings
+from torch.cuda._utils import _check_cuda_bindings, _check_cuda_bindings_driver
 from torch.cuda.graph_annotations import (
     clear_kernel_annotations,
     get_kernel_annotations,
@@ -1271,6 +1271,40 @@ class TestMarkKernels(TestCase):
     "cudaGraphNodeGetToolsId not available (needs cuda-compat >= 13.1)",
 )
 class TestGetGraphData(TestCase):
+    def test_batch_mem_op_node(self):
+        from cuda.bindings import driver
+
+        device = _check_cuda_bindings_driver(
+            driver.cuDeviceGet(torch.cuda.current_device())
+        )
+        can_use_stream_mem_ops = _check_cuda_bindings_driver(
+            driver.cuDeviceGetAttribute(
+                driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1,
+                device,
+            )
+        )
+        if not can_use_stream_mem_ops:
+            self.skipTest("device does not support stream memory operations")
+
+        value = torch.zeros(1, dtype=torch.int32, device="cuda")
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(g, capture_error_mode="relaxed"):
+            _check_cuda_bindings_driver(
+                driver.cuStreamWriteValue32(
+                    torch.cuda.current_stream().cuda_stream,
+                    value.data_ptr(),
+                    1,
+                    driver.CUstreamWriteValue_flags.CU_STREAM_WRITE_VALUE_DEFAULT,
+                )
+            )
+
+        g.instantiate()
+        data = g.get_graph_data()
+        batch_mem_op_nodes = [
+            node for node in data["nodes"] if node["node_type"] == "batch_mem_op"
+        ]
+        self.assertEqual(len(batch_mem_op_nodes), 1)
+
     def test_basic_structure(self):
         g = torch.cuda.CUDAGraph(keep_graph=True)
         x = torch.zeros([2000], device="cuda")

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -853,7 +853,10 @@ class CUDAGraph(_CUDAGraph):
         # Serve the shared cache when instantiate() has it live (see _caching_graph_data).
         if self._instantiate_graph_data is not None:
             return self._instantiate_graph_data
-        from torch.cuda._graph_annotations import _is_tools_id_unavailable
+        from torch.cuda._graph_annotations import (
+            _get_node_type,
+            _is_tools_id_unavailable,
+        )
 
         _require_cuda_bindings()
         # Narrow for the type checker (cuda bindings are present past the check).
@@ -869,23 +872,25 @@ class CUDAGraph(_CUDAGraph):
                 "(or cuda-compat >= 13.1 in LD_LIBRARY_PATH)"
             )
 
+        node_types = _cuda_driver.CUgraphNodeType
         node_type_names = {
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeKernel: "kernel",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemcpy: "memcpy",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemset: "memset",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeHost: "host",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeGraph: "child_graph",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEmpty: "empty",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeWaitEvent: "wait_event",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEventRecord: "event_record",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemAlloc: "mem_alloc",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemFree: "mem_free",
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeConditional: "conditional",
+            node_types.CU_GRAPH_NODE_TYPE_KERNEL: "kernel",
+            node_types.CU_GRAPH_NODE_TYPE_MEMCPY: "memcpy",
+            node_types.CU_GRAPH_NODE_TYPE_MEMSET: "memset",
+            node_types.CU_GRAPH_NODE_TYPE_HOST: "host",
+            node_types.CU_GRAPH_NODE_TYPE_GRAPH: "child_graph",
+            node_types.CU_GRAPH_NODE_TYPE_EMPTY: "empty",
+            node_types.CU_GRAPH_NODE_TYPE_WAIT_EVENT: "wait_event",
+            node_types.CU_GRAPH_NODE_TYPE_EVENT_RECORD: "event_record",
+            node_types.CU_GRAPH_NODE_TYPE_MEM_ALLOC: "mem_alloc",
+            node_types.CU_GRAPH_NODE_TYPE_MEM_FREE: "mem_free",
+            node_types.CU_GRAPH_NODE_TYPE_BATCH_MEM_OP: "batch_mem_op",
+            node_types.CU_GRAPH_NODE_TYPE_CONDITIONAL: "conditional",
         }
         # Node types whose work lives in a separate cudaGraph_t (see the warning below).
         nested_graph_types = {
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeGraph,
-            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeConditional,
+            node_types.CU_GRAPH_NODE_TYPE_GRAPH,
+            node_types.CU_GRAPH_NODE_TYPE_CONDITIONAL,
         }
         nested_node_types: set[str] = set()
 
@@ -903,7 +908,7 @@ class CUDAGraph(_CUDAGraph):
             node = nodes[i]
             handle_to_idx[int(node)] = i
 
-            ntype = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetType(node))
+            ntype = _get_node_type(node)
             if ntype in nested_graph_types:
                 nested_node_types.add(node_type_names.get(ntype, ntype))
             tools_id = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetToolsId(node))
@@ -911,7 +916,7 @@ class CUDAGraph(_CUDAGraph):
             node_id = tools_id & 0xFFFFFFFF
 
             kernel_name = None
-            if ntype == _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeKernel:
+            if ntype == node_types.CU_GRAPH_NODE_TYPE_KERNEL:
                 cu_node = _cuda_driver.CUgraphNode(init_value=int(node))
                 err, params = _cuda_driver.cuGraphKernelNodeGetParams(cu_node)
                 if err == _cuda_driver.CUresult.CUDA_SUCCESS and int(params.func):
@@ -927,13 +932,13 @@ class CUDAGraph(_CUDAGraph):
             # expected to succeed. Swallowing a failure would leave event_ptr 0 and make the
             # record/wait match quietly wrong rather than loud.
             event_ptr = 0
-            if ntype == _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEventRecord:
+            if ntype == node_types.CU_GRAPH_NODE_TYPE_EVENT_RECORD:
                 event_ptr = int(
                     _check_cuda_bindings(
                         _cuda_runtime.cudaGraphEventRecordNodeGetEvent(node)
                     )
                 )
-            elif ntype == _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeWaitEvent:
+            elif ntype == node_types.CU_GRAPH_NODE_TYPE_WAIT_EVENT:
                 event_ptr = int(
                     _check_cuda_bindings(
                         _cuda_runtime.cudaGraphEventWaitNodeGetEvent(node)
@@ -945,7 +950,7 @@ class CUDAGraph(_CUDAGraph):
             # _resolve_host_fn_name). Both are None/0 for other node types.
             host_fn_addr = 0
             host_fn_name = None
-            if ntype == _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeHost:
+            if ntype == node_types.CU_GRAPH_NODE_TYPE_HOST:
                 err, params = _cuda_runtime.cudaGraphHostNodeGetParams(node)
                 if err == _cuda_runtime.cudaError_t.cudaSuccess:
                     host_fn_addr = int(params.fn)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193091

cudaGraphNodeGetType returns cudaErrorUnknown (999) for driver-created batch
memory operation nodes. get_graph_data consequently raises, and the CUPTI
dependency and event-node recorders catch the exception and discard metadata
for the entire graph, leaving no dependency edges or EventRecord mappings.

Use cuGraphNodeGetType to classify nodes and expose batch_mem_op in the returned
graph data. This avoids the runtime node-type limitation while preserving the
existing runtime APIs used to inspect event and host nodes.

Test Plan:

```bash
uv tool run lintrunner -a torch/cuda/graphs.py test/test_cuda_graph_utils.py
```

The command reaches an unrelated existing Pyrefly error in torch/cuda/gds.py.
All other configured linters pass with:

```bash
uv tool run lintrunner -a --skip PYREFLY torch/cuda/graphs.py test/test_cuda_graph_utils.py
```

```bash
python -m py_compile torch/cuda/graphs.py test/test_cuda_graph_utils.py
```

An unmocked B200 probe with CUDA compatibility 13.3 also confirmed that the old
path raises CUDA error 999 and the new path returns one batch_mem_op node.

AI assistance: This change was authored with assistance from OpenAI Codex.