### PR TITLE
[Testcase Refactoring] Enable hw-classification for local_elastic_agent_test

### DIFF
--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -47,9 +47,11 @@ from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 from torch.distributed.elastic.utils.process_state import read_proc_state
 from torch.distributed.rpc.backend_registry import BackendType
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_WITH_TSAN,
+    TestCase,
 )
 
 
@@ -272,7 +274,9 @@ class Conf:
     tee: Std = Std.NONE
 
 
-class LocalElasticAgentTest(unittest.TestCase):
+class LocalElasticAgentTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         # start a standalone, single process etcd server to use for all tests
@@ -1755,12 +1759,14 @@ class LocalElasticAgentTest(unittest.TestCase):
                 os.environ[healthcheck_port_env_name] = original_healthcheck
 
 
-class LocalElasticAgentLogPrefixTest(unittest.TestCase):
+class LocalElasticAgentLogPrefixTest(TestCase):
     """Unit tests for ``log_line_prefix_template`` macro substitution.
 
     These tests do not require etcd or a real rendezvous; they mock out
     ``start_processes`` and inspect the prefixes the agent hands to it.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _make_agent(self, log_line_prefix_template: str) -> LocalElasticAgent:
         rdzv_handler = Mock()
@@ -1823,12 +1829,14 @@ class LocalElasticAgentLogPrefixTest(unittest.TestCase):
         )
 
 
-class LocalElasticAgentUninterruptibleStateTest(unittest.TestCase):
+class LocalElasticAgentUninterruptibleStateTest(TestCase):
     """Unit tests for uninterruptible (D-state) detection helpers in LocalElasticAgent.
 
     These tests do not require etcd or a real rendezvous and directly
     exercise the helpers with a mocked process context.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _make_agent(
         self, uninterruptible_state_timeout: float | None = None


### PR DESCRIPTION
## Summary

`test/distributed/elastic/agent/server/test/local_elastic_agent_test.py` holds three device-agnostic test classes covering the local elastic agent's control-plane orchestration (spawn / rendezvous / restart / fault tolerance / rank assignment / exit barrier / watchdog / log-line prefix / D-state detection): `LocalElasticAgentTest`, `LocalElasticAgentLogPrefixTest`, `LocalElasticAgentUninterruptibleStateTest`. They were unclassified under `--hw-classification` and derived from `unittest.TestCase`, which the `HardwareClassificationTestLoader` does not recognize (it requires a `common_utils.TestCase` base).

Changes:

- Migrate the three classes from `unittest.TestCase` to `common_utils.TestCase` and set `hw_classification = HardwareClassification.GENERIC` on each, so the loader recognizes them under `--hw-classification GENERIC`.
- Retain `import unittest` for the existing `@unittest.skipIf` guards.

`__main__` is unchanged (still raises `RuntimeError`); the file remains disabled and is enabled via `discover_tests.py` when required.

`LocalElasticAgentTest.setUpClass` starts an `EtcdServer`, which requires an etcd stack on the host (the `etcd` binary + the `python-etcd` client); this is an environment dependency, not addressed here.

## Test Plan

```
lintrunner test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
# -> No lint issues.

# The committed __main__ raises (file is disabled); for direct-run
# verification __main__ was temporarily set to invoke run_tests().
python test/distributed/elastic/agent/server/test/local_elastic_agent_test.py --hw-classification GENERIC
# -> Classification: total=83, unclassified=0, mismatched=0.
#    LocalElasticAgentLogPrefixTest + LocalElasticAgentUninterruptibleStateTest
#    (13 tests) run clean. LocalElasticAgentTest requires a working etcd
#    stack (etcd binary + python-etcd client) for its multi-process
#    rendezvous tests; not fully exercised on the verification environment.
```
