### PR TITLE
[inductor] Exclude invalid choices during pipelined autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3918,6 +3918,24 @@ class TestMaxAutotuneSubproc(TestCase):
             ),
         )
 
+    def test_async_autotuner_skips_unscheduled_choices(self):
+        inputs_key = "inputs"
+        scheduled_choice = mock.Mock(hash_key=lambda: "scheduled")
+        unscheduled_choice = mock.Mock(hash_key=lambda: "unscheduled")
+        future = mock.Mock()
+        future.result.return_value = 1.0
+        with mock.patch.object(
+            AsyncAutotuner,
+            "choice_hash_to_future",
+            {"scheduled" + inputs_key: future},
+        ):
+            self.assertEqual(
+                {scheduled_choice: 1.0},
+                AsyncAutotuner.get_results(
+                    [scheduled_choice, unscheduled_choice], inputs_key
+                ),
+            )
+
     @skipIfXpu(msg="XPU not support multiprocessing tensor reduction")
     def test_benchmark_choice_in_subproc(self):
         gm = make_fx(

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1736,6 +1736,11 @@ class AsyncAutotuner:
         for choice in choices:
             choice_hash = AsyncAutotuner.get_choice_hash(choice, inputs_key)
             future = AsyncAutotuner.choice_hash_to_future.get(choice_hash)
-            if future is not None:
-                timings[choice] = future.result()
+            if future is None:
+                autotuning_log.debug(
+                    "Skipping choice without a scheduled autotuning Future: %s",
+                    choice_hash,
+                )
+                continue
+            timings[choice] = future.result()
         return timings

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1725,7 +1725,8 @@ class AsyncAutotuner:
         Get autotuning results, blocking until complete.
 
         Args:
-            timeout: Maximum time to wait in seconds. None means wait forever.
+            choices: Candidate choices whose scheduled results should be collected.
+            inputs_key: Cache key used to identify each choice's Future.
 
         Returns:
             Dict mapping ChoiceCaller to benchmark timing
@@ -1734,5 +1735,7 @@ class AsyncAutotuner:
         timings = {}
         for choice in choices:
             choice_hash = AsyncAutotuner.get_choice_hash(choice, inputs_key)
-            timings[choice] = AsyncAutotuner.choice_hash_to_future[choice_hash].result()
+            future = AsyncAutotuner.choice_hash_to_future.get(choice_hash)
+            if future is not None:
+                timings[choice] = future.result()
         return timings

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4140,6 +4140,10 @@ class AlgorithmSelectorCache(PersistentCache):
                     # Await autotuning in subproc pool
                     autotune_start_ts = time.time()
                     results = AsyncAutotuner.get_results(final_choices, inputs_key)
+                    if not any(math.isfinite(timing) for timing in results.values()):
+                        raise self.create_no_valid_choices(
+                            name, "All choices failed to benchmark for backend."
+                        )
                     autotune_wait_ts = time.time() - autotune_start_ts
                     AlgorithmSelectorCache.log_results(
                         name,


### PR DESCRIPTION
# Problem:
Pipelined autotuning precompiles Triton choices before scheduling their benchmarks. Choices rejected during that step never receive an AsyncAutotuner Future. 

Later during scheduling we call get_timings() which asks for results using the original choice list. This assumes that every choice has a Future. If any choice gets filtered during precompilation we encounter KeyError instead of just excluding the invalid choice from selection.

We observed this happen where a missing hash belonged to a choice that had been filtered before AsyncAutotuner.start(), so no benchmark Future had ever been created for it.
```
 InductorError: KeyError: "triton_mm-cmxqbx6wwd3rchlmwf5b7fycua4lko57x46hjnht46oikegz5jdy[('cuda', 'torch.bfloat16', 11136, 1536, 1, 11136, 0), ('cuda', 'torch.bfloat16', 1536, 1024, 1024, 1, 0)]" 
```

# Fix:
Our fix is gated to scenarios where pipelined autotuning is enabled.
When collecting deferred results, AsyncAutotuner.get_results() omits choices without a scheduled Future. get_timings() then verifies that at least one returned timing is finite. If the result is empty or every scheduled benchmark returned inf, it raises NoValidChoicesError instead of selecting a failed choice

We observed followup job with this change succeed

Differential Revision: D111797017




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo