### PR TITLE
[Testcase Refactoring] Tag test_fsdp_comm_hooks.py with hw_classification

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -32,15 +32,13 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
-
 BFLOAT16_AVAILABLE = torch.cuda.is_bf16_supported() or torch.xpu.is_bf16_supported()
 
 
 class Net(nn.Module):
-    def __init__(self, has_wrapping, sharding_strategy, mixed_precision=None):
+    def __init__(
+        self, has_wrapping, sharding_strategy, mixed_precision=None, *, device_type
+    ):
         # to ensure determinism
         torch.manual_seed(0)
         torch.get_device_module(device_type).manual_seed(0)
@@ -176,14 +174,15 @@ class TestCommunicationHooks(FSDPTest):
             if not submodule.check_is_root()
         ]
 
-    def _init_model(self, core, sharding_strategy, mixed_precision=None):
-        device = torch.device(device_type)
+    def _init_model(self, core, sharding_strategy, mixed_precision=None, *, device):
+        # Type-only device: each rank stays on the device bound by the
+        # framework, and the injected `device` carries the primary index.
         return FSDP(
             core,
             device_id=torch.accelerator.current_device_index(),
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
-        ).to(device)
+        ).to(torch.device(torch.device(device).type))
 
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
@@ -207,9 +206,15 @@ class TestCommunicationHooks(FSDPTest):
         """
 
         # Initialize a model
+        device_type = torch.device(device).type
         fsdp_model_with_hook = self._init_model(
-            Net(has_wrapping=has_wrapping, sharding_strategy=sharding_strategy),
+            Net(
+                has_wrapping=has_wrapping,
+                sharding_strategy=sharding_strategy,
+                device_type=device_type,
+            ),
             sharding_strategy=sharding_strategy,
+            device=device,
         )
 
         # Check that by default, `_comm_hook` is None
@@ -258,8 +263,13 @@ class TestCommunicationHooks(FSDPTest):
         """
 
         fsdp_model_with_hook = self._init_model(
-            Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+            Net(
+                has_wrapping=True,
+                sharding_strategy=sharding_strategy,
+                device_type=torch.device(device).type,
+            ),
             sharding_strategy=sharding_strategy,
+            device=device,
         )
         dummy_state = DummyState(process_group=None, noise=1234)
         dummy_hook = (
@@ -278,11 +288,14 @@ class TestCommunicationHooks(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_registering_hook_hybrid_strategy(self, device):
+        device_type = torch.device(device).type
         for sharding_strategy in (
             ShardingStrategy.HYBRID_SHARD,
             ShardingStrategy._HYBRID_SHARD_ZERO2,
         ):
-            model = Net(False, None, None).to(device=device_type)
+            model = Net(False, None, None, device_type=device_type).to(
+                device=device_type
+            )
             fsdp_model = FSDP(
                 model,
                 auto_wrap_policy=ModuleWrapPolicy({nn.Linear}),
@@ -318,8 +331,13 @@ class TestCommunicationHooks(FSDPTest):
         """
 
         fsdp_model_with_hook = self._init_model(
-            Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+            Net(
+                has_wrapping=True,
+                sharding_strategy=sharding_strategy,
+                device_type=torch.device(device).type,
+            ),
             sharding_strategy=sharding_strategy,
+            device=device,
         )
         dummy_state = DummyState(process_group=None, noise=1234)
         dummy_hook = (
@@ -338,15 +356,21 @@ class TestCommunicationHooks(FSDPTest):
             fsdp_model_with_hook.register_comm_hook(dummy_state, dummy_hook)
 
     def _check_low_precision_hook(
-        self, state, hook, sharding_strategy, dtype, has_wrapping
+        self, state, hook, sharding_strategy, dtype, has_wrapping, device
     ):
+        device_type = torch.device(device).type
         # keep everything deterministic for input data
         torch.manual_seed(0)
         torch.get_device_module(device_type).manual_seed(0)
 
         fsdp_with_hook = self._init_model(
-            Net(has_wrapping=has_wrapping, sharding_strategy=sharding_strategy),
+            Net(
+                has_wrapping=has_wrapping,
+                sharding_strategy=sharding_strategy,
+                device_type=device_type,
+            ),
             sharding_strategy=sharding_strategy,
+            device=device,
         )
         fsdp_with_hook.register_comm_hook(state, hook)
 
@@ -356,9 +380,11 @@ class TestCommunicationHooks(FSDPTest):
                 has_wrapping=has_wrapping,
                 sharding_strategy=sharding_strategy,
                 mixed_precision=mp_only_grad,
+                device_type=device_type,
             ),
             sharding_strategy=sharding_strategy,
             mixed_precision=mp_only_grad,
+            device=device,
         )
 
         optim_hook = torch.optim.SGD(fsdp_with_hook.parameters(), lr=0.1)
@@ -401,7 +427,7 @@ class TestCommunicationHooks(FSDPTest):
         hook = default_hooks.fp16_compress_hook
 
         self._check_low_precision_hook(
-            state, hook, sharding_strategy, torch.float16, has_wrapping
+            state, hook, sharding_strategy, torch.float16, has_wrapping, device
         )
 
     @requires_accelerator_dist_backend(["nccl", "xccl"])
@@ -427,7 +453,7 @@ class TestCommunicationHooks(FSDPTest):
         hook = default_hooks.bf16_compress_hook
 
         self._check_low_precision_hook(
-            state, hook, sharding_strategy, torch.bfloat16, has_wrapping
+            state, hook, sharding_strategy, torch.bfloat16, has_wrapping, device
         )
 
 

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -11,9 +11,7 @@ from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
     requires_nccl_version,
@@ -457,7 +455,9 @@ class TestCommunicationHooks(FSDPTest):
         )
 
 
-instantiate_device_type_tests(TestCommunicationHooks, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestCommunicationHooks, globals(), except_for="cpu", allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -11,15 +11,18 @@ from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
-    requires_accelerator_dist_backend,
     requires_nccl_version,
-    skip_but_pass_in_sandcastle_if,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
 )
@@ -32,8 +35,6 @@ if not dist.is_available():
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
-
-BFLOAT16_AVAILABLE = torch.cuda.is_bf16_supported() or torch.xpu.is_bf16_supported()
 
 
 class Net(nn.Module):
@@ -109,7 +110,13 @@ class DummyHook:
 
 
 class TestCommunicationHooks(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize(
         "sharding_strategy",
         [
@@ -119,7 +126,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_default_communication_hook_behavior(
-        self, sharding_strategy: ShardingStrategy | None
+        self, device, sharding_strategy: ShardingStrategy | None
     ):
         """
         Tests FSDP's default communication hook's behavior and correctness.
@@ -181,6 +188,10 @@ class TestCommunicationHooks(FSDPTest):
         ).to(device)
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize("has_wrapping", [True, False])
     @parametrize(
         "sharding_strategy",
@@ -191,7 +202,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_default_communication_hook_initialization(
-        self, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
+        self, device, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
     ):
         """
         Tests FSDP's communication hook interface behavior.
@@ -232,6 +243,10 @@ class TestCommunicationHooks(FSDPTest):
             self.assertEqual(fsdp_module._comm_hook_state, dummy_state)
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize(
         "sharding_strategy",
         [
@@ -241,7 +256,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_registering_hook_non_root(
-        self, sharding_strategy: ShardingStrategy | None
+        self, device, sharding_strategy: ShardingStrategy | None
     ):
         """
         Tests FSDP's communication hook registering for submodules.
@@ -272,7 +287,11 @@ class TestCommunicationHooks(FSDPTest):
             submodules[1].register_comm_hook(dummy_state, dummy_hook)
 
     @skip_if_lt_x_gpu(2)
-    def test_registering_hook_hybrid_strategy(self):
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
+    def test_registering_hook_hybrid_strategy(self, device):
         for sharding_strategy in (
             ShardingStrategy.HYBRID_SHARD,
             ShardingStrategy._HYBRID_SHARD_ZERO2,
@@ -292,6 +311,10 @@ class TestCommunicationHooks(FSDPTest):
                 fsdp_model.register_comm_hook(dummy_state, dummy_hook)
 
     @skip_if_lt_x_gpu(2)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @parametrize(
         "sharding_strategy",
         [
@@ -301,7 +324,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_registering_hook_submodules(
-        self, sharding_strategy: ShardingStrategy | None
+        self, device, sharding_strategy: ShardingStrategy | None
     ):
         """
         Tests FSDP's communication hook registering for submodules.
@@ -378,7 +401,10 @@ class TestCommunicationHooks(FSDPTest):
         ):
             self.assertEqual(hook_param.grad, mp_param.grad)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+    )
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
     @parametrize(
@@ -390,7 +416,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_fp16_hook(
-        self, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
+        self, device, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
     ):
         state = default_hooks.LowPrecisionState(process_group=_get_default_group())
         hook = default_hooks.fp16_compress_hook
@@ -399,12 +425,12 @@ class TestCommunicationHooks(FSDPTest):
             state, hook, sharding_strategy, torch.float16, has_wrapping
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
-    @skip_but_pass_in_sandcastle_if(
-        not BFLOAT16_AVAILABLE,
-        "BFloat16 is only supported by CUDA 11+ or XPU",
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.fsdp,
+        Capability.dtype.bf16,
     )
+    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
     @parametrize(
@@ -416,7 +442,7 @@ class TestCommunicationHooks(FSDPTest):
         ],
     )
     def test_bf16_hook(
-        self, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
+        self, device, has_wrapping: bool, sharding_strategy: ShardingStrategy | None
     ):
         state = default_hooks.LowPrecisionState(process_group=_get_default_group())
         hook = default_hooks.bf16_compress_hook
@@ -426,7 +452,7 @@ class TestCommunicationHooks(FSDPTest):
         )
 
 
-instantiate_parametrized_tests(TestCommunicationHooks)
+instantiate_device_type_tests(TestCommunicationHooks, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -12,12 +12,12 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecis
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
     requires_nccl_version,
+    skip_but_pass_in_sandcastle_if,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_fsdp import FSDPTest
@@ -35,6 +35,8 @@ if not dist.is_available():
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
+
+BFLOAT16_AVAILABLE = torch.cuda.is_bf16_supported() or torch.xpu.is_bf16_supported()
 
 
 class Net(nn.Module):
@@ -113,10 +115,6 @@ class TestCommunicationHooks(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     @parametrize(
         "sharding_strategy",
         [
@@ -188,10 +186,6 @@ class TestCommunicationHooks(FSDPTest):
         ).to(device)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     @parametrize("has_wrapping", [True, False])
     @parametrize(
         "sharding_strategy",
@@ -243,10 +237,6 @@ class TestCommunicationHooks(FSDPTest):
             self.assertEqual(fsdp_module._comm_hook_state, dummy_state)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     @parametrize(
         "sharding_strategy",
         [
@@ -287,10 +277,6 @@ class TestCommunicationHooks(FSDPTest):
             submodules[1].register_comm_hook(dummy_state, dummy_hook)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     def test_registering_hook_hybrid_strategy(self, device):
         for sharding_strategy in (
             ShardingStrategy.HYBRID_SHARD,
@@ -311,10 +297,6 @@ class TestCommunicationHooks(FSDPTest):
                 fsdp_model.register_comm_hook(dummy_state, dummy_hook)
 
     @skip_if_lt_x_gpu(2)
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
     @parametrize(
         "sharding_strategy",
         [
@@ -401,10 +383,7 @@ class TestCommunicationHooks(FSDPTest):
         ):
             self.assertEqual(hook_param.grad, mp_param.grad)
 
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-    )
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
     @parametrize(
@@ -425,12 +404,12 @@ class TestCommunicationHooks(FSDPTest):
             state, hook, sharding_strategy, torch.float16, has_wrapping
         )
 
-    @requires_capabilities(
-        Capability.distributed.backend,
-        Capability.distributed.fsdp,
-        Capability.dtype.bf16,
-    )
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
+    @skip_but_pass_in_sandcastle_if(
+        not BFLOAT16_AVAILABLE,
+        "BFloat16 is only supported by CUDA 11+ or XPU",
+    )
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
     @parametrize(


### PR DESCRIPTION
## Summary

Adds `hw_classification` to `TestCommunicationHooks` and runs it through
`instantiate_device_type_tests`.

## Motivation

The class had no `hw_classification` bookkeeping despite being
accelerator-only. This mirrors the pure-tagging pass #191909 did for other
files in this suite.

`skip_if_lt_x_gpu`, `requires_accelerator_dist_backend`, `requires_nccl_version`,
and `skip_but_pass_in_sandcastle_if` are all left untouched on every method —
per team review, a capability is only registered where an existing decorator
already named it, and none of these name a specific `Capability` field.

## Changes

- `TestCommunicationHooks` gains `hw_classification = HardwareClassification.ACCELERATOR`.
- `instantiate_parametrized_tests(TestCommunicationHooks)` is **replaced** by
  `instantiate_device_type_tests(..., except_for="cpu")`, not joined by it —
  running both double-expands the nine `@parametrize` methods. The test
  methods gain the `device` parameter that call injects.
- No decorator is added, removed, or replaced on any of the seven test
  methods — `test_fp16_hook` and `test_bf16_hook` keep
  `@requires_accelerator_dist_backend(["nccl", "xccl"])` exactly as-is
  (including its `"hccl"`→`TEST_HPU` mapping bug, also tracked unresolved as
  #190153 — out of scope here), and `test_bf16_hook` keeps
  `@requires_nccl_version(...)` and `@skip_but_pass_in_sandcastle_if(not
  BFLOAT16_AVAILABLE, ...)` unchanged.

This change is purely additive to test coverage — no existing gate is removed,
and no test's skip/pass behavior on any currently-tested backend changes.

## Test Plan

`ruff check` and `ruff format --check` pass.

## Related

Part of #185590.

`skip_if_lt_x_gpu` is unchanged; its device-agnostic implementation has already
landed in #185184.
