### PR TITLE
[inductor] Fix mix-order reduction dropping writes to NonOwningLayout outputs

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -828,6 +828,44 @@ class MixOrderReductionTest(TestBase):
         # a single mix order reduction kernel get shared
         FileCheck().check_count("MixOrderReductionGrid", 1, exactly=True).run(wrapper)
 
+    @parametrize("split_reductions", (False, True))
+    def test_chained_modulated_norm_shared_table(self, split_reductions):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/193061
+
+        The grads of the chunk()-ed shared table assemble into one buffer via
+        cat, so the mix-order reduction outputs have NonOwningLayout. The
+        final reduction must write through the view instead of rebinding the
+        name, otherwise the second norm's slice grads are never written.
+        """
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        M, N = 32768, 512
+        eps = 1e-6
+
+        def f(x, table):
+            mods = table.chunk(4, dim=1)
+            for i in range(2):
+                shift, scale = mods[2 * i], mods[2 * i + 1]
+                x = x + (F.layer_norm(x, x.shape[-1:], eps=eps) * (1 + scale) + shift)
+            return x.square().mean()
+
+        x = torch.randn(1, M, N, device=GPU_TYPE)
+        table = torch.randn(1, 4, N, device=GPU_TYPE, requires_grad=True)
+
+        (ref_grad,) = torch.autograd.grad(f(x, table), table)
+        act = torch.compile(
+            f,
+            options={
+                "split_reductions": split_reductions,
+            },
+        )(x, table)
+        (act_grad,) = torch.autograd.grad(act, table)
+
+        self.assertTrue(metrics.codegen_mix_order_reduction > 0)
+        torch.testing.assert_close(ref_grad, act_grad, atol=1e-4, rtol=1e-4)
+
     @inductor_config.patch(split_reductions=False)
     def test_dont_fuse_nodes_that_introduce_producer_consumer_rel(self):
         """

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -861,9 +861,15 @@ class MixOrderReductionTest(TestBase):
                 "split_reductions": split_reductions,
             },
         )(x, table)
-        (act_grad,) = torch.autograd.grad(act, table)
+        (act_grad,), (wrapper,) = utils.run_and_get_code(
+            lambda: torch.autograd.grad(act, table)
+        )
 
-        self.assertTrue(metrics.codegen_mix_order_reduction > 0)
+        self.assertEqual(metrics.codegen_mix_order_reduction, 1)
+        # the slice grads alias the shared cat buffer: the final reduction
+        # must be written through the view, never bound to a fresh tensor
+        FileCheck().check(".copy_(workspace_").run(wrapper)
+        self.assertNotIn("= workspace_", wrapper)
         torch.testing.assert_close(ref_grad, act_grad, atol=1e-4, rtol=1e-4)
 
     @inductor_config.patch(split_reductions=False)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2967,7 +2967,9 @@ class SIMDScheduling(BaseScheduling):
             opname = reduction_type2op.get(
                 partial_accum.reduction_type, partial_accum.reduction_type
             )
-            final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+            reduced = (
+                f"{ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+            )
 
             # Restore the exact original shape via .view() to handle keepdim
             # and multi-dimensional reductions correctly.
@@ -2978,16 +2980,27 @@ class SIMDScheduling(BaseScheduling):
                     for s in buffer.get_layout().size
                 ]
                 final_shape_str = f"[{', '.join(final_shape)}]"
-                final_reduce += f".view({final_shape_str})"
+                reduced += f".view({final_shape_str})"
 
             # The workspace tensor is in torch.float, need a cast if the buffer is
             # not.
             if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
-                final_reduce += f".to({buffer_dtype})"
-            V.graph.wrapper_code.writeline(final_reduce)
-            # mark the buffer as allocated, so we don't try to allocate
-            # it again when it's later used
-            V.graph.wrapper_code.allocated.add(buffer_name)
+                reduced += f".to({buffer_dtype})"
+
+            if isinstance(buffer, ir.Buffer) and isinstance(
+                buffer.get_output_spec(), ir.NonOwningLayout
+            ):
+                # The buffer is a view into another buffer's storage (e.g. a
+                # cat destination). Rebinding the name would leave the
+                # underlying region never written; write through the view
+                # instead. See https://github.com/pytorch/pytorch/issues/193061
+                V.graph.wrapper_code.codegen_allocation(buffer)
+                V.graph.wrapper_code.writeline(f"{buffer_name}.copy_({reduced})")
+            else:
+                V.graph.wrapper_code.writeline(f"{buffer_name} = {reduced}")
+                # mark the buffer as allocated, so we don't try to allocate
+                # it again when it's later used
+                V.graph.wrapper_code.allocated.add(buffer_name)
 
         kernel.deallocate_workspaces()
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2956,6 +2956,8 @@ class SIMDScheduling(BaseScheduling):
         )
         for idx, partial_accum in enumerate(kernel.saved_partial_accumulate):
             buffer_name = partial_accum.buffer_name
+            if buffer_name in V.graph.removed_buffers:
+                continue
 
             stride_str = f"({nsplit}) * ({rnumel})"
             start = f"{idx} * {stride_str}"
@@ -2971,36 +2973,46 @@ class SIMDScheduling(BaseScheduling):
                 f"{ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
             )
 
+            buffer = V.graph.get_buffer(buffer_name)
+            if not isinstance(buffer, ir.Buffer):
+                raise AssertionError(type(buffer))
+
             # Restore the exact original shape via .view() to handle keepdim
             # and multi-dimensional reductions correctly.
-            buffer = V.graph.get_buffer(buffer_name)
-            if buffer is not None:
-                final_shape = [
-                    V.graph.wrapper_code.codegen_python_sizevar(s)
-                    for s in buffer.get_layout().size
-                ]
-                final_shape_str = f"[{', '.join(final_shape)}]"
-                reduced += f".view({final_shape_str})"
+            final_shape = [
+                V.graph.wrapper_code.codegen_python_sizevar(s)
+                for s in buffer.get_layout().size
+            ]
+            reduced += f".view([{', '.join(final_shape)}])"
 
-            # The workspace tensor is in torch.float, need a cast if the buffer is
-            # not.
-            if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
-                reduced += f".to({buffer_dtype})"
-
-            if isinstance(buffer, ir.Buffer) and isinstance(
-                buffer.get_output_spec(), ir.NonOwningLayout
-            ):
+            spec = buffer.get_output_spec()
+            if isinstance(spec, ir.NonOwningLayout):
                 # The buffer is a view into another buffer's storage (e.g. a
                 # cat destination). Rebinding the name would leave the
                 # underlying region never written; write through the view
-                # instead. See https://github.com/pytorch/pytorch/issues/193061
+                # instead. copy_() also handles any dtype conversion from the
+                # torch.float workspace.
+                # See https://github.com/pytorch/pytorch/issues/193061
                 V.graph.wrapper_code.codegen_allocation(buffer)
                 V.graph.wrapper_code.writeline(f"{buffer_name}.copy_({reduced})")
-            else:
+            elif type(spec) in (ir.FixedLayout, ir.FlexibleLayout):
+                # The workspace tensor is in torch.float, need a cast if the
+                # buffer is not.
+                if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
+                    reduced += f".to({buffer_dtype})"
                 V.graph.wrapper_code.writeline(f"{buffer_name} = {reduced}")
                 # mark the buffer as allocated, so we don't try to allocate
                 # it again when it's later used
                 V.graph.wrapper_code.allocated.add(buffer_name)
+            else:
+                # Rebinding the name silently drops the write for any spec
+                # that must be written through rather than bound (e.g.
+                # MutationLayoutSHOULDREMOVE, CommBufferLayout). Fail loudly
+                # rather than producing wrong results.
+                raise AssertionError(
+                    f"unsupported mix-order reduction output spec "
+                    f"{type(spec).__name__} for {buffer_name}"
+                )
 
         kernel.deallocate_workspaces()
 


### PR DESCRIPTION
Fixes #193061

## Problem

`torch.compile` silently computes wrong gradients for chained modulated LayerNorms whose scale/shift vectors are `chunk()`-ed slices of one shared parameter (the DiT/AdaLN `scale_shift_table` pattern, e.g. Wan 2.1), once the total reduction size is large enough to trigger mix-order reduction. Regression introduced when `triton.mix_order_reduction` became default-enabled in 2.10.

## Root cause

The slice gradients are assembled into one shared buffer by `cat`, so each mix-order-fused reduction output is a view into that buffer's storage (`ir.NonOwningLayout`). In `_codegen_mix_order_reduction`, the final-reduce step emits

```python
buf3 = workspace_0[...].view(nsplit, rnumel).sum(dim=0).view(...)
```

which **rebinds the Python variable** to a fresh standalone tensor. The `buf3 = reinterpret_tensor(buf13, ..., 2048)  # alias` line emitted by `mark_run()` is discarded, the corresponding region of the shared buffer is never written, and the returned gradient contains uninitialized (or bitwise-stale, when the allocator reuses the block across iterations) memory.

Generated backward before the fix (`buf13` is the `[1, 4, D]` table grad; offsets 2048/3072 never written):

```python
buf3 = workspace_0[0 * (1024) * (1024) : (0 + 1) * (1024) * (1024)].view(1024, 1024).sum(dim=0).view([1, 1, 1024])
buf5 = workspace_0[1 * (1024) * (1024) : (1 + 1) * (1024) * (1024)].view(1024, 1024).sum(dim=0).view([1, 1, 1024])
...
buf13 = empty_strided_cuda((1, 4, 1024), (4096, 1024, 1), torch.float32)
buf10 = reinterpret_tensor(buf13, (1, 1, 1024), (4096, 1024, 1), 0)  # alias
buf12 = reinterpret_tensor(buf13, (1, 1, 1024), (4096, 1024, 1), 1024)  # alias
return (buf13, None, )
```

## Fix

When the reduction output buffer has `NonOwningLayout`, emit the allocation for the view (idempotent) and write through it with `copy_()` instead of rebinding the name:

```python
buf3 = reinterpret_tensor(buf13, (1, 1, 1024), (4096, 1024, 1), 2048)  # alias
buf3.copy_(workspace_0[...].view(1024, 1024).sum(dim=0).view([1, 1, 1024]))
```

Non-view outputs keep the existing rebinding path unchanged.

## Test plan

- New regression test `test_chained_modulated_norm_shared_table` (parametrized over `split_reductions`) in `test/inductor/test_mix_order_reduction.py` — fails before the fix (max rel grad err ~1e+6), passes after (~1e-7).
- Full repro script from #193061 on H20: all 5 cases pass after the fix; also verified the issue's ablations (batch 8 × seq 4096, dim 5120 × seq 16384, and chunking a conditioning MLP's output instead of a parameter).
- `python -m pytest test/inductor/test_mix_order_reduction.py`: 277 passed, 221 skipped, 0 failed.
- `lintrunner` clean on changed files.

Per the [PyTorch AI policy](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md): this PR was authored with the assistance of an AI coding assistant. The root-cause analysis, the change, and all test results were reviewed and verified by the submitter.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @shunting314 @eellison @jansel @vkuzo