### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_pad_as_cat.py
+++ b/test/inductor/test_pad_as_cat.py
@@ -1,30 +1,41 @@
 # Owner(s): ["module: inductor"]
 """Tests for cat multi-consumer and pad-as-cat optimizations."""
 
+import functools
+import unittest
+
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor import metrics
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_MPS, HAS_TRITON
 
+
+requires_triton_or_mps = functools.partial(
+    unittest.skipIf, not (HAS_TRITON or HAS_MPS), "requires TRITON or MPS"
+)
 
 # required so that metrics.num_bytes_accessed is populated
 torch._logging.set_logs(inductor_metrics=True)
 
 
 class TestCatMultiConsumer(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @torch._inductor.config.patch(fx_graph_cache=False)
-    @requires_gpu()
-    def test_cat_to_fp16(self):
+    @requires_triton_or_mps()
+    def test_cat_to_fp16(self, device):
         """Multi-consumer cat avoids duplicate computation."""
 
         def fn(x):
-            z = torch.cat([x, torch.zeros([6, 768], device=GPU_TYPE)], dim=0)
+            z = torch.cat([x, torch.zeros([6, 768], device=device)], dim=0)
             y = x.to(torch.float16)
             return z, y
 
-        x = torch.randn(1024, 768, device=GPU_TYPE)
+        x = torch.randn(1024, 768, device=device)
         compiled = torch.compile(fn)
         metrics.reset()
         result = compiled(x)
@@ -49,14 +60,14 @@ class TestCatMultiConsumer(TestCase):
         )
 
     @torch._inductor.config.patch(fx_graph_cache=False)
-    @requires_gpu()
-    def test_single_consumer_cat_unchanged(self):
+    @requires_triton_or_mps()
+    def test_single_consumer_cat_unchanged(self, device):
         """Single-consumer cat unchanged."""
 
         def fn(x):
-            return torch.cat([x, torch.zeros([6, 768], device=GPU_TYPE)], dim=0)
+            return torch.cat([x, torch.zeros([6, 768], device=device)], dim=0)
 
-        x = torch.randn(1024, 768, device=GPU_TYPE)
+        x = torch.randn(1024, 768, device=device)
         compiled = torch.compile(fn)
         metrics.reset()
         result = compiled(x)
@@ -77,8 +88,10 @@ class TestCatMultiConsumer(TestCase):
 
 
 class TestPadAsCat(TestCase):
-    @requires_gpu()
-    def test_mul_pad_addmm(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_triton_or_mps()
+    def test_mul_pad_addmm(self, device):
         """Multi-consumer F.pad uses ConcatKernel zero-copy."""
         counters.clear()
 
@@ -88,10 +101,10 @@ class TestPadAsCat(TestCase):
             mm_result = torch.addmm(bias, mul_result, weight)
             return padded, mm_result
 
-        x = torch.randn(128, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
-        scale = torch.randn(128, 2880, device=GPU_TYPE, dtype=torch.bfloat16)
-        bias = torch.randn(1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        weight = torch.randn(2880, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        x = torch.randn(128, 2880, device=device, dtype=torch.bfloat16)
+        scale = torch.randn(128, 2880, device=device, dtype=torch.bfloat16)
+        bias = torch.randn(1024, device=device, dtype=torch.bfloat16)
+        weight = torch.randn(2880, 1024, device=device, dtype=torch.bfloat16)
 
         compiled = torch.compile(fn)
         result, (code,) = run_and_get_code(compiled, x, scale, bias, weight)
@@ -102,16 +115,16 @@ class TestPadAsCat(TestCase):
         self.assertIn("reinterpret_tensor", code)
         self.assertGreater(counters["inductor"]["pad_rewritten_as_cat"], 0)
 
-    @requires_gpu()
-    def test_single_consumer_pad(self):
+    @requires_triton_or_mps()
+    def test_single_consumer_pad(self, device):
         """Single-consumer F.pad is decomposed into cat, which fuses via pointwise_cat."""
         counters.clear()
 
         def fn(x, scale):
             return torch.nn.functional.pad(x * scale, [0, 192])
 
-        x = torch.randn(128, 2880, device=GPU_TYPE)
-        scale = torch.randn(128, 2880, device=GPU_TYPE)
+        x = torch.randn(128, 2880, device=device)
+        scale = torch.randn(128, 2880, device=device)
 
         compiled = torch.compile(fn)
         result = compiled(x, scale)
@@ -119,6 +132,22 @@ class TestPadAsCat(TestCase):
 
         self.assertEqual(result, ref)
         self.assertGreater(counters["inductor"]["pad_rewritten_as_cat"], 0)
+
+
+instantiate_device_type_tests(
+    TestCatMultiConsumer,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestPadAsCat,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_pad_as_cat.py
python test/inductor/test_pad_as_cat.py -v --hw-classification ACCELERATOR


## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo