### PR TITLE
[PyTorch][jit] Speed up restoreAccurateTypeTags via c10::FastSet and single hash lookup

### DIFF
--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -4,6 +4,7 @@
 #ifdef USE_RPC
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #endif
+#include <c10/util/FbcodeMaps.h>
 #include <c10/util/safe_numerics.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/mobile/type_parser.h>
@@ -40,7 +41,7 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
     IValue value;
   };
   std::vector<Work> to_process = {{type_tag, root}};
-  std::unordered_set<const void*> scanned;
+  c10::FastSet<const void*> scanned;
   while (!to_process.empty()) {
     Work w = std::move(to_process.back());
     to_process.pop_back();
@@ -49,11 +50,10 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
     // it would not terminate).
     if (w.value.isPtrType()) {
       const void* key = w.value.internalToPointer();
-      auto it = scanned.find(key);
-      if (it != scanned.end()) {
+      // insert() reports prior presence, so the key is hashed once.
+      if (!scanned.insert(key).second) {
         continue;
       }
-      scanned.emplace_hint(it, key);
     }
     auto kind = w.type->kind();
     if (auto dyn = w.type->castRaw<c10::DynamicType>()) {


### PR DESCRIPTION
Summary:
`restoreAccurateTypeTags` walks the whole unpickled object graph keeping a
`scanned` set of visited pointers. On large TorchScript modules that set grows
to one entry per distinct pointer, and it dominates deserialization.

On-CPU profiling (`strobe walltime`) of a Sigrid predictor full-snapshot
in-place transition on tenant m2140425308 caught the transition thread
(`inplace_worker`) at 100% RUNNING with 4497/4497 samples inside
`torch::jit::load` -> `Unpickler::parse_ivalue`. Attribution:

| frame | share of transition CPU |
|---|---|
| `restoreAccurateTypeTags` (in stack) | 71.0% |
| `std::_Hashtable::_M_emplace` (in stack) | 96.4% |
| `_Hash_node_base::_Hash_node_base` (leaf) | 35.9% |
| `std::_Hashtable::_M_rehash_aux` (leaf) | 9.8% |

Two changes, both behavior-identical:

1. Swap `std::unordered_set` for `c10::FastSet` (`c10/util/FbcodeMaps.h`),
   which resolves to `folly::F14FastSet` in fbcode and to `std::unordered_set`
   in OSS. libstdc++ allocates a node per element -- that allocation is the
   35.9% leaf frame -- while F14 stores entries inline and rehashes far more
   cheaply. `FbcodeMaps.h` is already the local idiom: the sibling
   `pickler.h`, in this same directory and build target, includes it, as do
   `torch/csrc/jit/runtime/static/impl.h` and
   `torch/csrc/autograd/python_variable.cpp`. No new build dependency, and OSS
   behavior is unchanged.

2. Replace `find()` then `emplace_hint()` with a single `insert()`. The old
   form hashed every key twice; `insert()` reports prior presence directly.

This does not change which pointers are visited or the traversal order.

Test Plan:
Build:
- `buck2 build fbcode//mode/opt fbcode//caffe2:_libtorch` -- OK.
  Note `fbcode//caffe2:torch-cpp` does **not** compile this file; `buck2 uquery
  "owner(caffe2/torch/csrc/jit/serialization/unpickler.cpp)"` gives
  `_libtorch` / `torch_sources` / `src-files`.
- Verified the TU is genuinely in the compile path rather than a cache no-op:
  injecting `#error` at the top of `unpickler.cpp` fails the build with
  `Action failed: fbcode//caffe2:_libtorch (cxx_compile
  torch/csrc/jit/serialization/unpickler.cpp)`; restoring it builds clean.
- `arc f` -- clean.

Correctness:
- Behavior-identical by construction: same set semantics, same skip-if-seen
  logic, same traversal order. `insert()` returns `pair<iterator, bool>` whose
  `.second` is exactly the `find() == end()` predicate it replaces.
- OSS unaffected: `c10::FastSet` is `std::unordered_set` when `FBCODE_CAFFE2`
  is not defined.

Production measurement (canaried on m2140425308):
Hotfix fbpkg `284d970997cd4714e02ce0ea4b12f1b0` (rev `d55412f1ab8d`, grafted
onto the running prod base `400273f585a6`) pinned to one task, measured against
an un-canaried peer taking the same snapshots in the same minutes.

**The optimization does what it claims.** On-CPU profile of `inplace_worker`,
paced vs prod peer:

| frame | prod | this diff |
|---|---|---|
| `_Hash_node_base` (leaf) | 33.4% | **0%** |
| `_M_rehash_aux` (leaf) | 9.9% | **0%** |
| `unordered_set::emplace_hint` (in stack) | 45.2% | **0%** |
| `F14Chunk::tagMatchIter` (leaf) | 0% | 20.5% |

The entire libstdc++ hash path is gone, replaced by F14 probing.

Differential Revision: D115295360


