### PR TITLE
[Testcase Refactoring] Add hw_classification label to test_mod_tracker.py

### DIFF
--- a/test/distributed/_tools/test_mod_tracker.py
+++ b/test/distributed/_tools/test_mod_tracker.py
@@ -4,11 +4,18 @@ from copy import copy
 
 import torch
 from torch.distributed._tools.mod_tracker import ModTracker
-from torch.testing._internal.common_utils import run_tests, TestCase, xfailIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+    xfailIfTorchDynamo,
+)
 from torch.utils.checkpoint import checkpoint
 
 
 class TestModTracker(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # "https://github.com/pytorch/pytorch/issues/127112
     @xfailIfTorchDynamo
     def test_module_hierarchy(self):


### PR DESCRIPTION
## Summary

`test/distributed/_tools/test_mod_tracker.py` tests `ModTracker`, a pure-Python
module hierarchy tracker. All four test methods
(`test_module_hierarchy`, `test_bw_detection`, `test_user_hooks`, `test_ac`)
use CPU-default tensors with no device parameter, no `torch.cuda.*` calls, no
`device="cuda"` hardcoding, and no accelerator admission gates. The test class
inherits plain `TestCase` and does not use `instantiate_device_type_tests`.

The class is missing the `hw_classification` attribute, which means it is not
selected by the `--hw-classification` CI filter and is effectively dead code
in the CI pipeline. This PR adds the `GENERIC` label so the tests are run in
nightly CI.

## Changes

- Added `HardwareClassification` to the `common_utils` import block (reformatted
  single-line import to multi-line, alphabetically ordered).
- Added `hw_classification = HardwareClassification.GENERIC` class attribute to
  `TestModTracker`.

## Not changed

- No test method bodies are modified.
- No decorators are modified (`@xfailIfTorchDynamo` is preserved as-is; it is
  not device-related).
- No assertions are modified.
- No `instantiate_device_type_tests` call is added. `GENERIC` tests must not
  use `instantiate_device_type_tests` because all device variants would
  perform identical CPU work, creating unnecessary test duplicates.
- No class splitting. All four tests are device-agnostic and belong to the
  same `GENERIC` class.
- No `torch_npu` side changes are needed. The tests are CPU-runnable and do
  not exercise any accelerator-specific behavior.

## Test plan

- `python test/distributed/_tools/test_mod_tracker.py` on CPU (PyTorch
  2.13.0a0+gitfad7424, Python 3.12.13, openEuler 22.03 SP2 aarch64):
  all 4 tests pass (`test_module_hierarchy`, `test_bw_detection`,
  `test_user_hooks`, `test_ac`). Result: `Ran 4 tests in 0.052s, OK`.
- `python test/distributed/_tools/test_mod_tracker.py` on NPU (torch_npu
  2.13.0+git45fbeae, CANN 9.1.0-beta.1, Ascend 910B3):
  all 4 tests pass. Result: `Ran 4 tests in 0.639s, OK`.
  GENERIC tests use CPU-default tensors and do not invoke any accelerator
  kernels; behavior is identical to CPU.
- `python test/distributed/_tools/test_mod_tracker.py` on CUDA (A100,
  PyTorch 2.13.0a0+gitfad7424, CUDA 12.8, cuDNN 9.7.0):
  all 4 tests pass. Result: `Ran 4 tests in 0.648s, OK`.
  This confirms the labeling change does not break existing CUDA behavior.