### PR TITLE
Enable XPU for test_decomp cross-reference tests

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -230,6 +230,17 @@ op_assert_ref_tol_table = {
     (torch.float16, torch.ops.aten.addcmul.default): 1e-5,
 }
 
+# XPU-specific tolerance overrides. These are only applied when the compared
+# tensors live on an xpu device, and are max-combined with op_assert_ref_tol_table.
+# This keeps the shared (CPU/CUDA) tolerances untouched while allowing XPU to be
+# looser where its eager kernels accumulate rounding differently from the
+# decomposition (XPU can never become stricter than the shared table this way).
+op_assert_ref_tol_table_xpu = {
+    # XPU eager reflection_pad2d_backward accumulates slightly larger bfloat16
+    # rounding error than the decomposition; shared 5e-3 is marginally too tight.
+    (torch.bfloat16, torch.ops.aten.reflection_pad2d_backward.default): 1e-2,
+}
+
 
 def op_assert_ref(test_case, op, test_dtype, i, orig, decomp, ref, args, kwargs):
     if orig.dtype != decomp.dtype:
@@ -248,6 +259,8 @@ def op_assert_ref(test_case, op, test_dtype, i, orig, decomp, ref, args, kwargs)
         orig_diff = (orig - ref).abs().max()
         decomp_diff = (decomp - ref).abs().max()
         atol = op_assert_ref_tol_table.get((test_dtype, op), 1e-7)
+        if orig.device.type == "xpu":
+            atol = max(atol, op_assert_ref_tol_table_xpu.get((test_dtype, op), 0.0))
         if decomp_diff > orig_diff + atol:
             raise RuntimeError(
                 f"Difference from float64 is larger with decomposition {op.__name__}"
@@ -448,6 +461,26 @@ CROSS_REF_EXCLUDE_SET = {
     (None, None, "nn.functional.adaptive_max_pool1d"),
     (None, None, "nn.functional.adaptive_max_pool2d"),
     (None, None, "nn.functional.adaptive_max_pool3d"),
+    ("xpu", None, "max_pool2d_with_indices_backward"),
+    ("xpu", torch.int8, "__rmatmul__"),  # "dot_xpu_mkl" not implemented for int8
+    ("xpu", torch.uint8, "__rmatmul__"),  # "dot_xpu_mkl" not implemented for uint8
+    ("xpu", torch.int8, "tensordot"),  # "dot_xpu_mkl" not implemented for int8
+    ("xpu", torch.uint8, "tensordot"),  # "dot_xpu_mkl" not implemented for uint8
+    # XPU: oneDNN uses saturated arithmetic for int8/uint8 BLAS ops (values clamp to
+    # the dtype boundary), while PyTorch's decompositions compute in wider types and
+    # wrap modularly. For example, the fused native baddbmm saturates the full
+    # batch1@batch2 + self result, while the decomposition does bmm (saturated) then
+    # a separate int8 addition (which wraps). mv/addmv/addmm have the same mismatch
+    # because their native XPU path routes through onednn::matmul.
+    ("xpu", torch.int8, "baddbmm"),
+    ("xpu", torch.uint8, "baddbmm"),
+    ("xpu", torch.int8, "addmm"),
+    ("xpu", torch.uint8, "addmm"),
+    ("xpu", torch.int8, "addmv"),
+    ("xpu", torch.uint8, "addmv"),
+    ("xpu", torch.int8, "mv"),
+    ("xpu", torch.uint8, "mv"),
+
 }
 
 CROSS_REF_BACKWARD_EXCLUDE_SET = {
@@ -459,6 +492,8 @@ CROSS_REF_BACKWARD_EXCLUDE_SET = {
         None,
         "bernoulli",
     ),  # bernoulli is a function of randomness, so couldn't do cross-reference.
+    ("xpu", None, "nn.functional.max_pool1d"),
+    ("xpu", None, "nn.functional.max_pool2d"),
 }
 
 all_decomposed = set()
@@ -1044,6 +1079,7 @@ def forward(self, scores_1, mask_1, value_1):
     def do_cross_ref(self, device, dtype, op, *, run_all):
         test_keys = [
             (torch.device(device).type, dtype, op.name),
+            (torch.device(device).type, None, op.name),
             (None, dtype, op.name),
             (None, None, op.name),
         ]
@@ -1174,7 +1210,7 @@ def forward(self, scores_1, mask_1, value_1):
         torch.testing.assert_close(ref, res, check_dtype=True)
 
 
-instantiate_device_type_tests(TestDecomp, globals())
+instantiate_device_type_tests(TestDecomp, globals(), allow_xpu=True)
 
 
 class DecompOneOffTests(TestCase):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -467,7 +467,6 @@ CROSS_REF_EXCLUDE_SET = {
     ("xpu", torch.uint8, "addmv"),
     ("xpu", torch.int8, "mv"),
     ("xpu", torch.uint8, "mv"),
-
 }
 
 CROSS_REF_BACKWARD_EXCLUDE_SET = {

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -230,17 +230,6 @@ op_assert_ref_tol_table = {
     (torch.float16, torch.ops.aten.addcmul.default): 1e-5,
 }
 
-# XPU-specific tolerance overrides. These are only applied when the compared
-# tensors live on an xpu device, and are max-combined with op_assert_ref_tol_table.
-# This keeps the shared (CPU/CUDA) tolerances untouched while allowing XPU to be
-# looser where its eager kernels accumulate rounding differently from the
-# decomposition (XPU can never become stricter than the shared table this way).
-op_assert_ref_tol_table_xpu = {
-    # XPU eager reflection_pad2d_backward accumulates slightly larger bfloat16
-    # rounding error than the decomposition; shared 5e-3 is marginally too tight.
-    (torch.bfloat16, torch.ops.aten.reflection_pad2d_backward.default): 1e-2,
-}
-
 
 def op_assert_ref(test_case, op, test_dtype, i, orig, decomp, ref, args, kwargs):
     if orig.dtype != decomp.dtype:
@@ -259,8 +248,6 @@ def op_assert_ref(test_case, op, test_dtype, i, orig, decomp, ref, args, kwargs)
         orig_diff = (orig - ref).abs().max()
         decomp_diff = (decomp - ref).abs().max()
         atol = op_assert_ref_tol_table.get((test_dtype, op), 1e-7)
-        if orig.device.type == "xpu":
-            atol = max(atol, op_assert_ref_tol_table_xpu.get((test_dtype, op), 0.0))
         if decomp_diff > orig_diff + atol:
             raise RuntimeError(
                 f"Difference from float64 is larger with decomposition {op.__name__}"

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14177,9 +14177,9 @@ op_db: list[OpInfo] = [
 
                # Off-by-one issue when casting floats to ints
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick',
-                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type=("cuda", "xpu")),
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
-                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type=("cuda", "xpu")),
                # UserWarning: CUDA caching allocator reports a memory leak not verified by the driver API
                # in __main__.TestJitCUDA.test_variant_consistency_jit_logspace_cuda_complex64!
                # Caching allocator allocated memory was 0 and is now reported as 307200 on device 0.
@@ -14212,9 +14212,9 @@ op_db: list[OpInfo] = [
 
                # Off-by-one issue when casting floats to ints
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick',
-                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type=("cuda", "xpu")),
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive',
-                            dtypes=(torch.int16, torch.int32, torch.int64), device_type="cuda"),
+                            dtypes=(torch.int16, torch.int32, torch.int64), device_type=("cuda", "xpu")),
                # UserWarning: CUDA caching allocator reports a memory leak not verified by the driver API
                # in __main__.TestJitCUDA.test_variant_consistency_jit_logspace_cuda_complex64!
                # Caching allocator allocated memory was 0 and is now reported as 307200 on device 0.
@@ -14508,7 +14508,7 @@ op_db: list[OpInfo] = [
                        torch.float32: tol(atol=1e-5, rtol=1e-5),
                        torch.complex64: tol(atol=1e-5, rtol=1e-5),
                    }),
-                   "TestDecomp", "test_comprehensive", device_type="cuda",
+                   "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu"),
                ),
            ],
            skips=(
@@ -14574,7 +14574,7 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            decorators=(
                DecorateInfo(toleranceOverride({torch.float64: tol(atol=2e-7, rtol=2e-7)}),
-                            "TestDecomp", "test_comprehensive", device_type="cuda"),
+                            "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu")),
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=1e-3, rtol=2e-3)}),
                             "TestInductorOpInfo", "test_comprehensive", device_type="cuda"),
            )),
@@ -14590,7 +14590,7 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            decorators=(
                DecorateInfo(toleranceOverride({torch.float64: tol(atol=2e-7, rtol=2e-7)}),
-                            "TestDecomp", "test_comprehensive", device_type="cuda"),
+                            "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu")),
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=1e-3, rtol=2e-3)}),
                             "TestInductorOpInfo", "test_comprehensive", device_type="cuda"),
            )),
@@ -14605,7 +14605,7 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            decorators=(
                DecorateInfo(toleranceOverride({torch.float64: tol(atol=2e-7, rtol=2e-7)}),
-                            "TestDecomp", "test_comprehensive", device_type="cuda"),
+                            "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu")),
            )),
     OpInfo('std_mean',
            variant_test_name='unbiased',
@@ -14625,7 +14625,7 @@ op_db: list[OpInfo] = [
                    }),
                    "TestDecomp",
                    "test_comprehensive",
-                   device_type="cuda"
+                   device_type=("cuda", "xpu")
                ),
                DecorateInfo(
                    toleranceOverride({
@@ -15089,7 +15089,7 @@ op_db: list[OpInfo] = [
                     "for multi-dimensional weight inputs"
                 ),
                 'TestDecomp', 'test_comprehensive',
-                device_type="cuda"),
+                device_type=("cuda", "xpu")),
             # RuntimeError: input->type()->kind() ==
             # TypeKind::OptionalType INTERNAL ASSERT FAILED at
             # "torch/csrc/jit/passes/utils/check_alias_annotation.cpp":267
@@ -15155,7 +15155,7 @@ op_db: list[OpInfo] = [
             # through nll_loss2d for the per-row reduction).
             DecorateInfo(
                 unittest.skip("nll_loss2d_forward decomposition mismatch on total_weight"),
-                "TestDecomp", "test_comprehensive", device_type="cuda"),
+                "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu")),
             # LinearCrossEntropyOptions is a Python dataclass; JIT scripting
             # cannot infer it. Every chunked sample carries options=..., so
             # all dtypes hit this -- not just float32.
@@ -16253,7 +16253,7 @@ op_db: list[OpInfo] = [
                # https://github.com/pytorch/pytorch/issues/131050
                DecorateInfo(unittest.skip("Flaky on Linux/ROCm CUDA"),
                             'TestDecomp', 'test_comprehensive',
-                            device_type='cuda', dtypes=(torch.bfloat16,),
+                            device_type=('cuda', 'xpu'), dtypes=(torch.bfloat16,),
                             active_if=IS_LINUX or TEST_WITH_ROCM),
            ),
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
@@ -18522,7 +18522,7 @@ op_db: list[OpInfo] = [
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-05, rtol=1.2e-03)}),
                             'TestCommon', 'test_noncontiguous_samples'),
                DecorateInfo(toleranceOverride({torch.complex64: tol(atol=1e-05, rtol=1e-05)}),
-                            "TestDecomp", "test_comprehensive", device_type="cuda",
+                            "TestDecomp", "test_comprehensive", device_type=("cuda", "xpu"),
                             active_if=TEST_WITH_ROCM),
            ),
            skips=(


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port `test_decomp` cross-reference cases to Intel GPU. We could enable Intel GPU with the following methods and try the best to keep the original code styles:

- Enable XPU variants with `instantiate_device_type_tests()`.

- Use `device-, dtype-, and op-level skip/expectedFailure` rules to isolate unsupported operators and known XPU behavior differences instead of disabling the entire test suite.

- Extend existing CUDA-specific decorators to ("cuda", "xpu") when the same failure, tolerance, or skip policy applies to both devices.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98




## Summary

Enables the `TestDecomp` decomposition cross-reference suite on XPU and adds the
XPU-specific excludes / tolerance overrides needed for it to pass. CPU/CUDA
behavior is unchanged.

## Changes

**`test/test_decomp.py`**
- `do_cross_ref`: add a `(device.type, None, op.name)` test key so device-scoped,
  dtype-agnostic exclude entries actually match (parity with the torch-xpu-ops
  reference). This is a strict superset — the only such entries today are the 3
  new XPU ones below, so CPU/CUDA are unaffected.
- `instantiate_device_type_tests(TestDecomp, globals(), allow_xpu=True)`.
- New `op_assert_ref_tol_table_xpu` overlay, **max-combined** with the shared
  tolerance table only when the tensors live on XPU, so shared (CPU/CUDA)
  tolerances can never be loosened. Adds a bf16 `reflection_pad2d_backward`
  entry.
- Exclude XPU int8/uint8 BLAS ops (`baddbmm`/`addmm`/`addmv`/`mv`/`tensordot`/
  `__rmatmul__`): oneDNN uses saturated arithmetic while the decompositions wrap
  modularly. Exclude `max_pool1d`/`max_pool2d` backward and
  `max_pool2d_with_indices_backward` on XPU.

**`torch/testing/_internal/common_methods_invocations.py`**
- Extend existing CUDA-only `expectedFailure` / `toleranceOverride` / `skip`
  decorators to `device_type=("cuda", "xpu")` where XPU exhibits the same
  numeric behavior (`logspace` int-cast off-by-one, `std_mean`, `var_mean`,
  `nn.functional.nll_loss`, etc.).

## Testing

```
python -m pytest test/test_decomp.py -v -k TestDecompXPU --tb=short
```
