### PR TITLE
[Testcase Refactoring] Add HardwareClassification to test_checkpointer.py

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_checkpointer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpointer.py
@@ -28,7 +28,12 @@ from torch.distributed.checkpoint._experimental.staging import (
     DefaultStager,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfRocm,
+    TestCase,
+)
 
 
 def subprocess_init_fn(name: str, parent_pid: int) -> None:
@@ -51,6 +56,8 @@ def ckpt_writer_init_fn(**kwargs) -> CheckpointWriter:
 
 class TestCheckpointer(TestCase):
     """Parameterized tests that work with both sync and async checkpointers."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -397,6 +404,8 @@ class TestCheckpointer(TestCase):
 
 class TestAsyncCheckpointerSpecific(TestCase):
     """Tests specific to AsyncCheckpointer functionality."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

Tags `TestCheckpointer` and `TestAsyncCheckpointerSpecific` in `test/distributed/checkpoint/_experimental/test_types.py`
with `hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/checkpoint/_experimental/test_checkpointer.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `TestCheckpointer` and `TestAsyncCheckpointerSpecific`.

## Context

`TestCheckpointer` and `TestAsyncCheckpointerSpecific` are plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so this class is classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `python test/distributed/checkpoint/_experimental/test_checkpointer.py`

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.