### PR TITLE
Add skip for tests using libtorchbind_test when library is not found

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -12623,7 +12623,6 @@ _hop_schema_test_schema_types = [
 
 
 @skipIfTorchDynamo("We don't expect users to torch.compile hop schema generation.")
-@unittest.skipIf(IS_WINDOWS, "Windows not supported for this test")
 class TestHopSchema(TestCase):
     def _get_example_val(self, ty: str):
         from torch.fx.experimental.sym_node import SymNode

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -179,6 +179,8 @@ def load_torchbind_test_lib():
         lib_file_path = find_library_location("torchbind_test.dll")
     else:
         lib_file_path = find_library_location("libtorchbind_test.so")
+    if not IS_SANDCASTLE and not IS_FBCODE and not lib_file_path.exists():
+        raise unittest.SkipTest(f"torchbind test library not found: {lib_file_path}")
     torch.ops.load_library(str(lib_file_path))
 
 

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -175,12 +175,15 @@ def load_torchbind_test_lib():
         raise unittest.SkipTest("non-portable load_library call used in test")
     elif IS_SANDCASTLE or IS_FBCODE:
         lib_file_path = Path("//caffe2/test/cpp/jit:test_custom_class_registrations")
-    elif IS_WINDOWS:
-        lib_file_path = find_library_location("torchbind_test.dll")
     else:
-        lib_file_path = find_library_location("libtorchbind_test.so")
-    if not IS_SANDCASTLE and not IS_FBCODE and not lib_file_path.exists():
-        raise unittest.SkipTest(f"torchbind test library not found: {lib_file_path}")
+        if IS_WINDOWS:
+            lib_file_path = find_library_location("torchbind_test.dll")
+        else:
+            lib_file_path = find_library_location("libtorchbind_test.so")
+        
+        if not lib_file_path.exists():
+            raise unittest.SkipTest(f"torchbind test library not found: {lib_file_path}")
+            
     torch.ops.load_library(str(lib_file_path))
 
 

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -180,10 +180,12 @@ def load_torchbind_test_lib():
             lib_file_path = find_library_location("torchbind_test.dll")
         else:
             lib_file_path = find_library_location("libtorchbind_test.so")
-        
+
         if not lib_file_path.exists():
-            raise unittest.SkipTest(f"torchbind test library not found: {lib_file_path}")
-            
+            raise unittest.SkipTest(
+                f"torchbind test library not found: {lib_file_path}"
+            )
+
     torch.ops.load_library(str(lib_file_path))
 
 


### PR DESCRIPTION
Fixes issues found here: https://github.com/intel/torch-xpu-ops/issues/4105
