### PR TITLE
[Testcase Refactoring] Add hardware classification for test_cupy_as_tensor.py

### DIFF
--- a/test/distributed/test_cupy_as_tensor.py
+++ b/test/distributed/test_cupy_as_tensor.py
@@ -118,11 +118,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         super().tearDownClass()
 
 
-instantiate_device_type_tests(
-    CupyAsTensorTest,
-    globals(),
-    only_for="cuda"
-)
+instantiate_device_type_tests(CupyAsTensorTest, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_cupy_as_tensor.py
+++ b/test/distributed/test_cupy_as_tensor.py
@@ -8,20 +8,17 @@ from dataclasses import dataclass
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
 from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     skip_if_rocm_multiprocess,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     requires_cuda_p2p_access,
     run_tests,
     skip_but_pass_in_sandcastle_if,
 )
-
-
-# So that tests are written in device-agnostic way
-device_type = "cuda"
-device_module = torch.get_device_module(device_type)
 
 
 @dataclass
@@ -54,32 +51,35 @@ def from_buffer(
 
 @requires_cuda_p2p_access()
 class CupyAsTensorTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
     @classmethod
     def backend_str(cls):
         return "gloo"
 
     def _init_device(self) -> None:
+        device_module = torch.get_device_module(self._device_type)
         # need to use vmm api to test it,
         # see https://forums.developer.nvidia.com/t/inconsistent-behavior-of-cudapointergetattributes-between-cudamalloc-ipc-and-vmm-based-ipc/339025/5
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+        torch._C._accelerator_setAllocatorSettings("expandable_segments:True")  # type: ignore[attr-defined]
         # init and pin the process to the device
         device_module.set_device(self.device)
         torch.empty(1, device=self.device)
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._device_type, self.rank)
 
     @skip_if_rocm_multiprocess  # RuntimeError: pidfd_getfd Operation not permitted"
     @skip_but_pass_in_sandcastle_if(
         SM100OrLater,
         "Fails if ran in docker environment without privileged access (https://github.com/pytorch/pytorch/issues/165170)",
     )
-    def test_cupy_as_tensor(self) -> None:
+    def test_cupy_as_tensor(self, device) -> None:
         """
         Test that torch.as_tensor works for cupy array interface
         with zero-copy when the pointer is p2p-shared across processes.
         """
+        self._device_type = torch.device(device).type
         self._init_device()
 
         tensor: torch.Tensor
@@ -106,7 +106,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         torch.distributed.barrier()
         if self.rank == 1:
             tensor.fill_(1)
-        device_module.synchronize()
+        torch.get_device_module(self._device_type).synchronize()
         torch.distributed.barrier()
         if not tensor.allclose(tensor, 1):
             raise AssertionError("Expected tensor to be close to 1")
@@ -114,9 +114,15 @@ class CupyAsTensorTest(MultiProcContinuousTest):
 
     @classmethod
     def tearDownClass(cls):
-        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+        torch._C._accelerator_setAllocatorSettings("expandable_segments:False")  # type: ignore[attr-defined]
         super().tearDownClass()
 
+
+instantiate_device_type_tests(
+    CupyAsTensorTest,
+    globals(),
+    only_for="cuda"
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_cupy_as_tensor.py
+++ b/test/distributed/test_cupy_as_tensor.py
@@ -52,22 +52,22 @@ def from_buffer(
 @requires_cuda_p2p_access()
 class CupyAsTensorTest(MultiProcContinuousTest):
     hw_classification = HardwareClassification.CUDA
+
     @classmethod
     def backend_str(cls):
         return "gloo"
 
-    def _init_device(self) -> None:
-        device_module = torch.get_device_module(self.device_type)
+    def _init_device(self, device_type) -> None:
+        device_module = torch.get_device_module(device_type)
         # need to use vmm api to test it,
         # see https://forums.developer.nvidia.com/t/inconsistent-behavior-of-cudapointergetattributes-between-cudamalloc-ipc-and-vmm-based-ipc/339025/5
         torch._C._accelerator_setAllocatorSettings("expandable_segments:True")  # type: ignore[attr-defined]
         # init and pin the process to the device
-        device_module.set_device(self.device)
-        torch.empty(1, device=self.device)
+        device_module.set_device(self.device(device_type))
+        torch.empty(1, device=self.device(device_type))
 
-    @property
-    def device(self) -> torch.device:
-        return torch.device(self.device_type, self.rank)
+    def device(self, device_type) -> torch.device:
+        return torch.device(device_type, self.rank)
 
     @skip_if_rocm_multiprocess  # RuntimeError: pidfd_getfd Operation not permitted"
     @skip_but_pass_in_sandcastle_if(
@@ -79,13 +79,13 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         Test that torch.as_tensor works for cupy array interface
         with zero-copy when the pointer is p2p-shared across processes.
         """
-        self.device_type = torch.device(device).type
-        self._init_device()
+        device_type = torch.device(device).type
+        self._init_device(device_type)
 
         tensor: torch.Tensor
         if self.rank == 1:
             # it seems only error from rank non-zero will be caught by this test
-            tensor = torch.randn(2333, device=self.device)
+            tensor = torch.randn(2333, device=self.device(device_type))
             tensor_meta = reduce_tensor(tensor)
             torch.distributed.broadcast_object_list([tensor_meta], src=1)
         else:
@@ -99,14 +99,14 @@ class CupyAsTensorTest(MultiProcContinuousTest):
             tensor = from_buffer(
                 ipc_tensor.data_ptr(),
                 ipc_tensor.numel() * ipc_tensor.element_size(),
-                self.device,
+                self.device(device_type),
                 ipc_tensor.dtype,
             )
 
         torch.distributed.barrier()
         if self.rank == 1:
             tensor.fill_(1)
-        torch.get_device_module(self.device_type).synchronize()
+        torch.get_device_module(device_type).synchronize()
         torch.distributed.barrier()
         if not tensor.allclose(tensor, 1):
             raise AssertionError("Expected tensor to be close to 1")

--- a/test/distributed/test_cupy_as_tensor.py
+++ b/test/distributed/test_cupy_as_tensor.py
@@ -57,7 +57,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         return "gloo"
 
     def _init_device(self) -> None:
-        device_module = torch.get_device_module(self._device_type)
+        device_module = torch.get_device_module(self.device_type)
         # need to use vmm api to test it,
         # see https://forums.developer.nvidia.com/t/inconsistent-behavior-of-cudapointergetattributes-between-cudamalloc-ipc-and-vmm-based-ipc/339025/5
         torch._C._accelerator_setAllocatorSettings("expandable_segments:True")  # type: ignore[attr-defined]
@@ -67,7 +67,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self._device_type, self.rank)
+        return torch.device(self.device_type, self.rank)
 
     @skip_if_rocm_multiprocess  # RuntimeError: pidfd_getfd Operation not permitted"
     @skip_but_pass_in_sandcastle_if(
@@ -79,7 +79,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         Test that torch.as_tensor works for cupy array interface
         with zero-copy when the pointer is p2p-shared across processes.
         """
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         self._init_device()
 
         tensor: torch.Tensor
@@ -106,7 +106,7 @@ class CupyAsTensorTest(MultiProcContinuousTest):
         torch.distributed.barrier()
         if self.rank == 1:
             tensor.fill_(1)
-        torch.get_device_module(self._device_type).synchronize()
+        torch.get_device_module(self.device_type).synchronize()
         torch.distributed.barrier()
         if not tensor.allclose(tensor, 1):
             raise AssertionError("Expected tensor to be close to 1")


### PR DESCRIPTION
## Summary:
  Add hardware classification for test_cupy_as_tensor.py and classify`CupyAsTensorTest` as CUDA, instantiate this class by `instantiate_device_type_tests`.

## Changes:

1.   Set `hw_classification = HardwareClassification.CUDA` on `CupyAsTensorTest`.
2.   Add test class instantiating and `device` param injection, so that devices can be initialized dynamically.
3.   Replace the deprecated API `torch.CUDA.memory._set_allocator_setting` with the new API  `torch._C._accelerator_setAllocatorSettings`.

## Test Plan:
`python test/distributed/test_cupy_as_tensor.py`