### PR TITLE
[Testcase Refactoring] Add proper hw_classification to test_api

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -61,6 +61,7 @@ class SampleModelForDimOne(torch.nn.Module):
 
 class TestExportAPIDynamo(common_utils.TestCase):
     """Tests for the ONNX exporter API when dynamo=True."""
+    hw_classification = common_utils.HardwareClassification.GENERIC
 
     def assert_export(
         self, *args, strategy: str | None = "TorchExportNonStrictStrategy", **kwargs
@@ -441,6 +442,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
 
 
 class TestCustomTranslationTable(common_utils.TestCase):
+    hw_classification = common_utils.HardwareClassification.GENERIC
     def test_custom_translation_table_overrides_ops(self):
         from onnxscript import opset18 as op
 

--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -10,6 +10,7 @@ import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.onnx.ops import _impl, _symbolic_impl
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
@@ -496,7 +497,6 @@ class SymbolicOpsTest(common_utils.TestCase):
             )
 
 
-@common_utils.instantiate_parametrized_tests
 class NativeOnnxOpsTest(common_utils.TestCase):
     def export(self, model, args=(), kwargs=None, **options) -> torch.onnx.ONNXProgram:
         onnx_program = torch.onnx.export(
@@ -1581,7 +1581,8 @@ class NativeOnnxOpsTest(common_utils.TestCase):
         )
 
         onnx_testing.assert_onnx_program(onnx_program)
-
+        
+instantiate_device_type_tests(NativeOnnxOpsTest, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -50,6 +50,10 @@ def _skipper(condition, reason):
 
 skipIfNoCuda = _skipper(lambda: not torch.cuda.is_available(), "CUDA is not available")
 
+skipIfNoAccelerator = _skipper(
+    lambda: not torch.accelerator.is_available(), "Accelerator is not available"
+)
+
 skipIfTravis = _skipper(lambda: os.getenv("TRAVIS"), "Skip In Travis")
 
 skipIfNoBFloat16Cuda = _skipper(

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -8,7 +8,7 @@ import parameterized
 from onnx_test_common import MAX_ONNX_OPSET_VERSION, MIN_ONNX_OPSET_VERSION
 from pytorch_test_common import (
     skipIfNoBFloat16Cuda,
-    skipIfNoCuda,
+    skipIfNoAccelerator,
     skipIfUnsupportedMinOpsetVersion,
     skipScriptTest,
 )
@@ -17,7 +17,9 @@ from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
 import torch
 from torch.cuda.amp import autocast
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
+device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
 
 @parameterized.parameterized_class(
     **_parameterized_class_attrs_and_values(
@@ -35,7 +37,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             raise unittest.SkipTest(f"onnxruntime {cls.ort_backend} is not available")
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     def test_gelu_fp16(self):
         class GeluModel(torch.nn.Module):
             def forward(self, x):
@@ -48,12 +50,12 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             6,
             requires_grad=True,
             dtype=torch.float16,
-            device=torch.device("cuda"),
+            device=device_type,
         )
         self.run_test(GeluModel(), x, rtol=1e-3, atol=1e-5)
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_layer_norm_fp16(self):
         class LayerNormModel(torch.nn.Module):
@@ -72,12 +74,12 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             10,
             requires_grad=True,
             dtype=torch.float16,
-            device=torch.device("cuda"),
+            device=device_type,
         )
         self.run_test(LayerNormModel().cuda(), x, rtol=1e-3, atol=1e-5)
 
     @skipIfUnsupportedMinOpsetVersion(12)
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_softmaxCrossEntropy_fusion_fp16(self):
         class FusionModel(torch.nn.Module):
@@ -92,8 +94,8 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 return output
 
         N, C = 5, 4
-        input = torch.randn(N, 16, dtype=torch.float16, device=torch.device("cuda"))
-        target = torch.empty(N, dtype=torch.long, device=torch.device("cuda")).random_(
+        input = torch.randn(N, 16, dtype=torch.float16, device=device_type)
+        target = torch.empty(N, dtype=torch.long, device=device_type).random_(
             0, C
         )
 
@@ -101,7 +103,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
         target[target == 1] = -100
         self.run_test(FusionModel(), (input, target))
 
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     @skipScriptTest()
     def test_apex_o2(self):
         class LinearModel(torch.nn.Module):
@@ -116,7 +118,7 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
             from apex import amp
         except Exception as e:
             raise unittest.SkipTest("Apex is not available") from e
-        input = torch.randn(3, 3, device=torch.device("cuda"))
+        input = torch.randn(3, 3, device=device_type)
         model = amp.initialize(LinearModel(), opt_level="O2")
         self.run_test(model, input)
 
@@ -127,18 +129,18 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
     def test_arithmetic_bfp16(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
-                y = torch.ones(3, 4, dtype=torch.bfloat16, device=torch.device("cuda"))
+                y = torch.ones(3, 4, dtype=torch.bfloat16, device=device_type)
                 x = x.type_as(y)
                 return torch.mul(torch.add(x, y), torch.sub(x, y)).to(
                     dtype=torch.float16
                 )
 
         x = torch.ones(
-            3, 4, requires_grad=True, dtype=torch.float16, device=torch.device("cuda")
+            3, 4, requires_grad=True, dtype=torch.float16, device=device_type
         )
         self.run_test(MyModule(), x, rtol=1e-3, atol=1e-5)
 
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     def test_deduplicate_initializers_diff_devices(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -146,15 +148,16 @@ class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
                 self.w = torch.nn.Parameter(
                     torch.ones(2, 3, device=torch.device("cpu"))
                 )
-                self.b = torch.nn.Parameter(torch.ones(3, device=torch.device("cuda")))
+                self.b = torch.nn.Parameter(torch.ones(3, device=device_type))
 
             def forward(self, x, y):
                 return torch.matmul(self.w, x), y + self.b
 
         x = torch.randn(3, 3, device=torch.device("cpu"))
-        y = torch.randn(3, 3, device=torch.device("cuda"))
+        y = torch.randn(3, 3, device=device_type)
         self.run_test(Model(), (x, y))
 
+instantiate_device_type_tests(TestONNXRuntime_cuda, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -12,7 +12,7 @@ import pytorch_test_common
 import torchvision
 from autograd_helper import CustomFunction as CustomFunction2
 from pytorch_test_common import (
-    skipIfNoCuda,
+    skipIfNoAccelerator,
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
 )
@@ -25,7 +25,9 @@ from torch.onnx._internal.torchscript_exporter._globals import GLOBALS
 from torch.onnx.symbolic_helper import _unpack_list, parse_args
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import skipIfNoLapack
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
+device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
 
 def _remove_test_environment_prefix_from_scope_name(scope_name: str) -> str:
     """Remove test environment prefix added to module.
@@ -1797,7 +1799,7 @@ class TestUtilityFuns(_BaseTestCase):
     def test_deduplicate_initializers_torchscript(self):
         self._test_deduplicate_initializers(torchscript=True)
 
-    @skipIfNoCuda
+    @skipIfNoAccelerator
     def test_deduplicate_initializers_diff_devices(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:
@@ -1806,14 +1808,14 @@ class TestUtilityFuns(_BaseTestCase):
                     torch.ones(3, device=torch.device("cpu"))
                 )
                 self.w_cuda = torch.nn.Parameter(
-                    torch.ones(3, device=torch.device("cuda"))
+                    torch.ones(3, device=device_type)
                 )
 
             def forward(self, x, y):
                 return x + self.w_cpu, y + self.w_cuda
 
         x = torch.randn(3, 3, device=torch.device("cpu"))
-        y = torch.randn(3, 3, device=torch.device("cuda"))
+        y = torch.randn(3, 3, device=device_type)
         f = io.BytesIO()
         torch.onnx.export(
             Model(), (x, y), f, opset_version=self.opset_version, dynamo=False
@@ -1929,6 +1931,7 @@ class TestUtilityFuns(_BaseTestCase):
         )
         torch.onnx.unregister_custom_op_symbolic("::cat", _onnx_opset_version)
 
+instantiate_device_type_tests(TestUtilityFuns, globals())
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
## Summary
- Add hw_classfication annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add "GENERIC" hw_classification to TestExportAPIDynamo and TestCustomTranslationTable in test_api.py.

## Test Plan
- python tset/onnx/test_api.py.

## Notes
- This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track #185590
