### PR TITLE
Enable XPU for DecompOneOffTests via accelerator-agnostic decorators

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -19,9 +19,10 @@ from torch._dispatch.python import enable_python_dispatcher
 from torch._export.utils import _is_cia_op
 from torch._ops import DispatchKey
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import SM70OrLater, tf32_off
+from torch.testing._internal.common_cuda import SM70OrLater, TEST_CUDA, tf32_off
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyAccelerator,
     onlyCPU,
     onlyCUDA,
     onlyNativeDeviceTypes,
@@ -1206,7 +1207,7 @@ class DecompOneOffTests(TestCase):
         res = torch._decomp.decompositions._log_softmax(x, -1, False)
         self.assertEqual(ref.stride(), res.stride())
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_exponential_non_inf(self, device):
         inp = torch.empty((4, 400, 256), device=device)
 
@@ -1219,9 +1220,8 @@ class DecompOneOffTests(TestCase):
 
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfCrossRef
-    @onlyCUDA
-    def test_amp_batch_norm_backward(self):
-        device = "cuda"
+    @onlyAccelerator
+    def test_amp_batch_norm_backward(self, device):
         grad_out = torch.randn((1, 2, 16, 16), dtype=torch.float16, device=device)
         x = torch.randn((1, 2, 16, 16), dtype=torch.float16, device=device)
         weight = torch.randn((2,), dtype=torch.float32, device=device)
@@ -1298,7 +1298,7 @@ class DecompOneOffTests(TestCase):
             torch._decomp.decompositions._weight_norm_interface(inp, inp2),
         )
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfCrossRef
     def test_fused_dropout_decomposition_extreme_p(self, device):
         input_tensor = torch.randn(10, 10, dtype=torch.float32, device=device)
@@ -1329,7 +1329,7 @@ class DecompOneOffTests(TestCase):
         self.assertEqual(decomp_out, ref_out)
         self.assertEqual(decomp_mask, ref_mask)
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfCrossRef
     def test_fused_dropout_compile_extreme_p(self, device):
         def fn(input_tensor, p, generator):
@@ -1421,8 +1421,8 @@ class DecompOneOffTests(TestCase):
         for o_ref, o in zip(out_ref, out):
             self.assertEqual(o_ref.dtype, o.dtype)
 
-    @onlyCUDA
-    @unittest.skipIf(not SM70OrLater, "triton")
+    @onlyAccelerator
+    @unittest.skipIf(TEST_CUDA and not SM70OrLater, "triton requires CUDA with SM>=7.0")
     def test_rms_norm_decomp_cuda(self, device):
         @torch.compile
         def rms_norm_sinh(a, b, c):
@@ -1447,7 +1447,7 @@ class DecompOneOffTests(TestCase):
             in generated_codes[1]
         )
 
-    @onlyCUDA
+    @onlyAccelerator
     @skipIfCrossRef
     def test_addmm_out_dtype_decomp(self, device):
         cases = [
@@ -1532,7 +1532,7 @@ class DecompOneOffTests(TestCase):
             )
 
 
-instantiate_device_type_tests(DecompOneOffTests, globals())
+instantiate_device_type_tests(DecompOneOffTests, globals(), allow_xpu=True)
 
 
 class HasDecompTest(TestCase):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -24,7 +24,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
     onlyCPU,
-    onlyCUDA,
     onlyNativeDeviceTypes,
     ops,
     skip,


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port device-specific one-off decomposition tests in test_decomp.py to Intel GPU. We could enable Intel GPU with the following methods and try the best to keep the original code styles:

- Replace `@onlyCUDA` with `@onlyAccelerator` for accelerator-compatible decomposition tests.

- Enable XPU test variants with `instantiate_device_type_tests()`.

- Keep CUDA-specific requirements guarded by `TEST_CUDA`; for example, apply the SM70OrLater Triton requirement only when running on CUDA.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98



### Motivation

`DecompOneOffTests` in `test/test_decomp.py` contained several device-specific
tests that were hard-coded to CUDA via `@onlyCUDA`, so they never exercised the
decompositions on other accelerators such as Intel XPU. This PR makes those
tests accelerator-agnostic so they run on any available accelerator.

### Changes

- Replace `@onlyCUDA` with `@onlyAccelerator` on:
  - `test_exponential_non_inf`
  - `test_amp_batch_norm_backward`
  - `test_fused_dropout_decomposition_extreme_p`
  - `test_fused_dropout_compile_extreme_p`
  - `test_rms_norm_decomp_cuda`
  - `test_addmm_out_dtype_decomp`
- `test_amp_batch_norm_backward`: take `device` from the parametrized test
  argument instead of hard-coding `device="cuda"`.
- `test_rms_norm_decomp_cuda`: gate the `SM70OrLater` triton requirement behind
  `TEST_CUDA` so the SM check only applies on CUDA (other accelerators are not
  skipped by a CUDA-specific capability check).
- `instantiate_device_type_tests(DecompOneOffTests, globals(), allow_xpu=True)`
  so XPU device variants are generated.

The changes are confined to `DecompOneOffTests`; `TestDecomp` and
`HasDecompTest` are untouched. CPU/CUDA behavior is preserved.

### Testing

Verified on Intel XPU :

```
python -m pytest test/test_decomp.py -k "DecompOneOffTestsXPU" -v
```

11 passed, 9 skipped, 0 failed.
