### PR TITLE
Compute atan2 backward in the op math type

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18121,6 +18121,33 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(x.grad, torch.zeros_like(x))
         self.assertEqual(y.grad, torch.zeros_like(y))
 
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_atan2_gradient_no_overflow(self, device, dtype):
+        # The reverse rule forms 1 / (self^2 + other^2), which over- and
+        # underflows in half precision well inside the range of the gradient
+        # it feeds.
+        for a, b in [(2e-3, 2e-3), (1e-4, 1e-4), (200.0, 200.0), (1.0, 1.0)]:
+            with self.subTest(a=a, b=b):
+                x = torch.tensor([a], device=device, dtype=dtype, requires_grad=True)
+                y = torch.tensor([b], device=device, dtype=dtype, requires_grad=True)
+                torch.atan2(x, y).backward()
+                x64 = x.detach().double().requires_grad_()
+                y64 = y.detach().double().requires_grad_()
+                torch.atan2(x64, y64).backward()
+                self.assertEqual(x.grad, x64.grad.to(dtype), atol=0, rtol=1e-3)
+                self.assertEqual(y.grad, y64.grad.to(dtype), atol=0, rtol=1e-3)
+
+    @dtypes(torch.uint8, torch.int32, torch.bool)
+    def test_atan2_gradient_integral_self(self, device, dtype):
+        # atan2 promotes integral inputs to float, so both -self and self^2 must
+        # be formed in the promoted type rather than the integral one.
+        a = 100000 if dtype == torch.int32 else 1
+        x = torch.full((1,), a, device=device, dtype=dtype)
+        y = torch.ones(1, device=device, requires_grad=True)
+        torch.atan2(x, y).backward()
+        expected = torch.full_like(y, -a / (a * a + 1.0))
+        self.assertEqual(y.grad, expected, atol=0, rtol=1e-3)
+
     # Test that torch.autograd.backward respects __torch_function__ on tensor subclasses.
     def test_backward_respects_torch_function(self):
         backward_called_with_subclass = [False]

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8,6 +8,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/LegacyBatchedTensorImpl.h>
+#include <ATen/OpMathType.h>
 #include <ATen/ScalarOps.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/TensorSubclassLikeUtils.h>
@@ -3638,7 +3639,14 @@ std::tuple<Tensor, Tensor> atan2_backward(
   if (!grad.defined()) {
     return std::tuple<Tensor, Tensor>{Tensor(), Tensor()};
   }
-  auto denom = self * self + other * other;
+  // `1 / (self^2 + other^2)` over/underflows in half precision for inputs whose
+  // gradient is representable, so form it in the op math type. `.to()` is a
+  // no-op if dtype is same.
+  const auto result_dtype = at::result_type(self, other);
+  const auto opmath_dtype = at::toOpMathType(result_dtype);
+  auto self_ = self.to(opmath_dtype);
+  auto other_ = other.to(opmath_dtype);
+  auto denom = self_ * self_ + other_ * other_;
   auto recip = denom.reciprocal();
   if (at::areAnyTensorSubclassLike({self, other, denom, recip}) ||
       at::GradMode::is_enabled()) {
@@ -3647,8 +3655,8 @@ std::tuple<Tensor, Tensor> atan2_backward(
     recip.masked_fill_(denom == 0, 0);
   }
   return std::tuple<Tensor, Tensor>{
-      output_mask[0] ? grad * other * recip : Tensor(),
-      output_mask[1] ? grad * -self * recip : Tensor()};
+      output_mask[0] ? (grad * other_ * recip).to(result_dtype) : Tensor(),
+      output_mask[1] ? (grad * -self_ * recip).to(result_dtype) : Tensor()};
 }
 
 Tensor gelu_double_backward(


### PR DESCRIPTION
## Issue

Fixes #193040

## Summary

`atan2_backward` forms `1 / (self^2 + other^2)` in the input dtype, which leaves float16's range long before the gradient it feeds does: `x = y = 2e-3` gives `±inf` instead of ~250, and `1e-4` and `200` give a silent `0`. Computing it in the op math type fixes all three, as `infinitely_differentiable_gelu_backward` already does.

Other dtypes change. `uint8` self=1, other=1.0 gave `grad_other = 127.5`, now `-0.5`; `bool` and `uint16`-`uint64` raised on the `-self` negation and now return a value. bfloat16 gains no exponent range from float32, so under ~7e-21 the square is still subnormal, the `denom == 0` guard stops firing, and a silent wrong `0` becomes `inf` (smallest true gradient there: 2.0). Nothing else moves by more than 1 ulp.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

float32/float64 are bit-identical; `.to()` is a no-op there. Integral, bool and bfloat16 change as above.

---
AI assistance (Claude) was used to reproduce the bug, compare candidate fixes against a float64 reference and prepare this PR; the change and its verification were reviewed end-to-end by me.
