### PR TITLE
[Testcase Refactoring] Refactor test_repros.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -10141,8 +10141,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             lambda msg: f"{msg}\nStrides should match in eager: {compiled_a_stride} against {compiled_cloned_stride}",
         )
 
-
-class CUDAReproTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     @torch._dynamo.config.patch(capture_scalar_outputs=False)
     def test_aot_backward_context_reentry_after_graph_break(self):
@@ -10178,24 +10176,26 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(x), opt_fn(x))
         self.assertEqual(cnt.frame_count, 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_torch_cuda_is_initialized(self):
+
+class CUDAReproTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_torch_cuda_is_initialized(self, device):
         @torch.compile(fullgraph=True, backend="eager")
         def f(x):
             if torch.cuda.is_initialized():
                 return x + 1
             return x + 2
 
-        inp = torch.randn(3)
+        inp = torch.randn(3, device=device)
         self.assertEqual(f(inp), inp + 1)
 
         with mock.patch("torch.cuda.is_initialized", lambda: False):
             self.assertEqual(f(inp), inp + 2)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_graph_metadata_does_not_retain_cuda_fake_constants(self):
+    def test_graph_metadata_does_not_retain_cuda_fake_constants(self, device):
         def f():
-            x = torch.tensor(5, dtype=torch.float32, device="cuda")
+            x = torch.tensor(5, dtype=torch.float32, device=device)
             copy.deepcopy(x)
 
         def clear_cuda_memory(*, reset_dynamo):
@@ -10218,13 +10218,12 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
         # retained the real CUDA scalar through FakeTensor.constant.
         self.assertIsNotNone(opt_f)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     @unittest.skipIf(not PLATFORM_SUPPORTS_BF16, "requires CUDA bf16 support")
-    def test_layer_norm_mixed_dtype_aot_eager_decomp_partition_errors(self):
+    def test_layer_norm_mixed_dtype_aot_eager_decomp_partition_errors(self, device):
         # https://github.com/pytorch/pytorch/issues/151478
         x = torch.tensor(
             [[1.0, 2.0, 3.0, 4.0], [2.0, 4.0, 6.0, 8.0]],
-            device="cuda",
+            device=device,
             dtype=torch.bfloat16,
         )
 
@@ -10271,39 +10270,12 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
             "expected scalar type BFloat16 but found Long",
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_device_context_matmul_avoids_native_bmm_router_graph_break(self):
-        torch._dynamo.utils.counters.clear()
-
-        @torch.compile(backend="inductor", dynamic=False)
-        def fn(q, k):
-            with torch.device("cuda"):
-                a = torch.reshape(q, [-1, 8, 1, 32])
-                return torch.matmul(a, k)
-
-        q = torch.randn(64, 8 * 32, device="cuda", dtype=torch.float16)
-        k = torch.randn(1, 8, 32, 128, device="cuda", dtype=torch.float16)
-
-        out = fn(q, k)
-        torch.cuda.synchronize()
-        self.assertEqual(out.shape, (64, 8, 1, 128))
-
-        graph_break_reasons = "\n".join(
-            torch._dynamo.utils.counters["graph_break"].keys()
-        )
-        # The native router should not run trace-unsafe eager predicates here.
-        # If it does, the COW probe on the reshaped operand graph-breaks before
-        # it can fold or install a guard.
-        self.assertNotIn("_is_cow_tensor", graph_break_reasons)
-        self.assertNotIn("call_boxed", graph_break_reasons)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     @unittest.skipIf(not dist.is_available(), "test requires distributed")
-    # TODO: Remoe this skip once nccl issue if fixed
+    # TODO: Remove this skip once nccl issue if fixed
     @unittest.skip(
         "Failing with ncc update 2.25.1 : https://github.com/pytorch/pytorch/issues/147141"
     )
-    def test_ddp_checkpoint(self):
+    def test_ddp_checkpoint(self, device):
         # https://github.com/pytorch/pytorch/issues/144035
         DIM = 256
         SEQ_LEN = 32
@@ -10354,12 +10326,12 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
             os.environ["MASTER_ADDR"] = "localhost"
             os.environ["MASTER_PORT"] = "12355"
             dist.init_process_group(backend="nccl", world_size=1, rank=0)
-            model = model.to("cuda")
+            model = model.to(device)
             model = nn.parallel.DistributedDataParallel(model)
 
             for batch in dataloader:
                 x, y = batch
-                x = x.to("cuda")
+                x = x.to(device)
                 output = model(x)
                 loss = output.sum()
                 loss.backward()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -77,6 +77,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     serialTest,
@@ -87,7 +88,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     xfailIfS390X,
 )
-from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
+from torch.testing._internal.logging_utils import LoggingTestCase
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._python_dispatch import TorchDispatchMode
 
@@ -98,9 +99,6 @@ _orig_module_call = torch.nn.Module.__call__
 lib = torch.library.Library("test_sample", "DEF")  # noqa: SCOPED_LIBRARY
 lib.define("foo(Tensor self) -> Tensor")
 lib.impl("foo", torch.sin, "CPU")
-
-
-requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
 
 
 _GLOBAL_CPU_TENSOR = torch.randn(3)
@@ -1008,6 +1006,8 @@ class LRUCacheWarningTests(LoggingTestCase):
 
 
 class ReproTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         try:
@@ -8848,6 +8848,547 @@ SavedForBackwardsAOTOutput(idx=5)""",
         self.assertEqual(opt_fn(inp2, grid2), fn(inp2, grid2))
         self.assertEqual(cnt.frame_count, 1)
 
+    def test_getattr_return(self):
+        _WrapperDescriptor = type(type.__call__)
+        _MethodWrapper = type(all.__call__)
+        _ClassMethodWrapper = type(int.__dict__["from_bytes"])
+
+        _NonUserDefinedCallables = (
+            _WrapperDescriptor,
+            _MethodWrapper,
+            _ClassMethodWrapper,
+            types.BuiltinFunctionType,
+        )
+
+        def _signature_get_user_defined_method(cls, method_name):
+            try:
+                meth = getattr(cls, method_name)
+            except AttributeError:
+                return
+            else:
+                if not isinstance(meth, _NonUserDefinedCallables):
+                    # Once '__signature__' will be added to 'C'-level
+                    # callables, this check won't be necessary
+                    return meth
+
+        def fn(x):
+            s = _signature_get_user_defined_method(type(torch.nn.Linear), "__call__")
+            if s is None:
+                return torch.cos(x)
+
+            return torch.sin(x)
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        x = torch.randn(4)
+        self.assertEqual(fn(x), opt_fn(x))
+
+    def test_data_dependent_error_log_no_print(self):
+        # This is a regression test case for
+        # https://github.com/pytorch/pytorch/pull/149831
+        from io import StringIO
+
+        capturedOutput = StringIO()
+        sys.stderr = capturedOutput
+
+        @torch.compile(fullgraph=True, backend="eager")
+        def func(a):
+            if a.sum() > 0:
+                return a + 1
+            return a + 2
+
+        a = torch.rand(10, 10)
+        try:
+            func(a)
+        except Exception:
+            pass
+        sys.stderr = sys.__stderr__
+
+        # Make sure we don't _print_ out the graph module.
+        output = capturedOutput.getvalue()
+        self.assertNotIn("class GraphModule", output)
+
+    def test_deepcopy_constant_tensor_in_aot_bwd(self):
+        class Fn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x + 1
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out * torch.tensor(2) * grad_out.shape[0]
+
+        def f(x):
+            return Fn.apply(x)
+
+        x = torch.randn(8, requires_grad=True)
+        out = f(x)  # should not raise
+        c_out = torch.compile(f, backend="aot_eager", dynamic=True)(x)
+        expected = torch.autograd.grad(out.sum(), inputs=(x,))
+        actual = torch.autograd.grad(c_out.sum(), inputs=(x,))
+        self.assertEqual(expected, actual)
+
+    def test_module_attribute_error(self):
+        @torch.compile(backend="eager")
+        def f1(x):
+            return torch._bar(x)
+
+        @torch.compile(backend="eager")
+        def f2(x):
+            try:
+                return torch._bar(x)
+            except AttributeError:
+                return x + 1
+
+        with self.assertRaises(AttributeError):
+            f1(torch.ones(3))
+
+        self.assertEqual(f2(torch.ones(3)), torch.ones(3) + 1)
+
+    def test_named_tuple_vt_clone(self):
+        # https://github.com/pytorch/pytorch/issues/157945
+        class SVDCompressor(nn.Module):
+            def __init__(self, k=10):
+                super().__init__()
+                self.k = k
+
+            def forward(self, x):
+                U, S = torch.linalg.svd(x)[:2]
+                reduced = U[:, :, : self.k] @ torch.diag_embed(S[:, : self.k])
+                return reduced
+
+        input = torch.randn(4, 8, 6)
+        model = SVDCompressor(k=5)
+
+        out1 = model(input.clone())
+        out2 = torch.compile(model, backend="eager")(input.clone())
+        self.assertEqual(out1, out2)
+
+    def test_filter_warnings(self):
+        x = torch.ones(2, 2, requires_grad=True)
+
+        def call_foobar(x):
+            warnings.warn("foobar")
+
+        @torch.compile(backend="eager")
+        def f(x):
+            call_foobar(x)
+            call_foobar(x)
+            call_foobar(x)
+            call_foobar(x)
+            return call_foobar(x)
+
+        with warnings.catch_warnings(record=True) as w:
+            f(x)
+            self.assertEqual(len(w), 1)
+            self.assertEqual(str(w[0].message), "foobar")
+
+    def test_filter_safe_grad_warning(self):
+        x = torch.ones(2, 2, requires_grad=True)
+        y = x * 5  # non-leaf, .grad should warn
+        torch._subclasses.meta_utils.safe_grad(y)  # filters out warning
+
+        def unsafe_grad(y):
+            return y.grad
+
+        with warnings.catch_warnings(record=True) as w:
+            unsafe_grad(y)  # should still warn, different callsite
+            self.assertEqual(len(w), 1)
+            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
+
+            unsafe_grad(y)  # should not warn
+            self.assertEqual(len(w), 1)
+
+    def test_filter_user_warnings(self):
+        x = torch.ones(2, 2, requires_grad=True)
+        y = x * 5  # non-leaf, .grad should warn
+
+        @torch._dynamo.eval_frame.TorchPatcher.suppress_torch_distributed_warnings
+        def mute_warn(y):
+            return y.grad
+
+        mute_warn(y)  # filters out warning
+
+        def unsafe_grad(y):
+            return y.grad
+
+        with warnings.catch_warnings(record=True) as w:
+            unsafe_grad(y)  # should still warn, different callsite
+            self.assertEqual(len(w), 1)
+            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
+
+            unsafe_grad(y)  # should not warn
+            self.assertEqual(len(w), 1)
+
+    def test_partial_export(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def parallelize(self):
+                fn = self._call_impl
+
+                def wrapped_fn(fn, *args, **kwargs):
+                    new_args_0 = args[0].to(torch.bfloat16)
+                    new_args_1 = args[1].to(torch.bfloat16)
+                    return fn(new_args_0, new_args_1)
+
+                fn = functools.partial(wrapped_fn, fn)
+                self._call_impl = fn
+
+            def forward(self, a, b):
+                return a + b
+
+        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
+
+        foo = Foo()
+        foo.parallelize()
+        x = torch.randn(4, 4, dtype=torch.float32)
+        y = torch.randn(4, 4, dtype=torch.float32)
+        ref = foo(x, y)
+        gm = dynamo_graph_capture_for_export(foo)(x, y)
+        res = gm(x, y)
+        self.assertEqual(res, ref)
+
+    def test_current_accelerator(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            torch.accelerator.current_accelerator()
+            return x + 1
+
+        self.assertEqual(fn(torch.ones(3)), torch.ones(3) + 1)
+
+    def test_pytree_get_node_type_not_traced(self):
+        # Test that torch.utils._pytree._get_node_type is not traced into
+        # and doesn't cause excessive trace time overhead
+        from torch.utils._pytree import _get_node_type
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(x, y):
+            # Call _get_node_type which is used internally by pytree operations
+            node_type = _get_node_type([x, y])
+            assert node_type is list  # noqa: S101
+            # Do some work with pytree structures
+            data = {"a": x, "b": y}
+            flat, spec = pytree.tree_flatten(data)
+            result = flat[0] + flat[1]
+            return result
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_pytree_get_node_type_with_namedtuple(self):
+        # Test that torch.utils._pytree._get_node_type handles namedtuples correctly
+        # without being traced into, even when is_namedtuple_class is True
+        from collections import namedtuple
+
+        from torch.utils._pytree import _get_node_type
+
+        Point = namedtuple("Point", ["x", "y"])
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(a, b):
+            # Create a namedtuple
+            point = Point(a, b)
+            # Call _get_node_type with a namedtuple instance
+            node_type = _get_node_type(point)
+            assert node_type is namedtuple  # noqa: S101
+            # Use pytree operations with namedtuples
+            flat, spec = pytree.tree_flatten(point)
+            result = flat[0] + flat[1]
+            return result
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_pytree_tree_is_leaf_not_traced(self):
+        # Test that torch.utils._pytree.tree_is_leaf is not traced into
+        # when is_leaf parameter is None (the common case)
+        from torch.utils._pytree import tree_is_leaf
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(x, y):
+            # Test with various types
+            # Tensors are leaves
+            is_leaf_tensor = tree_is_leaf(x)
+            assert is_leaf_tensor is True  # noqa: S101
+
+            # Lists are not leaves (they're in SUPPORTED_NODES)
+            is_leaf_list = tree_is_leaf([x, y])
+            assert is_leaf_list is False  # noqa: S101
+
+            # Dicts are not leaves
+            is_leaf_dict = tree_is_leaf({"a": x, "b": y})
+            assert is_leaf_dict is False  # noqa: S101
+
+            return x + y
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_ordered_set_doesnt_recompile_with_ac(self):
+        import torch
+
+        with torch._dynamo.config.patch({"error_on_recompile": True}):
+            import functools
+
+            from torch.utils._ordered_set import OrderedSet
+            from torch.utils.checkpoint import (
+                checkpoint,
+                CheckpointPolicy,
+                create_selective_checkpoint_contexts,
+            )
+
+            def policy(compute_heavy_ops, ctx, func, *args, **kwargs):
+                if func in compute_heavy_ops:
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            def g(x):
+                return torch.mm(x, x).sin().exp()
+
+            @torch.compile(fullgraph=True, backend="eager")
+            def f(x, policy):
+                return checkpoint(g, x, use_reentrant=False, context_fn=policy)
+
+            x = torch.randn(4, 4, requires_grad=True)
+            f(
+                x,
+                functools.partial(
+                    create_selective_checkpoint_contexts,
+                    functools.partial(policy, OrderedSet([torch.ops.aten.mm.default])),
+                ),
+            )
+            f(
+                x,
+                functools.partial(
+                    create_selective_checkpoint_contexts,
+                    functools.partial(policy, OrderedSet([torch.ops.aten.mm.default])),
+                ),
+            )
+
+    def test_mro_source_cache_includes_attr_name(self):
+        # Base -> Mid -> A hierarchy: two class attributes with the same
+        # interned integer value share the same id().  The mro_source_cache
+        # must include the attribute name in its key; otherwise the second
+        # lookup returns the first attribute's source, installing a guard
+        # on the wrong key and missing mutations to the second attribute.
+        class Base:
+            x = 1
+            y = 1
+
+        class Mid(Base):
+            pass
+
+        class A(Mid):
+            pass
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def fn(obj, t):
+            return t * obj.x + t * obj.y
+
+        obj = A()
+        t = torch.tensor([1.0])
+        result = fn(obj, t)
+        self.assertEqual(result, torch.tensor([2.0]))
+        self.assertEqual(cnt.frame_count, 1)
+
+        # Changing y on Base must trigger recompilation.
+        Base.y = 42
+        result = fn(obj, t)
+        self.assertEqual(result, torch.tensor([43.0]))
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_pytree_tree_is_leaf_with_namedtuple(self):
+        # Test that torch.utils._pytree.tree_is_leaf handles namedtuples correctly
+        from collections import namedtuple
+
+        from torch.utils._pytree import tree_is_leaf
+
+        Point = namedtuple("Point", ["x", "y"])
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(a, b):
+            # Namedtuples are not leaves (they're in SUPPORTED_NODES)
+            point = Point(a, b)
+            is_leaf_namedtuple = tree_is_leaf(point)
+            assert is_leaf_namedtuple is False  # noqa: S101
+
+            # But individual tensors are leaves
+            is_leaf_tensor = tree_is_leaf(a)
+            assert is_leaf_tensor is True  # noqa: S101
+
+            return a + b
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_data_attr_mutation_with_noop_add(self):
+        # Regression test: remove_no_ops incorrectly eliminated add(x, 0) -> x
+        # when x was subsequently mutated by set_, causing the return value to
+        # alias the mutated input instead of being an independent copy.
+        def fn(a, b):
+            a.data = b
+            b.data = torch.zeros_like(b)
+            return a + b
+
+        a = torch.tensor([True, False, True, False])
+        b = torch.tensor([False, False, True, True])
+        a_ = a.clone()
+        b_ = b.clone()
+        cfunc = torch.compile(fn, backend="inductor")
+        res1 = fn(a, b)
+        res2 = cfunc(a_, b_)
+        self.assertEqual(res1, res2)
+
+    def test_custom_op_mutation_with_noop_add(self):
+        @torch.library.custom_op("test_repros::mutate_tensor", mutates_args={"x"})
+        def mutate_tensor(x: torch.Tensor, src: torch.Tensor) -> None:
+            x.copy_(src)
+
+        def fn(b):
+            zeros = torch.zeros_like(b)
+            result = b + zeros
+            mutate_tensor(b, zeros)
+            return result
+
+        b = torch.tensor([4.0, 5.0, 6.0])
+        b_ = b.clone()
+        cfunc = torch.compile(fn, backend="inductor")
+        res1 = fn(b)
+        res2 = cfunc(b_)
+        self.assertEqual(res1, res2)
+
+    def test_getset_descriptor_objclass_identity(self):
+        # GetSetDescriptor.__objclass__ should preserve identity with the class
+        # under torch.compile. This is needed for inspect.getattr_static (and
+        # therefore inspect.signature) to work on callable class instances.
+        class Foo:
+            pass
+
+        desc = Foo.__dict__["__dict__"]
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            if desc.__objclass__ is Foo:
+                return x + 1.0
+            return x + 2.0
+
+        result = f(torch.tensor(0.0))
+        self.assertEqual(result.item(), 1.0)
+
+    def test_inspect_signature_callable_class(self):
+        # inspect.signature should work on callable class instances under
+        # torch.compile, needed by flex_attention's _get_mod_type.
+        class MyCallable:
+            def __call__(self, b, h, q_idx, kv_idx):
+                return q_idx >= kv_idx
+
+        obj = MyCallable()
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            sig = inspect.signature(obj)
+            num_params = sum(
+                1
+                for p in sig.parameters.values()
+                if p.default is inspect.Parameter.empty
+            )
+            return x + num_params
+
+        result = f(torch.tensor(0.0))
+        self.assertEqual(result.item(), 4.0)
+
+    def test_enum_with_class_values(self):
+        from enum import Enum
+
+        class AvgMetric:
+            def __init__(self):
+                self.sum = None
+                self.count = 0
+
+            def append(self, x):
+                if self.count > 0:
+                    self.sum = self.sum + x
+                else:
+                    self.sum = x.clone()
+                self.count += 1
+
+        class GlobalReduction(Enum):
+            AVG = AvgMetric
+
+        class ScalarLogger:
+            def __init__(self):
+                self.metrics = {}
+
+            def log(self, key, value, global_reduction):
+                if key not in self.metrics:
+                    self.metrics[key] = global_reduction.value()
+                self.metrics[key].append(value)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(logger, x):
+            logger.log("test", x, GlobalReduction.AVG)
+            return x + 1
+
+        logger = ScalarLogger()
+        fn(logger, torch.tensor(1.0))
+
+    def test_class_attr_mutation_recompiles(self):
+        class GlobalState:
+            factor = 1.0
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def fn(x):
+            return x * GlobalState.factor
+
+        x = torch.tensor([4.0])
+
+        GlobalState.factor = 1.0
+        result1 = fn(x)
+        self.assertEqual(result1, torch.tensor([4.0]))
+        self.assertEqual(cnt.frame_count, 1)
+
+        GlobalState.factor = 10.0
+        result2 = fn(x)
+        self.assertEqual(result2, torch.tensor([40.0]))
+        self.assertEqual(cnt.frame_count, 2)
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     @serialTest()
@@ -9403,121 +9944,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         # (aka if you set torch._functorch.config.treat_parameters_as_free_to_save = False)
         self.assertEqual(mode.ops_counter[torch.ops.aten._to_copy.default], 5)
 
-    def test_getattr_return(self):
-        _WrapperDescriptor = type(type.__call__)
-        _MethodWrapper = type(all.__call__)
-        _ClassMethodWrapper = type(int.__dict__["from_bytes"])
-
-        _NonUserDefinedCallables = (
-            _WrapperDescriptor,
-            _MethodWrapper,
-            _ClassMethodWrapper,
-            types.BuiltinFunctionType,
-        )
-
-        def _signature_get_user_defined_method(cls, method_name):
-            try:
-                meth = getattr(cls, method_name)
-            except AttributeError:
-                return
-            else:
-                if not isinstance(meth, _NonUserDefinedCallables):
-                    # Once '__signature__' will be added to 'C'-level
-                    # callables, this check won't be necessary
-                    return meth
-
-        def fn(x):
-            s = _signature_get_user_defined_method(type(torch.nn.Linear), "__call__")
-            if s is None:
-                return torch.cos(x)
-
-            return torch.sin(x)
-
-        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        x = torch.randn(4)
-        self.assertEqual(fn(x), opt_fn(x))
-
-    def test_data_dependent_error_log_no_print(self):
-        # This is a regression test case for
-        # https://github.com/pytorch/pytorch/pull/149831
-        from io import StringIO
-
-        capturedOutput = StringIO()
-        sys.stderr = capturedOutput
-
-        @torch.compile(fullgraph=True, backend="eager")
-        def func(a):
-            if a.sum() > 0:
-                return a + 1
-            return a + 2
-
-        a = torch.rand(10, 10)
-        try:
-            func(a)
-        except Exception:
-            pass
-        sys.stderr = sys.__stderr__
-
-        # Make sure we don't _print_ out the graph module.
-        output = capturedOutput.getvalue()
-        self.assertNotIn("class GraphModule", output)
-
-    def test_deepcopy_constant_tensor_in_aot_bwd(self):
-        class Fn(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, x):
-                return x + 1
-
-            @staticmethod
-            def backward(ctx, grad_out):
-                return grad_out * torch.tensor(2) * grad_out.shape[0]
-
-        def f(x):
-            return Fn.apply(x)
-
-        x = torch.randn(8, requires_grad=True)
-        out = f(x)  # should not raise
-        c_out = torch.compile(f, backend="aot_eager", dynamic=True)(x)
-        expected = torch.autograd.grad(out.sum(), inputs=(x,))
-        actual = torch.autograd.grad(c_out.sum(), inputs=(x,))
-        self.assertEqual(expected, actual)
-
-    def test_module_attribute_error(self):
-        @torch.compile(backend="eager")
-        def f1(x):
-            return torch._bar(x)
-
-        @torch.compile(backend="eager")
-        def f2(x):
-            try:
-                return torch._bar(x)
-            except AttributeError:
-                return x + 1
-
-        with self.assertRaises(AttributeError):
-            f1(torch.ones(3))
-
-        self.assertEqual(f2(torch.ones(3)), torch.ones(3) + 1)
-
-    def test_named_tuple_vt_clone(self):
-        # https://github.com/pytorch/pytorch/issues/157945
-        class SVDCompressor(nn.Module):
-            def __init__(self, k=10):
-                super().__init__()
-                self.k = k
-
-            def forward(self, x):
-                U, S = torch.linalg.svd(x)[:2]
-                reduced = U[:, :, : self.k] @ torch.diag_embed(S[:, : self.k])
-                return reduced
-
-        input = torch.randn(4, 8, 6)
-        model = SVDCompressor(k=5)
-
-        out1 = model(input.clone())
-        out2 = torch.compile(model, backend="eager")(input.clone())
-        self.assertEqual(out1, out2)
-
     @onlyAccelerator
     def test_zero_dim_param_mixed_device_grad(self, device):
         # cpu 0-dim params with cuda grads
@@ -9542,432 +9968,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(model.b.grad)
         self.assertEqual(model.a.grad.device, torch.device("cpu"))
         self.assertEqual(model.b.grad.device, torch.device("cpu"))
-
-    def test_filter_warnings(self):
-        x = torch.ones(2, 2, requires_grad=True)
-
-        def call_foobar(x):
-            warnings.warn("foobar")
-
-        @torch.compile(backend="eager")
-        def f(x):
-            call_foobar(x)
-            call_foobar(x)
-            call_foobar(x)
-            call_foobar(x)
-            return call_foobar(x)
-
-        with warnings.catch_warnings(record=True) as w:
-            f(x)
-            self.assertEqual(len(w), 1)
-            self.assertEqual(str(w[0].message), "foobar")
-
-    def test_filter_safe_grad_warning(self):
-        x = torch.ones(2, 2, requires_grad=True)
-        y = x * 5  # non-leaf, .grad should warn
-        torch._subclasses.meta_utils.safe_grad(y)  # filters out warning
-
-        def unsafe_grad(y):
-            return y.grad
-
-        with warnings.catch_warnings(record=True) as w:
-            unsafe_grad(y)  # should still warn, different callsite
-            self.assertEqual(len(w), 1)
-            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
-
-            unsafe_grad(y)  # should not warn
-            self.assertEqual(len(w), 1)
-
-    def test_filter_user_warnings(self):
-        x = torch.ones(2, 2, requires_grad=True)
-        y = x * 5  # non-leaf, .grad should warn
-
-        @torch._dynamo.eval_frame.TorchPatcher.suppress_torch_distributed_warnings
-        def mute_warn(y):
-            return y.grad
-
-        mute_warn(y)  # filters out warning
-
-        def unsafe_grad(y):
-            return y.grad
-
-        with warnings.catch_warnings(record=True) as w:
-            unsafe_grad(y)  # should still warn, different callsite
-            self.assertEqual(len(w), 1)
-            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
-
-            unsafe_grad(y)  # should not warn
-            self.assertEqual(len(w), 1)
-
-    def test_partial_export(self):
-        class Foo(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def parallelize(self):
-                fn = self._call_impl
-
-                def wrapped_fn(fn, *args, **kwargs):
-                    new_args_0 = args[0].to(torch.bfloat16)
-                    new_args_1 = args[1].to(torch.bfloat16)
-                    return fn(new_args_0, new_args_1)
-
-                fn = functools.partial(wrapped_fn, fn)
-                self._call_impl = fn
-
-            def forward(self, a, b):
-                return a + b
-
-        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
-
-        foo = Foo()
-        foo.parallelize()
-        x = torch.randn(4, 4, dtype=torch.float32)
-        y = torch.randn(4, 4, dtype=torch.float32)
-        ref = foo(x, y)
-        gm = dynamo_graph_capture_for_export(foo)(x, y)
-        res = gm(x, y)
-        self.assertEqual(res, ref)
-
-    def test_current_accelerator(self):
-        @torch.compile(backend="eager", fullgraph=True)
-        def fn(x):
-            torch.accelerator.current_accelerator()
-            return x + 1
-
-        self.assertEqual(fn(torch.ones(3)), torch.ones(3) + 1)
-
-    def test_pytree_get_node_type_not_traced(self):
-        # Test that torch.utils._pytree._get_node_type is not traced into
-        # and doesn't cause excessive trace time overhead
-        from torch.utils._pytree import _get_node_type
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(x, y):
-            # Call _get_node_type which is used internally by pytree operations
-            node_type = _get_node_type([x, y])
-            assert node_type is list  # noqa: S101
-            # Do some work with pytree structures
-            data = {"a": x, "b": y}
-            flat, spec = pytree.tree_flatten(data)
-            result = flat[0] + flat[1]
-            return result
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_pytree_get_node_type_with_namedtuple(self):
-        # Test that torch.utils._pytree._get_node_type handles namedtuples correctly
-        # without being traced into, even when is_namedtuple_class is True
-        from collections import namedtuple
-
-        from torch.utils._pytree import _get_node_type
-
-        Point = namedtuple("Point", ["x", "y"])
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(a, b):
-            # Create a namedtuple
-            point = Point(a, b)
-            # Call _get_node_type with a namedtuple instance
-            node_type = _get_node_type(point)
-            assert node_type is namedtuple  # noqa: S101
-            # Use pytree operations with namedtuples
-            flat, spec = pytree.tree_flatten(point)
-            result = flat[0] + flat[1]
-            return result
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_pytree_tree_is_leaf_not_traced(self):
-        # Test that torch.utils._pytree.tree_is_leaf is not traced into
-        # when is_leaf parameter is None (the common case)
-        from torch.utils._pytree import tree_is_leaf
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(x, y):
-            # Test with various types
-            # Tensors are leaves
-            is_leaf_tensor = tree_is_leaf(x)
-            assert is_leaf_tensor is True  # noqa: S101
-
-            # Lists are not leaves (they're in SUPPORTED_NODES)
-            is_leaf_list = tree_is_leaf([x, y])
-            assert is_leaf_list is False  # noqa: S101
-
-            # Dicts are not leaves
-            is_leaf_dict = tree_is_leaf({"a": x, "b": y})
-            assert is_leaf_dict is False  # noqa: S101
-
-            return x + y
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_ordered_set_doesnt_recompile_with_ac(self):
-        import torch
-
-        with torch._dynamo.config.patch({"error_on_recompile": True}):
-            import functools
-
-            from torch.utils._ordered_set import OrderedSet
-            from torch.utils.checkpoint import (
-                checkpoint,
-                CheckpointPolicy,
-                create_selective_checkpoint_contexts,
-            )
-
-            def policy(compute_heavy_ops, ctx, func, *args, **kwargs):
-                if func in compute_heavy_ops:
-                    return CheckpointPolicy.MUST_SAVE
-                return CheckpointPolicy.PREFER_RECOMPUTE
-
-            def g(x):
-                return torch.mm(x, x).sin().exp()
-
-            @torch.compile(fullgraph=True, backend="eager")
-            def f(x, policy):
-                return checkpoint(g, x, use_reentrant=False, context_fn=policy)
-
-            x = torch.randn(4, 4, requires_grad=True)
-            f(
-                x,
-                functools.partial(
-                    create_selective_checkpoint_contexts,
-                    functools.partial(policy, OrderedSet([torch.ops.aten.mm.default])),
-                ),
-            )
-            f(
-                x,
-                functools.partial(
-                    create_selective_checkpoint_contexts,
-                    functools.partial(policy, OrderedSet([torch.ops.aten.mm.default])),
-                ),
-            )
-
-    def test_mro_source_cache_includes_attr_name(self):
-        # Base -> Mid -> A hierarchy: two class attributes with the same
-        # interned integer value share the same id().  The mro_source_cache
-        # must include the attribute name in its key; otherwise the second
-        # lookup returns the first attribute's source, installing a guard
-        # on the wrong key and missing mutations to the second attribute.
-        class Base:
-            x = 1
-            y = 1
-
-        class Mid(Base):
-            pass
-
-        class A(Mid):
-            pass
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt)
-        def fn(obj, t):
-            return t * obj.x + t * obj.y
-
-        obj = A()
-        t = torch.tensor([1.0])
-        result = fn(obj, t)
-        self.assertEqual(result, torch.tensor([2.0]))
-        self.assertEqual(cnt.frame_count, 1)
-
-        # Changing y on Base must trigger recompilation.
-        Base.y = 42
-        result = fn(obj, t)
-        self.assertEqual(result, torch.tensor([43.0]))
-        self.assertEqual(cnt.frame_count, 2)
-
-    def test_pytree_tree_is_leaf_with_namedtuple(self):
-        # Test that torch.utils._pytree.tree_is_leaf handles namedtuples correctly
-        from collections import namedtuple
-
-        from torch.utils._pytree import tree_is_leaf
-
-        Point = namedtuple("Point", ["x", "y"])
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(a, b):
-            # Namedtuples are not leaves (they're in SUPPORTED_NODES)
-            point = Point(a, b)
-            is_leaf_namedtuple = tree_is_leaf(point)
-            assert is_leaf_namedtuple is False  # noqa: S101
-
-            # But individual tensors are leaves
-            is_leaf_tensor = tree_is_leaf(a)
-            assert is_leaf_tensor is True  # noqa: S101
-
-            return a + b
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_data_attr_mutation_with_noop_add(self):
-        # Regression test: remove_no_ops incorrectly eliminated add(x, 0) -> x
-        # when x was subsequently mutated by set_, causing the return value to
-        # alias the mutated input instead of being an independent copy.
-        def fn(a, b):
-            a.data = b
-            b.data = torch.zeros_like(b)
-            return a + b
-
-        a = torch.tensor([True, False, True, False])
-        b = torch.tensor([False, False, True, True])
-        a_ = a.clone()
-        b_ = b.clone()
-        cfunc = torch.compile(fn, backend="inductor")
-        res1 = fn(a, b)
-        res2 = cfunc(a_, b_)
-        self.assertEqual(res1, res2)
-
-    def test_custom_op_mutation_with_noop_add(self):
-        @torch.library.custom_op("test_repros::mutate_tensor", mutates_args={"x"})
-        def mutate_tensor(x: torch.Tensor, src: torch.Tensor) -> None:
-            x.copy_(src)
-
-        def fn(b):
-            zeros = torch.zeros_like(b)
-            result = b + zeros
-            mutate_tensor(b, zeros)
-            return result
-
-        b = torch.tensor([4.0, 5.0, 6.0])
-        b_ = b.clone()
-        cfunc = torch.compile(fn, backend="inductor")
-        res1 = fn(b)
-        res2 = cfunc(b_)
-        self.assertEqual(res1, res2)
-
-    def test_getset_descriptor_objclass_identity(self):
-        # GetSetDescriptor.__objclass__ should preserve identity with the class
-        # under torch.compile. This is needed for inspect.getattr_static (and
-        # therefore inspect.signature) to work on callable class instances.
-        class Foo:
-            pass
-
-        desc = Foo.__dict__["__dict__"]
-
-        @torch.compile(backend="eager", fullgraph=True)
-        def f(x):
-            if desc.__objclass__ is Foo:
-                return x + 1.0
-            return x + 2.0
-
-        result = f(torch.tensor(0.0))
-        self.assertEqual(result.item(), 1.0)
-
-    def test_inspect_signature_callable_class(self):
-        # inspect.signature should work on callable class instances under
-        # torch.compile, needed by flex_attention's _get_mod_type.
-        class MyCallable:
-            def __call__(self, b, h, q_idx, kv_idx):
-                return q_idx >= kv_idx
-
-        obj = MyCallable()
-
-        @torch.compile(backend="eager", fullgraph=True)
-        def f(x):
-            sig = inspect.signature(obj)
-            num_params = sum(
-                1
-                for p in sig.parameters.values()
-                if p.default is inspect.Parameter.empty
-            )
-            return x + num_params
-
-        result = f(torch.tensor(0.0))
-        self.assertEqual(result.item(), 4.0)
-
-    def test_enum_with_class_values(self):
-        from enum import Enum
-
-        class AvgMetric:
-            def __init__(self):
-                self.sum = None
-                self.count = 0
-
-            def append(self, x):
-                if self.count > 0:
-                    self.sum = self.sum + x
-                else:
-                    self.sum = x.clone()
-                self.count += 1
-
-        class GlobalReduction(Enum):
-            AVG = AvgMetric
-
-        class ScalarLogger:
-            def __init__(self):
-                self.metrics = {}
-
-            def log(self, key, value, global_reduction):
-                if key not in self.metrics:
-                    self.metrics[key] = global_reduction.value()
-                self.metrics[key].append(value)
-
-        @torch.compile(backend="eager", fullgraph=True)
-        def fn(logger, x):
-            logger.log("test", x, GlobalReduction.AVG)
-            return x + 1
-
-        logger = ScalarLogger()
-        fn(logger, torch.tensor(1.0))
-
-    def test_class_attr_mutation_recompiles(self):
-        class GlobalState:
-            factor = 1.0
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt)
-        def fn(x):
-            return x * GlobalState.factor
-
-        x = torch.tensor([4.0])
-
-        GlobalState.factor = 1.0
-        result1 = fn(x)
-        self.assertEqual(result1, torch.tensor([4.0]))
-        self.assertEqual(cnt.frame_count, 1)
-
-        GlobalState.factor = 10.0
-        result2 = fn(x)
-        self.assertEqual(result2, torch.tensor([40.0]))
-        self.assertEqual(cnt.frame_count, 2)
 
     @skipIfHpu
     def test_deterministic_pad_replicate_compile(self, device):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -74,7 +74,6 @@ from torch.testing._internal.common_device_type import (
     E4M3_MAX_POS,
     e4m3_type,
     instantiate_device_type_tests,
-    onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -979,12 +978,10 @@ class IncByTwo:
 
 
 class LRUCacheWarningTests(LoggingTestCase):
-    @unittest.skipUnless(torch.accelerator.is_available(), "requires accelerator")
-    @make_logging_test(dynamo=logging.DEBUG)
-    def test_lru_cache_warning_issued_during_tracing(self, records):
-        prev_default = torch._C._get_default_device()
-        try:
-            torch.set_default_device(torch.accelerator.current_accelerator())
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_lru_cache_warning_issued_during_tracing(self, device):
+        with self.assertNoLogs(level="WARNING"):
 
             @torch.compile(backend="eager")
             def f(x):
@@ -992,17 +989,8 @@ class LRUCacheWarningTests(LoggingTestCase):
                 x = x.cos().sin()
                 return x
 
-            result = f(torch.randn(1024))
+            result = f(torch.randn(1024, device=device))
             self.assertIsInstance(result, torch.Tensor)
-        finally:
-            if prev_default == "cpu":
-                torch.set_default_device(None)
-            else:
-                torch.set_default_device(prev_default)
-
-        for record in records:
-            if "call to a lru_cache wrapped function at:" in record.getMessage():
-                self.fail("lru_cache warning was incorrectly logged")
 
 
 class ReproTests(torch._dynamo.test_case.TestCase):
@@ -4765,49 +4753,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(x1, x2)
         self.assertEqual(x1.data, x2.data)
         self.assertEqual(y1, y2)
-
-    @requires_cuda
-    def test_tensor_set_data_cross_device(self):
-        def func(x):
-            x.data = x.data.to("cuda")
-            return x + 1
-
-        x_eager = torch.randn(4, device="cpu")
-        x_compiled = x_eager.clone()
-
-        out_eager = func(x_eager)
-        out_compiled = torch.compile(func, backend="eager", fullgraph=True)(x_compiled)
-
-        self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(x_eager.device, x_compiled.device)
-
-    @requires_cuda
-    def test_tensor_set_data_cross_device_shape_mismatch_graphbreaks(self):
-        def func(x):
-            x.data = torch.randn(8, device="cuda")
-            return x + 1
-
-        x = torch.randn(4, device="cpu")
-        with self.assertRaises(torch._dynamo.exc.Unsupported):
-            torch.compile(func, backend="eager", fullgraph=True)(x)
-
-    @requires_cuda
-    def test_tensor_set_data_cross_device_placeholder_metadata(self):
-        backend = torch._dynamo.testing.EagerAndRecordGraphs()
-
-        def func(x):
-            x.data = x.data.to("cuda")
-            return x + 1
-
-        x = torch.randn(4, device="cpu")
-        torch.compile(func, backend=backend, fullgraph=True)(x)
-
-        gm = backend.graphs[0]
-        for node in gm.graph.nodes:
-            if node.op == "placeholder":
-                ev = node.meta.get("example_value")
-                if isinstance(ev, torch.Tensor):
-                    self.assertEqual(ev.device.type, "cpu")
 
     def test_user_ctor_ctx_manager(self):
         class UserCtxManager:
@@ -9391,8 +9336,49 @@ SavedForBackwardsAOTOutput(idx=5)""",
 
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_tensor_set_data_cross_device(self, device):
+        def func(x):
+            x.data = x.data.to(device)
+            return x + 1
+
+        x_eager = torch.randn(4, device="cpu")
+        x_compiled = x_eager.clone()
+
+        out_eager = func(x_eager)
+        out_compiled = torch.compile(func, backend="eager", fullgraph=True)(x_compiled)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(x_eager.device, x_compiled.device)
+
+    def test_tensor_set_data_cross_device_shape_mismatch_graphbreaks(self, device):
+        def func(x):
+            x.data = torch.randn(8, device=device)
+            return x + 1
+
+        x = torch.randn(4, device="cpu")
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(func, backend="eager", fullgraph=True)(x)
+
+    def test_tensor_set_data_cross_device_placeholder_metadata(self, device):
+        backend = torch._dynamo.testing.EagerAndRecordGraphs()
+
+        def func(x):
+            x.data = x.data.to(device)
+            return x + 1
+
+        x = torch.randn(4, device="cpu")
+        torch.compile(func, backend=backend, fullgraph=True)(x)
+
+        gm = backend.graphs[0]
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                ev = node.meta.get("example_value")
+                if isinstance(ev, torch.Tensor):
+                    self.assertEqual(ev.device.type, "cpu")
+
     @serialTest()
-    @onlyAccelerator
     def test_mem_leak_guards(self, device):
         def gn(x0, x):
             return x0 * x
@@ -9584,7 +9570,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
     # https://github.com/pytorch/pytorch/issues/156580
     @serialTest()
-    @onlyAccelerator
     def test_dont_dce_rand(self, device):
         # https://github.com/pytorch/pytorch/issues/143431
         def f(image_latent):
@@ -9617,7 +9602,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
                 self.assertEqual(actual, expected)
 
     # https://github.com/pytorch/pytorch/issues/151670
-    @onlyAccelerator
     def test_diagonal_scatter_single_elem_cpu_with_gpu_tensor(self, device):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -9736,7 +9720,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(out3_ref.shape, out3_test.shape)
         self.assertEqual(out3_ref.stride(), out3_test.stride())
 
-    @onlyAccelerator
     def test_memleak_when_graph_input_has_tensor_attr(self, device):
         @torch.compile(backend="eager")
         def f(x):
@@ -9944,7 +9927,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         # (aka if you set torch._functorch.config.treat_parameters_as_free_to_save = False)
         self.assertEqual(mode.ops_counter[torch.ops.aten._to_copy.default], 5)
 
-    @onlyAccelerator
     def test_zero_dim_param_mixed_device_grad(self, device):
         # cpu 0-dim params with cuda grads
         # https://github.com/pytorch/pytorch/issues/160084
@@ -10141,9 +10123,8 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             lambda msg: f"{msg}\nStrides should match in eager: {compiled_a_stride} against {compiled_cloned_stride}",
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     @torch._dynamo.config.patch(capture_scalar_outputs=False)
-    def test_aot_backward_context_reentry_after_graph_break(self):
+    def test_aot_backward_context_reentry_after_graph_break(self, device):
         def fn(x, y, scalar):
             cpu = x.cpu()
             other_cpu = x.cpu()
@@ -10152,29 +10133,53 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             after_break = y.cos()
             return before_break, after_break
 
-        x = torch.randn(8, device="cuda", requires_grad=True)
-        y = torch.randn(8, device="cuda", requires_grad=True)
-        scalar = torch.randn((), device="cuda")
+        x = torch.randn(8, device=device, requires_grad=True)
+        y = torch.randn(8, device=device, requires_grad=True)
+        scalar = torch.randn((), device=device)
 
         before_break, after_break = torch.compile(fn, backend="aot_eager")(x, y, scalar)
-        loss = before_break.sum().to("cuda") + after_break.sum()
+        loss = before_break.sum().to(device) + after_break.sum()
         loss.backward()
 
         self.assertEqual(x.grad, torch.ones_like(x))
         self.assertEqual(y.grad, -y.detach().sin())
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_sync(self):
+    def test_accelerator_sync(self, device):
         def fn(x):
             y = x + 1
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             return y * 2
 
-        x = torch.ones(2, device="cuda")
+        x = torch.ones(2, device=device)
         cnt = torch._dynamo.testing.CompileCounter()
         opt_fn = torch.compile(fn, backend=cnt)
         self.assertEqual(fn(x), opt_fn(x))
         self.assertEqual(cnt.frame_count, 1)
+
+    def test_device_context_matmul_avoids_native_bmm_router_graph_break(self, device):
+        torch._dynamo.utils.counters.clear()
+
+        @torch.compile(backend="inductor", dynamic=False)
+        def fn(q, k):
+            with torch.device(device):
+                a = torch.reshape(q, [-1, 8, 1, 32])
+                return torch.matmul(a, k)
+
+        q = torch.randn(64, 8 * 32, device=device, dtype=torch.float16)
+        k = torch.randn(1, 8, 32, 128, device=device, dtype=torch.float16)
+
+        out = fn(q, k)
+        torch.accelerator.synchronize()
+        self.assertEqual(out.shape, (64, 8, 1, 128))
+
+        graph_break_reasons = "\n".join(
+            torch._dynamo.utils.counters["graph_break"].keys()
+        )
+        # The native router should not run trace-unsafe eager predicates here.
+        # If it does, the COW probe on the reshaped operand graph-breaks before
+        # it can fold or install a guard.
+        self.assertNotIn("_is_cow_tensor", graph_break_reasons)
+        self.assertNotIn("call_boxed", graph_break_reasons)
 
 
 class CUDAReproTests(torch._dynamo.test_case.TestCase):
@@ -10349,11 +10354,15 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
 
 
 instantiate_parametrized_tests(ReproTests)
-
-devices = ["cuda", "hpu", "xpu"]
 instantiate_device_type_tests(
-    ReproTestsDevice, globals(), only_for=devices, allow_xpu=True
+    LRUCacheWarningTests, globals(), except_for="cpu", allow_xpu=True, allow_mps=True
 )
+instantiate_device_type_tests(
+    ReproTestsDevice, globals(), except_for="cpu", allow_xpu=True, allow_mps=True
+)
+instantiate_device_type_tests(CUDAReproTests, globals(), only_for="cuda")
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -13,7 +13,6 @@ import gc
 import importlib
 import inspect
 import itertools
-import logging
 import os
 import random
 import sys
@@ -64,16 +63,12 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 from torch.profiler import profile, ProfilerActivity
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_BF16,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_FP8,
-    SM70OrLater,
-)
 from torch.testing._internal.common_device_type import (
+    Capability,
     E4M3_MAX_POS,
     e4m3_type,
     instantiate_device_type_tests,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -87,6 +82,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     xfailIfS390X,
 )
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.logging_utils import LoggingTestCase
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -6297,10 +6293,7 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
         )
         self.assertEqual(actual_str, expected_str)
 
-    @unittest.skipIf(
-        not SM70OrLater,
-        "Triton only supports devices of CUDA capability >= 7.0",
-    )
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     def test_add_complex_conj(self):
         def f(x):
             return x + x.conj()
@@ -9669,10 +9662,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             torch.set_default_device(None)
 
     @skipIfHpu
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "flash attention not supported",
-    )
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_flash_attn_backward_mixed_strides(self, device):
         # in this repro, "grad_out" and "value" are transposed tensors,
         # but "key" and "value" are contiguous
@@ -9788,7 +9778,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             out = f_compiled(x, s0, s1, s2)
             self.assertEqual(out_ref, out)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "requires gpu with fp8 support")
+    @requires_capabilities(Capability.dtype.fp8)
     def test_partitioner_saves_weights_for_bw(self, device):
         def mul_tiled(a, *bs):
             for b in bs:
@@ -9928,7 +9918,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(mode.ops_counter[torch.ops.aten._to_copy.default], 5)
 
     def test_zero_dim_param_mixed_device_grad(self, device):
-        # cpu 0-dim params with cuda grads
+        # cpu 0-dim params with accelerator grads
         # https://github.com/pytorch/pytorch/issues/160084
         class RegressionModel(torch.nn.Module):
             def __init__(self, a=0, b=0):
@@ -9966,10 +9956,9 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             ref_grad = torch.autograd.grad(ref.sum(), x)
             self.assertEqual(grad, ref_grad)
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM or not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "flash attention not supported",
-    )
+    @unittest.skipIf(TEST_WITH_ROCM, "ROCm not supported")
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_flex_attention_guard_on_constant_func_defaults(self, device):
         """
         Dynamo must guard on mask_mod.__defaults__ so that when a
@@ -9977,10 +9966,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         mask_mod has the same __code__ but different __defaults__,
         Dynamo recompiles instead of reusing the stale first graph.
         """
-        from torch.utils._triton import has_triton
-
-        if not has_triton():
-            self.skipTest("requires triton")
 
         @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def flex_chunk(q, k, v, block_mask, scale):
@@ -10223,7 +10208,7 @@ class CUDAReproTests(torch._dynamo.test_case.TestCase):
         # retained the real CUDA scalar through FakeTensor.constant.
         self.assertIsNotNone(opt_f)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_BF16, "requires CUDA bf16 support")
+    @requires_capabilities(Capability.dtype.bf16)
     def test_layer_norm_mixed_dtype_aot_eager_decomp_partition_errors(self, device):
         # https://github.com/pytorch/pytorch/issues/151478
         x = torch.tensor(
@@ -10358,7 +10343,10 @@ instantiate_device_type_tests(
     LRUCacheWarningTests, globals(), except_for="cpu", allow_xpu=True, allow_mps=True
 )
 instantiate_device_type_tests(
-    ReproTestsDevice, globals(), except_for="cpu", allow_xpu=True, allow_mps=True
+    ReproTestsDevice,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
 )
 instantiate_device_type_tests(CUDAReproTests, globals(), only_for="cuda")
 


### PR DESCRIPTION
## Summary

Refactored the test suite to replace CUDA‑specific imports and capability checks with device‑agnostic requires_capabilities and HardwareClassification tags, reclassified test cases across ReproTests, ReproTestsDevice, and CUDAReproTests (moving 22 cases into ReproTests and 4 into ReproTestsDevice). 

## Changes

- **Removed CUDA-specific imports**: 
  Replaced `from torch.testing._internal.common_cuda import (PLATFORM_SUPPORTS_BF16, PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_FP8, SM70OrLater)` with device-agnostic imports (`HardwareClassification`, `Capability`, `requires_capabilities`).
- **Replaced capability check**: 
  - Changed `@unittest.skipIf(not SM70OrLater, ...)` to `@requires_capabilities(Capability.lib.triton)`.
  - Changed `@unittest.skipIf(not PLATFORM_SUPPORTS_BF16, "requires CUDA bf16 support")` to `@requires_capabilities(Capability.dtype.bf16)`.
  - Changed `@unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "flash attention not supported",)` to`@requires_capabilities(Capability.attention.flash_attention)`.
  - Changed `@unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "requires gpu with fp8 support")` to `@requires_capabilities(Capability.dtype.fp8)`.
- **Added hardware classification tags**:
  - `ReproTests` → `hw_classification = HardwareClassification.GENERIC`
  - `LRUCacheWarningTests` → `hw_classification = HardwareClassification.ACCELERATOR`
  - `ReproTestsDevice` → `hw_classification = HardwareClassification.ACCELERATOR`
  - `CUDAReproTests` → `hw_classification = HardwareClassification.CUDA`
- **Updated `LRUCacheWarningTests.test_lru_cache_warning_issued_during_tracing`**: 
  Refactored from manual `torch.set_default_device()` pattern to use `device` parameter with `instantiate_device_type_tests` style.
- **Reclassify test cases**:
  - Move  22 cases from  `ReproTestsDevice` to `ReproTests` : 
`test_getattr_return、test_data_dependent_error_log_no_print、test_deepcopy_constant_tensor_in_aot_bwd、test_module_attribute_error、test_named_tuple_vt_clone、test_filter_warnings、test_filter_safe_grad_warning、test_filter_user_warnings、test_partial_export、test_current_accelerator、test_pytree_get_node_type_not_traced、test_pytree_get_node_type_with_namedtuple、test_pytree_tree_is_leaf_not_traced、test_ordered_set_doesnt_recompile_with_ac、test_mro_source_cache_includes_attr_name、
test_pytree_tree_is_leaf_with_namedtuple、test_data_attr_mutation_with_noop_add、test_custom_op_mutation_with_noop_add 、 test_getset_descriptor_objclass_identity、test_inspect_signature_callable_class、test_enum_with_class_values、 test_class_attr_mutation_recompiles`
  - Refactor and move 3 cases from `ReproTests` to `ReproTestsDevice`  : `test_tensor_set_data_cross_device`、`test_tensor_set_data_cross_device_shape_mismatch_graphbreaks`、`test_tensor_set_data_cross_device_placeholder_metadata`.
  - Refactor and move 1 case from `CUDAReproTests` to `ReproTestsDevice` : `test_device_context_matmul_avoids_native_bmm_router_graph_break`
- **Removed `@onlyAccelerator`**

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98

