### PR TITLE
[Testcase Refactoring] Classify debug utility tests by hardware

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -18,6 +18,7 @@ from torch._dynamo.debug_utils import (
 from torch._dynamo.test_case import TestCase
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
@@ -27,6 +28,8 @@ i32 = torch.int32
 
 
 class TestDebugUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_serialize_symbolic_storage_nbytes(self):
         from sympy import floor
 
@@ -197,6 +200,8 @@ def forward(self, x_1):
 
 
 class TestDebugUtilsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_aot_graph_parser(self, device):
         def forward(
             self,
@@ -307,6 +312,8 @@ class TestDebugUtilsDevice(TestCase):
 
 
 class TestNNModuleToStringBufferDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_nn_module_to_string_buffer_device(self, device):
         gm = torch.fx.symbolic_trace(torch.nn.Identity())
         gm.register_buffer("test_buf", torch.empty(5, device=device))
@@ -340,14 +347,14 @@ instantiate_device_type_tests(
     TestNNModuleToStringBufferDevice, globals(), allow_xpu=True
 )
 
-instantiate_device_type_tests(TestDebugUtils, globals())
-
 instantiate_device_type_tests(
     TestDebugUtilsDevice, globals(), except_for="mps", allow_xpu=True
 )
 
 
 class TestBackendOverrideIntegration(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()
@@ -513,6 +520,8 @@ instantiate_device_type_tests(
 
 
 class TestInductorConfigOverrideIntegration(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()
@@ -916,12 +925,13 @@ class TestInductorConfigOverrideIntegration(TestCase):
 instantiate_device_type_tests(
     TestInductorConfigOverrideIntegration,
     globals(),
-    only_for=["cpu", "cuda", "xpu"],
     allow_xpu=True,
 )
 
 
 class TestConfigOverrideValidation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         from torch._dynamo.graph_id_filter import (
@@ -971,6 +981,8 @@ class TestConfigOverrideValidation(TestCase):
 
 
 class TestDynamoConfigOverrideIntegration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -19,7 +19,6 @@ from torch._dynamo.test_case import TestCase
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification
-from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
 f32 = torch.float32
@@ -325,7 +324,6 @@ class TestNNModuleToStringBufferDevice(TestCase):
         else:
             expected_device = str(torch.empty(1, device=device).device)
             self.assertIn(f'.to("{expected_device}")', result)
-            self.assertNotIn(f".{GPU_TYPE}()", result)
 
     def test_nn_module_to_string_param_device(self, device):
         gm = torch.fx.symbolic_trace(torch.nn.Identity())
@@ -340,7 +338,6 @@ class TestNNModuleToStringBufferDevice(TestCase):
         else:
             expected_device = str(torch.empty(1, device=device).device)
             self.assertIn(f'device="{expected_device}"', result)
-            self.assertNotIn(f', device="{GPU_TYPE}")', result)
 
 
 instantiate_device_type_tests(
@@ -925,6 +922,7 @@ class TestInductorConfigOverrideIntegration(TestCase):
 instantiate_device_type_tests(
     TestInductorConfigOverrideIntegration,
     globals(),
+    except_for="hpu",
     allow_xpu=True,
 )
 

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -324,6 +324,7 @@ class TestNNModuleToStringBufferDevice(TestCase):
         else:
             expected_device = str(torch.empty(1, device=device).device)
             self.assertIn(f'.to("{expected_device}")', result)
+            self.assertNotIn(f".{torch.device(device).type}()", result)
 
     def test_nn_module_to_string_param_device(self, device):
         gm = torch.fx.symbolic_trace(torch.nn.Identity())
@@ -338,6 +339,7 @@ class TestNNModuleToStringBufferDevice(TestCase):
         else:
             expected_device = str(torch.empty(1, device=device).device)
             self.assertIn(f'device="{expected_device}"', result)
+            self.assertNotIn(f', device="{torch.device(device).type}")', result)
 
 
 instantiate_device_type_tests(


### PR DESCRIPTION
## Summary
Add hardware classification metadata for Dynamo debug utility tests.

## Changes
- Import HardwareClassification for the test file.
- Mark generic debug utility test classes as HardwareClassification.GENERIC.
- Mark device-instantiated debug utility test classes as HardwareClassification.ACCELERATOR.

## Test plan
```bash
python -m py_compile test/dynamo/test_debug_utils.py
git diff --check -- test/dynamo/test_debug_utils.py
```
ok


### Environment
| Item | Version |
|------|---------|
| PyTorch | 2.14.0+gitee7bc39 |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98