### PR TITLE
[TEST] Refactor test_package_fx and test_model.py with hw_classification

### DIFF
--- a/test/package/test_model.py
+++ b/test/package/test_model.py
@@ -6,7 +6,12 @@ from unittest import skipIf
 
 import torch
 from torch.package import PackageExporter, PackageImporter, sys_importer
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    IS_SANDCASTLE,
+    run_tests,
+)
 
 
 try:
@@ -31,6 +36,8 @@ except ImportError:
 @skipIfNoTorchVision
 class ModelTest(PackageTestCase):
     """End-to-end tests packaging an entire model."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIf(
         IS_FBCODE or IS_SANDCASTLE,

--- a/test/package/test_package_fx.py
+++ b/test/package/test_package_fx.py
@@ -10,7 +10,7 @@ from torch.package import (
     PackageImporter,
     sys_importer,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -26,6 +26,8 @@ torch.fx.wrap("len")
 
 class TestPackageFX(PackageTestCase):
     """Tests for compatibility with FX."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_package_fx_simple(self):
         class SimpleTest(torch.nn.Module):


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.GENERIC` to `TestPackageFX` (`test_package_fx.py`) — 7 tests covering FX tracing + package serialization
- Add `hw_classification = HardwareClassification.GENERIC` to `ModelTest` (`test_model.py`) — 3 tests covering model packaging/scripting (class is currently unconditionally skipped pending [#81115](https://github.com/pytorch/pytorch/issues/81115))

Both classes exercise `torch.package` serialization and FX/TorchScript integration with no device-specific code, making GENERIC the correct classification.

## Test Plan

```
python test/package/test_package_fx.py -v --hw-classification GENERIC
Ran 7 tests in 2.269s -- OK

python test/package/test_model.py -v --hw-classification GENERIC
Ran 3 tests in 0.899s -- OK (skipped=3)
```