### PR TITLE
[TEST] Tag package and cpp extension tests with hw_classification

### DIFF
--- a/test/package/test_directory_reader.py
+++ b/test/package/test_directory_reader.py
@@ -10,6 +10,7 @@ from unittest import skipIf
 import torch
 from torch.package import PackageExporter, PackageImporter
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_FBCODE,
     IS_SANDCASTLE,
     IS_WINDOWS,
@@ -44,6 +45,8 @@ packaging_directory = Path(__file__).parent
 )
 class DirectoryReaderTest(PackageTestCase):
     """Tests use of DirectoryReader as accessor for opened packages."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfNoTorchVision
     @skipIf(

--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -8,6 +8,7 @@ import torch
 import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_LINUX,
     skipIfTorchDynamo,
@@ -31,6 +32,7 @@ TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 class TestCppExtensionMTIABackend(common.TestCase):
     """Tests MTIA backend with C++ extensions."""
 
+    hw_classification = HardwareClassification.GENERIC
     module = None
 
     def setUp(self):

--- a/test/test_cpp_extensions_stream_and_event.py
+++ b/test/test_cpp_extensions_stream_and_event.py
@@ -8,6 +8,7 @@ import torch
 import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_LINUX,
     skipIfTorchDynamo,
@@ -40,6 +41,7 @@ TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 class TestCppExtensionStreamAndEvent(common.TestCase):
     """Tests Stream and Event with C++ extensions."""
 
+    hw_classification = HardwareClassification.GENERIC
     module = None
 
     def setUp(self):


### PR DESCRIPTION
Annotate test classes in `test/package/test_directory_reader.py`, `test/test_cpp_extensions_mtia_backend.py`, and `test/test_cpp_extensions_stream_and_event.py` with `hw_classification` as part of the ongoing test refactoring initiative [#186918](https://github.com/pytorch/pytorch/pull/186918).

### Changes

- **`DirectoryReaderTest`** → `GENERIC`: torch.package DirectoryReader tests with CPU tensors and filesystem I/O; no accelerator dependency (8 methods)
- **`TestCppExtensionMTIABackend`** → `GENERIC`: C++ extension tests via fake MTIA device backend shim exercising generic device/stream APIs; Linux-only with mutual-exclusion skips when real backends are present, not real MTIA hardware (7 methods)
- **`TestCppExtensionStreamAndEvent`** → `GENERIC`: C++ extension stream/event bindings tested through the same fake MTIA shim; single generic infrastructure test, mutually exclusive skip guards (1 method)

### Test plan

```
python test/package/test_directory_reader.py -v
python test/test_cpp_extensions_mtia_backend.py -v
python test/test_cpp_extensions_stream_and_event.py -v
```

Authored with an AI assistant.

cc: @mansiag05 @RiyaP2508 