### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -16,7 +16,9 @@ from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
 from torch._logging import trace_structured
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton
 
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
@@ -65,7 +67,7 @@ def tearDownModule():
         _PRIOR_FP32_MATMUL_PRECISION = None
 
 
-@unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU and Triton")
+@unittest.skipUnless(has_triton(), "Triton not available")
 @unittest.skipIf(not IS_ROCM, "Origami integration is ROCm-only")
 @unittest.skipIf(
     not ORIGAMI_ROCM_SUPPORTED,
@@ -78,23 +80,25 @@ def tearDownModule():
     "Set TORCHINDUCTOR_MAX_AUTOTUNE=1 TORCHINDUCTOR_ORIGAMI=1 to run.",
 )
 class TestOrigami(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def _make_fn_and_inputs(
-        self, op_name: str, size: int
+        self, op_name: str, size: int, device: str
     ) -> tuple[Callable[..., torch.Tensor], tuple[torch.Tensor, ...]]:
         torch.manual_seed(0)
 
         if op_name == "bmm":
             batch = 4
-            a = torch.randn(batch, size, size, device=GPU_TYPE, dtype=torch.float16)
-            b = torch.randn(batch, size, size, device=GPU_TYPE, dtype=torch.float16)
+            a = torch.randn(batch, size, size, device=device, dtype=torch.float16)
+            b = torch.randn(batch, size, size, device=device, dtype=torch.float16)
 
             def fn(x, y):
                 return torch.bmm(x, y)
 
             return fn, (a, b)
 
-        a = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(size, size, device=device, dtype=torch.float16)
+        b = torch.randn(size, size, device=device, dtype=torch.float16)
 
         if op_name == "mm":
 
@@ -104,7 +108,7 @@ class TestOrigami(TestCase):
             return fn, (a, b)
 
         if op_name == "addmm":
-            bias = torch.randn(size, size, device=GPU_TYPE, dtype=torch.float16)
+            bias = torch.randn(size, size, device=device, dtype=torch.float16)
 
             def fn(inp, x, y):
                 return torch.addmm(inp, x, y)
@@ -126,8 +130,9 @@ class TestOrigami(TestCase):
         patch_config: dict[str, object],
         *,
         size: int,
+        device: str,
     ) -> dict[str, object]:
-        fn, args = self._make_fn_and_inputs(op_name, size)
+        fn, args = self._make_fn_and_inputs(op_name, size, device)
         expected = fn(*args)
 
         torch._dynamo.reset()
@@ -187,13 +192,14 @@ class TestOrigami(TestCase):
             "triton.native_matmul": False,
         }
 
-    def test_origami_respects_gemm_search_space(self):
+    def test_origami_respects_gemm_search_space(self, device):
         for op_name in ("mm", "addmm", "bmm"):
             with self.subTest(op_name=op_name, search_space="DEFAULT"):
                 default_case = self._compile_with_config(
                     op_name,
                     self._origami_default_config(ORIGAMI_TOPK_VALUES[0]),
                     size=256,
+                    device=device,
                 )
                 self.assertGreater(default_case["topk_calls"], 0)
 
@@ -202,10 +208,11 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_exhaustive_config(),
                     size=256,
+                    device=device,
                 )
                 self.assertEqual(exhaustive_case["topk_calls"], 0)
 
-    def test_origami_reduces_compile_work_vs_regular_max_autotune(self):
+    def test_origami_reduces_compile_work_vs_regular_max_autotune(self, device):
         """Test that origami reduces compile work (GPU benchmarking calls) vs regular max_autotune.
 
         Uses benchmark_gpu_calls count instead of wall-clock timing to avoid flakiness
@@ -217,11 +224,13 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_default_config(ORIGAMI_COMPILE_TOPK),
                     size=256,
+                    device=device,
                 )
                 max_autotune_case = self._compile_with_config(
                     op_name,
                     self._max_autotune_default_config(),
                     size=256,
+                    device=device,
                 )
                 # Origami with topk should benchmark fewer configs than full max_autotune
                 self.assertLess(
@@ -235,7 +244,7 @@ class TestOrigami(TestCase):
         not DO_PERF_TEST,
         "Perf test not enabled; set DO_PERF_TEST=1 to enable runtime perf benchmarks",
     )
-    def test_origami_runtime_matches_regular_max_autotune(self):
+    def test_origami_runtime_matches_regular_max_autotune(self, device):
         for op_name in ("mm", "addmm", "bmm"):
             for size in (8192, 16384):
                 for topk in ORIGAMI_TOPK_VALUES:
@@ -244,11 +253,13 @@ class TestOrigami(TestCase):
                             op_name,
                             self._origami_default_config(topk),
                             size=size,
+                            device=device,
                         )
                         max_autotune_case = self._compile_with_config(
                             op_name,
                             self._max_autotune_default_config(),
                             size=size,
+                            device=device,
                         )
 
                         origami_runtime_ms = benchmarker.benchmark(
@@ -296,7 +307,7 @@ class TestOrigami(TestCase):
                             max_autotune_runtime_ms * PERF_SLOWDOWN_TOLERANCE,
                         )
 
-    def test_origami_topk_edge_cases(self):
+    def test_origami_topk_edge_cases(self, device):
         """Test edge cases for origami_topk parameter.
 
         This test validates:
@@ -315,6 +326,7 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_default_config(0),
                     size=size,
+                    device=device,
                 )
                 # Should complete compilation even with topk=0
                 self.assertIsNotNone(result["compiled"])
@@ -329,6 +341,7 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_default_config(1),
                     size=size,
+                    device=device,
                 )
                 self.assertIsNotNone(result["compiled"])
                 # With topk=1, origami should still be invoked for selection
@@ -344,6 +357,7 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_default_config(1000),
                     size=size,
+                    device=device,
                 )
                 self.assertIsNotNone(result["compiled"])
                 # Large topk should not cause issues, just select all available
@@ -360,6 +374,7 @@ class TestOrigami(TestCase):
                     op_name,
                     self._origami_default_config(-1),
                     size=size,
+                    device=device,
                 )
                 # If compilation succeeds with negative topk, that is also valid
                 # (implementation may coerce to 0 or similar)
@@ -378,6 +393,7 @@ class TestOrigami(TestCase):
                 op_name,
                 self._origami_default_config(3),
                 size=size,
+                device=device,
             )
             self.assertIsNotNone(result["compiled"])
 
@@ -390,6 +406,7 @@ class TestOrigami(TestCase):
                         op_name,
                         self._origami_default_config(topk_val),
                         size=size,
+                        device=device,
                     )
                     self.assertIsNotNone(result["compiled"])
                     # Valid topk should always trigger origami selection
@@ -401,14 +418,13 @@ class TestOrigami(TestCase):
                 except Exception as e:
                     self.fail(f"Compilation failed with valid topk={topk_val}: {e}")
 
-    def test_origami_configs_use_device_specific_values(self):
+    def test_origami_configs_use_device_specific_values(self, device):
         """Verify that origami configs use architecture-specific num_stages and num_warps.
 
         Tests that configurations are derived from device properties (MI300 vs MI350X)
         rather than hardcoded values. This ensures portability across AMD GPU models.
         """
-        device = torch.device("cuda:0")
-        device_props = torch.cuda.get_device_properties(device)
+        device_props = torch.get_device_module(device).get_device_properties(device)
 
         # Compile a simple MM operation with origami enabled
         torch.manual_seed(0)
@@ -444,7 +460,7 @@ class TestOrigami(TestCase):
             },
         )
 
-    def test_origami_fallback_when_disabled(self):
+    def test_origami_fallback_when_disabled(self, device):
         """Test that compilation succeeds when origami import fails or is disabled.
 
         Verifies that:
@@ -454,7 +470,7 @@ class TestOrigami(TestCase):
         """
         for op_name in ("mm", "addmm", "bmm"):
             with self.subTest(op_name=op_name):
-                fn, args = self._make_fn_and_inputs(op_name, 256)
+                fn, args = self._make_fn_and_inputs(op_name, 256, device)
                 expected = fn(*args)
 
                 torch._dynamo.reset()
@@ -481,6 +497,10 @@ class TestOrigami(TestCase):
                 # Verify compilation succeeded and produces correct results
                 torch.testing.assert_close(result, expected, atol=5e-2, rtol=5e-2)
                 self.assertIsNotNone(compiled)
+
+
+class TestOrigamiGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_origami_module_gate_when_env_var_disabled(self):
         """Verify origami is not imported/used when TORCHINDUCTOR_ORIGAMI=0.
@@ -530,7 +550,7 @@ class TestOrigami(TestCase):
 
 
 @unittest.skipIf(
-    HAS_GPU_AND_TRITON and ORIGAMI_ROCM_SUPPORTED,
+    has_triton() and ORIGAMI_ROCM_SUPPORTED,
     "Skipped on ROCm < 10.0 where origami is available",
 )
 class TestOrigamiSkippedOnNonROCm(TestCase):
@@ -544,7 +564,9 @@ class TestOrigamiSkippedOnNonROCm(TestCase):
     4. origami gracefully no-ops on unsupported hardware
     """
 
-    def test_origami_skipped_on_non_rocm(self):
+    hw_classification = HardwareClassification.CPU
+
+    def test_origami_skipped_on_non_rocm(self, device):
         """Verify that origami is properly skipped on non-ROCm devices.
 
         Tests that origami gracefully handles non-ROCm environments without
@@ -554,8 +576,8 @@ class TestOrigamiSkippedOnNonROCm(TestCase):
 
         # Use CPU device to ensure non-ROCm environment
         size = 128
-        a = torch.randn(size, size, device="cpu", dtype=torch.float32)
-        b = torch.randn(size, size, device="cpu", dtype=torch.float32)
+        a = torch.randn(size, size, device=device, dtype=torch.float32)
+        b = torch.randn(size, size, device=device, dtype=torch.float32)
 
         def test_fn(x, y):
             return torch.mm(x, y)
@@ -600,13 +622,13 @@ class TestOrigamiSkippedOnNonROCm(TestCase):
                 result = compiled(a, b)
                 torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-5)
 
-    def test_origami_disabled_uses_regular_config(self):
+    def test_origami_disabled_uses_regular_config(self, device):
         """Verify regular config generator is used when origami is explicitly disabled."""
         torch.manual_seed(0)
 
         size = 128
-        a = torch.randn(size, size, device="cpu", dtype=torch.float32)
-        b = torch.randn(size, size, device="cpu", dtype=torch.float32)
+        a = torch.randn(size, size, device=device, dtype=torch.float32)
+        b = torch.randn(size, size, device=device, dtype=torch.float32)
 
         def test_fn(x, y):
             return torch.mm(x, y)
@@ -656,6 +678,8 @@ class TestOrigamiVersionGate(TestCase):
     the module-level _rocm_version directly.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_origami_enabled_below_cutoff(self):
         """_origami_enabled() returns True on ROCm just below the cutoff."""
         import torch._inductor.heuristics.template.triton as th
@@ -697,6 +721,10 @@ class TestOrigamiVersionGate(TestCase):
             self.assertFalse(th._origami_enabled())
 
 
+instantiate_device_type_tests(TestOrigami, globals(), only_for="cuda")
+instantiate_device_type_tests(TestOrigamiSkippedOnNonROCm, globals(), only_for="cpu")
+
+
 if __name__ == "__main__":
-    if HAS_GPU_AND_TRITON and IS_ROCM:
+    if has_triton() and IS_ROCM:
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_origami.py
python test/inductor/test_origami.py -v --hw-classification CUDA
python test/inductor/test_origami.py -v --hw-classification GENERIC
python test/inductor/test_origami.py -v --hw-classification CPU

## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo