### PR TITLE
[Testcase Refactoring] Make test_runtime_estimator.py device-generic and add hw_classification label

### DIFF
--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -1,5 +1,4 @@
 # Owner(s): ["oncall: distributed"]
-import unittest
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
@@ -8,8 +7,16 @@ import torch
 from torch import nn, optim
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
-from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+    skipMPS,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -59,6 +66,8 @@ class SimpleCNN(nn.Module):
 
 
 class TestRuntimeEstimator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _train_step(
         self,
         model: nn.Module,
@@ -71,21 +80,23 @@ class TestRuntimeEstimator(TestCase):
         optimizer.step()
         optimizer.zero_grad()
 
-    def _measure_actual_cuda_time(
+    def _measure_actual_time(
         self,
         func: Callable,
         args: tuple[Any, ...],
+        device: str,
     ) -> float:
         warmup_iters, actual_iters = 2, 5
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
+        device_module = torch.get_device_module(torch.device(device))
+        start_event = device_module.Event(enable_timing=True)
+        end_event = device_module.Event(enable_timing=True)
         for _ in range(warmup_iters):
             func(*args)
         start_event.record()
         for _ in range(actual_iters):
             func(*args)
         end_event.record()
-        torch.cuda.synchronize()
+        device_module.synchronize()
         measured_time = start_event.elapsed_time(end_event) / actual_iters
         return measured_time
 
@@ -107,8 +118,9 @@ class TestRuntimeEstimator(TestCase):
         model_type: str,
         model_args: ConvArgs | ModelArgs,
         bsz: int,
+        device: str,
     ) -> tuple[nn.Module, optim.Optimizer, torch.Tensor]:
-        dev = torch.cuda.current_device()
+        dev = torch.device(device)
         if model_type == "Transformer":
             model_args = cast(ModelArgs, model_args)
             with torch.device(dev):
@@ -129,10 +141,9 @@ class TestRuntimeEstimator(TestCase):
             raise NotImplementedError("Only Transformer and CNN is supported")
         return (model, optimizer, inp)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_transformer_runtime(
-        self,
-    ):
+    @onlyAccelerator
+    @skipMPS
+    def test_transformer_runtime(self, device):
         """Runs a basic GPT-2 model"""
         vocab_size = 8192
         bsz, seq_len = 8, 1024
@@ -145,10 +156,10 @@ class TestRuntimeEstimator(TestCase):
             dropout_p=0.1,
         )
 
-        args = self._init_model_and_args("Transformer", model_args, bsz)
-        actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
+        args = self._init_model_and_args("Transformer", model_args, bsz, device)
+        actual_runtime = self._measure_actual_time(self._train_step, args, device)
         with FakeTensorMode():
-            fake_args = self._init_model_and_args("Transformer", model_args, bsz)
+            fake_args = self._init_model_and_args("Transformer", model_args, bsz, device)
             benchmark_estimate = self._runtime_estimate(
                 "operator-level-benchmark", self._train_step, fake_args
             )
@@ -165,18 +176,17 @@ class TestRuntimeEstimator(TestCase):
         # self.assertAlmostEqual(benchmark_accuracy, 1.0, delta=0.2)
         # self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.3)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_conv_model_runtime(
-        self,
-    ):
+    @onlyAccelerator
+    @skipMPS
+    def test_conv_model_runtime(self, device):
         """Runs a simple CNN model"""
         num_classes = 100
         bsz, img_sz = 256, 128
         model_args = ConvArgs(img_sz, num_classes)
-        args = self._init_model_and_args("CNN", model_args, bsz)
-        actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
+        args = self._init_model_and_args("CNN", model_args, bsz, device)
+        actual_runtime = self._measure_actual_time(self._train_step, args, device)
         with FakeTensorMode():
-            fake_args = self._init_model_and_args("CNN", model_args, bsz)
+            fake_args = self._init_model_and_args("CNN", model_args, bsz, device)
             benchmark_estimate = self._runtime_estimate(
                 "operator-level-benchmark", self._train_step, fake_args
             )
@@ -192,6 +202,9 @@ class TestRuntimeEstimator(TestCase):
         # No accuracy check for benchmark in CI as it is highly variable
         # self.assertAlmostEqual(benchmark_accuracy, 1.0, delta=0.2)
         # self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.4)
+
+
+instantiate_device_type_tests(TestRuntimeEstimator, globals())
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -7,11 +7,7 @@ import torch
 from torch import nn, optim
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-    skipMPS,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -141,8 +137,6 @@ class TestRuntimeEstimator(TestCase):
             raise NotImplementedError("Only Transformer and CNN is supported")
         return (model, optimizer, inp)
 
-    @onlyAccelerator
-    @skipMPS
     def test_transformer_runtime(self, device):
         """Runs a basic GPT-2 model"""
         vocab_size = 8192
@@ -159,7 +153,9 @@ class TestRuntimeEstimator(TestCase):
         args = self._init_model_and_args("Transformer", model_args, bsz, device)
         actual_runtime = self._measure_actual_time(self._train_step, args, device)
         with FakeTensorMode():
-            fake_args = self._init_model_and_args("Transformer", model_args, bsz, device)
+            fake_args = self._init_model_and_args(
+                "Transformer", model_args, bsz, device
+            )
             benchmark_estimate = self._runtime_estimate(
                 "operator-level-benchmark", self._train_step, fake_args
             )
@@ -167,7 +163,9 @@ class TestRuntimeEstimator(TestCase):
                 "operator-level-cost-model", self._train_step, fake_args
             )
         benchmark_accuracy = actual_runtime / benchmark_estimate
-        roofline_accuracy = actual_runtime / roofline_estimate
+        roofline_accuracy = (
+            actual_runtime / roofline_estimate if roofline_estimate else float("inf")
+        )
         print(
             f"Actual: {actual_runtime} Benchmark Estimate: {benchmark_estimate} Accuracy: {benchmark_accuracy}"
             f"\n Actual: {actual_runtime} Roofline Estimatee: {roofline_estimate} Accuracy: {roofline_accuracy}"
@@ -176,8 +174,6 @@ class TestRuntimeEstimator(TestCase):
         # self.assertAlmostEqual(benchmark_accuracy, 1.0, delta=0.2)
         # self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.3)
 
-    @onlyAccelerator
-    @skipMPS
     def test_conv_model_runtime(self, device):
         """Runs a simple CNN model"""
         num_classes = 100
@@ -194,7 +190,9 @@ class TestRuntimeEstimator(TestCase):
                 "operator-level-cost-model", self._train_step, fake_args
             )
         benchmark_accuracy = actual_runtime / benchmark_estimate
-        roofline_accuracy = actual_runtime / roofline_estimate
+        roofline_accuracy = (
+            actual_runtime / roofline_estimate if roofline_estimate else float("inf")
+        )
         print(
             f"Actual: {actual_runtime} Benchmark Estimate: {benchmark_estimate} Accuracy: {benchmark_accuracy}\n"
             f"Actual: {actual_runtime} Roofline Estimatee: {roofline_estimate} Accuracy: {roofline_accuracy}"
@@ -204,7 +202,7 @@ class TestRuntimeEstimator(TestCase):
         # self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.4)
 
 
-instantiate_device_type_tests(TestRuntimeEstimator, globals())
+instantiate_device_type_tests(TestRuntimeEstimator, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`test/distributed/_tools/test_runtime_estimator.py` measures actual device
execution time using `torch.cuda.Event(enable_timing=True)` and
`torch.cuda.synchronize()`, then compares it against `RuntimeEstimator`
estimates. Both test methods (`test_transformer_runtime` and
`test_conv_model_runtime`) use only Category A/B device APIs (Event, synchronize,
current_device) that have cross-backend equivalents, but their admission condition
is a hardcoded CUDA whitelist (`@unittest.skipIf(not TEST_CUDA, ...)`). This
wrongly skips them on any other accelerator backend (e.g. out-of-tree PrivateUse1
backends) that supports the Event timing interface.

This PR replaces the whitelist with `instantiate_device_type_tests(...,
except_for="cpu")` to exclude CPU variants at instantiation level, refactors
device acquisition from `torch.cuda.current_device()` to framework-injected
`torch.device(device)`, and adds a `hw_classification` label so the tests are
correctly selected by the `--hw-classification` CI filter.

## Changes

- Replaced `@unittest.skipIf(not TEST_CUDA, "CUDA not available")` with
  `except_for="cpu"` in `instantiate_device_type_tests` to exclude CPU variants
  at instantiation level.
- Removed the now-unused `import unittest` and
  `from torch.testing._internal.common_cuda import TEST_CUDA`.
- Added `device` parameter to both test methods (framework-injected via
  `instantiate_device_type_tests`).
- Changed device acquisition from `torch.cuda.current_device()` to
  `torch.device(device)` in `_init_model_and_args`.
- Changed Event creation from `torch.cuda.Event(enable_timing=True)` to
  `torch.get_device_module(torch.device(device)).Event(enable_timing=True)` in
  the renamed helper `_measure_actual_time` (was `_measure_actual_cuda_time`).
- Changed synchronization from `torch.cuda.synchronize()` to
  `device_module.synchronize()`.
- Passed `device` parameter to `_measure_actual_time` and
  `_init_model_and_args` from both test methods (including inside
  `FakeTensorMode` context).
- Added guard for zero division in roofline accuracy calculation.
  On backends where triton is unavailable (e.g. some out-of-tree PrivateUse1
  backends), `RuntimeEstimator` with `operator-level-cost-model` mode returns
  `total_runtime = 0.0` because the roofline cost model cannot query DRAM
  bandwidth without triton. The original code computes
  `roofline_accuracy = actual_runtime / roofline_estimate` unconditionally,
  which raises `ZeroDivisionError` on such backends. Since the accuracy
  assertions are commented out and the value is only printed, the guard
  (`roofline_estimate if roofline_estimate else float("inf")`) allows the
  test to pass without crash while still printing a meaningful value.
- Added `hw_classification = HardwareClassification.ACCELERATOR` class attribute.
- Added `instantiate_device_type_tests(TestRuntimeEstimator, globals(),
  except_for="cpu")` at file end.

## Not changed

- The `SimpleCNN` model and `ConvArgs` dataclass are unchanged.
- The `RuntimeEstimator` usage and `_runtime_estimate` helper are unchanged
  (already device-agnostic, operates in `FakeTensorMode`).
- The `_train_step` helper is unchanged (no device coupling).
- The accuracy assertions remain commented out
  (`# No accuracy check for benchmark in CI as it is highly variable`).
  The tests only print accuracy values without asserting them, so they pass on
  any accelerator that supports the Event timing interface.
- The `FakeTensorMode` usage pattern is unchanged; only the `device` parameter
  is passed through to `_init_model_and_args` inside the context.

## Test plan

- `python test/distributed/_tools/test_runtime_estimator.py` on CUDA (A100,
  PyTorch 2.13.0a0, CUDA 12.8):
  `TestRuntimeEstimatorCUDA.test_transformer_runtime_cuda` and
  `TestRuntimeEstimatorCUDA.test_conv_model_runtime_cuda` pass — both benchmark
  and roofline estimation modes produce valid timing estimates (`OK`, 2 tests).
- `python test/distributed/_tools/test_runtime_estimator.py` on an out-of-tree
  accelerator backend (PrivateUse1, torch_npu 2.13.0+git45fbeae on
  PyTorch 2.13.0a0+gitfad7424, Ascend 910B3):
  `TestRuntimeEstimatorPRIVATEUSE1.test_transformer_runtime` and
  `TestRuntimeEstimatorPRIVATEUSE1.test_conv_model_runtime` pass — benchmark
  mode produces valid timing estimates; roofline cost-model mode returns 0.0
  (triton unavailable on this backend) but zero-division guard prevents crash
  (`OK`, 2 tests).
- `python test/distributed/_tools/test_runtime_estimator.py` on CPU (no
  accelerator): `NO TESTS RAN` — CPU variants correctly excluded via
  `except_for="cpu"`.