### PR TITLE
[inductor] add GEMMDesc, a bit-exact GEMM descriptor (#193140)

### DIFF
--- a/test/inductor/test_gemm_desc.py
+++ b/test/inductor/test_gemm_desc.py
@@ -1,0 +1,851 @@
+# Owner(s): ["module: inductor"]
+from __future__ import annotations
+
+import dataclasses
+import itertools
+from collections.abc import Callable
+
+import torch
+from torch._inductor.gemm_desc import (
+    EpilogueOrder,
+    Equivalences,
+    GEMMAlgorithm,
+    GEMMDesc,
+    InputPrecision,
+    KCut,
+    KCutLayout,
+    MATRIX_INSTRUCTIONS,
+    MergeOrder,
+    produces_same_bits,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+def _fp16_matmul(**overrides: object) -> GEMMDesc:
+    """An ordinary fp16 tensor-core GEMM. Every case below bends one of its fields."""
+    fields: dict[str, object] = {
+        "operand_dtype": torch.float16,
+        "accumulate_dtype": torch.float32,
+        "output_dtype": torch.float16,
+        "algorithm": GEMMAlgorithm.MMA_SYNC,
+        "instruction_k": 16,
+        "use_fast_accum": True,
+    }
+    fields.update(overrides)
+    return GEMMDesc(**fields)  # type: ignore[arg-type]
+
+
+def _int8_matmul(**overrides: object) -> GEMMDesc:
+    fields: dict[str, object] = {
+        "operand_dtype": torch.int8,
+        "accumulate_dtype": torch.int32,
+        "output_dtype": torch.int32,
+    }
+    fields.update(overrides)
+    return _fp16_matmul(**fields)
+
+
+def _scalar_matmul(**overrides: object) -> GEMMDesc:
+    """A scalar-loop GEMM: no instruction_k and no use_fast_accum."""
+    fields: dict[str, object] = {
+        "algorithm": GEMMAlgorithm.SCALAR_FUSED_MULTIPLY_ADD,
+        "instruction_k": None,
+        "use_fast_accum": None,
+    }
+    fields.update(overrides)
+    return _fp16_matmul(**fields)
+
+
+def _cut(**overrides: object) -> KCut:
+    fields: dict[str, object] = {
+        "span": 1024,
+        "partial_dtype": torch.float32,
+        "merge_dtype": torch.float32,
+    }
+    fields.update(overrides)
+    return KCut(**fields)  # type: ignore[arg-type]
+
+
+def _equivalences(**overrides: object) -> Equivalences:
+    """Loose kwargs, so a case below can hand a field the wrong type on purpose."""
+    return Equivalences(**overrides)  # type: ignore[arg-type]
+
+
+# Written out here rather than imported from the module, so that dropping a dtype
+# from the module turns these red instead of quietly shrinking the sweep.
+_FLOAT_OPERAND_DTYPES = [
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.float64,
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+]
+_FLOAT_ACCUMULATE_DTYPES = [torch.float16, torch.float32, torch.float64]
+_FLOAT_OUTPUT_DTYPES = _FLOAT_OPERAND_DTYPES
+
+_INT_OPERAND_DTYPES = [torch.int8, torch.uint8]
+_INT_ACCUMULATE_DTYPES = [torch.int32, torch.int64]
+_INT_OUTPUT_DTYPES = [torch.int8, torch.int32]
+
+# Every triple the descriptor accepts: 6 x 3 x 6 floating plus 2 x 2 x 2 integer.
+_SUPPORTED_DTYPE_TRIPLES = list(
+    itertools.product(
+        _FLOAT_OPERAND_DTYPES, _FLOAT_ACCUMULATE_DTYPES, _FLOAT_OUTPUT_DTYPES
+    )
+) + list(
+    itertools.product(_INT_OPERAND_DTYPES, _INT_ACCUMULATE_DTYPES, _INT_OUTPUT_DTYPES)
+)
+
+# Written out here, like the dtypes above, so that adding an instruction to the
+# module or dropping one turns these red instead of quietly shrinking the sweep.
+_MATRIX_ALGORITHMS = [
+    GEMMAlgorithm.MMA_SYNC,
+    GEMMAlgorithm.WGMMA,
+    GEMMAlgorithm.TCGEN05_MMA,
+]
+
+_SCALAR_ALGORITHMS = [
+    GEMMAlgorithm.SCALAR_FUSED_MULTIPLY_ADD,
+    GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD,
+]
+
+_ALGORITHMS = _MATRIX_ALGORITHMS + _SCALAR_ALGORITHMS
+
+_INPUT_PRECISIONS = [InputPrecision.IEEE, InputPrecision.TF32, InputPrecision.TF32X3]
+
+_EPILOGUES = [EpilogueOrder.IN_ACCUMULATOR, EpilogueOrder.AFTER_ROUNDING]
+
+
+_FP32_OPERANDS: dict[str, object] = {
+    "operand_dtype": torch.float32,
+    "output_dtype": torch.float32,
+}
+
+_SCALAR: dict[str, object] = {
+    "algorithm": GEMMAlgorithm.SCALAR_FUSED_MULTIPLY_ADD,
+    "instruction_k": None,
+    "use_fast_accum": None,
+}
+
+# What only a matrix instruction has to obey, as (case, overrides, words the message
+# must carry). Each is run against every instruction, so an instruction cannot arrive
+# with the rules unwired for it.
+_MATRIX_RULES: list[tuple[str, dict[str, object], str]] = [
+    ("no_instruction_k", {"instruction_k": None}, "needs instruction_k"),
+    ("instruction_k_zero", {"instruction_k": 0}, "needs instruction_k"),
+    ("instruction_k_negative", {"instruction_k": -16}, "needs instruction_k"),
+    ("no_use_fast_accum", {"use_fast_accum": None}, "needs use_fast_accum"),
+]
+
+# What only a scalar algorithm has to obey, run against both of them. Every message
+# here ends just before the algorithm's name, so the test can check it is named.
+_SCALAR_RULES: list[tuple[str, dict[str, object], str]] = [
+    ("instruction_k", {"instruction_k": 1}, "instruction_k must be None for"),
+    ("use_fast_accum", {"use_fast_accum": True}, "use_fast_accum must be None for"),
+    (
+        "use_fast_accum_false",
+        {"use_fast_accum": False},
+        "use_fast_accum must be None for",
+    ),
+    ("k_loop_step", {"k_loop_step": 64}, "k_loop_step must be None for"),
+    (
+        "tf32",
+        {**_FP32_OPERANDS, "input_precision": InputPrecision.TF32},
+        "needs a matrix instruction, got",
+    ),
+    (
+        "tf32x3",
+        {**_FP32_OPERANDS, "input_precision": InputPrecision.TF32X3},
+        "needs a matrix instruction, got",
+    ),
+]
+
+_MATRIX_RULE_CASES = [
+    (f"{instruction.name}_{case}", instruction, overrides, expected)
+    for instruction in _MATRIX_ALGORITHMS
+    for case, overrides, expected in _MATRIX_RULES
+]
+
+_SCALAR_RULE_CASES = [
+    (f"{algorithm.name}_{case}", algorithm, overrides, expected)
+    for algorithm in _SCALAR_ALGORITHMS
+    for case, overrides, expected in _SCALAR_RULES
+]
+
+# Two descriptors that differ in exactly one field must not compare equal. Each entry
+# is (field, overrides for the left descriptor, overrides for the right one).
+_ONE_FIELD_CHANGES: list[tuple[str, dict[str, object], dict[str, object]]] = [
+    ("operand_dtype", {}, {"operand_dtype": torch.bfloat16}),
+    ("accumulate_dtype", {}, {"accumulate_dtype": torch.float16}),
+    ("output_dtype", {}, {"output_dtype": torch.float32}),
+    # Both sides are scalar, so this really is one field: the two scalar algorithms
+    # differ only in whether the multiply and the add round together.
+    (
+        "algorithm",
+        _SCALAR,
+        {**_SCALAR, "algorithm": GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD},
+    ),
+    # Two matrix instructions, which is the same field again. Kept apart from the
+    # scalar pair because a machine can declare these two interchangeable and can
+    # never declare the scalar pair to be the same descriptor.
+    ("matrix_instruction", {}, {"algorithm": GEMMAlgorithm.WGMMA}),
+    (
+        "input_precision",
+        _FP32_OPERANDS,
+        {**_FP32_OPERANDS, "input_precision": InputPrecision.TF32},
+    ),
+    ("instruction_k", {}, {"instruction_k": 8}),
+    ("use_fast_accum", {}, {"use_fast_accum": False}),
+    ("k_loop_step", {}, {"k_loop_step": 64}),
+    ("k_cuts", {}, {"k_cuts": (_cut(),)}),
+    ("epilogue", {}, {"epilogue": EpilogueOrder.IN_ACCUMULATOR}),
+]
+
+_STRIDED: dict[str, object] = {"layout": KCutLayout.STRIDED, "count": 4}
+
+_ONE_CUT_FIELD_CHANGES: list[tuple[str, dict[str, object], dict[str, object]]] = [
+    ("span", {}, {"span": 512}),
+    ("partial_dtype", {}, {"partial_dtype": torch.float16}),
+    ("merge_dtype", {}, {"merge_dtype": torch.float16}),
+    ("merge", {}, {"merge": MergeOrder.PAIRWISE_TREE}),
+    # layout and count move together: a CONTIGUOUS cut may not carry a count.
+    ("layout", {}, _STRIDED),
+    ("count", _STRIDED, {**_STRIDED, "count": 8}),
+    # An unset period is the plain rotation, so stating one has to be a different
+    # value -- otherwise a descriptor written before the field existed would silently
+    # become one that means something else.
+    ("period", _STRIDED, {**_STRIDED, "period": 37}),
+    (
+        "divisor",
+        {**_STRIDED, "period": 37},
+        {**_STRIDED, "period": 37, "divisor": 4},
+    ),
+]
+
+# Every combination the descriptor refuses, and the words its message must carry.
+# Building a descriptor is the only thing under test, so each case is a callable.
+_REJECTED: dict[str, tuple[Callable[[], object], str]] = {
+    "operand_dtype_unlisted": (
+        lambda: _fp16_matmul(operand_dtype=torch.complex64),
+        "unsupported operand_dtype",
+    ),
+    "operand_dtype_bool": (
+        lambda: _fp16_matmul(operand_dtype=torch.bool),
+        "unsupported operand_dtype",
+    ),
+    "operand_dtype_int32": (
+        lambda: _fp16_matmul(
+            operand_dtype=torch.int32,
+            accumulate_dtype=torch.int32,
+            output_dtype=torch.int32,
+        ),
+        "unsupported operand_dtype",
+    ),
+    "accumulate_dtype_fp8": (
+        lambda: _fp16_matmul(accumulate_dtype=torch.float8_e4m3fn),
+        "unsupported accumulate_dtype",
+    ),
+    "accumulate_dtype_bfloat16": (
+        lambda: _fp16_matmul(accumulate_dtype=torch.bfloat16),
+        "unsupported accumulate_dtype",
+    ),
+    "output_dtype_unlisted": (
+        lambda: _fp16_matmul(output_dtype=torch.complex64),
+        "unsupported output_dtype",
+    ),
+    "output_dtype_int64": (
+        lambda: _int8_matmul(output_dtype=torch.int64),
+        "unsupported output_dtype",
+    ),
+    "integer_operand_float_accumulate": (
+        lambda: _fp16_matmul(operand_dtype=torch.int8, output_dtype=torch.int8),
+        "floating point or all be integer",
+    ),
+    "float_operand_integer_accumulate": (
+        lambda: _fp16_matmul(accumulate_dtype=torch.int32),
+        "floating point or all be integer",
+    ),
+    "integer_operand_float_output": (
+        lambda: _int8_matmul(output_dtype=torch.float16),
+        "floating point or all be integer",
+    ),
+    "matrix_instruction_without_instruction_k": (
+        lambda: _fp16_matmul(instruction_k=None),
+        "MMA_SYNC is a matrix instruction and needs instruction_k",
+    ),
+    "instruction_k_zero": (
+        lambda: _fp16_matmul(instruction_k=0),
+        "MMA_SYNC is a matrix instruction and needs instruction_k",
+    ),
+    "matrix_instruction_without_use_fast_accum": (
+        lambda: _fp16_matmul(use_fast_accum=None),
+        "MMA_SYNC is a matrix instruction and needs use_fast_accum",
+    ),
+    "instruction_k_on_scalar_algorithm": (
+        lambda: _scalar_matmul(instruction_k=1),
+        "instruction_k must be None",
+    ),
+    "use_fast_accum_on_scalar_algorithm": (
+        lambda: _scalar_matmul(use_fast_accum=True),
+        "use_fast_accum must be None",
+    ),
+    "use_fast_accum_false_on_scalar_algorithm": (
+        lambda: _scalar_matmul(use_fast_accum=False),
+        "use_fast_accum must be None",
+    ),
+    "k_loop_step_on_scalar_algorithm": (
+        lambda: _scalar_matmul(
+            algorithm=GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD, k_loop_step=64
+        ),
+        "k_loop_step must be None",
+    ),
+    "k_loop_step_zero": (
+        lambda: _fp16_matmul(k_loop_step=0),
+        "k_loop_step must be at least 1",
+    ),
+    "tf32_on_fp16_operands": (
+        lambda: _fp16_matmul(input_precision=InputPrecision.TF32),
+        "needs float32 operands",
+    ),
+    "tf32x3_on_fp16_operands": (
+        lambda: _fp16_matmul(input_precision=InputPrecision.TF32X3),
+        "needs float32 operands",
+    ),
+    "tf32_on_scalar_algorithm": (
+        lambda: _scalar_matmul(
+            **_FP32_OPERANDS, input_precision=InputPrecision.TF32  # type: ignore[arg-type]
+        ),
+        "needs a matrix instruction",
+    ),
+    "tf32x3_on_scalar_algorithm": (
+        lambda: _scalar_matmul(
+            **_FP32_OPERANDS, input_precision=InputPrecision.TF32X3  # type: ignore[arg-type]
+        ),
+        "needs a matrix instruction",
+    ),
+    "k_cuts_as_list": (lambda: _fp16_matmul(k_cuts=[_cut()]), "must be a tuple"),
+    "k_cuts_holding_a_number": (lambda: _fp16_matmul(k_cuts=(1024,)), "must be a KCut"),
+    "k_cuts_holding_a_number_at_level_one": (
+        lambda: _fp16_matmul(k_cuts=(_cut(), 64)),
+        r"k_cuts\[1\] must be a KCut",
+    ),
+    "cut_partial_dtype_wrong_kind": (
+        lambda: _fp16_matmul(k_cuts=(_cut(partial_dtype=torch.int32),)),
+        "partial_dtype is torch.int32, which does not match",
+    ),
+    "cut_merge_dtype_wrong_kind": (
+        lambda: _fp16_matmul(k_cuts=(_cut(merge_dtype=torch.int64),)),
+        "merge_dtype is torch.int64, which does not match",
+    ),
+    "integer_gemm_with_float_cut": (
+        lambda: _int8_matmul(k_cuts=(_cut(),)),
+        "partial_dtype is torch.float32, which does not match",
+    ),
+    "cut_span_zero": (lambda: _cut(span=0), "span must be at least 1"),
+    "cut_span_negative": (lambda: _cut(span=-8), "span must be at least 1"),
+    "contiguous_cut_with_a_count": (
+        lambda: _cut(count=4),
+        "count must be None for a CONTIGUOUS cut",
+    ),
+    "strided_cut_without_a_count": (
+        lambda: _cut(layout=KCutLayout.STRIDED),
+        "STRIDED cut needs count",
+    ),
+    "strided_cut_with_one_part": (
+        lambda: _cut(layout=KCutLayout.STRIDED, count=1),
+        "STRIDED cut needs count",
+    ),
+    "cut_partial_dtype_fp8": (
+        lambda: _cut(partial_dtype=torch.float8_e5m2),
+        "unsupported partial_dtype",
+    ),
+    "cut_merge_dtype_fp8": (
+        lambda: _cut(merge_dtype=torch.float8_e4m3fn),
+        "unsupported merge_dtype",
+    ),
+    "cut_merge_dtype_int8": (
+        lambda: _cut(merge_dtype=torch.int8),
+        "unsupported merge_dtype",
+    ),
+    "contiguous_cut_with_a_period": (
+        lambda: _cut(period=8),
+        "period must be unset for a CONTIGUOUS cut",
+    ),
+    "contiguous_cut_with_a_divisor": (
+        lambda: _cut(divisor=2),
+        "divisor must be unset for a CONTIGUOUS cut",
+    ),
+    "divisor_without_a_period": (
+        lambda: _cut(layout=KCutLayout.STRIDED, count=4, divisor=4),
+        "divisor needs a period",
+    ),
+    "cut_period_zero": (
+        lambda: _cut(layout=KCutLayout.STRIDED, count=4, period=0),
+        "period must be at least 1",
+    ),
+    "cut_divisor_zero": (
+        lambda: _cut(layout=KCutLayout.STRIDED, count=4, period=8, divisor=0),
+        "divisor must be at least 1",
+    ),
+    "equivalence_groups_as_a_list": (
+        lambda: _equivalences(
+            interchangeable_instructions=[frozenset(_MATRIX_ALGORITHMS)]
+        ),
+        "must be a tuple",
+    ),
+    "equivalence_group_as_a_plain_set": (
+        lambda: _equivalences(interchangeable_instructions=(set(_MATRIX_ALGORITHMS),)),
+        r"interchangeable_instructions\[0\] must be a frozenset",
+    ),
+    "equivalence_group_of_one": (
+        lambda: Equivalences(
+            interchangeable_instructions=(frozenset({GEMMAlgorithm.WGMMA}),)
+        ),
+        "needs at least 2 algorithms",
+    ),
+    "equivalence_group_of_none": (
+        lambda: Equivalences(interchangeable_instructions=(frozenset(),)),
+        "needs at least 2 algorithms",
+    ),
+    "equivalence_group_of_names": (
+        lambda: _equivalences(
+            interchangeable_instructions=(frozenset({"MMA_SYNC", "WGMMA"}),)
+        ),
+        "must hold GEMMAlgorithm values",
+    ),
+    "equivalence_groups_overlap": (
+        lambda: Equivalences(
+            interchangeable_instructions=(
+                frozenset({GEMMAlgorithm.MMA_SYNC, GEMMAlgorithm.WGMMA}),
+                frozenset({GEMMAlgorithm.WGMMA, GEMMAlgorithm.TCGEN05_MMA}),
+            )
+        ),
+        r"interchangeable_instructions\[1\] names WGMMA",
+    ),
+}
+
+
+# Made-up machines. What a real one declares is measured per architecture and belongs
+# to the producer that measured it, never to the module under test.
+_NOTHING_DECLARED = Equivalences()
+
+_TWO_INSTRUCTIONS_AGREE = Equivalences(
+    interchangeable_instructions=(
+        frozenset({GEMMAlgorithm.MMA_SYNC, GEMMAlgorithm.TCGEN05_MMA}),
+    )
+)
+
+_FAST_ACCUM_FREE = Equivalences(fast_accum_is_free=True)
+
+_EVERYTHING_DECLARED = Equivalences(
+    interchangeable_instructions=(frozenset(_MATRIX_ALGORITHMS),),
+    fast_accum_is_free=True,
+)
+
+_MACHINES = [
+    ("nothing_declared", _NOTHING_DECLARED),
+    ("two_instructions_agree", _TWO_INSTRUCTIONS_AGREE),
+    ("fast_accum_free", _FAST_ACCUM_FREE),
+    ("everything_declared", _EVERYTHING_DECLARED),
+]
+
+# The only two entries of _ONE_FIELD_CHANGES that _EVERYTHING_DECLARED makes free.
+# Every other one must survive it, however much is declared.
+_FREE_UNDER_EVERYTHING = {"matrix_instruction", "use_fast_accum"}
+
+
+def _case_name(name: str, *_: object) -> str:
+    return name
+
+
+@instantiate_parametrized_tests
+class TestGEMMDesc(TestCase):
+    def test_plain_matmul_reads_back(self):
+        desc = _fp16_matmul()
+        self.assertEqual(desc.operand_dtype, torch.float16)
+        self.assertEqual(desc.accumulate_dtype, torch.float32)
+        self.assertEqual(desc.output_dtype, torch.float16)
+        self.assertEqual(desc.algorithm, GEMMAlgorithm.MMA_SYNC)
+        self.assertEqual(desc.instruction_k, 16)
+        self.assertEqual(desc.use_fast_accum, True)
+        # The defaults are the ordinary GEMM: no cut, no epilogue, full precision.
+        self.assertEqual(desc.input_precision, InputPrecision.IEEE)
+        self.assertEqual(desc.k_loop_step, None)
+        self.assertEqual(desc.k_cuts, ())
+        self.assertEqual(desc.epilogue, EpilogueOrder.NONE)
+        self.assertTrue(desc.is_floating_point)
+
+    @parametrize("algorithm", _ALGORITHMS, name_fn=lambda a: a.name)
+    def test_every_algorithm(self, algorithm):
+        matrix = algorithm in MATRIX_INSTRUCTIONS
+        desc = _fp16_matmul(
+            algorithm=algorithm,
+            instruction_k=16 if matrix else None,
+            use_fast_accum=False if matrix else None,
+        )
+        self.assertEqual(desc.algorithm, algorithm)
+        self.assertEqual(desc.instruction_k, 16 if matrix else None)
+        self.assertEqual(desc.use_fast_accum, False if matrix else None)
+
+    def test_the_algorithms_are_five_distinct_values(self):
+        """Each instruction is its own value, and the module agrees which are which."""
+        self.assertEqual(len(set(_ALGORITHMS)), 5)
+        self.assertEqual(MATRIX_INSTRUCTIONS, frozenset(_MATRIX_ALGORITHMS))
+        self.assertEqual(MATRIX_INSTRUCTIONS & frozenset(_SCALAR_ALGORITHMS), set())
+
+    @parametrize("instruction", _MATRIX_ALGORITHMS, name_fn=lambda a: a.name)
+    def test_every_matrix_instruction_builds(self, instruction):
+        desc = _fp16_matmul(algorithm=instruction)
+        self.assertEqual(desc.algorithm, instruction)
+        self.assertEqual(desc.instruction_k, 16)
+        self.assertEqual(desc.use_fast_accum, True)
+        # Two descriptors that name different instructions are different descriptors.
+        others = [i for i in _MATRIX_ALGORITHMS if i is not instruction]
+        for other in others:
+            self.assertNotEqual(desc, _fp16_matmul(algorithm=other))
+        self.assertEqual(len({desc, *(_fp16_matmul(algorithm=o) for o in others)}), 3)
+
+    @parametrize(
+        "case,instruction,overrides,expected", _MATRIX_RULE_CASES, name_fn=_case_name
+    )
+    def test_matrix_rule_bites_for_every_instruction(
+        self, case, instruction, overrides, expected
+    ):
+        message = rf"{instruction.name} is a matrix instruction and {expected}"
+        with self.assertRaisesRegex(ValueError, message):
+            _fp16_matmul(algorithm=instruction, **overrides)
+
+    @parametrize(
+        "case,algorithm,overrides,expected", _SCALAR_RULE_CASES, name_fn=_case_name
+    )
+    def test_scalar_rule_bites_for_every_scalar_algorithm(
+        self, case, algorithm, overrides, expected
+    ):
+        with self.assertRaisesRegex(ValueError, rf"{expected} {algorithm.name}"):
+            _scalar_matmul(algorithm=algorithm, **overrides)
+
+    @parametrize("use_fast_accum", [True, False])
+    def test_matrix_instruction_accumulate_choice_reads_back(self, use_fast_accum):
+        desc = _fp16_matmul(use_fast_accum=use_fast_accum)
+        self.assertEqual(desc.use_fast_accum, use_fast_accum)
+
+    def test_one_cut(self):
+        desc = _fp16_matmul(k_cuts=(_cut(span=4096),))
+        self.assertEqual(len(desc.k_cuts), 1)
+        self.assertEqual(desc.k_cuts[0].span, 4096)
+        self.assertEqual(desc.k_cuts[0].layout, KCutLayout.CONTIGUOUS)
+        self.assertEqual(desc.k_cuts[0].count, None)
+        self.assertEqual(desc.k_cuts[0].merge, MergeOrder.SEQUENTIAL)
+
+    def test_two_nested_cuts(self):
+        """Slices of k, and inside a slice an accumulator closed every 64 elements."""
+        desc = _fp16_matmul(k_cuts=(_cut(span=4096), _cut(span=64)))
+        self.assertEqual(len(desc.k_cuts), 2)
+        self.assertEqual(desc.k_cuts[0].span, 4096)
+        self.assertEqual(desc.k_cuts[1].span, 64)
+        self.assertEqual(desc.k_cuts[1].merge, MergeOrder.SEQUENTIAL)
+
+    def test_split_k_partials_kept_in_the_output_dtype(self):
+        """The merge dtypes are fields, so this is sayable rather than assumed."""
+        desc = _fp16_matmul(
+            k_cuts=(
+                KCut(
+                    span=2048,
+                    partial_dtype=torch.float16,
+                    merge_dtype=torch.float16,
+                ),
+            ),
+        )
+        self.assertEqual(desc.k_cuts[0].partial_dtype, torch.float16)
+        self.assertEqual(desc.k_cuts[0].merge_dtype, torch.float16)
+
+    def test_residue_first_matmul(self):
+        desc = _fp16_matmul(instruction_k=16, k_loop_step=32)
+        self.assertEqual(desc.k_loop_step, 32)
+
+    def test_strided_cut_with_a_lane_tree(self):
+        desc = _scalar_matmul(
+            k_cuts=(
+                KCut(
+                    span=4,
+                    partial_dtype=torch.float32,
+                    merge_dtype=torch.float32,
+                    layout=KCutLayout.STRIDED,
+                    count=32,
+                    merge=MergeOrder.PAIRWISE_TREE,
+                ),
+            ),
+        )
+        cut = desc.k_cuts[0]
+        self.assertEqual(cut.span, 4)
+        self.assertEqual(cut.layout, KCutLayout.STRIDED)
+        self.assertEqual(cut.count, 32)
+        self.assertEqual(cut.merge, MergeOrder.PAIRWISE_TREE)
+
+    def test_integer_gemm_with_integer_cuts(self):
+        desc = _int8_matmul(
+            k_cuts=(_cut(partial_dtype=torch.int32, merge_dtype=torch.int32),)
+        )
+        self.assertFalse(desc.is_floating_point)
+        self.assertEqual(desc.k_cuts[0].partial_dtype, torch.int32)
+
+    @parametrize("operand,accumulate,output", _SUPPORTED_DTYPE_TRIPLES)
+    def test_every_supported_dtype_triple(self, operand, accumulate, output):
+        desc = _fp16_matmul(
+            operand_dtype=operand,
+            accumulate_dtype=accumulate,
+            output_dtype=output,
+        )
+        self.assertEqual(desc.operand_dtype, operand)
+        self.assertEqual(desc.accumulate_dtype, accumulate)
+        self.assertEqual(desc.output_dtype, output)
+        self.assertEqual(desc.is_floating_point, operand.is_floating_point)
+
+    @parametrize("input_precision", _INPUT_PRECISIONS, name_fn=lambda p: p.name)
+    def test_fp32_input_precision(self, input_precision):
+        desc = _fp16_matmul(**_FP32_OPERANDS, input_precision=input_precision)
+        self.assertEqual(desc.input_precision, input_precision)
+
+    @parametrize("epilogue", _EPILOGUES, name_fn=lambda e: e.name)
+    def test_epilogue(self, epilogue):
+        desc = _fp16_matmul(epilogue=epilogue)
+        self.assertEqual(desc.epilogue, epilogue)
+
+    def test_equal_descriptors_are_equal_and_hash_alike(self):
+        a = _fp16_matmul(k_cuts=(_cut(),))
+        b = _fp16_matmul(k_cuts=(_cut(),))
+        self.assertIsNot(a, b)
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
+    def test_equal_cuts_are_equal_and_hash_alike(self):
+        a, b = _cut(), _cut()
+        self.assertIsNot(a, b)
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
+    @parametrize("field,left,right", _ONE_FIELD_CHANGES, name_fn=_case_name)
+    def test_one_changed_field_differs(self, field, left, right):
+        a, b = _fp16_matmul(**left), _fp16_matmul(**right)
+        self.assertNotEqual(a, b)
+        self.assertEqual(len({a, b}), 2)
+
+    @parametrize("field,left,right", _ONE_CUT_FIELD_CHANGES, name_fn=_case_name)
+    def test_one_changed_cut_field_differs(self, field, left, right):
+        a, b = _cut(**left), _cut(**right)
+        self.assertNotEqual(a, b)
+        self.assertNotEqual(_fp16_matmul(k_cuts=(a,)), _fp16_matmul(k_cuts=(b,)))
+
+    def test_cut_nesting_order_matters(self):
+        outer_first = _fp16_matmul(k_cuts=(_cut(span=4096), _cut(span=64)))
+        inner_first = _fp16_matmul(k_cuts=(_cut(span=64), _cut(span=4096)))
+        self.assertNotEqual(outer_first, inner_first)
+        self.assertEqual(len({outer_first, inner_first}), 2)
+
+    def test_usable_as_a_dict_key(self):
+        table = {
+            _fp16_matmul(): "matmul",
+            _fp16_matmul(k_cuts=(_cut(),)): "split k",
+        }
+        self.assertEqual(len(table), 2)
+        self.assertEqual(table[_fp16_matmul()], "matmul")
+        self.assertEqual(table[_fp16_matmul(k_cuts=(_cut(),))], "split k")
+
+    def test_descriptor_is_frozen(self):
+        desc = _fp16_matmul()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            desc.instruction_k = 8
+        self.assertEqual(desc.instruction_k, 16)
+
+    def test_cut_is_frozen(self):
+        cut = _cut()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            cut.span = 1
+        self.assertEqual(cut.span, 1024)
+
+    def test_replace_builds_a_new_value_and_revalidates(self):
+        base = _fp16_matmul()
+        wider = dataclasses.replace(base, instruction_k=32)
+        self.assertEqual(base.instruction_k, 16)
+        self.assertEqual(wider.instruction_k, 32)
+        with self.assertRaisesRegex(ValueError, "MMA_SYNC is a matrix instruction"):
+            dataclasses.replace(base, instruction_k=0)
+        with self.assertRaisesRegex(ValueError, "unsupported output_dtype"):
+            dataclasses.replace(base, output_dtype=torch.complex64)
+
+    def test_replace_on_a_cut_revalidates(self):
+        base = _cut()
+        shorter = dataclasses.replace(base, span=16)
+        self.assertEqual(shorter.span, 16)
+        with self.assertRaisesRegex(ValueError, "span must be at least 1"):
+            dataclasses.replace(base, span=0)
+        with self.assertRaisesRegex(ValueError, "CONTIGUOUS cut"):
+            dataclasses.replace(base, count=4)
+
+    @parametrize("case", sorted(_REJECTED))
+    def test_rejects(self, case):
+        build, expected = _REJECTED[case]
+        with self.assertRaisesRegex(ValueError, expected):
+            build()
+
+    def test_the_one_field_sweep_covers_every_field(self):
+        """A field added to GEMMDesc turns this red until the sweep covers it.
+
+        That matters more than it looks: the sweep below is what shows a new field
+        is significant to `produces_same_bits` until someone measures otherwise.
+        """
+        covered = {field for field, _, _ in _ONE_FIELD_CHANGES}
+        self.assertEqual(
+            covered - {"matrix_instruction"},
+            {field.name for field in dataclasses.fields(GEMMDesc)},
+        )
+
+    def test_the_one_cut_field_sweep_covers_every_cut_field(self):
+        covered = {field for field, _, _ in _ONE_CUT_FIELD_CHANGES}
+        self.assertEqual(covered, {field.name for field in dataclasses.fields(KCut)})
+
+    def test_equivalences_is_a_value(self):
+        self.assertEqual(Equivalences(), Equivalences())
+        self.assertEqual(hash(Equivalences()), hash(Equivalences()))
+        self.assertNotEqual(_NOTHING_DECLARED, _FAST_ACCUM_FREE)
+        self.assertEqual(len({_NOTHING_DECLARED, _TWO_INSTRUCTIONS_AGREE}), 2)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            _NOTHING_DECLARED.fast_accum_is_free = True
+
+    def test_nothing_declared_is_the_default(self):
+        self.assertEqual(Equivalences().interchangeable_instructions, ())
+        self.assertFalse(Equivalences().fast_accum_is_free)
+
+    @parametrize("machine,known", _MACHINES, name_fn=_case_name)
+    def test_produces_same_bits_is_reflexive(self, machine, known):
+        for desc in (
+            _fp16_matmul(),
+            _fp16_matmul(use_fast_accum=False),
+            _fp16_matmul(algorithm=GEMMAlgorithm.WGMMA),
+            _fp16_matmul(algorithm=GEMMAlgorithm.TCGEN05_MMA),
+            _scalar_matmul(),
+            _scalar_matmul(algorithm=GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD),
+            _int8_matmul(),
+            _fp16_matmul(k_cuts=(_cut(), _cut(span=64))),
+        ):
+            self.assertTrue(produces_same_bits(desc, desc, known))
+            # A separately built copy, so this is value equality and not identity.
+            twin = dataclasses.replace(desc)
+            self.assertIsNot(desc, twin)
+            self.assertTrue(produces_same_bits(desc, twin, known))
+
+    @parametrize("field,left,right", _ONE_FIELD_CHANGES, name_fn=_case_name)
+    def test_nothing_declared_means_plain_equality(self, field, left, right):
+        a, b = _fp16_matmul(**left), _fp16_matmul(**right)
+        self.assertFalse(produces_same_bits(a, b, _NOTHING_DECLARED))
+        self.assertFalse(produces_same_bits(b, a, _NOTHING_DECLARED))
+
+    @parametrize("field,left,right", _ONE_FIELD_CHANGES, name_fn=_case_name)
+    def test_only_the_declared_differences_are_free(self, field, left, right):
+        a, b = _fp16_matmul(**left), _fp16_matmul(**right)
+        free = field in _FREE_UNDER_EVERYTHING
+        self.assertEqual(produces_same_bits(a, b, _EVERYTHING_DECLARED), free)
+        self.assertEqual(produces_same_bits(b, a, _EVERYTHING_DECLARED), free)
+
+    def test_a_declared_pair_of_instructions_agrees(self):
+        a = _fp16_matmul(algorithm=GEMMAlgorithm.MMA_SYNC)
+        b = _fp16_matmul(algorithm=GEMMAlgorithm.TCGEN05_MMA)
+        self.assertNotEqual(a, b)
+        self.assertTrue(produces_same_bits(a, b, _TWO_INSTRUCTIONS_AGREE))
+        self.assertTrue(produces_same_bits(b, a, _TWO_INSTRUCTIONS_AGREE))
+        self.assertFalse(produces_same_bits(a, b, _NOTHING_DECLARED))
+        self.assertFalse(produces_same_bits(a, b, _FAST_ACCUM_FREE))
+
+    def test_an_instruction_outside_the_declared_group_does_not_agree(self):
+        """The Blackwell fp8 case: mma.sync and wgmma are simply two answers here."""
+        a = _fp16_matmul(algorithm=GEMMAlgorithm.MMA_SYNC)
+        b = _fp16_matmul(algorithm=GEMMAlgorithm.WGMMA)
+        self.assertFalse(produces_same_bits(a, b, _TWO_INSTRUCTIONS_AGREE))
+        self.assertFalse(produces_same_bits(b, a, _TWO_INSTRUCTIONS_AGREE))
+        self.assertTrue(produces_same_bits(a, b, _EVERYTHING_DECLARED))
+
+    def test_two_declared_instructions_still_differ_in_another_field(self):
+        a = _fp16_matmul(algorithm=GEMMAlgorithm.MMA_SYNC, instruction_k=16)
+        b = _fp16_matmul(algorithm=GEMMAlgorithm.TCGEN05_MMA, instruction_k=32)
+        self.assertFalse(produces_same_bits(a, b, _EVERYTHING_DECLARED))
+
+    def test_fast_accum_is_free_where_it_is_declared(self):
+        a = _fp16_matmul(use_fast_accum=True)
+        b = _fp16_matmul(use_fast_accum=False)
+        self.assertNotEqual(a, b)
+        self.assertTrue(produces_same_bits(a, b, _FAST_ACCUM_FREE))
+        self.assertTrue(produces_same_bits(b, a, _FAST_ACCUM_FREE))
+        self.assertFalse(produces_same_bits(a, b, _NOTHING_DECLARED))
+        self.assertFalse(produces_same_bits(a, b, _TWO_INSTRUCTIONS_AGREE))
+
+    def test_a_free_fast_accum_and_a_free_instruction_together(self):
+        a = _fp16_matmul(algorithm=GEMMAlgorithm.MMA_SYNC, use_fast_accum=True)
+        b = _fp16_matmul(algorithm=GEMMAlgorithm.TCGEN05_MMA, use_fast_accum=False)
+        self.assertFalse(produces_same_bits(a, b, _TWO_INSTRUCTIONS_AGREE))
+        self.assertFalse(produces_same_bits(a, b, _FAST_ACCUM_FREE))
+        self.assertTrue(produces_same_bits(a, b, _EVERYTHING_DECLARED))
+
+    def test_fast_accum_free_says_nothing_about_a_scalar_algorithm(self):
+        """use_fast_accum is None there, so there is no second form to be free of."""
+        fused = _scalar_matmul()
+        separate = _scalar_matmul(algorithm=GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD)
+        self.assertFalse(produces_same_bits(fused, separate, _EVERYTHING_DECLARED))
+        self.assertTrue(produces_same_bits(fused, fused, _EVERYTHING_DECLARED))
+        # Nor does it pull a scalar algorithm and a matrix instruction together.
+        for use_fast_accum in (True, False):
+            matrix = _fp16_matmul(use_fast_accum=use_fast_accum)
+            self.assertFalse(produces_same_bits(fused, matrix, _EVERYTHING_DECLARED))
+
+    @parametrize("field,left,right", _ONE_CUT_FIELD_CHANGES, name_fn=_case_name)
+    def test_a_changed_cut_field_is_never_free(self, field, left, right):
+        a = _fp16_matmul(k_cuts=(_cut(**left),))
+        b = _fp16_matmul(k_cuts=(_cut(**right),))
+        self.assertFalse(produces_same_bits(a, b, _EVERYTHING_DECLARED))
+        # Also one level down, where only the inner cut differs.
+        outer = _cut(span=4096)
+        self.assertFalse(
+            produces_same_bits(
+                _fp16_matmul(k_cuts=(outer, _cut(**left))),
+                _fp16_matmul(k_cuts=(outer, _cut(**right))),
+                _EVERYTHING_DECLARED,
+            )
+        )
+
+    def test_matching_cuts_do_not_block_a_free_instruction(self):
+        a = _fp16_matmul(algorithm=GEMMAlgorithm.MMA_SYNC, k_cuts=(_cut(),))
+        b = _fp16_matmul(
+            algorithm=GEMMAlgorithm.TCGEN05_MMA, k_cuts=(_cut(),)  # rebuilt, not shared
+        )
+        self.assertTrue(produces_same_bits(a, b, _TWO_INSTRUCTIONS_AGREE))
+
+    def test_cuts_of_different_depths_are_never_free(self):
+        one = _fp16_matmul(k_cuts=(_cut(),))
+        two = _fp16_matmul(k_cuts=(_cut(), _cut(span=64)))
+        swapped = _fp16_matmul(k_cuts=(_cut(span=64), _cut()))
+        self.assertFalse(produces_same_bits(one, two, _EVERYTHING_DECLARED))
+        self.assertFalse(produces_same_bits(two, swapped, _EVERYTHING_DECLARED))
+
+    def test_a_declared_scalar_pair_agrees(self):
+        """Integer arithmetic is exact, so a machine may declare the scalar pair."""
+        exact = Equivalences(
+            interchangeable_instructions=(frozenset(_SCALAR_ALGORITHMS),)
+        )
+        fused = _int8_matmul(**_SCALAR)
+        separate = _int8_matmul(
+            **{**_SCALAR, "algorithm": GEMMAlgorithm.SCALAR_MULTIPLY_THEN_ADD}
+        )
+        self.assertNotEqual(fused, separate)
+        self.assertTrue(produces_same_bits(fused, separate, exact))
+        self.assertFalse(produces_same_bits(fused, separate, _EVERYTHING_DECLARED))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/gemm_desc.md
+++ b/torch/_inductor/gemm_desc.md
@@ -1,0 +1,556 @@
+# `GEMMDesc`: how to compute a GEMM, written down precisely enough to pin the bits
+
+This is the long form of `gemm_desc.py`. The module keeps the short rules a reader
+needs while editing a line; everything here is the worked examples, the
+measurements they came from, and the reasoning behind what the type does and does
+not carry. Nothing here is needed to use the type. This file, in the repo next to
+the module, is the canonical long form; anything else is a copy of it.
+
+## Contents
+
+- [What a descriptor promises](#what-a-descriptor-promises)
+- [The five algorithms](#the-five-algorithms)
+- [`input_precision`: how fp32 is cut down](#input_precision-how-fp32-is-cut-down)
+- [Why a cut changes the answer](#why-a-cut-changes-the-answer)
+- [How cuts nest](#how-cuts-nest)
+- [Which k elements one part owns](#which-k-elements-one-part-owns)
+- [A part length, not a part count](#a-part-length-not-a-part-count)
+- [Two dtypes for a merge, not one](#two-dtypes-for-a-merge-not-one)
+- [Merge order: the count-down butterfly](#merge-order-the-count-down-butterfly)
+- [`period` and `divisor`: labelling a strided tile](#period-and-divisor-labelling-a-strided-tile)
+- [`instruction_k` is not the loop's k step](#instruction_k-is-not-the-loops-k-step)
+- [`use_fast_accum`](#use_fast_accum)
+- [`k_loop_step`: the short turn first](#k_loop_step-the-short-turn-first)
+- [The epilogue pipelines](#the-epilogue-pipelines)
+- [The three dtypes](#the-three-dtypes)
+- [Operand dtypes have no fall-through](#operand-dtypes-have-no-fall-through)
+- [What a real GEMM looks like here](#what-a-real-gemm-looks-like-here)
+- [What is deliberately not a field](#what-is-deliberately-not-a-field)
+- [What this cannot say](#what-this-cannot-say)
+- [The two relations](#the-two-relations)
+
+## What a descriptor promises
+
+A GEMM's floating-point result depends on the order its k products are added in,
+because floating-point addition is not associative. Two kernels that compute the
+same matrix product can therefore hand back different bits. `GEMMDesc` writes that
+order down: two runs on the same architecture that follow the same `GEMMDesc` owe
+you the same bits.
+
+Across architectures that is an open question, not a promise. What has been
+measured is narrower -- within one architecture the form of the matrix instruction
+often does not change the result, MMAv5 agreeing with MMAv2 on Blackwell and
+`mma.sync` with `wgmma` on Hopper -- and even that has fp8 as a known exception.
+Whether one descriptor holds across, say, an H100 and a GB300 has not been tested,
+so the module does not claim it.
+
+That exception is why `algorithm` names the matrix instruction that ran --
+`mma.sync`, `wgmma` or `tcgen05.mma` -- instead of saying only that a tensor core
+did it. One name covering all three would be one name for two answers on fp8, which
+is the thing this type exists to stop.
+
+There are two ways to get a descriptor. A person writes it by hand, so a result
+stays reproducible anywhere. Or a later layer produces one by reading what an
+existing library would do for a shape, so a Triton kernel can be made to agree with
+that library bit for bit. The module is only the description; the producers come
+later, and so do the `Equivalences` they measure.
+
+A `GEMMDesc` holds exactly two kinds of thing: which GEMM algorithm, and every
+parameter that changes the floating-point order. It holds nothing that is only a
+speed knob. Tile sizes, warp counts, pipeline depth, cluster shape and how much
+scratch memory a library may use are all absent for that reason: they move the run
+time, not the result.
+
+They can move the result indirectly, and a producer has to watch for it. A tile too
+small for an instruction makes a compiler fall back to a different one -- Triton
+leaves its native fp8 matrix-instruction path when the m tile drops below 64 -- and
+then the bits move, but they move through `algorithm`, which is a field. So the rule
+holds as stated and the obligation it creates is on the producer: emit a launch that
+really runs the instruction the descriptor names, and check it rather than assume it.
+
+Nothing in the module names a library, an algorithm id, or a vendor enum value. A
+library is a *producer* of a `GEMMDesc`, never a part of one. Where an algorithm
+there happens to equal a known library kernel, a comment says which one. A hardware
+instruction is not a vendor enum value in that sense: `mma.sync` is the name the
+instruction set gives the instruction, and which instruction ran is one of the
+things that decides the bits.
+
+## The five algorithms
+
+`GEMMAlgorithm` says how operands become an update to the accumulator. The five
+round in different places, so for the same inputs they are different answers:
+
+```
+a matrix instruction       [sum of instruction_k products + acc] -> acc
+                           one rounding per instruction
+SCALAR_FUSED_MULTIPLY_ADD  fma(a, b, acc) -> acc
+                           one rounding per k element
+SCALAR_MULTIPLY_THEN_ADD   t = a * b, then acc + t -> acc
+                           two roundings per k element
+```
+
+`MMA_SYNC`, `WGMMA` and `TCGEN05_MMA` all run on the tensor cores and differ in who
+issues the instruction and where the accumulator lives:
+
+| value | PTX | who issues it | accumulator | hardware | Triton path |
+| --- | --- | --- | --- | --- | --- |
+| `MMA_SYNC` | `mma.sync.aligned` | one warp, its 32 lanes cooperating | registers, a piece in each lane | Volta (sm_70) onward | MMAv2 |
+| `WGMMA` | `wgmma.mma_async.sync.aligned` | one warpgroup of four warps, asynchronously | registers | Hopper (sm_90) only | MMAv3 |
+| `TCGEN05_MMA` | `tcgen05.mma` | a single thread | tensor memory | Blackwell (sm_100) onward | MMAv5 |
+
+`wgmma` can also read its operands straight from shared memory.
+
+The two scalar values are the CUDA-core loop, one k element per step.
+`SCALAR_FUSED_MULTIPLY_ADD` is what cuBLAS's CUDA-core kernels do, and what Triton
+emits with `enable_fp_fusion=True` when no matrix instruction is involved.
+`SCALAR_MULTIPLY_THEN_ADD` is what Triton reaches with `enable_fp_fusion=False`.
+
+`mma.sync` is the oldest of the three matrix instructions. On most dtypes they do
+agree -- but only on most, and that exception is what stops them being one value.
+Naming them separately costs nothing where they do agree, because
+`produces_same_bits` reads a machine's measured agreements from `Equivalences`.
+
+They are the NVIDIA families. AMD's `v_mfma` and `v_wmma` are a separate family with
+no value in the enum yet, and so is NVIDIA's older `wmma.mma.sync`. A producer for
+one of those must add its own value rather than borrow a name; with no value to
+borrow, it declines instead, which is the safe way round.
+
+Adding an instruction means adding a value to `GEMMAlgorithm` and a member to
+`MATRIX_INSTRUCTIONS`. Membership of that set, rather than a check spelled out at
+each use, is what makes the field rules in the `GEMMDesc` docstring cover the new
+value.
+
+## `input_precision`: how fp32 is cut down
+
+fp32 operands can be fed to a matrix instruction in more than one way, and the
+choice changes the result while the dtype stays fp32. It cannot be read off
+`operand_dtype`, so it is its own field. The names are the ones Triton uses for
+`tl.dot(input_precision=...)`.
+
+`IEEE` multiplies the operands at their own precision, and is the only choice for
+anything that is not fp32. `TF32` rounds each fp32 operand to tf32 -- an 8-bit
+exponent and a 10-bit mantissa -- before the multiply, which is what cuBLAS calls
+`CUBLAS_COMPUTE_32F_FAST_TF32`. `TF32X3` splits each fp32 operand into three tf32
+pieces and sums the pieces' products, which recovers most of the fp32 mantissa; it
+is also known as 3xTF32.
+
+Both tf32 values need a matrix instruction and fp32 operands, because tf32 exists
+only as a matrix instruction's input format.
+
+## Why a cut changes the answer
+
+A `KCut` is worth describing because an accumulator that restarts at zero puts a
+bracket in the sum. Take K = 12 with one matrix instruction per 2 k elements, so
+six instruction results d0..d5. With no cut, one accumulator walks all six:
+
+```
+((((( d0+d1 )+d2 )+d3 )+d4 )+d5 )
+```
+
+With one cut at span 4, each group of two gets its own accumulator and the three
+totals are added:
+
+```
+( ( (d0+d1) + (d2+d3) ) + (d4+d5) )
+```
+
+Same six numbers, every level still added left to right, different brackets.
+Floating-point addition is not associative, so those are different answers. This is
+not a corner case: the Triton study this type replaces first missed the second level
+because a flat sum matched the reference exactly while k fit in one group and parted
+from it at the first k that needed two.
+
+## How cuts nest
+
+Cuts nest, outermost first. Level 0 cuts the whole k axis; level 1 cuts each part
+level 0 produced; and so on. With `k_cuts = (KCut(span=6, ...), KCut(span=2, ...))`
+over K = 12:
+
+```
+K = 12
+|-- part k[0:6]              level 0, its own accumulator
+|   |-- part k[0:2]          level 1, its own accumulator
+|   |-- part k[2:4]
+|   +-- part k[4:6]
+|   total = ((k[0:2] + k[2:4]) + k[4:6])
++-- part k[6:12]
+    |-- part k[6:8]
+    |-- part k[8:10]
+    +-- part k[10:12]
+    total = ((k[6:8] + k[8:10]) + k[10:12])
+result = k[0:6] total + k[6:12] total
+```
+
+The innermost part has no cut under it. One accumulator walks it in index order, and
+`GEMMDesc.algorithm` and `GEMMDesc.instruction_k` say what one step of that walk is.
+
+## Which k elements one part owns
+
+`KCutLayout` answers that. With K = 12:
+
+```
+CONTIGUOUS, span=4
+  part0 = k[0:4]   part1 = k[4:8]   part2 = k[8:12]
+
+STRIDED, span=2, count=3
+  tile:   t0     t1     t2     t3     t4     t5
+          k0 k1  k2 k3  k4 k5  k6 k7  k8 k9  k10 k11
+  part0 = t0 t3    part1 = t1 t4    part2 = t2 t5
+```
+
+Both hand three parts four k elements each, and the two answers differ, because
+which k elements share an accumulator is what decides the sum.
+
+cuBLAS's two-kernel gemv hands tiles out the `STRIDED` way.
+
+## A part length, not a part count
+
+`KCut.span` is the length itself and not a part count, and there is deliberately no
+`num_splits` field next to it.
+
+For a `CONTIGUOUS` cut the number of parts follows from the length being cut, as
+`ceil(length / span)`, so storing it too could only ever disagree with it.
+
+The length is also the more faithful of the two to write down, because the count a
+library is asked for and the count it then performs are not the same number. Ask for
+5 splits of K = 1000 on a 64-element grain: 1000 / 5 is 200, rounded up to the grain
+that is a 256-long slice, and K = 1000 in 256-long slices is 4 slices, not 5. A
+descriptor written from the request would describe a sum that never happened. The
+one written from `span` records the sum that did.
+
+A `STRIDED` cut is the other way round and does carry `count`, because which tiles
+land in which part cannot be recovered from the span alone.
+
+## Two dtypes for a merge, not one
+
+`KCut.partial_dtype` is the dtype a finished part is written at before it is merged.
+`KCut.merge_dtype` is the dtype the running merge sum is kept in. They are two
+fields because all the useful combinations are in use: fp32 partials summed in fp32,
+output-dtype partials summed in fp32, and a chain kept in the output dtype the whole
+way.
+
+Assuming the second one follows from the first is a bug that hid for a long time in
+the Triton study this type replaces -- the merge rounded to fp16 whatever the output
+dtype was, so every bf16 split-k result was wrong.
+
+## Merge order: the count-down butterfly
+
+`MergeOrder.SEQUENTIAL` is part 0, then part 1, and so on: `(((p0 + p1) + p2) + p3)`.
+That is what a loop over the parts does, so it is what a split-k merge kernel that
+walks the partials and adds each into a running sum does.
+
+`MergeOrder.PAIRWISE_TREE` is a balanced binary tree over the parts **in index
+order**: `((p0 + p1) + (p2 + p3))`. A cross-lane reduction that folds with butterfly
+shuffles is a balanced tree, but it is only this one when it pairs lanes in index
+order -- a count-up butterfly. A count-down butterfly is a balanced tree in
+bit-reversed order, which is a different sum.
+
+That was measured, not assumed. Over 88 measured cases, writing cuBLAS's count-down
+gemv merge as a single `PAIRWISE_TREE` matched 16, and those 16 are exactly the
+two-part rows where the two orders coincide.
+
+Write a fold whose pairing is not index order as nested two-part cuts instead, one
+level per round, which needs no vocabulary beyond `KCut` and always matched. Reach
+for `PAIRWISE_TREE` only when the tree really is over the parts as this cut numbers
+them.
+
+The two orders agree while a cut has two parts or fewer -- `(p0 + p1)` either way --
+so the distinction only starts to bite at three, and a producer that has only ever
+seen two-part cuts has not yet learned which one a kernel does.
+
+## `period` and `divisor`: labelling a strided tile
+
+These two fields on `KCut` say how a `STRIDED` cut labels a tile, for the case where
+the label does not simply repeat every `count` tiles:
+
+```
+label = (k // span) % period          None means period == count
+part  = (label // divisor) % count    which digit of the label to read
+```
+
+Left unset this is the plain rotation the layout describes, tile j to part
+`j % count`, so no descriptor written before these fields existed changes meaning.
+
+They are needed because a nest of plain `STRIDED` cuts can only ever label a tile by
+its index modulo the product of the counts, and a real kernel deals tiles out on a
+period the tree below it does not factor. cuBLAS's two-kernel gemv is one: its
+reduction tree has fixed level counts 4, 8, 2, 2 and so a product of 128, while the
+tiles are dealt to blocks on the split count, which over a sweep of 2,384 gemv shapes
+took values including 10, 37, 74, 148, 253, 296 and 592 -- 117 of 299 hits on a
+period 128 cannot express. Stating the period once and letting each level read its
+own digit of the label covers all of them.
+
+A part may end up empty, and that is not an error: with period 37 a level with
+count 2 at divisor 64 never sees a label that large, so its second part gets nothing
+and contributes a zero to the merge. The real kernel does the same.
+
+## `instruction_k` is not the loop's k step
+
+`GEMMDesc.instruction_k` is how many k elements one matrix instruction sums into the
+accumulator in a single rounding. It is the step size of the innermost chain, so it
+sets where that chain rounds, which is why it is a field rather than left to the
+compiler.
+
+It is not the loop's k step, and seeing why is also why the loop's k step is not a
+field at all. With a threadblock k step of 64 and `instruction_k` 16, one turn of the
+loop issues four instructions into the same accumulator:
+
+```
+turn 0:  [16][16][16][16]  -> added into acc one after another
+turn 1:  [16][16][16][16]  -> added into acc one after another
+```
+
+The chain steps by 16 either way. Widening the turn to 128 regroups the loop but not
+the chain, so it cannot move the bits.
+
+## `use_fast_accum`
+
+The field says where a matrix instruction's result meets the running accumulator:
+
+```
+True   a, b -> [instruction sums and adds into acc] -round-> acc
+
+False  a, b -> [instruction sums into zero]         -round-> part
+       acc + part                                   -round-> acc
+```
+
+`True` is `tl.dot(a, b, acc)` and rounds once a step; `False` is `acc + tl.dot(a, b)`
+and rounds twice. The two scalar algorithms draw the same distinction in their own
+names, so this is their matrix-instruction twin: it is required for a matrix
+instruction and `None` otherwise. The name is torch's -- the `use_fast_accum`
+argument of `torch._scaled_mm`, and `USE_FAST_ACCUM` in Inductor's GEMM templates.
+
+The name carries two things, and a producer needs both.
+
+One is the structural difference above, and it moves the result on every
+architecture. That is measured rather than assumed: over a 640x512 output at
+K = 4096 with fp16 operands and an fp32 accumulator, 326,703 of 327,680 elements
+differ between the two forms.
+
+The other is why it is called *fast* accumulate and why torch hands it to the caller
+at all. On Hopper an fp8 matrix instruction can keep accumulating inside the tensor
+core at reduced precision, which is quicker and loses bits, so there the choice is
+not only about where the add sits. Triton spells that out as `max_num_imprecise_acc`,
+how many instructions may pass before the value is pulled back into a full-precision
+accumulator.
+
+On Blackwell the two forms normally cannot be told apart, because Triton folds one
+into the other before codegen: `CombineDotAddFPattern` in
+`lib/Dialect/Triton/Transforms/Combine.cpp` turns `addf(dot(a, b, 0), acc)` into
+`dot(a, b, acc)`, so both reach the same machine code. The measurement above comes
+from blocking that fold. Triton leaves it unfolded on sm_90 for fp8 operands --
+`max_num_imprecise_acc_default` is non-zero only there -- which is exactly the case
+torch exposes.
+
+There is no default for the field, for the same reason the dtypes have none: it
+decides bits, so it has to be stated.
+
+## `k_loop_step`: the short turn first
+
+`GEMMDesc.k_loop_step` is the k loop step of one accumulator: how many k elements one
+turn of the mainloop covers. It is a field for one reason. When a part is not a whole
+number of turns, a kernel that runs the short turn FIRST puts the instruction group
+boundaries somewhere else than one that runs it last. With K = 10 and
+`instruction_k` 4:
+
+```
+None, short group last    [k0 k1 k2 k3][k4 k5 k6 k7][k8 k9]
+                                d0           d1        d2
+                          boundaries at k = 0, 4, 8
+
+4, short group first      [k0 k1][k2 k3 k4 k5][k6 k7 k8 k9]
+                             d0        d1          d2
+                          boundaries at k = 0, 2, 6
+```
+
+Same K, same `instruction_k`, three groups either way -- but different k elements are
+folded into the same rounding, so the two are different sums. `None` means the
+boundaries run on an even grid from 0 and the short group is last.
+
+## The epilogue pipelines
+
+`EpilogueOrder` says where the single rounding to `output_dtype` sits relative to the
+epilogue. A bias added to the accumulator before that rounding and the same bias
+added after it give different bits, so this has to be said out loud, not assumed:
+
+```
+NONE            [k sum] -round-> out
+IN_ACCUMULATOR  [k sum] -> +bias -> +beta*C -round-> out
+AFTER_ROUNDING  [k sum] -round-> +bias -round-> +beta*C
+```
+
+`AFTER_ROUNDING` is what an epilogue that is a separate pass over the stored result
+does: the GEMM writes `output_dtype` to memory and something else reads it back and
+adds the bias. Inductor's fused GEMM templates deliberately reproduce it --
+`select_algorithm.py` rounds the accumulator to the output dtype before the fused
+graph ops run, under a comment saying it is emulating unfused numerics -- so a fused
+kernel is `AFTER_ROUNDING`, not `IN_ACCUMULATOR`, for the ops the graph fused in. A
+library epilogue that really runs inside the GEMM kernel, such as cuBLAS adding a
+bias to the live accumulator, is `IN_ACCUMULATOR` instead.
+
+One thing the enum cannot say: Inductor puts the rounding in the *middle*, after the
+template's own epilogue and before the fused graph ops, so an addmm with a fused relu
+adds the bias in the accumulator dtype and applies the relu after the round. That is
+neither value. A descriptor for such a kernel would need to place the rounding within
+the epilogue rather than at one end of it, and a producer that meets one must decline.
+
+## The three dtypes
+
+`operand_dtype` is the dtype both operands are read at. It is one field and not two
+because a GEMM with two different operand dtypes is out of scope; when that changes
+the field splits in two, rather than growing a rule about which one wins.
+
+`accumulate_dtype` is the dtype the k sum is kept in. It is a field of its own
+because it is not implied by the operand dtype: fp16 operands are accumulated in
+fp32 by almost everything but not by everything, and fp32 and fp64 operands make
+"always fp32" wrong.
+
+`output_dtype` is the dtype the finished value is rounded to on the store. All three
+must be floating point, or all three integer.
+
+## Operand dtypes have no fall-through
+
+An operand may be read at any dtype in `OPERAND_DTYPES`. A dtype that is not listed
+is rejected, never quietly treated as one that is. That mistake is how a study of
+this problem in Triton ran an fp32 operand through the fp16 recipe and returned a
+wrong answer instead of declining.
+
+fp8 is missing from `ACCUMULATE_DTYPES` on purpose: no hardware accumulates in it,
+and allowing it would let a producer write a descriptor nobody can honour.
+
+## What a real GEMM looks like here
+
+The kinds of GEMM this vocabulary was checked against. Each one names the shape and
+the cuBLAS kernel it was read off, then says what `k_cuts` comes out as:
+
+```
+one accumulator over the whole k axis (nvjet)
+    no cut at all, so k_cuts is the empty tuple
+
+the same, but the short group of k runs first (CUTLASS)
+    still no cut; k_loop_step is what says the short group runs first
+
+split-k (nvjet split-k)
+    one cut: k in contiguous slices, each slice with its own accumulator
+
+split-k whose slices close an accumulator every block (nvjet split-k)
+    two cuts: first the slices, then the blocks inside one slice
+
+split-k over instruction groups (CUTLASS split-k)
+    one cut into slices, with k_loop_step describing the groups inside a slice
+
+a scalar chain of chunks (gemmSN_NN, magma_sgemmEx)
+    two cuts: first the chunks, then the smaller chunks inside one of them
+
+a gemv whose lanes interleave (gemv2T, gemv2N)
+    two cuts: first the lanes, each taking every count-th tile of k, then the
+    chunks that one lane walks in order
+
+a gemv whose lanes fold in bit-reversed order (gemv2T, gemv2N)
+    one cut per round of the fold, each cutting what is left in two
+
+a gemv dealt out to blocks on a period (dot_kernel + reduce_1Block)
+    strided cuts carrying `period`, because the tiles repeat on a number that
+    the cut counts do not multiply to
+```
+
+The first five run a matrix instruction and the rest a scalar one. A part count is
+never a field: for a contiguous cut it follows from `span` and the length being cut,
+and for a strided cut it is `count`.
+
+The kernel names are only a signpost. They are where each shape was read off, they
+are not part of any descriptor, and a shape stands on its own wherever else it turns
+up. Each was written out in full against the kernel it describes, and the four scalar
+ones were then checked by byte-comparing a literal walk of the descriptor against
+what the kernel returned.
+
+## What is deliberately not a field
+
+**Operand layout.** Row-major, column-major and arbitrary strides say which bytes are
+which matrix element; they describe the *problem*, not the algorithm. Reading an
+element never rounds, so two runs with the same `GEMMDesc` over differently laid out
+operands add the same products in the same order and return the same bits. Layout is
+an input to a producer -- it is one of the things a library looks at when it picks a
+kernel -- but it is not part of the description that comes out. Leaving it out is the
+point: Inductor sees arbitrary layouts, and a descriptor that pinned one layout per
+dtype would refuse work it can do.
+
+**The batch axis.** A batched GEMM is a set of independent GEMMs, and nothing is ever
+summed across the batch, so the batch cannot change the order of any one output
+element. One `GEMMDesc` describes every GEMM in the batch. Only a GEMM that reduced
+over the batch would need a field, and that is a different operation.
+
+**The values of alpha, beta and the bias.** Those are data, and data does not belong
+in a description of an algorithm. What changes the bits is *where* the single
+rounding to `output_dtype` sits relative to them, and that question is `epilogue`.
+
+**How operand scales are applied.** A scale that is one constant per output element
+could be described as an epilogue step, but a block-wise scale cannot: it multiplies
+each block of the k sum by its own factor, inside the k loop, so it cuts the k axis
+rather than following it. Covering only the first kind would be a field that quietly
+means "the quantization strategies we happened to think of", so this version has no
+scale field at all, and a descriptor for a scaled matmul is out of scope. When it
+returns it belongs on `KCut`, as a property of a cut, not as another epilogue enum.
+
+## What this cannot say
+
+The k reduction here is a nest of cuts that ends in one chain of hardware steps. Real
+kernels exist that do more than that -- for example a vector-wide load whose elements
+form their own summation group underneath a lane's chain. A producer that meets one
+must decline rather than write down the nearest `GEMMDesc`: a nearly-right order is
+wrong bits, and losing coverage is much cheaper than answering wrong.
+
+## The two relations
+
+There are two relations in the module, and they are not the same. `a == b` says the
+two descriptions are identical. `produces_same_bits(a, b, known)` says a particular
+machine hands back the same bits for both, which is weaker: it also holds for
+descriptions that differ in a way that machine cannot show you. Which differences
+those are is measured per architecture, so `known` is an argument. The module defines
+the shape of that answer and ships none of its content.
+
+A `GEMMDesc` is a value: it is frozen, it compares and hashes by its fields, and
+there is no module state anywhere near it, so it can be used as a cache key without
+a second thought. Equality never depends on which machine you are on; that is what
+the other relation is for.
+
+`Equivalences` is that argument. It holds groups of algorithms a machine cannot tell
+apart, and whether the two values of `use_fast_accum` are free there. Building one is
+the job of whoever did the measuring. One instance covers one machine and one
+question: the Blackwell fp8 exception is the reason a producer asking about fp8 there
+and one asking about fp16 need different instances, and a single instance that
+averaged the two would be wrong for both. Picking the matching one is the caller's
+job. `Equivalences()` -- nothing declared -- is the right value for a machine nobody
+has measured, and under it `produces_same_bits` is exactly `==`.
+
+Two descriptors that are equal except that one says `MMA_SYNC` and the other
+`TCGEN05_MMA` produce the same bits when one group holds both.
+
+The groups must not overlap, and construction rejects a pair that does. `{A, B}` and
+`{B, C}` together would say that A and C agree, which is a wider claim than either
+group makes; growing a claim quietly is how a wrong answer becomes a silent one, so
+it has to be written out instead.
+
+A group may name a scalar algorithm, which is what an integer GEMM would want:
+integer arithmetic is exact, so there fma and multiply-then-add really do agree.
+Integer addition is also associative, so for an integer GEMM the ordering fields
+describe the kernel without constraining the answer. Mixing a scalar algorithm and a
+matrix instruction into one group is allowed but can never make two descriptors
+equivalent, because the matrix one carries `instruction_k` and the scalar one may
+not, and that difference stays.
+
+`fast_accum_is_free` says nothing about a scalar algorithm: there `use_fast_accum`
+is `None`, so there is no second form for a machine to make free.
+
+The relation fails closed. The declared differences are rewritten to one form and
+then every remaining field is compared, rather than the significant fields being
+listed out. So a difference nobody has measured keeps the answer `False` --
+including a difference in a field added to `GEMMDesc` after the relation was
+written, which is the case a hand-written list would have got wrong. A difference
+stops counting only when someone measures it and gives it a field on `Equivalences`.
+
+The canonical form it compares is a dict of every field and not another `GEMMDesc`,
+for two reasons: a canonical form need not be a legal descriptor, and rebuilding one
+would re-run the constructor's checks and raise where the answer should simply be
+`False`. Comparing the dicts compares `k_cuts` too -- it is a tuple of frozen
+`KCut`s, so `==` walks it element by element and compares every field of every cut.

--- a/torch/_inductor/gemm_desc.py
+++ b/torch/_inductor/gemm_desc.py
@@ -1,0 +1,510 @@
+"""`GEMMDesc`: how to compute a GEMM, written down precisely enough to pin the bits.
+
+Floating-point addition is not associative, so the order a GEMM adds its k products
+in decides its bits. `GEMMDesc` writes that order down: two runs on the same
+architecture that follow the same `GEMMDesc` owe you the same bits. It carries only
+what changes that order -- never a speed knob, never a library name.
+
+A speed knob can still move the bits indirectly: a tile too small for an instruction
+makes the compiler fall back to a different one. That runs through `algorithm`,
+which is a field, so a producer must check that its launch really runs the
+instruction the descriptor names rather than assume it.
+
+Two relations live here and they are not the same. `a == b` says the two
+descriptions are identical. `produces_same_bits(a, b, known)` says one machine
+cannot show the difference between them, which is weaker and is measured per
+architecture.
+
+See gemm_desc.md, beside this file, for the long form: the worked examples, the
+measurements these rules came from, and what is deliberately not a field.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import auto, Enum
+
+import torch
+
+
+class GEMMAlgorithm(Enum):
+    """How operands become an update to the accumulator.
+
+    The matrix instructions are named one by one, not lumped into a single "tensor
+    core" value, because on fp8 they do not agree. AMD's `v_mfma` and `v_wmma` and
+    NVIDIA's older `wmma.mma.sync` have no value here -- add one rather than borrow
+    a name; see gemm_desc.md.
+    """
+
+    # `mma.sync.aligned`: one warp, accumulator in registers. Volta onward.
+    MMA_SYNC = auto()
+
+    # `wgmma.mma_async`: one warpgroup, operands from shared memory. Hopper only.
+    WGMMA = auto()
+
+    # `tcgen05.mma`: one thread, accumulator in tensor memory. Blackwell onward.
+    TCGEN05_MMA = auto()
+
+    # `acc = fma(a, b, acc)`: one rounding per k element.
+    SCALAR_FUSED_MULTIPLY_ADD = auto()
+
+    # `acc = acc + (a * b)`: two roundings per k element.
+    SCALAR_MULTIPLY_THEN_ADD = auto()
+
+
+# The algorithms that sum several k elements in one rounding.
+MATRIX_INSTRUCTIONS: frozenset[GEMMAlgorithm] = frozenset(
+    {
+        GEMMAlgorithm.MMA_SYNC,
+        GEMMAlgorithm.WGMMA,
+        GEMMAlgorithm.TCGEN05_MMA,
+    }
+)
+
+
+class InputPrecision(Enum):
+    """What the operands are rounded to before they are multiplied.
+
+    fp32 operands can be fed to a matrix instruction in more than one way, and the
+    choice changes the result while the dtype stays fp32.
+    """
+
+    # Operands multiplied at their own precision; the only choice for non-fp32 ones.
+    IEEE = auto()
+
+    # fp32 operands rounded to tf32, a 10-bit mantissa, before the multiply.
+    TF32 = auto()
+
+    # Each fp32 operand split into three tf32 pieces and the products summed.
+    TF32X3 = auto()
+
+
+class KCutLayout(Enum):
+    """Which k elements one part of a k cut owns.
+
+    Two layouts can hand out parts of the same size and still be different sums,
+    because which k elements share an accumulator is what decides the sum.
+    """
+
+    # Part i owns the run k in [i * span, (i + 1) * span). The last part may be short.
+    CONTIGUOUS = auto()
+
+    # `span`-long tiles dealt out: part i owns every tile j with j % count == i.
+    STRIDED = auto()
+
+
+class MergeOrder(Enum):
+    """The order the finished parts of a k cut are added together in.
+
+    The two agree at two parts or fewer, so a producer that has only seen two-part
+    cuts has not yet learned which one a kernel does.
+    """
+
+    # (((p0 + p1) + p2) + p3), which is what a loop over the parts does.
+    SEQUENTIAL = auto()
+
+    # ((p0 + p1) + (p2 + p3)), a balanced tree in index order -- a count-down butterfly
+    # is not this one, write it as nested two-part cuts; see gemm_desc.md.
+    PAIRWISE_TREE = auto()
+
+
+class EpilogueOrder(Enum):
+    """Where the single rounding to `output_dtype` sits relative to the epilogue.
+
+    A bias added to the accumulator before that rounding and the same bias added
+    after it give different bits.
+    """
+
+    # Nothing after the k sum: the accumulator is rounded once, on the store.
+    NONE = auto()
+
+    # Every epilogue step runs in `accumulate_dtype`, then one rounding on the store.
+    IN_ACCUMULATOR = auto()
+
+    # Rounded first, then the epilogue runs in `output_dtype` -- but Inductor rounds in
+    # the MIDDLE of a fused epilogue, which is neither value; see gemm_desc.md.
+    AFTER_ROUNDING = auto()
+
+
+# An operand may be read at any of these. An unlisted dtype is rejected, not guessed.
+FLOAT_OPERAND_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    }
+)
+INT_OPERAND_DTYPES: frozenset[torch.dtype] = frozenset({torch.int8, torch.uint8})
+OPERAND_DTYPES: frozenset[torch.dtype] = FLOAT_OPERAND_DTYPES | INT_OPERAND_DTYPES
+
+# What a k sum may be kept in. fp8 is absent on purpose: no hardware accumulates in it.
+ACCUMULATE_DTYPES: frozenset[torch.dtype] = frozenset(
+    {torch.float16, torch.float32, torch.float64, torch.int32, torch.int64}
+)
+
+OUTPUT_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+        torch.int8,
+        torch.int32,
+    }
+)
+
+# What a partial sum may be stored in, and what a merge may add in.
+MERGE_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+        torch.int32,
+        torch.int64,
+    }
+)
+
+
+def _dtype_names(dtypes: frozenset[torch.dtype]) -> str:
+    return ", ".join(sorted(str(d) for d in dtypes))
+
+
+@dataclasses.dataclass(frozen=True)
+class KCut:
+    """One cut of the k axis, not one part of it.
+
+    Slice the k range handed to this level into parts, give each part its own
+    accumulator starting at zero, then add the part totals. Cuts nest, outermost
+    first; the innermost part has no cut under it and one accumulator walks it in
+    index order.
+    """
+
+    # k elements in one part (CONTIGUOUS) or in one tile (STRIDED). A length, not a
+    # part count -- the count a library is asked for is not the count it performs.
+    span: int
+
+    # The dtype a finished part is written at, and the dtype the running merge sum is
+    # kept in -- merge_dtype does not follow partial_dtype; see gemm_desc.md.
+    partial_dtype: torch.dtype
+    merge_dtype: torch.dtype
+
+    layout: KCutLayout = KCutLayout.CONTIGUOUS
+    merge: MergeOrder = MergeOrder.SEQUENTIAL
+
+    # How many parts. STRIDED only; for CONTIGUOUS it follows from `span`.
+    count: int | None = None
+
+    # How a STRIDED cut labels a tile when the label does not repeat every `count`
+    # tiles. Unset means the plain rotation, tile j to part j % count.
+    period: int | None = None
+    divisor: int = 1
+
+    def __post_init__(self) -> None:
+        if self.span < 1:
+            raise ValueError(f"span must be at least 1, got {self.span}")
+        contiguous = self.layout is KCutLayout.CONTIGUOUS
+        if contiguous and self.count is not None:
+            raise ValueError(
+                "count must be None for a CONTIGUOUS cut: the number of parts "
+                f"follows from span and the length being cut, got count={self.count}"
+            )
+        if not contiguous and (self.count is None or self.count < 2):
+            raise ValueError(
+                "a STRIDED cut needs count >= 2, since a cut into one part is not a "
+                f"cut, got count={self.count}"
+            )
+        self._check_label()
+        for name, dtype in (
+            ("partial_dtype", self.partial_dtype),
+            ("merge_dtype", self.merge_dtype),
+        ):
+            if dtype not in MERGE_DTYPES:
+                raise ValueError(
+                    f"unsupported {name} {dtype}; "
+                    f"supported: {_dtype_names(MERGE_DTYPES)}"
+                )
+
+    def _check_label(self) -> None:
+        contiguous = self.layout is KCutLayout.CONTIGUOUS
+        for name, value in (("period", self.period), ("divisor", self.divisor)):
+            unset = value is None or (name == "divisor" and value == 1)
+            if contiguous and not unset:
+                raise ValueError(
+                    f"{name} must be unset for a CONTIGUOUS cut: it labels a tile, "
+                    f"and a contiguous cut has no tiles, got {name}={value}"
+                )
+            if value is not None and value < 1:
+                raise ValueError(f"{name} must be at least 1, got {value}")
+        if self.period is None and self.divisor != 1:
+            raise ValueError(
+                "divisor needs a period: it selects a digit of the label, and "
+                "without a period there is no label to read, got "
+                f"divisor={self.divisor}"
+            )
+
+
+@dataclasses.dataclass(frozen=True)
+class GEMMDesc:
+    """Everything about a GEMM that decides its bits, and nothing else.
+
+    The k sum is described from the outside in: `k_cuts` cuts the k axis into parts
+    that each get their own accumulator, and inside the innermost part one
+    accumulator runs a chain of steps in index order. It is frozen and compares by
+    its fields, so equal descriptors mean equal bits and it works as a cache key.
+
+    Five algorithms, and four fields that only mean anything for some of them. The
+    whole rule is::
+
+        MMA_SYNC                   mma.sync, one warp, Volta onward
+        WGMMA                      wgmma, one warpgroup, Hopper only
+        TCGEN05_MMA                tcgen05.mma, one thread, Blackwell onward
+            instruction_k     required   how many k one instruction folds in
+            use_fast_accum    required   where the instruction's result meets acc
+            k_loop_step       optional   only when the short turn comes first
+            input_precision   IEEE, or tf32 / tf32x3 when the operands are fp32
+
+        SCALAR_FUSED_MULTIPLY_ADD  fma(a, b, acc), one rounding per k element
+        SCALAR_MULTIPLY_THEN_ADD   a * b, then the add, two roundings per element
+            instruction_k     must be None
+            use_fast_accum    must be None
+            k_loop_step       must be None
+            input_precision   IEEE only
+
+    A scalar algorithm rounds once per k element, so it has no instruction to size,
+    no second place to put the add, and no instruction groups for a short first turn
+    to shift; tf32 is a matrix instruction's input format. Construction rejects every
+    other combination. Everything else applies to all five: the three dtypes,
+    `k_cuts`, and `epilogue`.
+    """
+
+    # The dtype both operands are read at; two operand dtypes are out of scope.
+    operand_dtype: torch.dtype
+
+    # The dtype the k sum is kept in. Not implied by the operand dtype.
+    accumulate_dtype: torch.dtype
+
+    # The dtype the finished value is rounded to on the store.
+    output_dtype: torch.dtype
+
+    algorithm: GEMMAlgorithm
+
+    input_precision: InputPrecision = InputPrecision.IEEE
+
+    # k elements one instruction folds into one rounding -- not the loop's k step.
+    instruction_k: int | None = None
+
+    # True is `tl.dot(a, b, acc)`, one rounding; False is `acc + tl.dot(a, b)`, two.
+    use_fast_accum: bool | None = None
+
+    # The mainloop's k step, set only when the short turn runs FIRST; None means last.
+    k_loop_step: int | None = None
+
+    # The nest of k cuts, outermost first. Empty is the ordinary non-split GEMM.
+    k_cuts: tuple[KCut, ...] = ()
+
+    epilogue: EpilogueOrder = EpilogueOrder.NONE
+
+    def __post_init__(self) -> None:
+        self._check_dtypes()
+        self._check_algorithm()
+        self._check_cuts()
+
+    @property
+    def is_floating_point(self) -> bool:
+        """Whether this GEMM rounds at all. An integer GEMM does not."""
+        return self.operand_dtype.is_floating_point
+
+    def _check_dtypes(self) -> None:
+        for name, dtype, allowed in (
+            ("operand_dtype", self.operand_dtype, OPERAND_DTYPES),
+            ("accumulate_dtype", self.accumulate_dtype, ACCUMULATE_DTYPES),
+            ("output_dtype", self.output_dtype, OUTPUT_DTYPES),
+        ):
+            if dtype not in allowed:
+                raise ValueError(
+                    f"unsupported {name} {dtype}; supported: {_dtype_names(allowed)}."
+                    " An unlisted dtype is rejected rather than run under some other"
+                    " dtype's recipe, which would return a wrong answer quietly."
+                )
+        kinds = {
+            self.operand_dtype.is_floating_point,
+            self.accumulate_dtype.is_floating_point,
+            self.output_dtype.is_floating_point,
+        }
+        if len(kinds) != 1:
+            raise ValueError(
+                f"operand_dtype {self.operand_dtype}, accumulate_dtype "
+                f"{self.accumulate_dtype} and output_dtype {self.output_dtype} must "
+                "all be floating point or all be integer"
+            )
+
+    def _check_algorithm(self) -> None:
+        name = self.algorithm.name
+        matrix = self.algorithm in MATRIX_INSTRUCTIONS
+        if matrix and (self.instruction_k is None or self.instruction_k < 1):
+            raise ValueError(
+                f"{name} is a matrix instruction and needs instruction_k >= 1, the "
+                "number of k elements one instruction sums in a single rounding, got "
+                f"{self.instruction_k}"
+            )
+        if not matrix and self.instruction_k is not None:
+            raise ValueError(
+                f"instruction_k must be None for {name}: a scalar step always covers "
+                f"exactly one k element, got {self.instruction_k}"
+            )
+        if not matrix and self.k_loop_step is not None:
+            raise ValueError(
+                f"k_loop_step must be None for {name}: with one rounding per k "
+                "element there are no instruction groups for a short first turn to "
+                "shift"
+            )
+        if matrix and self.use_fast_accum is None:
+            raise ValueError(
+                f"{name} is a matrix instruction and needs use_fast_accum: adding "
+                "into the accumulator and adding into zero then merging are two "
+                "different sums, and there is no safe default to pick for you"
+            )
+        if not matrix and self.use_fast_accum is not None:
+            raise ValueError(
+                f"use_fast_accum must be None for {name}: a scalar algorithm already "
+                "says whether the multiply and the add round together, got "
+                f"{self.use_fast_accum}"
+            )
+        if self.k_loop_step is not None and self.k_loop_step < 1:
+            raise ValueError(f"k_loop_step must be at least 1, got {self.k_loop_step}")
+        self._check_input_precision(matrix)
+
+    def _check_input_precision(self, matrix: bool) -> None:
+        if self.input_precision is InputPrecision.IEEE:
+            return
+        if self.operand_dtype is not torch.float32:
+            raise ValueError(
+                f"input_precision {self.input_precision.name} needs float32 operands,"
+                f" got {self.operand_dtype}: it names how fp32 is cut down before the"
+                " multiply"
+            )
+        if not matrix:
+            raise ValueError(
+                f"input_precision {self.input_precision.name} needs a matrix "
+                f"instruction, got {self.algorithm.name}: tf32 exists only as a "
+                "matrix instruction input"
+            )
+
+    def _check_cuts(self) -> None:
+        if not isinstance(self.k_cuts, tuple):
+            raise ValueError(
+                "k_cuts must be a tuple so the descriptor stays hashable, got "
+                f"{type(self.k_cuts).__name__}"
+            )
+        for level, part in enumerate(self.k_cuts):
+            if not isinstance(part, KCut):
+                raise ValueError(
+                    f"k_cuts[{level}] must be a KCut, got {type(part).__name__}"
+                )
+            self._check_cut_dtypes(level, part)
+
+    def _check_cut_dtypes(self, level: int, part: KCut) -> None:
+        for name, dtype in (
+            ("partial_dtype", part.partial_dtype),
+            ("merge_dtype", part.merge_dtype),
+        ):
+            if dtype.is_floating_point != self.is_floating_point:
+                raise ValueError(
+                    f"k_cuts[{level}].{name} is {dtype}, which does not match "
+                    f"an operand_dtype of {self.operand_dtype}"
+                )
+
+
+@dataclasses.dataclass(frozen=True)
+class Equivalences:
+    """What one machine treats as the same computation.
+
+    Which `GEMMDesc` differences a machine cannot show you. That is measured one
+    architecture at a time, so this module ships no instances; `Equivalences()`
+    declares nothing, and under it `produces_same_bits` is exactly `==`.
+    """
+
+    # Groups of algorithms this machine cannot tell apart. Groups must not overlap.
+    interchangeable_instructions: tuple[frozenset[GEMMAlgorithm], ...] = ()
+
+    # Whether the two values of `use_fast_accum` give the same bits here.
+    fast_accum_is_free: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.interchangeable_instructions, tuple):
+            raise ValueError(
+                "interchangeable_instructions must be a tuple so this stays "
+                f"hashable, got {type(self.interchangeable_instructions).__name__}"
+            )
+        claimed: set[GEMMAlgorithm] = set()
+        for index, group in enumerate(self.interchangeable_instructions):
+            self._check_group(index, group)
+            repeated = claimed & group
+            if repeated:
+                names = ", ".join(sorted(a.name for a in repeated))
+                raise ValueError(
+                    f"interchangeable_instructions[{index}] names {names}, which an "
+                    "earlier group already claimed: overlapping groups would mean a "
+                    "wider equivalence than either of them states"
+                )
+            claimed |= group
+
+    @staticmethod
+    def _check_group(index: int, group: frozenset[GEMMAlgorithm]) -> None:
+        if not isinstance(group, frozenset):
+            raise ValueError(
+                f"interchangeable_instructions[{index}] must be a frozenset, got "
+                f"{type(group).__name__}"
+            )
+        for member in group:
+            if not isinstance(member, GEMMAlgorithm):
+                raise ValueError(
+                    f"interchangeable_instructions[{index}] must hold GEMMAlgorithm "
+                    f"values, got {type(member).__name__}"
+                )
+        if len(group) < 2:
+            raise ValueError(
+                f"interchangeable_instructions[{index}] needs at least 2 algorithms, "
+                f"since a group of one says nothing, got {len(group)}"
+            )
+
+
+def produces_same_bits(a: GEMMDesc, b: GEMMDesc, known: Equivalences) -> bool:
+    """Whether the machine `known` describes returns the same bits for `a` and `b`.
+
+    The weaker of the two relations: equal descriptors always pass, different ones
+    only where `known` says the difference does not show. It fails closed -- every
+    field not declared free is compared, including a field added later.
+    """
+    return _normalised(a, known) == _normalised(b, known)
+
+
+def _normalised(desc: GEMMDesc, known: Equivalences) -> dict[str, object]:
+    """`desc` with the differences `known` declares free rewritten to one form.
+
+    A dict and not another `GEMMDesc`: it must keep comparing fields added later, and
+    a canonical form need not be a legal descriptor.
+    """
+    values: dict[str, object] = {
+        field.name: getattr(desc, field.name) for field in dataclasses.fields(desc)
+    }
+    values["algorithm"] = _canonical_algorithm(desc.algorithm, known)
+    if known.fast_accum_is_free and desc.use_fast_accum is not None:
+        values["use_fast_accum"] = True
+    return values
+
+
+def _canonical_algorithm(
+    algorithm: GEMMAlgorithm, known: Equivalences
+) -> GEMMAlgorithm:
+    for group in known.interchangeable_instructions:
+        if algorithm in group:
+            # Any fixed member will do; groups cannot overlap, so a pair lands together.
+            return min(group, key=lambda member: member.value)
+    return algorithm


### PR DESCRIPTION
Summary:

Two kernels that compute the same matrix product can hand back different bits: floating-point addition is not associative, so the order the k products are added in is a property of the kernel and not of the operation. Inductor has no way to write that order down, so it cannot say whether a Triton matmul it generates agrees with the one eager ran. `GEMMDesc` is a frozen value type that records it -- which matrix instruction, how the k axis is cut, what dtype each stage keeps, and where the single rounding to the output dtype sits. Nothing that only moves run time is in it, and nothing in it names a library.

Two descriptors that are not equal can still agree on a given machine, because which instructions agree there is measured per architecture. `produces_same_bits(a, b, known)` answers that, with the measured content as an argument; this diff ships none of it.

This is diff 1 of a stack and adds the type only. The producers -- an architecture profile, and a lookup that turns a shape into a descriptor -- come later, as does the Triton side that honours one. Scaled matmul is out of scope for now: a block-wise scale cuts the k axis rather than following it, so it will come back as a property of a cut rather than as an epilogue field.

Changes

`torch/_inductor/gemm_desc.py`: the type, its five algorithms and four supporting enums, the validation that rejects an inconsistent descriptor, and `produces_same_bits`.

`torch/_inductor/gemm_desc.md`: the worked examples, the measurements these rules came from, and what is deliberately not a field. It sits beside the module because this file is exported to OSS, where an internal link would be unreadable; `torch/package/mangling.md` is the convention followed. A copy open for comments at https://docs.google.com/document/d/1sUjaWzuOWTdDPdnNwfd9jlX6ps5cMtK4Kc55g5JmjgA/edit, but the repo file is canonical.

`test/inductor/test_gemm_desc.py`: 285 cases, no GPU and no cuBLAS.

Authored with Claude.

Test Plan:
`buck2 test mode/opt -c fbcode.nvcc_arch=b300a -c fbcode.platform010_cuda_version=13.0 fbcode//caffe2/test/inductor:gemm_desc` -- 285 pass, 0 fail.

Every `raise` in both `__post_init__` methods has a case asserting the exception type and a phrase of its message. Checked against a scratch copy that those cases bite: deleting one validation call turns between 3 and 37 of them red, and adding an unmeasured field to `GEMMDesc` leaves `produces_same_bits` correctly reporting two descriptors that differ only in it as not equivalent.

`arc lint -a` reports no issues on all three files.

Differential Revision: D115701162




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo