### PR TITLE
[TEST] Refactor test_xpu.py with hw_classification

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -39,6 +39,7 @@ from torch.testing._internal.common_optimizers import (
 )
 from torch.testing._internal.common_utils import (
     find_library_location,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_WINDOWS,
@@ -97,6 +98,7 @@ _xpu_computation_ops = [
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpu(TestCase):
+    hw_classification = HardwareClassification.XPU
     expandable_segments = False
 
     def test_device_behavior(self):
@@ -2973,6 +2975,8 @@ def caching_host_allocator_use_background_threads(use_background_threads: bool):
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestCachingHostAllocatorXpuGraph(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     @parametrize("use_xpu_host_register", [True, False])
     def test_pin_memory_no_use(self, use_xpu_host_register):
         # A pinned host memory block cannot be reused if it is not deleted
@@ -3059,6 +3063,8 @@ class TestCachingHostAllocatorXpuGraph(TestCase):
 class TestXpuNativeMath(TestCase):
     """Test SYCL native fast math functions in NumericUtils.h on XPU."""
 
+    hw_classification = HardwareClassification.XPU
+
     def test_cauchy_sanity(self):
         """cauchy_() exercises at::tan -> sycl::native::tan via TransformationHelper."""
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
@@ -3111,6 +3117,8 @@ class TestXpuNativeMath(TestCase):
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestXpuOptims(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     @optims(
         [optim for optim in optim_db if optim.has_capturable_arg],
         dtypes=[torch.float32],
@@ -3324,6 +3332,8 @@ class TestXpuOptims(TestCase):
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuOps(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     @suppress_warnings
     @ops(_xpu_computation_ops, dtypes=any_common_cpu_xpu_one)
     def test_compare_cpu(self, device, dtype, op):
@@ -3450,6 +3460,7 @@ instantiate_device_type_tests(TestXpuOps, globals(), only_for="xpu", allow_xpu=T
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuAutocast(TestAutocast):
+    hw_classification = HardwareClassification.XPU
     # These operators are not implemented on XPU backend and we can NOT fall back
     # them to CPU. So we have to skip them at this moment.
     # TODO: remove these operators from skip list when they are implemented on XPU backend.
@@ -3541,6 +3552,8 @@ class TestXpuAutocast(TestAutocast):
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestXpuTrace(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     def setUp(self):
         super().setUp()
         torch._C._activate_gpu_trace()
@@ -3604,6 +3617,8 @@ class TestXpuTrace(TestCase):
 
 
 class TestXPUAPISanity(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     def test_is_bf16_supported(self):
         self.assertEqual(
             torch.xpu.is_bf16_supported(including_emulation=True),
@@ -3641,6 +3656,8 @@ class TestXPUAPISanity(TestCase):
 
 @unittest.skipIf(not TEST_XPU, "XPU not available, skipping tests")
 class TestMemPool(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     def _alloc_record_free_sync(self, pool_ctx, stream, nbytes):
         """Allocate a block, record it on a second stream, free, synchronize,
         then try to reallocate. Returns (original_ptr, new_ptr)."""
@@ -3774,7 +3791,7 @@ class TestMemPool(TestCase):
 
 instantiate_parametrized_tests(TestXpu)
 instantiate_parametrized_tests(TestCachingHostAllocatorXpuGraph)
-instantiate_device_type_tests(TestXpuOptims, globals())
+instantiate_device_type_tests(TestXpuOptims, globals(), only_for="xpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Adds `hw_classification = HardwareClassification.XPU` to all 9 test classes in `test/test_xpu.py` as part of the device-agnostic testing initiative (#185590).

All classes are XPU-locked — methods hardcode `torch.xpu.*` APIs, `device="xpu"`, or `XPUGraph`/`XPUEvent` primitives with no equivalent on other accelerators.

**Changes:**
- Add `hw_classification = HardwareClassification.XPU` to: `TestXpu`, `TestCachingHostAllocatorXpuGraph`, `TestXpuNativeMath`, `TestXpuOptims`, `TestXpuOps`, `TestXpuAutocast`, `TestXpuTrace`, `TestXPUAPISanity`, `TestMemPool`
- Add `HardwareClassification` to `common_utils` import
- Fix `TestXpuOptims` instantiation: `instantiate_device_type_tests(TestXpuOptims, globals())` → `instantiate_device_type_tests(TestXpuOptims, globals(), only_for="xpu", allow_xpu=True)`

**Note on `TestXpuOps` and `TestXpuOptims`:** Both retain `instantiate_device_type_tests` because the `@ops` and `@optims` decorators require device-type instantiation to inject `op`/`optim_info` — this is not for device genericity. The `TestXpuOptims` fix corrects a pre-existing bug: the bare `globals()` call with `allow_xpu=False` (default) never generated an XPU variant, causing `@optims` to resolve `device_cls.device_type` as `"cpu"` and misapply decorator filtering. The fix generates `TestXpuOptimsXPU` instead of `TestXpuOptimsCPU`.