### PR TITLE
[Dynamo] Support graph breaks in checkpointed functions

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -26,6 +26,7 @@ from torch._dynamo.source import ConstantSource
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
     CompileCounterWithBackend,
+    EagerAndRecordGraphs,
     normalize_gm,
 )
 from torch._functorch.partitioners import has_recomputable_rng_ops, is_rng_op
@@ -39,6 +40,7 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_WINDOWS,
     parametrize,
     skipIfHpu,
@@ -906,10 +908,10 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
 
         self.assertEqual(result, expected)
 
-        # One graph for torch.sin on the input, and other for torch.cos.
-        self.assertEqual(cnt.frame_count, 2)
-        self.assertEqual(cnt.op_count, 2)
-        self.assertEqual(len(cnt.graphs), 2)
+        # sin and cos graphs in fn, plus gn compiled across its graph breaks
+        self.assertEqual(cnt.frame_count, 4)
+        self.assertEqual(cnt.op_count, 5)
+        self.assertEqual(len(cnt.graphs), 4)
 
     @requires_gpu_and_triton
     def test_kwargs(self, device):
@@ -3939,6 +3941,140 @@ def forward(self, x_1):
     alias_4 = torch.ops.aten.alias.default(sum_1);  sum_1 = None
     return (alias_4, mul_1)""",
         )
+
+
+class ActivationCheckpointingGraphBreakFallbackTests(torch._dynamo.test_case.TestCase):
+    class _Attention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(16, 16)
+            self.o_proj = nn.Linear(16, 16)
+
+        def forward(self, x, use_reentrant=False):
+            def attn_forward(x):
+                q = self.q_proj(x)
+                torch._dynamo.graph_break()
+                return self.o_proj(q.sin())
+
+            return checkpoint(attn_forward, x, use_reentrant=use_reentrant)
+
+    def _check_fn(self, fn, fn_ref, backend, *args, **kwargs):
+        args_ref = tuple(a.detach().clone().requires_grad_(True) for a in args)
+        expected = fn_ref(*args_ref, **kwargs)
+        expected.sum().backward()
+
+        cnt = CompileCounterWithBackend(backend)
+        result = torch.compile(fn, backend=cnt)(*args, **kwargs)
+        result.sum().backward()
+
+        self.assertEqual(result, expected)
+        for a, a_ref in zip(args, args_ref):
+            self.assertEqual(a.grad, a_ref.grad)
+        return cnt
+
+    def _check_model(self, model, x, backend, **model_kwargs):
+        model_ref = copy.deepcopy(model)
+        cnt = self._check_fn(model, model_ref, backend, x, **model_kwargs)
+        for p, p_ref in zip(model.parameters(), model_ref.parameters()):
+            self.assertEqual(p.grad, p_ref.grad)
+        return cnt
+
+    @parametrize("backend", ["eager", "aot_eager"])
+    def test_graph_break_in_checkpointed_fn(self, backend):
+        model = self._Attention()
+        x = torch.randn(2, 16, requires_grad=True)
+        cnt = self._check_model(model, x, backend)
+        # attn_forward is compiled as two graphs around its graph break
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.op_count, 3)
+
+    def test_graph_break_in_checkpointed_fn_reentrant(self):
+        model = self._Attention()
+        x = torch.randn(2, 16, requires_grad=True)
+        cnt = self._check_model(model, x, "eager", use_reentrant=True)
+        # two forward graphs under no_grad, two more for grad-enabled recompute
+        self.assertEqual(cnt.frame_count, 4)
+
+    def test_graph_break_nested_checkpoint(self):
+        def inner(x):
+            q = torch.sin(x)
+            torch._dynamo.graph_break()
+            return torch.cos(q)
+
+        def outer(x):
+            return checkpoint(inner, x, use_reentrant=False) * 2
+
+        def fn(x):
+            return checkpoint(outer, x, use_reentrant=False) + 1
+
+        x = torch.randn(4, 4, requires_grad=True)
+        cnt = self._check_fn(fn, fn, "aot_eager", x)
+        self.assertEqual(cnt.frame_count, 4)
+
+    def test_graph_break_call_function_ex(self):
+        def gn(x):
+            a = torch.sin(x)
+            torch._dynamo.graph_break()
+            return torch.cos(a)
+
+        def fn(x):
+            args = (gn, x)
+            kwargs = {"use_reentrant": False}
+            return checkpoint(*args, **kwargs)
+
+        x = torch.randn(4, 4, requires_grad=True)
+        cnt = self._check_fn(fn, fn, "eager", x)
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_graph_break_selective_checkpoint(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.mm.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def context_fn():
+            return create_selective_checkpoint_contexts(policy_fn)
+
+        def gn(x, y):
+            a = torch.sigmoid(torch.matmul(x, y))
+            torch._dynamo.graph_break()
+            return torch.cos(a)
+
+        def fn(x, y):
+            return checkpoint(
+                gn, torch.sin(x), y, use_reentrant=False, context_fn=context_fn
+            )
+
+        x = torch.randn(4, 4, requires_grad=True)
+        y = torch.randn(4, 4, requires_grad=True)
+        self._check_fn(fn, fn, "aot_eager", x, y)
+
+    def test_graph_break_fullgraph_still_errors(self):
+        model = self._Attention()
+        x = torch.randn(2, 16, requires_grad=True)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(model, backend="eager", fullgraph=True)(x)
+
+    def test_no_graph_break_still_captures_hop(self):
+        def gn(x):
+            return torch.sigmoid(torch.matmul(x, x))
+
+        def fn(x):
+            return torch.cos(checkpoint(gn, torch.sin(x), use_reentrant=False))
+
+        x = torch.randn(4, 4, requires_grad=True)
+        backend = EagerAndRecordGraphs()
+        torch.compile(fn, backend=backend, fullgraph=True)(x)
+        self.assertEqual(len(backend.graphs), 1)
+        self.assertTrue(
+            any(
+                node.target is tag_activation_checkpoint
+                for node in backend.graphs[0].graph.nodes
+            )
+        )
+
+
+instantiate_parametrized_tests(ActivationCheckpointingGraphBreakFallbackTests)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -50,6 +50,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_GPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
 from torch.testing._internal.two_tensor import TwoTensor
+from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils.checkpoint import (
     checkpoint,
     CheckpointPolicy,
@@ -4026,10 +4027,28 @@ class ActivationCheckpointingGraphBreakFallbackTests(torch._dynamo.test_case.Tes
         cnt = self._check_fn(fn, fn, "eager", x)
         self.assertEqual(cnt.frame_count, 2)
 
-    def test_graph_break_selective_checkpoint(self):
+    @parametrize("backend", ["aot_eager", "inductor"])
+    @parametrize(
+        "mm_policy", [CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_RECOMPUTE]
+    )
+    def test_graph_break_selective_checkpoint(self, backend, mm_policy):
+        class CountMM(TorchDispatchMode):
+            @classmethod
+            def ignore_compile_internals(cls):
+                return True
+
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                if func is torch.ops.aten.mm.default:
+                    self.count += 1
+                return func(*args, **(kwargs or {}))
+
         def policy_fn(ctx, op, *args, **kwargs):
             if op == torch.ops.aten.mm.default:
-                return CheckpointPolicy.MUST_SAVE
+                return mm_policy
             return CheckpointPolicy.PREFER_RECOMPUTE
 
         def context_fn():
@@ -4047,7 +4066,13 @@ class ActivationCheckpointingGraphBreakFallbackTests(torch._dynamo.test_case.Tes
 
         x = torch.randn(4, 4, requires_grad=True)
         y = torch.randn(4, 4, requires_grad=True)
-        self._check_fn(fn, fn, "aot_eager", x, y)
+        with CountMM() as counter:
+            cnt = self._check_fn(fn, fn, backend, x, y)
+        # per run: forward mm, two backward mms, plus a recompute unless saved
+        expected_mm = 3 if mm_policy is CheckpointPolicy.MUST_SAVE else 4
+        self.assertEqual(counter.count, expected_mm * 2)  # eager ref + compiled
+        # gn runs eagerly so the SAC policy sees every aten op
+        self.assertEqual(cnt.frame_count, 1)
 
     def test_graph_break_fullgraph_still_errors(self):
         model = self._Attention()

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -7128,10 +7128,10 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(result, expected)
 
-        # One graph for torch.sin on the input, and other for torch.cos.
-        self.assertEqual(cnt.frame_count, 2)
-        self.assertEqual(cnt.op_count, 2)
-        self.assertEqual(len(backend.graphs), 2)
+        # sin and cos graphs in fn, plus gn compiled after its graph break
+        self.assertEqual(cnt.frame_count, 3)
+        self.assertEqual(cnt.op_count, 4)
+        self.assertEqual(len(backend.graphs), 3)
 
     @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/3361")
     @requires_gpu_and_triton

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -104,6 +104,9 @@ def eager_noexcept(
     def inner(*args: Any) -> Any:
         try:
             return gm(*args)
+        # checkpoint early-stop is control flow, not a graph error
+        except torch.utils.checkpoint._StopRecomputationError:
+            raise
         except Exception as e:
             raise torch._dynamo.exc.TorchDynamoException(
                 "Unexpected exception when running generated GraphModule"

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1080,6 +1080,24 @@ def _make_warnings_warn_wrapper(filename: str, lineno: int) -> Callable[..., Any
     return wrapper
 
 
+# Reenter Dynamo around fn so forward and recompute run the same compiled code.
+def _checkpoint_with_dynamo_reenabled(
+    function: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    import torch.utils.checkpoint
+
+    callback = torch._C._dynamo.eval_frame.get_eval_frame_callback()
+
+    def function_with_dynamo(*fn_args: Any, **fn_kwargs: Any) -> Any:
+        prior = torch._C._dynamo.eval_frame.set_eval_frame(callback)
+        try:
+            return function(*fn_args, **fn_kwargs)
+        finally:
+            torch._C._dynamo.eval_frame.set_eval_frame(prior)
+
+    return torch.utils.checkpoint.checkpoint(function_with_dynamo, *args, **kwargs)
+
+
 # NOTE: for the purposes of nested graph breaks, break_graph_if_unsupported only works on instructions
 # with 0 or 1 outputs. If you wish to support bytecodes with 2+ outputs, either rewrite the instruction
 # into a sequence of simpler instructions, or file an issue for consultation.
@@ -1176,6 +1194,7 @@ def break_graph_if_unsupported(
             # naturally reconstructs the wrapper via LOAD_GLOBAL.
             if self.parent is not None:
                 self._maybe_replace_warnings_warn_on_stack(inst)
+            self._maybe_replace_checkpoint_on_stack(inst)
 
             log.debug("%s triggered compile", inst.opname)
             all_stack_locals_metadata = self.output.compile_subgraph(
@@ -3695,6 +3714,30 @@ class InstructionTranslatorBase(
         wrapper_name = self.output.install_global("__warnings_warn_wrapper", wrapper)
         self.stack[callable_idx] = SkipFunctionVariable(
             wrapper, source=GlobalSource(wrapper_name)
+        )
+
+    def _maybe_replace_checkpoint_on_stack(self, inst: Instruction) -> None:
+        from .variables.higher_order_ops import CheckpointHigherOrderVariable
+
+        try:
+            # 3.14 CALL_FUNCTION_EX has no oparg; depth does not use it there
+            depth = get_call_callable_depth(inst.opname, inst.arg or 0)
+        except ValueError:
+            return
+
+        callable_idx = len(self.stack) - depth
+        callable_var = self.stack[callable_idx]
+        if not (
+            isinstance(callable_var, CheckpointHigherOrderVariable)
+            and callable_var.from_utils_checkpoint
+        ):
+            return
+
+        wrapper_name = self.output.install_global_by_id(
+            "__checkpoint_with_dynamo_reenabled", _checkpoint_with_dynamo_reenabled
+        )
+        self.stack[callable_idx] = SkipFunctionVariable(
+            _checkpoint_with_dynamo_reenabled, source=GlobalSource(wrapper_name)
         )
 
     def create_call_resume_at(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1086,6 +1086,11 @@ def _checkpoint_with_dynamo_reenabled(
 ) -> Any:
     import torch.utils.checkpoint
 
+    # SAC policies see aten ops; compiled regions hide them, so keep fn eager.
+    noop_context_fn = torch.utils.checkpoint.noop_context_fn
+    if kwargs.get("context_fn", noop_context_fn) is not noop_context_fn:
+        return torch.utils.checkpoint.checkpoint(function, *args, **kwargs)
+
     callback = torch._C._dynamo.eval_frame.get_eval_frame_callback()
 
     def function_with_dynamo(*fn_args: Any, **fn_kwargs: Any) -> Any:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5087,6 +5087,7 @@ def build_checkpoint_variable(**options: Any) -> Any:
 
     return TorchHigherOrderOperatorVariable.make(
         activation_checkpoint_op,
+        from_utils_checkpoint=True,
         **options,
     )
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4430,8 +4430,11 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
 class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
     _HOP_NAME = "torch.utils.checkpoint.checkpoint"
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, *args: Any, from_utils_checkpoint: bool = False, **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
+        self.from_utils_checkpoint = from_utils_checkpoint
         self.allow_side_effects = (
             torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint
         )


### PR DESCRIPTION
## Related Issue

Fixes #139989.

## Why

- A graph break inside a checkpointed function made Dynamo skip the entire frame.
- The outer forward and the checkpointed function both ran eager, losing all speedups.
- Implements the fallback design @zou3519 proposed on the issue: turn `compile(ac(f))` with a graph break in `f` into `ac(compile(f))`, which already works.

## How

- Fall back to an eager checkpoint call that re-enters Dynamo on the checkpointed function.
- Run forward and backward recompute through the same compiled code, keeping recompute consistent.
- Keep raw `tag_activation_checkpoint` usage and `fullgraph=True` behavior unchanged.

Authored with an AI assistant. Reviewed by me.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98