### PR TITLE
[TEST] Tag MPS and metal tests with hw_classification

### DIFF
--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -3,11 +3,13 @@
 import torch
 from torch.nn import functional as F
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import HardwareClassification, TestCase, run_tests
 from torch.testing import FileCheck
 import io
 
 class TestMetalRewritePass(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @staticmethod
     def validate_transformed_module(
             # To please flake

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -27,7 +27,8 @@ from torch.export import Dim, export
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, parametrize, run_tests, TestCase, download_file, MACOS_VERSION, IS_CI,
-     NoTest, skipIfSlowGradcheckEnv, suppress_warnings, serialTest, instantiate_parametrized_tests, xfailIf)
+     NoTest, skipIfSlowGradcheckEnv, suppress_warnings, serialTest, instantiate_parametrized_tests, xfailIf,
+     HardwareClassification)
 from torch.testing._internal.common_mps import mps_ops_modifier, mps_ops_grad_modifier, mps_ops_error_inputs_modifier
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes, integral_types
@@ -174,6 +175,7 @@ class MpsMemoryLeakCheck:
             raise RuntimeError(msg)
 
 class TestAutocastMPS(TestCase):
+    hw_classification = HardwareClassification.MPS
 
     def test_matmul_autocast(self):
         autocast_tensor_A = torch.rand((8, 8), device="mps")
@@ -380,6 +382,7 @@ class TestAutocastMPS(TestCase):
 
 # Expand TestCase class with Memory Leak Detection on MPS device
 class TestCaseMPS(TestCase):
+    hw_classification = HardwareClassification.MPS
     _do_mps_memory_leak_check = True
 
     def __init__(self, method_name='runTest'):
@@ -11422,6 +11425,8 @@ class TestNLLLoss(TestCaseMPS):
 
 
 class TestTopK(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     def _test_topk(self, shape, largest):
         cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
         x = cpu_x.detach().clone().to('mps')
@@ -11473,6 +11478,7 @@ class TestTopK(TestCase):
                 self.assertEqual(ci, mi.cpu())
 
 class TestNNMPS(NNTestCase):
+    hw_classification = HardwareClassification.MPS
 
     def _create_basic_net(self):
         class Layer(nn.Module):
@@ -11961,6 +11967,8 @@ class TestPad(TestCaseMPS):
         self.assertEqual(gi.cpu(), gi_ref)
 
 class TestConv3dChannelsLast3dMPS(NNTestCase):
+    hw_classification = HardwareClassification.MPS
+
     def _run_conv3d_cl3d(self, *, input_shape, Cin, Cout, k, pad, with_bias, dtype, groups=1):
         torch.manual_seed(0)
         m_cpu = nn.Conv3d(Cin, Cout, k, stride=1, padding=pad, bias=with_bias,
@@ -15807,6 +15815,8 @@ class TestRNNMPS(TestCaseMPS):
 
 
 class TestFallbackWarning(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     # TODO: Remove once test_testing.py is running on MPS devices
     def test_no_warning_on_import(self):
         out = subprocess.check_output(
@@ -15872,6 +15882,8 @@ if len(w) != 1:
                                        e.output.decode("utf-8"))
 
 class TestNoRegression(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     def test_assert_close(self):
         a = torch.ones(1, device="mps")
         b = torch.zeros(1, device="mps")
@@ -16662,6 +16674,7 @@ class TestConsistency(TestCaseMPS):
 
 
 class TestErrorInputs(TestCase):
+    hw_classification = HardwareClassification.MPS
     _ignore_not_implemented_error = True
 
     @ops(
@@ -16763,6 +16776,8 @@ class TestErrorInputs(TestCase):
 
 
 class TestComplex(TestCase):
+    hw_classification = HardwareClassification.MPS
+
     def test_conj_imag(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/184379
         # MPS copy ignored the neg bit, so `.imag` on a conjugate view returned
@@ -16829,6 +16844,7 @@ class TestComplex(TestCase):
 # Copied from `TestCommon` in `test_ops.py`, just enough to duplicate the `test_numpy_ref` for MPS
 @skipIfSlowGradcheckEnv
 class TestCommon(TestCase):
+    hw_classification = HardwareClassification.MPS
     exact_dtype = True
 
     # Verifies, on teardown, that no OpInfo is still using dynamic dtypes in CI


### PR DESCRIPTION
Annotate test classes in test/test_mps.py and test/test_metal.py with hw_classification as part of the ongoing test refactoring initiative (#186918). TestCaseMPS subclasses with test methods now have explicit hw_classification.

This PR is intentionally a classification-only pass: test/test_mps.py and test/test_metal.py remain on the TEST_LINTER allowlist from #190173, so full migration to instantiate_device_type_tests(..., only_for="mps", allow_mps=True) with device-parameterized methods is deferred to a follow-up.

Test Plan:
```
python test/test_metal.py -v
python test/test_mps.py -v
```

Authored with an AI assistant.

cc: @mansiag05 @RiyaP2508