### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_needs_exact_strides.py
+++ b/test/inductor/test_needs_exact_strides.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils._triton import has_triton
 
+
 if has_triton():
     import triton
     import triton.language as tl
@@ -41,8 +42,8 @@ class TestNeedsExactStrides(InductorTestCase):
     @parametrize("dtype", [torch.float, torch.float8_e8m0fnu])
     def test_custom_op(self, device, dtype):
         # float8_e8m0fnu errors on "cpu"
-        x = torch.ones(4, 4, 2, 2, device=device, dtype=torch.float8_e8m0fnu)
-        other = torch.ones(4, 4, 2, 2, device=device, dtype=torch.float8_e8m0fnu)
+        x = torch.ones(4, 4, 2, 2, device=device, dtype=dtype)
+        other = torch.ones(4, 4, 2, 2, device=device, dtype=dtype)
 
         class _CustomPass(PatternMatcherPass):
             def __init__(self) -> None:

--- a/test/inductor/test_needs_exact_strides.py
+++ b/test/inductor/test_needs_exact_strides.py
@@ -8,15 +8,15 @@ from torch._inductor.pattern_matcher import (
     register_graph_pattern,
 )
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_LINUX,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import HAS_GPU_AND_TRITON
+from torch.utils._triton import has_triton
 
-
-if HAS_GPU_AND_TRITON:
+if has_triton():
     import triton
     import triton.language as tl
 
@@ -36,11 +36,11 @@ if HAS_GPU_AND_TRITON:
 
 
 class TestNeedsExactStrides(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize("dtype", [torch.float, torch.float8_e8m0fnu])
-    def test_custom_op(self, dtype):
-        device = (
-            torch.accelerator.current_accelerator()
-        )  # float8_e8m0fnu errors on "cpu"
+    def test_custom_op(self, device, dtype):
+        # float8_e8m0fnu errors on "cpu"
         x = torch.ones(4, 4, 2, 2, device=device, dtype=torch.float8_e8m0fnu)
         other = torch.ones(4, 4, 2, 2, device=device, dtype=torch.float8_e8m0fnu)
 
@@ -120,9 +120,8 @@ class TestNeedsExactStrides(InductorTestCase):
 
     @parametrize("n", [64, 128, 256])
     def test_dynamic_size_one_leading_dim_view_triton_kernel_wrapper_functional(
-        self, n
+        self, device, n
     ):
-        device = torch.accelerator.current_accelerator()
         inner = 8
 
         def fn(x):
@@ -152,8 +151,11 @@ class TestNeedsExactStrides(InductorTestCase):
         self.assertEqual(compiled(x.clone()), fn(x.clone()))
 
 
-instantiate_parametrized_tests(TestNeedsExactStrides)
+instantiate_device_type_tests(
+    TestNeedsExactStrides, globals(), except_for="cpu", allow_xpu=True
+)
+
 
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU_AND_TRITON:
+    if IS_LINUX and has_triton():
         run_tests(needs="filelock")


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Change 'instantiate_parametrized_tests' to 'instantiate_device_type_tests'
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_needs_exact_strides.py
python test/inductor/test_needs_exact_strides.py -v --hw-classification ACCELERATOR

## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo