### PR TITLE
[release] Revert on the release branch when the PR was reverted on trunk

### DIFF
--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -109,14 +109,19 @@ def resolve_trunk_revert(
     if not revert_sha:
         return None
 
-    if not is_ancestor(repo, commit_sha, onto_branch):
+    # This runs before create_cherry_pick_branch checks the branch out, so it
+    # only exists as a remote-tracking ref. git rev-parse's DWIM does not reach
+    # refs/remotes/origin/<branch> from a bare name, so qualify it.
+    onto_ref = f"{repo.remote}/{onto_branch}"
+
+    if not is_ancestor(repo, commit_sha, onto_ref):
         raise RuntimeError(
             f"Refuse to cherry pick #{pr.pr_num} onto {onto_branch}: it was reverted "
             f"on {pr.default_branch()} by {revert_sha}, and its landed commit "
             f"{commit_sha} is not on {onto_branch}, so there is nothing to revert there."
         )
 
-    if is_ancestor(repo, revert_sha, onto_branch):
+    if is_ancestor(repo, revert_sha, onto_ref):
         raise RuntimeError(
             f"Refuse to cherry pick #{pr.pr_num} onto {onto_branch}: the revert "
             f"{revert_sha} is already on {onto_branch}."

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -54,10 +54,16 @@ def parse_args() -> Any:
 def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> str | None:
     """
     Return the merge commit SHA iff the PR has been merged. For simplicity, we
-    will only cherry pick PRs that have been merged into main
+    will only cherry pick PRs that have been merged into main.
+
+    A merged PR that was later reverted is reopened by the revert bot, so
+    is_closed() alone would reject exactly the PRs the revert path exists for.
+    Accept an open PR only when its landed commit was in fact reverted.
     """
     commit_sha = get_pr_commit_sha(repo, pr)
-    return commit_sha if pr.is_closed() else None
+    if pr.is_closed():
+        return commit_sha
+    return commit_sha if find_revert_commit_sha(repo, pr, commit_sha) else None
 
 
 def is_ancestor(repo: GitRepo, ref: str, branch: str) -> bool:

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -59,6 +60,71 @@ def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> str | None:
     return commit_sha if pr.is_closed() else None
 
 
+def is_ancestor(repo: GitRepo, ref: str, branch: str) -> bool:
+    """
+    Return True if ref is already part of branch's history
+    """
+    return repo.get_merge_base(ref, branch) == repo.rev_parse(ref)
+
+
+def find_revert_commit_sha(repo: GitRepo, pr: GitHubPR, commit_sha: str) -> str | None:
+    """
+    Return the commit on the default branch that reverts commit_sha, or None if
+    the landed commit was never reverted.
+
+    The lookup is keyed on the exact landed SHA rather than the PR number: a PR
+    that landed and was reverted several times has one revert per land, and only
+    the one undoing the land that reached the release branch is the right pick.
+    """
+    default_branch = f"{repo.remote}/{pr.default_branch()}"
+    # `git revert`, which is what the revert bot runs, always records this line
+    revert_shas = repo._run_git(
+        "log",
+        "--format=%H",
+        "--fixed-strings",
+        f"--grep=This reverts commit {commit_sha}.",
+        default_branch,
+    ).strip()
+
+    if not revert_shas:
+        return None
+
+    # Newest first, so a re-reverted commit resolves to the most recent revert
+    return revert_shas.split("\n")[0]
+
+
+def resolve_trunk_revert(
+    repo: GitRepo, pr: GitHubPR, onto_branch: str, commit_sha: str
+) -> str | None:
+    """
+    Return the default-branch revert that the release branch is missing, or None
+    when the PR is a plain cherry pick.
+
+    When the PR landed and was later reverted on the default branch, applying the
+    landed commit would re-add a change trunk has already thrown out, to a branch
+    that already has it. What the release branch needs is for that change to be
+    undone, so the release branch ends up matching trunk.
+    """
+    revert_sha = find_revert_commit_sha(repo, pr, commit_sha)
+    if not revert_sha:
+        return None
+
+    if not is_ancestor(repo, commit_sha, onto_branch):
+        raise RuntimeError(
+            f"Refuse to cherry pick #{pr.pr_num} onto {onto_branch}: it was reverted "
+            f"on {pr.default_branch()} by {revert_sha}, and its landed commit "
+            f"{commit_sha} is not on {onto_branch}, so there is nothing to revert there."
+        )
+
+    if is_ancestor(repo, revert_sha, onto_branch):
+        raise RuntimeError(
+            f"Refuse to cherry pick #{pr.pr_num} onto {onto_branch}: the revert "
+            f"{revert_sha} is already on {onto_branch}."
+        )
+
+    return revert_sha
+
+
 def get_release_version(onto_branch: str) -> str | None:
     """
     Return the release version if the target branch is a release branch
@@ -95,13 +161,15 @@ def cherry_pick(
     classification: str,
     fixes: str,
     dry_run: bool = False,
+    trunk_revert_sha: str = "",
 ) -> None:
     """
     Create a local branch to cherry pick the commit and submit it as a pull request
     """
+    is_revert = bool(trunk_revert_sha)
     current_branch = repo.current_branch()
     cherry_pick_branch = create_cherry_pick_branch(
-        github_actor, repo, pr, commit_sha, onto_branch
+        github_actor, repo, pr, commit_sha, onto_branch, trunk_revert_sha
     )
 
     try:
@@ -109,7 +177,9 @@ def cherry_pick(
 
         cherry_pick_pr = ""
         if not dry_run:
-            cherry_pick_pr = submit_pr(repo, pr, cherry_pick_branch, onto_branch)
+            cherry_pick_pr = submit_pr(
+                repo, pr, cherry_pick_branch, onto_branch, commit_sha, trunk_revert_sha
+            )
 
         tracker_issues_comments = []
         tracker_issues = get_tracker_issues(org, project, onto_branch)
@@ -129,6 +199,7 @@ def cherry_pick(
                     classification,
                     fixes,
                     dry_run,
+                    is_revert,
                 ),
             )
 
@@ -137,6 +208,11 @@ def cherry_pick(
                 tracker_issues_comments.append(comment_url)
 
         msg = f"The cherry pick PR is at {cherry_pick_pr}"
+        if is_revert:
+            msg = (
+                f"This PR was reverted on {pr.default_branch()}, so the change was "
+                f"reverted on {onto_branch} instead of being applied there. {msg}"
+            )
         if fixes:
             msg += f" and it is linked with issue {fixes}."
         elif classification in REQUIRES_ISSUE:
@@ -155,7 +231,12 @@ def cherry_pick(
 
 
 def create_cherry_pick_branch(
-    github_actor: str, repo: GitRepo, pr: GitHubPR, commit_sha: str, onto_branch: str
+    github_actor: str,
+    repo: GitRepo,
+    pr: GitHubPR,
+    commit_sha: str,
+    onto_branch: str,
+    trunk_revert_sha: str = "",
 ) -> str:
     """
     Create a local branch and cherry pick the commit. Return the name of the local
@@ -172,7 +253,35 @@ def create_cherry_pick_branch(
 
     # We might want to support ghstack later
     # We don't want to resolve conflicts here.
-    repo._run_git("cherry-pick", "-x", commit_sha)
+    if trunk_revert_sha:
+        # Revert on the release branch rather than cherry picking the default
+        # branch's revert commit. The revert is then computed against the tree
+        # the release branch actually has, which is what makes it apply on a
+        # branch that has drifted from trunk, and it records the landed SHA that
+        # is really present here instead of trunk's.
+        try:
+            repo.revert(commit_sha)
+        except RuntimeError as error:
+            # Deciding what a conflicted revert should look like on a release
+            # branch is a judgement call, so hand it back rather than guess.
+            with contextlib.suppress(RuntimeError):
+                repo._run_git("revert", "--abort")
+            raise RuntimeError(
+                f"Reverting {commit_sha} on {onto_branch} hit a conflict, so nothing "
+                f"was pushed. Please revert #{pr.pr_num} on {onto_branch} by hand and "
+                f"open the pull request manually.\n\n{error}"
+            ) from error
+        repo.amend_commit_message(
+            "\n".join(
+                (
+                    repo.commit_message("HEAD").rstrip(),
+                    "",
+                    f"Reverted on {pr.default_branch()} by {trunk_revert_sha}.",
+                )
+            )
+        )
+    else:
+        repo._run_git("cherry-pick", "-x", commit_sha)
     repo.push(branch=cherry_pick_branch, dry_run=False)
 
     return cherry_pick_branch
@@ -183,6 +292,8 @@ def submit_pr(
     pr: GitHubPR,
     cherry_pick_branch: str,
     onto_branch: str,
+    commit_sha: str = "",
+    trunk_revert_sha: str = "",
 ) -> str:
     """
     Submit the cherry pick PR and return the link to the PR
@@ -192,6 +303,27 @@ def submit_pr(
     default_msg = f"Cherry pick #{pr.pr_num} onto {onto_branch} branch"
     title = pr.info.get("title", default_msg)
     body = pr.info.get("body", default_msg)
+
+    if trunk_revert_sha:
+        # Reusing the PR's own title and body would describe the change being
+        # undone, which reads as though the feature is being added to the release
+        title = f'[{onto_branch}] Revert "{title}"'
+        body = "\n".join(
+            (
+                f"Reverts #{pr.pr_num} on {onto_branch}.",
+                "",
+                f"#{pr.pr_num} landed before {onto_branch} was cut, so the change is "
+                f"on the release branch, but it was then reverted on "
+                f"{pr.default_branch()} by {trunk_revert_sha}. This brings "
+                f"{onto_branch} back in line with trunk.",
+                "",
+                f"The revert was generated on {onto_branch} rather than cherry picked "
+                f"from {pr.default_branch()}, so it undoes {commit_sha} as that commit "
+                "exists on the release branch.",
+                "",
+                repo.commit_message(trunk_revert_sha),
+            )
+        )
 
     try:
         response = gh_fetch_url(
@@ -257,10 +389,23 @@ def post_tracker_issue_comment(
     classification: str,
     fixes: str,
     dry_run: bool = False,
+    is_revert: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Post a comment on the tracker issue (if any) to record the cherry pick
     """
+    # Skip the empty parts, otherwise an unlinked cherry pick renders a dangling
+    # separator like "Critical - "
+    criteria = " - ".join(
+        part
+        for part in (
+            "Cherry-pick revert" if is_revert else "",
+            classification.capitalize(),
+            fixes.capitalize(),
+        )
+        if part
+    )
+
     comment = "\n".join(
         (
             "Link to landed trunk PR (if applicable):",
@@ -270,7 +415,7 @@ def post_tracker_issue_comment(
             f"* {cherry_pick_pr}",
             "",
             "Criteria Category:",
-            " - ".join((classification.capitalize(), fixes.capitalize())),
+            criteria,
         )
     )
     return gh_post_pr_comment(org, project, issue_num, comment, dry_run)
@@ -292,6 +437,8 @@ def main() -> None:
                 f"Refuse to cherry pick #{pr_num} because it hasn't been merged yet"
             )
 
+        trunk_revert_sha = resolve_trunk_revert(repo, pr, args.onto_branch, commit_sha)
+
         cherry_pick(
             args.github_actor,
             repo,
@@ -301,6 +448,7 @@ def main() -> None:
             args.classification,
             args.fixes,
             args.dry_run,
+            trunk_revert_sha or "",
         )
 
     except RuntimeError as error:

--- a/.github/scripts/test_cherry_pick.py
+++ b/.github/scripts/test_cherry_pick.py
@@ -118,6 +118,23 @@ class TestResolveTrunkRevert(TestCase):
             resolve_trunk_revert(repo, make_pr(), "release/2.14", OTHER_LANDED)
         )
 
+    def test_ancestry_is_checked_against_the_remote_tracking_ref(self) -> None:
+        # This runs before the branch is checked out, so it only exists as
+        # refs/remotes/origin/<branch>. git rev-parse's DWIM ladder does not
+        # reach that from a bare "release/2.14", so both guards would die with
+        # exit 128 on exactly the PRs this feature exists for.
+        seen: list[str] = []
+        repo = make_repo(f"{REVERT}\n", on_branch=(LANDED,))
+        repo.get_merge_base.side_effect = lambda ref, branch: (
+            seen.append(branch) or (ref if ref == LANDED else "base")
+        )
+
+        resolve_trunk_revert(repo, make_pr(), "release/2.14", LANDED)
+
+        self.assertTrue(seen)
+        for branch in seen:
+            self.assertEqual(branch, "origin/release/2.14")
+
 
 class TestCreateCherryPickBranch(TestCase):
     def _repo(self) -> Any:

--- a/.github/scripts/test_cherry_pick.py
+++ b/.github/scripts/test_cherry_pick.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 from unittest import main, TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from cherry_pick import (
     create_cherry_pick_branch,
     find_revert_commit_sha,
+    get_merge_commit_sha,
     is_ancestor,
     post_tracker_issue_comment,
     resolve_trunk_revert,
@@ -39,6 +40,36 @@ def make_pr(pr_num: int = 42, default_branch: str = "main") -> Any:
     pr.pr_num = pr_num
     pr.default_branch.return_value = default_branch
     return pr
+
+
+class TestGetMergeCommitSha(TestCase):
+    def _pr(self, closed: bool) -> Any:
+        pr = make_pr()
+        pr.is_closed.return_value = closed
+        return pr
+
+    def test_closed_pr_returns_its_landed_commit(self) -> None:
+        with patch("cherry_pick.get_pr_commit_sha", return_value=LANDED):
+            self.assertEqual(
+                get_merge_commit_sha(make_repo(""), self._pr(closed=True)), LANDED
+            )
+
+    def test_open_never_merged_pr_is_refused(self) -> None:
+        # No revert names this commit, so the PR is genuinely not merged.
+        with patch("cherry_pick.get_pr_commit_sha", return_value=LANDED):
+            self.assertIsNone(
+                get_merge_commit_sha(make_repo(""), self._pr(closed=False))
+            )
+
+    def test_reopened_after_revert_is_accepted(self) -> None:
+        # The revert bot reopens the PR it reverts, so the one case the revert
+        # path exists for arrives here open. Gating on is_closed() alone made
+        # the feature unreachable.
+        with patch("cherry_pick.get_pr_commit_sha", return_value=LANDED):
+            self.assertEqual(
+                get_merge_commit_sha(make_repo(f"{REVERT}\n"), self._pr(closed=False)),
+                LANDED,
+            )
 
 
 class TestFindRevertCommitSha(TestCase):

--- a/.github/scripts/test_cherry_pick.py
+++ b/.github/scripts/test_cherry_pick.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import main, TestCase
+from unittest.mock import MagicMock
+
+from cherry_pick import (
+    create_cherry_pick_branch,
+    find_revert_commit_sha,
+    is_ancestor,
+    post_tracker_issue_comment,
+    resolve_trunk_revert,
+)
+
+
+LANDED = "a" * 40
+REVERT = "b" * 40
+OTHER_LANDED = "c" * 40
+
+
+def make_repo(revert_log: str = "", on_branch: tuple[str, ...] = ()) -> Any:
+    """
+    A GitRepo stub. `revert_log` is what `git log --grep` returns and `on_branch`
+    lists the SHAs that the target branch already contains.
+    """
+    repo = MagicMock()
+    repo.remote = "origin"
+    repo._run_git.return_value = revert_log
+    repo.rev_parse.side_effect = lambda ref: ref
+    # get_merge_base returns the ref itself only when the branch contains it
+    repo.get_merge_base.side_effect = lambda ref, _branch: (
+        ref if ref in on_branch else "base"
+    )
+    return repo
+
+
+def make_pr(pr_num: int = 42, default_branch: str = "main") -> Any:
+    pr = MagicMock()
+    pr.pr_num = pr_num
+    pr.default_branch.return_value = default_branch
+    return pr
+
+
+class TestFindRevertCommitSha(TestCase):
+    def test_returns_none_when_not_reverted(self) -> None:
+        self.assertIsNone(find_revert_commit_sha(make_repo(""), make_pr(), LANDED))
+
+    def test_finds_the_revert(self) -> None:
+        self.assertEqual(
+            find_revert_commit_sha(make_repo(f"{REVERT}\n"), make_pr(), LANDED), REVERT
+        )
+
+    def test_greps_the_default_branch_for_the_exact_landed_sha(self) -> None:
+        repo = make_repo(f"{REVERT}\n")
+        find_revert_commit_sha(repo, make_pr(default_branch="main"), LANDED)
+        args = repo._run_git.call_args[0]
+        self.assertIn(f"--grep=This reverts commit {LANDED}.", args)
+        self.assertIn("--fixed-strings", args)
+        self.assertIn("origin/main", args)
+
+    def test_multiple_reverts_resolve_to_the_newest(self) -> None:
+        # git log is newest first
+        newest = "d" * 40
+        self.assertEqual(
+            find_revert_commit_sha(
+                make_repo(f"{newest}\n{REVERT}\n"), make_pr(), LANDED
+            ),
+            newest,
+        )
+
+
+class TestIsAncestor(TestCase):
+    def test_true_when_branch_contains_ref(self) -> None:
+        self.assertTrue(is_ancestor(make_repo(on_branch=(LANDED,)), LANDED, "release"))
+
+    def test_false_when_branch_does_not_contain_ref(self) -> None:
+        self.assertFalse(is_ancestor(make_repo(), LANDED, "release"))
+
+
+class TestResolveTrunkRevert(TestCase):
+    def test_never_reverted_is_a_plain_cherry_pick(self) -> None:
+        self.assertIsNone(
+            resolve_trunk_revert(make_repo(""), make_pr(), "release/2.14", LANDED)
+        )
+
+    def test_reverted_returns_the_trunk_revert(self) -> None:
+        repo = make_repo(f"{REVERT}\n", on_branch=(LANDED,))
+        self.assertEqual(
+            resolve_trunk_revert(repo, make_pr(), "release/2.14", LANDED), REVERT
+        )
+
+    def test_refuses_when_landed_commit_is_not_on_the_release_branch(self) -> None:
+        # Reverted on trunk but the change never reached the release branch, so
+        # there is nothing there to undo
+        repo = make_repo(f"{REVERT}\n", on_branch=())
+        with self.assertRaises(RuntimeError) as err:
+            resolve_trunk_revert(repo, make_pr(), "release/2.14", LANDED)
+        self.assertIn("nothing to revert", str(err.exception))
+
+    def test_refuses_when_the_revert_is_already_on_the_release_branch(self) -> None:
+        repo = make_repo(f"{REVERT}\n", on_branch=(LANDED, REVERT))
+        with self.assertRaises(RuntimeError) as err:
+            resolve_trunk_revert(repo, make_pr(), "release/2.14", LANDED)
+        self.assertIn("already on", str(err.exception))
+
+    def test_relanded_pr_keyed_on_the_land_that_reached_the_branch(self) -> None:
+        # A PR that landed twice has one revert per land. Only the revert naming
+        # the land that is on the release branch should be picked up, so a lookup
+        # for the other land finds nothing and it stays a plain cherry pick.
+        def run_git(*args: Any) -> str:
+            grep = next(a for a in args if a.startswith("--grep="))
+            return f"{REVERT}\n" if LANDED in grep else ""
+
+        repo = make_repo(on_branch=(OTHER_LANDED,))
+        repo._run_git.side_effect = run_git
+
+        self.assertIsNone(
+            resolve_trunk_revert(repo, make_pr(), "release/2.14", OTHER_LANDED)
+        )
+
+
+class TestCreateCherryPickBranch(TestCase):
+    def _repo(self) -> Any:
+        repo = MagicMock()
+        repo.remote = "origin"
+        repo.commit_message.return_value = 'Revert "thing"\n\nThis reverts commit x.'
+        return repo
+
+    def test_plain_cherry_pick_uses_cherry_pick(self) -> None:
+        repo = self._repo()
+        create_cherry_pick_branch("actor", repo, make_pr(), LANDED, "release/2.14")
+        repo.revert.assert_not_called()
+        repo._run_git.assert_any_call("cherry-pick", "-x", LANDED)
+        repo.push.assert_called_once()
+
+    def test_revert_case_reverts_the_landed_commit_on_the_release_branch(self) -> None:
+        repo = self._repo()
+        create_cherry_pick_branch(
+            "actor", repo, make_pr(), LANDED, "release/2.14", REVERT
+        )
+        # The landed commit is reverted here, not trunk's revert cherry picked
+        repo.revert.assert_called_once_with(LANDED)
+        for call in repo._run_git.call_args_list:
+            self.assertNotIn("cherry-pick", call[0])
+        repo.push.assert_called_once()
+
+    def test_revert_records_the_trunk_revert_in_the_message(self) -> None:
+        repo = self._repo()
+        create_cherry_pick_branch(
+            "actor", repo, make_pr(), LANDED, "release/2.14", REVERT
+        )
+        amended = repo.amend_commit_message.call_args[0][0]
+        self.assertIn(f"Reverted on main by {REVERT}.", amended)
+
+    def test_conflict_aborts_and_does_not_push(self) -> None:
+        repo = self._repo()
+        repo.revert.side_effect = RuntimeError("CONFLICT (content): merge conflict")
+
+        with self.assertRaises(RuntimeError) as err:
+            create_cherry_pick_branch(
+                "actor", repo, make_pr(), LANDED, "release/2.14", REVERT
+            )
+
+        self.assertIn("hit a conflict", str(err.exception))
+        self.assertIn("by hand", str(err.exception))
+        repo._run_git.assert_any_call("revert", "--abort")
+        repo.push.assert_not_called()
+
+    def test_conflict_still_reports_when_abort_also_fails(self) -> None:
+        repo = self._repo()
+        repo.revert.side_effect = RuntimeError("CONFLICT (content): merge conflict")
+
+        def run_git(*args: Any) -> str:
+            if args[:2] == ("revert", "--abort"):
+                raise RuntimeError("nothing to abort")
+            return ""
+
+        repo._run_git.side_effect = run_git
+
+        with self.assertRaises(RuntimeError) as err:
+            create_cherry_pick_branch(
+                "actor", repo, make_pr(), LANDED, "release/2.14", REVERT
+            )
+        self.assertIn("hit a conflict", str(err.exception))
+        repo.push.assert_not_called()
+
+
+class TestTrackerIssueComment(TestCase):
+    def _comment_body(self, is_revert: bool) -> str:
+        posted: dict[str, str] = {}
+
+        import cherry_pick
+
+        original = cherry_pick.gh_post_pr_comment
+
+        def capture(
+            org: str, project: str, num: int, comment: str, dry_run: bool = False
+        ) -> list[dict[str, Any]]:
+            posted["comment"] = comment
+            return []
+
+        cherry_pick.gh_post_pr_comment = capture  # type: ignore[assignment]
+        try:
+            post_tracker_issue_comment(
+                "pytorch",
+                "pytorch",
+                1,
+                42,
+                "https://github.com/pytorch/pytorch/pull/43",
+                "critical",
+                "",
+                True,
+                is_revert,
+            )
+        finally:
+            cherry_pick.gh_post_pr_comment = original  # type: ignore[assignment]
+        return posted["comment"]
+
+    def test_revert_is_flagged_in_the_criteria(self) -> None:
+        self.assertIn("Cherry-pick revert - Critical", self._comment_body(True))
+
+    def test_plain_cherry_pick_is_not_flagged(self) -> None:
+        body = self._comment_body(False)
+        self.assertNotIn("Cherry-pick revert", body)
+        self.assertIn("Critical", body)
+
+    def test_unlinked_cherry_pick_has_no_dangling_separator(self) -> None:
+        # fixes is empty here, so the criteria line must not end in " - "
+        for is_revert in (True, False):
+            criteria = self._comment_body(is_revert).splitlines()[-1]
+            self.assertFalse(criteria.rstrip().endswith("-"), criteria)
+
+    def test_links_the_reverted_pr_and_the_release_branch_pr(self) -> None:
+        body = self._comment_body(True)
+        self.assertIn("https://github.com/pytorch/pytorch/pull/42", body)
+        self.assertIn("https://github.com/pytorch/pytorch/pull/43", body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`@pytorchbot cherry-pick --onto release/X.Y -c critical` always applies the PR's landed commit. When that PR has since been reverted on trunk, that is the wrong thing to apply — it re-adds a change trunk already threw out, to a branch that already has it.

This shows up every release: a PR lands before the branch cut so it ships in the release branch, then gets reverted on `main` after the cut. The release branch keeps the bad change unless someone reverts it by hand. Two recent ones on `release/2.14`: #193033 (for #180283) and #193148 (for #192844).

## The command does not change

```
@pytorchbot cherry-pick --onto release/2.14 -c critical
```

Still `cherry-pick`. What changes is **what it does on the release branch** when it detects the PR was reverted on trunk: it runs `git revert` there instead of applying the landed commit. No new flag, and no change in the pytorchbot command parser (test-infra `cliParser.ts`) or in `cherry-pick.yml` — the decision comes entirely from git history, so this is a single-repo change.

## Revert generated on the release branch, not cherry picked from trunk

Release branches drift. Computing the revert against the tree the release branch **actually has** is what lets it apply, and the resulting `This reverts commit <sha>.` names the commit really present there rather than trunk's copy. The trunk revert SHA is recorded in the message for provenance:

```
Revert "<original title>"

This reverts commit <landed sha on the release branch>.

Reverted on main by <trunk revert sha>.
```

## Conflicts abort

If the revert conflicts, `git revert --abort` runs, nothing is pushed, and the bot comments on the PR asking for a manual revert. What a conflicted revert should look like on a release branch is a judgement call, so it is handed back rather than guessed at.

## How the revert is detected

Keyed on the `This reverts commit <sha>.` line that `git revert` — what the revert bot runs — always writes, matched against the **specific landed SHA** rather than the PR number.

That matters for a PR that landed and was reverted several times. #180283 went through three land/revert cycles; each revert names the land it undid, and only the one undoing the land that actually reached the release branch is relevant.

## Guards

Rather than produce a bad PR, it refuses when:

1. **the landed commit is not on the target branch** — nothing to revert there (the release branch was cut before the PR landed);
2. **the revert is already on the target branch** — nothing to do.

## Not silent

- PR titled `[release/X.Y] Revert "<title>"` with a body explaining the situation. Reusing the PR's own title/body, as the normal path does, would describe the change being *undone* and read as though the feature were being added to the release.
- Tracker nomination records `Cherry-pick revert`.
- The bot's reply on the original PR says the change was reverted rather than applied.

## Test plan

- New `.github/scripts/test_cherry_pick.py` — **18 tests**: detection, newest-revert-wins ordering, both guards, the re-land case keyed on the land that reached the branch, that the revert path calls `git revert` on the landed commit and never `cherry-pick`, that the trunk revert is recorded in the message, that a conflict aborts and does not push, and that it still reports when the abort itself fails. CI already runs this directory via `pytest .github/scripts` in `lint.yml`, so these execute with no workflow change.
- `PYTHONPATH=$(pwd) pytest .github/scripts -o "python_files=test*.py"` → **125 passed, 5 skipped**, including `test_trymerge.py`.
  (`test_map_ec2_to_arc`, `test_pytest_caching_utils` and `test_runner_determinator` don't collect in my local py3.9 env for pre-existing reasons — missing PyGithub and a 3.11-only annotation. None import `cherry_pick`.)
- `ruff check` and `ruff format --check` clean on both files.

Authored with the assistance of Claude Code.