### PR TITLE
[Testcase Refactoring] Refactor test_token_switch with instantiate_device_type_tests and hw-classification

### DIFF
--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -6,11 +6,13 @@ import logging
 import torch
 import torch.distributed as dist
 from torch.distributed._token_switch import _import_nccl_ep, TokenSwitchNCCL
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
 )
@@ -60,12 +62,12 @@ def _generate_topk(rank, world_size, num_tokens, top_k, device):
 
 
 @requires_nccl_ep()
-class TokenSwitchNCCLTest(MultiProcContinuousTest):
+class TokenSwitchTestBase(MultiProcContinuousTest):
     _cached_token_switch: TokenSwitchNCCL | None = None
 
     @classmethod
-    def backend_str(cls):
-        return "nccl"
+    def backend_str(cls) -> str:
+        raise NotImplementedError
 
     @property
     def device(self):
@@ -89,7 +91,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         dist.barrier()
 
     @skip_if_lt_x_gpu(2)
-    def test_create_routing(self):
+    def _test_create_routing(self):
         self._init()
         ts = self.get_token_switch()
         num_experts = self.world_size
@@ -107,7 +109,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         torch.cuda.synchronize()
 
     @skip_if_lt_x_gpu(2)
-    def test_dispatch(self):
+    def _test_dispatch(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -151,7 +153,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    def test_dispatch_combine_roundtrip(self):
+    def _test_dispatch_combine_roundtrip(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -197,7 +199,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         self.assertEqual(combined.cpu(), expected)
 
     @skip_if_lt_x_gpu(2)
-    def test_dispatch_autograd_backward(self):
+    def _test_dispatch_autograd_backward(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -228,7 +230,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         self.assertEqual(tokens.grad, torch.ones_like(tokens))
 
     @skip_if_lt_x_gpu(2)
-    def test_combine_autograd_backward(self):
+    def _test_combine_autograd_backward(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -277,7 +279,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         self.assertEqual(expert_tokens.grad, torch.ones_like(expert_tokens))
 
     @skip_if_lt_x_gpu(2)
-    def test_dispatch_combine_autograd_roundtrip(self):
+    def _test_dispatch_combine_autograd_roundtrip(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -311,7 +313,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         self.assertEqual(tokens.grad, torch.ones_like(tokens))
 
     @skip_if_lt_x_gpu(2)
-    def test_dispatch_combine_multiple_rounds(self):
+    def _test_dispatch_combine_multiple_rounds(self):
         self._init()
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
@@ -363,12 +365,68 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         self.assertEqual(combined, expected)
 
 
-class TokenSwitchNCCL2Test(TokenSwitchNCCLTest):
-    _cached_token_switch: TokenSwitchNCCL | None = None
+@requires_nccl_ep()
+class TokenSwitchNCCLTest(TokenSwitchTestBase):
+    hw_classification = HardwareClassification.CUDA
+
+    @classmethod
+    def backend_str(cls):
+        return "nccl"
+
+    def test_create_routing(self):
+        self._test_create_routing()
+
+    def test_dispatch(self):
+        self._test_dispatch()
+
+    def test_dispatch_combine_roundtrip(self):
+        self._test_dispatch_combine_roundtrip()
+
+    def test_dispatch_autograd_backward(self):
+        self._test_dispatch_autograd_backward()
+
+    def test_combine_autograd_backward(self):
+        self._test_combine_autograd_backward()
+
+    def test_dispatch_combine_autograd_roundtrip(self):
+        self._test_dispatch_combine_autograd_roundtrip()
+
+    def test_dispatch_combine_multiple_rounds(self):
+        self._test_dispatch_combine_multiple_rounds()
+
+
+@requires_nccl_ep()
+class TokenSwitchNCCL2Test(TokenSwitchTestBase):
+    hw_classification = HardwareClassification.CUDA
 
     @classmethod
     def backend_str(cls):
         return "nccl2"
+
+    def test_create_routing(self):
+        self._test_create_routing()
+
+    def test_dispatch(self):
+        self._test_dispatch()
+
+    def test_dispatch_combine_roundtrip(self):
+        self._test_dispatch_combine_roundtrip()
+
+    def test_dispatch_autograd_backward(self):
+        self._test_dispatch_autograd_backward()
+
+    def test_combine_autograd_backward(self):
+        self._test_combine_autograd_backward()
+
+    def test_dispatch_combine_autograd_roundtrip(self):
+        self._test_dispatch_combine_autograd_roundtrip()
+
+    def test_dispatch_combine_multiple_rounds(self):
+        self._test_dispatch_combine_multiple_rounds()
+
+
+instantiate_device_type_tests(TokenSwitchNCCLTest, globals(), only_for="cuda")
+instantiate_device_type_tests(TokenSwitchNCCL2Test, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -69,10 +69,6 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
     def backend_str(cls) -> str:
         raise NotImplementedError
 
-    @property
-    def device(self):
-        return torch.device("cuda", self.rank)
-
     @classmethod
     def get_token_switch(cls) -> TokenSwitchNCCL:
         if cls._cached_token_switch is None:
@@ -86,21 +82,25 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
             )
         return cls._cached_token_switch
 
-    def _init(self):
-        torch.cuda.set_device(self.device)
+    def _init(self, rank_device):
+        torch.cuda.set_device(rank_device)
         dist.barrier()
 
+    def _rank_device(self, device):
+        return torch.device(torch.device(device).type, self.rank)
+
     @skip_if_lt_x_gpu(2)
-    def _test_create_routing(self):
-        self._init()
+    def _test_create_routing(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_experts = self.world_size
         num_local_experts = num_experts // self.world_size
         topk_idx, _topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            num_local_experts, dtype=torch.int32, device=self.device
+            num_local_experts, dtype=torch.int32, device=rank_device
         )
         ts.create_routing(topk_idx, per_expert_counts)
         self.assertEqual(per_expert_counts.dtype, torch.int32)
@@ -109,31 +109,32 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         torch.cuda.synchronize()
 
     @skip_if_lt_x_gpu(2)
-    def _test_dispatch(self):
-        self._init()
+    def _test_dispatch(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
         token_val = float(self.rank + 1)
         tokens = torch.full(
-            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=rank_device
         )
         out_tokens = torch.zeros(
-            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=rank_device
         )
         out_topk_weights = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.float32, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.float32, device=rank_device
         )
         out_topk_idx = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.int64, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.int64, device=rank_device
         )
 
         ts.dispatch(
@@ -153,31 +154,32 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         )
 
     @skip_if_lt_x_gpu(2)
-    def _test_dispatch_combine_roundtrip(self):
-        self._init()
+    def _test_dispatch_combine_roundtrip(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
         token_val = float(self.rank + 1)
         tokens = torch.full(
-            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=rank_device
         )
         out_tokens = torch.zeros(
-            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=rank_device
         )
         out_topk_weights = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.float32, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.float32, device=rank_device
         )
         out_topk_idx = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.int64, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.int64, device=rank_device
         )
 
         ts.dispatch(
@@ -190,7 +192,7 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
 
         expert_tokens = out_tokens[:NUM_TOKENS].contiguous()
         combined = torch.zeros(
-            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=self.device
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=rank_device
         )
         ts.combine(routing, expert_tokens, out=combined)
         torch.cuda.synchronize()
@@ -199,16 +201,17 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         self.assertEqual(combined.cpu(), expected)
 
     @skip_if_lt_x_gpu(2)
-    def _test_dispatch_autograd_backward(self):
-        self._init()
+    def _test_dispatch_autograd_backward(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
@@ -216,7 +219,7 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
             (NUM_TOKENS, HIDDEN),
             float(self.rank + 1),
             dtype=torch.bfloat16,
-            device=self.device,
+            device=rank_device,
             requires_grad=True,
         )
         out_tokens, _out_weights, _out_idx = ts.dispatch(
@@ -230,16 +233,17 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         self.assertEqual(tokens.grad, torch.ones_like(tokens))
 
     @skip_if_lt_x_gpu(2)
-    def _test_combine_autograd_backward(self):
-        self._init()
+    def _test_combine_autograd_backward(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
@@ -248,16 +252,16 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
             (NUM_TOKENS, HIDDEN),
             float(self.rank + 1),
             dtype=torch.bfloat16,
-            device=self.device,
+            device=rank_device,
         )
         out_tokens_buf = torch.zeros(
-            num_recv_tokens, HIDDEN, dtype=torch.bfloat16, device=self.device
+            num_recv_tokens, HIDDEN, dtype=torch.bfloat16, device=rank_device
         )
         out_weights_buf = torch.zeros(
-            num_recv_tokens, TOP_K, dtype=torch.float32, device=self.device
+            num_recv_tokens, TOP_K, dtype=torch.float32, device=rank_device
         )
         out_idx_buf = torch.zeros(
-            num_recv_tokens, TOP_K, dtype=torch.int64, device=self.device
+            num_recv_tokens, TOP_K, dtype=torch.int64, device=rank_device
         )
         ts.dispatch(
             routing,
@@ -279,16 +283,17 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         self.assertEqual(expert_tokens.grad, torch.ones_like(expert_tokens))
 
     @skip_if_lt_x_gpu(2)
-    def _test_dispatch_combine_autograd_roundtrip(self):
-        self._init()
+    def _test_dispatch_combine_autograd_roundtrip(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
@@ -297,7 +302,7 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
             (NUM_TOKENS, HIDDEN),
             token_val,
             dtype=torch.bfloat16,
-            device=self.device,
+            device=rank_device,
             requires_grad=True,
         )
         dispatched, _weights, _idx = ts.dispatch(
@@ -313,30 +318,31 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
         self.assertEqual(tokens.grad, torch.ones_like(tokens))
 
     @skip_if_lt_x_gpu(2)
-    def _test_dispatch_combine_multiple_rounds(self):
-        self._init()
+    def _test_dispatch_combine_multiple_rounds(self, device):
+        rank_device = self._rank_device(device)
+        self._init(rank_device)
         ts = self.get_token_switch()
         num_recv_tokens = self.world_size * NUM_TOKENS
 
         topk_idx, topk_weights = _generate_topk(
-            self.rank, self.world_size, NUM_TOKENS, TOP_K, self.device
+            self.rank, self.world_size, NUM_TOKENS, TOP_K, rank_device
         )
         per_expert_counts = torch.zeros(
-            self.world_size, dtype=torch.int32, device=self.device
+            self.world_size, dtype=torch.int32, device=rank_device
         )
         routing = ts.create_routing(topk_idx, per_expert_counts)
 
         out_tokens = torch.zeros(
-            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=self.device
+            (num_recv_tokens, HIDDEN), dtype=torch.bfloat16, device=rank_device
         )
         out_topk_weights = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.float32, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.float32, device=rank_device
         )
         out_topk_idx = torch.zeros(
-            (num_recv_tokens, TOP_K), dtype=torch.int64, device=self.device
+            (num_recv_tokens, TOP_K), dtype=torch.int64, device=rank_device
         )
         combined = torch.zeros(
-            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=self.device
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device=rank_device
         )
 
         for r in range(NUM_MULTI_ROUND_DISPATCH_COMBINE):
@@ -345,7 +351,7 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
                 (NUM_TOKENS, HIDDEN),
                 token_val,
                 dtype=torch.bfloat16,
-                device=self.device,
+                device=rank_device,
             )
             ts.dispatch(
                 routing,
@@ -360,7 +366,7 @@ class TokenSwitchTestBase(MultiProcContinuousTest):
             torch.cuda.synchronize()
 
         expected = torch.full(
-            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=self.device
+            (NUM_TOKENS, HIDDEN), token_val, dtype=torch.bfloat16, device=rank_device
         )
         self.assertEqual(combined, expected)
 
@@ -373,26 +379,26 @@ class TokenSwitchNCCLTest(TokenSwitchTestBase):
     def backend_str(cls):
         return "nccl"
 
-    def test_create_routing(self):
-        self._test_create_routing()
+    def test_create_routing(self, device):
+        self._test_create_routing(device)
 
-    def test_dispatch(self):
-        self._test_dispatch()
+    def test_dispatch(self, device):
+        self._test_dispatch(device)
 
-    def test_dispatch_combine_roundtrip(self):
-        self._test_dispatch_combine_roundtrip()
+    def test_dispatch_combine_roundtrip(self, device):
+        self._test_dispatch_combine_roundtrip(device)
 
-    def test_dispatch_autograd_backward(self):
-        self._test_dispatch_autograd_backward()
+    def test_dispatch_autograd_backward(self, device):
+        self._test_dispatch_autograd_backward(device)
 
-    def test_combine_autograd_backward(self):
-        self._test_combine_autograd_backward()
+    def test_combine_autograd_backward(self, device):
+        self._test_combine_autograd_backward(device)
 
-    def test_dispatch_combine_autograd_roundtrip(self):
-        self._test_dispatch_combine_autograd_roundtrip()
+    def test_dispatch_combine_autograd_roundtrip(self, device):
+        self._test_dispatch_combine_autograd_roundtrip(device)
 
-    def test_dispatch_combine_multiple_rounds(self):
-        self._test_dispatch_combine_multiple_rounds()
+    def test_dispatch_combine_multiple_rounds(self, device):
+        self._test_dispatch_combine_multiple_rounds(device)
 
 
 @requires_nccl_ep()
@@ -403,26 +409,26 @@ class TokenSwitchNCCL2Test(TokenSwitchTestBase):
     def backend_str(cls):
         return "nccl2"
 
-    def test_create_routing(self):
-        self._test_create_routing()
+    def test_create_routing(self, device):
+        self._test_create_routing(device)
 
-    def test_dispatch(self):
-        self._test_dispatch()
+    def test_dispatch(self, device):
+        self._test_dispatch(device)
 
-    def test_dispatch_combine_roundtrip(self):
-        self._test_dispatch_combine_roundtrip()
+    def test_dispatch_combine_roundtrip(self, device):
+        self._test_dispatch_combine_roundtrip(device)
 
-    def test_dispatch_autograd_backward(self):
-        self._test_dispatch_autograd_backward()
+    def test_dispatch_autograd_backward(self, device):
+        self._test_dispatch_autograd_backward(device)
 
-    def test_combine_autograd_backward(self):
-        self._test_combine_autograd_backward()
+    def test_combine_autograd_backward(self, device):
+        self._test_combine_autograd_backward(device)
 
-    def test_dispatch_combine_autograd_roundtrip(self):
-        self._test_dispatch_combine_autograd_roundtrip()
+    def test_dispatch_combine_autograd_roundtrip(self, device):
+        self._test_dispatch_combine_autograd_roundtrip(device)
 
-    def test_dispatch_combine_multiple_rounds(self):
-        self._test_dispatch_combine_multiple_rounds()
+    def test_dispatch_combine_multiple_rounds(self, device):
+        self._test_dispatch_combine_multiple_rounds(device)
 
 
 instantiate_device_type_tests(TokenSwitchNCCLTest, globals(), only_for="cuda")


### PR DESCRIPTION
## Summary
Refactor `test/distributed/test_token_switch.py` to label both test classes `HardwareClassification.CUDA`, pass them through `instantiate_device_type_tests(only_for="cuda")`, and thread the framework `device` parameter through the `test_*`/`_test_*` methods, so the suite complies with the `TEST_LINTER` CUDA rules (PR #190173: a CUDA class must be instantiated with matching `only_for`, every `test_*` method must accept a `device`/`devices` parameter, no `except_for`). The test logic and CUDA runtime gates are unchanged.

## Changes
- Extract a `TokenSwitchTestBase(MultiProcContinuousTest)` holding the 7 test bodies (as `_test_*` helpers) + shared infra (`backend_str` abstract, `get_token_switch`, `_init`). Two concrete subclasses (`TokenSwitchNCCLTest` for `"nccl"`, `TokenSwitchNCCL2Test` for `"nccl2"`) each set `hw_classification = HardwareClassification.CUDA` and carry their own 7 `test_*` wrappers (instantiate processes only a class's own `__dict__` `test_*`, so the subclass must carry its own for the nccl2 variant to survive instantiation).
- Thread the framework `device` parameter through the `test_*(self, device)` wrappers into the `_test_*(self, device)` helpers. Each helper derives the per-rank GPU via a shared `_rank_device(self, device)` method returning `torch.device(torch.device(device).type, self.rank)`, and passes it to `_init(self, rank_device)`. The previous `self.device` property is dropped; `_init` takes the derived device explicitly.
- Two `instantiate_device_type_tests(..., only_for="cuda")` calls (one per class).
- No change to the test logic or the `@requires_nccl_ep()` / `@skip_if_lt_x_gpu(2)` gates; the 7 bodies are preserved as `_test_*` (per-rank device now from `_rank_device(device)`, equivalent to the prior `self.device`).

## Motivation
`test_token_switch` exercises NCCL EP (`torch._nccl_ep`) token-switch dispatch/combine/autograd through CUDA-specific APIs (`torch.cuda.set_device`/`torch.cuda.synchronize`, `torch.device("cuda")`, ncclEp* primitives) -- CUDA-specific behavior per the classification spec, so the classes are labeled `CUDA` (not `ACCELERATOR`). PR #190173's `TEST_LINTER` will enforce that a `CUDA` class is instantiated with `only_for="cuda"` and that every `test_*` method takes a `device` parameter; this PR makes the file compliant. This is part of the test case refactoring initiative to label all test-case classes with `hw_classification`.

## Notes
- `device` is singular: instantiate injects the framework primary device (`"cuda:0"`, captured once for all ranks); the per-rank index comes from `self.rank` (set per-worker at spawn), so `_rank_device` reproduces the previous `torch.device("cuda", self.rank)`. `MultiProcContinuousTest` + `instantiate_device_type_tests` compose: the worker calls the wrapper, which injects `device` from its closure.
- `backend_str` ("nccl"/"nccl2") is a class-level PG-backend choice (consumed in `_init_pg`/`setUp` before any test runs), so the two classes are kept rather than `@parametrize`-merged.
- No framework dependency: `HardwareClassification` + `instantiate_device_type_tests` are already on `origin/main`. On a non-CUDA build the cuda variant is not generated (CUDATestBase is absent from the device-type bases without `torch.cuda.is_available()`), so `instantiate_test` is not called and the file remains a no-op there.

