### PR TITLE
[MPS] Add native _int_mm support

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -11,17 +11,16 @@ using namespace metal;
 
 constant uint TILE_DIM = 16;
 
-template <typename T>
-inline c10::metal::opmath_t<T> matmul_inner(
-    constant T* mat1Data,
-    constant T* mat2Data,
+template <typename T1, typename T2, typename TA>
+inline TA matmul_inner(
+    constant T1* mat1Data,
+    constant T2* mat2Data,
     constant array<ulong2, 3>& strides,
     constant uint3& sizes,
-    threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM],
-    threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM],
+    threadgroup TA A_tile[TILE_DIM][TILE_DIM],
+    threadgroup TA B_tile[TILE_DIM][TILE_DIM],
     uint2 tid,
     uint2 thread_id) {
-  using TA = c10::metal::opmath_t<T>;
   TA sum = 0;
 
   uint numTiles = (sizes.y + TILE_DIM - 1) / TILE_DIM;
@@ -120,6 +119,25 @@ kernel void matmul(
   if (thread_id.y < sizes.x && thread_id.x < sizes.z) {
     outputData[thread_id.y * strides[2].x + thread_id.x * strides[2].y] =
         static_cast<T>(sum);
+  }
+}
+
+template <typename T>
+kernel void int_mm(
+    constant T* mat1Data [[buffer(0)]],
+    constant char* mat2Data [[buffer(1)]],
+    device int* outputData [[buffer(2)]],
+    constant array<ulong2, 3>& strides [[buffer(3)]],
+    constant uint3& sizes [[buffer(4)]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 thread_id [[thread_position_in_grid]]) {
+  threadgroup int A_tile[TILE_DIM][TILE_DIM];
+  threadgroup int B_tile[TILE_DIM][TILE_DIM];
+
+  auto sum = matmul_inner(
+      mat1Data, mat2Data, strides, sizes, A_tile, B_tile, tid, thread_id);
+  if (thread_id.y < sizes.x && thread_id.x < sizes.z) {
+    outputData[thread_id.y * strides[2].x + thread_id.x * strides[2].y] = sum;
   }
 }
 
@@ -2026,6 +2044,76 @@ kernel void gemmSimdLU(
     __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
 
+template <int BM, int BN, int NSG>
+kernel void int_mm_mpp(
+    device int8_t* mat1Data [[buffer(0)]],
+    device int8_t* mat2Data [[buffer(1)]],
+    device int* outputData [[buffer(2)]],
+    constant array<ulong2, 3>& strides [[buffer(3)]],
+    constant uint3& sizes [[buffer(4)]],
+    uint3 tgid [[threadgroup_position_in_grid]]) {
+  const int m = int(sizes.x);
+  const int k = int(sizes.y);
+  const int n = int(sizes.z);
+  const int row = int(tgid.y) * BM;
+  const int col = int(tgid.x) * BN;
+
+  constexpr auto desc = mpp::tensor_ops::matmul2d_descriptor(
+      BM,
+      BN,
+      static_cast<int>(dynamic_extent),
+      false,
+      false,
+      false,
+      mpp::tensor_ops::matmul2d_descriptor::mode::multiply);
+  mpp::tensor_ops::matmul2d<desc, execution_simdgroups<NSG>> op;
+
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> mat1(
+      mat1Data,
+      dextents<int32_t, 2>(k, m),
+      array<int32_t, 2>{int(strides[0].y), int(strides[0].x)});
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> mat2(
+      mat2Data,
+      dextents<int32_t, 2>(n, k),
+      array<int32_t, 2>{int(strides[1].y), int(strides[1].x)});
+  tensor<device int, dextents<int32_t, 2>, tensor_inline> output(
+      outputData,
+      dextents<int32_t, 2>(n, m),
+      array<int32_t, 2>{int(strides[2].y), int(strides[2].x)});
+
+  const bool inside = row + BM <= m && col + BN <= n;
+  if (inside) {
+    auto a = mat1.template slice<dynamic_extent, BM>(0, row);
+    auto b = mat2.template slice<BN, dynamic_extent>(col, 0);
+    auto c = output.template slice<BN, BM>(col, row);
+    auto result = op.template get_destination_cooperative_tensor<
+        decltype(a),
+        decltype(b),
+        int>();
+    op.run(a, b, result);
+    result.store(c);
+  } else {
+    auto a = mat1.slice(0, row);
+    auto b = mat2.slice(col, 0);
+    auto c = output.slice(col, row);
+    auto result = op.template get_destination_cooperative_tensor<
+        decltype(a),
+        decltype(b),
+        int>();
+    op.run(a, b, result);
+    result.store(c);
+  }
+}
+
+template [[host_name("int_mm_mpp_64_64_4")]]
+kernel void int_mm_mpp<64, 64, 4>(
+    device int8_t* mat1Data [[buffer(0)]],
+    device int8_t* mat2Data [[buffer(1)]],
+    device int* outputData [[buffer(2)]],
+    constant array<ulong2, 3>& strides [[buffer(3)]],
+    constant uint3& sizes [[buffer(4)]],
+    uint3 tgid [[threadgroup_position_in_grid]]);
+
 // Same Schur update C -= A*B (sgemm) as gemmSimdLU, but via MetalPerformance-
 // Primitives matmul2d (macOS 26.2+, gated by lu_has_matmul2d()).
 template <int BM, int BN, int NSG>
@@ -2714,6 +2802,19 @@ INSTANTIATE_MM_OPS(int);
 INSTANTIATE_MM_OPS(short);
 INSTANTIATE_MM_OPS(char);
 INSTANTIATE_MM_OPS(uchar);
+
+#define INSTANTIATE_INT_MM_OP(DTYPE)                                  \
+  template [[host_name("int_mm_" #DTYPE)]] kernel void int_mm<DTYPE>( \
+      constant DTYPE * mat1Data [[buffer(0)]],                        \
+      constant char* mat2Data [[buffer(1)]],                          \
+      device int* outputData [[buffer(2)]],                           \
+      constant array<ulong2, 3>& strides [[buffer(3)]],               \
+      constant uint3& sizes [[buffer(4)]],                            \
+      uint2 tid [[thread_position_in_threadgroup]],                   \
+      uint2 thread_id [[thread_position_in_grid]])
+
+INSTANTIATE_INT_MM_OP(char);
+INSTANTIATE_INT_MM_OP(uchar);
 
 #define REGISTER_ORGQR(T)                            \
   template [[host_name("orgqr_" #T)]]                \

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -22,6 +22,7 @@
 #else
 #include <ATen/ScalarOps.h>
 #include <ATen/ops/_cholesky_solve_helper_native.h>
+#include <ATen/ops/_int_mm_native.h>
 #include <ATen/ops/_linalg_check_errors.h>
 #include <ATen/ops/_linalg_eigh.h>
 #include <ATen/ops/_linalg_solve_ex_native.h>
@@ -58,8 +59,10 @@
 #include <ATen/ops/zeros.h>
 #endif
 
+#include <c10/util/TypeCast.h>
 #include <c10/util/env.h>
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -346,6 +349,77 @@ Tensor& do_metal_mm(const Tensor& self, const Tensor& other, Tensor& output) {
     }
   });
   return output;
+}
+
+Tensor& int_mm_out_mps_impl(const Tensor& self, const Tensor& mat2, Tensor& result) {
+  static constexpr std::string_view func_name = "int_mm_out_mps";
+  TORCH_CHECK(self.dim() == 2, func_name, ": Expected self to be of dimension 2 but got ", self.dim());
+  TORCH_CHECK(mat2.dim() == 2, func_name, ": Expected mat2 to be of dimension 2 but got ", mat2.dim());
+  TORCH_CHECK(self.size(1) == mat2.size(0),
+              func_name,
+              ": self.size(1) needs to match mat2.size(0) but got ",
+              self.size(1),
+              " and ",
+              mat2.size(0));
+  TORCH_CHECK(self.dtype() == at::kChar || self.dtype() == at::kByte,
+              func_name,
+              ": Expected self dtype to be int8 or uint8 but got ",
+              self.dtype());
+  TORCH_CHECK(mat2.dtype() == at::kChar, func_name, ": Expected mat2 dtype to be of type int8 but got ", mat2.dtype());
+  TORCH_CHECK(
+      result.dtype() == at::kInt, func_name, ": Expected result dtype to be of type kInt but got ", result.dtype());
+  TORCH_CHECK(result.size(0) == self.size(0),
+              func_name,
+              ": Expected result.size(0) to be ",
+              self.size(0),
+              " but got ",
+              result.size(0));
+  TORCH_CHECK(result.size(1) == mat2.size(1),
+              func_name,
+              ": Expected result.size(1) to be ",
+              mat2.size(1),
+              " but got ",
+              result.size(1));
+  TORCH_CHECK(result.dim() == 2, func_name, ": Expected result to be of dimension 2 but got ", result.dim());
+  TORCH_CHECK(result.is_contiguous(), func_name, ": Expected result to be contiguous.");
+
+  if (result.numel() == 0 || self.size(1) == 0) {
+    return result.zero_();
+  }
+
+  const auto m = c10::checked_convert<uint32_t>(self.size(0), "self.size(0)");
+  const auto k = c10::checked_convert<uint32_t>(self.size(1), "self.size(1)");
+  const auto n = c10::checked_convert<uint32_t>(mat2.size(1), "mat2.size(1)");
+  constexpr auto int_max = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+  constexpr const char* mpp_kernel = "int_mm_mpp_64_64_4";
+  // MPP integer matmul requires operands with matching signedness, while _int_mm permits uint8 only for self.
+  const bool use_mpp = self.scalar_type() == at::kChar && self.stride(1) == 1 && mat2.stride(1) == 1 && m <= int_max &&
+      k <= int_max && n <= int_max && self.stride(0) <= int_max && mat2.stride(0) <= int_max && has_mpp() &&
+      lib.hasFunction(mpp_kernel);
+  const auto kernel_name = use_mpp ? mpp_kernel : self.scalar_type() == at::kByte ? "int_mm_uchar" : "int_mm_char";
+  auto stream = getCurrentMPSStream();
+  auto pso = lib.getPipelineStateForFunc(kernel_name);
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "int_mm", {self, mat2}, stream);
+      auto computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:pso];
+      const c10::metal::vec3<uint32_t> sizes = {m, k, n};
+      const std::array<int64_t, 6> strides = {
+          self.stride(0), self.stride(1), mat2.stride(0), mat2.stride(1), result.stride(0), result.stride(1)};
+      const uint32_t tile_dim = use_mpp ? 64 : 16;
+      const auto grid_size_x = at::ceil_div(n, tile_dim);
+      const auto grid_size_y = at::ceil_div(m, tile_dim);
+      const auto threads_per_threadgroup = use_mpp ? MTLSizeMake(128, 1, 1) : MTLSizeMake(16, 16, 1);
+
+      mtl_setArgs(computeEncoder, self, mat2, result, strides, sizes);
+      [computeEncoder dispatchThreadgroups:MTLSizeMake(grid_size_x, grid_size_y, 1)
+                     threadsPerThreadgroup:threads_per_threadgroup];
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
+  return result;
 }
 
 Tensor& do_metal_bmm(const Tensor& batch1, const Tensor& batch2, Tensor& output) {
@@ -2358,6 +2432,15 @@ Tensor& addr_out_mps(const Tensor& self,
 
 TORCH_IMPL_FUNC(mm_out_mps)(const Tensor& self, const Tensor& mat2, const Tensor& result) {
   mps::mm_out_mps_impl(self, mat2, const_cast<Tensor&>(result));
+}
+
+Tensor& _int_mm_out_mps(const Tensor& self, const Tensor& mat2, Tensor& result) {
+  return mps::int_mm_out_mps_impl(self, mat2, result);
+}
+
+Tensor _int_mm_mps(const Tensor& self, const Tensor& mat2) {
+  auto result = at::empty({self.size(0), mat2.size(1)}, self.options().dtype(at::kInt));
+  return _int_mm_out_mps(self, mat2, result);
 }
 
 TORCH_IMPL_FUNC(addmm_out_mps)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4170,12 +4170,14 @@
   dispatch:
     CPU: _int_mm_cpu
     CUDA: _int_mm_cuda
+    MPS: _int_mm_mps
     XPU: _int_mm_xpu
 
 - func: _int_mm.out(Tensor self, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _int_mm_out_cpu
     CUDA: _int_mm_out_cuda
+    MPS: _int_mm_out_mps
     XPU: _int_mm_out_xpu
 
 - func: _convert_weight_to_int4pack(Tensor self, int innerKTiles) -> Tensor

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -9424,8 +9424,6 @@ GPU_TEST_FAILURES = {
 MPS_TEST_FAILURES = {
     # aten::_scaled_dot_product_efficient_attention is not currently implemented for the MPS device.
     "test_scaled_dot_product_efficient_attention": fail_mps(),
-    # aten::_int_mm is not implemented for MPS backend
-    "test__int_mm": fail_mps(),
     # MPS doesn't support float64
     "test_while_loop_with_conv_dynamic_True": fail_mps(),
     "test_while_loop_with_conv_dynamic_False": fail_mps(),

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12056,6 +12056,68 @@ class TestConv3dChannelsLast3dMPS(NNTestCase):
 
 
 class TestLinalgMPS(TestCaseMPS):
+    def test__int_mm(self):
+        torch.manual_seed(0)
+
+        def make_input(shape, dtype):
+            low, high = (-128, 128) if dtype == torch.int8 else (0, 256)
+            return make_tensor(shape, device="cpu", dtype=dtype, low=low, high=high)
+
+        cases = []
+        for m, k, n in ((1, 7, 5), (15, 16, 17), (16, 17, 15), (17, 15, 16), (65, 64, 65),
+                        (0, 7, 5), (3, 0, 5), (3, 7, 0)):
+            for lhs_dtype in (torch.int8, torch.uint8):
+                cases.append((make_input((m, k), lhs_dtype), make_input((k, n), torch.int8)))
+
+        cases.extend([
+            (make_input((16, 17), torch.int8).t(), make_input((15, 16), torch.int8).t()),
+            (make_input((18, 31), torch.uint8)[1:, 1::2], make_input((31, 33), torch.int8)[1::2, 1::2]),
+            (torch.full((1, 32), 127, dtype=torch.int8), torch.full((32, 1), 127, dtype=torch.int8)),
+        ])
+
+        for lhs, rhs in cases:
+            expected = torch._int_mm(lhs, rhs)
+            lhs_mps = lhs.to("mps")
+            rhs_mps = rhs.to("mps")
+            actual = torch._int_mm(lhs_mps, rhs_mps)
+
+            self.assertEqual(actual.dtype, torch.int32)
+            self.assertEqual(actual.device.type, "mps")
+            self.assertEqual(actual.cpu(), expected)
+
+            out = torch.empty(expected.shape, dtype=torch.int32, device="mps")
+            returned = torch._int_mm(lhs_mps, rhs_mps, out=out)
+            self.assertIs(returned, out)
+            self.assertEqual(out.cpu(), expected)
+
+    def test__int_mm_errors(self):
+        lhs = torch.empty((3, 7), dtype=torch.int8, device="mps")
+        rhs = torch.empty((7, 5), dtype=torch.int8, device="mps")
+
+        error_cases = [
+            ("Expected self to be of dimension 2", lambda: torch._int_mm(lhs[0], rhs)),
+            ("Expected mat2 to be of dimension 2",
+             lambda: torch._int_mm(
+                 lhs, rhs[:, 0], out=torch.empty((3, 5), dtype=torch.int32, device="mps"))),
+            (r"self.size\(1\) needs to match mat2.size\(0\)",
+             lambda: torch._int_mm(lhs, torch.empty((6, 5), dtype=torch.int8, device="mps"))),
+            ("Expected self dtype to be int8 or uint8", lambda: torch._int_mm(lhs.float(), rhs)),
+            ("Expected mat2 dtype to be of type int8", lambda: torch._int_mm(lhs, rhs.to(torch.uint8))),
+            ("Expected result dtype to be of type kInt",
+             lambda: torch._int_mm(lhs, rhs, out=torch.empty((3, 5), device="mps"))),
+            ("Expected result to be of dimension 2",
+             lambda: torch._int_mm(lhs, rhs, out=torch.empty((3, 5, 1), dtype=torch.int32, device="mps"))),
+            (r"Expected result.size\(0\) to be 3",
+             lambda: torch._int_mm(lhs, rhs, out=torch.empty((2, 5), dtype=torch.int32, device="mps"))),
+            (r"Expected result.size\(1\) to be 5",
+             lambda: torch._int_mm(lhs, rhs, out=torch.empty((3, 4), dtype=torch.int32, device="mps"))),
+            ("Expected result to be contiguous",
+             lambda: torch._int_mm(lhs, rhs, out=torch.empty((5, 3), dtype=torch.int32, device="mps").t())),
+        ]
+        for message, operation in error_cases:
+            with self.assertRaisesRegex(RuntimeError, message):
+                operation()
+
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
         dtype = t.dtype
         numpy_dtype = dtype

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -28,6 +28,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__fused_rms_norm(AtenTensorHandle
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__grouped_mm(AtenTensorHandle self, AtenTensorHandle mat2, AtenTensorHandle* offs, AtenTensorHandle* bias, int32_t* out_dtype, AtenTensorHandle* ret0);
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__histogramdd_from_bin_cts(AtenTensorHandle self, const int64_t* bins, int64_t bins_len_, const double** range, int64_t range_len_, AtenTensorHandle* weight, int32_t density, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__int_mm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2);
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__scaled_dot_product_attention_math_for_mps_v2(AtenTensorHandle query, AtenTensorHandle key, AtenTensorHandle value, AtenTensorHandle* attn_mask, double dropout_p, int32_t is_causal, AtenTensorHandle* dropout_mask, double* scale, int32_t enable_gqa, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0


### PR DESCRIPTION

## Issue

Related to https://github.com/pytorch/pytorch/issues/141287#issuecomment-5207370082

## Summary

MPS has no native dispatch for `aten::_int_mm`, so int8 matrix multiplication and AOTInductor workloads fail when the input tensors reside on MPS. This change registers the functional and out variants for MPS and adds exact int8/uint8 by int8 to int32 execution. Eligible unit-inner-stride int8 inputs use a Metal 4 MetalPerformancePrimitives `matmul2d` fast path; uint8 inputs, non-unit inner strides, and systems without the required MPP support use a 16x16 tiled Metal kernel. The implementation preserves validation, non-contiguous views, storage offsets, zero-size behavior, and AOTInductor support.

## Validation

- Full `USE_MPS=ON` editable build completed
- Metal 3.1 and Metal 4.0 kernel compilation and linking completed
- MPS correctness and error tests: 2 passed
- AOTInductor MPS test: 1 passed
- Changed-file lint and `git diff --check` passed

## Local benchmark

Apple M4 Pro median timings for native `_int_mm.out`:

| Shape (M, K, N) | Median |
| --- | ---: |
| (10032, 3072, 3072) | 33.140 ms |
| (10032, 3072, 12288) | 133.193 ms |

These measurements characterize the local implementation and are not a general cross-device performance claim. Upstream has no native MPS implementation to use as a native baseline.

## Environment

```text
Apple M4 Pro
macOS 26.6 (arm64)
Xcode 26.6 (17F113)
macOS SDK 26.5
Metal Toolchain 17F109
Apple Clang 21.0.0
Python 3.12.13
upstream/main: 35eadc3dfd50c88bc1935da2e36551344445fe2d
contribution commit: dad3c165acac96514f9937a5535405906d01f3f1
```

## Checklist

- [x] Passes lint (`spin quicklint -a`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable; no user-facing documentation change)
- [x] Included benchmark results

## BC-breaking?

No.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
