### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_selective_lowering.py
+++ b/test/inductor/test_selective_lowering.py
@@ -6,27 +6,21 @@ Test selective lowering control via node metadata annotations.
 import torch
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
-)
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU,
-    patch_custom_fallback_pass,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, parametrize
+from torch.testing._internal.inductor_utils import patch_custom_fallback_pass
+from torch.utils._triton import has_triton
 
 
-@instantiate_parametrized_tests
 class SelectiveLoweringTest(InductorTestCase):
     """
     Tests for user-controllable selective lowering using node.meta annotations.
     """
 
-    device = GPU_TYPE
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @parametrize("fallback", (True, False))
-    def test_basic_selective_lowering(self, fallback: bool):
+    def test_basic_selective_lowering(self, device, fallback: bool):
         """
         Test that nodes marked for fallback use fallback handlers instead of lowerings.
         """
@@ -36,8 +30,8 @@ class SelectiveLoweringTest(InductorTestCase):
             b = a * 2  # This will use normal lowering
             return b
 
-        x = torch.randn(10, device=self.device)
-        y = torch.randn(10, device=self.device)
+        x = torch.randn(10, device=device)
+        y = torch.randn(10, device=device)
 
         # Mark all add operations for fallback
         def should_fallback_add(node: torch.fx.Node) -> bool:
@@ -58,8 +52,13 @@ class SelectiveLoweringTest(InductorTestCase):
         self.assertEqual("aten.add" in code, fallback)
 
 
+instantiate_device_type_tests(
+    SelectiveLoweringTest, globals(), except_for="cpu", allow_xpu=True
+)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
+    if has_triton():
         run_tests(needs="filelock")


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Change 'instantiate_parametrized_tests' to 'instantiate_device_type_tests'
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_selective_lowering.py
python test/inductor/test_selective_lowering.py -v --hw-classification ACCELERATOR

## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo