### PR TITLE
[TEST] Add `hw_classification` to Utils CUDA/ACCELERATOR test files

### DIFF
--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -1,16 +1,14 @@
 # Owner(s): ["module: cuda"]
 
-import sys
 import unittest
 import unittest.mock
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    NoTest,
     run_tests,
-    TEST_CUDA,
     TestCase,
 )
 
@@ -18,28 +16,26 @@ from torch.testing._internal.common_utils import (
 # NOTE: Each test needs to be run in a brand new process, to reset the registered hooks
 # and make sure the CUDA streams are initialized for each test that uses them.
 
-if not TEST_CUDA:
-    print("CUDA not available, skipping tests", file=sys.stderr)
-    TestCase = NoTest
-
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
     hw_classification = HardwareClassification.CUDA
+    _do_cuda_memory_leak_check = False
+    _do_cuda_non_default_stream = False
 
     def setUp(self):
         super().setUp()
         torch._C._activate_gpu_trace()
         self.mock = unittest.mock.MagicMock()
 
-    def test_event_creation_callback(self):
+    def test_event_creation_callback(self, device):
         gpu_trace.register_callback_for_event_creation(self.mock)
 
         event = torch.cuda.Event()
         event.record()
         self.mock.assert_called_once_with(event._as_parameter_.value)
 
-    def test_event_deletion_callback(self):
+    def test_event_deletion_callback(self, device):
         gpu_trace.register_callback_for_event_deletion(self.mock)
 
         event = torch.cuda.Event()
@@ -48,66 +44,66 @@ class TestCudaTrace(TestCase):
         del event
         self.mock.assert_called_once_with(event_id)
 
-    def test_event_record_callback(self):
+    def test_event_record_callback(self, device):
         gpu_trace.register_callback_for_event_record(self.mock)
 
         event = torch.cuda.Event()
         event.record()
         self.mock.assert_called_once_with(
-            event._as_parameter_.value, torch.cuda.default_stream().cuda_stream
+            event._as_parameter_.value, torch.cuda.current_stream().cuda_stream
         )
 
-    def test_event_wait_callback(self):
+    def test_event_wait_callback(self, device):
         gpu_trace.register_callback_for_event_wait(self.mock)
 
         event = torch.cuda.Event()
         event.record()
         event.wait()
         self.mock.assert_called_once_with(
-            event._as_parameter_.value, torch.cuda.default_stream().cuda_stream
+            event._as_parameter_.value, torch.cuda.current_stream().cuda_stream
         )
 
-    def test_memory_allocation_callback(self):
+    def test_memory_allocation_callback(self, device):
         gpu_trace.register_callback_for_memory_allocation(self.mock)
 
-        tensor = torch.empty(10, 4, device="cuda")
+        tensor = torch.empty(10, 4, device=device)
         self.mock.assert_called_once_with(tensor.data_ptr())
 
-    def test_memory_deallocation_callback(self):
+    def test_memory_deallocation_callback(self, device):
         gpu_trace.register_callback_for_memory_deallocation(self.mock)
 
-        tensor = torch.empty(3, 8, device="cuda")
+        tensor = torch.empty(3, 8, device=device)
         data_ptr = tensor.data_ptr()
         del tensor
         self.mock.assert_called_once_with(data_ptr)
 
-    def test_stream_creation_callback(self):
+    def test_stream_creation_callback(self, device):
         gpu_trace.register_callback_for_stream_creation(self.mock)
 
         # see Note [HIP Lazy Streams]
         if torch.version.hip:
             user_stream = torch.cuda.Stream()
             with torch.cuda.stream(user_stream):
-                torch.ones(5, device="cuda")
+                torch.ones(5, device=device)
         else:
             torch.cuda.Stream()
 
         self.mock.assert_called()
 
-    def test_device_synchronization_callback(self):
+    def test_device_synchronization_callback(self, device):
         gpu_trace.register_callback_for_device_synchronization(self.mock)
 
         torch.cuda.synchronize()
         self.mock.assert_called()
 
-    def test_stream_synchronization_callback(self):
+    def test_stream_synchronization_callback(self, device):
         gpu_trace.register_callback_for_stream_synchronization(self.mock)
 
         stream = torch.cuda.Stream()
         stream.synchronize()
         self.mock.assert_called_once_with(stream.cuda_stream)
 
-    def test_event_synchronization_callback(self):
+    def test_event_synchronization_callback(self, device):
         gpu_trace.register_callback_for_event_synchronization(self.mock)
 
         event = torch.cuda.Event()
@@ -115,22 +111,24 @@ class TestCudaTrace(TestCase):
         event.synchronize()
         self.mock.assert_called_once_with(event._as_parameter_.value)
 
-    def test_memcpy_synchronization(self):
+    def test_memcpy_synchronization(self, device):
         gpu_trace.register_callback_for_stream_synchronization(self.mock)
 
-        tensor = torch.rand(5, device="cuda")
+        tensor = torch.rand(5, device=device)
         tensor.nonzero()
-        self.mock.assert_called_once_with(torch.cuda.default_stream().cuda_stream)
+        self.mock.assert_called_once_with(torch.cuda.current_stream().cuda_stream)
 
-    def test_all_trace_callbacks_called(self):
+    def test_all_trace_callbacks_called(self, device):
         other = unittest.mock.MagicMock()
         gpu_trace.register_callback_for_memory_allocation(self.mock)
         gpu_trace.register_callback_for_memory_allocation(other)
 
-        tensor = torch.empty(10, 4, device="cuda")
+        tensor = torch.empty(10, 4, device=device)
         self.mock.assert_called_once_with(tensor.data_ptr())
         other.assert_called_once_with(tensor.data_ptr())
 
+
+instantiate_device_type_tests(TestCudaTrace, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -6,7 +6,13 @@ import unittest.mock
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
-from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    NoTest,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 # NOTE: Each test needs to be run in a brand new process, to reset the registered hooks
@@ -19,6 +25,8 @@ if not TEST_CUDA:
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         torch._C._activate_gpu_trace()

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_cuda import (
     TEST_MULTIGPU,
     TEST_NUMBA_CUDA,
 )
-from torch.testing._internal.common_utils import TEST_NUMPY
+from torch.testing._internal.common_utils import HardwareClassification, TEST_NUMPY
 
 
 if TEST_NUMPY:
@@ -20,6 +20,8 @@ if TEST_NUMBA_CUDA:
 
 
 class TestNumbaIntegration(common.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     def test_cuda_array_interface(self):

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -4,11 +4,8 @@ import unittest
 
 import torch
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_cuda import (
-    TEST_CUDA,
-    TEST_MULTIGPU,
-    TEST_NUMBA_CUDA,
-)
+from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_NUMBA_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, TEST_NUMPY
 
 
@@ -23,8 +20,7 @@ class TestNumbaIntegration(common.TestCase):
     hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
-    def test_cuda_array_interface(self):
+    def test_cuda_array_interface(self, device):
         """torch.Tensor exposes __cuda_array_interface__ for cuda tensors.
 
         An object t is considered a cuda-tensor if:
@@ -78,7 +74,7 @@ class TestNumbaIntegration(common.TestCase):
                     AttributeError, lambda: sparse_t.__cuda_array_interface__
                 )
 
-                sparse_cuda_t = torch.sparse_coo_tensor(indices_t, cput).cuda()
+                sparse_cuda_t = torch.sparse_coo_tensor(indices_t, cput).to(device)
 
                 self.assertFalse(hasattr(sparse_cuda_t, "__cuda_array_interface__"))
                 self.assertRaises(
@@ -86,7 +82,7 @@ class TestNumbaIntegration(common.TestCase):
                 )
 
             # CUDA tensors have the attribute and v2 interface
-            cudat = tp(10).cuda()
+            cudat = tp(10).to(device)
 
             self.assertTrue(hasattr(cudat, "__cuda_array_interface__"))
 
@@ -103,9 +99,8 @@ class TestNumbaIntegration(common.TestCase):
             self.assertEqual(ar_dict["data"], (cudat.data_ptr(), False))
             self.assertEqual(ar_dict["version"], 2)
 
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
-    def test_array_adaptor(self):
+    def test_array_adaptor(self, device):
         """Torch __cuda_array_adaptor__ exposes tensor data to numba.cuda."""
 
         torch_dtypes = [
@@ -136,7 +131,7 @@ class TestNumbaIntegration(common.TestCase):
                 numba.cuda.as_cuda_array(cput)
 
             # Any cuda tensor is a cuda array.
-            cudat = cput.to(device="cuda")
+            cudat = cput.to(device=device)
             self.assertTrue(numba.cuda.is_cuda_array(cudat))
 
             numba_view = numba.cuda.as_cuda_array(cudat)
@@ -151,11 +146,12 @@ class TestNumbaIntegration(common.TestCase):
             # float16 comparisons, which aren't supported cpu-side.
 
             # The data is identical in the view.
-            self.assertEqual(cudat, torch.tensor(numba_view.copy_to_host()).to("cuda"))
+            self.assertEqual(cudat, torch.tensor(numba_view.copy_to_host()).to(device))
 
             # Writes to the torch.Tensor are reflected in the numba array.
             cudat[:5] = 11
-            self.assertEqual(cudat, torch.tensor(numba_view.copy_to_host()).to("cuda"))
+            torch.cuda.synchronize()
+            self.assertEqual(cudat, torch.tensor(numba_view.copy_to_host()).to(device))
 
             # Strided tensors are supported.
             strided_cudat = cudat[::2]
@@ -169,9 +165,8 @@ class TestNumbaIntegration(common.TestCase):
             # As of numba 0.40.0 support for strided views is ...limited...
             # Cannot verify correctness of strided view operations.
 
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
-    def test_conversion_errors(self):
+    def test_conversion_errors(self, device):
         """Numba properly detects array interface for tensor.Tensor variants."""
 
         # CPU tensors are not cuda arrays.
@@ -188,7 +183,7 @@ class TestNumbaIntegration(common.TestCase):
         with self.assertRaises(TypeError):
             numba.cuda.as_cuda_array(sparset)
 
-        sparset.cuda()
+        sparset.to(device)
 
         self.assertFalse(numba.cuda.is_cuda_array(sparset))
         with self.assertRaises(TypeError):
@@ -206,7 +201,7 @@ class TestNumbaIntegration(common.TestCase):
         #
         # Use of hasattr for interface detection causes interface change in
         # python2; it swallows all exceptions not just AttributeError.
-        cuda_gradt = torch.zeros(100).requires_grad_(True).cuda()
+        cuda_gradt = torch.zeros(100).requires_grad_(True).to(device)
 
         # conversion raises RuntimeError
         with self.assertRaises(RuntimeError):
@@ -214,14 +209,13 @@ class TestNumbaIntegration(common.TestCase):
         with self.assertRaises(RuntimeError):
             numba.cuda.as_cuda_array(cuda_gradt)
 
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
     @unittest.skipIf(not TEST_MULTIGPU, "No multigpu")
-    def test_active_device(self):
+    def test_active_device(self, device):
         """'as_cuda_array' tensor device must match active numba context."""
 
         # Both torch/numba default to device 0 and can interop freely
-        cudat = torch.arange(10, device="cuda")
+        cudat = torch.arange(10, device=device)
         self.assertEqual(cudat.device.index, 0)
         self.assertIsInstance(
             numba.cuda.as_cuda_array(cudat), numba.cuda.devicearray.DeviceNDArray
@@ -243,9 +237,8 @@ class TestNumbaIntegration(common.TestCase):
         "Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418"
     )
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
-    def test_from_cuda_array_interface(self):
+    def test_from_cuda_array_interface(self, device):
         """torch.as_tensor() and torch.tensor() supports the __cuda_array_interface__ protocol.
 
         If an object exposes the __cuda_array_interface__, .as_tensor() and .tensor()
@@ -280,7 +273,7 @@ class TestNumbaIntegration(common.TestCase):
             # Zero-copy when using `torch.as_tensor()`
             for numpy_ary in numpy_arys:
                 numba_ary = numba.cuda.to_device(numpy_ary)
-                torch_ary = torch.as_tensor(numba_ary, device="cuda")
+                torch_ary = torch.as_tensor(numba_ary, device=device)
                 self.assertEqual(
                     numba_ary.__cuda_array_interface__,
                     torch_ary.__cuda_array_interface__,
@@ -312,7 +305,7 @@ class TestNumbaIntegration(common.TestCase):
             # Explicit-copy when using `torch.tensor()`
             for numpy_ary in numpy_arys:
                 numba_ary = numba.cuda.to_device(numpy_ary)
-                torch_ary = torch.tensor(numba_ary, device="cuda")
+                torch_ary = torch.tensor(numba_ary, device=device)
                 self.assertEqual(
                     torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype)
                 )
@@ -325,9 +318,8 @@ class TestNumbaIntegration(common.TestCase):
                 )
 
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
-    def test_from_cuda_array_interface_inferred_strides(self):
+    def test_from_cuda_array_interface_inferred_strides(self, device):
         """torch.as_tensor(numba_ary) should have correct inferred (contiguous) strides"""
         # This could, in theory, be combined with test_from_cuda_array_interface but that test
         # is overly strict: it checks that the exported protocols are exactly the same, which
@@ -345,19 +337,18 @@ class TestNumbaIntegration(common.TestCase):
             numpy_ary = numpy.arange(6).reshape(2, 3).astype(dtype)
             numba_ary = numba.cuda.to_device(numpy_ary)
             self.assertTrue(numba_ary.is_c_contiguous())
-            torch_ary = torch.as_tensor(numba_ary, device="cuda")
+            torch_ary = torch.as_tensor(numba_ary, device=device)
             self.assertTrue(torch_ary.is_contiguous())
 
     @unittest.skip(
         "Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418"
     )
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
-    def test_from_cuda_array_interface_lifetime(self):
+    def test_from_cuda_array_interface_lifetime(self, device):
         """torch.as_tensor(obj) tensor grabs a reference to obj so that the lifetime of obj exceeds the tensor"""
         numba_ary = numba.cuda.to_device(numpy.arange(6))
-        torch_ary = torch.as_tensor(numba_ary, device="cuda")
+        torch_ary = torch.as_tensor(numba_ary, device=device)
         self.assertEqual(
             torch_ary.__cuda_array_interface__, numba_ary.__cuda_array_interface__
         )  # No copy
@@ -370,15 +361,14 @@ class TestNumbaIntegration(common.TestCase):
         "Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418"
     )
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
-    @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
     @unittest.skipIf(not TEST_MULTIGPU, "No multigpu")
-    def test_from_cuda_array_interface_active_device(self):
+    def test_from_cuda_array_interface_active_device(self, device):
         """torch.as_tensor() tensor device must match active numba context."""
 
         # Zero-copy: both torch/numba default to device 0 and can interop freely
         numba_ary = numba.cuda.to_device(numpy.arange(6))
-        torch_ary = torch.as_tensor(numba_ary, device="cuda")
+        torch_ary = torch.as_tensor(numba_ary, device=device)
         self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
         self.assertEqual(
             torch_ary.__cuda_array_interface__, numba_ary.__cuda_array_interface__
@@ -395,6 +385,9 @@ class TestNumbaIntegration(common.TestCase):
         del if1["data"]
         del if2["data"]
         self.assertEqual(if1, if2)
+
+
+instantiate_device_type_tests(TestNumbaIntegration, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -35,8 +35,6 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
-    onlyCUDA,
-    onlyOn,
     e4m3_type,
     e5m2_type,
     E4M3_MAX_POS,
@@ -767,286 +765,6 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
-    @onlyCUDA
-    @skipIfRocm
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    def test_float8_scale_result(self, device) -> None:
-        torch.manual_seed(0)
-        a = torch.randint(-1, 2, (32, 16), device=device).float().to(e4m3_type)
-        b = torch.randint(-1, 2, (16, 32), device=device).float().t().contiguous().t().to(e4m3_type)
-        scale = torch.ones((), device=device)
-        scale_result = torch.full((), 0.5, device=device)
-
-        actual = torch._scaled_mm(
-            a,
-            b,
-            scale_a=scale,
-            scale_b=scale,
-            scale_result=scale_result,
-            out_dtype=e4m3_type,
-        )
-        expected = (a.float() @ b.float()).mul(scale_result).to(e4m3_type)
-
-        self.assertEqual(actual, expected)
-
-        high_precision = torch._scaled_mm(
-            a,
-            b,
-            scale_a=scale,
-            scale_b=scale,
-            scale_result=scale_result,
-            out_dtype=torch.bfloat16,
-        )
-        unscaled = torch._scaled_mm(
-            a,
-            b,
-            scale_a=scale,
-            scale_b=scale,
-            out_dtype=torch.bfloat16,
-        )
-        self.assertEqual(high_precision, unscaled)
-
-
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
-    @parametrize("G", [1, 4, 16])
-    @parametrize("M", [2048, 2049])
-    @parametrize("N", [8192])
-    @parametrize("K", [16640])
-    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
-    @parametrize("use_out", [False, True])
-    def test_mxfp8_nvfp4_scaled_grouped_mm_2d_2d(self, G, M, N, K, format, use_out, device):
-        torch.manual_seed(42)
-
-        if format == "mxfp4" and SM120OrLater:
-            raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
-
-        total_K = K  # Alias for clarity, communicating this consists of several groups along this dim
-        input_group_end_offsets = generate_jagged_offs(
-            G, total_K, multiple_of=32, device=device
-        )
-        X = torch.randn((M, total_K), dtype=torch.bfloat16, device=device) * 0.1
-        W = torch.randn((N, total_K), dtype=torch.bfloat16, device=device) * 0.01
-
-        xh, xq, x_blocked_scales, x_global_scales = _2d_grouped_tensor_to_blocked_scaled(
-            X, M, G, input_group_end_offsets, format=format
-        )
-        wh, wq, w_blocked_scales, w_global_scales = _2d_grouped_tensor_to_blocked_scaled(
-            W, N, G, input_group_end_offsets, format=format
-        )
-
-        if format in ["mxfp4", "mxfp8"]:
-            kwargs = _build_scaled_grouped_mm_kwargs(
-                x_blocked_scales,
-                w_blocked_scales,
-                input_group_end_offsets,
-                format,
-            )
-        elif format == "nvfp4":
-            kwargs = _build_scaled_grouped_mm_kwargs(
-                [x_blocked_scales, x_global_scales],
-                [w_blocked_scales, w_global_scales],
-                input_group_end_offsets,
-                format,
-            )
-        else:
-            raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
-
-        if format == 'nvfp4':
-            if x_global_scales.numel() != w_global_scales.numel():
-                raise AssertionError(f"scale numel mismatch: {x_global_scales.numel()} != {w_global_scales.numel()}")
-            if x_global_scales.numel() != G:
-                raise AssertionError(f"scale numel should be {G}, got {x_global_scales.numel()}")
-
-        # When requested, route through the structured `.out` overload so the
-        # correctness assertion below also covers the out= path.
-        if use_out:
-            kwargs["out"] = torch.empty(
-                (G, M, N), dtype=torch.bfloat16, device=device
-            )
-
-        # Compute mxfp8 grouped mm output
-        y_lp = scaled_grouped_mm_wrap(
-            xq,
-            wq.transpose(-2, -1),
-            **kwargs,
-        )
-
-        if use_out:
-            self.assertEqual(y_lp.data_ptr(), kwargs["out"].data_ptr())
-
-        # bf16 reference output
-        y_bf16 = grouped_mm(
-            # Note: Reference result should be on reconstructed, not original values.
-            #       as-in float(fp4(t)) not t itself.
-            xh, wh.t(), offs=input_group_end_offsets, out_dtype=torch.bfloat16
-        )
-
-        # Assert no NaNs
-        if y_lp.isnan().any():
-            raise AssertionError("low-precision output contains NaN")
-
-        # Assert outputs are close
-        torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
-
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
-    @parametrize("G", [1, 4, 16])
-    @parametrize("M", [16640])
-    @parametrize("N", [8192])
-    @parametrize("K", [4096])
-    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
-    @parametrize("use_out", [False, True])
-    def test_mxfp8_scaled_grouped_mm_2d_3d(self, G, M, N, K, format, use_out, device):
-        torch.manual_seed(42)
-
-        if format == "mxfp4" and SM120OrLater:
-            raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
-
-        # Simulate 2d-3d grouped gemm `out = input @ weight.t()`
-        # 2D inputs with groups along M, 3D weights.
-        block_size = 32
-        total_M = M  # Alias for clarity that M dim contains groups.
-        X = torch.randn((total_M, K), dtype=torch.bfloat16, device=device) * 0.1
-        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=device) * 0.01
-        input_group_end_offsets = generate_jagged_offs(
-            G, total_M, multiple_of=32, device=device
-        )
-
-        # For each constituent 2d subtensor in the 3d weights, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
-        def _3d_to_blocked_scaled(W, G, format):
-            wh_list = []
-            wq_list = []
-            w_scale_list = []
-            w_global_scale_list = []
-            for i in range(G):
-                if format == "mxfp8":
-                    wh, wq, w_scale = _convert_to_mxfp8_with_hp_ref(W[i])
-                elif format == "nvfp4":
-                    wh, wq, w_scale, w_global_scale = _convert_to_nvfp4_with_hp_ref(W[i])
-                    w_global_scale_list.append(w_global_scale)
-                elif format == "mxfp4":
-                    wh, wq, w_scale = _convert_to_mxfp4_with_hp_ref(W[i])
-                else:
-                    raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
-
-                # Swizzle scaled
-                if torch.version.cuda:
-                    w_scale = to_blocked(w_scale)
-
-                wh_list.append(wh)
-                wq_list.append(wq)
-                w_scale_list.append(w_scale)
-            wh = torch.stack(wh_list, dim=0).contiguous()
-            wq = torch.stack(wq_list, dim=0).contiguous()
-            w_scale = torch.stack(w_scale_list, dim=0).contiguous()
-            # Global scales only exist for nvfp4
-            if len(w_global_scale_list) > 0:
-                w_global_scales = torch.stack(w_global_scale_list)
-            else:
-                w_global_scales = None
-            return wh, wq, w_scale, w_global_scales
-
-        wh, wq, w_blocked_scales, w_global_scales = _3d_to_blocked_scaled(W, G, format)
-
-        # For each group along `total_M` in the 2D tensor, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
-        def _2d_to_blocked_scaled(X, K, G, offs, format):
-            xh_list = []
-            xq_list = []
-            x_scale_list = []
-            x_global_scale_list = []
-            for i in range(G):
-                prev_group_end = 0 if i == 0 else input_group_end_offsets[i - 1]
-                curr_group_end = input_group_end_offsets[i]
-                group_size = curr_group_end - prev_group_end
-                if group_size > 0:
-                    x_slice = X[prev_group_end:curr_group_end, :]
-                    if format == "mxfp8":
-                        xh, xq, x_scale = _convert_to_mxfp8_with_hp_ref(x_slice)
-                    elif format == "nvfp4":
-                        xh, xq, x_scale, x_global_scale = _convert_to_nvfp4_with_hp_ref(x_slice)
-                        x_global_scale_list.append(x_global_scale)
-                    elif format == "mxfp4":
-                        xh, xq, x_scale = _convert_to_mxfp4_with_hp_ref(x_slice)
-                    else:
-                        raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
-
-                    if torch.version.cuda:
-                        x_scale = to_blocked(x_scale)
-                    xh_list.append(xh)
-                    xq_list.append(xq)
-                    x_scale_list.append(x_scale)
-            xh = torch.cat(xh_list, dim=0).contiguous()
-            xq = torch.cat(xq_list, dim=0).contiguous()
-            x_scale = torch.cat(x_scale_list, dim=0).contiguous()
-            x_scale = x_scale.reshape(-1, K // block_size)
-            xq = xq.view(-1, xq.shape[-1])
-            xh = xh.view(-1, xh.shape[-1])
-
-            x_global_scales = None
-            if len(x_global_scale_list) > 0:
-                x_global_scales = torch.stack(x_global_scale_list)
-
-            return xh, xq, x_scale, x_global_scales
-
-        xh, xq, x_blocked_scales, x_global_scales = _2d_to_blocked_scaled(X, K, G, input_group_end_offsets, format)
-
-        if format in ["mxfp8", "mxfp4"]:
-            kwargs = _build_scaled_grouped_mm_kwargs(
-                x_blocked_scales,
-                w_blocked_scales,
-                input_group_end_offsets,
-                format,
-            )
-        elif format == "nvfp4":
-            kwargs = _build_scaled_grouped_mm_kwargs(
-                [x_blocked_scales, x_global_scales],
-                [w_blocked_scales, w_global_scales],
-                input_group_end_offsets,
-                format,
-            )
-        else:
-            raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
-
-        if format == 'nvfp4':
-            if x_global_scales.numel() != w_global_scales.numel():
-                raise AssertionError(f"scale numel mismatch: {x_global_scales.numel()} != {w_global_scales.numel()}")
-            if x_global_scales.numel() != G:
-                raise AssertionError(f"scale numel should be {G}, got {x_global_scales.numel()}")
-
-        # When requested, route through the structured `.out` overload so the
-        # correctness assertion below also covers the out= path. The 2d-3d case
-        # produces a 2D [total_M, N] output.
-        if use_out:
-            kwargs["out"] = torch.empty(
-                (total_M, N), dtype=torch.bfloat16, device=device
-            )
-
-        # Compute low-precision grouped gemm.
-        y_lp = scaled_grouped_mm_wrap(
-            xq,
-            wq.transpose(-2, -1),
-            **kwargs
-        )
-
-        if use_out:
-            self.assertEqual(y_lp.data_ptr(), kwargs["out"].data_ptr())
-
-        # Compute reference bf16 grouped gemm.
-        # Note: Reference result should be on reconstructed, not original values.
-        #       as-in float(fp4(t)) not t itself.
-        y_bf16 = grouped_mm(
-            xh,
-            wh.transpose(-2, -1),
-            offs=input_group_end_offsets,
-            out_dtype=torch.bfloat16,
-        )
-
-        # Assert outputs are close.
-        torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
-
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
     @parametrize("x_cm", [True, False])
@@ -1210,20 +928,6 @@ class TestFP8Matmul(TestCase):
                 "Bias is not supported when out_dtype is set to Float32",
                 lambda: scaled_mm_wrap(x, y, scale_a, scale_b, bias=bias, out_dtype=torch.float32),
             )
-
-    @onlyCUDA
-    @unittest.skipIf(PLATFORM_SUPPORTS_FP8 or not torch.cuda.is_available(), f8_msg)
-    def test_error_message_fp8_pre_sm89(self, device) -> None:
-        (k, l, m) = (16, 48, 32)
-        x = torch.rand((k, l), device=device).to(e4m3_type)
-        y = torch.rand((m, l), device=device).to(e4m3_type).t()
-        scale_a = torch.tensor(1.0, device=device)
-        scale_b = torch.tensor(1.0, device=device)
-        self.assertRaisesRegex(
-            RuntimeError,
-            r"torch\.\_scaled\_mm is only supported on CUDA devices with compute capability \>\= 9\.0 or 8\.9, or ROCm MI300\+",
-            lambda: scaled_mm_wrap(x, y, scale_a, scale_b, out_dtype=torch.float32),
-        )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @skipCUDAIf(SM100OrLater, "fast_accum is SM90-only")
@@ -1480,40 +1184,7 @@ class TestFP8Matmul(TestCase):
         else:
             self.assertEqual(out, out_emulated, atol=7e-2, rtol=7e-2)
 
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @skipCUDAIf(not SM89OrLater, "rowwise implementation is currently sm89-sm100 specific")
-    @parametrize("wrap_v2", [True, False])
-    def test_scaled_mm_row_wise_fp32_out_with_bias_errors(self, wrap_v2, device):
-        # fp32 output combined with a bias is not supported on the row-wise path.
-        if torch.version.hip:
-            raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
-
-        M, K, N = 16, 32, 48
-        input_dtype = e4m3_type
-        x = random_matrix_with_scaled_reduction_dim(M, K, dtype=torch.float32, device=device, reduction_dim=-1)
-        y = random_matrix_with_scaled_reduction_dim(N, K, dtype=torch.float32, device=device, reduction_dim=-1).t()
-        x_scales = tensor_to_scale(x, input_dtype, dim=1).float()
-        y_scales = tensor_to_scale(y, input_dtype, dim=0).float()
-        x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
-        y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)
-        bias = torch.randn((N,), device=device, dtype=torch.bfloat16)
-
-        with self.assertRaisesRegex(
-            (ValueError, RuntimeError),
-            "Bias is not supported when out_dtype is set to Float32",
-        ):
-            scaled_mm_wrap(
-                x_fp8,
-                y_fp8,
-                scale_a=x_scales.reciprocal(),
-                scale_b=y_scales.reciprocal(),
-                out_dtype=torch.float32,
-                bias=bias,
-                wrap_v2=wrap_v2,
-            )
-
-    @onlyOn(["cuda", "xpu"])
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @skipCUDAIf(not IS_SM90, "DeepSeek style (1x128, 128x128) blockwise scaling requires SM90 (Hopper)")
     @skipCUDAIf(
@@ -1767,7 +1438,7 @@ class TestFP8Matmul(TestCase):
                   y_hp, y_recipe, y_fp8, y_scales, y_scales_original)
 
 
-    @onlyOn(["cuda", "xpu"])
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @skipCUDAIf(not IS_SM90, "DeepSeek style (1x128, 128x128) blockwise scaling requires SM90 (Hopper)")
     @skipCUDAIf(
@@ -1853,65 +1524,6 @@ class TestFP8Matmul(TestCase):
             output_dtype
         )
 
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
-    @unittest.skipIf(IS_SM90, "DeepSeek style (1x128, 128x128) blockwise scaling works on SM90 (Hopper)")
-    @unittest.skipIf(
-        not torch.version.hip and _get_torch_cuda_version() < (12, 9),
-        "cuBLAS blockwise scaling added in CUDA 12.9",
-    )
-    @runOnRocmArch(MI350_ARCH)
-    @parametrize("output_dtype", [torch.bfloat16, ])
-    @parametrize("lhs_block,rhs_block", [(1, 1), (128, 1), (1, 128)])
-    @parametrize("M,N,K", [(256, 256, 256), (256, 256, 512)])
-    def test_scaled_mm_deepseek_error_messages(
-        self, output_dtype, lhs_block, rhs_block, M, N, K, device
-    ):
-
-        torch.manual_seed(42)
-
-        x = torch.randn(M, K, device=device, dtype=output_dtype).pow(3)
-        y = torch.randn(N, K, device=device, dtype=output_dtype).pow(3)
-
-        x_fp8, x_scales = tensor_to_scale_block(x, e4m3_type, lhs_block, 128)
-        y_fp8, y_scales = tensor_to_scale_block(y, e4m3_type, rhs_block, 128)
-
-        # 1x128 blocks need scales to be outer-dim-major
-        if lhs_block == 1:
-            x_scales = x_scales.t().contiguous().t()
-            lhs_recipe = ScalingType.BlockWise1x128
-        else:
-            lhs_recipe = ScalingType.BlockWise128x128
-
-        if rhs_block == 1:
-            y_scales = y_scales.t().contiguous().t()
-            rhs_recipe = ScalingType.BlockWise1x128
-        else:
-            rhs_recipe = ScalingType.BlockWise128x128
-
-        # Verify that actual F8 mm raises expected error
-        if torch.version.hip:
-            # ROCm does not yet support DeepSeek-style blockwise scaling
-            expected_error = NotImplementedError
-            expected_pattern = "1x128 and 128x128 scaling not available with ROCm"
-        else:
-            # CUDA non-SM90 should raise NotImplementedError
-            expected_error = NotImplementedError
-            expected_pattern = ".*DeepSeek.*scaling.*only supported in CUDA for SM90.*"
-        with self.assertRaisesRegex(
-            expected_error,
-            expected_pattern
-        ):
-            scaled_mm_wrap(
-                x_fp8,
-                y_fp8.t(),
-                scale_a=x_scales,
-                scale_recipe_a=lhs_recipe,
-                scale_b=y_scales.t(),
-                scale_recipe_b=rhs_recipe,
-                out_dtype=output_dtype,
-            )
-
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("which_dim_zero", [0, 1, 2])
     @parametrize("use_torch_compile", [False, True])
@@ -1938,88 +1550,8 @@ class TestFP8Matmul(TestCase):
         self.assertEqual(out_dtype, out_fp8.dtype)
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/164271")
-    @onlyCUDA
-    @unittest.skipIf(IS_WINDOWS, "Windows doesn't support row-wise scaling")
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
-    @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")
-    def test_honor_sm_carveout(self, device) -> None:
-        torch.manual_seed(42)
-
-        x = torch.randn(8192, 2048, device=device, dtype=torch.float32)
-        y = torch.randn(8192, 2048, device=device, dtype=torch.float32).t()
-        x_scales = tensor_to_scale(x, e4m3_type, dim=1).reciprocal()
-        y_scales = tensor_to_scale(y, e4m3_type, dim=0).reciprocal()
-        x_fp8 = to_fp8_saturated(x / x_scales, e4m3_type)
-        y_fp8 = to_fp8_saturated(y / y_scales, e4m3_type)
-
-        cu_count = torch.cuda.get_device_properties().multi_processor_count
-        carveout = 66 if torch.version.cuda else cu_count // 8
-
-        # Warm up so hipBLASLt's one-time init kernel does not appear in the profile trace below.
-        scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
-        torch.cuda.synchronize()
-
-        with tempfile.NamedTemporaryFile() as f:
-            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
-                self.assertIsNone(torch._C._get_sm_carveout_experimental())
-                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
-                torch._C._set_sm_carveout_experimental(0)
-                self.assertEqual(torch._C._get_sm_carveout_experimental(), 0)
-                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
-                torch._C._set_sm_carveout_experimental(66)
-                self.assertEqual(torch._C._get_sm_carveout_experimental(), 66)
-                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
-                torch._C._set_sm_carveout_experimental(None)
-                self.assertIsNone(torch._C._get_sm_carveout_experimental())
-                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
-
-            prof.export_chrome_trace(f.name)
-            if torch.version.hip:
-                with open(f.name) as file:
-                    events = [evt for evt in json.load(file)["traceEvents"] if evt.get("cat", "") == "kernel"]
-                # events were returned out of order; need to be sorted on "ts" timestamp
-                events = sorted(events, key=lambda x: x['ts'])
-                # ROCm carveout is invisible except for kernels running slower on fewer CUs
-                no_carveout, carveout_0, carveout, no_carveout_again = [float(evt.get("dur", "0.0")) for evt in events]
-                if True or not (no_carveout < carveout and carveout_0 < carveout and no_carveout_again < carveout):  # noqa: SIM222
-                    # something went wrong, print more info to help debug flaky test
-                    print("ROCm debug info for test_honor_sm_carveout")
-                    print("cu_count", cu_count)
-                    print("no_carveout", no_carveout)
-                    print("carveout_0", carveout_0)
-                    print("carveout", carveout)
-                    print("no_carveout_again", no_carveout_again)
-                self.assertTrue(no_carveout < carveout)
-                self.assertTrue(carveout_0 < carveout)
-                self.assertTrue(no_carveout_again < carveout)
-                # ROCm carveout will create new streams when enabled, and go back to the original stream when disabled
-                no_carveout, carveout_0, carveout, no_carveout_again = [int(evt.get("tid", "0")) for evt in events]
-                self.assertTrue(no_carveout == no_carveout_again)
-                self.assertTrue(no_carveout == carveout_0)
-                self.assertTrue(no_carveout != carveout)
-                self.assertTrue(carveout_0 != carveout)
-            else:
-                with open(f.name) as file:
-                    no_carveout, carveout_0, carveout_66, no_carveout_again = [
-                        math.prod(evt.get("args", {}).get("grid", []))
-                        for evt in json.load(file)["traceEvents"]
-                        if evt.get("cat", "") == "kernel"
-                    ]
-
-                self.assertEqual(no_carveout, no_carveout_again)
-                if SM100OrLater:
-                    # expected failure
-                    # CUTLASS only supports SM carveout via green contexts on SM100
-                    self.assertEqual(no_carveout, carveout_66)
-                    self.assertEqual(carveout_66, carveout_0)
-                else:
-                    # correct behavior
-                    self.assertNotEqual(no_carveout, carveout_66)
-                    self.assertNotEqual(carveout_66, carveout_0)
-
     @skipXPU
-    def test_pack_uint4(self):
+    def test_pack_uint4(self, device):
         """
         Verify that given a tensor with high precision values [val0, val1],
         the x2 packed representation is val1:val0 (from MSB to LSB), and
@@ -2034,7 +1566,7 @@ class TestFP8Matmul(TestCase):
         torch.testing.assert_close(lp_data_actual, lp_data_expected, atol=0, rtol=0)
 
     @skipIfRocm
-    @onlyOn(["cuda", "xpu"])
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     @parametrize("mkn", [
         # Nice shapes
@@ -2095,7 +1627,6 @@ class TestFP8Matmul(TestCase):
 
     @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
-    @onlyOn(["cuda", "xpu"])
     @parametrize("test_case_name", [
         "a_eye_b_eye",
         "a_ones_b_ones",
@@ -2849,7 +2380,469 @@ class TestFP8Matmul(TestCase):
         self.assertEqual(actual, expected)
 
 
+class TestFP8MatmulCudaOnly(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_float8_scale_result(self, device) -> None:
+        torch.manual_seed(0)
+        a = torch.randint(-1, 2, (32, 16), device=device).float().to(e4m3_type)
+        b = torch.randint(-1, 2, (16, 32), device=device).float().t().contiguous().t().to(e4m3_type)
+        scale = torch.ones((), device=device)
+        scale_result = torch.full((), 0.5, device=device)
+
+        actual = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            scale_result=scale_result,
+            out_dtype=e4m3_type,
+        )
+        expected = (a.float() @ b.float()).mul(scale_result).to(e4m3_type)
+
+        self.assertEqual(actual, expected)
+
+        high_precision = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            scale_result=scale_result,
+            out_dtype=torch.bfloat16,
+        )
+        unscaled = torch._scaled_mm(
+            a,
+            b,
+            scale_a=scale,
+            scale_b=scale,
+            out_dtype=torch.bfloat16,
+        )
+        self.assertEqual(high_precision, unscaled)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
+    @parametrize("G", [1, 4, 16])
+    @parametrize("M", [2048, 2049])
+    @parametrize("N", [8192])
+    @parametrize("K", [16640])
+    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
+    @parametrize("use_out", [False, True])
+    def test_mxfp8_nvfp4_scaled_grouped_mm_2d_2d(self, G, M, N, K, format, use_out, device):
+        torch.manual_seed(42)
+
+        if format == "mxfp4" and SM120OrLater:
+            raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
+
+        total_K = K  # Alias for clarity, communicating this consists of several groups along this dim
+        input_group_end_offsets = generate_jagged_offs(
+            G, total_K, multiple_of=32, device=device
+        )
+        X = torch.randn((M, total_K), dtype=torch.bfloat16, device=device) * 0.1
+        W = torch.randn((N, total_K), dtype=torch.bfloat16, device=device) * 0.01
+
+        xh, xq, x_blocked_scales, x_global_scales = _2d_grouped_tensor_to_blocked_scaled(
+            X, M, G, input_group_end_offsets, format=format
+        )
+        wh, wq, w_blocked_scales, w_global_scales = _2d_grouped_tensor_to_blocked_scaled(
+            W, N, G, input_group_end_offsets, format=format
+        )
+
+        if format in ["mxfp4", "mxfp8"]:
+            kwargs = _build_scaled_grouped_mm_kwargs(
+                x_blocked_scales,
+                w_blocked_scales,
+                input_group_end_offsets,
+                format,
+            )
+        elif format == "nvfp4":
+            kwargs = _build_scaled_grouped_mm_kwargs(
+                [x_blocked_scales, x_global_scales],
+                [w_blocked_scales, w_global_scales],
+                input_group_end_offsets,
+                format,
+            )
+        else:
+            raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
+
+        if format == 'nvfp4':
+            if x_global_scales.numel() != w_global_scales.numel():
+                raise AssertionError(f"scale numel mismatch: {x_global_scales.numel()} != {w_global_scales.numel()}")
+            if x_global_scales.numel() != G:
+                raise AssertionError(f"scale numel should be {G}, got {x_global_scales.numel()}")
+
+        # When requested, route through the structured `.out` overload so the
+        # correctness assertion below also covers the out= path.
+        if use_out:
+            kwargs["out"] = torch.empty(
+                (G, M, N), dtype=torch.bfloat16, device=device
+            )
+
+        # Compute mxfp8 grouped mm output
+        y_lp = scaled_grouped_mm_wrap(
+            xq,
+            wq.transpose(-2, -1),
+            **kwargs,
+        )
+
+        if use_out:
+            self.assertEqual(y_lp.data_ptr(), kwargs["out"].data_ptr())
+
+        # bf16 reference output
+        y_bf16 = grouped_mm(
+            # Note: Reference result should be on reconstructed, not original values.
+            #       as-in float(fp4(t)) not t itself.
+            xh, wh.t(), offs=input_group_end_offsets, out_dtype=torch.bfloat16
+        )
+
+        # Assert no NaNs
+        if y_lp.isnan().any():
+            raise AssertionError("low-precision output contains NaN")
+
+        # Assert outputs are close
+        torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
+    @parametrize("G", [1, 4, 16])
+    @parametrize("M", [16640])
+    @parametrize("N", [8192])
+    @parametrize("K", [4096])
+    @parametrize("format", ["mxfp8"] + (["nvfp4", "mxfp4"] if torch.version.cuda else []))
+    @parametrize("use_out", [False, True])
+    def test_mxfp8_scaled_grouped_mm_2d_3d(self, G, M, N, K, format, use_out, device):
+        torch.manual_seed(42)
+
+        if format == "mxfp4" and SM120OrLater:
+            raise unittest.SkipTest("MXFP4 on CUDA only supported on B200/B300")
+
+        # Simulate 2d-3d grouped gemm `out = input @ weight.t()`
+        # 2D inputs with groups along M, 3D weights.
+        block_size = 32
+        total_M = M  # Alias for clarity that M dim contains groups.
+        X = torch.randn((total_M, K), dtype=torch.bfloat16, device=device) * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device=device) * 0.01
+        input_group_end_offsets = generate_jagged_offs(
+            G, total_M, multiple_of=32, device=device
+        )
+
+        # For each constituent 2d subtensor in the 3d weights, quantize and convert scale to blocked format separately,
+        # as they each used for independent gemm in the grouped gemm.
+        def _3d_to_blocked_scaled(W, G, format):
+            wh_list = []
+            wq_list = []
+            w_scale_list = []
+            w_global_scale_list = []
+            for i in range(G):
+                if format == "mxfp8":
+                    wh, wq, w_scale = _convert_to_mxfp8_with_hp_ref(W[i])
+                elif format == "nvfp4":
+                    wh, wq, w_scale, w_global_scale = _convert_to_nvfp4_with_hp_ref(W[i])
+                    w_global_scale_list.append(w_global_scale)
+                elif format == "mxfp4":
+                    wh, wq, w_scale = _convert_to_mxfp4_with_hp_ref(W[i])
+                else:
+                    raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
+
+                # Swizzle scaled
+                if torch.version.cuda:
+                    w_scale = to_blocked(w_scale)
+
+                wh_list.append(wh)
+                wq_list.append(wq)
+                w_scale_list.append(w_scale)
+            wh = torch.stack(wh_list, dim=0).contiguous()
+            wq = torch.stack(wq_list, dim=0).contiguous()
+            w_scale = torch.stack(w_scale_list, dim=0).contiguous()
+            # Global scales only exist for nvfp4
+            if len(w_global_scale_list) > 0:
+                w_global_scales = torch.stack(w_global_scale_list)
+            else:
+                w_global_scales = None
+            return wh, wq, w_scale, w_global_scales
+
+        wh, wq, w_blocked_scales, w_global_scales = _3d_to_blocked_scaled(W, G, format)
+
+        # For each group along `total_M` in the 2D tensor, quantize and convert scale to blocked format separately,
+        # as they each used for independent gemm in the grouped gemm.
+        def _2d_to_blocked_scaled(X, K, G, offs, format):
+            xh_list = []
+            xq_list = []
+            x_scale_list = []
+            x_global_scale_list = []
+            for i in range(G):
+                prev_group_end = 0 if i == 0 else input_group_end_offsets[i - 1]
+                curr_group_end = input_group_end_offsets[i]
+                group_size = curr_group_end - prev_group_end
+                if group_size > 0:
+                    x_slice = X[prev_group_end:curr_group_end, :]
+                    if format == "mxfp8":
+                        xh, xq, x_scale = _convert_to_mxfp8_with_hp_ref(x_slice)
+                    elif format == "nvfp4":
+                        xh, xq, x_scale, x_global_scale = _convert_to_nvfp4_with_hp_ref(x_slice)
+                        x_global_scale_list.append(x_global_scale)
+                    elif format == "mxfp4":
+                        xh, xq, x_scale = _convert_to_mxfp4_with_hp_ref(x_slice)
+                    else:
+                        raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
+
+                    if torch.version.cuda:
+                        x_scale = to_blocked(x_scale)
+                    xh_list.append(xh)
+                    xq_list.append(xq)
+                    x_scale_list.append(x_scale)
+            xh = torch.cat(xh_list, dim=0).contiguous()
+            xq = torch.cat(xq_list, dim=0).contiguous()
+            x_scale = torch.cat(x_scale_list, dim=0).contiguous()
+            x_scale = x_scale.reshape(-1, K // block_size)
+            xq = xq.view(-1, xq.shape[-1])
+            xh = xh.view(-1, xh.shape[-1])
+
+            x_global_scales = None
+            if len(x_global_scale_list) > 0:
+                x_global_scales = torch.stack(x_global_scale_list)
+
+            return xh, xq, x_scale, x_global_scales
+
+        xh, xq, x_blocked_scales, x_global_scales = _2d_to_blocked_scaled(X, K, G, input_group_end_offsets, format)
+
+        if format in ["mxfp8", "mxfp4"]:
+            kwargs = _build_scaled_grouped_mm_kwargs(
+                x_blocked_scales,
+                w_blocked_scales,
+                input_group_end_offsets,
+                format,
+            )
+        elif format == "nvfp4":
+            kwargs = _build_scaled_grouped_mm_kwargs(
+                [x_blocked_scales, x_global_scales],
+                [w_blocked_scales, w_global_scales],
+                input_group_end_offsets,
+                format,
+            )
+        else:
+            raise ValueError(f'format must be mxfp8|nvfp4, got "{format}"')
+
+        if format == 'nvfp4':
+            if x_global_scales.numel() != w_global_scales.numel():
+                raise AssertionError(f"scale numel mismatch: {x_global_scales.numel()} != {w_global_scales.numel()}")
+            if x_global_scales.numel() != G:
+                raise AssertionError(f"scale numel should be {G}, got {x_global_scales.numel()}")
+
+        # When requested, route through the structured `.out` overload so the
+        # correctness assertion below also covers the out= path. The 2d-3d case
+        # produces a 2D [total_M, N] output.
+        if use_out:
+            kwargs["out"] = torch.empty(
+                (total_M, N), dtype=torch.bfloat16, device=device
+            )
+
+        # Compute low-precision grouped gemm.
+        y_lp = scaled_grouped_mm_wrap(
+            xq,
+            wq.transpose(-2, -1),
+            **kwargs
+        )
+
+        if use_out:
+            self.assertEqual(y_lp.data_ptr(), kwargs["out"].data_ptr())
+
+        # Compute reference bf16 grouped gemm.
+        # Note: Reference result should be on reconstructed, not original values.
+        #       as-in float(fp4(t)) not t itself.
+        y_bf16 = grouped_mm(
+            xh,
+            wh.transpose(-2, -1),
+            offs=input_group_end_offsets,
+            out_dtype=torch.bfloat16,
+        )
+
+        # Assert outputs are close.
+        torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
+
+    @unittest.skipIf(PLATFORM_SUPPORTS_FP8 or not torch.cuda.is_available(), f8_msg)
+    def test_error_message_fp8_pre_sm89(self, device) -> None:
+        (k, l, m) = (16, 48, 32)
+        x = torch.rand((k, l), device=device).to(e4m3_type)
+        y = torch.rand((m, l), device=device).to(e4m3_type).t()
+        scale_a = torch.tensor(1.0, device=device)
+        scale_b = torch.tensor(1.0, device=device)
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"torch\.\_scaled\_mm is only supported on CUDA devices with compute capability \>\= 9\.0 or 8\.9, or ROCm MI300\+",
+            lambda: scaled_mm_wrap(x, y, scale_a, scale_b, out_dtype=torch.float32),
+        )
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
+    @skipCUDAIf(not SM89OrLater, "rowwise implementation is currently sm89-sm100 specific")
+    @parametrize("wrap_v2", [True, False])
+    def test_scaled_mm_row_wise_fp32_out_with_bias_errors(self, wrap_v2, device):
+        if torch.version.hip:
+            raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
+
+        M, K, N = 16, 32, 48
+        input_dtype = e4m3_type
+        x = random_matrix_with_scaled_reduction_dim(M, K, dtype=torch.float32, device=device, reduction_dim=-1)
+        y = random_matrix_with_scaled_reduction_dim(N, K, dtype=torch.float32, device=device, reduction_dim=-1).t()
+        x_scales = tensor_to_scale(x, input_dtype, dim=1).float()
+        y_scales = tensor_to_scale(y, input_dtype, dim=0).float()
+        x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
+        y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)
+        bias = torch.randn((N,), device=device, dtype=torch.bfloat16)
+
+        with self.assertRaisesRegex(
+            (ValueError, RuntimeError),
+            "Bias is not supported when out_dtype is set to Float32",
+        ):
+            scaled_mm_wrap(
+                x_fp8,
+                y_fp8,
+                scale_a=x_scales.reciprocal(),
+                scale_b=y_scales.reciprocal(),
+                out_dtype=torch.float32,
+                bias=bias,
+                wrap_v2=wrap_v2,
+            )
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
+    @unittest.skipIf(IS_SM90, "DeepSeek style (1x128, 128x128) blockwise scaling works on SM90 (Hopper)")
+    @unittest.skipIf(
+        not torch.version.hip and _get_torch_cuda_version() < (12, 9),
+        "cuBLAS blockwise scaling added in CUDA 12.9",
+    )
+    @runOnRocmArch(MI350_ARCH)
+    @parametrize("output_dtype", [torch.bfloat16, ])
+    @parametrize("lhs_block,rhs_block", [(1, 1), (128, 1), (1, 128)])
+    @parametrize("M,N,K", [(256, 256, 256), (256, 256, 512)])
+    def test_scaled_mm_deepseek_error_messages(
+        self, output_dtype, lhs_block, rhs_block, M, N, K, device
+    ):
+
+        torch.manual_seed(42)
+
+        x = torch.randn(M, K, device=device, dtype=output_dtype).pow(3)
+        y = torch.randn(N, K, device=device, dtype=output_dtype).pow(3)
+
+        x_fp8, x_scales = tensor_to_scale_block(x, e4m3_type, lhs_block, 128)
+        y_fp8, y_scales = tensor_to_scale_block(y, e4m3_type, rhs_block, 128)
+
+        # 1x128 blocks need scales to be outer-dim-major
+        if lhs_block == 1:
+            x_scales = x_scales.t().contiguous().t()
+            lhs_recipe = ScalingType.BlockWise1x128
+        else:
+            lhs_recipe = ScalingType.BlockWise128x128
+
+        if rhs_block == 1:
+            y_scales = y_scales.t().contiguous().t()
+            rhs_recipe = ScalingType.BlockWise1x128
+        else:
+            rhs_recipe = ScalingType.BlockWise128x128
+
+        # Verify that actual F8 mm raises expected error
+        if torch.version.hip:
+            # ROCm does not yet support DeepSeek-style blockwise scaling
+            expected_error = NotImplementedError
+            expected_pattern = "1x128 and 128x128 scaling not available with ROCm"
+        else:
+            # CUDA non-SM90 should raise NotImplementedError
+            expected_error = NotImplementedError
+            expected_pattern = ".*DeepSeek.*scaling.*only supported in CUDA for SM90.*"
+        with self.assertRaisesRegex(
+            expected_error,
+            expected_pattern
+        ):
+            scaled_mm_wrap(
+                x_fp8,
+                y_fp8.t(),
+                scale_a=x_scales,
+                scale_recipe_a=lhs_recipe,
+                scale_b=y_scales.t(),
+                scale_recipe_b=rhs_recipe,
+                out_dtype=output_dtype,
+            )
+
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/164271")
+    @unittest.skipIf(IS_WINDOWS, "Windows doesn't support row-wise scaling")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")
+    def test_honor_sm_carveout(self, device) -> None:
+        torch.manual_seed(42)
+
+        x = torch.randn(8192, 2048, device=device, dtype=torch.float32)
+        y = torch.randn(8192, 2048, device=device, dtype=torch.float32).t()
+        x_scales = tensor_to_scale(x, e4m3_type, dim=1).reciprocal()
+        y_scales = tensor_to_scale(y, e4m3_type, dim=0).reciprocal()
+        x_fp8 = to_fp8_saturated(x / x_scales, e4m3_type)
+        y_fp8 = to_fp8_saturated(y / y_scales, e4m3_type)
+
+        cu_count = torch.cuda.get_device_properties().multi_processor_count
+        carveout = 66 if torch.version.cuda else cu_count // 8
+
+        # Warm up so hipBLASLt's one-time init kernel does not appear in the profile trace below.
+        scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+        torch.cuda.synchronize()
+
+        with tempfile.NamedTemporaryFile() as f:
+            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
+                self.assertIsNone(torch._C._get_sm_carveout_experimental())
+                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+                torch._C._set_sm_carveout_experimental(0)
+                self.assertEqual(torch._C._get_sm_carveout_experimental(), 0)
+                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+                torch._C._set_sm_carveout_experimental(66)
+                self.assertEqual(torch._C._get_sm_carveout_experimental(), 66)
+                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+                torch._C._set_sm_carveout_experimental(None)
+                self.assertIsNone(torch._C._get_sm_carveout_experimental())
+                scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+
+            prof.export_chrome_trace(f.name)
+            if torch.version.hip:
+                with open(f.name) as file:
+                    events = [evt for evt in json.load(file)["traceEvents"] if evt.get("cat", "") == "kernel"]
+                # events were returned out of order; need to be sorted on "ts" timestamp
+                events = sorted(events, key=lambda x: x['ts'])
+                # ROCm carveout is invisible except for kernels running slower on fewer CUs
+                no_carveout, carveout_0, carveout, no_carveout_again = [float(evt.get("dur", "0.0")) for evt in events]
+                if True or not (no_carveout < carveout and carveout_0 < carveout and no_carveout_again < carveout):  # noqa: SIM222
+                    # something went wrong, print more info to help debug flaky test
+                    print("ROCm debug info for test_honor_sm_carveout")
+                    print("cu_count", cu_count)
+                    print("no_carveout", no_carveout)
+                    print("carveout_0", carveout_0)
+                    print("carveout", carveout)
+                    print("no_carveout_again", no_carveout_again)
+                self.assertTrue(no_carveout < carveout)
+                self.assertTrue(carveout_0 < carveout)
+                self.assertTrue(no_carveout_again < carveout)
+                # ROCm carveout will create new streams when enabled, and go back to the original stream when disabled
+                no_carveout, carveout_0, carveout, no_carveout_again = [int(evt.get("tid", "0")) for evt in events]
+                self.assertTrue(no_carveout == no_carveout_again)
+                self.assertTrue(no_carveout == carveout_0)
+                self.assertTrue(no_carveout != carveout)
+                self.assertTrue(carveout_0 != carveout)
+            else:
+                with open(f.name) as file:
+                    no_carveout, carveout_0, carveout_66, no_carveout_again = [
+                        math.prod(evt.get("args", {}).get("grid", []))
+                        for evt in json.load(file)["traceEvents"]
+                        if evt.get("cat", "") == "kernel"
+                    ]
+
+                self.assertEqual(no_carveout, no_carveout_again)
+                if SM100OrLater:
+                    # expected failure
+                    # CUTLASS only supports SM carveout via green contexts on SM100
+                    self.assertEqual(no_carveout, carveout_66)
+                    self.assertEqual(carveout_66, carveout_0)
+                else:
+                    # correct behavior
+                    self.assertNotEqual(no_carveout, carveout_66)
+                    self.assertNotEqual(carveout_66, carveout_0)
+
+
 instantiate_device_type_tests(TestFP8Matmul, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestFP8MatmulCudaOnly, globals(), only_for="cuda")
 
 if __name__ == '__main__':
     TestCase._default_dtype_check_enabled = True

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -47,6 +47,7 @@ from torch.testing._internal.common_device_type import (
 
 from torch.testing._internal.common_xpu import Xe2_Or_Later
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     MI350_ARCH,
     parametrize,
@@ -659,6 +660,7 @@ def _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, format):
     return kwargs[format]
 
 class TestFP8Matmul(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _test_tautological_mm(self, device: str,
                               x_dtype: torch.dtype = e4m3_type,


### PR DESCRIPTION
## Summary

Add `hw_classification` and migrate to `instantiate_device_type_tests` for 3 test files, addressing KarhouTam's review feedback on the CUDA structural contract.

### test_cuda_trace.py
- `TestCudaTrace` → CUDA with `instantiate_device_type_tests(only_for="cuda")`
- All 12 tests use CUDA-specific APIs (Events, Streams, synchronize)
- Added `device` parameter to all test methods
- Fixed stream handle assertions: `default_stream()` → `current_stream()`

### test_numba_integration.py
- `TestNumbaIntegration` → CUDA with `instantiate_device_type_tests(only_for="cuda")`
- All 8 tests require `numba.cuda` interop with real CUDA hardware
- Added `device` parameter, replaced hardcoded `.cuda()` with `.to(device)`
- Fixed stream sync race exposed by CUDATestBase

### test_scaled_matmul_cuda.py
- `TestFP8Matmul` → ACCELERATOR (retained, `allow_xpu=True`)
- `TestFP8MatmulCudaOnly` → CUDA (new, `only_for="cuda"`) — 7 extracted @onlyCUDA methods
- Added missing `device` parameter to `test_pack_uint4`
- Replaced `@onlyOn(["cuda","xpu"])` with `@onlyAccelerator` where appropriate

**Note:** `test_cuda.py` addressed in #193154

## Test plan

- [x] All 3 files: baseline vs ours comparison on H200 (torch-2.15.0a0+gitc187ef3)
- [x] test_cuda_trace: 12/12 pass (baseline identical)
- [x] test_numba_integration: 5 pass, 3 skip (baseline identical, 5 stability runs)
- [x] test_scaled_matmul: 113 pass, 1 pre-existing failure (baseline identical)
- [x] `lintrunner -a` clean on all 3 files
- [x] `ast.parse` validates all 3 files

Depends on #186918 for the `HardwareClassification` enum.

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508