### PR TITLE
[dynamo] Hoist requires_grad_(True) on an unused graph input in front of the graph

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -500,6 +500,11 @@ use_recursive_dict_tags_for_guards = False
 # useful for regional compilation.
 max_saved_pointers_for_recursive_dict_tags_check = 256
 
+# Hoist Tensor.requires_grad_(True) on an unused graph input in front of the
+# graph instead of graph breaking. See method_requires_grad_ in
+# variables/tensor.py.
+hoist_requires_grad_on_inputs = os.environ.get("TORCH_HOIST_REQUIRES_GRAD", "0") == "1"
+
 # If True, raises exception if TorchDynamo is called with a context manager
 raise_on_ctx_manager_usage = True
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -957,6 +957,9 @@ class OutputGraph(OutputGraphCommon):
 
         # Bytecode to insert right before we call the graph
         self.pregraph_bytecode: list[Instruction] = []
+        # ids of GraphArgs whose requires_grad_(True) was hoisted in front of
+        # the graph, see TensorVariable.hoist_requires_grad_to_pregraph.
+        self.hoisted_requires_grad_args: set[int] = set()
 
         # Maps SyntheticLocalSource → (fn, args, arg_sources) for hoisted
         # graph inputs created by synthetic_graph_input, so invoke_subgraph
@@ -3318,7 +3321,19 @@ class OutputGraph(OutputGraphCommon):
         return next_name
 
     def example_inputs(self) -> list[torch.Tensor]:
-        result = [arg.example for arg in self.graphargs]
+        result = []
+        for arg in self.graphargs:
+            # A hoisted requires_grad_() input is traced as requiring grad while
+            # the real tensor still does not (the mutation happens in the
+            # pregraph bytecode, at runtime). The backend has to see the traced
+            # state or it will build an inference-only graph.
+            if (
+                arg.fake_tensor is not None
+                and id(arg) in self.hoisted_requires_grad_args
+            ):
+                result.append(arg.fake_tensor)
+            else:
+                result.append(arg.example)
         # pyrefly: ignore[bad-return]
         return result
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2196,6 +2196,35 @@ class TensorVariable(VariableTracker):
         tx.output.side_effects.register_hook(self, hook, handle_variable, name)
         return handle_variable
 
+    def hoist_requires_grad_to_pregraph(self, tx: "InstructionTranslatorBase") -> None:
+        """Run ``x.requires_grad_(True)`` before the compiled graph is called.
+
+        The graph then takes the input as already requiring grad, which is what
+        AOTAutograd needs in order to build a backward for it.
+        """
+        from ..codegen import PyCodegen
+
+        cg = PyCodegen(tx.output.root_tx)
+        cg(self.source)
+        cg.load_method("requires_grad_")
+        cg(variables.ConstantVariable.create(True))
+        cg.call_method(1)
+        cg.pop_top()
+        tx.output.pregraph_bytecode.extend(cg.get_instructions())
+
+        # The rest of the trace, and the backend, must see a differentiable
+        # input. The real tensor is left alone; the bytecode above mutates it at
+        # runtime, before the graph runs.
+        node = self.as_proxy().node
+        example_value = node.meta["example_value"]
+        with torch.no_grad():
+            example_value.requires_grad_(True)
+        self.requires_grad = True
+
+        grapharg = node.meta.get("grapharg", None)
+        if grapharg is not None:
+            tx.output.hoisted_requires_grad_args.add(id(grapharg))
+
     def method_requires_grad_(
         self,
         tx: "InstructionTranslatorBase",
@@ -2207,9 +2236,23 @@ class TensorVariable(VariableTracker):
         node = self.as_proxy().node
         example_value = node.meta["example_value"]
         if example_value.requires_grad != requires_grad:
-            # For graph inputs (tensors with source), requires_grad_() is a
-            # metadata mutation that we can't trace — graph break as before.
             if self.source:
+                # A graph input cannot have its requires_grad flipped inside the
+                # graph: AOTAutograd fixes an input's differentiability from the
+                # metadata it was traced with, so an in-graph toggle leaves the
+                # runtime forward non-differentiable. Hoist the call in front of
+                # the graph instead, and trace the rest of the frame with the
+                # input already requiring grad. Only sound while nothing has
+                # consumed the input yet, otherwise ops traced before the call
+                # would wrongly become differentiable.
+                if (
+                    requires_grad
+                    and torch._dynamo.config.hoist_requires_grad_on_inputs
+                    and node.op == "placeholder"
+                    and len(node.users) == 0
+                ):
+                    self.hoist_requires_grad_to_pregraph(tx)
+                    return self
                 unimplemented(
                     gb_type="Unsupported Tensor.requires_grad_() call",
                     context=f"call_method {self} requires_grad_",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193227
* #193220
* #193219
* #192009
* __->__ #193162
* #193157
* #193161
* #193160
* #193159
* #193158

Calling requires_grad_() on a graph input graph breaks. Models that compute
forces by autograd do exactly this - FairChem UMA calls
data_dict["pos"].requires_grad_(True) before generating its graph - so the
frame is split there and the model cannot be captured with fullgraph=True.

Tracing the toggle into the graph, which is what Dynamo already does for
intermediates, does not work for an input: AOTAutograd fixes an input's
differentiability from the metadata it was traced with, so the in-graph toggle
leaves the runtime forward non-differentiable and a later autograd.grad fails
with "element 0 of tensors does not require grad and does not have a grad_fn".

Hoist the call instead. When the input has no users yet, emit
x.requires_grad_(True) into pregraph_bytecode, which runs before the compiled
graph on every call (the mechanism synthetic_graph_input already uses), and flip
the placeholder's fake so the rest of the trace and the backend see a
differentiable input. example_inputs() has to hand the backend that fake rather
than GraphArg.example, because the real tensor's requires_grad is still False at
compile time - the mutation is in the bytecode, not yet executed - and the
backend would otherwise build an inference-only graph.

Guarding is on the entry state, so a fresh tensor per call reuses one graph
rather than recompiling, and a tensor that is passed in already requiring grad
recompiles once and then stabilizes. The hoist is only sound while nothing has
consumed the input: ops traced before the call would otherwise become
differentiable when eager would not have tracked them. Anything else keeps
today's graph break.

Gated behind torch._dynamo.config.hoist_requires_grad_on_inputs, default off,
while the corner cases are explored.

Test plan:

```
python test/dynamo/test_misc.py                  # with the knob both off and on
```

matches a baseline run in both cases. Correctness of the hoisted path was
checked against eager for backends eager, aot_eager and inductor, comparing
energy and the gradient taken outside the compiled region, plus the
`if x.requires_grad:` branch under fullgraph=True, and the recompile behaviour
described above.

On UMA the graph breaks disappear (21 frames -> 19) and total
entire_frame_compile goes from 48.2s to 47.6s; the value here is mostly that
the model becomes capturable rather than the compile time.

This PR was authored with the assistance of an AI coding agent.