### PR TITLE
[TEST] Add `hw_classification` to Sparse/Tensor/Linalg test files

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -26,7 +26,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
+     freeze_rng_state, HardwareClassification, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
@@ -126,6 +126,8 @@ def get_tunableop_untuned_filename():
 
 
 class TestLinalg(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         # Snapshot fp32_precision (not allow_tf32) so the round-trip is exact:
@@ -9449,6 +9451,8 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
 class TestLinalgCudaOnly(TestCase):
     """CUDA/ROCm-specific linalg tests (TunableOp, backend library selection)."""
+
+    hw_classification = HardwareClassification.CUDA
 
     def setUp(self):
         super().setUp()

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_BF16, PLATFORM_SUPPORTS_BF16_ATOMICS, PLATFORM_SUPPORTS_HALF_ATOMICS)
 from torch.testing._internal.common_utils import \
     (TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, TEST_CUDA_CUDSS, TEST_SCIPY, TEST_NUMPY, TEST_MKL, IS_WINDOWS, TestCase,
-     run_tests, load_tests, coalescedonoff, parametrize, subtest, skipIfTorchDynamo,
+     run_tests, load_tests, coalescedonoff, HardwareClassification, parametrize, subtest, skipIfTorchDynamo,
      IS_FBCODE, IS_REMOTE_GPU, suppress_warnings)
 from torch.testing._internal.common_device_type import \
     (ops, instantiate_device_type_tests, dtypes, OpDTypes, dtypesIfCUDA, onlyCPU, onlyCUDA, skipCUDAIfNoSparseGeneric,
@@ -133,6 +133,8 @@ def _test_addmm_addmv(
 
 
 class TestSparseCSRSampler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
 
     def test_make_crow_indices(self):
         # Here we test the correctness of the crow_indices algorithm
@@ -190,6 +192,8 @@ def hybrid_nonhybrid(test_name='hybrid'):
 
 
 class TestSparseCompressed(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     """Testing sparse compressed (CSR, CSC, BSR, BSC) tensor generic features.
     """
 
@@ -1038,6 +1042,8 @@ def _npref_block_addmm_addmv(c, a, b, alpha, beta):
 
 
 class TestSparseCSR(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
 
     @onlyCPU
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
@@ -3562,6 +3568,8 @@ def skipIfNoTriton(cls):
 
 @skipIfNoTriton
 class TestSparseCompressedTritonKernels(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
 
     def _to_block_triangular_inplace(self, d, row_block, col_block):
         """

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_dtype import all_types_and_complex
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     parametrize,
     run_tests,
@@ -182,6 +183,8 @@ def rand_sparse_semi_structured_all_patterns(r, c, dtype, device):
 
 
 class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) == 0:
             self.skipTest("semi-structured sparsity has no available backend!")
@@ -337,6 +340,8 @@ class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
 
 
 class TestSparseSemiStructured(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) == 0:
@@ -695,6 +700,8 @@ def create_random_mask(shape) -> torch.Tensor:
 
 
 class TestSparseSemiStructuredTraining(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         if not _IS_SM8X:
@@ -1091,6 +1098,8 @@ class TestSparseSemiStructuredTraining(TestCase):
 
 
 class TestSparseSemiStructuredCUTLASS(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """
     This contains CUTLASS specific tests for
          - torch._sparse_semi_structured_linear
@@ -1355,6 +1364,8 @@ def to_float8(x, dtype=torch.float8_e4m3fn):
 
 
 class TestSparseSemiStructuredCUSPARSELT(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """
     This contains cuSPARSELt specific tests for
         torch._cslt_compress


### PR DESCRIPTION
## Summary

Add `hw_classification` to 3 test files (11 classes):

**test/test_sparse_csr.py:**
- `TestSparseCSRSampler`: `GENERIC` — CPU-only sampling algorithm
- `TestSparseCompressed`, `TestSparseCSR`, `TestSparseCompressedTritonKernels`: `ACCELERATOR`

**test/test_sparse_semi_structured.py:**
- All 5 classes: `CUDA` (SM80+ semi-structured sparsity)

**test/test_linalg.py:**
- `TestLinalg`: `ACCELERATOR` (device-agnostic linalg ops)
- `TestLinalgCudaOnly`: `CUDA` (TunableOp, `only_for="cuda"`)

Consolidates PRs #192795 #192781 #192767

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590)

## Test Plan

```
python test/test_sparse_csr.py TestSparseCSRSampler -v
python test/test_sparse_semi_structured.py      # Ran 57 tests — OK (skipped=57, no sparse backend on test machine)
python test/test_linalg.py                      # Ran 3025 tests in 213s — 1 pre-existing failure, 17 pre-existing errors, 1052 skips 
```


Verified on H200


Co-authored with Opus 4.6


cc @vishalgoyal316 @mansiag05 @RiyaP2508