### PR TITLE
[MPS] Add Metal kernel for conv3d DHWIO weight permute

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Convolution.h
+++ b/aten/src/ATen/native/mps/kernels/Convolution.h
@@ -3,15 +3,15 @@
 
 // Source element strides of the OIDHW weight view (may be non-contiguous).
 struct ConvWeightPermuteParams {
-  int32_t output_channels;
-  int32_t input_channels_per_group;
-  int32_t kernel_height;
-  int32_t kernel_width;
-  int32_t output_channel_stride;
-  int32_t input_channel_stride;
-  int32_t depth_stride;
-  int32_t height_stride;
-  int32_t width_stride;
+  uint32_t output_channels;
+  uint32_t input_channels_per_group;
+  uint32_t kernel_height;
+  uint32_t kernel_width;
+  uint32_t output_channel_stride;
+  uint32_t input_channel_stride;
+  uint32_t depth_stride;
+  uint32_t height_stride;
+  uint32_t width_stride;
 };
 
 struct Conv2DParams {

--- a/aten/src/ATen/native/mps/kernels/Convolution.h
+++ b/aten/src/ATen/native/mps/kernels/Convolution.h
@@ -1,6 +1,19 @@
 #pragma once
 #include <c10/metal/common.h>
 
+// Source element strides of the OIDHW weight view (may be non-contiguous).
+struct ConvWeightPermuteParams {
+  int32_t output_channels;
+  int32_t input_channels_per_group;
+  int32_t kernel_height;
+  int32_t kernel_width;
+  int32_t output_channel_stride;
+  int32_t input_channel_stride;
+  int32_t depth_stride;
+  int32_t height_stride;
+  int32_t width_stride;
+};
+
 struct Conv2DParams {
   int32_t N;
   int32_t C_in;

--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -268,6 +268,48 @@ INSTANTIATE_NCHW_TO_NHWC_ALL(float)
 INSTANTIATE_NCHW_TO_NHWC_ALL(half)
 INSTANTIATE_NCHW_TO_NHWC_ALL(bfloat)
 
+// DHWIO copy of an OIDHW weight view; ATen's generic permute copy runs well
+// below memory bandwidth for this permutation. Each thread streams one kW row.
+template <typename T>
+kernel void conv_weight_to_dhwio(
+    device const T* source [[buffer(0)]],
+    device T* destination [[buffer(1)]],
+    constant ConvWeightPermuteParams& params [[buffer(2)]],
+    uint3 position [[thread_position_in_grid]]) {
+  const int output_channel = int(position.x);
+  const int input_channel = int(position.y);
+  const int kernel_plane_index = int(position.z);
+  const int kernel_height_index = kernel_plane_index % params.kernel_height;
+  const int kernel_depth_index = kernel_plane_index / params.kernel_height;
+  device const T* source_row = source +
+      (int64_t)output_channel * params.output_channel_stride +
+      (int64_t)input_channel * params.input_channel_stride +
+      (int64_t)kernel_depth_index * params.depth_stride +
+      (int64_t)kernel_height_index * params.height_stride;
+  device T* destination_row = destination +
+      ((int64_t)kernel_plane_index * params.kernel_width *
+           params.input_channels_per_group +
+       input_channel) *
+          params.output_channels +
+      output_channel;
+  for (int kernel_width_index = 0; kernel_width_index < params.kernel_width;
+       ++kernel_width_index) {
+    destination_row
+        [(int64_t)kernel_width_index * params.input_channels_per_group *
+         params.output_channels] =
+            source_row[(int64_t)kernel_width_index * params.width_stride];
+  }
+}
+
+#define INSTANTIATE_CONV_WEIGHT_TO_DHWIO(DT)                      \
+  template [[host_name("conv_weight_to_dhwio_" #DT)]] kernel void \
+  conv_weight_to_dhwio<DT>(                                       \
+      device const DT*, device DT*, constant ConvWeightPermuteParams&, uint3);
+
+INSTANTIATE_CONV_WEIGHT_TO_DHWIO(float)
+INSTANTIATE_CONV_WEIGHT_TO_DHWIO(half)
+INSTANTIATE_CONV_WEIGHT_TO_DHWIO(bfloat)
+
 #if __METAL_VERSION__ >= 400 && \
     __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>

--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -276,18 +276,18 @@ kernel void conv_weight_to_dhwio(
     device T* destination [[buffer(1)]],
     constant ConvWeightPermuteParams& params [[buffer(2)]],
     uint3 position [[thread_position_in_grid]]) {
-  const int output_channel = int(position.x);
-  const int input_channel = int(position.y);
-  const int kernel_plane_index = int(position.z);
+  const int output_channel = position.x;
+  const int input_channel = position.y;
+  const int kernel_plane_index = position.z;
   const int kernel_height_index = kernel_plane_index % params.kernel_height;
   const int kernel_depth_index = kernel_plane_index / params.kernel_height;
   device const T* source_row = source +
-      (int64_t)output_channel * params.output_channel_stride +
-      (int64_t)input_channel * params.input_channel_stride +
-      (int64_t)kernel_depth_index * params.depth_stride +
-      (int64_t)kernel_height_index * params.height_stride;
+      output_channel * params.output_channel_stride +
+      input_channel * params.input_channel_stride +
+      kernel_depth_index * params.depth_stride +
+      kernel_height_index * params.height_stride;
   device T* destination_row = destination +
-      ((int64_t)kernel_plane_index * params.kernel_width *
+      (kernel_plane_index * params.kernel_width *
            params.input_channels_per_group +
        input_channel) *
           params.output_channels +
@@ -295,9 +295,9 @@ kernel void conv_weight_to_dhwio(
   for (int kernel_width_index = 0; kernel_width_index < params.kernel_width;
        ++kernel_width_index) {
     destination_row
-        [(int64_t)kernel_width_index * params.input_channels_per_group *
+        [kernel_width_index * params.input_channels_per_group *
          params.output_channels] =
-            source_row[(int64_t)kernel_width_index * params.width_stride];
+            source_row[kernel_width_index * params.width_stride];
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -160,16 +160,17 @@ static Tensor conv3d_weights_to_dhwio(const Tensor& weight) {
   const auto kernel_width = weight.size(4);
   auto output = at::empty({kernel_depth, kernel_height, kernel_width, input_channels_per_group, output_channels},
                           weight.options());
-  ConvWeightPermuteParams params;
-  params.output_channels = static_cast<int32_t>(output_channels);
-  params.input_channels_per_group = static_cast<int32_t>(input_channels_per_group);
-  params.kernel_height = static_cast<int32_t>(kernel_height);
-  params.kernel_width = static_cast<int32_t>(kernel_width);
-  params.output_channel_stride = static_cast<int32_t>(weight.stride(0));
-  params.input_channel_stride = static_cast<int32_t>(weight.stride(1));
-  params.depth_stride = static_cast<int32_t>(weight.stride(2));
-  params.height_stride = static_cast<int32_t>(weight.stride(3));
-  params.width_stride = static_cast<int32_t>(weight.stride(4));
+  const ConvWeightPermuteParams params{
+      .output_channels = static_cast<uint32_t>(output_channels),
+      .input_channels_per_group = static_cast<uint32_t>(input_channels_per_group),
+      .kernel_height = static_cast<uint32_t>(kernel_height),
+      .kernel_width = static_cast<uint32_t>(kernel_width),
+      .output_channel_stride = static_cast<uint32_t>(weight.stride(0)),
+      .input_channel_stride = static_cast<uint32_t>(weight.stride(1)),
+      .depth_stride = static_cast<uint32_t>(weight.stride(2)),
+      .height_stride = static_cast<uint32_t>(weight.stride(3)),
+      .width_stride = static_cast<uint32_t>(weight.stride(4)),
+  };
   auto pipeline = lib.getPipelineStateForFunc(fmt::format("conv_weight_to_dhwio_{}", scalarToMetalTypeString(weight)));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -149,6 +149,48 @@ static Tensor conv3d_to_ndhwc(const Tensor& tensor) {
   return output;
 }
 
+// DHWIO weight copy; ATen's strided permute copy runs well below memory
+// bandwidth for this permutation, 2-4x slower than the flat kernel.
+static Tensor conv3d_weights_to_dhwio(const Tensor& weight) {
+  using namespace mps;
+  constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+  const int64_t output_channels = weight.size(0);
+  const int64_t input_channels_per_group = weight.size(1);
+  const int64_t kernel_depth = weight.size(2);
+  const int64_t kernel_height = weight.size(3);
+  const int64_t kernel_width = weight.size(4);
+  const auto [min_stride, max_stride] = std::minmax_element(weight.strides().begin(), weight.strides().end());
+  if (weight.numel() == 0 || weight.numel() > kInt32Max || *max_stride > kInt32Max || *min_stride < -kInt32Max) {
+    return weight.permute({2, 3, 4, 1, 0}).contiguous();
+  }
+  auto output = at::empty({kernel_depth, kernel_height, kernel_width, input_channels_per_group, output_channels},
+                          weight.options());
+  ConvWeightPermuteParams params;
+  params.output_channels = static_cast<int32_t>(output_channels);
+  params.input_channels_per_group = static_cast<int32_t>(input_channels_per_group);
+  params.kernel_height = static_cast<int32_t>(kernel_height);
+  params.kernel_width = static_cast<int32_t>(kernel_width);
+  params.output_channel_stride = static_cast<int32_t>(weight.stride(0));
+  params.input_channel_stride = static_cast<int32_t>(weight.stride(1));
+  params.depth_stride = static_cast<int32_t>(weight.stride(2));
+  params.height_stride = static_cast<int32_t>(weight.stride(3));
+  params.width_stride = static_cast<int32_t>(weight.stride(4));
+  auto pipeline = lib.getPipelineStateForFunc(fmt::format("conv_weight_to_dhwio_{}", scalarToMetalTypeString(weight)));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto encoder = stream->commandEncoder();
+      getMPSProfiler().beginProfileKernel(pipeline, "conv_weight_to_dhwio", {weight}, stream);
+      [encoder setComputePipelineState:pipeline];
+      mtl_setArgs(encoder, weight, output, params);
+      [encoder dispatchThreads:MTLSizeMake(output_channels, input_channels_per_group, kernel_depth * kernel_height)
+          threadsPerThreadgroup:MTLSizeMake(std::min<int64_t>(output_channels, 256), 1, 1)];
+      getMPSProfiler().endProfileKernel(pipeline, stream);
+    }
+  });
+  return output;
+}
+
 struct Conv3dMppSpecialization {
   std::string dtype;
   int kernel_depth, kernel_height, kernel_width;
@@ -270,7 +312,7 @@ static void conv3d_metal_forward(const Tensor& input_t,
   const bool use_mpp = !use_long_index && has_mpp();
 
   const auto activation = conv3d_to_ndhwc(input_t); // NDHWC
-  const auto weights = weight_t.permute({2, 3, 4, 1, 0}).contiguous(); // DHWIO
+  const auto weights = conv3d_weights_to_dhwio(weight_t); // DHWIO
   std::optional<Tensor> bias;
   if (bias_defined) {
     bias = bias_opt->scalar_type() == dtype ? bias_opt->contiguous() : bias_opt->to(dtype).contiguous();

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -153,16 +153,11 @@ static Tensor conv3d_to_ndhwc(const Tensor& tensor) {
 // bandwidth for this permutation, 2-4x slower than the flat kernel.
 static Tensor conv3d_weights_to_dhwio(const Tensor& weight) {
   using namespace mps;
-  constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
-  const int64_t output_channels = weight.size(0);
-  const int64_t input_channels_per_group = weight.size(1);
-  const int64_t kernel_depth = weight.size(2);
-  const int64_t kernel_height = weight.size(3);
-  const int64_t kernel_width = weight.size(4);
-  const auto [min_stride, max_stride] = std::minmax_element(weight.strides().begin(), weight.strides().end());
-  if (weight.numel() == 0 || weight.numel() > kInt32Max || *max_stride > kInt32Max || *min_stride < -kInt32Max) {
-    return weight.permute({2, 3, 4, 1, 0}).contiguous();
-  }
+  const auto output_channels = weight.size(0);
+  const auto input_channels_per_group = weight.size(1);
+  const auto kernel_depth = weight.size(2);
+  const auto kernel_height = weight.size(3);
+  const auto kernel_width = weight.size(4);
   auto output = at::empty({kernel_depth, kernel_height, kernel_width, input_channels_per_group, output_channels},
                           weight.options());
   ConvWeightPermuteParams params;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -17283,6 +17283,23 @@ class TestMetalLibrary(TestCaseMPS):
         kernel(src, dst, [11, 35], threads=(256, 1, 2), group_size=(256, 1, 1), arg_casts="int32")
         self.assertEqual(dst, src.permute(0, 2, 1))
 
+    def test_conv_weight_to_dhwio_kernel(self):
+        path = os.path.join(_CONFORMANCE_REPO_ROOT, "aten/src/ATen/native/mps/kernels/Convolution.metal")
+        lib = torch.mps.compile_shader(embed_headers(path))
+        oc, ic, kd, kh, kw = 5, 3, 2, 2, 4
+        weight = torch.randn(oc, ic, kd, kh, kw, device="mps")
+        # contiguous, permuted, and width-sliced source strides
+        for source in (
+            weight,
+            weight.permute(2, 3, 4, 1, 0).contiguous().permute(4, 3, 0, 1, 2),
+            torch.randn(oc, ic, kd, kh, 2 * kw, device="mps")[..., ::2],
+        ):
+            destination = torch.empty(kd, kh, kw, ic, oc, dtype=source.dtype, device="mps")
+            params = [oc, ic, kh, kw, *source.stride()]
+            lib.conv_weight_to_dhwio_float(source, destination, params,
+                                           threads=(oc, ic, kd * kh), group_size=(oc, 1, 1), arg_casts="int32")
+            self.assertEqual(destination, source.permute(2, 3, 4, 1, 0))
+
 
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the


### PR DESCRIPTION
Discovered when trying to port conv1d to metal kernels.
Replaces the permute copy of conv3d weights to a metal kernel which is in general faster. Perf below:

`permute({2,3,4,1,0}).contiguous()` vs the kernel, fp32:

| weight (OxIx3x3x3) | size | permute ms | kernel ms | ratio |
|---|---|---|---|---|
| 64x64 | 0.44 MB | 0.031 | 0.008 | 4.1x |
| 96x96 | 1.0 MB | 0.028 | 0.008 | 3.6x |
| 128x128 | 1.8 MB | 0.036 | 0.012 | 3.0x |
| 256x256 | 7.1 MB | 0.177 | 0.088 | 2.0x |
| 512x512 | 28.3 MB | 1.696 | 0.447 | 3.8x |

Conv3d perf itself:

| shape (Cin-Cout, kernel, stride, DxHxW, dtype) | weight | before ms | after ms | speedup |
|---|---|---|---|---|
| 512-512 k3 s1 4x7x7 bf16 | 13.5 MB | 0.973 | 0.487 | 2.00x |
| 128-256 k3 s2 8x28x28 bf16 | 1.7 MB | 0.153 | 0.105 | 1.46x |
| 64-64 k3 s1 16x56x56 bf16 | 0.2 MB | 0.522 | 0.515 | 1.01x |
| 64-64 g2 k3 s1 8x28x28 fp32 | 0.2 MB | 2.658 | 2.649 | 1.00x |