### PR TITLE
[Testcase Refactoring] Classify sparse qlinear packed params tests as generic

### DIFF
--- a/test/ao/sparsity/test_qlinear_packed_params.py
+++ b/test/ao/sparsity/test_qlinear_packed_params.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_utils import HardwareClassification, TestCas
 
 
 class TestQlinearPackedParams(TestCase):
-    hw_classification = HardwareClassification.CPU
+    hw_classification = HardwareClassification.GENERIC
 
     def qlinear_packed_params_test(self, allow_non_zero_zero_points=False):
         # copied from https://pytorch.org/docs/stable/sparse.html#csr-tensor-operations,

--- a/test/ao/sparsity/test_qlinear_packed_params.py
+++ b/test/ao/sparsity/test_qlinear_packed_params.py
@@ -11,10 +11,12 @@ from torch.testing._internal.common_quantized import (
     override_quantized_engine,
     qengine_is_qnnpack,
 )
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestQlinearPackedParams(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def qlinear_packed_params_test(self, allow_non_zero_zero_points=False):
         # copied from https://pytorch.org/docs/stable/sparse.html#csr-tensor-operations,
         # so row/col block indices match that example, but with blocks and


### PR DESCRIPTION
## Background

This change is part of the PyTorch test case refactoring effort tracked in #185590.

`TestQlinearPackedParams` exercises sparse quantized linear packed-parameter serialization, unpacking, deserialization, and FBGEMM/QNNPACK compatibility. Although these tests use CPU quantized engines, the class is not parameterized by device and does not create a CPU-specific device test variant. It therefore belongs to the generic CPU-side test category rather than the CPU device-specific category.

## Changes

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Set `TestQlinearPackedParams.hw_classification` to `HardwareClassification.GENERIC`.
- Keep all three existing test methods, inputs, expected values, assertions, random seeds, quantized-engine overrides, and FBGEMM/QNNPACK skip guards unchanged.
- Keep the existing non-device-parameterized execution model without adding `instantiate_device_type_tests`.

## Test Plan

- Confirmed that default discovery still collects the same three test methods:
  - `TestQlinearPackedParams::test_qlinear_packed_params_fbgemm`
  - `TestQlinearPackedParams::test_qlinear_packed_params_fbgemm_qnnpack_cross_compatibility`
  - `TestQlinearPackedParams::test_qlinear_packed_params_qnnpack`
- A source-equivalent compatibility loader produced the expected classification counts:
  - default: 3
  - `GENERIC`: 3
  - `CPU`: 0
  - `ACCELERATOR`: 0
- CPU-side validation was also run on an Ascend 950PR host with PyTorch `2.14.0a0+gitbe42873` and the `qnnpack`, `fbgemm`, `x86`, and `onednn` quantized engines available.
- Without compatibility settings, the updated file and the remote Git `HEAD` baseline both ran three tests and produced the same three pre-existing `torch.load()` weights-only deserialization errors. This confirms that the metadata change does not introduce the failures.
- With `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1`, a diagnostic run of the updated file passed all three tests. This result is diagnostic evidence only and is not treated as the formal default test result.
- `git diff --check` passed.
- `lintrunner -a` was attempted but could not complete on Windows because the repository's non-ASCII path was decoded incorrectly and several linter commands could not access the target file.
- No NPU operators were exercised; the remote validation used the CPU quantization backends required by these tests.

## Risk Assessment

The change only adds class-level hardware metadata. It does not add, remove, rename, parameterize, or alter any test method. Existing FBGEMM/QNNPACK guards and execution behavior remain unchanged when hardware-classification filtering is not requested.

When hardware-classification filtering is enabled, the class is selected by `GENERIC` and excluded from `CPU`-only and accelerator-only selections.