### PR TITLE
Reject complex scale/zero_point in quantize_per_tensor before scalar conversion

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -69,7 +69,13 @@ Tensor quantize_per_tensor_tensor_qparams(
     const Tensor& scale,
     const Tensor& zero_point,
     ScalarType dtype) {
-  auto quantizer = make_per_tensor_affine_quantizer(scale.item().toDouble(), zero_point.item().toLong(), dtype);
+  TORCH_CHECK_VALUE(
+      !scale.is_complex(), "quantize_per_tensor: scale must be real-valued");
+  TORCH_CHECK_VALUE(
+      !zero_point.is_complex(),
+      "quantize_per_tensor: zero_point must be real-valued");
+  auto quantizer = make_per_tensor_affine_quantizer(
+      scale.item().toDouble(), zero_point.item().toLong(), dtype);
   return quantizer->quantize(self);
 }
 

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -150,6 +150,17 @@ class TestQuantizedTensor(TestCase):
         y_q = torch.quantize_per_tensor(x, 0.1, 10, torch.quint4x2)
         self.assertTrue(torch.equal(x_q, y_q))
 
+    def test_quantize_per_tensor_rejects_complex_qparams(self):
+        x = torch.randn(2, 2)
+        with self.assertRaisesRegex(ValueError, "scale must be real-valued"):
+            torch.quantize_per_tensor(
+                x, torch.tensor(1 + 0j), torch.tensor(0), torch.qint8
+            )
+        with self.assertRaisesRegex(ValueError, "zero_point must be real-valued"):
+            torch.quantize_per_tensor(
+                x, torch.tensor(1.0), torch.tensor(0 + 0j), torch.qint8
+            )
+
     def test_per_tensor_qtensor_to_memory_format(self):
         n = np.random.randint(1, 10)
         c = np.random.randint(2, 10)


### PR DESCRIPTION
Complex qparams were  getting cast to scalars instead of being caught, so this makes sure they're validated and rejected with a clear error first.

> Prepared with OpenAI Codex.
>
> Fixes #137468.
>
> Complex tensor scale and zero_point arguments were converted to scalars before validation. Reject them with `ValueError` before conversion.
>
> Test Plan:
>
> `python test/test_quantization.py TestQuantizedTensor.test_quantize_per_tensor_rejects_complex_qparams -v`
>
> `python test/test_quantization.py TestQuantizedTensor -q`
>
> `spin quicklint`
