### PR TITLE
[ROCm] Update rocm preview version to 21st August wheel

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -216,7 +216,7 @@ case "$tag" in
   pytorch-linux-noble-rocm-preview-py3)
     ANACONDA_PYTHON_VERSION=3.12
     GCC_VERSION=13
-    ROCM_VERSION=10.1.0a20260818
+    ROCM_VERSION=10.1.0a20260821
     THEROCK_INDEX_URL="https://rocm.nightlies.amd.com/whl-multi-arch/"
     USE_MSLK=0
     TRITON=yes

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -216,7 +216,7 @@ case "$tag" in
   pytorch-linux-noble-rocm-preview-py3)
     ANACONDA_PYTHON_VERSION=3.12
     GCC_VERSION=13
-    ROCM_VERSION=10.1.0a20260805
+    ROCM_VERSION=10.1.0a20260819
     THEROCK_INDEX_URL="https://rocm.nightlies.amd.com/whl-multi-arch/"
     USE_MSLK=0
     TRITON=yes

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -216,7 +216,7 @@ case "$tag" in
   pytorch-linux-noble-rocm-preview-py3)
     ANACONDA_PYTHON_VERSION=3.12
     GCC_VERSION=13
-    ROCM_VERSION=10.1.0a20260819
+    ROCM_VERSION=10.1.0a20260818
     THEROCK_INDEX_URL="https://rocm.nightlies.amd.com/whl-multi-arch/"
     USE_MSLK=0
     TRITON=yes

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -8,6 +8,8 @@ install_ubuntu() {
     apt-get install -y --no-install-recommends kmod libc++1 libc++abi1
     # FIXME: Needed for rocSHMEM in ROCm7.14 since it had a dependency on libnuma.so
     apt-get install -y libnuma-dev
+    # AOTriton configure calls pkg_search_module(liblzma); liblzma-dev provides the .pc file.
+    apt-get install -y --no-install-recommends liblzma-dev
 
     install_rocm
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -10784,8 +10784,7 @@ class TestCudaAutocast(TestAutocast):
                 _ = torch.ones(10)
 
 
-# ROCm runtime HIPRTC issue currently being fixed (AIRUNTIME-2707).
-@skipIfRocmVersionAtLeast([10, 1])
+@unittest.skipIf(torch.version.rocm == "10.1.0", "HIPRTC issue (AIRUNTIME-2707)")
 class TestCompileKernel(TestCase):
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel(self):
@@ -11317,8 +11316,7 @@ class TestCompileKernel(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):
-    # ROCm runtime HIPRTC issue currently being fixed (AIRUNTIME-2707).
-    @skipIfRocmVersionAtLeast([10, 1])
+    @unittest.skipIf(torch.version.rocm == "10.1.0", "HIPRTC issue (AIRUNTIME-2707)")
     @skipIfRocmVersionLessThan((7, 0))
     @skipCUDAIf(
         not SM70OrLater, "Compute capability >= SM70 required for relaxed ptx flag"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -10784,6 +10784,8 @@ class TestCudaAutocast(TestAutocast):
                 _ = torch.ones(10)
 
 
+# ROCm runtime HIPRTC issue currently being fixed (AIRUNTIME-2707).
+@skipIfRocmVersionAtLeast([10, 1])
 class TestCompileKernel(TestCase):
     @unittest.skipIf(not TEST_CUDA, "No CUDA")
     def test_compile_kernel(self):
@@ -11315,6 +11317,8 @@ class TestCompileKernel(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):
+    # ROCm runtime HIPRTC issue currently being fixed (AIRUNTIME-2707).
+    @skipIfRocmVersionAtLeast([10, 1])
     @skipIfRocmVersionLessThan((7, 0))
     @skipCUDAIf(
         not SM70OrLater, "Compute capability >= SM70 required for relaxed ptx flag"


### PR DESCRIPTION
## Summary
- Set the ROCm preview package to `10.1.0a20260821`.
- Install `liblzma-dev` in Ubuntu ROCm images. AOTriton 0.13 needs this package during configure (`pkg_search_module(liblzma)`).
- Skip `TestCompileKernel` and `test_graph_external_wait_and_record` on ROCm 10.1 and later. These tests fail in HIPRTC. The ROCm runtime issue is under investigation and fix ([AIRUNTIME-2707](https://amd-hub.atlassian.net/browse/AIRUNTIME-2707)).

## Test plan
- [x] Run `ciflow/rocm-preview` on this PR.
- [x] Confirm the preview build completes.
- [x] Confirm the HIPRTC tests above are skipped on ROCm 10.1+.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang