### PR TITLE
Refresh release runner groups when a release tag is pushed

### DIFF
--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -1,17 +1,5 @@
 name: Refresh release runner groups
 
-# Release binaries build from tags, and the self-hosted runner groups they need
-# are allow-listed per exact ref. That allow-list is reconciled by
-# pytorch/test-infra, which cannot see a tag push in this repo -- so tell it.
-#
-# Without this, a freshly cut RC is not authorized for the release runner groups
-# and every one of its build jobs queues indefinitely with no error, until
-# somebody notices and dispatches the reconcile by hand. That happened on
-# v2.14.0-rc2: https://github.com/pytorch/pytorch/actions/runs/31597398139
-#
-# This must exist on the branch the tag is cut from, since a tag build runs the
-# workflow as of the tagged commit. Cherry-pick it to release branches.
-
 on:
   push:
     tags:
@@ -23,17 +11,8 @@ permissions:
 
 jobs:
   dispatch:
-    # A fork has neither the token nor any business reconciling pytorch's
-    # runner groups.
     if: github.repository_owner == 'pytorch'
-    # GH_PYTORCHBOT_TOKEN is an environment secret; the job only sees it if it
-    # declares the environment. Note pytorchbot-env restricts which refs may
-    # deploy to it, and the tag patterns currently allow-listed there do not
-    # cover GA tags or rc>=10 on a two-digit minor (e.g. v2.14.0, v2.14.0-rc10).
-    # Those pushes fail here until v2.??.? and v2.??.?-rc?? are added to the
-    # environment's deployment tag policies.
     environment: pytorchbot-env
-    # Never gate this on the very runner groups it exists to unblock.
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch test-infra reconcile
@@ -41,8 +20,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           set -euo pipefail
-          # Dispatched on main, not at this tag: the reconcile discovers the new
-          # tag itself, and it only exists in test-infra's default branch.
           gh workflow run release-manage-runner-groups.yml \
             --repo pytorch/test-infra \
             --ref main \

--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -1,0 +1,43 @@
+name: Refresh release runner groups
+
+# Release binaries build from tags, and the self-hosted runner groups they need
+# are allow-listed per exact ref. That allow-list is reconciled by
+# pytorch/test-infra, which cannot see a tag push in this repo -- so tell it.
+#
+# Without this, a freshly cut RC is not authorized for the release runner groups
+# and every one of its build jobs queues indefinitely with no error, until
+# somebody notices and dispatches the reconcile by hand. That happened on
+# v2.14.0-rc2: https://github.com/pytorch/pytorch/actions/runs/31597398139
+#
+# This must exist on the branch the tag is cut from, since a tag build runs the
+# workflow as of the tagged commit. Cherry-pick it to release branches.
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    # Never gate this on the very runner groups it exists to unblock.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch test-infra reconcile
+        env:
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Dispatched on main, not at this tag: the reconcile discovers the new
+          # tag itself, and it only exists in test-infra's default branch.
+          gh workflow run release-manage-runner-groups.yml \
+            --repo pytorch/test-infra \
+            --ref main \
+            --field apply=true
+          echo "Dispatched runner-group reconcile for ${GITHUB_REF}." \
+            >> "${GITHUB_STEP_SUMMARY}"
+          echo "Runs: https://github.com/pytorch/test-infra/actions/workflows/release-manage-runner-groups.yml" \
+            >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -23,6 +23,9 @@ permissions:
 
 jobs:
   dispatch:
+    # A fork has neither the token nor any business reconciling pytorch's
+    # runner groups.
+    if: github.repository_owner == 'pytorch'
     # Never gate this on the very runner groups it exists to unblock.
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -26,6 +26,13 @@ jobs:
     # A fork has neither the token nor any business reconciling pytorch's
     # runner groups.
     if: github.repository_owner == 'pytorch'
+    # GH_PYTORCHBOT_TOKEN is an environment secret; the job only sees it if it
+    # declares the environment. Note pytorchbot-env restricts which refs may
+    # deploy to it, and the tag patterns currently allow-listed there do not
+    # cover GA tags or rc>=10 on a two-digit minor (e.g. v2.14.0, v2.14.0-rc10).
+    # Those pushes fail here until v2.??.? and v2.??.?-rc?? are added to the
+    # environment's deployment tag policies.
+    environment: pytorchbot-env
     # Never gate this on the very runner groups it exists to unblock.
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Release binaries build from **tags**, and the self-hosted runner groups they need are allow-listed per **exact ref** by a reconcile job in [pytorch/test-infra](https://github.com/pytorch/test-infra/actions/workflows/release-manage-runner-groups.yml). That job cannot observe a tag push in this repo, so today the allow-list only refreshes when an unrelated change lands in test-infra, or when somebody dispatches it by hand.

When it is stale, a freshly cut RC is not authorized for the release runner groups and its build jobs **queue indefinitely, with no error**.

That is what happened to `v2.14.0-rc2`. It was tagged at 12:36 UTC; all 7 `mt-rel-*` jobs of its [docker-release run](https://github.com/pytorch/pytorch/actions/runs/31597398139) were still queued ~2h later. The allow-list still pinned `v2.14.0-rc1`, because the last reconcile had run the previous evening — before rc2 existed. A test-infra dry run confirmed the exact gap:

```
Target refs: [... 'refs/tags/v2.14.0-rc2', ...]
Discovered 9 release workflow(s) on pytorch/pytorch@v2.14.0-rc2
    + .../docker-release.yml@refs/tags/v2.14.0-rc2
    - .../docker-release.yml@refs/tags/v2.14.0-rc1
```

## What this does

On a release tag push, dispatch the test-infra reconcile. It is dispatched on test-infra's `main` rather than at this tag — the reconcile discovers the new tag itself via `git/matching-refs`, and the workflow only exists on that default branch.

Design points worth noting:

- **`runs-on: ubuntu-latest`** — deliberately GitHub-hosted, so this is never gated by the very runner groups it exists to unblock.
- **Tag filters match `create_release.yml` and `docker-release.yml`** (`v[0-9]+.[0-9]+.[0-9]+` and the `-rc[0-9]+` form), so it fires for exactly the tags that build release binaries, and not for `ciflow/*` tags.
- **A failed dispatch fails the job**, surfacing in the tag's checks, rather than silently leaving the queue stuck — which is the failure mode this is meant to eliminate.
- **`permissions: contents: read`**; the cross-repo call uses `GH_PYTORCHBOT_TOKEN`.

## Two things reviewers should check

**1. Token scope.** This uses `secrets.GH_PYTORCHBOT_TOKEN`, which is already used cross-repo here — `nightly.yml` and `weekly.yml` pass it to the commit-hash-update action targeting other org repos. If it is a classic PAT with `repo` scope it can already dispatch test-infra workflows and no new secret is needed, but **I could not verify its scopes**. Someone who can should confirm `actions: write` on `pytorch/test-infra` before relying on this. If it turns out to be insufficient, the alternative is a narrowly scoped app token.

**2. This does nothing for 2.14 until cherry-picked.** A tag build runs the workflow as of the tagged commit, so landing here only covers tags cut from `main`. For `v2.14.0-rc3` to be covered it must be on `release/2.14` before rc3 is cut. @atalman is handling that cherry-pick.

## Related

pytorch/test-infra#8510 adds an hourly poll on the test-infra side. The two are complementary rather than redundant: this hook is the fast path (~1-2 min), and the poll is the backstop for tags cut from branches that do not carry this workflow, for manual runner-group edits drifting, and for reconcile-script changes.

## Test plan

`lintrunner` ACTIONLINT clean (pinned actionlint via `.lintbin`). The dispatch path cannot be exercised before merge, since tag-triggered workflows do not run from a PR ref — it will first execute on the next release tag cut from a branch carrying it.