### PR TITLE
[dynamo] Fix ActivationCheckpointingViaTags test_pattern_matcher with a fresh Inductor cache

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1937,7 +1937,6 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         res = opt_fn(x, [y, z])
         self.assertEqual(ref, res)
 
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/3393")
     @requires_gpu_and_triton
     def test_pattern_matcher(self, device):
         # Check that the sdpa op is recomputed in the backward graph
@@ -1969,6 +1968,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         # Save the AOT graphs
         aot_graphs = []
         from torch._inductor import compile_fx
+        from torch._inductor.utils import fresh_cache
 
         def debug_compile_fx_inner(graph, example_inputs, *args, **kwargs):
             aot_graphs.append(graph)
@@ -1979,7 +1979,10 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
         )
 
         opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
-        opt_fn(*args1).sum().backward()
+        # A warm FX-graph cache short-circuits inner_compile, leaving aot_graphs
+        # empty; use a fresh cache so the hook always runs.
+        with fresh_cache():
+            opt_fn(*args1).sum().backward()
 
         fwd_graph = aot_graphs[0]
         # Determine which fused attention backend is expected based on the


### PR DESCRIPTION
## Summary

`test_pattern_matcher` in `test/dynamo/test_activation_checkpointing.py` captures the AOT forward graph by installing an `inner_compile` hook that appends to a local `aot_graphs` list:

    def debug_compile_fx_inner(graph, example_inputs, *args, **kwargs):
        aot_graphs.append(graph)
        return compile_fx.compile_fx_inner(graph, example_inputs, *args, **kwargs)
    ...
    opt_fn(*args1).sum().backward()
    fwd_graph = aot_graphs[0]

On a warm FX-graph cache the compiled artifact is loaded from the cache and `compile_fx_inner` is never invoked, so `aot_graphs` stays empty and `aot_graphs[0]` raises:

    fwd_graph = aot_graphs[0]
    IndexError: list index out of range

This makes the test order/cache dependent: it passes with a cold cache and fails on any subsequent run against a warm cache.

## Fix

Run the compiled function inside `torch._inductor.utils.fresh_cache()` so the `inner_compile` hook always fires and `aot_graphs` is populated regardless of prior cache state. This matches the isolation other graph-inspecting tests use.

Since the underlying failure is resolved, the `@skipIfXpu(msg=".../issues/3393")` marker is removed.

## Test plan

- `python test/dynamo/test_activation_checkpointing.py -k test_pattern_matcher`
- Verified the test passes with both a cold and a warm Inductor cache (previously the warm-cache run failed with the `IndexError` above).

Fixes intel/torch-xpu-ops#3393

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98