### PR TITLE
[Test][XPU] Enable XPU for `test_autocast.py`

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -474,8 +474,10 @@ class TestTorchAutocastDevice(TestCase):
             (out2.mean() + out4.mean()).backward()
 
 
-instantiate_device_type_tests(TestAutocastDevice, globals(), allow_mps=True)
-instantiate_device_type_tests(TestTorchAutocastDevice, globals())
+instantiate_device_type_tests(
+    TestAutocastDevice, globals(), allow_mps=True, allow_xpu=True
+)
+instantiate_device_type_tests(TestTorchAutocastDevice, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
- add `allow_xpu=True` to both `instantiate_device_type_tests` calls

Before: 19 passed,  5 skipped
After:  26 passed,  7 skipped
\----------------------------
Delta:  +7 passed, +2 skipped

Newly passing tests:
- TestAutocastDeviceXPU::test_autocast_prioritize_xpu
- TestAutocastDeviceXPU::test_cache_disabled_xpu
- TestAutocastDeviceXPU::test_cast_cache_is_global_xpu
- TestTorchAutocastDeviceXPU::test_autocast_caching_still_works_with_gradients_xpu
- TestTorchAutocastDeviceXPU::test_autocast_inference_mode_interaction_xpu
- TestTorchAutocastDeviceXPU::test_autocast_mixed_grad_contexts_xpu
- TestTorchAutocastDeviceXPU::test_autocast_nograd_caching_issue_158232_xpu

Newly skipped tests (expected as these are MPS only tests):
- TestAutocastDeviceXPU::test_mps_autocast_bfloat16_supported_xpu
- TestAutocastDeviceXPU::test_mps_autocast_error_message_xpu

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5