### PR TITLE
Fix opaque constant corruption when graph has tensor-subclass outputs

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3,8 +3,13 @@
 import contextlib
 import enum
 import gc
+import os
 import random
 import re
+import subprocess
+import sys
+import tempfile
+import textwrap
 import unittest
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -51,7 +56,9 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.graph import _illegal_char_regex
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    IS_FBCODE,
     IS_LINUX,
+    IS_SANDCASTLE,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import (
@@ -2528,6 +2535,136 @@ class GraphModule(torch.nn.Module):
         self.assertIsNotNone(x.grad)
         expected_grad = torch.ones_like(x) * 2.5
         self.assertTrue(torch.allclose(x.grad, expected_grad))
+
+    def test_opaque_constant_output_with_subclass_output(self):
+        """Constant-type opaque created inside a compiled region must not be
+        corrupted when the same graph also produces a tensor-subclass output.
+        """
+        a = torch.randn(3, 3, requires_grad=True)
+        b = torch.randn(3, 3, requires_grad=True)
+        counter = Counter(start=1, end=5)
+        size = SizeStore(3)
+        x = TensorWithCounter(a, b, counter, size)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.cfgs = []
+                self.w = torch.nn.Parameter(torch.randn(3, 3))
+
+            def forward(self, x):
+                cfg = ValueConfig("square")
+                self.cfgs.append(cfg)
+                return x * self.w
+
+        m = M()
+        opt_m = torch.compile(m, backend="aot_eager", fullgraph=True)
+        result = opt_m(x)
+
+        # Without the fix: type(m.cfgs[0]) is FakeScriptObject
+        self.assertIs(type(m.cfgs[0]), ValueConfig)
+        self.assertEqual(m.cfgs[0].mode, "square")
+        self.assertIsInstance(result, TensorWithCounter)
+
+    @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")
+    def test_opaque_constant_output_with_subclass_output_cache_hit(self):
+        """Cross-process FX graph cache hit must not lose opaque constants
+        when the graph also produces a tensor-subclass output.
+        """
+        script = textwrap.dedent(
+            """
+            import torch
+            from torch._library.opaque_object import register_custom_class
+            from torch._inductor import config
+            from torch._dynamo.utils import counters
+
+            config.fx_graph_cache = True
+            config.fx_graph_remote_cache = False
+
+            class Q:
+                def __init__(self, scale):
+                    self.scale = scale
+                def __eq__(self, other):
+                    return type(other) is Q and other.scale == self.scale
+                def __hash__(self):
+                    return hash(self.scale)
+                def __fx_repr__(self):
+                    return (f"Q({self.scale!r})", {"Q": Q})
+
+            register_custom_class(Q, typ="constant")
+
+            class WS(torch.Tensor):
+                @staticmethod
+                def __new__(cls, data, q):
+                    return torch.Tensor._make_wrapper_subclass(
+                        cls, data.shape, dtype=data.dtype, device=data.device
+                    )
+                def __init__(self, data, q):
+                    self._data, self._q = data, q
+                def __tensor_flatten__(self):
+                    return ["_data"], {"q": self._q}
+                @staticmethod
+                def __tensor_unflatten__(inner, ctx, size, stride):
+                    return WS(inner["_data"], ctx["q"])
+                @classmethod
+                def __torch_dispatch__(cls, func, types, args, kwargs=None):
+                    from torch.utils._pytree import tree_map
+                    def unwrap(t):
+                        return t._data if isinstance(t, WS) else t
+                    return func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs or {}))
+
+            class M(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.qs = []
+                    self.ws = None
+                    self.w = torch.nn.Parameter(torch.randn(8, 8))
+                def forward(self, x):
+                    if not self.qs:
+                        q = Q(0.5)
+                        self.qs.append(q)
+                    else:
+                        q = self.qs[0]
+                    out = x @ self.w
+                    self.ws = WS(out, q)
+                    return out
+
+            m = M()
+            c = torch.compile(m, fullgraph=True)
+            with torch.no_grad():
+                c(torch.randn(4, 8))
+            hit = counters["inductor"]["fxgraph_cache_hit"]
+            miss = counters["inductor"]["fxgraph_cache_miss"]
+            cfg_type = type(m.qs[0]).__name__ if m.qs else "empty"
+            print(f"RESULT hit={hit} miss={miss} cfg_type={cfg_type}")
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = os.environ.copy()
+            env["TORCHINDUCTOR_CACHE_DIR"] = tmpdir
+            env["PYTHONPATH"] = os.pathsep.join(
+                x for x in (os.getcwd(), env.get("PYTHONPATH", "")) if x
+            )
+
+            def run_and_parse():
+                out = subprocess.check_output(
+                    [sys.executable, "-c", script],
+                    env=env,
+                    stderr=subprocess.STDOUT,
+                ).decode()
+                for line in out.splitlines():
+                    if line.startswith("RESULT "):
+                        return line
+                self.fail(f"No RESULT line in subprocess output:\n{out}")
+
+            # Run 1: populate cache (cold compile)
+            line1 = run_and_parse()
+            self.assertEqual(line1, "RESULT hit=0 miss=1 cfg_type=Q")
+
+            # Run 2: cache hit in a fresh process, opaque must survive
+            line2 = run_and_parse()
+            self.assertEqual(line2, "RESULT hit=1 miss=0 cfg_type=Q")
 
     def test_tensor_subclass_opaque_backward_compiled_autograd(self):
         """Test opaque objects work with compiled autograd backward."""

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -2536,7 +2536,8 @@ class GraphModule(torch.nn.Module):
         expected_grad = torch.ones_like(x) * 2.5
         self.assertTrue(torch.allclose(x.grad, expected_grad))
 
-    def test_opaque_constant_output_with_subclass_output(self):
+    @parametrize("backend", ["aot_eager", "inductor"])
+    def test_opaque_constant_output_with_subclass_output(self, backend):
         """Constant-type opaque created inside a compiled region must not be
         corrupted when the same graph also produces a tensor-subclass output.
         """
@@ -2549,21 +2550,18 @@ class GraphModule(torch.nn.Module):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.cfgs = []
                 self.w = torch.nn.Parameter(torch.randn(3, 3))
 
             def forward(self, x):
                 cfg = ValueConfig("square")
-                self.cfgs.append(cfg)
-                return x * self.w
+                return x * self.w, cfg
 
         m = M()
-        opt_m = torch.compile(m, backend="aot_eager", fullgraph=True)
-        result = opt_m(x)
+        opt_m = torch.compile(m, backend=backend, fullgraph=True)
+        result, cfg = opt_m(x)
 
-        # Without the fix: type(m.cfgs[0]) is FakeScriptObject
-        self.assertIs(type(m.cfgs[0]), ValueConfig)
-        self.assertEqual(m.cfgs[0].mode, "square")
+        # Without the fix: type(cfg) is FakeScriptObject
+        self.assertIs(type(cfg), ValueConfig)
         self.assertIsInstance(result, TensorWithCounter)
 
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Skip in fbcode/sandcastle")

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -309,13 +309,23 @@ def unwrap_tensor_subclasses(
     def _maybe_fakeify_opaque(v: Any) -> Any:
         # Registered opaque types need to be wrapped as FakeScriptObject for
         # compile-time FX tracing (proxy slot tracking, hashability, etc.).
+        # Exception: non-hoisted constant-type opaques are inlined as literals
+        # (matching VariableBuilder and PythonKeyTracer behavior), so
+        # fakeifying them would inject a FakeScriptObject that downstream
+        # layers do not expect and cannot unwrap without extra codegen.
         if isinstance(v, CustomClassBase):
             from torch._guards import detect_fake_mode
             from torch._library.fake_class_registry import maybe_to_fake_obj
-            from torch._library.opaque_object import is_custom_class
+            from torch._library.opaque_object import (
+                is_custom_class,
+                is_opaque_constant_type,
+                should_hoist,
+            )
 
             fake_mode = detect_fake_mode()
             if fake_mode is not None and is_custom_class(type(v)):
+                if is_opaque_constant_type(type(v)) and not should_hoist(type(v)):
+                    return v
                 return maybe_to_fake_obj(fake_mode, v)
         return v
 

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -12,8 +12,17 @@ import torch
 import torch.utils._pytree as pytree
 from torch import SymInt, Tensor
 from torch._custom_class_base import CustomClassBase
-from torch._library.fake_class_registry import maybe_unwrap_fake_script_object
-from torch._library.opaque_object import is_opaque_symbolic_type
+from torch._guards import detect_fake_mode
+from torch._library.fake_class_registry import (
+    maybe_to_fake_obj,
+    maybe_unwrap_fake_script_object,
+)
+from torch._library.opaque_object import (
+    is_custom_class,
+    is_opaque_constant_type,
+    is_opaque_symbolic_type,
+    should_hoist,
+)
 from torch._subclasses.fake_tensor import get_plain_tensors
 from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_eq
 from torch.types import IntLikeType
@@ -310,18 +319,11 @@ def unwrap_tensor_subclasses(
         # Registered opaque types need to be wrapped as FakeScriptObject for
         # compile-time FX tracing (proxy slot tracking, hashability, etc.).
         # Exception: non-hoisted constant-type opaques are inlined as literals
-        # (matching VariableBuilder and PythonKeyTracer behavior), so
-        # fakeifying them would inject a FakeScriptObject that downstream
-        # layers do not expect and cannot unwrap without extra codegen.
+        # by the tracing layers that produce the FX graph (VariableBuilder._wrap,
+        # track_tensor_tree's wrap_with_proxy, TracerBase.create_arg), so they
+        # must stay real here too -- fakeifying would route them through
+        # torchbind_constants and return a FakeScriptObject at runtime.
         if isinstance(v, CustomClassBase):
-            from torch._guards import detect_fake_mode
-            from torch._library.fake_class_registry import maybe_to_fake_obj
-            from torch._library.opaque_object import (
-                is_custom_class,
-                is_opaque_constant_type,
-                should_hoist,
-            )
-
             fake_mode = detect_fake_mode()
             if fake_mode is not None and is_custom_class(type(v)):
                 if is_opaque_constant_type(type(v)) and not should_hoist(type(v)):


### PR DESCRIPTION
Repro
```bash
# Cold compile
python repro.py

# Cache hit
TORCHINDUCTOR_CACHE_DIR=/tmp/repro_cache python repro.py  # populate
TORCHINDUCTOR_CACHE_DIR=/tmp/repro_cache python repro.py  # hit
```

```python
import torch
from torch._library.opaque_object import register_custom_class

class Q:
    def __init__(self, scale):
        self.scale = scale
        self.internal = False

    def __eq__(self, other):
        return type(other) is Q and other.scale == self.scale

    def __hash__(self):
        return hash(self.scale)

    def __fx_repr__(self):
        return (f"Q({self.scale!r})", {"Q": Q})


register_custom_class(Q, typ="constant")


class WS(torch.Tensor):
    @staticmethod
    def __new__(cls, data, q):
        return torch.Tensor._make_wrapper_subclass(
            cls, data.shape, dtype=data.dtype, device=data.device
        )

    def __init__(self, data, q):
        self._data, self._q = data, q

    def __tensor_flatten__(self):
        return ["_data"], {"q": self._q}

    @staticmethod
    def __tensor_unflatten__(inner, ctx, size, stride):
        return WS(inner["_data"], ctx["q"])

    @classmethod
    def __torch_dispatch__(cls, func, types, args, kwargs=None):
        from torch.utils._pytree import tree_map
        unwrap = lambda t: t._data if isinstance(t, WS) else t
        return func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs or {}))


class M(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.qs = []
        self.ws = None
        self.w = torch.nn.Parameter(torch.randn(8, 8))

    def forward(self, x):
        if not self.qs:
            q = Q(0.5)
            self.qs.append(q)
        else:
            q = self.qs[0]

        out = x @ self.w
        self.ws = WS(out, q)  # subclass output triggers the bug
        return out


m = M()
c = torch.compile(m, fullgraph=True)

print("=== Step 1: no_grad forward ===")
with torch.no_grad():
    result = c(torch.randn(4, 8))

print(f"qs after step1: {m.qs}")
print(f"type(qs[0]): {type(m.qs[0]) if m.qs else 'empty'}")
# Expected: Q(scale=0.5)

print("\n=== Step 2: grad forward (should trigger recompile) ===")
try:
    result2 = c(torch.randn(4, 8, requires_grad=True))
    print("step2 ok")
except Exception as e:
    print(f"step2 FAILED: {type(e).__name__}: {e}")
```


## Problem

When a compiled region creates a constant-type opaque object (registered via `register_custom_class(typ="constant")`) and the same graph also produces a tensor-subclass output, the opaque constant was returned corrupted as `FakeScriptObject` instead of the real object.

## Root Cause

`_maybe_fakeify_opaque` in `unwrap_tensor_subclasses` (subclass_utils.py) wraps ALL opaque types as `FakeScriptObject` unconditionally. This is correct for symbolic-type opaques (they need proxy slot tracking), but wrong for non-hoisted constant-type opaques — the tracing layers that produce the FX graph keep them real:

| Layer | Behavior for constant opaques |
|---|---|
| `VariableBuilder._wrap` | `fake_script_obj = value` (keeps real) |
| `track_tensor_tree` / `wrap_with_proxy` | `set_meta` only, no proxy slot |
| `TracerBase.create_arg` | returns real object directly |
| `CustomClassObjectVariable.as_proxy` | returns real object (not a Proxy) |
| `_maybe_fakeify_opaque` **(bug)** | wraps as FakeScriptObject |

The fakeification causes the constant opaque to be interned as a `get_attr` node (since `FakeScriptObject` is in `_constant_attribute_types`), stored in Inductor's `torchbind_constants`, and returned as `FakeScriptObject` at runtime.

## Fix

Skip fakeification for non-hoisted constant-type opaques in `_maybe_fakeify_opaque`, matching the behavior of all sibling layers. The constant opaque stays real, gets inlined as a literal via `__fx_repr__`, and is never routed through `torchbind_constants`.

## DTensor Safety

DTensor's `Placement`/`Shard`/`Replicate`/`Partial`/`_StridedShard`/`_MaskPartial` are all registered as non-hoisted constant-type opaques (`placement_types.py:_register_placements_as_opaque`). However, they **cannot reach `_maybe_fakeify_opaque`**:

1. `DTensor.__tensor_flatten__()` returns `(["_local_tensor", "device_mesh"], (placements, tensor_meta, ...))` — placements are in the **ctx** tuple, not in `inner_keys`
2. `flatten_subclass` only iterates over `inner_keys` (the first element) and discards the ctx: `attrs, _ = t.__tensor_flatten__()`
3. Even if a constant-type opaque were somehow placed in `inner_keys`, `create_subclass_metadata` explicitly rejects it with a `RuntimeError` (only symbolic opaques are allowed in tensor attrs)
4. `DeviceMesh` (the one opaque that IS an inner key of DTensor) is registered as `typ="symbolic"`, so the narrowing does not apply to it

CI covers the DTensor compile path (`test/distributed/tensor/test_dtensor_compile.py`, `test/distributed/tensor/test_dtensor.py`).

## Enums

`Enum` is registered as a non-hoisted constant type (`opaque_object.py:300`), so `is_opaque_constant_type` is True for enum members. However, enums **cannot reach `_maybe_fakeify_opaque`**: `VariableBuilder._wrap` routes them through the `isinstance(value, enum.Enum)` branch (builder.py) which returns a `UserDefinedObjectVariable`, and `is_safe_constant` lists `enum.Enum` so codegen emits `LOAD_CONST` — the enum is burned into bytecode and never becomes an FX graph output.

## Test Plan

```
python test/test_opaque_obj_v2.py TestOpaqueObject.test_opaque_constant_output_with_subclass_output -v
python test/test_opaque_obj_v2.py TestOpaqueObject.test_opaque_constant_output_with_subclass_output_cache_hit -v
python test/test_opaque_obj_v2.py -v
```

- `test_opaque_constant_output_with_subclass_output` — end-to-end: constant opaque returned as a direct graph output alongside a subclass tensor output, parametrized over aot_eager/inductor, verifies `type(cfg) is ValueConfig` (exact type check that fails for FakeScriptObject)
- `test_opaque_constant_output_with_subclass_output_cache_hit` — cross-process cache hit: verifies the constant opaque survives a cache round-trip

This PR was authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo