### PR TITLE
[inductor] Skip layout optimization for MPS training graphs

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 
 import torch
+from torch._inductor import config as inductor_config
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
@@ -195,11 +196,9 @@ class MPSBasicTests(TestCase):
             check_gradient=True,
         )
 
+    @inductor_config.patch(layout_optimization=True, force_layout_optimization=False)
     def test_layout_opt_skipped_for_conv_training(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/192551:
-        # MPS convolution_backward is much slower on channels_last inputs, so
-        # layout optimization must stay off for training graphs while staying
-        # available for inference graphs.
+        # Regression test for https://github.com/pytorch/pytorch/issues/192551
         from torch._inductor.graph import GraphLowering
         from torch.fx.experimental.proxy_tensor import make_fx
 
@@ -214,6 +213,7 @@ class MPSBasicTests(TestCase):
         gm = make_fx(fn)(x, w)
 
         self.assertFalse(GraphLowering.decide_layout_opt(gm, is_inference=False))
+        # inference must keep layout opt
         self.assertTrue(GraphLowering.decide_layout_opt(gm, is_inference=True))
 
     def test_cholesky(self):

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -195,6 +195,27 @@ class MPSBasicTests(TestCase):
             check_gradient=True,
         )
 
+    def test_layout_opt_skipped_for_conv_training(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/192551:
+        # MPS convolution_backward is much slower on channels_last inputs, so
+        # layout optimization must stay off for training graphs while staying
+        # available for inference graphs.
+        from torch._inductor.graph import GraphLowering
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(x, w):
+            return torch.ops.aten.convolution.default(
+                x, w, None, [1, 1], [1, 1], [1, 1], False, [0, 0], 1
+            )
+
+        # channels > 64 so no other decide_layout_opt heuristic fires
+        x = torch.rand(8, 128, 32, 32, device=self.device)
+        w = torch.rand(128, 128, 3, 3, device=self.device)
+        gm = make_fx(fn)(x, w)
+
+        self.assertFalse(GraphLowering.decide_layout_opt(gm, is_inference=False))
+        self.assertTrue(GraphLowering.decide_layout_opt(gm, is_inference=True))
+
     def test_cholesky(self):
         def fn(x):
             return (

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -817,12 +817,10 @@ class GraphLowering(torch.fx.Interpreter):
         ):
             return True
 
-        # MPS convolution_backward is roughly an order of magnitude slower on
-        # channels_last inputs than on contiguous ones at common shapes, so a
-        # training graph pays that penalty for every convolution. Forward
-        # convolution on MPS is faster with channels_last, so inference keeps
-        # the heuristics below. https://github.com/pytorch/pytorch/issues/192551
-        if not is_inference and all(
+        # MPS convolution_backward is much slower on channels_last inputs, so
+        # skip layout opt for training graphs; forward convolution prefers
+        # channels_last, so inference keeps the heuristics below.
+        if not is_inference and any(
             n.args[idx].meta["val"].device.type == "mps"
             for n in conv_nodes
             for idx in [0, 1]

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -817,6 +817,19 @@ class GraphLowering(torch.fx.Interpreter):
         ):
             return True
 
+        # MPS convolution_backward is roughly an order of magnitude slower on
+        # channels_last inputs than on contiguous ones at common shapes, so a
+        # training graph pays that penalty for every convolution. Forward
+        # convolution on MPS is faster with channels_last, so inference keeps
+        # the heuristics below. https://github.com/pytorch/pytorch/issues/192551
+        if not is_inference and all(
+            n.args[idx].meta["val"].device.type == "mps"
+            for n in conv_nodes
+            for idx in [0, 1]
+        ):
+            log.debug("Skip layout opt for MPS training graph")
+            return False
+
         # Following models are skipped due to this:
         # jx_nest_base
         # volo_d1_224


### PR DESCRIPTION
Fixes #192551

## Problem

Compiled conv-net training on MPS runs 4-5x slower than eager. `decide_layout_opt` in `torch/_inductor/graph.py` enables channels_last for graphs containing convolutions using heuristics derived from CUDA benchmarks (the code carries a `TODO - get different values per hardware`), and it has no MPS branch. MPS `convolution_backward` is roughly an order of magnitude slower on channels_last inputs than on contiguous ones at common shapes (measured in #192551: 12.8x at input `(256,24,32,32)`, weight `(24,24,3,3)`, bf16), so a compiled training step pays that penalty for every convolution.

## Fix

Skip layout optimization when the graph is a training graph and the convolution inputs are on MPS.

Inference deliberately keeps the existing heuristics: forward convolution on MPS is *faster* with channels_last (0.48 ms vs 0.94 ms at the issue's 32x32 shape per the issue's measurements), and inference graphs never run `convolution_backward`. An alternative — MPS-specific multipliers in the inference weighted-flop heuristic — was not taken because there is no MPS benchmark corpus to derive such constants from; the training skip follows the direct `convolution_backward` measurements in the issue. The channels_last penalty inside MPS `convolution_backward` itself is a separate kernel-level bug, tracked in #193349 (root cause: the 2D backward has no channels_last graph path and strided inputs go through MPSGraph's slow gather/scatter); this PR does not address it, and the gate here stays correct even once it is fixed, since channels_last backward remains slower than contiguous at the measured shapes.

## Results

Apple Silicon, macOS, torch 2.14 nightly wheel with this patch applied. The issue's training benchmark (bf16 autocast, SGD step); each config in a fresh process with a fresh inductor cache; before = unpatched, after = this PR:

| shape | eager | compiled before | compiled after |
|---|---|---|---|
| 8x8 b256 | 6.24 ms | 9.09 ms (1.46x) | 3.01 ms (0.47x) |
| 16x16 b256 | 6.59 ms | 29.40 ms (4.46x) | 5.41 ms (0.84x) |
| 24x24 b128 | 7.14 ms | 32.73 ms (4.59x) | 5.89 ms (0.82x) |
| 32x32 b128 | 11.22 ms | 57.12 ms (5.09x) | 8.78 ms (0.78x) |
| 32x32 b256 | 22.48 ms | 113.61 ms (5.05x) | 15.47 ms (0.69x) |

Compiled goes from 1.5-5x slower than eager to faster than eager at every shape, matching the issue's `TORCHINDUCTOR_LAYOUT_OPTIMIZATION=0` table. fp32 (no autocast) at 32x32 b256: 121.53 ms -> 25.37 ms compiled (4.58x slower -> 0.96x). Forward-only inference on the same net is byte-for-byte unaffected (layout opt stays on): 5.14 ms before vs 5.15 ms after, both ~0.7x of eager.

`decide_layout_opt` driven directly: MPS training graph -> `False`, same graph as inference -> `True`, CPU training graph -> `True` (unchanged).

## Test Plan

New regression test in `test/inductor/test_mps_basic.py` asserts `decide_layout_opt` returns `False` for an MPS conv training graph and `True` for the same graph as inference. It fails without the fix and passes with it.

```
python test/inductor/test_mps_basic.py -k test_layout_opt_skipped_for_conv_training
python test/inductor/test_mps_basic.py   # full file: Ran 62 tests, OK
```

---

This PR was authored with AI assistance (Claude Code). The diff, benchmarks, and tests were reviewed and run locally by the submitter.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @malfet @DenisVieriu97 @jhavukainen @Isalia20 @eellison @eyupcanakman

🤖 Generated with [Claude Code](https://claude.com/claude-code)

