### PR TITLE
[ONNX] Keep while_loop RNN decompositions during the decomposition step

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -387,6 +387,42 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         self.assertEqual(onnx_program.model.graph.inputs[0].shape[1].value, "time")
         onnx_testing.assert_onnx_program(onnx_program, args=(torch.randn(2, 7, 4),))
 
+    @common_utils.parametrize("rnn_class", [torch.nn.LSTM, torch.nn.GRU])
+    def test_dynamic_shape_manual_bidirectional_rnn(self, rnn_class):
+        def reverse(x, mask):
+            positions = torch.ones_like(mask, dtype=torch.long).cumsum(dim=1) - 1
+            lengths = (~mask).to(dtype=torch.long).sum(dim=1).unsqueeze(1)
+            source = torch.where(
+                positions < lengths, lengths - 1 - positions, positions
+            ).clamp_min(0)
+            return x.gather(1, source.unsqueeze(-1).expand_as(x))
+
+        class ManualBidirectionalRnn(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.forward_rnn = rnn_class(4, 3, batch_first=True)
+                self.backward_rnn = rnn_class(4, 3, batch_first=True)
+
+            def forward(self, x, mask):
+                forward, _ = self.forward_rnn(x)
+                backward, _ = self.backward_rnn(reverse(x, mask))
+                return torch.cat((forward, reverse(backward, mask)), dim=-1)
+
+        time = torch.export.Dim("time")
+        onnx_program = self.export(
+            ManualBidirectionalRnn(),
+            (torch.randn(2, 5, 4), torch.zeros(2, 5, dtype=torch.bool)),
+            input_names=["x", "mask"],
+            dynamic_shapes={"x": {1: time}, "mask": {1: time}},
+            optimize=False,
+        )
+        # The sequence length of the RNN output must not be specialized to 5
+        self.assertEqual(onnx_program.model.graph.outputs[0].shape[1].value, "time")
+        onnx_testing.assert_onnx_program(
+            onnx_program,
+            args=(torch.randn(2, 7, 4), torch.zeros(2, 7, dtype=torch.bool)),
+        )
+
     def test_export_with_specialized_input_during_tracing(self):
         class Model(torch.nn.Module):
             def forward(self, x, y):

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -58,8 +58,14 @@ def _patch_dynamo_unsupported_functions():
 
 
 @contextlib.contextmanager
-def _patch_dynamic_shape_rnn_decompositions(dynamic_shapes):
-    if not dynamic_shapes:
+def patch_dynamic_shape_rnn_decompositions(dynamic: object):
+    """Use while_loop based RNN decompositions when the model has dynamic shapes.
+
+    The default LSTM/GRU decompositions unroll the sequence loop in Python, which
+    specializes the sequence length to the example input length. ``dynamic`` is any
+    value that is truthy when the model is exported with dynamic shapes.
+    """
+    if not dynamic:
         yield
         return
 
@@ -176,7 +182,7 @@ class TorchExportStrictStrategy(CaptureStrategy):
     ) -> torch.export.ExportedProgram:
         with (
             _patch_dynamo_unsupported_functions(),
-            _patch_dynamic_shape_rnn_decompositions(dynamic_shapes),
+            patch_dynamic_shape_rnn_decompositions(dynamic_shapes),
             # Support the dynamism with 0/1 input dim
             torch.fx.experimental._config.patch(backed_size_oblivious=True),  # type: ignore[attr-defined]
         ):
@@ -232,7 +238,7 @@ class TorchExportNonStrictStrategy(CaptureStrategy):
         self, model, args, kwargs, dynamic_shapes
     ) -> torch.export.ExportedProgram:
         with (
-            _patch_dynamic_shape_rnn_decompositions(dynamic_shapes),
+            patch_dynamic_shape_rnn_decompositions(dynamic_shapes),
             # Support the dynamism with 0/1 input dim
             torch.fx.experimental._config.patch(backed_size_oblivious=True),  # type: ignore[attr-defined]
         ):

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -1045,6 +1045,12 @@ def _prepare_exported_program_for_export(
     with (
         # Support the dynamism with 0/1 input dim
         torch.fx.experimental._config.patch(backed_size_oblivious=True),  # type: ignore[attr-defined]
+        # RNN ops are preserved for ONNX, but decomposition retraces the graph and
+        # recomputes their meta values. Keep the while_loop based decompositions so
+        # that dynamic sequence lengths are not specialized to the example length.
+        _capture_strategies.patch_dynamic_shape_rnn_decompositions(
+            exported_program.range_constraints
+        ),
     ):
         # Decompose the graph given the implemented torch ops in ONNX
         exported_program = _fx_passes.decompose_with_registry(


### PR DESCRIPTION
Reopen of #191881

## Summary

`torch.onnx.export(dynamo=True)` froze the example sequence length into the ONNX graph for a manual bidirectional LSTM/GRU, so the model only ran at the export-time length (`invalid expand shape` in ORT otherwise).

The `while_loop` based LSTM/GRU decompositions are registered only around the capture step. Step 2 (`_prepare_exported_program_for_export` -> `run_decompositions`) retraces the graph and recomputes meta for the preserved `aten::lstm`/`aten::gru` nodes with the default Python-loop decomposition, which specializes the time dim back to the example length:

```
x         (s59, s27, 16)
lstm      [(s59, 6, 8), ...]   # time dim specialized during run_decompositions
expand_1  (s59, 6, 8)          # expand_as(rnn_out) emits Concat(Shape(x,0:1), [6], [8])
```

Only patterns that consume the RNN output's shape (here `expand_as` on the reversed backward output) surface the bug; a bare RNN never reads the bad shape, which is why the control cases pass.

Changes:

- **`_capture_strategies.py`**: rename `_patch_dynamic_shape_rnn_decompositions` to `patch_dynamic_shape_rnn_decompositions` so it can be reused outside capture; document what it guards against.
- **`_core.py`**: wrap `decompose_with_registry` in the same context, gated on `exported_program.range_constraints` so static exports keep their current decomposition path.
- **`test_small_models_e2e.py`**: parameterized LSTM/GRU regression test asserting the output time dim stays symbolic and that the exported model runs at a different sequence length.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes #191855

cc @titaiwangms