### PR TITLE
[CUDA] Speed up torch.isin for large test_elements

### DIFF
--- a/aten/src/ATen/native/cuda/TensorCompare.cpp
+++ b/aten/src/ATen/native/cuda/TensorCompare.cpp
@@ -1,6 +1,17 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorCompare.h>
+#include <cmath>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/isin_native.h>
+#include <ATen/ops/result_type.h>
+#include <ATen/ops/searchsorted.h>
+#include <ATen/ops/where.h>
+#endif
 
 namespace at::native {
 
@@ -16,8 +27,64 @@ void isin_default_kernel_gpu(
             : elements.unsqueeze(-1).eq(test_elements.view(bc_shape)).any(-1));
 }
 
+// Sorts test_elements, then binary-searches each element into it and checks
+// the value it lands on for an exact match.
+void isin_sorting(
+    const Tensor& elements,
+    const Tensor& test_elements,
+    bool invert,
+    const Tensor& out) {
+  // Empty test_elements is routed to the brute-force kernel.
+  TORCH_INTERNAL_ASSERT(test_elements.numel() > 0);
+  const ScalarType common_dtype = at::result_type(elements, test_elements);
+  Tensor elements_flat = elements.to(common_dtype).ravel();
+  Tensor test_elements_flat = test_elements.to(common_dtype).ravel();
+  // NaNs in the haystack derail searchsorted's binary search, as every
+  // comparison against a NaN is false. Overwriting each with an existing
+  // non-NaN element is sound, since a NaN never compares equal to anything.
+  if (isFloatingType(common_dtype)) {
+    Tensor nan_mask = test_elements_flat.isnan();
+    Tensor replacement_index = nan_mask.to(kByte).argmin();
+    test_elements_flat = at::where(
+        nan_mask,
+        test_elements_flat.index_select(0, replacement_index),
+        test_elements_flat);
+  }
+  Tensor sorted_test_elements = std::get<0>(test_elements_flat.sort());
+  Tensor indices = at::searchsorted(sorted_test_elements, elements_flat);
+  indices.clamp_(0, sorted_test_elements.numel() - 1);
+  Tensor candidates = sorted_test_elements.index_select(0, indices);
+  Tensor mask =
+      invert ? candidates.ne(elements_flat) : candidates.eq(elements_flat);
+  out.copy_(mask.view_as(out));
+}
+
 } // anonymous namespace
 
 REGISTER_CUDA_DISPATCH(isin_default_stub, &isin_default_kernel_gpu)
+
+// assume_unique is unused because neither path relies on uniqueness.
+TORCH_IMPL_FUNC(isin_Tensor_Tensor_out_cuda)
+(const Tensor& elements,
+ const Tensor& test_elements,
+ bool /*assume_unique*/,
+ bool invert,
+ const Tensor& out) {
+  if (elements.numel() == 0) {
+    return;
+  }
+
+  // Heuristic taken from numpy's implementation. Kept separate from the CPU
+  // copy so the two sorting paths can be tuned independently.
+  // See
+  // https://github.com/numpy/numpy/blob/fb215c76967739268de71aa4bda55dd1b062bc2e/numpy/lib/arraysetops.py#L575
+  if (test_elements.numel() <
+      static_cast<int64_t>(
+          10.0f * std::pow(static_cast<double>(elements.numel()), 0.145))) {
+    isin_default_stub(kCUDA, elements, test_elements, invert, out);
+  } else {
+    isin_sorting(elements, test_elements, invert, out);
+  }
+}
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3118,7 +3118,8 @@
   variants: function
   structured: True
   dispatch:
-    CPU, CUDA, XPU: isin_Tensor_Tensor_out
+    CPU, XPU: isin_Tensor_Tensor_out
+    CUDA: isin_Tensor_Tensor_out_cuda
     MPS: isin_Tensor_Tensor_out_mps
 
 - func: isin.Tensor_Tensor(Tensor elements, Tensor test_elements, *, bool assume_unique=False, bool invert=False) -> Tensor

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -1317,6 +1317,23 @@ class TestSortAndSelectDevice(TestCase):
                     c = torch.isin(a, b, invert=invert, assume_unique=assume_unique)
                     self.assertEqual(c, ec)
 
+    @dtypes(*floating_types_and(torch.half, torch.bfloat16))
+    @parametrize("invert", [False, True])
+    def test_isin_nan(self, device, dtype, invert):
+        elements = torch.tensor([1.0, nan, 2.0, 5.0], device=device, dtype=dtype)
+        cases = [
+            ([nan, 1.0, 2.0], [True, False, True, False]),
+            ([nan] * 200 + [1.0, 2.0], [True, False, True, False]),
+            ([nan] * 200, [False] * 4),
+        ]
+        for test_values, expected_values in cases:
+            test_elements = torch.tensor(test_values, device=device, dtype=dtype)
+            expected = torch.tensor(expected_values, device=device)
+            if invert:
+                expected = expected.logical_not()
+            actual = torch.isin(elements, test_elements, invert=invert)
+            self.assertEqual(actual, expected)
+
     def test_isin_different_dtypes(self, device):
         supported_types = all_types() if device == "cpu" else all_types_and(torch.half)
         for mult in [1, 10]:


### PR DESCRIPTION
Closes #193196

## Summary

For large `test_elements`, `torch.isin` currently uses the generic sorting implementation, which computes `unique()` over both inputs, concatenates them, and stable-sorts the combined tensor.

This PR adds a CUDA-specific implementation for `isin.Tensor_Tensor_out`. The existing broadcast path is retained below the current size threshold. Above the threshold, the CUDA implementation instead sorts only `test_elements` and uses `searchsorted` to find candidate matches for `elements`.

This avoids the `unique()` operations, concatenation, and stable sort over the combined inputs.

The new path promotes both inputs to a common dtype and supports non-contiguous inputs. Floating-point `test_elements` containing NaNs are handled before sorting so that they do not produce false membership matches. The CUDA implementation does not rely on either input being unique, so the same path is used with `assume_unique=True`.

Tests cover NaN-containing `test_elements` across floating-point dtypes and both `invert` modes, including the sorting path and all-NaN inputs.

### Performance

Benchmarked on:

- GPU: NVIDIA RTX 4090
- CUDA: 12.8
- Baseline: `c00fc93`
- Benchmark commit: `8873114`
- Timing: `torch.utils.benchmark.Timer.blocked_autorange(min_run_time=1.0)`, median

Across the 14-case core N/M sweep, the new path shows a **4.28× geometric mean speedup**, with individual cases ranging from **2.34× to 11.71×**.

| elements | test_elements | main | PR | speedup |
| ---: | ---: | ---: | ---: | ---: |
| 1K | 1K | 0.213 ms | 0.063 ms | 3.38× |
| 10K | 1K | 0.267 ms | 0.063 ms | 4.24× |
| 100K | 1K | 0.290 ms | 0.065 ms | 4.46× |
| 1M | 1K | 0.499 ms | 0.065 ms | 7.68× |
| 10M | 1K | 8.341 ms | 0.712 ms | 11.71× |
| 100K | 10K | 0.332 ms | 0.098 ms | 3.39× |
| 1M | 10K | 0.539 ms | 0.109 ms | 4.94× |
| 10M | 10K | 8.329 ms | 0.766 ms | 10.87× |
| 1M | 100K | 0.566 ms | 0.190 ms | 2.98× |
| 100K | 100K | 0.351 ms | 0.100 ms | 3.51× |
| 1M | 1M | 0.766 ms | 0.328 ms | 2.34× |
| 10M | 1M | 8.763 ms | 2.057 ms | 4.26× |
| 1K | 1M | 0.427 ms | 0.180 ms | 2.37× |
| 10K | 1M | 0.475 ms | 0.180 ms | 2.64× |

Additional cases cover the dispatch boundary, dtypes, duplicate density, `assume_unique`, and non-contiguous inputs:

| case | main | PR | speedup |
| --- | ---: | ---: | ---: |
| boundary `m=64` | 0.330 ms | 0.330 ms | 1.00× |
| boundary `m=80` | 0.500 ms | 0.075 ms | 6.67× |
| int32 | 0.405 ms | 0.145 ms | 2.79× |
| float32 | 0.405 ms | 0.168 ms | 2.41× |
| float64 | 0.587 ms | 0.222 ms | 2.64× |
| duplicates, 1M × 100K | 0.437 ms | 0.184 ms | 2.38× |
| duplicate-heavy, 1M × 10M | 1.993 ms | 3.620 ms | **0.55×** |
| `assume_unique=True` | 0.236 ms | 0.187 ms | 1.26× |
| strided `elements` | 0.585 ms | 0.197 ms | 2.97× |
| strided `test_elements` | 0.606 ms | 0.192 ms | 3.16× |

`m=64` stays on the existing broadcast path and is unchanged. `m=80` crosses the current size threshold and uses the new sorting path.

The `1M × 10M` duplicate-heavy case is a known regression. The existing implementation benefits from its `unique()` step when `test_elements` contains relatively few distinct values, while the new CUDA path sorts `test_elements` directly without deduplication. This tradeoff is accepted in favor of the speedups seen across the broader input-size sweep.

<details>
<summary>Benchmark script</summary>

```python
import torch
import torch.utils.benchmark as benchmark

DEVICE = "cuda"
MIN_RUN_TIME = 1.0


def make_inputs(n, m, dtype=torch.int64, mode="distinct"):
    if mode == "distinct":
        high = 100 * max(n, m)

        if dtype == torch.float32:
            high = min(high, 2**24)
        elif dtype == torch.float64:
            high = min(high, 2**53)
        elif dtype == torch.int32:
            high = min(high, 2**31 - 1)

        elements = torch.randint(
            0, high, (n,), device=DEVICE, dtype=torch.int64
        ).to(dtype)
        test_elements = torch.randint(
            0, high, (m,), device=DEVICE, dtype=torch.int64
        ).to(dtype)

    elif mode == "duplicates":
        high = max(max(n, m) // 100, 2)

        elements = torch.randint(
            0, high, (n,), device=DEVICE, dtype=torch.int64
        )
        test_elements = torch.randint(
            0, high, (m,), device=DEVICE, dtype=torch.int64
        )

    elif mode == "unique":
        span = 2 * max(n, m)

        elements = torch.randperm(span, device=DEVICE)[:n]
        test_elements = torch.randperm(span, device=DEVICE)[:m]

    else:
        raise ValueError(f"unknown mode: {mode}")

    return elements, test_elements


def make_strided_inputs(n, m, which):
    high = 100 * max(n, m)

    if which == "elements":
        elements = torch.randint(
            0, high, (2 * n,), device=DEVICE, dtype=torch.int64
        )[::2]

        test_elements = torch.randint(
            0, high, (m,), device=DEVICE, dtype=torch.int64
        )

    elif which == "test_elements":
        elements = torch.randint(
            0, high, (n,), device=DEVICE, dtype=torch.int64
        )

        test_elements = torch.randint(
            0, high, (2 * m,), device=DEVICE, dtype=torch.int64
        )[::2]

    else:
        raise ValueError(which)

    return elements, test_elements


CASES = [
    # Core N/M sweep
    ("1K x 1K", 1_000, 1_000, torch.int64, "distinct", False, None),
    ("10K x 1K", 10_000, 1_000, torch.int64, "distinct", False, None),
    ("100K x 1K", 100_000, 1_000, torch.int64, "distinct", False, None),
    ("1M x 1K", 1_000_000, 1_000, torch.int64, "distinct", False, None),
    ("10M x 1K", 10_000_000, 1_000, torch.int64, "distinct", False, None),

    ("100K x 10K", 100_000, 10_000, torch.int64, "distinct", False, None),
    ("1M x 10K", 1_000_000, 10_000, torch.int64, "distinct", False, None),
    ("10M x 10K", 10_000_000, 10_000, torch.int64, "distinct", False, None),
    ("1M x 100K", 1_000_000, 100_000, torch.int64, "distinct", False, None),

    ("100K x 100K", 100_000, 100_000, torch.int64, "distinct", False, None),
    ("1M x 1M", 1_000_000, 1_000_000, torch.int64, "distinct", False, None),
    ("10M x 1M", 10_000_000, 1_000_000, torch.int64, "distinct", False, None),

    ("1K x 1M", 1_000, 1_000_000, torch.int64, "distinct", False, None),
    ("10K x 1M", 10_000, 1_000_000, torch.int64, "distinct", False, None),

    # Dispatch boundary
    ("boundary m=64", 1_000_000, 64, torch.int64, "distinct", False, None),
    ("boundary m=80", 1_000_000, 80, torch.int64, "distinct", False, None),

    # Dtypes
    ("int32", 1_000_000, 100_000, torch.int32, "distinct", False, None),
    ("float32", 1_000_000, 100_000, torch.float32, "distinct", False, None),
    ("float64", 1_000_000, 100_000, torch.float64, "distinct", False, None),

    # Input characteristics
    ("duplicates", 1_000_000, 100_000, torch.int64, "duplicates", False, None),
    (
        "large dup test",
        1_000_000,
        10_000_000,
        torch.int64,
        "duplicates",
        False,
        None,
    ),
    ("assume_unique", 1_000_000, 100_000, torch.int64, "unique", True, None),

    # Layout
    ("strided elem", 1_000_000, 100_000, torch.int64, None, False, "elements"),
    (
        "strided test",
        1_000_000,
        100_000,
        torch.int64,
        None,
        False,
        "test_elements",
    ),
]


def main():
    if not torch.cuda.is_available():
        raise RuntimeError("CUDA is required")

    torch.manual_seed(0)
    torch.cuda.manual_seed_all(0)

    print(f"PyTorch: {torch.__version__}")
    print(f"Commit:  {torch.version.git_version}")
    print(f"CUDA:    {torch.version.cuda}")
    print(f"GPU:     {torch.cuda.get_device_name(0)}")
    print()

    torch.empty(1, device=DEVICE)
    torch.cuda.synchronize()

    print(
        f"{'case':<19} {'elements':>12} {'test_elements':>14} "
        f"{'dtype':>10} {'median':>12}"
    )
    print("-" * 73)

    for label, n, m, dtype, mode, assume_unique, strided in CASES:
        if strided is not None:
            elements, test_elements = make_strided_inputs(n, m, strided)
        else:
            elements, test_elements = make_inputs(n, m, dtype, mode)

        for _ in range(3):
            torch.isin(
                elements,
                test_elements,
                assume_unique=assume_unique,
            )

        torch.cuda.synchronize()

        result = benchmark.Timer(
            stmt="torch.isin(elements, test_elements, assume_unique=assume_unique)",
            globals={
                "torch": torch,
                "elements": elements,
                "test_elements": test_elements,
                "assume_unique": assume_unique,
            },
        ).blocked_autorange(min_run_time=MIN_RUN_TIME)

        print(
            f"{label:<19} {n:>12,} {m:>14,} "
            f"{str(dtype).removeprefix('torch.'):>10} "
            f"{result.median * 1e3:>9.3f} ms"
        )

        del elements, test_elements


if __name__ == "__main__":
    main()
```

</details>