### PR TITLE
[Eager] Add a CuTeDSL inner-tree nansum reduction override

### DIFF
--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -385,6 +385,19 @@ class TestSumCuteDSLOverride(TestCase):
             got = x.prod(dim=1)
         self.assertFalse(torch.equal(got, ref))
 
+    @skipIfRocm
+    def test_prod_output_hash(self):
+        cases = [
+            (torch.float32, 128, 8192, "37bd2a1dc47b71c5"),
+            (torch.float64, 8, 200000, "374e728d5c174437"),
+        ]
+        for dtype, m, n, expected in cases:
+            with self.subTest(dtype=dtype, m=m, n=n):
+                x = self._make_prod_input(m, n, dtype)
+                with self._inner_tree_flag():
+                    result = x.prod(dim=1)
+                self.assertEqual(self._sha(result), expected)
+
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_prod_low_precision_matches_aten(self, dtype):
         # 0.75 and 1.25 are exactly representable in fp16/bf16; a sparse set of
@@ -455,6 +468,159 @@ class TestSumCuteDSLOverride(TestCase):
         with self._inner_tree_flag():
             result = x.prod(dim=1)
         self.assertEqual(result, torch.ones(17, device="cuda", dtype=dtype))
+
+    # --- nansum (shares the inner-tree sum DAG after filtering loaded NaNs) ---
+
+    def _make_nansum_input(self, m, n, dtype):
+        compute_dtype = torch.float64 if dtype == torch.float64 else torch.float32
+        cols = torch.arange(n, device="cuda", dtype=compute_dtype).reshape(1, n)
+        rows = torch.arange(m, device="cuda", dtype=compute_dtype).reshape(m, 1)
+        values = (cols % 9) - 4 + (rows % 3) - 1
+        values[:, ::17] = float("nan")
+        return values.to(dtype)
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_nansum_override_matches_aten(self, dtype):
+        # Exact small integers keep every fp32 partial sum below 2**24, making
+        # the reference independent of its different reduction order.
+        for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_nansum_input(m, n, dtype)
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.nansum(x, dim=1)
+                with self._inner_tree_flag():
+                    got = torch.nansum(x, dim=1)
+                self.assertEqual(got, ref, rtol=0, atol=0)
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_nansum_matches_sum_of_nan_to_num(self, dtype):
+        view_dtype = torch.int32 if dtype == torch.float32 else torch.int64
+        for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_order_sensitive_input(m, n, dtype)
+                x[:, ::17] = float("nan")
+                zero = torch.zeros((), device=x.device, dtype=x.dtype)
+                with self._inner_tree_flag():
+                    got = torch.nansum(x, dim=1)
+                    expected = torch.sum(torch.where(torch.isnan(x), zero, x), dim=1)
+                self.assertTrue(
+                    torch.equal(got.view(view_dtype), expected.view(view_dtype))
+                )
+
+    def test_nansum_override_engaged(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_nansum_input(128, 8195, torch.float32)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.nansum(x, dim=1)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_nansum_into",
+                wraps=inner_tree_kernel.inner_tree_nansum_into,
+            ) as nansum_into,
+            self._inner_tree_flag(),
+        ):
+            got = torch.nansum(x, dim=1)
+        self.assertEqual(nansum_into.call_count, 1)
+        self.assertEqual(got, ref, rtol=0, atol=0)
+
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_nansum_low_precision_matches_aten(self, dtype):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        for m, n in [(64, 32), (8, 4096), (8, 65536)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_nansum_input(m, n, dtype)
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.nansum(x, dim=1)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_nansum_into",
+                        wraps=inner_tree_kernel.inner_tree_nansum_into,
+                    ) as nansum_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.nansum(x, dim=1)
+                self.assertEqual(nansum_into.call_count, 1)
+                self.assertEqual(got, ref, rtol=2e-2, atol=2e-2)
+
+    def test_nansum_override_out_variant(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        x[:, ::17] = float("nan")
+        with self._inner_tree_flag():
+            functional = torch.nansum(x, dim=1)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_nansum_into",
+                wraps=inner_tree_kernel.inner_tree_nansum_into,
+            ) as nansum_into,
+            self._inner_tree_flag(),
+        ):
+            returned = torch.nansum(x, dim=1, out=out)
+        self.assertEqual(nansum_into.call_count, 1)
+        self.assertIs(returned, out)
+        self.assertTrue(
+            torch.equal(out.view(torch.int32), functional.view(torch.int32))
+        )
+
+    def test_nansum_nan_to_zero(self):
+        n = 32769
+        x = torch.zeros(3, n, device="cuda", dtype=torch.float32)
+        x[0].fill_(float("nan"))
+        x[1, 0] = 1.0
+        x[1, 3:5] = float("nan")
+        x[1, 4097] = 2.0
+        x[1, 8191:8193] = float("nan")
+        x[1, -1] = -4.0
+        x[2, 0] = float("inf")
+        x[2, 1] = -float("inf")
+        x[2, 8192] = float("nan")
+        x[2, -1] = 1.0
+        with self._inner_tree_flag():
+            result = torch.nansum(x, dim=1)
+        self.assertEqual(result[0].view(torch.int32).item(), 0)
+        self.assertEqual(result[1].item(), -1.0)
+        self.assertTrue(torch.isnan(result[2]).item())
+
+    def test_nansum_unsupported_calls_fall_through(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_nansum_input(4, 32, torch.float32)
+        complex_x = torch.ones(4, 32, device="cuda", dtype=torch.complex64)
+        complex_x[:, ::17] = complex(float("nan"), 0.0)
+        cases = [
+            ("dim_none", x, {"dim": None}),
+            ("multi_dim", x.reshape(2, 2, 32), {"dim": (1, 2)}),
+            ("explicit_dtype", x, {"dim": 1, "dtype": torch.float64}),
+            ("noncontiguous", x[:, ::2], {"dim": 1}),
+            (
+                "integer",
+                torch.arange(128, device="cuda", dtype=torch.int64).reshape(4, 32),
+                {"dim": 1},
+            ),
+            ("complex", complex_x, {"dim": 1}),
+        ]
+        for name, input_, kwargs in cases:
+            with self.subTest(name=name):
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.nansum(input_, **kwargs)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_nansum_into",
+                        wraps=inner_tree_kernel.inner_tree_nansum_into,
+                    ) as nansum_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.nansum(input_, **kwargs)
+                self.assertEqual(nansum_into.call_count, 0)
+                self.assertEqual(got, ref, rtol=0, atol=0)
 
 
 instantiate_parametrized_tests(TestSumCuteDSLOverride)

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -1,4 +1,4 @@
-"""CuTeDSL override registrations for ``aten::sum`` / ``aten::prod`` (inner-tree).
+"""CuTeDSL overrides for ``aten::sum`` / ``aten::prod`` / ``aten::nansum``.
 
 CuTeDSL port of the Triton-style inner-tree reduction kernel that
 otherwise lives in ``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu``
@@ -8,14 +8,15 @@ is the feature-rollout gate for these operators -- it is *not* gated by the
 global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
 ``cutedsl_utils`` at registration time).
 
-We register four ATen dispatcher entries on ``CUDA``:
+We register six ATen dispatcher entries on ``CUDA``:
 
 * ``sum.dim_IntList`` / ``sum.IntList_out`` -- ``x.sum(dim=...)`` + ``.out``.
 * ``prod.dim_int`` / ``prod.int_out`` -- ``x.prod(dim=...)`` + ``.out``.
+* ``nansum`` / ``nansum.out`` -- ``x.nansum(dim=...)`` + ``.out``.
 
-sum/prod share the identical inner-tree geometry and eligibility; only the
-combiner (``+`` vs ``*``) and its identity (``0`` vs ``1``) differ, threaded
-through the kernel in ``inner_tree_kernel.py``.
+sum/prod/nansum share the identical inner-tree geometry and eligibility. Their
+combiner, identity, and optional per-element map are threaded through the kernel
+in ``inner_tree_kernel.py``.
 
 ``sum.dim_IntList`` is ``structured_delegate: sum.IntList_out``, so its
 delegation to the ``.out`` kernel happens *below* the dispatcher; overriding
@@ -175,6 +176,8 @@ def _geometry(self: torch.Tensor, out: torch.Tensor, it: TensorIterator):
 def _base_cond_ok(self: torch.Tensor, dim, dtype) -> int | None:
     """Shared front gate. Returns the normalized reduced dim if the call is a
     candidate, else ``None``."""
+    if dim is None:
+        return None
     if not _inner_tree_enabled():
         return None
     if not self.is_cuda or is_fake_tensor(self):
@@ -192,7 +195,7 @@ def _base_cond_ok(self: torch.Tensor, dim, dtype) -> int | None:
     return d
 
 
-def _cond(self, dim, keepdim=False, *, dtype=None) -> bool:
+def _cond(self, dim=None, keepdim=False, *, dtype=None) -> bool:
     d = _base_cond_ok(self, dim, dtype)
     if d is None:
         return False
@@ -200,7 +203,7 @@ def _cond(self, dim, keepdim=False, *, dtype=None) -> bool:
     return _eligibility(self, d, out) is not None
 
 
-def _out_cond(self, dim, keepdim=False, *, dtype=None, out) -> bool:
+def _out_cond(self, dim=None, keepdim=False, *, dtype=None, out) -> bool:
     d = _base_cond_ok(self, dim, dtype)
     if d is None:
         return False
@@ -227,6 +230,12 @@ def _prod_into():
     return inner_tree_prod_into
 
 
+def _nansum_into():
+    from .inner_tree_kernel import inner_tree_nansum_into
+
+    return inner_tree_nansum_into
+
+
 def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
     """Run ``reduce_into`` writing the reduction of ``self`` along ``d`` into
     the keepdim-shaped ``out_kd``. Caller has validated eligibility."""
@@ -242,7 +251,9 @@ def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
 
 
 def _make_impl(reduce_into):
-    def _impl(self, dim, keepdim=False, *, dtype=None):
+    def _impl(self, dim=None, keepdim=False, *, dtype=None):
+        if dim is None:
+            raise AssertionError("_cond guaranteed a non-None dim")
         d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
         out_kd = torch.empty(
             _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
@@ -254,7 +265,9 @@ def _make_impl(reduce_into):
 
 
 def _make_out_impl(reduce_into):
-    def _out_impl(self, dim, keepdim=False, *, dtype=None, out):
+    def _out_impl(self, dim=None, keepdim=False, *, dtype=None, out):
+        if dim is None:
+            raise AssertionError("_out_cond guaranteed a non-None dim")
         d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
         out_kd = _out_keepdim_view(self, d, keepdim, out)
         if out_kd is None:
@@ -269,7 +282,7 @@ def _make_out_impl(reduce_into):
 
 def register_to_dispatch() -> None:
     # Eligibility (_cond/_out_cond) is reduction-agnostic; only the kernel
-    # entry differs between sum and prod.
+    # entry differs among sum, prod, and nansum.
     cu.register_op_override(
         "aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_make_impl(_sum_into)
     )
@@ -285,4 +298,14 @@ def register_to_dispatch() -> None:
     )
     cu.register_op_override(
         "aten", "prod.int_out", "CUDA", cond=_out_cond, impl=_make_out_impl(_prod_into)
+    )
+    cu.register_op_override(
+        "aten", "nansum", "CUDA", cond=_cond, impl=_make_impl(_nansum_into)
+    )
+    cu.register_op_override(
+        "aten",
+        "nansum.out",
+        "CUDA",
+        cond=_out_cond,
+        impl=_make_out_impl(_nansum_into),
     )

--- a/torch/_native/ops/reductions/inner_tree_kernel.py
+++ b/torch/_native/ops/reductions/inner_tree_kernel.py
@@ -118,13 +118,21 @@ def _mul(a, b):
 
 
 class _Reduction(NamedTuple):
-    name: str  # aten op name ("sum" / "prod"); disambiguates the compile cache
+    name: str  # aten op name; disambiguates the compile cache
     op: Callable  # trace-time combiner: _add / _mul
     identity: float  # reduction identity: 0.0 for sum, 1.0 for prod
+    # Trace-time per-element map applied to each loaded value before the combiner.
+    pre: Callable | None = None
+
+
+def _nan_to_zero(v):
+    dtype = v.dtype
+    return dtype(cutlass.select_(v != v, dtype(0.0), v))
 
 
 _SUM = _Reduction("sum", _add, 0.0)
 _PROD = _Reduction("prod", _mul, 1.0)
+_NANSUM = _Reduction("nansum", _add, 0.0, pre=_nan_to_zero)
 
 
 # ---------------------------------------------------------------------------
@@ -185,12 +193,17 @@ def _warp_butterfly(val, op):
     return val
 
 
-def _load_vec_static(mIn, row, base: int, N: int, vec_size: int, acc, zero, op):
+def _load_vec_static(mIn, row, base: int, N: int, vec_size: int, acc, zero, op, pre):
     """Load + reduce one vector group with compile-time ``base`` (multirow)."""
     vals = []
     for i in range(vec_size):
         off = base + i
-        vals.append(acc(mIn[row, off]) if off < N else zero)
+        v = zero
+        if off < N:
+            v = acc(mIn[row, off])
+            if const_expr(pre is not None):
+                v = pre(v)
+        vals.append(v)
     return _reduce_vec(vals, vec_size, op)
 
 
@@ -204,6 +217,7 @@ def _load_vec_dyn(
     acc: cutlass.Constexpr,
     zero,
     op: cutlass.Constexpr,
+    pre: cutlass.Constexpr,
 ):
     """Load + reduce one vector group with a runtime ``base`` (warp paths).
 
@@ -219,6 +233,8 @@ def _load_vec_dyn(
         v = zero
         if off < Int32(N):
             v = acc(mIn[row, off])
+            if const_expr(pre is not None):
+                v = pre(v)
         vals.append(v)
     return _reduce_vec(vals, vec_size, op)
 
@@ -242,7 +258,15 @@ def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int, red: _Reduction):
             tree = []
             for load in cutlass.range_constexpr(num_loads):
                 val = _load_vec_static(
-                    mIn, row, load * vec_size, N, vec_size, acc, zero, red.op
+                    mIn,
+                    row,
+                    load * vec_size,
+                    N,
+                    vec_size,
+                    acc,
+                    zero,
+                    red.op,
+                    red.pre,
                 )
                 _streaming_push(tree, val, load, _MULTIROW_MAX_DEPTH, red.op)
             mOut[row] = out_dt(tree[0])
@@ -321,7 +345,9 @@ def _make_looped(
                 v = zero
                 if Int32(load) < this_batch_loads:
                     v = _warp_butterfly(
-                        _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero, red.op),
+                        _load_vec_dyn(
+                            mIn, row, base, N, vec_size, acc, zero, red.op, red.pre
+                        ),
                         red.op,
                     )
                 _streaming_push(tree, v, load, p.depth, red.op)
@@ -422,7 +448,9 @@ def _make_two_partial(
             v = zero
             if Int32(load) < this_batch_loads:
                 v = _warp_butterfly(
-                    _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero, red.op),
+                    _load_vec_dyn(
+                        mIn, row, base, N, vec_size, acc, zero, red.op, red.pre
+                    ),
                     red.op,
                 )
             _streaming_push(tree, v, load, p.depth, red.op)
@@ -642,7 +670,8 @@ def _inner_tree_reduce_into(
     out: torch.Tensor, src: torch.Tensor, red: _Reduction
 ) -> None:
     """Compute ``out[r] = reduce(src[r, :])`` for every row ``r`` in the
-    inner-tree order, where ``reduce`` is ``red`` (``sum`` or ``prod``).
+    inner-tree order, where ``reduce`` is ``red`` (``sum``, ``prod``, or
+    ``nansum``).
 
     ``src`` is a 2D ``(M, N)`` view with inner-dim stride 1 (outer row stride
     may differ from N); ``out`` is a 1D ``(M,)`` view (its stride may differ
@@ -702,3 +731,8 @@ def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
 def inner_tree_prod_into(out: torch.Tensor, src: torch.Tensor) -> None:
     """Row-wise inner-tree ``prod`` (see ``_inner_tree_reduce_into``)."""
     _inner_tree_reduce_into(out, src, _PROD)
+
+
+def inner_tree_nansum_into(out: torch.Tensor, src: torch.Tensor) -> None:
+    """Row-wise inner-tree ``nansum`` (see ``_inner_tree_reduce_into``)."""
+    _inner_tree_reduce_into(out, src, _NANSUM)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* #193205
* #193204
* #193203
* #193202
* #193201
* #193200
* __->__ #193199

Extends the inner-tree reduction engine to nansum: input NaNs are treated as 0
and reduced in the same bitwise inner-tree order as sum.

- _Reduction gains an optional `pre` hook: a trace-time per-element map applied
  to each loaded value before the combiner. sum/prod keep pre=None (a pure
  compile-time no-op) and remain BITWISE-IDENTICAL.
- _NANSUM = _Reduction("nansum", +, 0.0, pre=NaN->0). `pre` is applied only in
  the loaders (_load_vec_static/_load_vec_dyn), NOT in _make_two_accum, so
  arithmetic NaNs (e.g. +inf + -inf across partials) are preserved.
- Registers aten::nansum and aten::nansum.out, reusing the shared eligibility
  gate. dim=None / explicit dtype= / multi-dim / unsupported layout / integer /
  complex all fall through to ATen (dim=None default on _cond/_out_cond, which
  _base_cond_ok rejects as ineligible).

Test Plan:
- python test/python_native/test_sum_cutedsl.py -- 33/33 pass, incl:
  - bitwise nansum(x) == sum(nan_to_num(x, 0)) on ORDER-SENSITIVE fp32/fp64
    inputs across multirow/looped/two-kernel (proves nansum reuses sum's exact
    inner-tree DAG),
  - two-kernel-scale NaN handling: all-NaN row == +0.0 by bit pattern; a
    +inf/-inf/NaN row stays NaN (guards the _make_two_accum exclusion),
  - fp16/bfloat16 kernel-spy coverage; out= path spy + byte-equality,
  - dispatcher fallbacks (dim=None / dtype= / multi-dim / integer / complex).
- sum SHA (test_bitwise) and prod exact-output tests UNCHANGED -> sum/prod bytes
  are bit-for-bit preserved.

Note: drafted with AI assistance (Codex gpt-5.6-sol) under an orchestrated
plan -> implement -> 2x independent review -> fix -> GPU bitwise-validate loop;
human-reviewed before commit.