### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to nansum

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -49,11 +49,31 @@ PROD_CASES = (
     ("split_fp32", (8, 65536), 1, torch.float32),
 )
 
+# Split fp16/bf16 is excluded due to a pre-existing strict Triton compile hang
+# tracked separately, consistent with SUM_CASES/PROD_CASES.
+NANSUM_CASES = (
+    ("persistent_fp16", (64, 256), 1, torch.float16),
+    ("persistent_bf16", (64, 256), 1, torch.bfloat16),
+    ("persistent_fp32", (64, 256), 1, torch.float32),
+    ("persistent_fp64", (64, 256), 1, torch.float64),
+    ("looped_fp16", (8, 12000), 1, torch.float16),
+    ("looped_bf16", (8, 12000), 1, torch.bfloat16),
+    ("looped_fp32", (8, 12000), 1, torch.float32),
+    ("looped_fp64", (8, 12000), 1, torch.float64),
+    ("split_fp32", (8, 65536), 1, torch.float32),
+    ("split_fp64", (8, 65536), 1, torch.float64),
+)
+
 DYNAMIC_CASES = (("plan_change", (512, 65537), {}),)
 
 OUT_OF_SCOPE_CASES = (
     ("multidim", lambda z: torch.sum(z, (0, 1))),
     ("dtype", lambda z: torch.sum(z, 1, dtype=torch.float64)),
+)
+
+NANSUM_OUT_OF_SCOPE_CASES = (
+    ("dtype", lambda z: torch.nansum(z, 1, dtype=torch.float64)),
+    ("dim_none", lambda z: torch.nansum(z, dim=None)),
 )
 
 LAYOUT_CASES = (
@@ -163,10 +183,44 @@ class StrictNumericsTest(TestCase):
         if name.startswith("split"):
             self.assertEqual(code.count(INNER_TREE_CALL), 2)
 
+    def _make_nansum_input(self, shape, dtype, device):
+        # Standard-normal values keep magnitudes reasonable while making the
+        # reduction order observable.
+        x = torch.randn(*shape, device=device, dtype=dtype)
+        x[:, ::17] = torch.nan
+        return x.contiguous()
+
+    @parametrize("case", NANSUM_CASES, name_fn=lambda c: c[0])
+    def test_nansum_bitwise(self, device, case):
+        name, shape, dim, dtype = case
+        x = self._make_nansum_input(shape, dtype, device)
+
+        def fn(z):
+            return torch.nansum(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn(INNER_TREE_CALL, code)
+        if name.startswith("persistent"):
+            self.assertIn("@triton_heuristics.persistent_reduction(", code)
+        elif name.startswith("looped"):
+            self.assertIn("for r0_offset in", code)
+            self.assertEqual(code.count(INNER_TREE_CALL), 1)
+        else:
+            self.assertEqual(code.count(INNER_TREE_CALL), 2)
+
     def test_prod_out_of_scope_uses_default_order(self, device):
         # A dtype-casting prod is out of scope -> falls back to the default order.
         x = self._make_prod_input((64, 300), torch.float32, device)
         _, code = self._run(lambda z: torch.prod(z, 1, dtype=torch.float64), x)
+        self.assertNotIn(INNER_TREE_CALL, code)
+
+    @parametrize("case", NANSUM_OUT_OF_SCOPE_CASES, name_fn=lambda c: c[0])
+    def test_nansum_out_of_scope_uses_default_order(self, device, case):
+        _, fn = case
+        x = self._make_nansum_input((64, 300), torch.float32, device)
+        _, code = self._run(fn, x)
         self.assertNotIn(INNER_TREE_CALL, code)
 
     @parametrize("case", SUM_VARIANTS, name_fn=lambda c: c[0])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* #193205
* #193204
* #193203
* #193202
* #193201
* __->__ #193200
* #193199

nansum needs no new inductor codegen: it decomposes to
where(isnan(x), 0, x) -> aten.sum.dim_IntList, and the strict path already
routes that sum through INNER_TREE. The NaN->0 map becomes a per-element
prologue on the reduction's load, so the inner-tree order is unchanged; split
reductions apply it only in the first (source-reading) stage, so arithmetic
NaNs across partials are preserved; R0_BLOCK pinning and standalone-fusion
guards remain active.

Tests-only: add NANSUM_CASES bitwise checks (eager inner-tree nansum vs
compiled numerics="strict", compared bytewise) for persistent/looped across
fp16/bf16/fp32/fp64 and split for fp32/fp64, plus an out-of-scope fallback
(dtype=/dim=None -> default order). split fp16/bf16 are intentionally excluded
because they trigger a PRE-EXISTING strict Triton make_llir compile hang that
also affects sum/prod (only ever tested at split fp32/fp64) -- tracked
separately. sum/prod cases unchanged.

Test Plan: python test/inductor/test_strict_numerics.py -- 42 tests OK; nansum
bitwise eager==inductor-strict for all covered shapes. AI-assisted, human-reviewed.