### PR TITLE
[Eager] Add a CuTeDSL inner-tree mean reduction override

### DIFF
--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -622,6 +622,136 @@ class TestSumCuteDSLOverride(TestCase):
                 self.assertEqual(nansum_into.call_count, 0)
                 self.assertEqual(got, ref, rtol=0, atol=0)
 
+    # --- mean (sum DAG followed by one final division) ---
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_mean_matches_sum_over_n(self, dtype):
+        view_dtype = torch.int32 if dtype == torch.float32 else torch.int64
+        for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_order_sensitive_input(m, n, dtype)
+                with self._inner_tree_flag():
+                    got = torch.mean(x, dim=1)
+                    # IEEE true division (tensor/tensor, div.rn) to match the
+                    # kernel's divide-by-N. NOTE: `tensor / python_int` lowers to
+                    # reciprocal-multiply (sum * (1/n)) which differs by ~1 ULP.
+                    expected = torch.sum(x, dim=1) / torch.tensor(
+                        n, device=x.device, dtype=dtype
+                    )
+                self.assertTrue(
+                    torch.equal(got.view(view_dtype), expected.view(view_dtype))
+                )
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_mean_matches_aten(self, dtype):
+        rtol, atol = (1e-5, 1e-6) if dtype == torch.float32 else (1e-12, 1e-12)
+        for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_order_sensitive_input(m, n, dtype)
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.mean(x, dim=1)
+                with self._inner_tree_flag():
+                    got = torch.mean(x, dim=1)
+                self.assertEqual(got, ref, rtol=rtol, atol=atol)
+
+    def test_mean_override_engaged(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_mean_into",
+                wraps=inner_tree_kernel.inner_tree_mean_into,
+            ) as mean_into,
+            self._inner_tree_flag(),
+        ):
+            torch.mean(x, dim=1)
+        self.assertEqual(mean_into.call_count, 1)
+
+    def test_mean_override_out_variant(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        with self._inner_tree_flag():
+            functional = torch.mean(x, dim=1)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_mean_into",
+                wraps=inner_tree_kernel.inner_tree_mean_into,
+            ) as mean_into,
+            self._inner_tree_flag(),
+        ):
+            returned = torch.mean(x, dim=1, out=out)
+        self.assertEqual(mean_into.call_count, 1)
+        self.assertIs(returned, out)
+        self.assertTrue(
+            torch.equal(out.view(torch.int32), functional.view(torch.int32))
+        )
+
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_mean_low_precision_matches_aten(self, dtype):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        for m, n in [(64, 32), (8, 4096), (8, 65536)]:
+            with self.subTest(m=m, n=n):
+                x = self._make_order_sensitive_input(m, n, dtype)
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.mean(x, dim=1)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_mean_into",
+                        wraps=inner_tree_kernel.inner_tree_mean_into,
+                    ) as mean_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.mean(x, dim=1)
+                self.assertEqual(mean_into.call_count, 1)
+                self.assertEqual(got, ref, rtol=2e-2, atol=2e-2)
+
+    def test_mean_unsupported_calls_fall_through(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(4, 32, torch.float32)
+        cases = [
+            ("bare", x, {}),
+            ("explicit_dtype", x, {"dim": 1, "dtype": torch.float64}),
+            ("multi_dim", x.reshape(2, 2, 32), {"dim": (1, 2)}),
+            ("noncontiguous", x[:, ::2], {"dim": 1}),
+            ("complex", x.to(torch.complex64), {"dim": 1}),
+        ]
+        for name, input_, kwargs in cases:
+            with self.subTest(name=name):
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.mean(input_, **kwargs)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_mean_into",
+                        wraps=inner_tree_kernel.inner_tree_mean_into,
+                    ) as mean_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.mean(input_, **kwargs)
+                self.assertEqual(mean_into.call_count, 0)
+                self.assertEqual(got, ref, rtol=0, atol=0)
+
+        integer = torch.ones(4, 32, device="cuda", dtype=torch.int64)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_mean_into",
+                wraps=inner_tree_kernel.inner_tree_mean_into,
+            ) as mean_into,
+            self._inner_tree_flag(),
+            self.assertRaisesRegex(RuntimeError, "could not infer output dtype"),
+        ):
+            torch.mean(integer, dim=1)
+        self.assertEqual(mean_into.call_count, 0)
+
 
 instantiate_parametrized_tests(TestSumCuteDSLOverride)
 

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -1,4 +1,4 @@
-"""CuTeDSL overrides for ``aten::sum`` / ``aten::prod`` / ``aten::nansum``.
+"""CuTeDSL overrides for inner-tree ``sum``, ``prod``, ``nansum``, and ``mean``.
 
 CuTeDSL port of the Triton-style inner-tree reduction kernel that
 otherwise lives in ``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu``
@@ -8,14 +8,15 @@ is the feature-rollout gate for these operators -- it is *not* gated by the
 global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
 ``cutedsl_utils`` at registration time).
 
-We register six ATen dispatcher entries on ``CUDA``:
+We register eight ATen dispatcher entries on ``CUDA``:
 
 * ``sum.dim_IntList`` / ``sum.IntList_out`` -- ``x.sum(dim=...)`` + ``.out``.
 * ``prod.dim_int`` / ``prod.int_out`` -- ``x.prod(dim=...)`` + ``.out``.
 * ``nansum`` / ``nansum.out`` -- ``x.nansum(dim=...)`` + ``.out``.
+* ``mean.dim`` / ``mean.out`` -- ``x.mean(dim=...)`` + ``.out``.
 
-sum/prod/nansum share the identical inner-tree geometry and eligibility. Their
-combiner, identity, and optional per-element map are threaded through the kernel
+The reductions share identical inner-tree geometry and eligibility. Their
+combiner, identity, and optional pre/post maps are threaded through the kernel
 in ``inner_tree_kernel.py``.
 
 ``sum.dim_IntList`` is ``structured_delegate: sum.IntList_out``, so its
@@ -236,6 +237,12 @@ def _nansum_into():
     return inner_tree_nansum_into
 
 
+def _mean_into():
+    from .inner_tree_kernel import inner_tree_mean_into
+
+    return inner_tree_mean_into
+
+
 def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
     """Run ``reduce_into`` writing the reduction of ``self`` along ``d`` into
     the keepdim-shaped ``out_kd``. Caller has validated eligibility."""
@@ -282,7 +289,7 @@ def _make_out_impl(reduce_into):
 
 def register_to_dispatch() -> None:
     # Eligibility (_cond/_out_cond) is reduction-agnostic; only the kernel
-    # entry differs among sum, prod, and nansum.
+    # entry differs among sum, prod, nansum, and mean.
     cu.register_op_override(
         "aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_make_impl(_sum_into)
     )
@@ -308,4 +315,14 @@ def register_to_dispatch() -> None:
         "CUDA",
         cond=_out_cond,
         impl=_make_out_impl(_nansum_into),
+    )
+    cu.register_op_override(
+        "aten", "mean.dim", "CUDA", cond=_cond, impl=_make_impl(_mean_into)
+    )
+    cu.register_op_override(
+        "aten",
+        "mean.out",
+        "CUDA",
+        cond=_out_cond,
+        impl=_make_out_impl(_mean_into),
     )

--- a/torch/_native/ops/reductions/inner_tree_kernel.py
+++ b/torch/_native/ops/reductions/inner_tree_kernel.py
@@ -123,6 +123,8 @@ class _Reduction(NamedTuple):
     identity: float  # reduction identity: 0.0 for sum, 1.0 for prod
     # Trace-time per-element map applied to each loaded value before the combiner.
     pre: Callable | None = None
+    # Trace-time map applied once to the final reduced scalar before its store.
+    post: Callable | None = None
 
 
 def _nan_to_zero(v):
@@ -130,9 +132,14 @@ def _nan_to_zero(v):
     return dtype(cutlass.select_(v != v, dtype(0.0), v))
 
 
+def _divide_by_n(v, N):
+    return v / v.dtype(N)
+
+
 _SUM = _Reduction("sum", _add, 0.0)
 _PROD = _Reduction("prod", _mul, 1.0)
 _NANSUM = _Reduction("nansum", _add, 0.0, pre=_nan_to_zero)
+_MEAN = _Reduction("mean", _add, 0.0, post=_divide_by_n)
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +276,11 @@ def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int, red: _Reduction):
                     red.pre,
                 )
                 _streaming_push(tree, val, load, _MULTIROW_MAX_DEPTH, red.op)
-            mOut[row] = out_dt(tree[0])
+            result = tree[0]
+            if const_expr(red.post is not None):
+                assert red.post is not None  # noqa: S101
+                result = red.post(result, N)
+            mOut[row] = out_dt(result)
 
     @cute.jit
     def _launch(
@@ -370,6 +381,9 @@ def _make_looped(
         if row_active:
             if lane == Int32(0):
                 if warp_id == Int32(0):
+                    if const_expr(red.post is not None):
+                        assert red.post is not None  # noqa: S101
+                        final_sum = red.post(final_sum, N)
                     mOut[row] = out_dt(final_sum)
 
     @cute.jit
@@ -488,7 +502,7 @@ def _make_two_partial(
     return _launch
 
 
-def _make_two_accum(acc, out_dt, num_batches: int, red: _Reduction):
+def _make_two_accum(acc, out_dt, N: int, num_batches: int, red: _Reduction):
     @cute.kernel
     def _kernel(mPartials: cute.Tensor, mOut: cute.Tensor, num_outputs: Int32):
         tx, _, _ = cute.arch.thread_idx()
@@ -505,6 +519,9 @@ def _make_two_accum(acc, out_dt, num_batches: int, red: _Reduction):
             # kernel regardless of unroll.
             for b in cutlass.range(1, num_batches):
                 s = red.op(s, mPartials[base + b])
+            if const_expr(red.post is not None):
+                assert red.post is not None  # noqa: S101
+                s = red.post(s, N)
             mOut[row] = out_dt(s)
 
     @cute.jit
@@ -647,14 +664,16 @@ def _compile_two_partial(
 
 @instrumented_cutedsl_cache(
     lambda red, *a, **k: f"aten::{red.name}",
-    key_fn=lambda red, torch_dtype, num_batches: (
-        f"{red.name} two_accum {torch_dtype} batches={num_batches}"
+    key_fn=lambda red, torch_dtype, N, num_batches: (
+        f"{red.name} two_accum {torch_dtype} N={N} batches={num_batches}"
     ),
 )
-def _compile_two_accum(red: _Reduction, torch_dtype: torch.dtype, num_batches: int):
+def _compile_two_accum(
+    red: _Reduction, torch_dtype: torch.dtype, N: int, num_batches: int
+):
     out_dt = _TORCH_TO_CUTE[torch_dtype]
     acc = _acc_for(out_dt)
-    launcher = _make_two_accum(acc, out_dt, num_batches, red)
+    launcher = _make_two_accum(acc, out_dt, N, num_batches, red)
     return cute.compile(
         launcher,
         _fake_1d_contig(acc),
@@ -670,8 +689,8 @@ def _inner_tree_reduce_into(
     out: torch.Tensor, src: torch.Tensor, red: _Reduction
 ) -> None:
     """Compute ``out[r] = reduce(src[r, :])`` for every row ``r`` in the
-    inner-tree order, where ``reduce`` is ``red`` (``sum``, ``prod``, or
-    ``nansum``).
+    inner-tree order, where ``reduce`` is ``red`` (``sum``, ``prod``,
+    ``nansum``, or ``mean``).
 
     ``src`` is a 2D ``(M, N)`` view with inner-dim stride 1 (outer row stride
     may differ from N); ``out`` is a 1D ``(M,)`` view (its stride may differ
@@ -719,7 +738,7 @@ def _inner_tree_reduce_into(
         p.effective_loads,
     )
     c1(src, partials, m * p.num_batches)
-    c2 = _compile_two_accum(red, dtype, p.num_batches)
+    c2 = _compile_two_accum(red, dtype, n, p.num_batches)
     c2(partials, out, m, _ceil_div(m, _ACCUM_THREADS))
 
 
@@ -736,3 +755,8 @@ def inner_tree_prod_into(out: torch.Tensor, src: torch.Tensor) -> None:
 def inner_tree_nansum_into(out: torch.Tensor, src: torch.Tensor) -> None:
     """Row-wise inner-tree ``nansum`` (see ``_inner_tree_reduce_into``)."""
     _inner_tree_reduce_into(out, src, _NANSUM)
+
+
+def inner_tree_mean_into(out: torch.Tensor, src: torch.Tensor) -> None:
+    """Row-wise inner-tree ``mean`` (see ``_inner_tree_reduce_into``)."""
+    _inner_tree_reduce_into(out, src, _MEAN)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* #193205
* #193204
* #193203
* #193202
* __->__ #193201
* #193200
* #193199

Extends the inner-tree reduction engine to mean, reusing sum's exact bitwise
inner-tree order and dividing once at the end.

- _Reduction gains an optional `post` hook: a trace-time map applied ONCE to the
  final reduced scalar of a row (after the whole reduction, before the store).
  sum/prod/nansum keep post=None (a compile-time no-op) and stay BITWISE-identical.
- _MEAN = _Reduction("mean", +, 0.0, post=divide-by-N). `post` is applied at the
  single final-write site of each of the three kernel shapes: multirow, looped,
  and two-kernel (in _make_two_accum, only after ALL partials are linearly
  combined -- never per-partial). N is threaded into the two-kernel compile cache
  key so a different row length can't reuse a kernel with the wrong divisor. The
  division is IEEE round-to-nearest (CuTeDSL div.rn) in the accumulation dtype.
- Registers aten::mean.dim and aten::mean.out, reusing the shared eligibility
  gate. bare mean (dim=None) / explicit dtype= / multi-dim / integer / complex /
  unsupported layouts fall through to ATen.

Note on numerics: eager mean divides with true IEEE division, matching default
inductor's mean (Triton fdiv). ATen CUDA mean uses reciprocal-multiply
(sum * 1/n), so eager mean differs from ATen by <=1 ULP -- expected, since strict
already differs from ATen in the sum order.

Test Plan: python test/python_native/test_sum_cutedsl.py -- 42 tests OK, incl:
- test_mean_matches_sum_over_n: mean(x) == inner_tree_sum(x) / n BYTEWISE (IEEE
  tensor/tensor division) on order-sensitive fp32/fp64 across multirow/looped/
  two-kernel -- proves mean reuses sum's exact DAG then divides once;
- matches-ATen (tolerance), out= spy + byte-equality, fp16/bf16 spy, and
  dispatcher fallbacks (dim=None/dtype=/multidim/int/complex).
- sum/prod/nansum tests unchanged. AI-assisted, human-reviewed.