### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to mean

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -49,9 +49,22 @@ PROD_CASES = (
     ("split_fp32", (8, 65536), 1, torch.float32),
 )
 
-# Split fp16/bf16 is excluded due to a pre-existing strict Triton compile hang
-# tracked separately, consistent with SUM_CASES/PROD_CASES.
+# Split fp16/bf16 is excluded from NANSUM_CASES/MEAN_CASES due to a pre-existing
+# strict Triton compile hang tracked separately, consistent with SUM_CASES/PROD_CASES.
 NANSUM_CASES = (
+    ("persistent_fp16", (64, 256), 1, torch.float16),
+    ("persistent_bf16", (64, 256), 1, torch.bfloat16),
+    ("persistent_fp32", (64, 256), 1, torch.float32),
+    ("persistent_fp64", (64, 256), 1, torch.float64),
+    ("looped_fp16", (8, 12000), 1, torch.float16),
+    ("looped_bf16", (8, 12000), 1, torch.bfloat16),
+    ("looped_fp32", (8, 12000), 1, torch.float32),
+    ("looped_fp64", (8, 12000), 1, torch.float64),
+    ("split_fp32", (8, 65536), 1, torch.float32),
+    ("split_fp64", (8, 65536), 1, torch.float64),
+)
+
+MEAN_CASES = (
     ("persistent_fp16", (64, 256), 1, torch.float16),
     ("persistent_bf16", (64, 256), 1, torch.bfloat16),
     ("persistent_fp32", (64, 256), 1, torch.float32),
@@ -74,6 +87,11 @@ OUT_OF_SCOPE_CASES = (
 NANSUM_OUT_OF_SCOPE_CASES = (
     ("dtype", lambda z: torch.nansum(z, 1, dtype=torch.float64)),
     ("dim_none", lambda z: torch.nansum(z, dim=None)),
+)
+
+MEAN_OUT_OF_SCOPE_CASES = (
+    ("dim_none", lambda z: torch.mean(z, dim=None)),
+    ("dtype", lambda z: torch.mean(z, 1, dtype=torch.float64)),
 )
 
 LAYOUT_CASES = (
@@ -210,6 +228,29 @@ class StrictNumericsTest(TestCase):
         else:
             self.assertEqual(code.count(INNER_TREE_CALL), 2)
 
+    @parametrize("case", MEAN_CASES, name_fn=lambda c: c[0])
+    def test_mean_bitwise(self, device, case):
+        name, shape, dim, dtype = case
+        x = torch.randn(*shape, device=device, dtype=dtype)
+
+        def fn(z):
+            return torch.mean(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn(INNER_TREE_CALL, code)
+        if name.startswith("persistent"):
+            self.assertIn("@triton_heuristics.persistent_reduction(", code)
+            self.assertEqual(code.count(INNER_TREE_CALL), 1)
+        elif name.startswith("looped"):
+            self.assertIn("for r0_offset in", code)
+            self.assertEqual(code.count(INNER_TREE_CALL), 1)
+        else:
+            self.assertEqual(code.count(INNER_TREE_CALL), 2)
+        if dtype in (torch.float16, torch.bfloat16, torch.float32):
+            self.assertIn("triton.language.div_rn", code)
+
     def test_prod_out_of_scope_uses_default_order(self, device):
         # A dtype-casting prod is out of scope -> falls back to the default order.
         x = self._make_prod_input((64, 300), torch.float32, device)
@@ -220,6 +261,13 @@ class StrictNumericsTest(TestCase):
     def test_nansum_out_of_scope_uses_default_order(self, device, case):
         _, fn = case
         x = self._make_nansum_input((64, 300), torch.float32, device)
+        _, code = self._run(fn, x)
+        self.assertNotIn(INNER_TREE_CALL, code)
+
+    @parametrize("case", MEAN_OUT_OF_SCOPE_CASES, name_fn=lambda c: c[0])
+    def test_mean_out_of_scope_uses_default_order(self, device, case):
+        _, fn = case
+        x = torch.randn(64, 300, device=device)
         _, code = self._run(fn, x)
         self.assertNotIn(INNER_TREE_CALL, code)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7424,6 +7424,7 @@ def _make_scan_inner(x, *, axis, dtype):
 
 @register_lowering(aten.mean)
 def mean(x, axis=None, keepdim=False, *, dtype=None):
+    strict_reduction = _strict_reduction_layout_eligible(axis, dtype)
     if dtype is not None:
         x = to_dtype(x, dtype)
     size = x.get_size()
@@ -7432,11 +7433,14 @@ def mean(x, axis=None, keepdim=False, *, dtype=None):
     output_dtype = x.get_dtype()
     if output_dtype in (torch.float16, torch.bfloat16):
         x = to_dtype(x, torch.float)
-    sum_result = sum_(x, axis, keepdim)
+    sum_result = make_reduction("sum", strict_reduction=strict_reduction)(
+        x, axis, keepdim
+    )
     denom = sympy_product(size[i] for i in axis)
     denom = ir.IndexingConstant(index=denom, dtype=x.get_dtype(), device=x.get_device())
     denom = ExpandView.create(denom, list(sum_result.get_size()))
-    return to_dtype(div(sum_result, denom), output_dtype)
+    divide = _div_rn if strict_reduction else div
+    return to_dtype(divide(sum_result, denom), output_dtype)
 
 
 def var_mean_sum_(x, axis, correction, keepdim, return_mean):
@@ -7908,7 +7912,8 @@ def _strict_reduction_layout_eligible(axis, dtype) -> bool:
     if (
         current_node is None
         or config.numerics != "strict"
-        or current_node.target not in (aten.sum.dim_IntList, aten.prod.dim_int)
+        or current_node.target
+        not in (aten.sum.dim_IntList, aten.prod.dim_int, aten.mean.dim)
         or dtype is not None
         or axis is None
         or not has_triton_reduction_ordering()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* #193205
* #193204
* #193203
* __->__ #193202
* #193201
* #193200
* #193199

Routes torch.compile(numerics="strict") mean through the inner-tree path so it
is bitwise-equal to eager inner-tree mean.

- Add aten.mean.dim to the strict target gate in _strict_reduction_layout_eligible.
- In the mean lowering, compute strict eligibility BEFORE casting dtype /
  normalizing axis (so explicit dtype= and dim=None still fall through), and
  route mean's internal sum via make_reduction("sum", strict_reduction=...) so it
  emits INNER_TREE. The existing reduction codegen (keyed on sum/prod + the strict
  marker) needs no change.
- Use _div_rn for the divide on the eligible strict path: ordinary Triton `/`
  lowers fp32 to approximate div.full, which differs from eager's IEEE div.rn by
  1 ULP. default / out-of-scope mean keeps ordinary div.
- No scheduler/epilogue/fusion change: the divide is a pointwise epilogue after
  the completed strict reduction; R0_BLOCK pinning + standalone guards intact.

Test Plan: python test/inductor/test_strict_numerics.py -- 54 tests OK, incl
test_mean_bitwise (eager inner-tree mean == compiled strict mean, BYTEWISE via
uint8) for persistent/looped fp16/bf16/fp32/fp64 and split fp32/fp64, asserting
INNER_TREE and triton.language.div_rn; out-of-scope (dim=None, dtype=) uses
default order. split fp16/bf16 excluded (pre-existing strict Triton make_llir /
LLVM-SLP compile blowup, affects sum/prod too, tracked separately). sum/prod/
nansum bitwise unchanged. AI-assisted, human-reviewed.