### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to nanmean

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -49,8 +49,9 @@ PROD_CASES = (
     ("split_fp32", (8, 65536), 1, torch.float32),
 )
 
-# Split fp16/bf16 is excluded from NANSUM_CASES/MEAN_CASES due to a pre-existing
-# strict Triton compile hang tracked separately, consistent with SUM_CASES/PROD_CASES.
+# Split fp16/bf16 is excluded from NANSUM_CASES/MEAN_CASES/NANMEAN_CASES due to
+# a pre-existing strict Triton compile hang tracked separately, consistent with
+# SUM_CASES/PROD_CASES.
 NANSUM_CASES = (
     ("persistent_fp16", (64, 256), 1, torch.float16),
     ("persistent_bf16", (64, 256), 1, torch.bfloat16),
@@ -65,6 +66,19 @@ NANSUM_CASES = (
 )
 
 MEAN_CASES = (
+    ("persistent_fp16", (64, 256), 1, torch.float16),
+    ("persistent_bf16", (64, 256), 1, torch.bfloat16),
+    ("persistent_fp32", (64, 256), 1, torch.float32),
+    ("persistent_fp64", (64, 256), 1, torch.float64),
+    ("looped_fp16", (8, 12000), 1, torch.float16),
+    ("looped_bf16", (8, 12000), 1, torch.bfloat16),
+    ("looped_fp32", (8, 12000), 1, torch.float32),
+    ("looped_fp64", (8, 12000), 1, torch.float64),
+    ("split_fp32", (8, 65536), 1, torch.float32),
+    ("split_fp64", (8, 65536), 1, torch.float64),
+)
+
+NANMEAN_CASES = (
     ("persistent_fp16", (64, 256), 1, torch.float16),
     ("persistent_bf16", (64, 256), 1, torch.bfloat16),
     ("persistent_fp32", (64, 256), 1, torch.float32),
@@ -92,6 +106,11 @@ NANSUM_OUT_OF_SCOPE_CASES = (
 MEAN_OUT_OF_SCOPE_CASES = (
     ("dim_none", lambda z: torch.mean(z, dim=None)),
     ("dtype", lambda z: torch.mean(z, 1, dtype=torch.float64)),
+)
+
+NANMEAN_OUT_OF_SCOPE_CASES = (
+    ("dim_none", lambda z: torch.nanmean(z, dim=None)),
+    ("dtype", lambda z: torch.nanmean(z, 1, dtype=torch.float64)),
 )
 
 LAYOUT_CASES = (
@@ -251,6 +270,29 @@ class StrictNumericsTest(TestCase):
         if dtype in (torch.float16, torch.bfloat16, torch.float32):
             self.assertIn("triton.language.div_rn", code)
 
+    @parametrize("case", NANMEAN_CASES, name_fn=lambda c: c[0])
+    def test_nanmean_bitwise(self, device, case):
+        name, shape, dim, dtype = case
+        x = self._make_nansum_input(shape, dtype, device)
+
+        def fn(z):
+            return torch.nanmean(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn(INNER_TREE_CALL, code)
+        if name.startswith("persistent"):
+            self.assertIn("@triton_heuristics.persistent_reduction(", code)
+            self.assertEqual(code.count(INNER_TREE_CALL), 1)
+        elif name.startswith("looped"):
+            self.assertIn("for r0_offset in", code)
+            self.assertEqual(code.count(INNER_TREE_CALL), 1)
+        else:
+            self.assertEqual(code.count(INNER_TREE_CALL), 2)
+        if dtype in (torch.float16, torch.bfloat16, torch.float32):
+            self.assertIn("triton.language.div_rn", code)
+
     def test_prod_out_of_scope_uses_default_order(self, device):
         # A dtype-casting prod is out of scope -> falls back to the default order.
         x = self._make_prod_input((64, 300), torch.float32, device)
@@ -270,6 +312,14 @@ class StrictNumericsTest(TestCase):
         x = torch.randn(64, 300, device=device)
         _, code = self._run(fn, x)
         self.assertNotIn(INNER_TREE_CALL, code)
+
+    @parametrize("case", NANMEAN_OUT_OF_SCOPE_CASES, name_fn=lambda c: c[0])
+    def test_nanmean_out_of_scope_uses_default_order(self, device, case):
+        _, fn = case
+        x = self._make_nansum_input((64, 300), torch.float32, device)
+        _, code = self._run(fn, x)
+        self.assertNotIn(INNER_TREE_CALL, code)
+        self.assertNotIn("triton.language.div_rn", code)
 
     @parametrize("case", SUM_VARIANTS, name_fn=lambda c: c[0])
     def test_sum_variants(self, device, case):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7744,6 +7744,28 @@ def truncdiv(a, b):
     return ops.truncdiv(a, b)
 
 
+def _is_strict_reduction_result(x) -> bool:
+    name = ir.try_get_name(x)
+    if name is None:
+        return False
+    buffer = V.graph.try_get_buffer(name)
+    return (
+        isinstance(buffer, ir.ComputedBuffer)
+        and isinstance(buffer.data, Reduction)
+        and buffer.data.strict_reduction_rblock is not None
+    )
+
+
+def _lowp_pointwise_barrier(x):
+    dtype = x.get_dtype()
+
+    def inner(value):
+        value = ops.to_dtype(value, dtype, use_compute_types=False)
+        return ops.to_dtype(value, dtype)
+
+    return make_pointwise(inner, override_return_dtype=dtype)(x)
+
+
 @make_pointwise
 def _div_rn(a, b):
     return ops.div_rn(a, b)
@@ -7887,6 +7909,11 @@ def div(a, b):
     a, b = promote_constants(
         (a, b), type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
     )
+    if _is_strict_reduction_result(a):
+        if a.get_dtype() in (torch.float16, torch.bfloat16):
+            a = _lowp_pointwise_barrier(a)
+            b = _lowp_pointwise_barrier(b)
+        return _div_rn(a, b)
     return div_prim(a, b)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* #193205
* __->__ #193204
* #193203
* #193202
* #193201
* #193200
* #193199

nanmean's numerator (nansum) already routes through the strict INNER_TREE path
via its decomposition (where(isnan,0,x) -> aten.sum). The only gap was the final
div(nansum, count): ordinary Triton `/` lowers fp32 to approximate div.full,
which differed from eager's IEEE div.rn (persistent fp32: 42/64 outputs).

Fix: in the div lowering, use _div_rn when the numerator resolves to an engaged
strict-reduction result (via V.graph.try_get_buffer + strict_reduction_rblock);
otherwise keep ordinary div. A low-precision barrier is applied for fp16/bf16.
This is narrow (only strict-reduction numerators) and also generalizes
`strict_reduction / tensor`. The count reduction ((~isnan).sum, bool->int) stays
a normal reduction; no decomposition or eligibility change; mean/sum/prod/nansum
are unchanged (mean uses its own _div_rn path).

Test Plan: python test/inductor/test_strict_numerics.py -- 66 tests OK, incl
test_nanmean_bitwise (eager inner-tree nanmean == compiled strict, BYTEWISE via
uint8) for persistent/looped fp16/bf16/fp32/fp64 and split fp32/fp64, asserting
INNER_TREE counts (1 persistent/looped, 2 split -> only the numerator is
inner-tree) and triton.language.div_rn; out-of-scope (dim=None, dtype=) uses
default order. split fp16/bf16 excluded (pre-existing Triton LLVM-SLP hang).
mean/sum/prod/nansum bitwise unchanged. AI-assisted, human-reviewed.