### PR TITLE
[Eager] Add a CuTeDSL inner-tree vector_norm reduction override

### DIFF
--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -752,6 +752,318 @@ class TestSumCuteDSLOverride(TestCase):
             torch.mean(integer, dim=1)
         self.assertEqual(mean_into.call_count, 0)
 
+    # --- vector norm (abs/square pre-map plus optional sqrt post-map) ---
+
+    def test_vector_norm_cond_orders(self):
+        impl = _cutedsl_impl()
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        with self._inner_tree_flag():
+            for order in (1, 1.0, 2, 2.0):
+                with self.subTest(order=order):
+                    self.assertTrue(impl._vector_norm_cond(x, order, [1]))
+                    self.assertTrue(impl._vector_norm_out_cond(x, order, [1], out=out))
+            self.assertTrue(impl._vector_norm_cond(x, dim=[1]))
+            self.assertTrue(impl._vector_norm_out_cond(x, dim=[1], out=out))
+
+            for order in (0, 3, float("inf"), -float("inf"), 1 + 0j, True):
+                with self.subTest(rejected_order=order):
+                    self.assertFalse(impl._vector_norm_cond(x, order, [1]))
+                    self.assertFalse(impl._vector_norm_out_cond(x, order, [1], out=out))
+
+            self.assertFalse(impl._vector_norm_cond(x, 2, [1], dtype=torch.float32))
+            self.assertFalse(
+                impl._vector_norm_out_cond(x, 2, [1], dtype=torch.float32, out=out)
+            )
+            self.assertFalse(impl._vector_norm_cond(x, 2, None))
+            self.assertFalse(impl._vector_norm_out_cond(x, 2, None, out=out))
+            x_3d = x.reshape(2, 64, 8195)
+            self.assertFalse(impl._vector_norm_cond(x_3d, 2, [1, 2]))
+            self.assertFalse(
+                impl._vector_norm_out_cond(
+                    x_3d,
+                    2,
+                    [1, 2],
+                    out=torch.empty(2, device="cuda", dtype=torch.float32),
+                )
+            )
+
+            for unsupported in (
+                torch.ones(4, 32, device="cuda", dtype=torch.int64),
+                torch.ones(4, 32, device="cuda", dtype=torch.complex64),
+                x[:, ::2],
+            ):
+                with self.subTest(dtype=unsupported.dtype, stride=unsupported.stride()):
+                    unsupported_out = torch.empty(
+                        unsupported.shape[0],
+                        device="cuda",
+                        dtype=(
+                            torch.float32
+                            if unsupported.is_complex()
+                            else unsupported.dtype
+                        ),
+                    )
+                    self.assertFalse(impl._vector_norm_cond(unsupported, 2, [1]))
+                    self.assertFalse(
+                        impl._vector_norm_out_cond(
+                            unsupported, 2, [1], out=unsupported_out
+                        )
+                    )
+
+            singleton = torch.ones(4, 1, device="cuda", dtype=torch.float32)
+            singleton_out = torch.empty(4, device="cuda", dtype=torch.float32)
+            self.assertFalse(impl._vector_norm_cond(singleton, 2, [1]))
+            self.assertFalse(
+                impl._vector_norm_out_cond(singleton, 2, [1], out=singleton_out)
+            )
+
+            self.assertTrue(impl._vector_norm_cond(x, 2, [1]))
+            for invalid_out in (
+                torch.empty(129, device="cuda", dtype=torch.float32),
+                torch.empty(128, device="cuda", dtype=torch.float64),
+            ):
+                self.assertFalse(impl._vector_norm_out_cond(x, 2, [1], out=invalid_out))
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_vector_norm_matches_inner_tree_composition(self, dtype):
+        view_dtype = torch.int32 if dtype == torch.float32 else torch.int64
+        for order in (2, 1):
+            for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+                with self.subTest(order=order, m=m, n=n):
+                    x = self._make_order_sensitive_input(m, n, dtype)
+                    with self._inner_tree_flag():
+                        got = torch.linalg.vector_norm(x, ord=order, dim=1)
+                        if order == 2:
+                            expected = torch.sqrt(torch.sum(x * x, dim=1))
+                        else:
+                            expected = torch.sum(torch.abs(x), dim=1)
+                    self.assertTrue(
+                        torch.equal(got.view(view_dtype), expected.view(view_dtype))
+                    )
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_vector_norm_matches_aten(self, dtype):
+        rtol, atol = (1e-5, 1e-6) if dtype == torch.float32 else (1e-12, 1e-12)
+        for order in (2, 1):
+            for m, n in [(128, 15), (128, 8195), (8, 200003)]:
+                with self.subTest(order=order, m=m, n=n):
+                    x = self._make_order_sensitive_input(m, n, dtype)
+                    with torch.backends.python_native.cutedsl.disabled():
+                        ref = torch.linalg.vector_norm(x, ord=order, dim=1)
+                    with self._inner_tree_flag():
+                        got = torch.linalg.vector_norm(x, ord=order, dim=1)
+                    self.assertEqual(got, ref, rtol=rtol, atol=atol)
+
+    def test_vector_norm_override_engaged(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        calls = [
+            (
+                "torch.linalg.vector_norm",
+                lambda: torch.linalg.vector_norm(x, ord=2, dim=1),
+            ),
+            (
+                "torch.linalg.norm",
+                lambda: torch.linalg.norm(x, ord=2, dim=1),
+            ),
+            ("torch.norm", lambda: torch.norm(x, p=2, dim=1)),
+            (
+                "default_order",
+                lambda: torch.linalg.vector_norm(x, dim=1),
+            ),
+        ]
+        for name, call in calls:
+            with self.subTest(name=name):
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_vector_norm_into",
+                        wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                    ) as vector_norm_into,
+                    self._inner_tree_flag(),
+                ):
+                    call()
+                self.assertEqual(vector_norm_into.call_count, 1)
+
+    def test_vector_norm_out_variant(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        for order in (2, 1):
+            for keepdim in (False, True):
+                with self.subTest(order=order, keepdim=keepdim):
+                    with self._inner_tree_flag():
+                        functional = torch.linalg.vector_norm(
+                            x, ord=order, dim=1, keepdim=keepdim
+                        )
+                    out_shape = (128, 1) if keepdim else (128,)
+                    out = torch.empty(out_shape, device="cuda", dtype=torch.float32)
+                    with (
+                        mock.patch.object(
+                            inner_tree_kernel,
+                            "inner_tree_vector_norm_into",
+                            wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                        ) as vector_norm_into,
+                        self._inner_tree_flag(),
+                    ):
+                        returned = torch.linalg.vector_norm(
+                            x, ord=order, dim=1, keepdim=keepdim, out=out
+                        )
+                    self.assertEqual(vector_norm_into.call_count, 1)
+                    self.assertIs(returned, out)
+                    self.assertTrue(
+                        torch.equal(out.view(torch.int32), functional.view(torch.int32))
+                    )
+
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.linalg.vector_norm(x, ord=3, dim=1)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_vector_norm_into",
+                wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+            ) as vector_norm_into,
+            self._inner_tree_flag(),
+        ):
+            returned = torch.linalg.vector_norm(x, ord=3, dim=1, out=out)
+        self.assertEqual(vector_norm_into.call_count, 0)
+        self.assertIs(returned, out)
+        self.assertEqual(out, ref, rtol=0, atol=0)
+
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_vector_norm_low_precision_matches_aten(self, dtype):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        for order in (2, 1):
+            for m, n in [(64, 32), (8, 4096), (8, 65536)]:
+                with self.subTest(order=order, m=m, n=n):
+                    x = self._make_order_sensitive_input(m, n, dtype)
+                    with torch.backends.python_native.cutedsl.disabled():
+                        ref = torch.linalg.vector_norm(x, ord=order, dim=1)
+                    with (
+                        mock.patch.object(
+                            inner_tree_kernel,
+                            "inner_tree_vector_norm_into",
+                            wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                        ) as vector_norm_into,
+                        self._inner_tree_flag(),
+                    ):
+                        got = torch.linalg.vector_norm(x, ord=order, dim=1)
+                    self.assertEqual(vector_norm_into.call_count, 1)
+                    self.assertEqual(got, ref, rtol=2e-2, atol=2e-2)
+
+        overflow = torch.zeros(64, 32, device="cuda", dtype=dtype)
+        overflow[:, :2] = 30000
+        cases = [("overflow", overflow)]
+        if dtype == torch.bfloat16:
+            underflow = torch.zeros(64, 32, device="cuda", dtype=dtype)
+            underflow[:, :2] = 2**-70
+            cases.append(("underflow", underflow))
+
+        for name, x in cases:
+            with self.subTest(name=name):
+                with torch.backends.python_native.cutedsl.disabled():
+                    expected = torch.sqrt(
+                        torch.sum(x.to(torch.float32) ** 2, dim=1)
+                    ).to(dtype)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_vector_norm_into",
+                        wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                    ) as vector_norm_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.linalg.vector_norm(x, ord=2, dim=1)
+                self.assertEqual(vector_norm_into.call_count, 1)
+                self.assertTrue(torch.isfinite(got).all().item())
+                self.assertTrue(
+                    torch.equal(got.view(torch.int16), expected.view(torch.int16))
+                )
+
+    def test_vector_norm_unsupported_calls_fall_through(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(4, 32, torch.float32)
+        cases = [
+            ("order_zero", x, {"ord": 0, "dim": 1}),
+            ("order_three", x, {"ord": 3, "dim": 1}),
+            ("order_inf", x, {"ord": float("inf"), "dim": 1}),
+            ("order_neg_inf", x, {"ord": -float("inf"), "dim": 1}),
+            ("explicit_dtype", x, {"ord": 2, "dim": 1, "dtype": torch.float64}),
+            ("dim_none", x, {"ord": 2, "dim": None}),
+            (
+                "multi_dim",
+                x.reshape(2, 2, 32),
+                {"ord": 2, "dim": (1, 2)},
+            ),
+            ("noncontiguous", x[:, ::2], {"ord": 2, "dim": 1}),
+            ("complex", x.to(torch.complex64), {"ord": 2, "dim": 1}),
+        ]
+        for name, input_, kwargs in cases:
+            with self.subTest(name=name):
+                with torch.backends.python_native.cutedsl.disabled():
+                    ref = torch.linalg.vector_norm(input_, **kwargs)
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_vector_norm_into",
+                        wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                    ) as vector_norm_into,
+                    self._inner_tree_flag(),
+                ):
+                    got = torch.linalg.vector_norm(input_, **kwargs)
+                self.assertEqual(vector_norm_into.call_count, 0)
+                self.assertEqual(got, ref, rtol=0, atol=0)
+
+        error_cases = [
+            (
+                "integer_input",
+                torch.ones(4, 32, device="cuda", dtype=torch.int64),
+                2,
+                "floating point or complex",
+            ),
+            ("complex_order", x, 1 + 0j, "Expected a non-complex scalar"),
+        ]
+        for name, input_, order, error in error_cases:
+            with self.subTest(name=name):
+                with (
+                    mock.patch.object(
+                        inner_tree_kernel,
+                        "inner_tree_vector_norm_into",
+                        wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+                    ) as vector_norm_into,
+                    self._inner_tree_flag(),
+                    self.assertRaisesRegex(RuntimeError, error),
+                ):
+                    torch.linalg.vector_norm(input_, ord=order, dim=1)
+                self.assertEqual(vector_norm_into.call_count, 0)
+
+        limit = torch.finfo(torch.float32).max
+        extreme = torch.tensor(
+            [[limit], [-limit], [limit / 2], [-limit / 2]],
+            device="cuda",
+            dtype=torch.float32,
+        )
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_vector_norm_into",
+                wraps=inner_tree_kernel.inner_tree_vector_norm_into,
+            ) as vector_norm_into,
+            self._inner_tree_flag(),
+        ):
+            got = torch.linalg.vector_norm(extreme, ord=2, dim=1)
+        self.assertEqual(vector_norm_into.call_count, 0)
+        self.assertTrue(torch.isfinite(got).all().item())
+        self.assertTrue(
+            torch.equal(
+                got.view(torch.int32), extreme.abs().squeeze(1).view(torch.int32)
+            )
+        )
+
     # --- nanmean (ATen composite over nansum + count/div) ---
 
     def _make_nanmean_input(self, m, n, dtype):

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -1,4 +1,4 @@
-"""CuTeDSL overrides for inner-tree ``sum``, ``prod``, ``nansum``, and ``mean``.
+"""CuTeDSL overrides for inner-tree reductions.
 
 CuTeDSL port of the Triton-style inner-tree reduction kernel that
 otherwise lives in ``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu``
@@ -8,12 +8,13 @@ is the feature-rollout gate for these operators -- it is *not* gated by the
 global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
 ``cutedsl_utils`` at registration time).
 
-We register eight ATen dispatcher entries on ``CUDA``:
+We register ten ATen dispatcher entries on ``CUDA``:
 
 * ``sum.dim_IntList`` / ``sum.IntList_out`` -- ``x.sum(dim=...)`` + ``.out``.
 * ``prod.dim_int`` / ``prod.int_out`` -- ``x.prod(dim=...)`` + ``.out``.
 * ``nansum`` / ``nansum.out`` -- ``x.nansum(dim=...)`` + ``.out``.
 * ``mean.dim`` / ``mean.out`` -- ``x.mean(dim=...)`` + ``.out``.
+* ``linalg_vector_norm`` / ``linalg_vector_norm.out`` -- p=1 and p=2 norms.
 
 ``nanmean`` is covered compositionally and intentionally has no dispatcher
 entry here. ATen's CompositeImplicitAutograd implementation computes an
@@ -109,6 +110,16 @@ def _single_dim(dim, ndim: int) -> int | None:
     if len(dims) != 1:
         return None
     return _normalize_dim(dims[0], ndim)
+
+
+def _vector_norm_order(ord) -> int | None:
+    if isinstance(ord, bool) or not isinstance(ord, (int, float)):
+        return None
+    if ord == 1:
+        return 1
+    if ord == 2:
+        return 2
+    return None
 
 
 def _keepdim_out_shape(self: torch.Tensor, d: int) -> list[int]:
@@ -227,6 +238,24 @@ def _out_cond(self, dim=None, keepdim=False, *, dtype=None, out) -> bool:
     return _eligibility(self, d, out_kd) is not None
 
 
+def _vector_norm_cond(self, ord=2, dim=None, keepdim=False, *, dtype=None) -> bool:
+    if _vector_norm_order(ord) is None or not _cond(self, dim, keepdim, dtype=dtype):
+        return False
+    d = _single_dim(dim, self.ndim)
+    return d is not None and self.shape[d] != 1
+
+
+def _vector_norm_out_cond(
+    self, ord=2, dim=None, keepdim=False, *, dtype=None, out
+) -> bool:
+    if _vector_norm_order(ord) is None or not _out_cond(
+        self, dim, keepdim, dtype=dtype, out=out
+    ):
+        return False
+    d = _single_dim(dim, self.ndim)
+    return d is not None and self.shape[d] != 1
+
+
 def _sum_into():
     from .inner_tree_kernel import inner_tree_sum_into
 
@@ -251,7 +280,13 @@ def _mean_into():
     return inner_tree_mean_into
 
 
-def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
+def _vector_norm_into():
+    from .inner_tree_kernel import inner_tree_vector_norm_into
+
+    return inner_tree_vector_norm_into
+
+
+def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into, *args) -> None:
     """Run ``reduce_into`` writing the reduction of ``self`` along ``d`` into
     the keepdim-shaped ``out_kd``. Caller has validated eligibility."""
     it = _eligibility(self, d, out_kd)
@@ -262,7 +297,7 @@ def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor, reduce_into) -> None:
         return
     in_2d = self.as_strided((m, n), (in_rs, 1))
     out_1d = out_kd.as_strided((m,), (out_rs,))
-    reduce_into()(out_1d, in_2d)
+    reduce_into()(out_1d, in_2d, *args)
 
 
 def _make_impl(reduce_into):
@@ -295,9 +330,37 @@ def _make_out_impl(reduce_into):
     return _out_impl
 
 
+def _vector_norm_impl(self, ord=2, dim=None, keepdim=False, *, dtype=None):
+    p = _vector_norm_order(ord)
+    if p is None:
+        raise AssertionError("_vector_norm_cond guaranteed p=1 or p=2")
+    if dim is None:
+        raise AssertionError("_vector_norm_cond guaranteed a non-None dim")
+    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+    out_kd = torch.empty(
+        _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
+    )
+    _run(self, d, out_kd, _vector_norm_into, p)
+    return out_kd if keepdim else out_kd.squeeze(d)
+
+
+def _vector_norm_out_impl(self, ord=2, dim=None, keepdim=False, *, dtype=None, out):
+    p = _vector_norm_order(ord)
+    if p is None:
+        raise AssertionError("_vector_norm_out_cond guaranteed p=1 or p=2")
+    if dim is None:
+        raise AssertionError("_vector_norm_out_cond guaranteed a non-None dim")
+    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+    out_kd = _out_keepdim_view(self, d, keepdim, out)
+    if out_kd is None:
+        raise AssertionError("_vector_norm_out_cond guaranteed a reduced-shape out")
+    _run(self, d, out_kd, _vector_norm_into, p)
+    return out
+
+
 def register_to_dispatch() -> None:
-    # Eligibility (_cond/_out_cond) is reduction-agnostic; only the kernel
-    # entry differs among sum, prod, nansum, and mean.
+    # Eligibility (_cond/_out_cond) is reduction-agnostic; vector norm adds
+    # its order check before using the same geometry predicate.
     cu.register_op_override(
         "aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_make_impl(_sum_into)
     )
@@ -333,4 +396,18 @@ def register_to_dispatch() -> None:
         "CUDA",
         cond=_out_cond,
         impl=_make_out_impl(_mean_into),
+    )
+    cu.register_op_override(
+        "aten",
+        "linalg_vector_norm",
+        "CUDA",
+        cond=_vector_norm_cond,
+        impl=_vector_norm_impl,
+    )
+    cu.register_op_override(
+        "aten",
+        "linalg_vector_norm.out",
+        "CUDA",
+        cond=_vector_norm_out_cond,
+        impl=_vector_norm_out_impl,
     )

--- a/torch/_native/ops/reductions/inner_tree_kernel.py
+++ b/torch/_native/ops/reductions/inner_tree_kernel.py
@@ -53,6 +53,8 @@ import cutlass.cute as cute
 # fp64 is part of the bitwise contract; import Float64 directly so an
 # unsupported runtime surfaces a clear error rather than silently dropping it.
 from cutlass import BFloat16, const_expr, Float16, Float32, Float64, Int32
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
 
 import torch
 from torch._native.instrumentation import instrumented_cutedsl_cache
@@ -136,10 +138,73 @@ def _divide_by_n(v, N):
     return v / v.dtype(N)
 
 
+# Keep x*x and the final sqrt as distinct IEEE-rounded instructions. Without
+# the inline multiply, CuTe contracts the square into a reduction add.
+def _ptx_float_type(v):
+    dtype = v.dtype
+    if dtype is Float32:
+        return dtype, "f32", "f"
+    if dtype is Float64:
+        return dtype, "f64", "d"
+    raise TypeError(f"rounded PTX operation requires fp32 or fp64, got {dtype}")
+
+
+@dsl_user_op
+def _mul_rn(a, b, *, loc=None, ip=None):
+    dtype, suffix, register = _ptx_float_type(a)
+    return dtype(
+        llvm.inline_asm(
+            dtype.mlir_type,
+            [a.ir_value(loc=loc, ip=ip), b.ir_value(loc=loc, ip=ip)],
+            f"mul.rn.{suffix} $0, $1, $2;",
+            f"={register},{register},{register}",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _sqrt_rn(v, *, loc=None, ip=None):
+    dtype, suffix, register = _ptx_float_type(v)
+    return dtype(
+        llvm.inline_asm(
+            dtype.mlir_type,
+            [v.ir_value(loc=loc, ip=ip)],
+            f"sqrt.rn.{suffix} $0, $1;",
+            f"={register},{register}",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _square(v):
+    return _mul_rn(v, v)
+
+
+def _abs(v):
+    return abs(v)
+
+
+def _sqrt(v, _N):
+    return _sqrt_rn(v)
+
+
 _SUM = _Reduction("sum", _add, 0.0)
 _PROD = _Reduction("prod", _mul, 1.0)
 _NANSUM = _Reduction("nansum", _add, 0.0, pre=_nan_to_zero)
 _MEAN = _Reduction("mean", _add, 0.0, post=_divide_by_n)
+_VECTOR_NORM_P2 = _Reduction(
+    "linalg_vector_norm_p2", _add, 0.0, pre=_square, post=_sqrt
+)
+_VECTOR_NORM_P1 = _Reduction("linalg_vector_norm_p1", _add, 0.0, pre=_abs)
 
 
 # ---------------------------------------------------------------------------
@@ -760,3 +825,16 @@ def inner_tree_nansum_into(out: torch.Tensor, src: torch.Tensor) -> None:
 def inner_tree_mean_into(out: torch.Tensor, src: torch.Tensor) -> None:
     """Row-wise inner-tree ``mean`` (see ``_inner_tree_reduce_into``)."""
     _inner_tree_reduce_into(out, src, _MEAN)
+
+
+def inner_tree_vector_norm_into(
+    out: torch.Tensor, src: torch.Tensor, p: int | float
+) -> None:
+    """Row-wise inner-tree vector norm (see ``_inner_tree_reduce_into``)."""
+    if p == 1:
+        red = _VECTOR_NORM_P1
+    elif p == 2:
+        red = _VECTOR_NORM_P2
+    else:
+        raise ValueError(f"unsupported vector norm order: {p}")
+    _inner_tree_reduce_into(out, src, red)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* #193206
* __->__ #193205
* #193204
* #193203
* #193202
* #193201
* #193200
* #193199

Adds linalg_vector_norm for ord in {1, 2} to the inner-tree engine, reusing the
bitwise sum with a per-element pre-map and a final-scalar post-map.

- p=2: pre squares in the fp32/fp64 accumulation dtype via mul.rn (an inline-PTX
  wrapper, to prevent FMA contraction of the square with the tree add), post is a
  correctly-rounded IEEE sqrt via a sqrt.rn inline-PTX wrapper. Generic cute.sqrt
  is 1-2 ULP off IEEE, so it is not used.
- p=1: pre = abs, post = identity.
- ord-aware eligibility: ord in {1, 1.0, 2, 2.0} and the default (2) are eligible;
  ord in {0, 3, +-inf}, complex ord, explicit dtype=, dim=None, multi-dim,
  integer/complex inputs, and unsupported layouts fall through to ATen.
- Registers aten::linalg_vector_norm and aten::linalg_vector_norm.out
  (torch.norm / torch.linalg.norm route through for eligible calls). p=1 and p=2
  use distinct descriptor names so the compile cache does not alias them.
- sum/prod/nansum/mean/nanmean remain bitwise-unchanged.

Numerics: eager uses mul.rn + sqrt.rn (correctly rounded); default inductor
already emits tl.sqrt_rn, so eager and compiled strict match by construction.

Test Plan: python test/python_native/test_sum_cutedsl.py -- 62 tests OK, incl:
- bitwise vector_norm == sqrt(inner_tree_sum(x*x)) (p=2) / inner_tree_sum(abs(x))
  (p=1) on order-sensitive fp32/fp64 across multirow/looped/two-kernel;
- matches-ATen (tolerance), engagement spy (vector_norm/norm/linalg.norm/default),
  out= (both orders + keepdim + ord=3 fallthrough), and fp16/bf16 with an explicit
  fp32-square proof (overflow + underflow inputs), plus dispatcher fallbacks.
- sum/prod/nansum/mean/nanmean bitwise unchanged. AI-assisted, human-reviewed.