### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to vector_norm

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -49,9 +49,32 @@ PROD_CASES = (
     ("split_fp32", (8, 65536), 1, torch.float32),
 )
 
-# Split fp16/bf16 is excluded from NANSUM_CASES/MEAN_CASES/NANMEAN_CASES due to
-# a pre-existing strict Triton compile hang tracked separately, consistent with
-# SUM_CASES/PROD_CASES.
+# Split fp16/bf16 is excluded from VECNORM_CASES/NANSUM_CASES/MEAN_CASES/
+# NANMEAN_CASES due to a pre-existing strict Triton LLVM-SLP compile hang
+# tracked separately, consistent with SUM_CASES/PROD_CASES.
+VECNORM_CASES = (
+    ("persistent_fp16_p1", (64, 256), 1, torch.float16, 1),
+    ("persistent_bf16_p1", (64, 256), 1, torch.bfloat16, 1),
+    ("persistent_fp32_p1", (64, 256), 1, torch.float32, 1),
+    ("persistent_fp64_p1", (64, 256), 1, torch.float64, 1),
+    ("persistent_fp16_p2", (64, 256), 1, torch.float16, 2),
+    ("persistent_bf16_p2", (64, 256), 1, torch.bfloat16, 2),
+    ("persistent_fp32_p2", (64, 256), 1, torch.float32, 2),
+    ("persistent_fp64_p2", (64, 256), 1, torch.float64, 2),
+    ("looped_fp16_p1", (8, 12000), 1, torch.float16, 1),
+    ("looped_bf16_p1", (8, 12000), 1, torch.bfloat16, 1),
+    ("looped_fp32_p1", (8, 12000), 1, torch.float32, 1),
+    ("looped_fp64_p1", (8, 12000), 1, torch.float64, 1),
+    ("looped_fp16_p2", (8, 12000), 1, torch.float16, 2),
+    ("looped_bf16_p2", (8, 12000), 1, torch.bfloat16, 2),
+    ("looped_fp32_p2", (8, 12000), 1, torch.float32, 2),
+    ("looped_fp64_p2", (8, 12000), 1, torch.float64, 2),
+    ("split_fp32_p1", (8, 65536), 1, torch.float32, 1),
+    ("split_fp64_p1", (8, 65536), 1, torch.float64, 1),
+    ("split_fp32_p2", (8, 65536), 1, torch.float32, 2),
+    ("split_fp64_p2", (8, 65536), 1, torch.float64, 2),
+)
+
 NANSUM_CASES = (
     ("persistent_fp16", (64, 256), 1, torch.float16),
     ("persistent_bf16", (64, 256), 1, torch.bfloat16),
@@ -111,6 +134,15 @@ MEAN_OUT_OF_SCOPE_CASES = (
 NANMEAN_OUT_OF_SCOPE_CASES = (
     ("dim_none", lambda z: torch.nanmean(z, dim=None)),
     ("dtype", lambda z: torch.nanmean(z, 1, dtype=torch.float64)),
+)
+
+VECNORM_OUT_OF_SCOPE_CASES = (
+    ("ord3", lambda z: torch.linalg.vector_norm(z, ord=3, dim=1)),
+    (
+        "dtype",
+        lambda z: torch.linalg.vector_norm(z, ord=2, dim=1, dtype=torch.float64),
+    ),
+    ("dim_none", lambda z: torch.linalg.vector_norm(z, ord=2, dim=None)),
 )
 
 LAYOUT_CASES = (
@@ -220,6 +252,36 @@ class StrictNumericsTest(TestCase):
         if name.startswith("split"):
             self.assertEqual(code.count(INNER_TREE_CALL), 2)
 
+    @parametrize("case", VECNORM_CASES, name_fn=lambda c: c[0])
+    def test_vector_norm_bitwise(self, device, case):
+        name, shape, dim, dtype, order = case
+        x = torch.randn(*shape, device=device, dtype=dtype)
+
+        def fn(z):
+            return torch.linalg.vector_norm(z, ord=order, dim=dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        strict_kernel_count = 2 if name.startswith("split") else 1
+        self.assertEqual(code.count(INNER_TREE_CALL), strict_kernel_count)
+        self.assertEqual(code.count("'enable_fp_fusion': False"), strict_kernel_count)
+        if order == 2:
+            sqrt = "libdevice.sqrt" if dtype == torch.float64 else "tl.sqrt_rn"
+            self.assertIn(sqrt, code)
+
+    def test_vector_norm_p2_subnormal(self, device):
+        x = torch.full((64, 256), 2**-65, device=device, dtype=torch.float32)
+
+        def fn(z):
+            return torch.linalg.vector_norm(z, ord=2, dim=1)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertTrue((result != 0).all().item())
+        self.assertIn(INNER_TREE_CALL, code)
+
     def _make_nansum_input(self, shape, dtype, device):
         # Standard-normal values keep magnitudes reasonable while making the
         # reduction order observable.
@@ -320,6 +382,12 @@ class StrictNumericsTest(TestCase):
         _, code = self._run(fn, x)
         self.assertNotIn(INNER_TREE_CALL, code)
         self.assertNotIn("triton.language.div_rn", code)
+
+    @parametrize("case", VECNORM_OUT_OF_SCOPE_CASES, name_fn=lambda c: c[0])
+    def test_vector_norm_out_of_scope_uses_default_order(self, device, case):
+        _, fn = case
+        _, code = self._run(fn, torch.randn(64, 300, device=device))
+        self.assertNotIn(INNER_TREE_CALL, code)
 
     @parametrize("case", SUM_VARIANTS, name_fn=lambda c: c[0])
     def test_sum_variants(self, device, case):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7322,6 +7322,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             },
         )
 
+        if self._strict_reduction_rblock() is not None:
+            triton_meta["enable_fp_fusion"] = False
+
         if self.cooperative_reduction:
             # Cooperative reductions rely on multi-block synchronization that
             # requires cooperative-grid launches to avoid hanging.

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -151,6 +151,44 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
 
 remove_decompositions(decompositions, decomps_to_exclude)
 
+_vector_norm_decomposition = decompositions[aten.linalg_vector_norm.default]
+_STRICT_VECTOR_NORM_DTYPES = (
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.float64,
+)
+
+
+@functools.wraps(_vector_norm_decomposition)
+def _strict_vector_norm_decomposition(
+    x: torch.Tensor,
+    ord: float | int = 2,
+    dim: int | list[int] | tuple[int, ...] | None = None,
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if config.numerics == "strict":
+        dims = [dim] if isinstance(dim, int) else dim
+        if (
+            isinstance(ord, bool)
+            or not isinstance(ord, (int, float))
+            or ord not in (1, 2)
+            or dims is None
+            or len(dims) != 1
+            or dtype is not None
+            or not x.is_cuda
+            or x.dtype not in _STRICT_VECTOR_NORM_DTYPES
+        ):
+            return NotImplemented
+    return _vector_norm_decomposition(x, ord, dim, keepdim, dtype=dtype, out=out)
+
+
+decompositions[aten.linalg_vector_norm.default] = _strict_vector_norm_decomposition
+decompositions[aten.linalg_vector_norm.out] = _strict_vector_norm_decomposition
+
 
 def register_decomposition(
     ops: _GenericOperator | list[_GenericOperator],

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3810,6 +3810,7 @@ make_fallback(aten.resize_)
 make_fallback(aten.resize_as_)
 
 # Linalg
+make_fallback(aten.linalg_vector_norm, override_decomp=True, warn=False)
 make_fallback(aten._linalg_det)
 make_fallback(aten.linalg_householder_product)
 make_fallback(aten.linalg_inv_ex)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* #193207
* __->__ #193206
* #193205
* #193204
* #193203
* #193202
* #193201
* #193200
* #193199

vector_norm decomposes to abs -> sum (ord=1) / square -> sum -> sqrt (ord=2), and
the sum is aten.sum.dim_IntList, so the existing strict gate already routes it to
INNER_TREE (no gate change). Two fixes make it bitwise-equal to eager:

- ord=2 square+add FMA contraction: Triton fused the square (fmul) with the tree
  add (fadd) into an fma, differing from eager's separate mul.rn. Set
  enable_fp_fusion=False on strict kernels so the multiply and add are separately
  rounded (non-FTZ mul.rn + add.rn). Not ops.mul_rn (its libdevice path can FTZ).
  sqrt already lowers to tl.sqrt_rn (libdevice.sqrt = sqrt.rn.f64 for fp64).
- Out-of-scope provenance: ord not in {1,2}, explicit dtype=, and dim=None
  otherwise decompose to a strict sum and would wrongly get INNER_TREE. Gate the
  vector_norm decomposition (strict-only) to decline those, with a conditional
  make_fallback, so they fall through to ATen -- matching eager.

Default numerics codegen is unchanged (both fixes are strict-gated), and
sum/prod/nansum/mean/nanmean remain bitwise unchanged.

Test Plan: python test/inductor/test_strict_numerics.py -- 90 tests OK, incl
test_vector_norm_bitwise (eager inner-tree == compiled strict, BYTEWISE) for
ord 1/2 persistent/looped fp16/bf16/fp32/fp64 + split fp32/fp64, asserting
INNER_TREE counts, 'enable_fp_fusion': False, tl.sqrt_rn, a subnormal (2**-65)
no-FTZ case, and out-of-scope (ord=3/dtype=/dim=None) using default order.
split fp16/bf16 excluded (pre-existing Triton LLVM-SLP hang). AI-assisted,
human-reviewed.