### PR TITLE
[Eager] Add a CuTeDSL inner-tree logsumexp reduction override

### DIFF
--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -1200,6 +1200,208 @@ class TestSumCuteDSLOverride(TestCase):
             self.assertNotWarn(lambda: torch.nanmean(x, dim=1).sum().backward())
         self.assertIsNotNone(x.grad)
 
+    # --- logsumexp (ATen max masking/exp/log over inner-tree sum) ---
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    @parametrize("m,n", [(128, 15), (128, 8195), (8, 200003)])
+    def test_logsumexp_matches_inner_tree_composition(self, dtype, m, n):
+        view_dtype = torch.int32 if dtype == torch.float32 else torch.int64
+        x = self._make_order_sensitive_input(m, n, dtype)
+        with self._inner_tree_flag():
+            got = torch.logsumexp(x, dim=1)
+            maxes = torch.amax(x, dim=1, keepdim=True)
+            squeezed_maxes = maxes.squeeze(1)
+            safe = torch.where(torch.isfinite(maxes), maxes, 0)
+            expected = squeezed_maxes + torch.log(torch.sum(torch.exp(x - safe), dim=1))
+        self.assertEqual(
+            got.view(view_dtype), expected.view(view_dtype), rtol=0, atol=0
+        )
+
+    @parametrize("m,n", [(128, 15), (128, 8195), (8, 200003)])
+    def test_logsumexp_override_engaged(self, m, n):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(m, n, torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            torch.logsumexp(x, dim=1)
+        self.assertEqual(sum_into.call_count, 1)
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    @parametrize("m,n", [(128, 15), (128, 8195), (8, 200003)])
+    def test_logsumexp_matches_aten(self, dtype, m, n):
+        rtol, atol = (1e-5, 1e-6) if dtype == torch.float32 else (1e-12, 1e-12)
+        x = self._make_order_sensitive_input(m, n, dtype)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.logsumexp(x, dim=1)
+        with self._inner_tree_flag():
+            got = torch.logsumexp(x, dim=1)
+        self.assertEqual(got, ref, rtol=rtol, atol=atol)
+
+    @parametrize("keepdim", [False, True])
+    def test_logsumexp_out_variant(self, keepdim):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        with self._inner_tree_flag():
+            functional = torch.logsumexp(x, dim=1, keepdim=keepdim)
+        out_shape = (128, 1) if keepdim else (128,)
+        out = torch.empty(out_shape, device="cuda", dtype=torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            returned = torch.logsumexp(x, dim=1, keepdim=keepdim, out=out)
+        self.assertEqual(sum_into.call_count, 1)
+        self.assertIs(returned, out)
+        self.assertEqual(
+            out.view(torch.int32), functional.view(torch.int32), rtol=0, atol=0
+        )
+
+    def test_logsumexp_mis_sized_out(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(128, 8195, torch.float32)
+        with (
+            torch.backends.python_native.cutedsl.disabled(),
+            self.assertWarnsRegex(
+                UserWarning, "An output with one or more elements was resized"
+            ),
+        ):
+            native_out = torch.empty(1, device="cuda", dtype=torch.float32)
+            native_returned = torch.logsumexp(x, dim=1, out=native_out)
+        out = torch.empty(1, device="cuda", dtype=torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+            self.assertWarnsRegex(
+                UserWarning, "An output with one or more elements was resized"
+            ),
+        ):
+            returned = torch.logsumexp(x, dim=1, out=out)
+        self.assertEqual(sum_into.call_count, 0)
+        self.assertIs(native_returned, native_out)
+        self.assertIs(returned, out)
+        self.assertEqual(out.shape, native_out.shape)
+        self.assertEqual(
+            out.view(torch.int32), native_out.view(torch.int32), rtol=0, atol=0
+        )
+
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("m,n", [(64, 32), (8, 4096), (8, 65536)])
+    def test_logsumexp_low_precision_matches_aten(self, dtype, m, n):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(m, n, dtype)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.logsumexp(x, dim=1)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            got = torch.logsumexp(x, dim=1)
+        self.assertEqual(sum_into.call_count, 1)
+        self.assertEqual(got, ref, rtol=2e-2, atol=2e-2)
+
+    def test_logsumexp_all_negative_infinity(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(2, 8195, torch.float32)
+        x[0].fill_(-float("inf"))
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.logsumexp(x, dim=1)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            got = torch.logsumexp(x, dim=1)
+        self.assertEqual(sum_into.call_count, 1)
+        self.assertTrue(torch.isneginf(got[0]).item())
+        self.assertFalse(torch.isnan(got[0]).item())
+        self.assertEqual(got, ref, rtol=1e-5, atol=1e-6)
+
+    def test_logsumexp_multi_dim_falls_through(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(4, 32, torch.float32).reshape(2, 2, 32)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = torch.logsumexp(x, dim=[0, 1])
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            got = torch.logsumexp(x, dim=[0, 1])
+        self.assertEqual(sum_into.call_count, 0)
+        self.assertEqual(got, ref, rtol=0, atol=0)
+
+    @parametrize(
+        "kwargs,error",
+        [
+            ({"dim": None}, "argument 'dim' must be tuple of ints"),
+            (
+                {"dim": 1, "dtype": torch.float64},
+                "unexpected keyword argument 'dtype'",
+            ),
+        ],
+    )
+    def test_logsumexp_schema_errors(self, kwargs, error):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(4, 32, torch.float32)
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+            self.assertRaisesRegex(TypeError, error),
+        ):
+            torch.logsumexp(x, **kwargs)
+        self.assertEqual(sum_into.call_count, 0)
+
+    def test_logsumexp_requires_grad(self):
+        from torch._native.ops.reductions import inner_tree_kernel
+
+        x = self._make_order_sensitive_input(4, 32, torch.float32).requires_grad_()
+        with (
+            mock.patch.object(
+                inner_tree_kernel,
+                "inner_tree_sum_into",
+                wraps=inner_tree_kernel.inner_tree_sum_into,
+            ) as sum_into,
+            self._inner_tree_flag(),
+        ):
+            self.assertNotWarn(lambda: torch.logsumexp(x, dim=1).sum().backward())
+        self.assertEqual(sum_into.call_count, 1)
+        self.assertIsNotNone(x.grad)
+
 
 instantiate_parametrized_tests(TestSumCuteDSLOverride)
 

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -8,13 +8,14 @@ is the feature-rollout gate for these operators -- it is *not* gated by the
 global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
 ``cutedsl_utils`` at registration time).
 
-We register ten ATen dispatcher entries on ``CUDA``:
+We register eleven ATen dispatcher entries on ``CUDA``:
 
 * ``sum.dim_IntList`` / ``sum.IntList_out`` -- ``x.sum(dim=...)`` + ``.out``.
 * ``prod.dim_int`` / ``prod.int_out`` -- ``x.prod(dim=...)`` + ``.out``.
 * ``nansum`` / ``nansum.out`` -- ``x.nansum(dim=...)`` + ``.out``.
 * ``mean.dim`` / ``mean.out`` -- ``x.mean(dim=...)`` + ``.out``.
 * ``linalg_vector_norm`` / ``linalg_vector_norm.out`` -- p=1 and p=2 norms.
+* ``logsumexp`` -- functional logsumexp, composed over ``sum.IntList_out``.
 
 ``nanmean`` is covered compositionally and intentionally has no dispatcher
 entry here. ATen's CompositeImplicitAutograd implementation computes an
@@ -24,9 +25,15 @@ through the overrides above, preserving the inner-tree nansum numerator while
 ATen retains the count, tensor/tensor true division, and composite autograd
 behavior. Registering ``nanmean`` here would shadow that composite.
 
-The reductions share identical inner-tree geometry and eligibility. Their
-combiner, identity, and optional pre/post maps are threaded through the kernel
-in ``inner_tree_kernel.py``.
+``logsumexp`` is also covered compositionally. Its functional override
+pre-sizes the output and delegates to ATen's ``logsumexp.out`` implementation,
+whose nested ``sum.IntList_out`` call routes through the sum override above.
+The out overload is intentionally not registered, preserving ATen's native
+resize/error behavior for mis-sized outputs.
+
+The kernel-backed reductions share identical inner-tree geometry and
+eligibility. Their combiner, identity, and optional pre/post maps are threaded
+through the kernel in ``inner_tree_kernel.py``.
 
 ``sum.dim_IntList`` is ``structured_delegate: sum.IntList_out``, so its
 delegation to the ``.out`` kernel happens *below* the dispatcher; overriding
@@ -223,6 +230,10 @@ def _cond(self, dim=None, keepdim=False, *, dtype=None) -> bool:
     return _eligibility(self, d, out) is not None
 
 
+def _logsumexp_cond(self, dim, keepdim=False) -> bool:
+    return _cond(self, dim, keepdim)
+
+
 def _out_cond(self, dim=None, keepdim=False, *, dtype=None, out) -> bool:
     d = _base_cond_ok(self, dim, dtype)
     if d is None:
@@ -330,6 +341,17 @@ def _make_out_impl(reduce_into):
     return _out_impl
 
 
+def _logsumexp_impl(self, dim, keepdim=False):
+    d = _single_dim(dim, self.ndim)
+    if d is None:
+        raise AssertionError("_logsumexp_cond guaranteed a single dim")
+    out_kd = torch.empty(
+        _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
+    )
+    out = out_kd if keepdim else out_kd.squeeze(d)
+    return torch.ops.aten.logsumexp.out(self, dim, keepdim=keepdim, out=out)
+
+
 def _vector_norm_impl(self, ord=2, dim=None, keepdim=False, *, dtype=None):
     p = _vector_norm_order(ord)
     if p is None:
@@ -410,4 +432,7 @@ def register_to_dispatch() -> None:
         "CUDA",
         cond=_vector_norm_out_cond,
         impl=_vector_norm_out_impl,
+    )
+    cu.register_op_override(
+        "aten", "logsumexp", "CUDA", cond=_logsumexp_cond, impl=_logsumexp_impl
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193208
* __->__ #193207
* #193206
* #193205
* #193204
* #193203
* #193202
* #193201
* #193200
* #193199

logsumexp is covered compositionally, with no kernel or _Reduction change.
_logsumexp_impl delegates to aten.logsumexp.out; ATen's logsumexp internally
calls sum.IntList_out, which routes through the CuTeDSL inner-tree sum override,
so the reduction uses the bitwise inner-tree order while ATen keeps its native
max-masking (an all -inf row yields -inf, not NaN), inf handling, and autograd.

Only the functional aten::logsumexp is registered (a pre-sized out= already
routes its nested sum through the override; a mis-sized out keeps native
behavior). Eligibility: single contiguous dim, CUDA, real float; multi-dim
falls through. The schema has no dtype= and dim is required.

Test Plan: python test/python_native/test_sum_cutedsl.py -- 91 tests OK, incl:
- bytewise logsumexp(x) == maxes + log(inner_tree_sum(exp(x - safe))) (safe masks
  a non-finite max only inside the exp) on order-sensitive fp32/fp64 across
  multirow/looped/two-kernel;
- inner_tree_sum_into engagement spy (one call) across all three geometries;
- matches-ATen (tolerance), out= identity + byte-equality, fp16/bf16 tolerant,
  an all -inf row (-> -inf), multi-dim fallthrough, and a requires_grad smoke.
- sum/prod/nansum/mean/nanmean/vector_norm bitwise unchanged. AI-assisted,
  human-reviewed.