### PR TITLE
[inductor] Extend strict_numerics INNER_TREE ordering to logsumexp

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -915,6 +915,31 @@ class TestSubprocessEnv(TestCase):
 
 
 class TestSetTritonLibdevicePath(TestCase):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @config.patch(
+        {
+            "numerics": "strict",
+            "eager_numerics.use_pytorch_libdevice": False,
+            "emulate_precision_casts": False,
+            "force_disable_caches": True,
+        }
+    )
+    def test_strict_numerics_sets_libdevice_path(self):
+        """Test strict numerics sets libdevice path without legacy numerics flags."""
+        from triton import knobs
+
+        old_env = os.environ.pop("TRITON_LIBDEVICE_PATH", None)
+        old_knob = knobs.nvidia.libdevice_path
+        knobs.nvidia.libdevice_path = None
+        try:
+            self._test_libdevice_path_with_compilation()
+        finally:
+            if old_env is not None:
+                os.environ["TRITON_LIBDEVICE_PATH"] = old_env
+            else:
+                os.environ.pop("TRITON_LIBDEVICE_PATH", None)
+            knobs.nvidia.libdevice_path = old_knob
+
     @config.patch({"compile_threads": 1, "emulate_precision_casts": True})
     def test_emulate_precision_casts_sets_libdevice_path(self):
         """Test eager numerics mode sets libdevice path for CUDA libdevice calls."""

--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -114,6 +114,22 @@ NANMEAN_CASES = (
     ("split_fp64", (8, 65536), 1, torch.float64),
 )
 
+LOGSUMEXP_CASES = (
+    ("persistent_fp32", (64, 256), 1, torch.float32),
+    ("persistent_fp64", (64, 256), 1, torch.float64),
+    ("looped_fp32", (8, 12000), 1, torch.float32),
+    ("looped_fp64", (8, 12000), 1, torch.float64),
+    ("split_fp32", (8, 65536), 1, torch.float32),
+    ("split_fp64", (8, 65536), 1, torch.float64),
+)
+
+LOGSUMEXP_FALLBACK_CASES = (
+    ("persistent_fp16", (64, 256), 1, torch.float16),
+    ("persistent_bf16", (64, 256), 1, torch.bfloat16),
+    ("looped_fp16", (8, 12000), 1, torch.float16),
+    ("looped_bf16", (8, 12000), 1, torch.bfloat16),
+)
+
 DYNAMIC_CASES = (("plan_change", (512, 65537), {}),)
 
 OUT_OF_SCOPE_CASES = (
@@ -281,6 +297,92 @@ class StrictNumericsTest(TestCase):
         self._assert_bitwise_equal(eager, result)
         self.assertTrue((result != 0).all().item())
         self.assertIn(INNER_TREE_CALL, code)
+
+    def _make_logsumexp_input(self, shape, dtype, device):
+        m, n = shape
+        values = torch.arange(m * n, device=device, dtype=torch.float64).reshape(m, n)
+        return (((values % 29) - 14) / 29 + ((values % 7) - 3) / 13).to(dtype)
+
+    @parametrize("case", LOGSUMEXP_CASES, name_fn=lambda c: c[0])
+    def test_logsumexp_bitwise(self, device, case):
+        name, shape, dim, dtype = case
+        x = self._make_logsumexp_input(shape, dtype, device)
+
+        def fn(z):
+            return torch.logsumexp(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn("libdevice.exp(", code)
+        self.assertIn("libdevice.log(", code)
+        self.assertNotIn("tl_math.exp", code)
+        self.assertNotIn("tl_math.log", code)
+        expected_count = 2 if name.startswith("split") else 1
+        self.assertEqual(code.count(INNER_TREE_CALL), expected_count)
+        if name.startswith("persistent"):
+            self.assertIn("@triton_heuristics.persistent_reduction(", code)
+        elif name.startswith("looped"):
+            self.assertIn("for r0_offset in", code)
+
+    def test_logsumexp_strict_overrides_fast_math(self, device):
+        x = self._make_logsumexp_input((64, 256), torch.float32, device)
+
+        def fn(z):
+            return torch.logsumexp(z, 1)
+
+        eager = fn(x)
+        result, code = self._run(fn, x, use_fast_math=True)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn("libdevice.exp(", code)
+        self.assertIn("libdevice.log(", code)
+        self.assertNotIn("tl_math.exp", code)
+        self.assertNotIn("tl_math.log", code)
+        self.assertEqual(code.count(INNER_TREE_CALL), 1)
+
+    def test_logsumexp_all_negative_infinity(self, device):
+        x = self._make_logsumexp_input((64, 256), torch.float32, device)
+        x[0].fill_(-torch.inf)
+
+        def fn(z):
+            return torch.logsumexp(z, 1)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertTrue(torch.isneginf(result[0]).item())
+        self.assertFalse(torch.isnan(result[0]).item())
+        self.assertIn(INNER_TREE_CALL, code)
+        self.assertIn("libdevice.exp(", code)
+        self.assertIn("libdevice.log(", code)
+
+    @parametrize("case", LOGSUMEXP_FALLBACK_CASES, name_fn=lambda c: c[0])
+    def test_logsumexp_low_precision_fallback(self, device, case):
+        _, shape, dim, dtype = case
+        x = self._make_logsumexp_input(shape, dtype, device)
+
+        def fn(z):
+            return torch.logsumexp(z, dim)
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn("torch.ops.aten.logsumexp.default", code)
+        self.assertNotIn(INNER_TREE_CALL, code)
+
+    def test_logsumexp_multidim_fallback(self, device):
+        x = self._make_logsumexp_input((64, 256), torch.float32, device).reshape(
+            2, 32, 256
+        )
+
+        def fn(z):
+            return torch.logsumexp(z, (0, 1))
+
+        eager = fn(x)
+        result, code = self._run(fn, x)
+        self._assert_bitwise_equal(eager, result)
+        self.assertIn("torch.ops.aten.logsumexp.default", code)
+        self.assertNotIn(INNER_TREE_CALL, code)
 
     def _make_nansum_input(self, shape, dtype, device):
         # Standard-normal values keep magnitudes reasonable while making the

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1552,6 +1552,8 @@ class TritonOverrides(OpOverrides):
         Check https://github.com/triton-lang/triton/issues/5735 for
         more details.
         """
+        if config.numerics == "strict":
+            return f"libdevice.exp({x})"
         if config.use_fast_math:
             return f"tl_math.exp({x})"
         else:
@@ -2308,7 +2310,7 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     # pyrefly: ignore [bad-override]
     def log(x):
-        if config.eager_numerics.use_pytorch_libdevice:
+        if config.numerics == "strict" or config.eager_numerics.use_pytorch_libdevice:
             # Strict numerics should use the backend math library entry point.
             # On ROCm this maps to OCML and avoids Triton's generic log lowering.
             return f"libdevice.log({x})"

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -151,6 +151,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
 
 remove_decompositions(decompositions, decomps_to_exclude)
 
+_logsumexp_decomposition = decompositions[aten.logsumexp.default]
 _vector_norm_decomposition = decompositions[aten.linalg_vector_norm.default]
 _STRICT_VECTOR_NORM_DTYPES = (
     torch.float16,
@@ -158,6 +159,23 @@ _STRICT_VECTOR_NORM_DTYPES = (
     torch.float32,
     torch.float64,
 )
+
+
+@functools.wraps(_logsumexp_decomposition)
+def _strict_logsumexp_decomposition(
+    self: torch.Tensor,
+    dim: int | list[int] | tuple[int, ...],
+    keepdim: bool = False,
+) -> torch.Tensor:
+    if config.numerics == "strict":
+        dims = [dim] if isinstance(dim, int) else dim
+        if (
+            len(dims) != 1
+            or not self.is_cuda
+            or self.dtype not in (torch.float32, torch.float64)
+        ):
+            return NotImplemented
+    return _logsumexp_decomposition(self, dim, keepdim)
 
 
 @functools.wraps(_vector_norm_decomposition)
@@ -186,6 +204,7 @@ def _strict_vector_norm_decomposition(
     return _vector_norm_decomposition(x, ord, dim, keepdim, dtype=dtype, out=out)
 
 
+decompositions[aten.logsumexp.default] = _strict_logsumexp_decomposition
 decompositions[aten.linalg_vector_norm.default] = _strict_vector_norm_decomposition
 decompositions[aten.linalg_vector_norm.out] = _strict_vector_norm_decomposition
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3810,6 +3810,7 @@ make_fallback(aten.resize_)
 make_fallback(aten.resize_as_)
 
 # Linalg
+make_fallback(aten.logsumexp, override_decomp=True, warn=False)
 make_fallback(aten.linalg_vector_norm, override_decomp=True, warn=False)
 make_fallback(aten._linalg_det)
 make_fallback(aten.linalg_householder_product)

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -57,13 +57,15 @@ def _set_triton_libdevice_path() -> None:
     """
     Use the CUDA toolkit's libdevice instead of Triton's bundled version.
     This ensures Triton's libdevice calls match CUDA eager numerics for bitwise
-    precision.  Gated by config.eager_numerics.use_pytorch_libdevice and by
-    config.emulate_precision_casts, which also requests eager-like numerics.
+    precision. Gated by config.numerics == "strict",
+    config.eager_numerics.use_pytorch_libdevice, or config.emulate_precision_casts.
     """
     from torch._inductor import config
 
     if not (
-        config.eager_numerics.use_pytorch_libdevice or config.emulate_precision_casts
+        config.numerics == "strict"
+        or config.eager_numerics.use_pytorch_libdevice
+        or config.emulate_precision_casts
     ):
         return
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193208
* #193207
* #193206
* #193205
* #193204
* #193203
* #193202
* #193201
* #193200
* #193199

logsumexp decomposes to max + sum(exp(x - m)) + log; the inner sum is
aten.sum.dim_IntList, so the strict gate routes it through INNER_TREE. To make
the transcendentals match eager/ATen bit-for-bit, TritonOverrides.exp/log emit
libdevice.exp/libdevice.log under numerics="strict" (before use_fast_math), and
_set_triton_libdevice_path selects the toolkit libdevice matching the CUDA
toolkit ATen was built with (explicit TRITON_LIBDEVICE_PATH still wins).

The aten.logsumexp decomposition is gated (strict + single dim + CUDA + fp32/fp64)
and otherwise returns NotImplemented, with make_fallback(aten.logsumexp,
override_decomp=True) so out-of-scope calls (multi-dim, unsupported dtype/device)
fall through to ATen. fp16/bf16 strict is kept opaque (fused inductor holds the
exp/log intermediates in fp32 whereas eager rounds between ops, so it is not
claimed bitwise). The global exp/log override is inert for sum/prod/nansum/mean/
nanmean/vector_norm (they emit no exp/log), which remain bitwise-unchanged.

Test Plan: python test/inductor/test_strict_numerics.py -- 103 tests OK, incl
LOGSUMEXP fp32/fp64 persistent/looped/split eager==inductor BYTEWISE, asserting
libdevice.exp/log present + tl_math absent + INNER_TREE counts (schedule-specific
persistent vs looped) + a use_fast_math strict case + an all -inf row (-> -inf);
fp16/bf16 persistent/looped and multi-dim fall back (no INNER_TREE); and a
strict libdevice-path case in test_compile_worker.py. AI-assisted, human-reviewed.