### PR TITLE
[CI] Validate PYTORCH_ROOT before binary env generation

### DIFF
--- a/.ci/pytorch/binary_populate_env.sh
+++ b/.ci/pytorch/binary_populate_env.sh
@@ -17,12 +17,8 @@ tagged_version() {
 }
 
 envfile=${BINARY_ENV_FILE:-/tmp/env}
-if [[ -n "${PYTORCH_ROOT}"  ]]; then
-  workdir=$(dirname "${PYTORCH_ROOT}")
-else
-  # docker executor (binary builds)
-  workdir="/"
-fi
+: "${PYTORCH_ROOT:?PYTORCH_ROOT must point to the PyTorch checkout root}"
+workdir=$(dirname "${PYTORCH_ROOT}")
 
 if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   export BUILD_PYTHONLESS=1

--- a/tools/test/test_binary_populate_env.py
+++ b/tools/test/test_binary_populate_env.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".ci" / "pytorch" / "binary_populate_env.sh"
+
+
+class TestBinaryPopulateEnv(unittest.TestCase):
+    def test_missing_pytorch_root_has_actionable_error(self) -> None:
+        env = {
+            "BINARY_ENV_FILE": os.devnull,
+            "DESIRED_CUDA": "cpu",
+            "GPU_ARCH_TYPE": "cuda",
+            "PACKAGE_TYPE": "wheel",
+            "PATH": os.environ["PATH"],
+        }
+
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "PYTORCH_ROOT must point to the PyTorch checkout root",
+            result.stderr,
+        )


### PR DESCRIPTION
Fixes #177425.

`binary_populate_env.sh` reads `PYTORCH_ROOT` under `set -u` before its optional
fallback can run, so a missing root produces only an unbound-variable error.
Validate the required input before first use and remove the unreachable fallback
so callers receive an actionable diagnostic.

The regression test runs the script with its other required settings but no
`PYTORCH_ROOT`, and verifies the explicit failure message. A real success-path
invocation continues to generate the expected environment.

- [x] The issue is linked.
- [x] Tests cover the changed behavior.
- [x] No backward-incompatible public API change.

> **AI assistance disclosure:** Codex helped prepare the change, tests, and this
> PR summary.

**Human commentary:** I reviewed and verified this contribution end to end before authorizing submission.
