### PR TITLE
[autograd] Disable Dynamo while eager engine runs backward

### DIFF
--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -1401,5 +1401,29 @@ backward() with non-leaf tensor
         self.assertEqual(compiled_grad, eager_grad)
 
 
+@skipIfTorchDynamo()
+class TestEagerEngineDynamoBoundary(TestCase):
+    def test_backward_does_not_reenter_dynamo(self):
+        def true_fn(x):
+            return x.sin()
+
+        def false_fn(x):
+            return x.cos()
+
+        def fn(x):
+            y = torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
+            y.sum().backward()
+            return y + 1
+
+        x = torch.randn(4, requires_grad=True)
+        backend = EagerAndRecordGraphs()
+        compiled_fn = torch.compile(fn, backend=backend)
+
+        with torch.autograd.set_multithreading_enabled(False):
+            compiled_fn(x)
+
+        self.assertEqual(len(backend.graphs), 2)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -1068,11 +1068,15 @@ def _engine_run_backward(
     # Need to save the context so compiler config will be visible in device threads
     torch._C._stash_obj_in_tls("context", contextvars.copy_context())
 
+    # Python autograd nodes can run on the calling thread. Do not let an ambient
+    # Dynamo callback trace them as part of the surrounding compiled function.
+    prior_dynamo_callback = torch._C._dynamo.eval_frame.set_eval_frame(None)
     try:
         return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
             t_outputs, *args, **kwargs
         )  # Calls into the C++ engine to run the backward pass
     finally:
+        torch._C._dynamo.eval_frame.set_eval_frame(prior_dynamo_callback)
         if attach_logging_hooks:
             unregister_hooks()  # type: ignore[possibly-undefined]
         # Erase rather than overwrite-with-None so the thread_local map is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192004
* __->__ #193210

Dynamo's eval-frame callback is thread-local. When eager autograd executes a
Python node on the caller thread, it inherits the callback from a surrounding
compiled function. Backward code that materializes fresh FX GraphModules can
then be captured accidentally. The resulting guard misses attempt to recompile
during CUDA graph capture, where compilation is forbidden.

Clear the callback only while the execution engine runs, then restore it before
returning to the surrounding Python frame. Using the low-level callback API
also keeps an ordinary eager backward from importing torch._dynamo. Explicit
AOTAutograd, trace_autograd_ops, and Compiled Autograd capture remain available.

Test Plan:

```bash
python test/dynamo/test_fwd_loss_bwd.py
```

```bash
python test/inductor/test_compiled_autograd.py TestCompiledAutograd.test_torch_compile_only_backward_call TestCompiledAutograd.test_torch_compile_graph_break TestCompiledAutograd.test_no_nested_compiled_autograd -v
```

```bash
python test/functorch/test_control_flow.py TestControlFlow.test_cond_autograd_simple TestControlFlowNN.test_cond_in_NN -v
```

```bash
lintrunner -a
```

Authored with the assistance of an AI coding assistant (OpenAI Codex).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98