### PR TITLE
[c10][cuda] Expandable-segment VA observability + out-of-VM diagnostics (#193211)

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -78,6 +78,16 @@ namespace cuda::CUDACachingAllocator {
 using namespace c10::CachingAllocator;
 using namespace c10::CachingDeviceAllocator;
 
+namespace {
+// Process-wide expandable-segment virtual-address gauges. Bumped in the
+// ExpandableSegment ctor (after a successful reservation) and dtor; read by
+// getExpandableSegmentsReservedBytes()/getExpandableSegmentsCount() for ODS and
+// out-of-VM diagnostics. Relaxed atomics: plain counters, not used for
+// synchronization.
+std::atomic<size_t> g_expandable_segments_reserved_bytes{0};
+std::atomic<size_t> g_expandable_segments_count{0};
+} // namespace
+
 #if defined(PYTORCH_C10_DRIVER_API_SUPPORTED) || defined(USE_ROCM)
 static int get_self_pid() {
 #ifdef _WIN32
@@ -455,13 +465,48 @@ struct ExpandableSegment {
           CUDAAllocatorConfig::clamp_reserve_bytes(decision, full_reserve);
     }
     max_handles_ = numSegments(reserve);
+    const size_t reserve_bytes = segment_size_ * max_handles_;
+    // Log expandable-segment VA context immediately BEFORE the (unchanged)
+    // driver check throws, so an out-of-virtual-memory crash is self-explaining
+    // in task logs. Built only on the failure branch -> perf-neutral on
+    // success.
+    auto logVaExhaustion = [&](const char* err_str) {
+      LOG(ERROR)
+          << "[ExpandableSegmentVA] Failed to reserve " << reserve_bytes
+          << " bytes (~" << (reserve_bytes >> 30)
+          << " GiB) of virtual address space for an expandable CUDA segment on device "
+          << static_cast<int>(device_) << " (driver reported: " << err_str
+          << "). This process already holds " << getExpandableSegmentsCount()
+          << " live expandable segment(s) reserving "
+          << getExpandableSegmentsReservedBytes()
+          << " bytes of virtual address space. This is virtual-address-space "
+             "(VSZ) exhaustion from expandable segments, not physical GPU OOM. "
+             "Reduce it via PYTORCH_CUDA_ALLOC_CONF expandable_segments_reserve / "
+             "expandable_segments_reserve_by_class, or by using fewer CUDA streams.";
+    };
 #ifdef USE_ROCM
-    C10_CUDA_CHECK(hipMemAddressReserve(
-        &ptr_, segment_size_ * max_handles_, 0ULL, 0, 0ULL));
+    hipError_t reserve_err =
+        hipMemAddressReserve(&ptr_, reserve_bytes, 0ULL, 0, 0ULL);
+    if (C10_UNLIKELY(reserve_err != hipSuccess)) {
+      const char* err_str = hipGetErrorString(reserve_err);
+      logVaExhaustion(err_str ? err_str : "unknown error");
+    }
+    C10_CUDA_CHECK(reserve_err);
 #else
-    C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemAddressReserve_(
-        &ptr_, segment_size_ * max_handles_, 0ULL, 0, 0ULL));
+    CUresult reserve_err = DriverAPI::get()->cuMemAddressReserve_(
+        &ptr_, reserve_bytes, 0ULL, 0, 0ULL);
+    if (C10_UNLIKELY(reserve_err != CUDA_SUCCESS)) {
+      const char* err_str = nullptr;
+      DriverAPI::get()->cuGetErrorString_(reserve_err, &err_str);
+      logVaExhaustion(err_str ? err_str : "unknown error");
+    }
+    C10_CUDA_DRIVER_CHECK(reserve_err);
 #endif
+    // Reservation succeeded (a failure would have thrown above): publish
+    // gauges.
+    g_expandable_segments_reserved_bytes.fetch_add(
+        reserve_bytes, std::memory_order_relaxed);
+    g_expandable_segments_count.fetch_add(1, std::memory_order_relaxed);
   }
   ExpandableSegment(const ExpandableSegment&) = delete;
   ExpandableSegment(ExpandableSegment&&) = delete;
@@ -855,6 +900,12 @@ struct ExpandableSegment {
     C10_CUDA_DRIVER_CHECK(DriverAPI::get()->cuMemAddressFree_(
         ptr_, segment_size_ * max_handles_));
 #endif
+    // Decrement only after a successful free (the checks above throw on
+    // failure), so the gauges never under-report VA that is still reserved by
+    // the driver.
+    g_expandable_segments_reserved_bytes.fetch_sub(
+        segment_size_ * max_handles_, std::memory_order_relaxed);
+    g_expandable_segments_count.fetch_sub(1, std::memory_order_relaxed);
   }
 
  private:
@@ -2011,7 +2062,18 @@ class DeviceCachingAllocator {
               reserved_bytes - allocated_bytes - allocated_in_private_pools),
           " is reserved by PyTorch but unallocated.",
           CUDAAllocatorConfig::expandable_segments()
-              ? ""
+              // Suppressed when the reserve-specific hint below applies: that
+              // one says to RAISE the reserve, so the generic "you may be
+              // over-reserving, reduce it" advice would contradict it.
+              ? (!expandable_reserve_msg.empty()
+                     ? ""
+                     : " expandable_segments is enabled. If instead the process"
+                       " is running out of virtual address space (VSZ),"
+                       " expandable segments may be over-reserving VA (each"
+                       " segment reserves ~9/8 of device memory, times the"
+                       " number of streams); reduce it via"
+                       " PYTORCH_CUDA_ALLOC_CONF expandable_segments_reserve /"
+                       " expandable_segments_reserve_by_class.")
               : " If reserved but unallocated memory is large try setting"
                 " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
                 " fragmentation.  See documentation for Memory Management "
@@ -5517,6 +5579,14 @@ void setDefaultExpandableSegmentReserveFractionForClass(
   CUDAAllocatorConfig::set_default_reserve_for_class(
       reserve_class,
       ExpandableSegmentReserveSpec{/*is_fraction=*/true, fraction});
+}
+
+size_t getExpandableSegmentsReservedBytes() {
+  return g_expandable_segments_reserved_bytes.load(std::memory_order_relaxed);
+}
+
+size_t getExpandableSegmentsCount() {
+  return g_expandable_segments_count.load(std::memory_order_relaxed);
 }
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -598,6 +598,13 @@ C10_CUDA_API void setDefaultExpandableSegmentReserveFractionForClass(
     const std::string& reserve_class,
     double fraction);
 
+// Process-wide expandable-segment virtual-address gauges, for observability
+// (ODS) and out-of-VM diagnostics: total VA bytes reserved by all live
+// ExpandableSegments, and the number of live segments. Cheap relaxed-atomic
+// reads; safe to call at any time.
+C10_CUDA_API size_t getExpandableSegmentsReservedBytes();
+C10_CUDA_API size_t getExpandableSegmentsCount();
+
 } // namespace c10::cuda::CUDACachingAllocator
 
 namespace c10::cuda {


### PR DESCRIPTION
Summary:

Adds observability and self-explaining diagnostics for expandable-segment
virtual-address (VA) reservations, so an out-of-virtual-memory crash is quickly
attributable to expandable segments over-reserving VA. Perf-neutral: nothing is
added to the allocation/success path.

- Process-wide gauges (c10): `getExpandableSegmentsReservedBytes()` /
  `getExpandableSegmentsCount()`, backed by relaxed atomics bumped in the
  `ExpandableSegment` ctor (after a successful reservation) and dtor -- i.e. per
  segment create/destroy, never per allocation.
- VA-exhaustion diagnostic: on `cuMemAddressReserve`/`hipMemAddressReserve`
  failure in the `ExpandableSegment` ctor, emit a greppable `LOG(ERROR)`
  `[ExpandableSegmentVA]` with the requested reserve size, the live segment
  count/bytes, and the remediation knobs, immediately BEFORE the unchanged driver
  check throws. The exception itself is unchanged (same `C10_CUDA_DRIVER_CHECK` /
  `C10_CUDA_CHECK` -> `c10_cuda_check_implementation`); we only prepend context.
  The message is built solely on the failure branch.
- OOM builder: when `expandable_segments` is enabled, the "CUDA out of memory"
  message now points at possible VA over-reservation and the reserve knobs
  instead of the previous empty string.

Motivation: a true VA-exhaustion failure surfaces from the ctor as a terse
`CUDA driver error: out of memory` that bypasses the friendly OOM builder, giving
someone debugging the crash no hint it is expandable-segment VA over-reservation.
The `[ExpandableSegmentVA]` log makes that immediately discoverable in task logs.

Depends on the reserve-mechanism diff (the reserve knobs referenced in the
messages).

Test Plan:
# Unit tests

```
buck2 build //caffe2/c10/cuda:cuda
buck2 build //sigrid/predictor/utils:log_gpu_ods_stats
buck2 test //caffe2/c10/cuda/test:expandable_segment_reserve_test
```
All build; test reports `Pass 5. Fail 0.`. Perf-neutrality: gauges are two
relaxed atomics per segment create/destroy (rare); the `LOG(ERROR)` and the OOM
hint execute only when an exception is being raised; ODS publishes on the existing
periodic cadence.

Authored with the assistance of an AI agent (Claude Code); all changes reviewed by
the author.

# Various real life test runs

Ran against Meta internal AMD and NV production code and checked if logs and metrics outputs were as expected

Reviewed By: banitag1

Differential Revision: D114810528


