### PR TITLE
[Profiler] Add a killswitch for TEARDOWN_CUPTI in Kineto (#193212)

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -442,6 +442,55 @@ class TestProfilerITT(TestCase):
 
 @instantiate_parametrized_tests
 class TestProfiler(TestCase):
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @parametrize(
+        "knob_value,explicit_value,expected_value",
+        [
+            (True, None, "1"),
+            (False, None, "0"),
+            (True, "0", "0"),
+            (False, "1", "1"),
+        ],
+    )
+    def test_teardown_cupti_environment(
+        self, knob_value, explicit_value, expected_value
+    ):
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "torch.profiler.profiler.profiler_should_teardown_cupti",
+                return_value=knob_value,
+            ) as teardown_cupti,
+            patch("torch.profiler.profiler.is_fbcode", return_value=True),
+        ):
+            if explicit_value is None:
+                os.environ.pop("TEARDOWN_CUPTI", None)
+            else:
+                os.environ["TEARDOWN_CUPTI"] = explicit_value
+
+            with profile(activities=[ProfilerActivity.CPU]):
+                pass
+
+            self.assertEqual(expected_value, os.environ["TEARDOWN_CUPTI"])
+            self.assertEqual(explicit_value is None, teardown_cupti.called)
+
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_teardown_cupti_environment_oss(self):
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "torch.profiler.profiler.profiler_should_teardown_cupti"
+            ) as teardown_cupti,
+            patch("torch.profiler.profiler.is_fbcode", return_value=False),
+        ):
+            os.environ.pop("TEARDOWN_CUPTI", None)
+
+            with profile(activities=[ProfilerActivity.CPU]):
+                pass
+
+            self.assertNotIn("TEARDOWN_CUPTI", os.environ)
+            teardown_cupti.assert_not_called()
+
     @unittest.skipIf(
         TEST_WITH_CROSSREF, "crossref intercepts calls and changes the callsite."
     )

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -324,6 +324,10 @@ def profiler_allow_cudagraph_cupti_lazy_reinit_cuda12():
     return True
 
 
+def profiler_should_teardown_cupti():
+    return True
+
+
 def deprecated():
     """
     When we deprecate a function that might still be in use, we make it internal

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -24,7 +24,10 @@ from torch._C._profiler import (
     _remove_execution_trace_observer,
 )
 from torch._environment import is_fbcode
-from torch._utils_internal import profiler_allow_cudagraph_cupti_lazy_reinit_cuda12
+from torch._utils_internal import (
+    profiler_allow_cudagraph_cupti_lazy_reinit_cuda12,
+    profiler_should_teardown_cupti,
+)
 from torch.autograd import kineto_available, ProfilerActivity
 from torch.profiler._memory_profiler import MemoryProfile, MemoryProfileTimeline
 
@@ -406,6 +409,10 @@ class _KinetoProfile:
             self.execution_trace_observer.start()
         if self.profiler is None:
             raise AssertionError("Profiler must be initialized before starting trace")
+        if kineto_available() and is_fbcode() and "TEARDOWN_CUPTI" not in os.environ:
+            os.environ["TEARDOWN_CUPTI"] = (
+                "1" if profiler_should_teardown_cupti() else "0"
+            )
         self.profiler._start_trace()
         if self._use_cupti_monitor and self._cupti_profiler_observer is not None:
             # Open the trace window here (stamps the start boundary, native clock, no


### PR DESCRIPTION
Summary:

Enable setting TEARDOWN_CUPTI via `profiler_should_teardown_cupti`.

Test Plan: CI, unit tests

Differential Revision: D115748254


