### PR TITLE
[_native] Decline nonzero-storage-offset tensors (DLPack byte_offset)

### DIFF
--- a/test/python_native/test_reductions_cutedsl.py
+++ b/test/python_native/test_reductions_cutedsl.py
@@ -496,7 +496,6 @@ class TestCuTeDSLReductionWiring(TestCase):
         base = torch.empty(4096, device="cuda")
         targets = (
             ("contiguous", torch.empty(1024, device="cuda")),
-            ("unaligned", base[1:1025]),
             ("transposed", torch.empty(32, 32, device="cuda").t()),
             ("strided", torch.empty(2048, device="cuda")[::2]),
             ("0-dim", torch.empty((), device="cuda")),
@@ -506,6 +505,14 @@ class TestCuTeDSLReductionWiring(TestCase):
                 served(lambda t=t: t.fill_(2.5)), 1, f"{name} must be served"
             )
             self.assertTrue(bool((t == 2.5).all()), name)
+        # A nonzero STORAGE OFFSET declines for now (cap.dlpack_offset_ok): CuteDSL's
+        # tvm-ffi entry asserts the DLPack byte_offset is 0, and pytorch#182924 made that
+        # field carry the offset. It is a layout we can otherwise serve -- the strided
+        # route handles it -- so this expectation flips back to `served == 1` when that
+        # gate is removed. Values must still be right, via aten.
+        offset_target = base[1:1025]
+        self.assertEqual(served(lambda t=offset_target: t.fill_(2.5)), 0)
+        self.assertTrue(bool((offset_target == 2.5).all()))
         # Every constructor aten builds on empty()+fill_ rides the same override, with no
         # per-constructor row: full / zeros / ones / full_like, floats and ints alike.
         for fn in (

--- a/torch/_native/ops/pointwise/overrides.py
+++ b/torch/_native/ops/pointwise/overrides.py
@@ -114,6 +114,7 @@ def _supported(t, dtypes) -> bool:
         and t.numel() > 0
         and not t.is_neg()
         and not t.is_conj()
+        and cap.dlpack_offset_ok(t)
         and not cap.is_traced(t)
     )
 
@@ -274,6 +275,7 @@ def _make_cond(row: PointwiseDef, variant):
                 and tgt.is_contiguous()
                 and tgt.device == ref.device
                 and K._is_16b_aligned(tgt)
+                and cap.dlpack_offset_ok(tgt)
                 and not cap.is_traced(tgt)
             ):
                 return False
@@ -602,6 +604,8 @@ def _copy_cond(self, src, non_blocking=False):
         return False
     if not K._is_16b_aligned(self):
         return False
+    if not cap.dlpack_offset_ok(self):
+        return False
     # An EMPTY destination is a no-op for aten but a zero-element grid for us
     # (cudaErrorInvalidConfiguration, or an invalid cute layout when the shape has a 0
     # extent). _conv_serveable only rejects an empty SOURCE, and copy_ broadcasts, so a
@@ -649,6 +653,7 @@ def _fill_cond(self, value):
         and self.numel() > 0
         and not self.is_neg()
         and not self.is_conj()
+        and cap.dlpack_offset_ok(self)
         and not cap.is_traced(self)
         and cap.device_ok(self)
         and cap.on_current_device(self)
@@ -720,6 +725,7 @@ def _range_out_serveable(out) -> bool:
         and out.numel() > 0
         and not out.is_neg()
         and not out.is_conj()
+        and cap.dlpack_offset_ok(out)
         and not cap.is_traced(out)
         and cap.device_ok(out)
         and cap.on_current_device(out)

--- a/torch/_native/ops/reductions/overrides.py
+++ b/torch/_native/ops/reductions/overrides.py
@@ -195,6 +195,7 @@ def _base_cond(self, dim, nouts=1, has_index=False) -> bool:
         and cap.on_current_device(self)
         and not self.is_neg()
         and not self.is_conj()
+        and cap.dlpack_offset_ok(self)
         and self.const_data_ptr() % 16 == 0
         and _dims_ok(dim, self.dim())
         and _geometry_supported(self, dim, nouts, has_index)

--- a/torch/_native/ops/rng/impl.py
+++ b/torch/_native/ops/rng/impl.py
@@ -46,6 +46,7 @@ def _serveable(self) -> bool:
         and self.numel() > 0
         and not self.is_neg()
         and not self.is_conj()
+        and cap.dlpack_offset_ok(self)
         and not cap.is_traced(self)
         and cap.device_ok(self)
         and cap.on_current_device(self)

--- a/torch/_native/utils/capability.py
+++ b/torch/_native/utils/capability.py
@@ -21,6 +21,30 @@ def is_cow(t: torch.Tensor) -> bool:
     return torch._C._is_cow_tensor(t)  # pyrefly: ignore[missing-attribute]
 
 
+def dlpack_offset_ok(t: torch.Tensor) -> bool:
+    """TEMPORARY: decline any tensor whose DLPack byte_offset would be nonzero.
+
+    CuteDSL's tvm-ffi entry point loads `byte_offset` from the DLTensor purely to assert
+    it is ZERO (base_dsl/tvm_ffi_builder/tvm_ffi_builder.py -- the value is never added
+    to `data`, so the kernel addresses the storage BASE). pytorch#182924 then made DLPack
+    export report `byte_offset = storage_offset * itemsize` for every device instead of
+    folding it into `data`, so any view with a nonzero storage offset -- x[4:], chunk /
+    split / narrow, an arena or KV-cache slice -- now trips that assert mid-call.
+
+    Serving such a tensor is not an option: with the assert suppressed the kernel would
+    silently read and write from the storage base. So this is a genuine CAPABILITY limit
+    ("we cannot hand CuteDSL a nonzero byte_offset"), the same species as the neg/conj
+    and 16-byte-alignment gates -- not a performance threshold. Declining costs only the
+    acceleration; aten computes the same values.
+
+    Remove this (and its call sites) once CuteDSL folds byte_offset into the pointer on
+    ingest, which it already does for direct-address devices in
+    tvm/ffi/container/tensor.h, or drops the assert. Tracked as task #38; standalone
+    repro in agent_space/cutedsl_byte_offset_repro.py.
+    """
+    return t.storage_offset() == 0
+
+
 def is_traced(t: torch.Tensor) -> bool:
     # FakeTensor (compile/export tracing) and meta tensors have no real storage to
     # launch a kernel on; the decomposition / shape-inference path should use aten's


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193213
* #193164
* #191222
* #191221
* #191220
* #191219
* #191218
* #191217
* #191216
* #191215
* #191214
* #191213
* #191212
* #191211
* #191210
* #191209
* #191208

TEMPORARY, DROP-ME COMMIT. Deliberately last in the stack so it can be reverted on
its own once the upstream cause is fixed; nothing below it depends on it.

CuteDSL's tvm-ffi entry point loads `byte_offset` out of the DLTensor purely to assert
it is zero (base_dsl/tvm_ffi_builder/tvm_ffi_builder.py) -- the value never reaches the
address computation, so the kernel indexes from the storage BASE. pytorch#182924 then
changed DLPack export to report `byte_offset = storage_offset * itemsize` for every
device instead of folding it into `data`. Together those make every view with a nonzero
storage offset fail mid-call with

    ValueError: Mismatched Tensor on mIns[0] ... expected byte_offset=0

Measured on an offset view (base[4:2052], contiguous and 16-byte aligned): 10 of 11
ordinary ops broke -- sin, add, mul, fill_, relu_, sin(out=), sum, sum(dim), mean(dim),
amax(dim). x[4:], chunk / split / narrow and any arena or KV-cache slice all produce
such a tensor, so this was not a corner case.

So `cap.dlpack_offset_ok()` declines them and aten computes the same values. This is a
CAPABILITY gate, not a performance threshold: we cannot hand CuteDSL a nonzero
byte_offset at all, the same way we cannot hand it a neg/conj bit or a misaligned base
pointer. Suppressing the assert instead was rejected -- the kernel would then silently
read and write the wrong addresses.

Alternatives that were tried and rejected, for the record:
  * upgrading nvidia-cutlass-dsl to 4.7.0 -- identical assert, reproduced live;
  * upgrading apache-tvm-ffi to 0.1.13 -- no byte_offset changes;
  * forcing the non-tvm-ffi calling convention -- ReadOnlyTensorWrapper only supports
    the fast C exchange, and on the capsule route it yields garbage shape metadata
    (LLVM SmallVector abort);
  * reverting pytorch#182924 locally -- works, but leaves local behaviour diverging
    from upstream and does nothing for CI.

The real fix belongs in CuteDSL, which already folds byte_offset into the pointer for
direct-address devices in tvm/ffi/container/tensor.h; the tvm-ffi entry path just needs
to do the same instead of asserting zero. Revert this commit then.

Test Plan:

```
python test/python_native/test_reductions_cutedsl.py
python test/python_native/test_rng_dsl.py
python test/python_native/test_sum_cutedsl.py
python test/python_native/test_native_dsl_ops.py
python test/test_reductions.py TestReductionsCUDA
```

25/25, 5/5, 22/22 and 18/18 pass; test_reductions.py TestReductionsCUDA runs 4755 with
one pre-existing unrelated failure (test_bucketization_cuda, a wrapped-number
toPyObject assert). Before this commit the four offset-view tests in
test_reductions_cutedsl.py failed. The blast-radius matrix above goes from 10 of 11
failing to 0 of 11.

test_nullary_fill_serves_every_layout keeps its offset target but now expects it to
DECLINE while still producing correct values; flip that expectation back when the gate
goes away.

Authored with assistance from an AI coding agent (Claude Code).