### PR TITLE
Add a resolver for which GPU each arch-gated test needs

### DIFF
--- a/tools/testing/arch_coverage.py
+++ b/tools/testing/arch_coverage.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Work out which GPU each arch-gated test needs, by reading its skip decorator.
+
+Reports the tests that require an H100 or B200, grouped into the .ci/pytorch/test.sh
+function that runs there, plus an inventory of gates it could not classify.
+
+Only two decorator shapes are treated as a requirement:
+
+    @skipIf(not PRED, ...)      @skipUnless(PRED, ...)      @skipCUDAIf(not PRED, ...)
+
+Anything else -- a compound condition, or a bare `skipIf(PRED)` which excludes
+rather than requires -- is declined and listed, never guessed at. Guessing is how
+an earlier version decided test__int_mm "requires" sm90 when its gate is
+`skipIf(SM90OrLater, "Expected failure on sm90")`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOT = REPO_ROOT / "test"
+COMMON_CUDA = REPO_ROOT / "torch/testing/_internal/common_cuda.py"
+
+SKIP_DECORATORS = {"skipIf", "skipUnless", "skipCUDAIf"}
+
+# Capability of the highest runner reached without a curated list. Anything a test
+# can run on at or below this already runs in CI, so it needs no entry.
+AUTO_DISCOVERED_MAX = (8, 9)
+
+# (label, runner capability, test.sh function). The labels are independent, so a
+# test that runs on both belongs in both lists.
+TARGETS = [
+    ("ciflow/h100", (9, 0), "test_python_smoke"),
+    ("ciflow/b200", (10, 0), "test_python_smoke_b200"),
+]
+
+
+class Gate(NamedTuple):
+    file: str  # run_test.py style, e.g. "inductor/test_user_streams"
+    test: str
+    line: int
+    predicate: str
+
+
+class Unclassified(NamedTuple):
+    file: str
+    line: int
+    reason: str
+    source: str
+
+
+def load_tables() -> tuple[dict, set[str]]:
+    """(GATE_ARCH_RANGES, NOT_ARCH_GATED), read as source so this needs no torch."""
+    found: dict[str, object] = {}
+    for node in ast.parse(COMMON_CUDA.read_text(encoding="utf-8")).body:
+        target = node.target if isinstance(node, ast.AnnAssign) else None
+        name = getattr(target, "id", "")
+        if name in ("GATE_ARCH_RANGES", "NOT_ARCH_GATED"):
+            found[name] = ast.literal_eval(node.value)
+    missing = {"GATE_ARCH_RANGES", "NOT_ARCH_GATED"} - set(found)
+    if missing:
+        raise SystemExit(f"arch_coverage: {missing} not found in {COMMON_CUDA}")
+    return found["GATE_ARCH_RANGES"], set(found["NOT_ARCH_GATED"])
+
+
+def requires(node: ast.Call) -> ast.expr | None:
+    """The predicate a decorator requires, or None if it isn't a requirement."""
+    name = ast.unparse(node.func).split(".")[-1]
+    if name not in SKIP_DECORATORS or not node.args:
+        return None
+    cond = node.args[0]
+    negated = isinstance(cond, ast.UnaryOp) and isinstance(cond.op, ast.Not)
+    inner = cond.operand if negated else cond
+    if isinstance(inner, ast.BoolOp):
+        return None
+    if negated or name == "skipUnless":
+        return inner
+    return None
+
+
+def predicate_name(node: ast.expr) -> str:
+    """`SM90OrLater` / `has_triton_tma_device()` -> the bare name."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    return ast.unparse(node).split(".")[-1]
+
+
+def scan(
+    path: Path, rel: str, ranges: dict, exempt: set[str]
+) -> tuple[list[Gate], list[Unclassified]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return [], []
+    gates: list[Gate] = []
+    unclassified: list[Unclassified] = []
+
+    def visit(node: ast.AST, cls: str | None) -> None:
+        for child in ast.iter_child_nodes(node):
+            if not isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+            is_class = isinstance(child, ast.ClassDef)
+            named = child.name.startswith("Test" if is_class else "test")
+            for dec in child.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                src = ast.unparse(dec)
+                if not ARCH_HINT.search(src):
+                    continue
+                pred = requires(dec)
+                if pred is None:
+                    if named:
+                        unclassified.append(
+                            Unclassified(
+                                rel, dec.lineno, "not a requirement", src[:100]
+                            )
+                        )
+                    continue
+                name = predicate_name(pred)
+                if name in exempt:
+                    continue
+                if name not in ranges:
+                    if named:
+                        unclassified.append(
+                            Unclassified(
+                                rel,
+                                dec.lineno,
+                                f"{name} has no declared range",
+                                src[:100],
+                            )
+                        )
+                    continue
+                if named:
+                    gates.append(Gate(rel, child.name, child.lineno, name))
+            if is_class:
+                visit(child, child.name)
+
+    visit(tree, None)
+    return gates, unclassified
+
+
+def rel_name(path: Path) -> str | None:
+    if not path.name.startswith("test_") or path.suffix != ".py":
+        return None
+    return str(path.relative_to(TEST_ROOT).with_suffix(""))
+
+
+def collect(ranges: dict, exempt: set[str]) -> tuple[list[Gate], list[Unclassified]]:
+    gates: list[Gate] = []
+    unclassified: list[Unclassified] = []
+    for root, dirs, files in os.walk(TEST_ROOT):
+        # Vendored CPython tests and fbcode-only trees are not ours to schedule.
+        dirs[:] = [d for d in dirs if d not in ("fb", "cpython")]
+        for name in sorted(files):
+            path = Path(root) / name
+            rel = rel_name(path)
+            if rel:
+                g, u = scan(path, rel, ranges, exempt)
+                gates.extend(g)
+                unclassified.extend(u)
+    return gates, unclassified
+
+
+def needed(gates: list[Gate], ranges: dict) -> dict[str, dict[str, set[str]]]:
+    """{test.sh function: {file: test names}} for tests a curated list must carry."""
+    out: dict[str, dict[str, set[str]]] = {fn: {} for _, _, fn in TARGETS}
+    for gate in gates:
+        lo, hi = ranges[gate.predicate]
+        if lo <= AUTO_DISCOVERED_MAX and (hi is None or AUTO_DISCOVERED_MAX < hi):
+            continue
+        for _, cap, fn in TARGETS:
+            if cap >= lo and (hi is None or cap < hi):
+                out[fn].setdefault(gate.file, set()).add(gate.test)
+    return out
+
+
+ARCH_HINT = re.compile(
+    r"\b(SM\d+OrLater|IS_SM\w+|has_\w*tma\w*|has_datacenter\w*|PLATFORM_SUPPORTS_\w+)\b"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument(
+        "--unclassified", action="store_true", help="list gates that were declined"
+    )
+    args = parser.parse_args()
+
+    ranges, exempt = load_tables()
+    gates, unclassified = collect(ranges, exempt)
+    plan = needed(gates, ranges)
+
+    if args.json:
+        json.dump(
+            {
+                "needed": {
+                    fn: {f: sorted(t) for f, t in files.items()}
+                    for fn, files in plan.items()
+                },
+                "unclassified": [u._asdict() for u in unclassified],
+            },
+            sys.stdout,
+            indent=2,
+        )
+        print()
+        return 0
+
+    if args.unclassified:
+        print(f"{len(unclassified)} arch gate(s) could not be classified:\n")
+        for u in unclassified:
+            print(f"  test/{u.file}.py:{u.line}  {u.reason}")
+            print(f"      {u.source}")
+        return 0
+
+    for _, _, fn in TARGETS:
+        files = plan[fn]
+        total = sum(len(t) for t in files.values())
+        print(f"{fn}(): {len(files)} file(s), {total} test(s)")
+        for f in sorted(files):
+            print(f'  --include {f} -k "{" or ".join(sorted(files[f]))}"')
+        print()
+    print(f"{len(unclassified)} gate(s) unclassified (see --unclassified)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/testing/test_arch_coverage.py
+++ b/tools/testing/test_arch_coverage.py
@@ -1,0 +1,82 @@
+# Owner(s): ["module: ci"]
+
+# Plain unittest, not torch's TestCase: arch_coverage must work in the lint image,
+# which has no torch build, so its test must not require one either.
+import ast
+import unittest
+
+import arch_coverage
+
+
+def classify(decorator_src):
+    """-> the required predicate name, or None if the decorator is not a requirement."""
+    node = ast.parse(f"{decorator_src}\ndef test_x(): pass").body[0].decorator_list[0]
+    pred = arch_coverage.requires(node)
+    return None if pred is None else arch_coverage.predicate_name(pred)
+
+
+class TestRequires(unittest.TestCase):
+    def test_negated_skip_if_is_a_requirement(self):
+        self.assertEqual(
+            classify("@skipIf(not SM90OrLater, 'needs sm90')"), "SM90OrLater"
+        )
+        self.assertEqual(
+            classify("@unittest.skipIf(not has_triton_tma_device(), 'tma')"),
+            "has_triton_tma_device",
+        )
+        self.assertEqual(
+            classify("@skipCUDAIf(not SM80OrLater, 'bf16')"), "SM80OrLater"
+        )
+
+    def test_skip_unless_is_a_requirement(self):
+        self.assertEqual(
+            classify("@unittest.skipUnless(SM90OrLater, 'sm90')"), "SM90OrLater"
+        )
+
+    def test_bare_skip_if_excludes_rather_than_requires(self):
+        # The case an earlier text-matching version got backwards: this skips *on*
+        # sm90, so the test does not require an H100.
+        self.assertIsNone(classify("@unittest.skipIf(SM90OrLater, 'fails on sm90')"))
+
+    def test_compound_conditions_are_declined(self):
+        self.assertIsNone(classify("@skipIf(not SM90OrLater or SM120OrLater, 'x')"))
+        self.assertIsNone(classify("@skipIf(IS_WINDOWS and SM89OrLater, 'x')"))
+        self.assertIsNone(classify("@skipUnless(SM90OrLater and TEST_CUDA, 'x')"))
+
+    def test_non_skip_decorators_are_ignored(self):
+        self.assertIsNone(classify("@parametrize('x', [SM90OrLater])"))
+
+
+class TestRanges(unittest.TestCase):
+    def test_tables_load_without_torch(self):
+        ranges, exempt = arch_coverage.load_tables()
+        self.assertIn("SM90OrLater", ranges)
+        self.assertEqual(ranges["SM90OrLater"], ((9, 0), None))
+        # Bounded, not a floor: the predicate is SM90OrLater and not SM100OrLater.
+        self.assertEqual(
+            ranges["PLATFORM_SUPPORTS_FP8_GROUPED_GEMM"], ((9, 0), (10, 0))
+        )
+        self.assertIn("PLATFORM_SUPPORTS_SYMM_MEM", exempt)
+
+    def test_targets_follow_the_declared_ranges(self):
+        ranges, _ = arch_coverage.load_tables()
+        gates = [
+            arch_coverage.Gate("f", "t_floor", 1, "SM90OrLater"),
+            arch_coverage.Gate(
+                "f", "t_blackwell", 2, "has_datacenter_blackwell_tma_device"
+            ),
+            arch_coverage.Gate("f", "t_exact90", 3, "IS_SM90"),
+            arch_coverage.Gate("f", "t_ampere", 4, "SM80OrLater"),
+        ]
+        plan = arch_coverage.needed(gates, ranges)
+        h100 = plan["test_python_smoke"]["f"]
+        b200 = plan["test_python_smoke_b200"]["f"]
+        # sm90+ runs on both; blackwell only on b200; exactly-sm90 only on h100.
+        self.assertEqual(h100, {"t_floor", "t_exact90"})
+        self.assertEqual(b200, {"t_floor", "t_blackwell"})
+        # sm80 is reached by auto-discovery, so it needs no curated entry.
+        self.assertNotIn("t_ampere", h100 | b200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reads skip decorators in `test/` and reports which tests require an H100 or B200, grouped by the `.ci/pytorch/test.sh` function that runs there. Generator for the smoke-list lint that follows; on its own it only reports.

### It refuses to guess

Only two shapes count as a requirement:

```
@skipIf(not PRED, ...)   @skipUnless(PRED, ...)   @skipCUDAIf(not PRED, ...)
```

Everything else is declined and listed. That distinction is the design. An earlier attempt matched predicate names anywhere in the decorator text and assumed a requirement, so it read `@skipIf(SM90OrLater, "Expected failure on sm90")` as *requires sm90* and wanted to add 16 `test__int_mm` variants to the H100 run — where they are skipped by construction. A bare `skipIf(PRED)` **excludes**; a compound condition isn't resolvable at all.

### No torch

Ranges come from `GATE_ARCH_RANGES`, read out of `common_cuda.py` **as source**, so this runs in the lint image, which has no CUDA build. Predicates in `NOT_ARCH_GATED` are skipped — `PLATFORM_SUPPORTS_SYMM_MEM` is true for any CUDA device, so its 41 tests need no entry.

Tests reachable at sm89 or below are ignored: trunk runs `default` on g6 (L4, sm89) by auto-discovery. Curation exists only at sm90 and sm100, which have no auto-discovery config — which is why only those two lists can drift.

```
test_python_smoke(): 24 file(s), 132 test(s)
test_python_smoke_b200(): 28 file(s), 292 test(s)
148 gate(s) unclassified (see --unclassified)
```

~8s over 1192 files. Unit tests pin the polarity rules, including the case the earlier version got backwards.

Stacked on the `GATE_ARCH_RANGES` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)