### PR TITLE
Skip complex_utils.h in the headeronly self-containment check

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -330,12 +330,17 @@ def check_headeronly_symbols(install_root: Path) -> None:
         "win32-headers.h",
     ]
 
+    # Headers that #error on direct inclusion and are reached via a parent header
+    non_self_contained_keywords = [
+        "util/complex_utils.h",
+    ]
+
+    skip_keywords = platform_specific_keywords + non_self_contained_keywords
+
     filtered_headers = []
     for header in headeronly_headers:
         rel_path = header.relative_to(include_dir).as_posix()
-        if not any(
-            keyword in rel_path.lower() for keyword in platform_specific_keywords
-        ):
+        if not any(keyword in rel_path.lower() for keyword in skip_keywords):
             filtered_headers.append(header)
 
     includes = []


### PR DESCRIPTION
Forward fix for the nightly binary test failure in [this run](https://github.com/pytorch/pytorch/actions/runs/31576551348/job/94092390948):

```
File ".ci/pytorch/smoke_test/check_binary_symbols.py", line 361, in check_headeronly_symbols
RuntimeError: Compilation failed:
  torch/include/torch/headeronly/util/complex_utils.h:4:2: error: #error
    "torch/headeronly/util/complex_utils.h is not meant to be individually included.
     Include torch/headeronly/util/complex.h instead."
```

## Cause

`check_headeronly_symbols` globs **every** header under `torch/headeronly` and includes each one individually in a generated `test.cpp`, filtering only `cpu/vec` and `win32-headers.h`.

#192552 migrated `c10/util/complex_utils.h` into that directory, and that header deliberately refuses direct inclusion:

```cpp
#if !defined(C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H)
#error "torch/headeronly/util/complex_utils.h is not meant to be individually included..."
#endif
```

So the generated translation unit stops compiling. `check_binary.sh:76-80` runs this on every non-Darwin platform, so this fails **all Linux binary tests**, not just s390x — that job is simply where it was spotted.

## Fix

Skip it, alongside the existing platform-specific exclusions.

It is the **only** header under `torch/headeronly` with such a guard (verified via code search for the guard text across that path), so this stays a one-entry list rather than a new category to maintain. Coverage is not lost: `complex.h` remains in the set and pulls `complex_utils.h` in transitively, which is the supported way to reach it.

## Verification

Reproduced the failure and the fix against a synthetic header tree replicating the guard, running the same filter logic and then compiling what each selection produces:

```
BEFORE includes: [util/complex.h, util/complex_utils.h, util/plain.h]
AFTER  includes: [util/complex.h, util/plain.h]

  BEFORE -> FAILS: error: #error "torch/headeronly/util/complex_utils.h ..."
  AFTER  -> compiles
```

`ruff format` and `ruff check` clean.

## Alternative considered

Teaching the check to detect the guard automatically (e.g. grep for `#error` before including) would avoid the explicit list, but it is more machinery for a single case, and an explicit list makes it visible when another non-self-contained header is migrated in. Happy to switch if reviewers prefer that.