### PR TITLE
[torch.distributed] force nccl-legacy for internal users

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -909,6 +909,17 @@ def _register_builtin_nccl_legacy_backend() -> None:
     )
 
 
+def _register_builtin_nccl_as_legacy() -> None:
+    _FR_SELF_RECORDING_BACKENDS.add(Backend.NCCL)
+    Backend.register_backend(
+        Backend.NCCL,
+        _create_nccl_process_group,
+        extended_api=True,
+        devices=Backend.backend_capability[Backend.NCCL],
+        _backend_type=ProcessGroup.BackendType.NCCL,
+    )
+
+
 def _register_builtin_nccl2_backend() -> None:
     Backend.register_backend(
         "nccl2",
@@ -2720,9 +2731,9 @@ def _get_split_source(pg: ProcessGroup) -> C10DBackend | None:
 # plugins -- is invisible to the flight recorder unless a hook is attached.
 #
 # Backend.NCCL is not in here by construction: which implementation the name
-# builds is a runtime choice, so _register_builtin_nccl_backend puts it in or
-# takes it out when it makes that choice, and this stays the single answer to
-# "does this backend record itself".
+# builds is a runtime choice, so its registrar puts it in or takes it out when
+# it makes that choice, and this stays the single answer to "does this backend
+# record itself".
 _FR_SELF_RECORDING_BACKENDS = {
     Backend.GLOO,
     "nccl-legacy",


### PR DESCRIPTION
Summary:
This is a prereq to https://github.com/pytorch/pytorch/pull/192281 to allow us to roll out nccl2 integration internally safely.

This forces it to use nccl-legacy until we do release testing to switch it over. This should be a noop as nccl-legacy is default currently for nccl.

Created from CodeHub with https://fburl.com/edit-in-codehub

Test Plan: buck test fbcode//caffe2/test/distributed/fb:test_c10d_backend_entry_points --build-default-info

Reviewed By: kapilsh, dolpm

Differential Revision: D115762680


