### PR TITLE
Preserving Custom Rank Layouts in DeviceMesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -105,6 +105,37 @@ class DeviceMeshTestGlooBackend(DTensorTestBase):
         else:
             self.assertEqual(mesh_group, default_group)
 
+    @with_comms
+    def test_device_mesh_reuse_default_group_for_custom_order_by_default(self):
+        # Without opting in via preserve_rank_order, a mesh dim whose size
+        # equals world_size must still take the default_group shortcut even
+        # when _rank_map is a permutation of [0, .., world_size). Skipping the
+        # shortcut unconditionally would silently change subgroup rank order
+        # for callers whose existing code relies on default_group's rank order.
+        reversed_ranks = list(reversed(range(self.world_size)))
+        mesh = DeviceMesh(self.device_type, torch.tensor(reversed_ranks))
+        mesh_group = mesh.get_group()
+        default_group = _get_default_group()
+        if torch.cuda.is_available():
+            self.assertEqual(mesh_group.group_desc, "mesh_default")
+        else:
+            self.assertEqual(mesh_group, default_group)
+
+    @with_comms
+    def test_device_mesh_skips_default_group_reuse_when_opted_in(self):
+        # With preserve_rank_order=True, a permuted full-world mesh dim must
+        # get a dedicated group instead of silently reusing default_group.
+        reversed_ranks = list(reversed(range(self.world_size)))
+        mesh = DeviceMesh(
+            self.device_type,
+            torch.tensor(reversed_ranks),
+            preserve_rank_order=True,
+        )
+        mesh_group = mesh.get_group()
+        default_group = _get_default_group()
+        self.assertEqual(mesh_group.group_desc, "mesh_dim_0")
+        self.assertEqual(get_world_size(mesh_group), get_world_size(default_group))
+
 
 class DeviceMeshSetDeviceTest(DTensorTestBase):
     @property
@@ -448,6 +479,36 @@ class DeviceMeshTestNDim(DTensorTestBase):
             for ranks in dim_ranks:
                 if self.rank in ranks:
                     self.assertEqual(global_ranks, ranks.tolist())
+
+    @with_comms
+    def test_device_mesh_preserve_rank_order(self):
+        # Permute the innermost dim so dim-2 subgroups are [1, 0], [3, 2], [5, 4], [7, 6].
+        mesh_tensor = torch.arange(8).reshape(2, 2, 2).flip(-1)
+        dim_ranks = mesh_tensor.reshape(-1, 2)
+
+        default_mesh = DeviceMesh(self.device_type, mesh_tensor)
+        default_group = default_mesh.get_group(2)
+        default_global_ranks = [
+            get_global_rank(default_group, i)
+            for i in range(get_world_size(default_group))
+        ]
+        for ranks in dim_ranks:
+            if self.rank in ranks:
+                # Without opting in, subgroup ranks are still sorted ascending.
+                self.assertEqual(default_global_ranks, sorted(ranks.tolist()))
+
+        ordered_mesh = DeviceMesh(
+            self.device_type, mesh_tensor, preserve_rank_order=True
+        )
+        ordered_group = ordered_mesh.get_group(2)
+        ordered_global_ranks = [
+            get_global_rank(ordered_group, i)
+            for i in range(get_world_size(ordered_group))
+        ]
+        for ranks in dim_ranks:
+            if self.rank in ranks:
+                # With preserve_rank_order=True, subgroup ranks follow the mesh tensor order.
+                self.assertEqual(ordered_global_ranks, ranks.tolist())
 
     @with_comms
     def test_device_mesh_hash(self):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -560,20 +560,22 @@ else:
                 None,
                 None,
             ):
-                # Append the default pg to the first dim groups only if the default pg is compatible with `self._device_type`.
-                # Otherwise, create new pg.
-                ranks = list(range(get_world_size()))
-                dim_group = (
-                    new_group(
-                        backend=backend,
-                        ranks=ranks,
-                        group_desc="mesh_default",
+                sub_ranks = pg_ranks_by_dim.flatten().tolist()
+                sequential_ranks = list(range(get_world_size()))
+                if sub_ranks == sequential_ranks:
+                    # Append default pg to first dim groups if compatible
+                    # with `self._device_type`. Otherwise, create new pg.
+                    dim_group = (
+                        new_group(
+                            backend=backend,
+                            ranks=sequential_ranks,
+                            group_desc="mesh_default",
+                        )
+                        if torch.cuda.is_available()
+                        and get_backend(default_group) == "gloo"
+                        else default_group
                     )
-                    if torch.cuda.is_available()
-                    and get_backend(default_group) == "gloo"
-                    else default_group
-                )
-                return dim_group.group_name  # type: ignore[union-attr]
+                    return dim_group.group_name  # type: ignore[union-attr]
 
             # If bound_device_id exists, it means the nccl communicator has been eagerly initialized
             # so that we can use `split_group` to create subgroups through `ncclCommSplit`.
@@ -619,6 +621,9 @@ else:
             pg_name = None
             for dim_mesh in pg_ranks_by_dim:
                 subgroup_ranks = dim_mesh.tolist()
+                # Preserves topology-aware rank order by skipping sorting if ranks
+                # are custom-ordered.
+                is_sorted = subgroup_ranks == sorted(subgroup_ranks)
                 dim_group = new_group(
                     ranks=subgroup_ranks,
                     timeout=timeout,
@@ -626,6 +631,7 @@ else:
                     pg_options=pg_options,
                     group_desc=group_desc,
                     use_local_synchronization=use_hashed,
+                    sort_ranks=is_sorted,
                 )
 
                 # only add to dim_groups if the current rank in the subgroup

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -578,18 +578,17 @@ else:
                 ranks = list(range(get_world_size()))
                 ranks_match_default = ranks == pg_ranks_by_dim.flatten().tolist()
                 if not preserve_rank_order or ranks_match_default:
-                    # Append default pg to first dim groups if compatible
-                    # with `self._device_type`. Otherwise, create new pg.
-                    dim_group = (
-                        new_group(
+                    if (
+                        torch.cuda.is_available()
+                        and get_backend(default_group) == "gloo"
+                    ):
+                        dim_group = new_group(
                             backend=backend,
                             ranks=ranks,
                             group_desc="mesh_default",
                         )
-                        if torch.cuda.is_available()
-                        and get_backend(default_group) == "gloo"
-                        else default_group
-                    )
+                    else:
+                        dim_group = default_group
                     return dim_group.group_name  # type: ignore[union-attr]
 
             # If bound_device_id exists, it means the nccl communicator has been eagerly initialized

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -560,15 +560,15 @@ else:
                 None,
                 None,
             ):
-                sub_ranks = pg_ranks_by_dim.flatten().tolist()
-                sequential_ranks = list(range(get_world_size()))
-                if sub_ranks == sequential_ranks:
+                # Reuse default_group when ranks match standard [0..N-1] order.
+                ranks = list(range(get_world_size()))
+                if ranks == pg_ranks_by_dim.flatten().tolist():
                     # Append default pg to first dim groups if compatible
                     # with `self._device_type`. Otherwise, create new pg.
                     dim_group = (
                         new_group(
                             backend=backend,
-                            ranks=sequential_ranks,
+                            ranks=ranks,
                             group_desc="mesh_default",
                         )
                         if torch.cuda.is_available()
@@ -621,9 +621,6 @@ else:
             pg_name = None
             for dim_mesh in pg_ranks_by_dim:
                 subgroup_ranks = dim_mesh.tolist()
-                # Preserves topology-aware rank order by skipping sorting if ranks
-                # are custom-ordered.
-                is_sorted = subgroup_ranks == sorted(subgroup_ranks)
                 dim_group = new_group(
                     ranks=subgroup_ranks,
                     timeout=timeout,
@@ -631,7 +628,7 @@ else:
                     pg_options=pg_options,
                     group_desc=group_desc,
                     use_local_synchronization=use_hashed,
-                    sort_ranks=is_sorted,
+                    sort_ranks=False,
                 )
 
                 # only add to dim_groups if the current rank in the subgroup

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -210,6 +210,11 @@ else:
             device_type (str): The device type of the mesh. Currently supports: "cpu", "cuda/cuda-like".
             mesh (ndarray): A multi-dimensional array or an integer tensor describing the layout
                 of devices, where the IDs are global IDs of the default process group.
+            preserve_rank_order (bool, optional):
+                If True, subgroup ranks are ordered instead of being sorted ascending, and a mesh
+                dim spanning the full world whose ranks are a permutation of [0..N) gets a
+                dedicated group honoring that order instead of silently reusing default_group.
+                Default: False.
             _rank (int): (experimental/internal)
                 The global rank of the current process. If not provided, it will
                 be inferred from the default process group.
@@ -239,6 +244,7 @@ else:
         _mesh_dim_names: tuple[str, ...] | None
         _layout: _MeshLayout
         _root_mesh: "DeviceMesh | None" = None
+        _preserve_rank_order: bool
         _thread_id: int | None
         # Record flatten mesh name to its flattened mesh in root mesh.
         _flatten_mapping: dict[str, "DeviceMesh"]
@@ -252,6 +258,7 @@ else:
             *,
             mesh_dim_names: tuple[str, ...] | None = None,
             backend_override: tuple[BackendConfig, ...] | None = None,
+            preserve_rank_order: bool = False,
             _init_backend: bool = True,
             _rank: int | None = None,
             _layout: _MeshLayout | None = None,
@@ -303,6 +310,7 @@ else:
             self._rank_map = _rank_map
             self._mesh_dim_names = tuple(mesh_dim_names) if mesh_dim_names else None
             self._root_mesh = _root_mesh
+            self._preserve_rank_order = preserve_rank_order
 
             if backend_override is None:
                 backend_override = ((None, None),) * len(self._layout)
@@ -351,6 +359,7 @@ else:
                         self._rank_map,
                         self._mesh_dim_names,
                         backend_override,
+                        self._preserve_rank_order,
                     )
                     # Populate the process group registry
                     # If we have a root mesh, add to root's registry for lookups
@@ -537,6 +546,7 @@ else:
             rank_map: torch.Tensor,
             dim_name: str,
             backend_override: BackendConfig,
+            preserve_rank_order: bool,
         ) -> GroupName | None:
             # Generate a 2D global mesh tensor for the current dim for PG creation.
             pg_ranks_by_dim = _MeshLayout([sub_layout]).remap_to_tensor(rank_map)
@@ -560,9 +570,14 @@ else:
                 None,
                 None,
             ):
-                # Reuse default_group when ranks match standard [0..N-1] order.
+                # Reuse default_group when ranks match standard [0..N-1] order, or
+                # when the caller hasn't opted in to honoring a permuted rank order
+                # (the fallthrough below preserves order unconditionally via
+                # split_group, so skipping the shortcut for an unsorted rank_map
+                # would silently change subgroup rank order for existing callers).
                 ranks = list(range(get_world_size()))
-                if ranks == pg_ranks_by_dim.flatten().tolist():
+                ranks_match_default = ranks == pg_ranks_by_dim.flatten().tolist()
+                if not preserve_rank_order or ranks_match_default:
                     # Append default pg to first dim groups if compatible
                     # with `self._device_type`. Otherwise, create new pg.
                     dim_group = (
@@ -628,7 +643,7 @@ else:
                     pg_options=pg_options,
                     group_desc=group_desc,
                     use_local_synchronization=use_hashed,
-                    sort_ranks=False,
+                    sort_ranks=not preserve_rank_order,
                 )
 
                 # only add to dim_groups if the current rank in the subgroup
@@ -651,6 +666,7 @@ else:
             rank_map: torch.Tensor,
             mesh_dim_names: tuple[str, ...] | None,
             backend_override: tuple[BackendConfig, ...],
+            preserve_rank_order: bool = False,
         ) -> list[GroupName]:
             # group_name associated with each mesh dimension, each
             # mesh dimension should have one sub-group per rank
@@ -664,6 +680,7 @@ else:
                         rank_map,
                         dim_name,
                         backend_override[dim],
+                        preserve_rank_order,
                     )
                 )
             # Filter out None values. If any are None then they should all be None.
@@ -713,6 +730,7 @@ else:
                 self._device_type,
                 self._mesh_dim_names,
                 self._thread_id,
+                self._preserve_rank_order,
             )
 
         def __hash__(self):
@@ -733,6 +751,7 @@ else:
                 and self._device_type == other._device_type
                 and self._mesh_dim_names == other._mesh_dim_names
                 and self._thread_id == other._thread_id
+                and self._preserve_rank_order == other._preserve_rank_order
             )
 
         def _stable_hash(self) -> str:
@@ -923,6 +942,7 @@ else:
                     mesh_dim_names=submesh_dim_names,
                     _root_mesh=root_mesh,
                     _init_backend=False,
+                    preserve_rank_order=root_mesh._preserve_rank_order,
                 )
                 res_submesh._dim_group_names = slice_dim_group_name
                 return res_submesh
@@ -970,6 +990,7 @@ else:
                 mesh_dim_names=(mesh_dim_name,),
                 _root_mesh=root_mesh,
                 backend_override=(backend_override,),
+                preserve_rank_order=root_mesh._preserve_rank_order,
             )
             root_mesh._flatten_mapping[mesh_dim_name] = res_flattened_mesh
 
@@ -1088,6 +1109,7 @@ else:
                     mesh_1d,
                     mesh_dim_names=(mesh_dim_name,),
                     _init_backend=False,
+                    preserve_rank_order=self._preserve_rank_order,
                 )
                 submesh._dim_group_names = (  # type: ignore[has-type]
                     [self._dim_group_names[mesh_dim]]  # type: ignore[has-type]
@@ -1389,6 +1411,7 @@ else:
                 mesh_dim_names=tuple(unflattened_mesh_dim_names),
                 _root_mesh=root_mesh,
                 _init_backend=False,
+                preserve_rank_order=root_mesh._preserve_rank_order,
             )
 
             # If original mesh has initiated its backend, we need to initialize the backend
@@ -1402,6 +1425,7 @@ else:
                     root_mesh._rank_map,
                     mesh_dim_names,
                     backend_override,
+                    root_mesh._preserve_rank_order,
                 )
                 dim_group_names[dim : dim + 1] = new_group_names
                 res_mesh._dim_group_names = dim_group_names
@@ -1503,6 +1527,7 @@ else:
                 mesh_dim_names=tuple(concat_dim_names),
                 _root_mesh=device_mesh_list[0]._get_root_mesh(),
                 _init_backend=False,
+                preserve_rank_order=device_mesh_list[0]._preserve_rank_order,
             )
             res_mesh._dim_group_names = concat_dim_group_name
             return res_mesh
@@ -1737,6 +1762,7 @@ def _register_distributed_opaque_types():
             obj._device_type,
             obj._mesh_dim_names,
             obj._thread_id,
+            obj._preserve_rank_order,
         ],
         members={
             # USE_REAL: Evaluate these with the real object at compile time
@@ -1746,6 +1772,7 @@ def _register_distributed_opaque_types():
             "_device_type": MemberType.USE_REAL,
             "_mesh_dim_names": MemberType.USE_REAL,
             "_thread_id": MemberType.USE_REAL,
+            "_preserve_rank_order": MemberType.USE_REAL,
             "get_rank": MemberType.USE_REAL,
             "size": MemberType.USE_REAL,
             "get_coordinate": MemberType.USE_REAL,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -211,10 +211,13 @@ else:
             mesh (ndarray): A multi-dimensional array or an integer tensor describing the layout
                 of devices, where the IDs are global IDs of the default process group.
             preserve_rank_order (bool, optional):
-                If True, subgroup ranks are ordered instead of being sorted ascending, and a mesh
-                dim spanning the full world whose ranks are a permutation of [0..N) gets a
-                dedicated group honoring that order instead of silently reusing default_group.
-                Default: False.
+                If True, subgroup rank order is preserved instead of being sorted in
+                ascending order, and a mesh dim spanning the full world whose ranks are a
+                permutation of [0..N) gets a dedicated process group honoring that order
+                instead of silently reusing default_group. This provides flexibility for
+                custom or topology-aware rank ordering. Defaults to False for backward
+                compatibility with existing code that relies on sorted ranks and
+                default_group reuse.
             _rank (int): (experimental/internal)
                 The global rank of the current process. If not provided, it will
                 be inferred from the default process group.


### PR DESCRIPTION
## Proposal: Preserving Custom Rank Layouts in `DeviceMesh`

### 1. Context & Motivation
`DeviceMesh` allows users to configure custom device topologies (via `DeviceMesh(device_type, mesh=...)` or`_rank_map`), which is critical for hardware and cluster topologies with non-uniform interconnects (e.g. ring orderings).

However, `DeviceMesh._init_one_process_group` currently loses custom rank ordering in two places:
1. **Unconditional `default_group` reuse**: When a mesh dimension has size equal to `world_size`, `DeviceMesh` unconditionally returns `default_group` (`[0, 1, ..., N-1]`), ignoring any custom rank permutation specified in `_rank_map`.
2. **Default `sort_ranks=True` in `new_group`**: When creating process groups for subgroups, `DeviceMesh` calls `dist.new_group(...)` with `sort_ranks=True` by default, which causes `c10d` to sort subgroup ranks ascending, losing the custom sequence defined in `_rank_map`.

### 2. Proposed Changes

1. **Add `preserve_rank_order` Option to `DeviceMesh`**:
   Introduce a `preserve_rank_order: bool = False` argument in `DeviceMesh.__init__`, propagating it through submesh operations (slicing, flattening, unflattening, concatenating) and torchdynamo opaque type registration.

2. **Conditional `default_group` Reuse**:
   When `preserve_rank_order=True` and ranks are permuted (do not match `[0, 1, ..., world_size - 1]`), bypass reusing `default_group` and instantiate a dedicated process group that respects the custom permutation. When `preserve_rank_order=False` (default), the existing shortcut is preserved.

3. **Preserve Subgroup Ordering in `new_group`**:
   Pass `sort_ranks=not preserve_rank_order` to `dist.new_group(...)`. When opted in (`preserve_rank_order=True`), `sort_ranks=False` ensures that `c10d` respects the exact rank sequence from `_rank_map`.

### 3. Backward Compatibility

- **100% Backward Compatible**: Defaults to `preserve_rank_order=False`, so all existing pipelines and tests continue to sort subgroup ranks and reuse `default_group` exactly as before.
- **Explicit Opt-in**: Callers requiring topology-aware rank preservation can opt in cleanly via `preserve_rank_order=True` without risking regressions for existing workloads.