### PR TITLE
Retry and validate the randomtemp.exe download on Windows CUDA builds

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -120,9 +120,15 @@ if "%USE_CUDA%"=="1" (
   ::
   :: CMake requires a single command as CUDA_NVCC_EXECUTABLE, so we push the wrappers
   :: randomtemp.exe and sccache.exe into a batch file which CMake invokes.
-  curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.4/randomtemp.exe --output %TMP_DIR_WIN%\bin\randomtemp.exe
+  curl --retry 3 --retry-all-errors --fail -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.4/randomtemp.exe --output %TMP_DIR_WIN%\bin\randomtemp.exe
   if errorlevel 1 goto fail
   if not errorlevel 0 goto fail
+  for %%I in ("%TMP_DIR_WIN%\bin\randomtemp.exe") do (
+    if %%~zI LSS 100000 (
+      echo randomtemp.exe is %%~zI bytes, expected ~310KB - download was truncated
+      goto fail
+    )
+  )
   echo @"%TMP_DIR_WIN%\bin\randomtemp.exe" "%TMP_DIR_WIN%\bin\sccache.exe" "%CUDA_PATH%\bin\nvcc.exe" %%* > "%TMP_DIR%/bin/nvcc.bat"
   cat %TMP_DIR%/bin/nvcc.bat
   set CUDA_NVCC_EXECUTABLE=%TMP_DIR%/bin/nvcc.bat


### PR DESCRIPTION
`win-vs2022-cuda13.0-py3 / build` and `win-vs2022-cuda13.2-py3 / build` (both viable/strict-gating) have been intermittently red on `main`, **27 failures against 416 passes on Aug 12** versus a 0-8/day baseline.

## Cause

github.com is returning **HTTP 503** on release-asset downloads, and this line had neither `--fail` nor `--retry`:

```bat
curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.4/randomtemp.exe --output %TMP_DIR_WIN%\bin\randomtemp.exe
if errorlevel 1 goto fail
if not errorlevel 0 goto fail
```

Without `--fail`, curl writes the 503 body — **107 bytes instead of 310,272** — and **exits 0**. So the two `errorlevel` guards pass, the truncated file is baked into `nvcc.bat`, and the build dies much later with a completely misleading message:

```
CUDA was explicitly requested (USE_CUDA=1) but cannot be found
```

There is a second form from the same line: `curl: (56) Connection died, tried 5 times before giving up`, which does exit non-zero and fails fast with no CUDA red herring. So the `107` string is not in every red job.

## Fix

`--retry 3 --retry-all-errors` matches what the sibling Windows downloads already do:

```
curl --retry 3 --retry-all-errors -k .../Miniconda3-latest-Windows-x86_64.exe
curl --retry 3 --retry-all-errors -k .../magma_2.5.4_..._%BUILD_TYPE%.7z
curl --retry 3 --retry-all-errors -k .../sccache-v0.7.4.exe
```

`--fail` is the piece that turns an HTTP error into a non-zero exit rather than a 107-byte executable. Note those siblings pull from the `ossci-windows` S3 mirror rather than github.com, which is why they were never exposed to this — they retry but none of them use `--fail`.

The size check is belt and braces for a 200 carrying a wrong body. It uses the `for` variable rather than a `set`/`%VAR%` pair because this sits inside a parenthesised `if` block and the script never enables delayed expansion, so `%VAR%` would not expand.

## What I could and could not verify

- Paren balance of the `USE_CUDA` block re-checked programmatically: opens L116, closes L137, balanced.
- Nested `for ... do (` inside a block has precedent in `.ci` batch files (`test_libtorch.bat:22`, `windows/internal/smoke_test.bat:24`).
- `%%~zI` for file size has **no existing precedent in this repo**, and I have **no way to execute batch on this machine** — no wine, no cmd. The construct is standard, and the paren/expansion hazards are the ones I checked for, but it is untested. Please let the Windows CUDA build in CI be the real check before merging, since a batch syntax error here would break every Windows CUDA build rather than just the flaky ones.

## Alternative

The issue also suggests mirroring the asset to `s3://ossci-windows`, which is what every sibling download already does and would remove the github.com dependency entirely. That is the more durable fix, but it needs someone with write access to the bucket, so this is the change that can land now.

Fixes https://github.com/meta-pytorch/pytorch-gha-infra/issues/1416