### PR TITLE
[DO NOT LAND] gpu-coverage probe: B200-only test, not in the smoke list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,7 @@ nn/qat/ @jerryzh168
 
 # Custom Test Infrastructure
 /test/run_test.py @pytorch/pytorch-dev-infra
+/test/test_gpu_coverage_probe.py @pytorch/pytorch-dev-infra
 /torch/testing/_internal/common_device_type.py @mruberry
 /torch/testing/_internal/common_utils.py @pytorch/pytorch-dev-infra
 
@@ -1254,6 +1255,7 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 # /test/scripts/
 # /test/spincli/
 # /test/strobelight/
+# /test/test_gpu_coverage_probe.py
 # /test/test_public_bindings.py
 # /test/test_testing.py
 # /test/test_utils.py

--- a/test/test_gpu_coverage_probe.py
+++ b/test/test_gpu_coverage_probe.py
@@ -1,0 +1,18 @@
+# Owner(s): ["module: ci"]
+
+"""Scratch file for exercising the gpu-coverage check. Not for landing."""
+
+import unittest
+
+from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestGpuCoverageProbe(TestCase):
+    @unittest.skipIf(not SM100OrLater, "needs a B200")
+    def test_gpu_coverage_probe(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

Adds a test gated `@skipIf(not SM100OrLater, ...)` and deliberately does **not**
add it to `.ci/pytorch/test.sh`.

Expected: `gpu-coverage` fails, naming `test_gpu_coverage_probe` as missing from
`test_python_smoke_b200()` **only**. `SM100OrLater` is above the H100, so the h100
list should be untouched.

Locally:
```
GPU coverage gap: test/test_gpu_coverage_probe.py
  not selected by test_python_smoke_b200() in .ci/pytorch/test.sh
```