### PR TITLE
[DO NOT LAND] gpu-coverage probe: sm90+ test, wired into both smoke lists

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -443,6 +443,7 @@ test_python_smoke() {
   time python test/run_test.py --include test_matmul_cuda test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_foreach -k TestForeachMM $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_linalg -k polar $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_gpu_coverage_probe -k "test_gpu_coverage_probe" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 
@@ -467,6 +468,7 @@ test_python_smoke_b200() {
       $PYTHON_TEST_EXTRA_OPTION \
       --upload-artifacts-while-running
   time python test/run_test.py --include test_linalg -k "mm or addmv" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_gpu_coverage_probe -k "test_gpu_coverage_probe" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,7 @@ nn/qat/ @jerryzh168
 
 # Custom Test Infrastructure
 /test/run_test.py @pytorch/pytorch-dev-infra
+/test/test_gpu_coverage_probe.py @pytorch/pytorch-dev-infra
 /torch/testing/_internal/common_device_type.py @mruberry
 /torch/testing/_internal/common_utils.py @pytorch/pytorch-dev-infra
 
@@ -1254,6 +1255,7 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 # /test/scripts/
 # /test/spincli/
 # /test/strobelight/
+# /test/test_gpu_coverage_probe.py
 # /test/test_public_bindings.py
 # /test/test_testing.py
 # /test/test_utils.py

--- a/test/test_gpu_coverage_probe.py
+++ b/test/test_gpu_coverage_probe.py
@@ -1,0 +1,18 @@
+# Owner(s): ["module: ci"]
+
+"""Scratch file for exercising the gpu-coverage check. Not for landing."""
+
+import unittest
+
+from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestGpuCoverageProbe(TestCase):
+    @unittest.skipIf(not SM90OrLater, "needs sm90 or later")
+    def test_gpu_coverage_probe(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing. This is the
green control.

Adds a test gated `@skipIf(not SM90OrLater, ...)` **and** adds it to both smoke
lists. The two `test.sh` lines were generated by `gpu_coverage.py --write`, not
written by hand, so this also exercises the autofix.

Expected: `gpu-coverage` passes.

`ciflow/h100` and `ciflow/b200` are independent labels, so an sm90+ test belongs in
both lists -- a b200-labelled PR runs only the b200 list and would otherwise skip
it.