### PR TITLE
[DO NOT LAND] gpu-coverage probe: drop a file from the H100 smoke list

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -440,7 +440,7 @@ test_python_smoke() {
   # Smoke tests for H100/B200
   install_nvmath
   time python test/run_test.py --include inductor/test_flex_attention -k test_tma_with_customer_kernel_options $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include test_matmul_cuda test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_foreach -k TestForeachMM $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_linalg -k polar $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

Removes `test_matmul_cuda` from `test_python_smoke()`. **No test file is touched**,
so this exercises the second trigger: editing `test.sh` can drop coverage without
any test change.

Expected: `gpu-coverage` fails under `GPU coverage removed`, naming the three sm90+
tests in `test_matmul_cuda` that lost coverage -- and saying nothing about the other
16 files `test.sh` lists. Pre-existing gaps there are not this PR's to answer for;
only regressions are reported.

Locally:
```
GPU coverage removed: test/test_matmul_cuda.py
    test_grouped_gemm_compiled  -- runs on h100, not on a10g
    test_legacy_cublas_honors_sm_carveout  -- runs on h100, not on a10g
    test_sm_carveout_invalid_value_throws  -- runs on h100, not on a10g
  no longer selected by test_python_smoke() in .ci/pytorch/test.sh
```
Wall-clock for that run (17-file union): 1m08s.