### PR TITLE
Split manywheel build/test/upload into independent per-arch chains

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -561,7 +561,7 @@ jobs:
 
   !{{ job['name'] }}:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: !{{ owner_if }}
     permissions:
       id-token: write
       contents: read
@@ -671,7 +671,7 @@ jobs:
 
   libtorch-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: !{{ owner_if }}
     permissions:
       id-token: write
       contents: read

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -245,9 +245,8 @@ jobs:
     across iterations. libtorch_cpu/libtorch_cuda are Python-ABI-free; only
     libtorch_python + _C are recompiled per interpreter via the cmake.py cache
     invalidation. -#}
-{%- set unified_job_names = [] %}
-{#- Same groups again, but carrying the build job name, so the test and upload
-    jobs below can each depend on just their own group. -#}
+{#- Carries each group's build job name, so the test and upload jobs below can
+    each depend on just their own group. -#}
 {%- set unified_upload_groups = [] %}
 {%- for g in ns.groups %}
   {%- set group = g['configs'] %}
@@ -265,7 +264,6 @@ jobs:
       E.g. "manywheel-py3_10-cuda-aarch64-12_6" -> "-cuda-aarch64-12_6". -#}
   {%- set py_dotless = first['python_version'] | replace('.', '_') %}
   {%- set build_name_suffix = first['build_name'] | replace('manywheel-py' ~ py_dotless, '') %}
-  {%- set _ = unified_job_names.append(job_name) %}
   {%- set _ = unified_upload_groups.append({
         'job_name': job_name,
         'test_name': job_name | replace('-build', '-test'),

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -246,6 +246,9 @@ jobs:
     libtorch_python + _C are recompiled per interpreter via the cmake.py cache
     invalidation. -#}
 {%- set unified_job_names = [] %}
+{#- Same groups again, but carrying the build job name, so the test and upload
+    jobs below can each depend on just their own group. -#}
+{%- set unified_upload_groups = [] %}
 {%- for g in ns.groups %}
   {%- set group = g['configs'] %}
   {%- set arch_type = g['arch_type'] %}
@@ -263,6 +266,10 @@ jobs:
   {%- set py_dotless = first['python_version'] | replace('.', '_') %}
   {%- set build_name_suffix = first['build_name'] | replace('manywheel-py' ~ py_dotless, '') %}
   {%- set _ = unified_job_names.append(job_name) %}
+  {%- set _ = unified_upload_groups.append({
+        'job_name': job_name,
+        'test_name': job_name | replace('-build', '-test'),
+        'configs': group}) %}
 
   !{{ job_name }}:
     name: !{{ job_name }}
@@ -376,21 +383,39 @@ jobs:
 {%- endif %}
 
 {%- if test_standard_configs %}
-{# manywheel-test depends only on the builds it actually consumes: the unified
-   cpu/cuda jobs, plus manywheel-build only when that matrix builds a standard
-   (non-ROCm/XPU) config such as cpu-s390x. ROCm/XPU are tested by
-   manywheel-test-rocm / manywheel-test-xpu, so a ROCm/XPU build failure must not
-   skip the cpu/cuda tests. #}
-  manywheel-test:
+{#- One test job per arch group, matching the build jobs, so each group runs
+    build -> test -> upload independently. A single shared test job would make
+    every group's upload wait on the slowest group's tests, since `needs` is
+    evaluated per job rather than per matrix leg.
+
+    ROCm/XPU already have their own test jobs below. -#}
+{%- set standard_test_jobs = [] %}
+{%- for u in unified_upload_groups %}
+  {%- set _ = standard_test_jobs.append({
+        'name': u['test_name'],
+        'needs': [u['job_name']],
+        'configs': u['configs']}) %}
+{%- endfor %}
+{%- if matrix_standard_configs %}
+  {#- Standard configs built by the manywheel-build matrix (e.g. cpu-s390x)
+      keep the manywheel-test name. -#}
+  {%- set _ = standard_test_jobs.append({
+        'name': 'manywheel-test',
+        'needs': ['manywheel-build'],
+        'configs': matrix_standard_configs}) %}
+{%- endif %}
+{%- for test_job in standard_test_jobs %}
+
+  !{{ test_job['name'] }}:
     name: ${{ matrix.build_name }}-test
     if: !{{ owner_if }}
-    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}{%- if matrix_standard_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, !{{ test_job['needs'] | join(', ') }}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
       matrix:
         include:
-        {%- for config in test_standard_configs %}
+        {%- for config in test_job['configs'] %}
           {%- if "aarch64" in build_environment %}
           {%- set _runs_on = "l-arm64g3-16-62" %}
           {%- elif "s390x" in build_environment %}
@@ -427,6 +452,7 @@ jobs:
       ALPINE_IMAGE: "!{{ alpine_image }}"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+{%- endfor %}
 {%- endif %}
 
 {%- if rocm_configs %}
@@ -496,20 +522,56 @@ jobs:
 {%- endif %}
 
 {%- if branches == "nightly" and build_configs %}
+{#- One upload job per arch group rather than a single job over every config.
+    `needs` is evaluated per job, not per matrix leg, so a single upload job
+    cannot start until the slowest group in the whole workflow has finished --
+    an XPU test waiting hours on a scarce runner held up the CPU and CUDA
+    wheels behind it. Split by group, each set of wheels publishes as soon as
+    its own build and test are done.
 
-  manywheel-upload:
+    The groups below partition build_configs exactly: unified groups (cpu /
+    cuda per version), the standard configs built by the manywheel-build matrix
+    (e.g. cpu-s390x), then rocm and xpu. -#}
+{%- set upload_jobs = [] %}
+{%- for u in unified_upload_groups %}
+  {%- set _ = upload_jobs.append({
+        'name': u['job_name'] | replace('-build', '-upload'),
+        'needs': [u['job_name']] + ([u['test_name']] if test_standard_configs else []),
+        'configs': u['configs']}) %}
+{%- endfor %}
+{%- if matrix_standard_configs %}
+  {%- set _ = upload_jobs.append({
+        'name': 'manywheel-upload',
+        'needs': ['manywheel-build'] + (['manywheel-test'] if test_standard_configs else []),
+        'configs': matrix_standard_configs}) %}
+{%- endif %}
+{%- if rocm_configs %}
+  {%- set _ = upload_jobs.append({
+        'name': 'manywheel-rocm-upload',
+        'needs': ['manywheel-build', 'manywheel-test-rocm'],
+        'configs': rocm_configs}) %}
+{%- endif %}
+{%- if xpu_configs %}
+  {%- set _ = upload_jobs.append({
+        'name': 'manywheel-xpu-upload',
+        'needs': ['manywheel-build', 'manywheel-test-xpu'],
+        'configs': xpu_configs}) %}
+{%- endif %}
+{%- for job in upload_jobs %}
+
+  !{{ job['name'] }}:
     name: ${{ matrix.build_name }}-upload
     if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
-    needs: [{%- if pin_docker_image %}get-docker-tag, {% endif %}{%- if matrix_build_configs %}manywheel-build, {% endif %}{%- for n in unified_job_names %}!{{ n }}, {% endfor %}manywheel-test{%- if rocm_configs %}, manywheel-test-rocm{%- endif %}{%- if xpu_configs %}, manywheel-test-xpu{%- endif %}]
+    needs: [{%- if pin_docker_image %}get-docker-tag, {% endif %}!{{ job['needs'] | join(', ') }}]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
       matrix:
         include:
-        {%- for config in build_configs %}
+        {%- for config in job['configs'] %}
           - desired_python: "!{{ config['python_version'] }}"
             desired_cuda: "!{{ config['desired_cuda'] }}"
             gpu_arch_version: "!{{ config['gpu_arch_version'] | default('') }}"
@@ -533,6 +595,7 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+{%- endfor %}
 {%- endif %}
 
 {%- if libtorch_extraction_configs %}

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -584,10 +584,10 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_4/*
 
-  manywheel-test:
+  manywheel-cpu-aarch64-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-cuda-aarch64-cu134-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-aarch64-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -601,38 +601,6 @@ jobs:
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_10-cpu-aarch64"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.10"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_10-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.10"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_10-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.10"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_10-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -640,6 +608,90 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_11-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.12"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_12-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.13"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_13-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_14-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_14t-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15t-cpu-aarch64"
+            runs_on: "l-arm64g3-16-62"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-aarch64-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "arm64v8/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-aarch64-cu126-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-aarch64-cu126-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_10-cuda-aarch64-12_6"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu126"
@@ -649,6 +701,90 @@ jobs:
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_11-cuda-aarch64-12_6"
             runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.12"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_12-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.13"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_13-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+            runs_on: "l-arm64g3-16-62"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-aarch64-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "arm64v8/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-aarch64-cu130-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-aarch64-cu130-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_10-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -657,6 +793,90 @@ jobs:
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_11-cuda-aarch64-13_0"
             runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.12"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_12-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.13"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_13-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14t-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
+            runs_on: "l-arm64g3-16-62"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-aarch64-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "arm64v8/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-aarch64-cu132-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-aarch64-cu132-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_10-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -664,6 +884,90 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.12"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_12-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.13"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_13-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.14t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
+            runs_on: "l-arm64g3-16-62"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-aarch64-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "arm64v8/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-aarch64-cu134-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-aarch64-cu134-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_10-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu134"
@@ -674,76 +978,12 @@ jobs:
             build_name: "manywheel-py3_11-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_12-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.12"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_12-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.12"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.12"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.12"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_12-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_13-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.13"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_13-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.13"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.13"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cu134"
@@ -754,76 +994,12 @@ jobs:
             build_name: "manywheel-py3_13-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_14-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14t-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cu134"
@@ -834,76 +1010,12 @@ jobs:
             build_name: "manywheel-py3_14t-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_15-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_15-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_15t-cpu-aarch64"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cu134"
@@ -932,13 +1044,13 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  manywheel-upload:
+  manywheel-cpu-aarch64-upload:
     name: ${{ matrix.build_name }}-upload
     if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
-    needs: [get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-cuda-aarch64-cu134-build, manywheel-test]
+    needs: [get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cpu-aarch64-test]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -951,6 +1063,83 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_10-cpu-aarch64"
+          - desired_python: "3.11"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_11-cpu-aarch64"
+          - desired_python: "3.12"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_12-cpu-aarch64"
+          - desired_python: "3.13"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_13-cpu-aarch64"
+          - desired_python: "3.14"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_14-cpu-aarch64"
+          - desired_python: "3.14t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_14t-cpu-aarch64"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15-cpu-aarch64"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15t-cpu-aarch64"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-aarch64-cu126-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu126-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -958,6 +1147,83 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_10-cuda-aarch64-12_6"
+          - desired_python: "3.11"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_11-cuda-aarch64-12_6"
+          - desired_python: "3.12"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_12-cuda-aarch64-12_6"
+          - desired_python: "3.13"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_13-cuda-aarch64-12_6"
+          - desired_python: "3.14"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14-cuda-aarch64-12_6"
+          - desired_python: "3.14t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-aarch64-cu130-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu130-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -965,6 +1231,83 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_10-cuda-aarch64-13_0"
+          - desired_python: "3.11"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_11-cuda-aarch64-13_0"
+          - desired_python: "3.12"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_12-cuda-aarch64-13_0"
+          - desired_python: "3.13"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_13-cuda-aarch64-13_0"
+          - desired_python: "3.14"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14-cuda-aarch64-13_0"
+          - desired_python: "3.14t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14t-cuda-aarch64-13_0"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-aarch64-cu132-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-aarch64-cu132-build, manywheel-cuda-aarch64-cu132-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -972,6 +1315,83 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda-aarch64-13_2"
+          - desired_python: "3.11"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_11-cuda-aarch64-13_2"
+          - desired_python: "3.12"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_12-cuda-aarch64-13_2"
+          - desired_python: "3.13"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_13-cuda-aarch64-13_2"
+          - desired_python: "3.14"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14-cuda-aarch64-13_2"
+          - desired_python: "3.14t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-aarch64-cu134-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-aarch64-cu134-build, manywheel-cuda-aarch64-cu134-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
@@ -980,68 +1400,12 @@ jobs:
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_10-cuda-aarch64-13_4"
           - desired_python: "3.11"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_11-cpu-aarch64"
-          - desired_python: "3.11"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_11-cuda-aarch64-12_6"
-          - desired_python: "3.11"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_11-cuda-aarch64-13_0"
-          - desired_python: "3.11"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_11-cuda-aarch64-13_2"
-          - desired_python: "3.11"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_11-cuda-aarch64-13_4"
-          - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_12-cpu-aarch64"
-          - desired_python: "3.12"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_12-cuda-aarch64-12_6"
-          - desired_python: "3.12"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_0"
-          - desired_python: "3.12"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_2"
           - desired_python: "3.12"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
@@ -1050,68 +1414,12 @@ jobs:
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_12-cuda-aarch64-13_4"
           - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_13-cpu-aarch64"
-          - desired_python: "3.13"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_13-cuda-aarch64-12_6"
-          - desired_python: "3.13"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_0"
-          - desired_python: "3.13"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_2"
-          - desired_python: "3.13"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_13-cuda-aarch64-13_4"
-          - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14-cpu-aarch64"
-          - desired_python: "3.14"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14-cuda-aarch64-12_6"
-          - desired_python: "3.14"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_0"
-          - desired_python: "3.14"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_2"
           - desired_python: "3.14"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
@@ -1120,34 +1428,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_14-cuda-aarch64-13_4"
           - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14t-cpu-aarch64"
-          - desired_python: "3.14t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
-          - desired_python: "3.14t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_0"
-          - desired_python: "3.14t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
-          - desired_python: "3.14t"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -1155,68 +1435,12 @@ jobs:
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_4"
           - desired_python: "3.15"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_15-cpu-aarch64"
-          - desired_python: "3.15"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
-          - desired_python: "3.15"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
-          - desired_python: "3.15"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
-          - desired_python: "3.15"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"
             gpu_arch_type: "cuda-aarch64"
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_15-cuda-aarch64-13_4"
-          - desired_python: "3.15t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_15t-cpu-aarch64"
-          - desired_python: "3.15t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
-          - desired_python: "3.15t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
-          - desired_python: "3.15t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
           - desired_python: "3.15t"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4-aarch64"

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -1046,7 +1046,7 @@ jobs:
 
   manywheel-cpu-aarch64-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1130,7 +1130,7 @@ jobs:
 
   manywheel-cuda-aarch64-cu126-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1214,7 +1214,7 @@ jobs:
 
   manywheel-cuda-aarch64-cu130-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1298,7 +1298,7 @@ jobs:
 
   manywheel-cuda-aarch64-cu132-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1382,7 +1382,7 @@ jobs:
 
   manywheel-cuda-aarch64-cu134-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1496,7 +1496,7 @@ jobs:
 
   manywheel-cpu-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1580,7 +1580,7 @@ jobs:
 
   manywheel-cuda-cu126-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1664,7 +1664,7 @@ jobs:
 
   manywheel-cuda-cu130-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1748,7 +1748,7 @@ jobs:
 
   manywheel-cuda-cu132-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1832,7 +1832,7 @@ jobs:
 
   manywheel-cuda-cu134-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -1916,7 +1916,7 @@ jobs:
 
   manywheel-rocm-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -2056,7 +2056,7 @@ jobs:
 
   manywheel-xpu-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
@@ -2257,7 +2257,7 @@ jobs:
 
   libtorch-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -831,10 +831,10 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  manywheel-test:
+  manywheel-cpu-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-cuda-cu134-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -848,38 +848,6 @@ jobs:
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_10-cpu"
             runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.10"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_10-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.10"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_10-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.10"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_10-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -888,6 +856,90 @@ jobs:
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_11-cpu"
             runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.12"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_12-cpu"
+            runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.13"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_13-cpu"
+            runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.14"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_14-cpu"
+            runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.14t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_14t-cpu"
+            runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15-cpu"
+            runs_on: "l-x86iavx512-16-128"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15t-cpu"
+            runs_on: "l-x86iavx512-16-128"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-cu126-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-cu126-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_10-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -895,6 +947,90 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_11-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.12"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_12-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.13"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_13-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14t-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda12_6"
+            runs_on: "l-x86iavx512-29-115-t4"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-cu130-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-cu130-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_10-cuda13_0"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu130"
@@ -904,6 +1040,90 @@ jobs:
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_11-cuda13_0"
             runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.12"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_12-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.13"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_13-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14t-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda13_0"
+            runs_on: "l-x86iavx512-29-115-t4"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-cu132-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-cu132-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_10-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -911,6 +1131,90 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.12"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_12-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.13"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_13-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.14t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14t-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda13_2"
+            runs_on: "l-x86iavx512-29-115-t4"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DOCKER_IMAGE_REGISTRY_HOST: "${{ needs.get-docker-tag.outputs.docker_registry_host }}"
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+      build_environment: linux-binary-manywheel
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ matrix.runs_on }}
+      use_container_directive: true
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  manywheel-cuda-cu134-test:
+    name: ${{ matrix.build_name }}-test
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag, manywheel-cuda-cu134-build]
+    uses: ./.github/workflows/_binary-test-linux.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_10-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu134"
@@ -921,76 +1225,12 @@ jobs:
             build_name: "manywheel-py3_11-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_12-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.12"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_12-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.12"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_12-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.12"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_12-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.12"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4"
             gpu_arch_type: "cuda"
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_12-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_13-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.13"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_13-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.13"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_13-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.13"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_13-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.13"
             desired_cuda: "cu134"
@@ -1001,76 +1241,12 @@ jobs:
             build_name: "manywheel-py3_13-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.14"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4"
             gpu_arch_type: "cuda"
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_14-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14t-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.14t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14t-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14t-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14t-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14t"
             desired_cuda: "cu134"
@@ -1081,76 +1257,12 @@ jobs:
             build_name: "manywheel-py3_14t-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_15-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.15"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4"
             gpu_arch_type: "cuda"
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_15-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_15t-cpu"
-            runs_on: "l-x86iavx512-16-128"
-          - desired_python: "3.15t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15t-cuda12_6"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15t-cuda13_0"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15t-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15t"
             desired_cuda: "cu134"
@@ -1382,13 +1494,13 @@ jobs:
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
 
-  manywheel-upload:
+  manywheel-cpu-upload:
     name: ${{ matrix.build_name }}-upload
     if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read
-    needs: [get-docker-tag, manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-cuda-cu134-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
+    needs: [get-docker-tag, manywheel-cpu-build, manywheel-cpu-test]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -1401,6 +1513,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_10-cpu"
+          - desired_python: "3.11"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_11-cpu"
+          - desired_python: "3.12"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_12-cpu"
+          - desired_python: "3.13"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_13-cpu"
+          - desired_python: "3.14"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_14-cpu"
+          - desired_python: "3.14t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_14t-cpu"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15-cpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15t-cpu"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-cu126-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-cu126-build, manywheel-cuda-cu126-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -1408,6 +1597,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_10-cuda12_6"
+          - desired_python: "3.11"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_11-cuda12_6"
+          - desired_python: "3.12"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_12-cuda12_6"
+          - desired_python: "3.13"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_13-cuda12_6"
+          - desired_python: "3.14"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14-cuda12_6"
+          - desired_python: "3.14t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_14t-cuda12_6"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda12_6"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-cu130-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-cu130-build, manywheel-cuda-cu130-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -1415,6 +1681,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_10-cuda13_0"
+          - desired_python: "3.11"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_11-cuda13_0"
+          - desired_python: "3.12"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_12-cuda13_0"
+          - desired_python: "3.13"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_13-cuda13_0"
+          - desired_python: "3.14"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14-cuda13_0"
+          - desired_python: "3.14t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_14t-cuda13_0"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda13_0"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda13_0"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-cu132-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-cu132-build, manywheel-cuda-cu132-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -1422,6 +1765,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda13_2"
+          - desired_python: "3.11"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_11-cuda13_2"
+          - desired_python: "3.12"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_12-cuda13_2"
+          - desired_python: "3.13"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_13-cuda13_2"
+          - desired_python: "3.14"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14-cuda13_2"
+          - desired_python: "3.14t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_14t-cuda13_2"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda13_2"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda13_2"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-cuda-cu134-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-cuda-cu134-build, manywheel-cuda-cu134-test]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "cu134"
             gpu_arch_version: "13.4"
@@ -1429,6 +1849,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.4"
             build_name: "manywheel-py3_10-cuda13_4"
+          - desired_python: "3.11"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_11-cuda13_4"
+          - desired_python: "3.12"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_12-cuda13_4"
+          - desired_python: "3.13"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_13-cuda13_4"
+          - desired_python: "3.14"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_14-cuda13_4"
+          - desired_python: "3.14t"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_14t-cuda13_4"
+          - desired_python: "3.15"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_15-cuda13_4"
+          - desired_python: "3.15t"
+            desired_cuda: "cu134"
+            gpu_arch_version: "13.4"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.4"
+            build_name: "manywheel-py3_15t-cuda13_4"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-rocm-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-build, manywheel-test-rocm]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - desired_python: "3.10"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1443,48 +1940,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_10-rocm7_14"
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-          - desired_python: "3.11"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_11-cpu"
-          - desired_python: "3.11"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_11-cuda12_6"
-          - desired_python: "3.11"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_11-cuda13_0"
-          - desired_python: "3.11"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_11-cuda13_2"
-          - desired_python: "3.11"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_11-cuda13_4"
           - desired_python: "3.11"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1499,48 +1954,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_11-rocm7_14"
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-          - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_12-cpu"
-          - desired_python: "3.12"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_12-cuda12_6"
-          - desired_python: "3.12"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_12-cuda13_0"
-          - desired_python: "3.12"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_12-cuda13_2"
-          - desired_python: "3.12"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_12-cuda13_4"
           - desired_python: "3.12"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1555,48 +1968,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_12-rocm7_14"
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-          - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_13-cpu"
-          - desired_python: "3.13"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_13-cuda12_6"
-          - desired_python: "3.13"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_13-cuda13_0"
-          - desired_python: "3.13"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_13-cuda13_2"
-          - desired_python: "3.13"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_13-cuda13_4"
           - desired_python: "3.13"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1611,48 +1982,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_13-rocm7_14"
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-          - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14-cpu"
-          - desired_python: "3.14"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14-cuda12_6"
-          - desired_python: "3.14"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14-cuda13_0"
-          - desired_python: "3.14"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14-cuda13_2"
-          - desired_python: "3.14"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14-cuda13_4"
           - desired_python: "3.14"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1667,48 +1996,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_14-rocm7_14"
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-          - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14t-cpu"
-          - desired_python: "3.14t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_14t-cuda12_6"
-          - desired_python: "3.14t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_14t-cuda13_0"
-          - desired_python: "3.14t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_14t-cuda13_2"
-          - desired_python: "3.14t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14t-cuda13_4"
           - desired_python: "3.14t"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1723,48 +2010,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_14t-rocm7_14"
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-          - desired_python: "3.15"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_15-cpu"
-          - desired_python: "3.15"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15-cuda12_6"
-          - desired_python: "3.15"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15-cuda13_0"
-          - desired_python: "3.15"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15-cuda13_2"
-          - desired_python: "3.15"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15-cuda13_4"
           - desired_python: "3.15"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1779,48 +2024,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_15-rocm7_14"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-          - desired_python: "3.15t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_15t-cpu"
-          - desired_python: "3.15t"
-            desired_cuda: "cu126"
-            gpu_arch_version: "12.6"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda12.6"
-            build_name: "manywheel-py3_15t-cuda12_6"
-          - desired_python: "3.15t"
-            desired_cuda: "cu130"
-            gpu_arch_version: "13.0"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.0"
-            build_name: "manywheel-py3_15t-cuda13_0"
-          - desired_python: "3.15t"
-            desired_cuda: "cu132"
-            gpu_arch_version: "13.2"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.2"
-            build_name: "manywheel-py3_15t-cuda13_2"
-          - desired_python: "3.15t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15t-cuda13_4"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1835,6 +2038,83 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "rocm7.14"
             build_name: "manywheel-py3_15t-rocm7_14"
+    with:
+      PYTORCH_ROOT: /pytorch
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: ${{ matrix.desired_cuda }}
+      GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      DOCKER_IMAGE: ${{ matrix.docker_image }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      DESIRED_PYTHON: ${{ matrix.desired_python }}
+      build_name: ${{ matrix.build_name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+  manywheel-xpu-upload:
+    name: ${{ matrix.build_name }}-upload
+    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    permissions:
+      id-token: write
+      contents: read
+    needs: [get-docker-tag, manywheel-build, manywheel-test-xpu]
+    uses: ./.github/workflows/_binary-upload.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - desired_python: "3.10"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_10-xpu"
+          - desired_python: "3.11"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_11-xpu"
+          - desired_python: "3.12"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_12-xpu"
+          - desired_python: "3.13"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_13-xpu"
+          - desired_python: "3.14"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14-xpu"
+          - desired_python: "3.14t"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_14t-xpu"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
           - desired_python: "3.15t"
             desired_cuda: "xpu"
             gpu_arch_version: ""

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -212,7 +212,7 @@ jobs:
 
   manywheel-upload:
     name: ${{ matrix.build_name }}-upload
-    if: ${{ !cancelled() && github.repository_owner == 'pytorch' }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
`manywheel-test` was one matrixed job over every standard config and `manywheel-upload` one matrixed job over every config, each gated on all the builds and tests before it. **`needs` is evaluated per job, not per matrix leg**, so nothing could be tested or uploaded until the slowest group in the whole workflow had finished.

Seen on the **v2.14.0-rc2** build ([run 31597398097](https://github.com/pytorch/pytorch/actions/runs/31597398097)): every manywheel build and test was green except `manywheel-py3_10-xpu-test`, which sat queued for hours on a scarce `linux.idc.xpu` runner. `manywheel-upload` was therefore never scheduled and no wheels published — while the libtorch uploads, which only need `libtorch-extract`, had long since completed. That asymmetry is what made it look like the manywheel upload had gone missing.

## Each arch group now runs its own chain

```
manywheel-cpu-build          -> manywheel-cpu-test          -> manywheel-cpu-upload
manywheel-cuda-cu126-build   -> manywheel-cuda-cu126-test   -> manywheel-cuda-cu126-upload
manywheel-cuda-cu130-build   -> ...
manywheel-cuda-cu132-build
manywheel-cuda-cu134-build
manywheel-build              -> manywheel-test-rocm         -> manywheel-rocm-upload
manywheel-build              -> manywheel-test-xpu          -> manywheel-xpu-upload
```

A group publishes as soon as it is ready. Names mirror the existing build jobs so the pairing is obvious. ROCm and XPU already had their own test jobs; they just get their own upload jobs now.

The groups partition the configs exactly: the unified cpu/cuda groups, the standard configs built by the `manywheel-build` matrix (`cpu-s390x`, which keeps the `manywheel-test` / `manywheel-upload` names since it is the only group there), then rocm and xpu.

Failure behaviour is unchanged — `if: !cancelled()` already meant a *failed* dependency did not block the upload. What changes is waiting on a dependency that is still *running*.

## Test plan

- Regenerated with `python .github/scripts/generate_ci_workflows.py`; a second run is byte-identical (md5), so the up-to-date lint check is satisfied.
- **Verified the split loses nothing** by parsing before/after and comparing the set of `build_name`s across all test jobs and all upload jobs:

| workflow | stage | build_names | jobs | identical set | duplicates |
| --- | --- | --- | --- | --- | --- |
| linux | test | 40 -> 40 | 1 -> 5 | yes | none |
| linux | upload | 71 -> 71 | 2 -> 8 | yes | none |
| linux-aarch64 | test | 40 -> 40 | 1 -> 5 | yes | none |
| linux-aarch64 | upload | 40 -> 40 | 1 -> 5 | yes | none |
| linux-s390x | test / upload | 6 -> 6 | 1 -> 1 | yes | none |

- Verified every `needs` entry on every generated job resolves to a job that exists in the same file, and that each chain is build -> test -> upload within one group only. s390x correctly omits `get-docker-tag` since it does not pin the docker image.
- `actionlint`: **3 findings before, 3 after** — the same pre-existing `github.triggering_actor` schema warnings in `get-label-type`. No new findings.

Authored with the assistance of Claude Code.