### PR TITLE
[DO NOT LAND] gpu-coverage probe: sm90+ test appended to an existing file

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -2198,5 +2198,11 @@ class TestForeachMM(TestCase):
 instantiate_parametrized_tests(TestForeachMM)
 
 
+class TestGpuCoverageProbe(TestCase):
+    @unittest.skipIf(not SM90OrLater, "needs sm90 or later")
+    def test_gpu_coverage_probe(self):
+        self.assertTrue(True)
+
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

The other probes add a new test file. This one appends the gated test to an existing
one, so no CODEOWNERS entry is involved -- and it covers the more interesting shape:
`test_foreach` is **already** in `test_python_smoke()`, but behind `-k TestForeachMM`,
which does not select a test in a different class.

Expected: `gpu-coverage` fails with two blocks.

- `test_python_smoke()`: `test_gpu_coverage_probe` only. The existing
  `-k TestForeachMM` covers the file's other sm90+ tests but not this one.
- `test_python_smoke_b200()`: `test_gpu_coverage_probe` **plus**
  `test_foreach_mm_cond_rejects` and `test_foreach_mm_fallback_correctness` --
  `test_foreach` is not in the b200 list at all.

Those last two are a **real pre-existing gap in main**, not something this PR
introduces. They were invisible until the suite-truncation fix in #193235: with the
GPU hidden, `_should_stop_test_suite` aborted the suite partway through
`test_foreach.py`, dropping 47 of 7544 tests into neither the ran nor the skipped
bucket, so a truncated file read as a clean one.