### PR TITLE
[PyTorch][Inductor] Keep symbolic size queries in lite mode

### DIFF
--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -5,7 +5,7 @@ import logging
 from unittest import mock
 
 import torch
-from torch._inductor import utils
+from torch._inductor import config, utils
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import do_bench_using_profiling
@@ -20,6 +20,16 @@ device_type = (
     if (acc := torch.accelerator.current_accelerator(check_available=True))
     else "cpu"
 )
+
+
+class TestFallbackByDefault(TestCase):
+    def test_sym_size_uses_inductor_lowering_in_lite_mode(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        sym_size = graph.call_function(torch.ops.aten.sym_size.int, (x, 0))
+
+        with config.patch({"fallback_by_default": True}):
+            self.assertFalse(utils.should_fallback_by_default(sym_size))
 
 
 class FakeKinetoEvent:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4727,6 +4727,7 @@ def should_fallback_by_default(node: torch.fx.Node) -> bool:
         [
             torch.ops.aten._assert_scalar.default,
             torch.ops.aten.lift_fresh_copy.default,
+            torch.ops.aten.sym_size.int,
         ]
     )
 


### PR DESCRIPTION
Summary:
Inductor lite mode uses `fallback_by_default` so unannotated numerical operators execute through eager ATen. That policy incorrectly applies to `aten.sym_size.int`, which is a metadata-only symbolic shape query rather than numerical computation.

The Inductor lowering for `aten.sym_size.int` records the runtime tensor dimension as the source of its `SymInt`. Routing the operation through the generic ATen fallback bypasses that symbolic lowering and can leave dynamic input symbols unbound during AOTI compilation.

Keep `aten.sym_size.int` in Inductor alongside the existing non-numerical dynamic-shape exceptions, and cover the lite-mode decision with a regression test.

Test Plan:
Added `TestFallbackByDefault.test_sym_size_uses_inductor_lowering_in_lite_mode` to `test/inductor/test_inductor_utils.py`.

The test file is explicitly registered as `inductor/test_inductor_utils` in `test/run_test.py`, belongs to the `INDUCTOR_TESTS` set, and is exercised by the GitHub `test_inductor_core` CI shard.

Differential Revision: D115806426




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo