### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_node_hook.py

### DIFF
--- a/test/fx/test_fx_node_hook.py
+++ b/test/fx/test_fx_node_hook.py
@@ -1,10 +1,12 @@
 # Owner(s): ["module: fx"]
 import torch
 from torch.fx import symbolic_trace
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestFXNodeHook(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_hooks_for_node_update(self):
         global create_node_hook1_called
         global create_node_hook2_called


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestFXNodeHook class, enabling hardware-based test classification and filtering.

## Changes
test_fx_node_hook.py : import HardwareClassification and add hw_classification to TestFXNodeHook class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
local: python -m unittest fx.test_fx_node_hook.TestFXNodeHook.test_hooks_for_node_update -v

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian