### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_param_shape_control_flow.py

### DIFF
--- a/test/fx/test_fx_param_shape_control_flow.py
+++ b/test/fx/test_fx_param_shape_control_flow.py
@@ -2,7 +2,11 @@
 
 import torch
 import torch.fx
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase
+)
 
 
 class MyModuleBase(torch.nn.Module):
@@ -81,6 +85,8 @@ class MyModuleParamNElement(MyModuleBase):
 
 
 class TestConstParamShapeInControlFlow(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def verify_mm_relu_mods(self, mm_only_mod, relu_mod):
         """
         Verify one module only does a mm op while the other


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestConstParamShapeInControlFlow class, enabling hardware-based test classification and filtering.

## Changes
test_fx_param_shape_control_flow.py : import HardwareClassification and add hw_classification to TestConstParamShapeInControlFlow class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
CI: python test_fx.py TestConstParamShapeInControlFlow

##  Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian