### PR TITLE
[Testcase Refactoring] Add hardware classification for test_typing.py

### DIFF
--- a/test/distributed/_pycute/test_typing.py
+++ b/test/distributed/_pycute/test_typing.py
@@ -40,7 +40,11 @@ Unit tests for _pycute.typing
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/test/distributed/_pycute/test_typing.py
+++ b/test/distributed/_pycute/test_typing.py
@@ -40,13 +40,15 @@ Unit tests for _pycute.typing
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class TestTyping(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def helper_test_typing(self, _cls, _obj, cls, expected: bool):
         _LOGGER.debug(f"issubclass({_cls}, {cls})")
         _LOGGER.debug(f"isinstance({_obj}, {cls})")


### PR DESCRIPTION
## Summary:
  Add hardware classification for `test_typing.py` and classify
  `TestTyping` as `GENERIC`.

## Changes:
  Set `hw_classification = HardwareClassification.GENERIC` on
  `TestTyping`.

## Test Plan:
  `python test/distributed/_pycute/test_typing.py -v --hw-classification GENERIC`