### PR TITLE
[aot_autograd] Fix PendingUnbackedSymbolNotFound leak from saved_tensors_hooks GraphModule inlining

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -246,15 +246,13 @@ class AOTTestCase(TestCase):
                     self.assertTensorMetadataEqual(actual_inner, expected_inner)
 
 
-# Module-level `@torch.fx.wrap`ed helper used by
-# `test_saved_tensors_hooks_gm_data_dependent_probe`. Must live at module
-# scope because `torch.fx.wrap` requires that. See the test's docstring for
-# the regression it exercises.
+# Module-level `@torch.fx.wrap`ed helper for
+# `test_saved_tensors_hooks_gm_data_dependent_probe`. `torch.fx.wrap`
+# requires module scope.
 @torch.fx.wrap
 def _il_log_tensor_stats_for_regression(t, name):
     try:
-        non_nan_infs = torch.isfinite(t)
-        if torch.all(non_nan_infs):
+        if torch.all(torch.isfinite(t)):
             pass
     except Exception:
         pass
@@ -4938,24 +4936,11 @@ def forward(self, tangents_1):
 
     @torch._functorch.config.patch(saved_tensors_hooks_filtering_mode="no_static")
     def test_saved_tensors_hooks_gm_data_dependent_probe(self):
-        # Regression: `maybe_inline_graph_saved_tensors_hooks` used to run the
-        # user-supplied pack GraphModule twice — once as a subclass-detection
-        # probe (with NO ProxyTorchDispatchMode on the stack) and again as a
-        # fake execution to grab an example output value. Any data-dependent
-        # op inside the pack body (e.g. `bool(<fake_tensor>)` from user-side
-        # instrumentation like intermediate logging) would take the C++
-        # `Tensor.__bool__` shortcut, allocate a fresh unbacked SymInt via
-        # `_local_scalar_dense`, and — because no proxy tracer was active —
-        # never get bound. The symbol leaked into
-        # `pending_fresh_unbacked_symbols` and a later trace boundary raised
-        # `PendingUnbackedSymbolNotFound`.
-        #
-        # Reproduction shape (mirrors MAST job
-        # aps-aps_omnifmv5_1k_0517_0523_gb200_il_58_logging-fc1fad3f10):
-        # the pack GraphModule is built from `torch.fx.symbolic_trace` and
-        # contains an `@torch.fx.wrap`ed function whose body does
-        # `if torch.all(torch.isfinite(t)): ...`.  Under fake tracing, the
-        # `if` invokes `Tensor.__bool__` -> `.item()` and leaks.
+        # Regression: pack GraphModule bodies that allocate a fresh unbacked
+        # SymInt (e.g. via `.item()` / `bool(<fake_tensor>)` / nonzero) used
+        # to leak into `pending_fresh_unbacked_symbols` because
+        # `maybe_inline_graph_saved_tensors_hooks` ran the hook without a
+        # ProxyTorchDispatchMode, leaving no tracker to bind the symbol.
 
         def pack(x):
             x = _il_log_tensor_stats_for_regression(x, "in")

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -246,9 +246,6 @@ class AOTTestCase(TestCase):
                     self.assertTensorMetadataEqual(actual_inner, expected_inner)
 
 
-# Module-level `@torch.fx.wrap`ed helper for
-# `test_saved_tensors_hooks_gm_data_dependent_probe`. `torch.fx.wrap`
-# requires module scope.
 @torch.fx.wrap
 def _il_log_tensor_stats_for_regression(t, name):
     try:

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -248,11 +248,11 @@ class AOTTestCase(TestCase):
 
 @torch.fx.wrap
 def _il_log_tensor_stats_for_regression(t, name):
-    try:
-        if torch.all(torch.isfinite(t)):
-            pass
-    except Exception:
-        pass
+    # Directly exercise the unbacked-symbol allocation path: `.item()` on a
+    # fake tensor allocates a fresh unbacked SymInt. Bare (no if/bool, no
+    # try/except) so an unrelated swallowed exception can't turn the
+    # regression into a no-op.
+    torch.all(torch.isfinite(t)).item()
     return t
 
 
@@ -4938,26 +4938,55 @@ def forward(self, tangents_1):
         # to leak into `pending_fresh_unbacked_symbols` because
         # `maybe_inline_graph_saved_tensors_hooks` ran the hook without a
         # ProxyTorchDispatchMode, leaving no tracker to bind the symbol.
-
-        def pack(x):
-            x = _il_log_tensor_stats_for_regression(x, "in")
-            return _il_log_tensor_stats_for_regression(x, "out")
-
-        def unpack(x):
-            return x
+        #
+        # The list / dict variants additionally cover container-typed pack
+        # outputs: `pack_out_val` is extracted from the traced graph's output
+        # node args (immutable_list / immutable_dict) and must be normalized
+        # back to plain list / dict so the unpack hook traces against the same
+        # runtime container type it would see in eager.
 
         def fn(x, w):
             return torch.matmul(x, w).sin()
 
-        pack_gm, unpack_gm = saved_tensors_hooks_to_gm(
-            pack, unpack, "pack_hash", "unpack_hash"
-        )
-        x = torch.randn(8, 16, requires_grad=True)
-        w = torch.randn(16, 16, requires_grad=True)
-        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
-        with torch.autograd.graph.saved_tensors_hooks(pack_gm, unpack_gm):
-            out = compiled(x, w)
-            out.sum().backward()
+        def _run(pack, unpack):
+            pack_gm, unpack_gm = saved_tensors_hooks_to_gm(
+                pack, unpack, "pack_hash", "unpack_hash"
+            )
+            x = torch.randn(8, 16, requires_grad=True)
+            w = torch.randn(16, 16, requires_grad=True)
+            compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+            with torch.autograd.graph.saved_tensors_hooks(pack_gm, unpack_gm):
+                out = compiled(x, w)
+                out.sum().backward()
+
+        # single-tensor pack output
+        def pack_tensor(x):
+            x = _il_log_tensor_stats_for_regression(x, "in")
+            return _il_log_tensor_stats_for_regression(x, "out")
+
+        def unpack_tensor(x):
+            return x
+
+        _run(pack_tensor, unpack_tensor)
+
+        # list-typed pack output — exercises immutable_list normalization
+        def pack_list(x):
+            return [_il_log_tensor_stats_for_regression(x, "in")]
+
+        def unpack_list(packed):
+            (x,) = packed
+            return x
+
+        _run(pack_list, unpack_list)
+
+        # dict-typed pack output — exercises immutable_dict normalization
+        def pack_dict(x):
+            return {"t": _il_log_tensor_stats_for_regression(x, "in")}
+
+        def unpack_dict(packed):
+            return packed["t"]
+
+        _run(pack_dict, unpack_dict)
 
     def test_mark_activations_dynamic_with_nested(self):
         # The flattened tensors of the nested tensor aren't

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -246,6 +246,21 @@ class AOTTestCase(TestCase):
                     self.assertTensorMetadataEqual(actual_inner, expected_inner)
 
 
+# Module-level `@torch.fx.wrap`ed helper used by
+# `test_saved_tensors_hooks_gm_data_dependent_probe`. Must live at module
+# scope because `torch.fx.wrap` requires that. See the test's docstring for
+# the regression it exercises.
+@torch.fx.wrap
+def _il_log_tensor_stats_for_regression(t, name):
+    try:
+        non_nan_infs = torch.isfinite(t)
+        if torch.all(non_nan_infs):
+            pass
+    except Exception:
+        pass
+    return t
+
+
 class TestPythonKey(AOTTestCase):
     def test_make_fx(self, device):
         def f(x):
@@ -4920,6 +4935,47 @@ def forward(self, tangents_1):
                     y.sum().backward()
             except torch._dynamo.exc.BackendCompilerFailed as e:
                 raise e.inner_exception from e
+
+    @torch._functorch.config.patch(saved_tensors_hooks_filtering_mode="no_static")
+    def test_saved_tensors_hooks_gm_data_dependent_probe(self):
+        # Regression: `maybe_inline_graph_saved_tensors_hooks` used to run the
+        # user-supplied pack GraphModule twice — once as a subclass-detection
+        # probe (with NO ProxyTorchDispatchMode on the stack) and again as a
+        # fake execution to grab an example output value. Any data-dependent
+        # op inside the pack body (e.g. `bool(<fake_tensor>)` from user-side
+        # instrumentation like intermediate logging) would take the C++
+        # `Tensor.__bool__` shortcut, allocate a fresh unbacked SymInt via
+        # `_local_scalar_dense`, and — because no proxy tracer was active —
+        # never get bound. The symbol leaked into
+        # `pending_fresh_unbacked_symbols` and a later trace boundary raised
+        # `PendingUnbackedSymbolNotFound`.
+        #
+        # Reproduction shape (mirrors MAST job
+        # aps-aps_omnifmv5_1k_0517_0523_gb200_il_58_logging-fc1fad3f10):
+        # the pack GraphModule is built from `torch.fx.symbolic_trace` and
+        # contains an `@torch.fx.wrap`ed function whose body does
+        # `if torch.all(torch.isfinite(t)): ...`.  Under fake tracing, the
+        # `if` invokes `Tensor.__bool__` -> `.item()` and leaks.
+
+        def pack(x):
+            x = _il_log_tensor_stats_for_regression(x, "in")
+            return _il_log_tensor_stats_for_regression(x, "out")
+
+        def unpack(x):
+            return x
+
+        def fn(x, w):
+            return torch.matmul(x, w).sin()
+
+        pack_gm, unpack_gm = saved_tensors_hooks_to_gm(
+            pack, unpack, "pack_hash", "unpack_hash"
+        )
+        x = torch.randn(8, 16, requires_grad=True)
+        w = torch.randn(16, 16, requires_grad=True)
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        with torch.autograd.graph.saved_tensors_hooks(pack_gm, unpack_gm):
+            out = compiled(x, w)
+            out.sum().backward()
 
     def test_mark_activations_dynamic_with_nested(self):
         # The flattened tensors of the nested tensor aren't

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -246,14 +246,41 @@ class AOTTestCase(TestCase):
                     self.assertTensorMetadataEqual(actual_inner, expected_inner)
 
 
+_pack_body_calls: list[int] = []
+
+
 @torch.fx.wrap
-def _il_log_tensor_stats_for_regression(t, name):
+def _alloc_unbacked_symint(t):
     # Directly exercise the unbacked-symbol allocation path: `.item()` on a
     # fake tensor allocates a fresh unbacked SymInt. Bare (no if/bool, no
     # try/except) so an unrelated swallowed exception can't turn the
     # regression into a no-op.
+    #
+    # Also records each execution of the enclosing pack body. torch.fx.wrap
+    # means symbolic_trace turns this into a node without calling it, so the
+    # count only reflects real executions of the pack GraphModule.
+    _pack_body_calls.append(1)
     torch.all(torch.isfinite(t)).item()
     return t
+
+
+# `type(c) is`, not isinstance: immutable_list / immutable_dict subclass
+# list / dict, so isinstance cannot tell them apart. These are torch.fx.wrap'd
+# so the check survives symbolic_trace as a call_function node and runs against
+# the real container when the unpack GraphModule is traced, rather than being
+# constant-folded away against a Proxy.
+@torch.fx.wrap
+def _unwrap_exact_list(c):
+    if type(c) is not list:
+        raise AssertionError(f"expected a plain list, got {type(c).__name__}")
+    return c[0]
+
+
+@torch.fx.wrap
+def _unwrap_exact_dict(c):
+    if type(c) is not dict:
+        raise AssertionError(f"expected a plain dict, got {type(c).__name__}")
+    return c["t"]
 
 
 class TestPythonKey(AOTTestCase):
@@ -4932,61 +4959,74 @@ def forward(self, tangents_1):
                 raise e.inner_exception from e
 
     @torch._functorch.config.patch(saved_tensors_hooks_filtering_mode="no_static")
-    def test_saved_tensors_hooks_gm_data_dependent_probe(self):
+    @parametrize("pack_out", ["tensor", "list", "dict"])
+    def test_saved_tensors_hooks_gm_data_dependent_probe(self, pack_out):
         # Regression: pack GraphModule bodies that allocate a fresh unbacked
         # SymInt (e.g. via `.item()` / `bool(<fake_tensor>)` / nonzero) used
         # to leak into `pending_fresh_unbacked_symbols` because
         # `maybe_inline_graph_saved_tensors_hooks` ran the hook without a
         # ProxyTorchDispatchMode, leaving no tracker to bind the symbol.
         #
-        # The list / dict variants additionally cover container-typed pack
-        # outputs: `pack_out_val` is extracted from the traced graph's output
-        # node args (immutable_list / immutable_dict) and must be normalized
-        # back to plain list / dict so the unpack hook traces against the same
-        # runtime container type it would see in eager.
+        # The list / dict variants additionally pin the immutable_list /
+        # immutable_dict -> list / dict normalization of the pack output. Their
+        # unpack hooks check `type(c) is list` / `type(c) is dict`, which is the
+        # only way the container type is observable: the immutable types are
+        # list / dict subclasses, so an isinstance-based unpack hook (or one that
+        # only does getitem) cannot distinguish them and passes either way.
 
         def fn(x, w):
             return torch.matmul(x, w).sin()
 
-        def _run(pack, unpack):
-            pack_gm, unpack_gm = saved_tensors_hooks_to_gm(
-                pack, unpack, "pack_hash", "unpack_hash"
-            )
-            x = torch.randn(8, 16, requires_grad=True)
-            w = torch.randn(16, 16, requires_grad=True)
-            compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
-            with torch.autograd.graph.saved_tensors_hooks(pack_gm, unpack_gm):
-                out = compiled(x, w)
-                out.sum().backward()
+        # `allocs_per_body` is how many times each variant's pack body calls
+        # _alloc_unbacked_symint, so the assertion below is in units of pack
+        # body executions regardless of variant.
+        if pack_out == "tensor":
+            allocs_per_body = 2
 
-        # single-tensor pack output
-        def pack_tensor(x):
-            x = _il_log_tensor_stats_for_regression(x, "in")
-            return _il_log_tensor_stats_for_regression(x, "out")
+            def pack(x):
+                x = _alloc_unbacked_symint(x)
+                return _alloc_unbacked_symint(x)
 
-        def unpack_tensor(x):
-            return x
+            def unpack(packed):
+                return packed
 
-        _run(pack_tensor, unpack_tensor)
+        elif pack_out == "list":
+            allocs_per_body = 1
 
-        # list-typed pack output — exercises immutable_list normalization
-        def pack_list(x):
-            return [_il_log_tensor_stats_for_regression(x, "in")]
+            def pack(x):
+                return [_alloc_unbacked_symint(x)]
 
-        def unpack_list(packed):
-            (x,) = packed
-            return x
+            def unpack(packed):
+                return _unwrap_exact_list(packed)
 
-        _run(pack_list, unpack_list)
+        else:
+            allocs_per_body = 1
 
-        # dict-typed pack output — exercises immutable_dict normalization
-        def pack_dict(x):
-            return {"t": _il_log_tensor_stats_for_regression(x, "in")}
+            def pack(x):
+                return {"t": _alloc_unbacked_symint(x)}
 
-        def unpack_dict(packed):
-            return packed["t"]
+            def unpack(packed):
+                return _unwrap_exact_dict(packed)
 
-        _run(pack_dict, unpack_dict)
+        pack_gm, unpack_gm = saved_tensors_hooks_to_gm(
+            pack, unpack, "pack_hash", "unpack_hash"
+        )
+        x = torch.randn(8, 16, requires_grad=True)
+        w = torch.randn(16, 16, requires_grad=True)
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+
+        _pack_body_calls.clear()
+        with torch.autograd.graph.saved_tensors_hooks(pack_gm, unpack_gm):
+            out = compiled(x, w)
+            out.sum().backward()
+
+        # `fn` saves 3 tensors, and the pack hook is now only traced -- not
+        # additionally executed to obtain an example value. Re-adding that
+        # second execution doubles this count, which is the regression this
+        # pins.
+        pack_body_runs, remainder = divmod(len(_pack_body_calls), allocs_per_body)
+        self.assertEqual(remainder, 0)
+        self.assertEqual(pack_body_runs, 3)
 
     def test_mark_activations_dynamic_with_nested(self):
         # The flattened tensors of the nested tensor aren't

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -251,24 +251,13 @@ _pack_body_calls: list[int] = []
 
 @torch.fx.wrap
 def _alloc_unbacked_symint(t):
-    # Directly exercise the unbacked-symbol allocation path: `.item()` on a
-    # fake tensor allocates a fresh unbacked SymInt. Bare (no if/bool, no
-    # try/except) so an unrelated swallowed exception can't turn the
-    # regression into a no-op.
-    #
-    # Also records each execution of the enclosing pack body. torch.fx.wrap
-    # means symbolic_trace turns this into a node without calling it, so the
-    # count only reflects real executions of the pack GraphModule.
     _pack_body_calls.append(1)
     torch.all(torch.isfinite(t)).item()
     return t
 
 
 # `type(c) is`, not isinstance: immutable_list / immutable_dict subclass
-# list / dict, so isinstance cannot tell them apart. These are torch.fx.wrap'd
-# so the check survives symbolic_trace as a call_function node and runs against
-# the real container when the unpack GraphModule is traced, rather than being
-# constant-folded away against a Proxy.
+# list / dict, so isinstance cannot tell them apart.
 @torch.fx.wrap
 def _unwrap_exact_list(c):
     if type(c) is not list:
@@ -4970,9 +4959,7 @@ def forward(self, tangents_1):
         # The list / dict variants additionally pin the immutable_list /
         # immutable_dict -> list / dict normalization of the pack output. Their
         # unpack hooks check `type(c) is list` / `type(c) is dict`, which is the
-        # only way the container type is observable: the immutable types are
-        # list / dict subclasses, so an isinstance-based unpack hook (or one that
-        # only does getitem) cannot distinguish them and passes either way.
+        # only way the container type is observable.
 
         def fn(x, w):
             return torch.matmul(x, w).sin()

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1508,7 +1508,25 @@ def maybe_inline_graph_saved_tensors_hooks(
             return {"_fw_graph": fw_g, "_bw_graph": bw_g, "_node": saved}
 
         with _saved_tensor_hook_context(_get_extra_info()):
-            pack_out_val = pack_hook_gm(val)
+            pack_gm = prepare_hook_gm(aot_config, pack_hook_gm, (val,))
+            pack_g = pack_gm.graph
+            maybe_log_graph(
+                pack_gm,
+                f"saved_tensors_pack_hook {saved.name}",  # type: ignore[union-attr]
+                aot_config,
+                lambda: f"aot_saved_tensors_hooks_pack {saved.name}",  # type: ignore[union-attr]
+                structured_logs,
+            )
+            # Extract pack_out_val from the traced graph's output-node meta.
+            # `pack_g` is what gets inlined into the joint graph below via
+            # `node_copy`, so its output meta uses the same symbols the
+            # inlined nodes carry — no identity mismatch, no need to re-run
+            # the hook to get an "example value".
+            pack_out_val = pytree.tree_map_only(
+                torch.fx.Node,
+                lambda n: n.meta["val"],
+                pack_g.output_node().args[0],
+            )
 
         requires_sc_handling = any(
             is_traceable_wrapper_subclass(x) for x in pytree.tree_leaves(pack_out_val)
@@ -1519,18 +1537,6 @@ def maybe_inline_graph_saved_tensors_hooks(
                 "You can workaround it by manually returning subclass's inner tensors"
                 " in the pack hook, and reconstructing the subclass in the unpack hook"
             )
-
-        with _saved_tensor_hook_context(_get_extra_info()):
-            pack_gm = prepare_hook_gm(aot_config, pack_hook_gm, (val,))
-            pack_g = pack_gm.graph
-            maybe_log_graph(
-                pack_gm,
-                f"saved_tensors_pack_hook {saved.name}",  # type: ignore[union-attr]
-                aot_config,
-                lambda: f"aot_saved_tensors_hooks_pack {saved.name}",  # type: ignore[union-attr]
-                structured_logs,
-            )
-            pack_out_val = pack_gm(val)
 
         # Install pack hook graph as eiplogue of fw_module.
         # Saved tensor output becomes input of pack hook graph.

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -44,6 +44,7 @@ from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import is_sym_node
 from torch.fx.experimental.symbolic_shapes import fx_placeholder_vals, guard_or_true
 from torch.fx.graph_module import GraphModule
+from torch.fx.immutable_collections import immutable_dict, immutable_list
 from torch.fx.passes._tensorify_python_scalars import tensorify_python_scalars
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.types import py_sym_types
@@ -1517,15 +1518,39 @@ def maybe_inline_graph_saved_tensors_hooks(
                 lambda: f"aot_saved_tensors_hooks_pack {saved.name}",  # type: ignore[union-attr]
                 structured_logs,
             )
+
             # Extract pack_out_val from the traced graph's output-node meta.
             # `pack_g` is what gets inlined into the joint graph below via
             # `node_copy`, so its output meta uses the same symbols the
             # inlined nodes carry — no identity mismatch, no need to re-run
             # the hook to get an "example value".
+            #
+            # FX stores the output node's container args as immutable_list /
+            # immutable_dict. Executing the hook (the old code path) instead
+            # returned plain list / dict. `pack_out_val` feeds the unpack hook
+            # trace below (`prepare_hook_gm(unpack_hook_gm, (pack_out_val,))`),
+            # so normalize the containers back to their runtime types to keep
+            # the unpack trace in parity with eager and avoid tracing a
+            # different backward for container-type-sensitive unpack hooks.
+            def _materialize_fx_output_containers(x: Any) -> Any:
+                if type(x) in (immutable_list, list):
+                    return [_materialize_fx_output_containers(v) for v in x]
+                if type(x) in (immutable_dict, dict):
+                    return {
+                        k: _materialize_fx_output_containers(v) for k, v in x.items()
+                    }
+                if isinstance(x, tuple):
+                    values = tuple(_materialize_fx_output_containers(v) for v in x)
+                    return type(x)(*values) if hasattr(x, "_fields") else values
+                return x
+
+            pack_out_args = _materialize_fx_output_containers(
+                pack_g.output_node().args[0]
+            )
             pack_out_val = pytree.tree_map_only(
                 torch.fx.Node,
                 lambda n: n.meta["val"],
-                pack_g.output_node().args[0],
+                pack_out_args,
             )
 
         requires_sc_handling = any(

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1372,6 +1372,27 @@ def prepare_hook_gm(
     return gm
 
 
+def _materialize_fx_output_containers(x: Any) -> Any:
+    # FX stores an output node's container args as immutable_list /
+    # immutable_dict. The pack hook's return value is handed to the unpack hook
+    # trace (`prepare_hook_gm(unpack_hook_gm, (pack_out_val,))`), and
+    # `create_wrap_fn` tree_maps it, which preserves those immutable types.
+    # Unpack hooks that check `type(c) is list` / `type(c) is dict` rather than
+    # isinstance would therefore see a different container than in eager, so
+    # normalize back to the plain runtime types.
+    #
+    # Note this only recovers `list` / `dict`, not other subclasses: FX's
+    # create_arg already collapses e.g. an OrderedDict pack output to
+    # immutable_dict, so that distinction is gone before we get here.
+    if type(x) in (immutable_list, list):
+        return [_materialize_fx_output_containers(v) for v in x]
+    if type(x) in (immutable_dict, dict):
+        return {k: _materialize_fx_output_containers(v) for k, v in x.items()}
+    if type(x) is tuple:
+        return tuple(_materialize_fx_output_containers(v) for v in x)
+    return x
+
+
 # Inline Autograd saved_tensors_hooks into epilogue of forward graph
 # and prologue of backward graph.
 # This changes forward graph outputs and inputs.
@@ -1522,28 +1543,8 @@ def maybe_inline_graph_saved_tensors_hooks(
             # Extract pack_out_val from the traced graph's output-node meta.
             # `pack_g` is what gets inlined into the joint graph below via
             # `node_copy`, so its output meta uses the same symbols the
-            # inlined nodes carry — no identity mismatch, no need to re-run
+            # inlined nodes carry -- no identity mismatch, no need to re-run
             # the hook to get an "example value".
-            #
-            # FX stores the output node's container args as immutable_list /
-            # immutable_dict. Executing the hook (the old code path) instead
-            # returned plain list / dict. `pack_out_val` feeds the unpack hook
-            # trace below (`prepare_hook_gm(unpack_hook_gm, (pack_out_val,))`),
-            # so normalize the containers back to their runtime types to keep
-            # the unpack trace in parity with eager and avoid tracing a
-            # different backward for container-type-sensitive unpack hooks.
-            def _materialize_fx_output_containers(x: Any) -> Any:
-                if type(x) in (immutable_list, list):
-                    return [_materialize_fx_output_containers(v) for v in x]
-                if type(x) in (immutable_dict, dict):
-                    return {
-                        k: _materialize_fx_output_containers(v) for k, v in x.items()
-                    }
-                if isinstance(x, tuple):
-                    values = tuple(_materialize_fx_output_containers(v) for v in x)
-                    return type(x)(*values) if hasattr(x, "_fields") else values
-                return x
-
             pack_out_args = _materialize_fx_output_containers(
                 pack_g.output_node().args[0]
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193258

Fix a latent bug in maybe_inline_graph_saved_tensors_hooks (torch/_functorch/_aot_autograd/graph_compile.py) that caused PendingUnbackedSymbolNotFound whenever a user-supplied pack GraphModule's body allocated a fresh unbacked SymInt.

The function was running the pack hook body three times per saved tensor:

1. A subclass-detection probe at line 1511 (pack_hook_gm(val)) — with no ProxyTorchDispatchMode on the stack, just fake tensor execution. We do not need to track pending unbacked symbols here, but we do aggregate them in the shape env without clearing them. If we wanted to keep it, we should have used ignore_fresh_unbacked_symbols.
2. The real make_fx trace via prepare_hook_gm at line 1527.
3. A metadata re-execution at line 1536 (pack_gm(val)) — allocating fresh unbacked symbols that didn't match the ones bound during (2). I don't know why we did this — it's wrong because for unbacked it will allocate new unbacked but we do not rebind the inlined op symbols in the graph with the new symbol
.
Executions (1) and (3) both allocated unbacked symbols that either had no proxy tracer to bind them (1) or created identity mismatches with pack_g's captured node symbols.

### Fix
Replace three executions with one:

1. Keep the single prepare_hook_gm call (make_fx trace with proper proxy tracker).
2. Extract pack_out_val from pack_g.output_node().args[0]'s meta["val"] — same symbols as the nodes that get node_copy'd into the joint graph.
3. Delete the redundant probe (line 1511) and metadata re-execution (line 1536).
### Why this is correct

- pack_g is what actually gets inlined into the joint forward via fw_g.node_copy(node, ...) — unchanged by this PR.
- make_fx inside prepare_hook_gm sets up ProxyTorchDispatchMode properly, so any unbacked producing op inside the pack body has a chance to proxy_call → track_tensor_tree → _set_unbacked_bindings normally.
- The extracted pack_out_val uses the same symbols as the inlined nodes, eliminating identity mismatch when the loop below propagates meta.
- one fake tensor prop instead of 3! 

Fixed with help of Claude after hours of guiding and co-debugging.
