### PR TITLE
spaceship operator for comparisons in List.h

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -188,24 +188,8 @@ private:
     return lhs.iterator_ == rhs.iterator_;
   }
 
-  friend bool operator!=(const ListIterator& lhs, const ListIterator& rhs) {
-    return !(lhs == rhs);
-  }
-
-  friend bool operator<(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ < rhs.iterator_;
-  }
-
-  friend bool operator<=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ <= rhs.iterator_;
-  }
-
-  friend bool operator>(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ > rhs.iterator_;
-  }
-
-  friend bool operator>=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ >= rhs.iterator_;
+  friend auto operator<=>(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ <=> rhs.iterator_;
   }
 
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -188,9 +188,27 @@ private:
     return lhs.iterator_ == rhs.iterator_;
   }
 
+#ifdef __cpp_lib_three_way_comparison
   friend auto operator<=>(const ListIterator& lhs, const ListIterator& rhs) {
     return lhs.iterator_ <=> rhs.iterator_;
   }
+#else // This can be removed after upgrading clang used in macos-py3-arm64
+  friend bool operator<(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ < rhs.iterator_;
+  }
+
+  friend bool operator<=(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ <= rhs.iterator_;
+  }
+
+  friend bool operator>(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ > rhs.iterator_;
+  }
+
+  friend bool operator>=(const ListIterator& lhs, const ListIterator& rhs) {
+    return lhs.iterator_ >= rhs.iterator_;
+  }
+#endif
 
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;
   friend class List<T>;


### PR DESCRIPTION
We have C++20 in PyTorch now https://github.com/pytorch/pytorch/issues/176662
Spaceship/Three-way comparison operator automatically generates <, <=, >, >=
operator== automatically generates operator!=
This reduces a little bit of code.