### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard extensions

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
@@ -23,10 +23,7 @@ from torch.testing._internal.common_fsdp import (
     get_devtype,
     MLP,
 )
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -229,7 +226,7 @@ class TestFullyShardAllGatherExtensionsMultiProcess(
     hw_classification = HardwareClassification.ACCELERATOR
 
     @skip_if_lt_x_gpu(2)
-    def test_all_gather_extensions_train_parity(self):
+    def test_all_gather_extensions_train_parity(self, device):
         with self._patch_two_tensor_fsdp_all_gather(pre_all_gather_version=1):
             self.run_subtests(
                 {"reshard_after_forward": [True, False]},
@@ -288,7 +285,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
         return torch.device(device_type)
 
     @skip_if_lt_x_gpu(1)
-    def test_all_gather_extensions_end_to_end(self):
+    def test_all_gather_extensions_end_to_end(self, device):
         with self._patch_two_tensor_fsdp_all_gather(pre_all_gather_version=1):
             self.run_subtests(
                 {"reshard_after_forward": [True, False]},
@@ -328,7 +325,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
             optim.zero_grad()
 
     @skip_if_lt_x_gpu(1)
-    def test_all_gather_extensions_monkey_patch(self):
+    def test_all_gather_extensions_monkey_patch(self, device):
         tls = threading.local()
         tls.ran_pre_all_gather = False
 
@@ -405,7 +402,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
             raise AssertionError("Expected tls.ran_pre_all_gather to be True")
 
     @skip_if_lt_x_gpu(1)
-    def test_release_all_gather_outputs_after_post_all_gather(self):
+    def test_release_all_gather_outputs_after_post_all_gather(self, device):
         self.run_subtests(
             {"reshard_after_forward": [True, False]},
             self._test_release_all_gather_outputs_after_post_all_gather,
@@ -541,7 +538,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
         self.assertEqual(tls.num_post_all_gather_calls, expected_post_all_gather_calls)
 
     @skip_if_lt_x_gpu(1)
-    def test_all_gather_extension_outer_size_stride(self):
+    def test_all_gather_extension_outer_size_stride(self, device):
         """
         NOTE: We cannot easily test the incorrect case where the user-defined
         ``fsdp_pre_all_gather`` does not correctly pad the local tensor because
@@ -570,7 +567,7 @@ class TestFullyShardAllGatherExtensionsMultiThread(
         optim.zero_grad()
 
     @skip_if_lt_x_gpu(1)
-    def test_all_gather_extension_hsdp_mesh(self):
+    def test_all_gather_extension_hsdp_mesh(self, device):
         tls = threading.local()
         replicate_size = 2
         shard_size = self.world_size // replicate_size

--- a/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
@@ -14,6 +14,7 @@ import torch.utils._pytree as pytree
 from torch.autograd.grad_mode import _unsafe_preserve_version_counter
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
@@ -22,7 +23,10 @@ from torch.testing._internal.common_fsdp import (
     get_devtype,
     MLP,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -222,6 +226,8 @@ class TestFullyShardAllGatherExtensionsCommon:
 class TestFullyShardAllGatherExtensionsMultiProcess(
     TestFullyShardAllGatherExtensionsCommon, FSDPTest
 ):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skip_if_lt_x_gpu(2)
     def test_all_gather_extensions_train_parity(self):
         with self._patch_two_tensor_fsdp_all_gather(pre_all_gather_version=1):
@@ -271,6 +277,8 @@ class TestFullyShardAllGatherExtensionsMultiProcess(
 class TestFullyShardAllGatherExtensionsMultiThread(
     TestFullyShardAllGatherExtensionsCommon, FSDPTestMultiThread
 ):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 8
@@ -622,6 +630,20 @@ class TestFullyShardAllGatherExtensionsMultiThread(
         self.assertEqual(tls.mesh.ndim, 1)
         self.assertEqual(tls.mesh.size(), shard_size)
 
+
+instantiate_device_type_tests(
+    TestFullyShardAllGatherExtensionsMultiProcess,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
+instantiate_device_type_tests(
+    TestFullyShardAllGatherExtensionsMultiThread,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the fully_shard extensions test classes and instantiates the two device-test classes via instantiate_device_type_tests, so they are discovered per device type under the hardware-classification selection.

Test Plan: Ran the two commands below; each executed only the tests matching the requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_extensions.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_extensions.py --hw-classification GENERIC