### PR TITLE
[Testcase Refactoring] Add hardware classification for test_right_inverse.py

### DIFF
--- a/test/distributed/_pycute/test_right_inverse.py
+++ b/test/distributed/_pycute/test_right_inverse.py
@@ -40,13 +40,15 @@ Unit tests for _pycute.left_inverse
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class TestRightInverse(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def helper_test_right_inverse(self, layout):
         inv_layout = right_inverse(layout)
 

--- a/test/distributed/_pycute/test_right_inverse.py
+++ b/test/distributed/_pycute/test_right_inverse.py
@@ -40,7 +40,11 @@ Unit tests for _pycute.left_inverse
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary：
  Add hardware classification for `test_right_inverse.py` and classify
  `TestRightInverse` as `GENERIC`.

## Changes:
  Set `hw_classification = HardwareClassification.GENERIC` on
  `TestRightInverse`.

## Test Plan:
  `python test/distributed/_pycute/test_right_inverse.py -v --hw-classification GENERIC`