### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_split_node_finder.py

### DIFF
--- a/test/fx/test_fx_split_node_finder.py
+++ b/test/fx/test_fx_split_node_finder.py
@@ -16,7 +16,7 @@ from torch.fx.passes.splitter_base import (
     NODES_SUFFIX,
     ShapeProp,
 )
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 # Wrappepr function to make it supported
@@ -26,6 +26,8 @@ def sup_f(x):
 
 
 class TestFxSplitNodeFinder(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.save_path = sys.path[:]


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestFxSplitNodeFinder class, enabling hardware-based test classification and filtering.

## Changes
test_fx_split_node_finder.py : import HardwareClassification and add hw_classification to TestFxSplitNodeFinder class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
local: python -m unittest fx.test_fx_split_node_finder.TestFxSplitNodeFinder -v

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian