### PR TITLE
[Testcase Refactoring] Add hardware classification for test_coalesce.py

### DIFF
--- a/test/distributed/_pycute/test_coalesce.py
+++ b/test/distributed/_pycute/test_coalesce.py
@@ -40,7 +40,11 @@ Unit tests for _pycute.coalesce
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/test/distributed/_pycute/test_coalesce.py
+++ b/test/distributed/_pycute/test_coalesce.py
@@ -40,13 +40,15 @@ Unit tests for _pycute.coalesce
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class TestCoalesce(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def helper_test_coalesce(self, layout, expected_coalesced_layout):
         layoutR = coalesce(layout)
 


### PR DESCRIPTION
## Summary:
  Add hardware classification for `test_coalesce.py` and classify
  `TestCoalesce` as `GENERIC`.

## Changes:
  Set `hw_classification = HardwareClassification.GENERIC` on
  `TestCoalesce`.

## Test Plan:
  `python test/distributed/_pycute/test_coalesce.py -v --hw-classification GENERIC`