### PR TITLE
[Testcase Refactoring] Add hardware classification to sparsity scheduler tests

### DIFF
--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -4,7 +4,11 @@ import warnings
 
 from torch import nn
 from torch.ao.pruning import BaseScheduler, CubicSL, LambdaSL, WeightNormSparsifier
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ImplementedScheduler(BaseScheduler):
@@ -16,6 +20,8 @@ class ImplementedScheduler(BaseScheduler):
 
 
 class TestScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_constructor(self):
         model = nn.Sequential(nn.Linear(16, 16))
         sparsifier = WeightNormSparsifier()
@@ -98,6 +104,8 @@ class TestScheduler(TestCase):
 
 
 class TestCubicScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.model_sparse_config = [


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestScheduler` and `TestCubicScheduler` in `test/ao/sparsity/test_scheduler.py` cover sparsifier scheduler construction and step behavior. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and both classes are classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestScheduler` and `TestCubicScheduler`.
- Keep all test methods and their behavior unchanged.

## Self-test

Environment:

- macOS darwin, Python 3.12.13
- PyTorch `2.15.0.dev20260812`
- CPU-only (`torch.cuda.is_available() == False`)

Commands:

```bash
python -m pytest -vv -ra test/ao/sparsity/test_scheduler.py
python -m pytest -vv -ra test/ao/sparsity/test_scheduler.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_scheduler.py
```

Results:

- Unfiltered: 6 passed
- GENERIC filter: `total=6, passed=6, unclassified=0, mismatched=0`
- Collect-only: 6 tests collected, set unchanged
- All command exit codes were 0

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.