### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_split.py

### DIFF
--- a/test/fx/test_fx_split.py
+++ b/test/fx/test_fx_split.py
@@ -7,7 +7,7 @@ import torch
 import torch.fx.passes.operator_support as op_support
 import torch.fx.passes.splitter_base as splitter_base
 from torch.fx.passes.split_utils import split_by_tags
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 @torch.jit.script
@@ -24,6 +24,8 @@ def wrapped_add(_dataclass, y):
 
 
 class TestFXSplit(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_split_preserve_node_meta(self):
         class TestModule(torch.nn.Module):
             def forward(self, x, y):
@@ -115,6 +117,8 @@ class TestFXSplit(TestCase):
 
 
 class TestSplitByTags(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     class TestModule(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
@@ -227,6 +231,8 @@ class TestSplitByTags(TestCase):
 
 
 class TestSplitOutputType(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     class TestModule(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC attribute to TestFXSplit、TestSplitByTags、TestSplitOutputType class, enabling hardware-based test classification and filtering.

## Changes
 test/fx/test_fx_split.py : import HardwareClassification and add hw_classification to TestFXSplit、TestSplitByTags、TestSplitOutputType class。

## Motivation
These tests are hardware-agnostic and should be classified as GENERIC so they can be properly selected and filtered when running on different hardware backends.

## Test Plan
local: python -m unittest fx.test_fx_split -v

## Notes
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian