### PR TITLE
[Testcase Refactoring] Add hardware classification for test_local_tensor_tutorial_examples.py

### DIFF
--- a/test/distributed/local_tensor_tutorial_examples/test_local_tensor_tutorial_examples.py
+++ b/test/distributed/local_tensor_tutorial_examples/test_local_tensor_tutorial_examples.py
@@ -52,11 +52,12 @@ from example_06_multidim_mesh import create_2d_mesh, create_3d_mesh, hybrid_para
 import torch
 import torch.distributed as dist
 from torch.distributed._local_tensor import LocalTensor
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
 
 
 class TestExample01BasicOperations(TestCase):
     """Tests for Example 1: Basic LocalTensor Operations."""
+    hw_classification = HardwareClassification.GENERIC
 
     def test_create_local_tensor(self):
         """Test creating a LocalTensor from per-rank tensors."""
@@ -101,6 +102,7 @@ class TestExample01BasicOperations(TestCase):
 
 class TestExample02CollectiveOperations(TestCase):
     """Tests for Example 2: Collective Operations."""
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -143,6 +145,7 @@ class TestExample02CollectiveOperations(TestCase):
 
 class TestExample03DTensorIntegration(TestCase):
     """Tests for Example 3: DTensor Integration."""
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -177,6 +180,7 @@ class TestExample03DTensorIntegration(TestCase):
 
 class TestExample04UnevenSharding(TestCase):
     """Tests for Example 4: Uneven Sharding."""
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):
@@ -215,6 +219,7 @@ class TestExample04UnevenSharding(TestCase):
 
 class TestExample05RankSpecific(TestCase):
     """Tests for Example 5: Rank-Specific Computations."""
+    hw_classification = HardwareClassification.GENERIC
 
     def test_use_rank_map(self):
         """Test rank_map creates per-rank values."""
@@ -248,6 +253,7 @@ class TestExample05RankSpecific(TestCase):
 
 class TestExample06MultidimMesh(TestCase):
     """Tests for Example 6: Multi-Dimensional Meshes."""
+    hw_classification = HardwareClassification.GENERIC
 
     @classmethod
     def setUpClass(cls):

--- a/test/distributed/local_tensor_tutorial_examples/test_local_tensor_tutorial_examples.py
+++ b/test/distributed/local_tensor_tutorial_examples/test_local_tensor_tutorial_examples.py
@@ -52,11 +52,16 @@ from example_06_multidim_mesh import create_2d_mesh, create_3d_mesh, hybrid_para
 import torch
 import torch.distributed as dist
 from torch.distributed._local_tensor import LocalTensor
-from torch.testing._internal.common_utils import HardwareClassification, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestExample01BasicOperations(TestCase):
     """Tests for Example 1: Basic LocalTensor Operations."""
+
     hw_classification = HardwareClassification.GENERIC
 
     def test_create_local_tensor(self):
@@ -102,6 +107,7 @@ class TestExample01BasicOperations(TestCase):
 
 class TestExample02CollectiveOperations(TestCase):
     """Tests for Example 2: Collective Operations."""
+
     hw_classification = HardwareClassification.GENERIC
 
     @classmethod
@@ -145,6 +151,7 @@ class TestExample02CollectiveOperations(TestCase):
 
 class TestExample03DTensorIntegration(TestCase):
     """Tests for Example 3: DTensor Integration."""
+
     hw_classification = HardwareClassification.GENERIC
 
     @classmethod
@@ -180,6 +187,7 @@ class TestExample03DTensorIntegration(TestCase):
 
 class TestExample04UnevenSharding(TestCase):
     """Tests for Example 4: Uneven Sharding."""
+
     hw_classification = HardwareClassification.GENERIC
 
     @classmethod
@@ -219,6 +227,7 @@ class TestExample04UnevenSharding(TestCase):
 
 class TestExample05RankSpecific(TestCase):
     """Tests for Example 5: Rank-Specific Computations."""
+
     hw_classification = HardwareClassification.GENERIC
 
     def test_use_rank_map(self):
@@ -253,6 +262,7 @@ class TestExample05RankSpecific(TestCase):
 
 class TestExample06MultidimMesh(TestCase):
     """Tests for Example 6: Multi-Dimensional Meshes."""
+
     hw_classification = HardwareClassification.GENERIC
 
     @classmethod


### PR DESCRIPTION
## Summary:
  Add hardware classification for `test_local_tensor_tutorial_examples.py` and classify
  `TestExample01BasicOperations`, `TestExample02CollectiveOperations`,
  `TestExample03DTensorIntegration`, `TestExample04UnevenSharding`,
  `TestExample05RankSpecific` and `TestExample06MultidimMesh` as `GENERIC`.

## Changes:
  Set `hw_classification = HardwareClassification.GENERIC` on
  `TestExample01BasicOperations`, `TestExample02CollectiveOperations`,
  `TestExample03DTensorIntegration`, `TestExample04UnevenSharding`,
  `TestExample05RankSpecific` and `TestExample06MultidimMesh`.

## Test Plan:
  `python test/distributed/local_tensor_tutorial_examples/test_local_tensor_tutorial_examples.py -v --hw-classification GENERIC`