### PR TITLE
[Testcase Refactoring] Refactor test_misc.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -78,35 +78,29 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.nn import functional as F
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    SM80OrLater,
-    TEST_CUDA,
-)
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
-    onlyCUDA,
     PYTORCH_CUDA_MEMCHECK,
+    requires_capabilities,
 )
 from torch.testing._internal.common_methods_invocations import (
     sample_inputs_take_along_dim,
 )
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
     recover_orig_fp32_precision,
     scoped_load_inline,
     set_default_dtype,
-    skipIfHpu,
-    skipIfNNModuleInlined,
     skipIfWindows,
     subtest,
-    TEST_HPU,
-    TEST_XPU,
     wrapDeterministicFlagAPITest,
 )
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.testing._internal.jit_utils import JitTestCase
 
 
@@ -202,6 +196,8 @@ class UserDefineSetAttr:
 
 
 class MiscTests(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_cache_entry(self):
         def f(x):
             return x + 1
@@ -283,61 +279,6 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val3, correct3))
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
-
-    @unittest.skipIf(not TEST_CUDA, "cuda needed")
-    def test_assume_32_bit_indexing(self):
-        @torch.compile(backend="inductor")
-        def func(a, b):
-            # Multiple concat operations
-            x = torch.concat([a, b], dim=0)
-            y = torch.concat([a, b], dim=1)
-
-            # Reshape to create indexing patterns
-            x_flat = x.reshape(-1)
-            y_flat = y.reshape(-1)
-
-            # Take the smaller one and expand
-            min_size = min(x_flat.shape[0], y_flat.shape[0])
-            x_trunc = x_flat[:min_size]
-            y_trunc = y_flat[:min_size]
-
-            # Combine and compute
-            result = (x_trunc + y_trunc) * 10
-
-            # Cumulative operations create complex indexing
-            cumsum = result.cumsum(dim=0)
-
-            return cumsum.sum()
-
-        a = torch.rand(100, 30, device="cuda")
-        b = torch.rand(100, 30, device="cuda")
-
-        torch._dynamo.decorators.mark_unbacked(a, 0)
-        torch._dynamo.decorators.mark_unbacked(a, 1)
-        torch._dynamo.decorators.mark_unbacked(b, 0)
-        torch._dynamo.decorators.mark_unbacked(b, 1)
-
-        source_code = run_and_get_code(func, a, b)[1]
-        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
-        self.assertTrue(
-            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-        )
-        # Check that 32-bit indexing is NOT used
-        self.assertFalse(
-            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
-            and ".to(tl.int64)" not in str(source_code)
-        )
-
-        torch._dynamo.reset()
-
-        with torch._inductor.config.patch(assume_32bit_indexing=True):
-            source_code = run_and_get_code(func, a, b)[1]
-            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
-            self.assertFalse(
-                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-            )
 
     def test_dynamo_side_effect(self):
         class GlobalContext:
@@ -1188,102 +1129,6 @@ graph():
         res = opt_f(x, True)
         self.assertEqual(res, torch.ones(5) + 1)
         self.assertTrue(res.offloading_activation)
-
-    @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-        "requires Hopper+ (SM >= 9.0) for TMA",
-    )
-    @unittest.skipIf(
-        not torch.utils._triton.has_triton()
-        or not hasattr(__import__("triton"), "set_allocator"),
-        "requires triton with set_allocator support",
-    )
-    def test_triton_set_allocator_no_graph_break(self):
-        """set_allocator inside torch.compile does not graph break and
-        replays correctly at runtime (including cache hits)."""
-        import triton
-        import triton.language as tl
-        from triton.runtime._allocation import NullAllocator
-
-        @triton.jit
-        def tma_copy_kernel(
-            x_ptr,
-            out_ptr,
-            M,
-            N,
-            stride_m,
-            stride_n,
-            BLOCK_M: tl.constexpr,
-            BLOCK_N: tl.constexpr,
-        ):
-            pid = tl.program_id(0)
-            desc = tl.make_tensor_descriptor(
-                x_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
-            out_desc = tl.make_tensor_descriptor(
-                out_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
-
-        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
-
-        def run_kernel(x):
-            out = torch.empty_like(x)
-            tma_copy_kernel[(M // BLOCK_M,)](
-                x,
-                out,
-                M,
-                N,
-                x.stride(0),
-                x.stride(1),
-                BLOCK_M=BLOCK_M,
-                BLOCK_N=BLOCK_N,
-            )
-            return out
-
-        x = torch.randn(M, N, device="cuda")
-
-        from contextlib import contextmanager
-
-        from triton.runtime._allocation import _allocator
-
-        @contextmanager
-        def triton_allocator(allocator):
-            prev = _allocator.get()
-            triton.set_allocator(allocator)
-            try:
-                yield
-            finally:
-                triton.set_allocator(prev)
-
-        def fn_with_set_allocator(x):
-            triton.set_allocator(
-                lambda size, alignment, stream: torch.empty(
-                    size, device="cuda", dtype=torch.int8
-                )
-            )
-            return run_kernel(x)
-
-        opt_fn = torch.compile(
-            fn_with_set_allocator, backend="aot_eager", fullgraph=True
-        )
-
-        # set_allocator inside compiled region does NOT graph break
-        with triton_allocator(NullAllocator()):
-            out = opt_fn(x)
-            self.assertEqual(out, x)
-
-            # Verify set_allocator replays on cache hit (not just tracing)
-            triton.set_allocator(NullAllocator())
-            out2 = opt_fn(x)
-            self.assertEqual(out2, x)
 
     def test_closure_recompiles(self):
         cnt = CompileCounter()
@@ -6742,34 +6587,6 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
                 # Make sure sparse clone is successful.
                 self.assertEqual(sparse_input, sparse_copy)
 
-    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
-    @unittest.skipIf(
-        PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
-    )
-    def test_clone_input_preserves_pinned_cpu_tensor_metadata(self):
-        base = torch.randn(4, 6, pin_memory=True)
-        x = base[:, ::2].requires_grad_()
-        x.grad = torch.ones_like(x).pin_memory()
-        x._dynamo_dynamic_indices = {1}
-
-        cloned = torch._dynamo.utils.clone_input(x)
-
-        self.assertTrue(cloned.is_pinned())
-        self.assertEqual(cloned.stride(), x.stride())
-        self.assertEqual(cloned, x)
-        self.assertNotEqual(cloned.data_ptr(), x.data_ptr())
-        self.assertTrue(cloned.requires_grad)
-        self.assertIsNotNone(cloned.grad)
-        self.assertTrue(cloned.grad.is_pinned())
-        self.assertEqual(cloned.grad, x.grad)
-        self.assertEqual(cloned._dynamo_dynamic_indices, x._dynamo_dynamic_indices)
-        self.assertIsNot(cloned._dynamo_dynamic_indices, x._dynamo_dynamic_indices)
-
-        expanded = torch.arange(3, dtype=torch.float32, pin_memory=True).expand(2, 3)
-        expanded_cloned = torch._dynamo.utils.clone_input(expanded)
-        self.assertTrue(expanded_cloned.is_pinned())
-        self.assertEqual(expanded_cloned, expanded)
-
     def test_clone_input_does_not_check_pinned_memory_for_wrapper_subclass(self):
         class WrapperSubclass(torch.Tensor):
             @staticmethod
@@ -9572,23 +9389,6 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         for guard in all_guards:
             # This guard was created
             self.assertTrue(guard.name != "nested_fn.__closure__[0].cell_contents")
-
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
-    def test_symint_as_device_kwarg_non_strict_export(self):
-        class Mod(torch.nn.Module):
-            def forward(self, x):
-                # -2 to make device id 0 for easier testing on CI
-                return torch.ones(10, device=x.size(0) - 2)
-
-        x = torch.randn(2)
-        m = Mod()
-        d1 = torch.export.Dim("d1", max=2048)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.UserError, r"Constraints violated \(d1\)"
-        ):
-            ep = torch.export.export(
-                m, (x,), dynamic_shapes={"x": {0: d1}}, strict=False
-            )
 
     def test_call_parent_non_class_methods_from_child(self):
         class A:
@@ -17629,11 +17429,94 @@ def forward(self, L_x_ : torch.Tensor):
         with self.assertRaises(RuntimeError):
             fn(torch.randn(3))
 
+    def test_scalar_isin_decomposition(self):
+        def f():
+            x = torch.tensor(0)
+            return torch.isin(x, x)
+
+        opt_f = torch.compile(f, backend="inductor", fullgraph=True)
+        ref = f()
+        res = opt_f()
+        self.assertEqual(ref, res)
+
+    def test_randint_no_graphbreak(self):
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def f(actions, n_act, epsilon=0.1):
+            actions_random = torch.randint_like(actions, n_act)
+
+            return actions_random
+
+        x = torch.ones([1], dtype=torch.int64)
+        y = torch.tensor(5)
+        f(x, y)
+
+    def test_full_graph_capture_scalar_outputs(self):
+        @torch.compile(fullgraph=True, backend="eager")
+        def foo(a):
+            return torch.randn(5) * a.item()
+
+        # We expect to no longer raise here
+        foo(torch.tensor(2.0))
+
+    def test_full_graph_capture_dynamic_output_shape_ops(self):
+        def fn(x):
+            nz = torch.nonzero(x)
+            squared = nz * nz
+            sliced = torch.ops.aten.slice.Tensor(squared, dim=1, start=-2, end=None)
+            view = sliced.unsqueeze(dim=0)
+            return view.squeeze(dim=0)
+
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        # we expect to no longer raise here
+        torch.compile(fn, fullgraph=True, backend="eager")(*example_inputs)
+
+    def test_dynamic_fill_diagonal_(self):
+        @torch.compile(dynamic=True, backend="eager")
+        def f(x):
+            x.fill_diagonal_(True)
+
+        x = torch.zeros(4, 4)
+        f(x)
+
+    def test_dynamic_float_scalar_tensor_coersion(self):
+        # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367
+        class Foo:
+            def __init__(self):
+                self.config = type(
+                    "Config", (), {"pad_val": 1123581321.0, "tolerance": 1e-6}
+                )
+
+            @torch.compile(fullgraph=True, backend="eager")
+            def forward(self, input):
+                outputs = torch.where(
+                    torch.abs(input - self.config.pad_val) < self.config.tolerance,
+                    torch.tensor(
+                        self.config.pad_val, dtype=input.dtype, device=input.device
+                    ),
+                    torch.tensor(
+                        self.config.pad_val + 1, dtype=input.dtype, device=input.device
+                    ),
+                )
+                return outputs
+
+        foo = Foo()
+        inputs = torch.randn(3, 4)
+        result = foo.forward(inputs)
+
+        original_pad_val = foo.config.pad_val
+        foo.config.pad_val += 1.0
+        result2 = foo.forward(inputs)
+
+        # Previously would crash with:
+        #   RuntimeError: value cannot be converted to type at::Half without overflow
+
 
 instantiate_parametrized_tests(MiscTests)
 
 
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize_pytree_module
     def test_tracing_pytree(self, pytree):
         def fn(xs):
@@ -17955,6 +17838,8 @@ class MiscTestsPyTree(torch._inductor.test_case.TestCase):
 
 
 class TestTracer(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_jit_save(self):
         def fn():
             class Foo(torch.nn.Module):
@@ -17984,6 +17869,8 @@ class TestTracer(JitTestCase):
 
 
 class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_autograd_function_with_matmul_folding_at_output(self):
         """
         When tensor folding occurs during matmul operation returned tensor is a view.
@@ -18048,6 +17935,78 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
 
 
 class MiscTestsDevice(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_assume_32_bit_indexing(self, device):
+        @torch.compile(backend="inductor")
+        def func(a, b):
+            # Multiple concat operations
+            x = torch.concat([a, b], dim=0)
+            y = torch.concat([a, b], dim=1)
+
+            # Reshape to create indexing patterns
+            x_flat = x.reshape(-1)
+            y_flat = y.reshape(-1)
+
+            # Take the smaller one and expand
+            min_size = min(x_flat.shape[0], y_flat.shape[0])
+            x_trunc = x_flat[:min_size]
+            y_trunc = y_flat[:min_size]
+
+            # Combine and compute
+            result = (x_trunc + y_trunc) * 10
+
+            # Cumulative operations create complex indexing
+            cumsum = result.cumsum(dim=0)
+
+            return cumsum.sum()
+
+        a = torch.rand(100, 30, device=device)
+        b = torch.rand(100, 30, device=device)
+
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 1)
+
+        source_code = run_and_get_code(func, a, b)[1]
+        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
+        self.assertTrue(
+            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+        )
+        # Check that 32-bit indexing is NOT used
+        self.assertFalse(
+            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
+            and ".to(tl.int64)" not in str(source_code)
+        )
+
+        torch._dynamo.reset()
+
+        with torch._inductor.config.patch(assume_32bit_indexing=True):
+            source_code = run_and_get_code(func, a, b)[1]
+            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
+            self.assertFalse(
+                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+            )
+
+    def test_symint_as_device_kwarg_non_strict_export(self, device):
+        class Mod(torch.nn.Module):
+            def forward(self, x):
+                # -2 to make device id 0 for easier testing on CI
+                return torch.ones(10, device=x.size(0) - 2)
+
+        x = torch.randn(2, device=device)
+        m = Mod()
+        d1 = torch.export.Dim("d1", max=2048)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError, r"Constraints violated \(d1\)"
+        ):
+            ep = torch.export.export(
+                m, (x,), dynamic_shapes={"x": {0: d1}}, strict=False
+            )
+
     def test_rand(self, device):
         cnts = torch._dynamo.testing.CompileCounter()
         device = device
@@ -18068,10 +18027,7 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
 
         self.assertTrue(same(res, ref_run1))
 
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Can't run fused SDPA on this platform",
-    )
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_parsing_sdpa(self, device):
         class MyModule(torch.nn.Module):
             def forward(self, query, key, value):
@@ -18131,71 +18087,6 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(x)
         self.assertTrue(same(ref, res))
-
-    @onlyCUDA
-    @unittest.skipIf(not torch.backends.cudnn.is_available(), "requires cudnn")
-    def test_torch_cudnn_is_acceptable(self, device):
-        def fn(x):
-            if torch.backends.cudnn.is_acceptable(tensor=x):
-                return x + 1
-            return x
-
-        x = torch.rand(4).to(device)
-        ref = fn(x)
-        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        res = opt_fn(x)
-        self.assertTrue(same(ref, res))
-
-    @onlyCUDA
-    @unittest.skipIf(not torch.backends.cudnn.is_available(), "requires cudnn")
-    def test_torch_cudnn_is_acceptable_bad_inputs(self, device):
-        def fn1(x):
-            if torch.backends.cudnn.is_acceptable("invalid"):
-                return x + 1
-            return x
-
-        def fn2(x):
-            if torch.backends.cudnn.is_acceptable(x, 3.14):
-                return x + 1
-            return x
-
-        with self.assertRaisesRegex(
-            AssertionError, "Expect input to cudnn.is_acceptable to be a tensor"
-        ):
-            x1 = torch.rand(4).to(device)
-            opt_fn1 = torch.compile(fn1, backend="eager", fullgraph=True)
-            res1 = opt_fn1(x1)
-
-        with self.assertRaisesRegex(
-            AssertionError, "Expect 1 input to cudnn.is_acceptable"
-        ):
-            x2 = torch.rand(4).to(device)
-            opt_fn2 = torch.compile(fn2, backend="eager", fullgraph=True)
-            res = opt_fn2(x2)
-
-    @onlyCUDA
-    @torch._dynamo.config.patch(recompile_limit=999)
-    def test_legacy_cuda_tensor(self, device):
-        typs = [
-            torch.cuda.FloatTensor,
-            torch.cuda.DoubleTensor,
-            torch.cuda.HalfTensor,
-            torch.cuda.BFloat16Tensor,
-            torch.cuda.ByteTensor,
-            torch.cuda.CharTensor,
-            torch.cuda.IntTensor,
-            torch.cuda.ShortTensor,
-            torch.cuda.LongTensor,
-        ]
-
-        def f2(typ):
-            return typ([1, 2, 3])
-
-        compiled_f2 = torch.compile(f2, backend="eager", fullgraph=True)
-        for typ in typs:
-            output = compiled_f2(typ)
-            expected = f2(typ)
-            self.assertEqual(output, expected)
 
     def test_get_device(self, device):
         def fn(x, y):
@@ -18284,87 +18175,6 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
         torch._dynamo.reset()
         gc.collect()
         self.assertTrue(all(ref() is None for ref in real_tensor_refs))
-
-    def test_scalar_isin_decomposition(self):
-        def f():
-            x = torch.tensor(0)
-            return torch.isin(x, x)
-
-        opt_f = torch.compile(f, backend="inductor", fullgraph=True)
-        ref = f()
-        res = opt_f()
-        self.assertEqual(ref, res)
-
-    def test_randint_no_graphbreak(self):
-        @torch.compile(backend="aot_eager", fullgraph=True)
-        def f(actions, n_act, epsilon=0.1):
-            actions_random = torch.randint_like(actions, n_act)
-
-            return actions_random
-
-        x = torch.ones([1], dtype=torch.int64)
-        y = torch.tensor(5)
-        f(x, y)
-
-    def test_full_graph_capture_scalar_outputs(self):
-        @torch.compile(fullgraph=True, backend="eager")
-        def foo(a):
-            return torch.randn(5) * a.item()
-
-        # We expect to no longer raise here
-        foo(torch.tensor(2.0))
-
-    def test_full_graph_capture_dynamic_output_shape_ops(self):
-        def fn(x):
-            nz = torch.nonzero(x)
-            squared = nz * nz
-            sliced = torch.ops.aten.slice.Tensor(squared, dim=1, start=-2, end=None)
-            view = sliced.unsqueeze(dim=0)
-            return view.squeeze(dim=0)
-
-        example_inputs = (torch.randn(1, 1, 1, 1),)
-        # we expect to no longer raise here
-        torch.compile(fn, fullgraph=True, backend="eager")(*example_inputs)
-
-    def test_dynamic_fill_diagonal_(self):
-        @torch.compile(dynamic=True, backend="eager")
-        def f(x):
-            x.fill_diagonal_(True)
-
-        x = torch.zeros(4, 4)
-        f(x)
-
-    def test_dynamic_float_scalar_tensor_coersion(self):
-        # Minified version of https://github.com/pytorch/pytorch/issues/158376#issuecomment-3079591367
-        class Foo:
-            def __init__(self):
-                self.config = type(
-                    "Config", (), {"pad_val": 1123581321.0, "tolerance": 1e-6}
-                )
-
-            @torch.compile(fullgraph=True, backend="eager")
-            def forward(self, input):
-                outputs = torch.where(
-                    torch.abs(input - self.config.pad_val) < self.config.tolerance,
-                    torch.tensor(
-                        self.config.pad_val, dtype=input.dtype, device=input.device
-                    ),
-                    torch.tensor(
-                        self.config.pad_val + 1, dtype=input.dtype, device=input.device
-                    ),
-                )
-                return outputs
-
-        foo = Foo()
-        inputs = torch.randn(3, 4)
-        result = foo.forward(inputs)
-
-        original_pad_val = foo.config.pad_val
-        foo.config.pad_val += 1.0
-        result2 = foo.forward(inputs)
-
-        # Previously would crash with:
-        #   RuntimeError: value cannot be converted to type at::Half without overflow
 
     def test_symbool_tensor_mul(self, device):
         def symbool_mul_fn(x_bool, sentinel):
@@ -18501,6 +18311,8 @@ instantiate_device_type_tests(
 
 
 class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_tensorify_track_item_symint(self):
         def _random_resize(image: torch.Tensor):
@@ -18609,6 +18421,194 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
                 torch._dynamo.reset()
                 got = torch.compile(fn, backend=backend, fullgraph=True)(a, b)
                 self.assertEqual(got, expected)
+
+
+class MiscTestsCUDA(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+        "requires Hopper+ (SM >= 9.0) for TMA",
+    )
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_triton_set_allocator_no_graph_break(self, device):
+        """set_allocator inside torch.compile does not graph break and
+        replays correctly at runtime (including cache hits)."""
+        import triton
+        import triton.language as tl
+        from triton.runtime._allocation import NullAllocator
+
+        @triton.jit
+        def tma_copy_kernel(
+            x_ptr,
+            out_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid = tl.program_id(0)
+            desc = tl.make_tensor_descriptor(
+                x_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
+            out_desc = tl.make_tensor_descriptor(
+                out_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
+
+        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
+
+        def run_kernel(x):
+            out = torch.empty_like(x)
+            tma_copy_kernel[(M // BLOCK_M,)](
+                x,
+                out,
+                M,
+                N,
+                x.stride(0),
+                x.stride(1),
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+            return out
+
+        x = torch.randn(M, N, device=device)
+
+        from contextlib import contextmanager
+
+        from triton.runtime._allocation import _allocator
+
+        @contextmanager
+        def triton_allocator(allocator):
+            prev = _allocator.get()
+            triton.set_allocator(allocator)
+            try:
+                yield
+            finally:
+                triton.set_allocator(prev)
+
+        def fn_with_set_allocator(x):
+            triton.set_allocator(
+                lambda size, alignment, stream: torch.empty(
+                    size, device=device, dtype=torch.int8
+                )
+            )
+            return run_kernel(x)
+
+        opt_fn = torch.compile(
+            fn_with_set_allocator, backend="aot_eager", fullgraph=True
+        )
+
+        # set_allocator inside compiled region does NOT graph break
+        with triton_allocator(NullAllocator()):
+            out = opt_fn(x)
+            self.assertEqual(out, x)
+
+            # Verify set_allocator replays on cache hit (not just tracing)
+            triton.set_allocator(NullAllocator())
+            out2 = opt_fn(x)
+            self.assertEqual(out2, x)
+
+    @unittest.skipIf(
+        PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
+    )
+    def test_clone_input_preserves_pinned_cpu_tensor_metadata(self, device):
+        base = torch.randn(4, 6, pin_memory=True)
+        x = base[:, ::2].requires_grad_()
+        x.grad = torch.ones_like(x).pin_memory()
+        x._dynamo_dynamic_indices = {1}
+
+        cloned = torch._dynamo.utils.clone_input(x)
+
+        self.assertTrue(cloned.is_pinned())
+        self.assertEqual(cloned.stride(), x.stride())
+        self.assertEqual(cloned, x)
+        self.assertNotEqual(cloned.data_ptr(), x.data_ptr())
+        self.assertTrue(cloned.requires_grad)
+        self.assertIsNotNone(cloned.grad)
+        self.assertTrue(cloned.grad.is_pinned())
+        self.assertEqual(cloned.grad, x.grad)
+        self.assertEqual(cloned._dynamo_dynamic_indices, x._dynamo_dynamic_indices)
+        self.assertIsNot(cloned._dynamo_dynamic_indices, x._dynamo_dynamic_indices)
+
+        expanded = torch.arange(3, dtype=torch.float32, pin_memory=True).expand(2, 3)
+        expanded_cloned = torch._dynamo.utils.clone_input(expanded)
+        self.assertTrue(expanded_cloned.is_pinned())
+        self.assertEqual(expanded_cloned, expanded)
+
+    @unittest.skipIf(not torch.backends.cudnn.is_available(), "requires cudnn")
+    def test_torch_cudnn_is_acceptable(self, device):
+        def fn(x):
+            if torch.backends.cudnn.is_acceptable(tensor=x):
+                return x + 1
+            return x
+
+        x = torch.rand(4).to(device)
+        ref = fn(x)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x)
+        self.assertTrue(same(ref, res))
+
+    @unittest.skipIf(not torch.backends.cudnn.is_available(), "requires cudnn")
+    def test_torch_cudnn_is_acceptable_bad_inputs(self, device):
+        def fn1(x):
+            if torch.backends.cudnn.is_acceptable("invalid"):
+                return x + 1
+            return x
+
+        def fn2(x):
+            if torch.backends.cudnn.is_acceptable(x, 3.14):
+                return x + 1
+            return x
+
+        with self.assertRaisesRegex(
+            AssertionError, "Expect input to cudnn.is_acceptable to be a tensor"
+        ):
+            x1 = torch.rand(4).to(device)
+            opt_fn1 = torch.compile(fn1, backend="eager", fullgraph=True)
+            res1 = opt_fn1(x1)
+
+        with self.assertRaisesRegex(
+            AssertionError, "Expect 1 input to cudnn.is_acceptable"
+        ):
+            x2 = torch.rand(4).to(device)
+            opt_fn2 = torch.compile(fn2, backend="eager", fullgraph=True)
+            res = opt_fn2(x2)
+
+    @torch._dynamo.config.patch(recompile_limit=999)
+    def test_legacy_cuda_tensor(self, device):
+        typs = [
+            torch.cuda.FloatTensor,
+            torch.cuda.DoubleTensor,
+            torch.cuda.HalfTensor,
+            torch.cuda.BFloat16Tensor,
+            torch.cuda.ByteTensor,
+            torch.cuda.CharTensor,
+            torch.cuda.IntTensor,
+            torch.cuda.ShortTensor,
+            torch.cuda.LongTensor,
+        ]
+
+        def f2(typ):
+            return typ([1, 2, 3])
+
+        compiled_f2 = torch.compile(f2, backend="eager", fullgraph=True)
+        for typ in typs:
+            output = compiled_f2(typ)
+            expected = f2(typ)
+            self.assertEqual(output, expected)
+
+
+instantiate_device_type_tests(MiscTestsCUDA, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR makes `test/dynamo/test_misc.py` device-agnostic by separating tests into hardware-independent (GENERIC), accelerator-generic (ACCELERATOR), and CUDA-specific (CUDA) test classes. 

## Changes

- **Class reorganization by hardware dependency:**
  - Marked `MiscTests`, `MiscTestsPyTree`, `TestTracer`, `TestCustomFunction`, and `DynamoOpPromotionTests` as `HardwareClassification.GENERIC` (CPU-only, no device parameter needed).
  - Marked `MiscTestsDevice` as `HardwareClassification.ACCELERATOR` with `instantiate_device_type_tests` for device-parameterized testing.
  - Created new `MiscTestsCUDA` class (`HardwareClassification.CUDA`) for tests that directly exercise CUDA-specific APIs (TMA, pinned memory, cuDNN, legacy CUDA tensors).

- **Test migration to appropriate classes:**
  - Moved `test_assume_32_bit_indexing` and `test_symint_as_device_kwarg_non_strict_export` from `MiscTests` to `MiscTestsDevice` with `device` parameter.
  - Moved `test_scalar_isin_decomposition`, `test_randint_no_graphbreak`, `test_full_graph_capture_*`, `test_dynamic_fill_diagonal_`, and `test_dynamic_float_scalar_tensor_coersion` from `MiscTestsDevice` to `MiscTests`.
  - Moved `test_triton_set_allocator_no_graph_break`, `test_clone_input_preserves_pinned_cpu_tensor_metadata`, `test_torch_cudnn_is_acceptable*`, and `test_legacy_cuda_tensor` to `MiscTestsCUDA`.

- **Import and decorator modernization:**
  - Removed hardcoded imports: `TEST_CUDA`, `TEST_HPU`, `TEST_XPU`, `onlyCUDA`, `skipIfHpu`, `skipIfNNModuleInlined`, `PLATFORM_SUPPORTS_FLASH_ATTENTION`, `SM80OrLater`.
  - Added `HardwareClassification`, `Capability`, and `requires_capabilities` imports.
  - Replaced `@unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, ...)` with `@requires_capabilities(Capability.attention.flash_attention)`.
  - Replaced `@onlyCUDA` decorators with class-level `hw_classification = HardwareClassification.CUDA`.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
