### PR TITLE
[ROCm][c10d] Enable NCCL2 windows and enforce allocator provenance

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -855,9 +855,13 @@ class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
         pool = torch.cuda.MemPool()
         tensor = self._pool_tensor(pool)
         # register_mem_pool validates provenance before touching any state, so a
-        # rejected pool is never recorded -- nothing to deregister afterwards.
+        # rejected pool is never recorded.
         with self.assertRaisesRegex(RuntimeError, "mem_allocator|ncclMemAlloc"):
             backend.register_mem_pool(pool, symm=True)
+        # Guard the no-leftover-state contract: a revert to insert-then-throw
+        # would leave the pool registered and this deregister would succeed.
+        with self.assertRaisesRegex(RuntimeError, "not previously registered"):
+            backend.deregister_mem_pool(pool)
         del tensor
 
     @requires_nccl()

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -846,6 +846,22 @@ class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
         self._check_all_reduce_over_pool(symm=True)
 
     @requires_nccl()
+    @unittest.skipUnless(torch.version.hip is not None, "ROCm-only contract")
+    @skip_if_lt_x_gpu(2)
+    def test_register_mem_pool_symmetric_rejects_unrelated_allocator(
+        self,
+    ) -> None:
+        backend = self._backend()
+        pool = torch.cuda.MemPool()
+        tensor = self._pool_tensor(pool)
+        with self.assertRaisesRegex(RuntimeError, "invalid argument"):
+            backend.register_mem_pool(pool, symm=True)
+        # register_mem_pool records the pool before it upgrades each segment.
+        # Remove the plain registration left by the expected upgrade failure.
+        backend.deregister_mem_pool(pool)
+        del tensor
+
+    @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_register_mem_pool_round_trip(self) -> None:
         # Megatron re-enters its allocator context once per bucket: deregister,

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -854,7 +854,7 @@ class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
         backend = self._backend()
         pool = torch.cuda.MemPool()
         tensor = self._pool_tensor(pool)
-        with self.assertRaisesRegex(RuntimeError, "invalid argument"):
+        with self.assertRaisesRegex(RuntimeError, "Failed to register segment"):
             backend.register_mem_pool(pool, symm=True)
         # register_mem_pool records the pool before it upgrades each segment.
         # Remove the plain registration left by the expected upgrade failure.

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -854,11 +854,10 @@ class ProcessGroupNCCL2MemPoolTest(MultiProcContinuousTest):
         backend = self._backend()
         pool = torch.cuda.MemPool()
         tensor = self._pool_tensor(pool)
-        with self.assertRaisesRegex(RuntimeError, "Failed to register segment"):
+        # register_mem_pool validates provenance before touching any state, so a
+        # rejected pool is never recorded -- nothing to deregister afterwards.
+        with self.assertRaisesRegex(RuntimeError, "mem_allocator|ncclMemAlloc"):
             backend.register_mem_pool(pool, symm=True)
-        # register_mem_pool records the pool before it upgrades each segment.
-        # Remove the plain registration left by the expected upgrade failure.
-        backend.deregister_mem_pool(pool)
         del tensor
 
     @requires_nccl()

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -203,8 +203,10 @@ class AbstractWindowTest:
     def test_register_errors(self):
         self._init_pg()
         pool = self._make_pool()
-        self._probe_window_support(pool)
         win = dist._new_window()
+        # These rejections are rank-local and return before any transport work,
+        # so they must be asserted before _probe_window_support, which skips the
+        # test on hosts without a symmetric-memory-capable transport.
         # Registering a tensor outside the backend mempool must fail.
         plain = torch.ones(16, dtype=torch.float, device=self.device)
         with self.assertRaisesRegex(RuntimeError, "mempool|MemPool"):
@@ -220,6 +222,8 @@ class AbstractWindowTest:
             win.put(plain, 0, 0, False)
         with self.assertRaisesRegex(RuntimeError, "not registered"):
             win.signal(0, False)
+        # The remaining check needs a live symmetric window.
+        self._probe_window_support(pool)
         # Double registration must fail.
         with torch.cuda.use_mem_pool(pool):
             win_buf = torch.ones(16, dtype=torch.float, device=self.device)

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -19,10 +19,7 @@ if not dist.is_available():
     print("distributed package not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
-    skip_if_rocm_ver_atleast_multiprocess,
-)
+from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA
 
 
@@ -203,7 +200,6 @@ class AbstractWindowTest:
         self.assertIsInstance(attr.access_type, WindowAccessType)
         win.tensor_deregister()
 
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_register_errors(self):
         self._init_pg()
         pool = self._make_pool()
@@ -213,6 +209,12 @@ class AbstractWindowTest:
         plain = torch.ones(16, dtype=torch.float, device=self.device)
         with self.assertRaisesRegex(RuntimeError, "mempool|MemPool"):
             win.tensor_register(plain)
+        # A private pool using the default allocator must also fail.
+        unrelated_pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(unrelated_pool):
+            unrelated = torch.ones(16, dtype=torch.float, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "mempool|MemPool"):
+            win.tensor_register(unrelated)
         # Ops before registration must fail.
         with self.assertRaisesRegex(RuntimeError, "not registered"):
             win.put(plain, 0, 0, False)

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -338,6 +338,11 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);
+#if defined(USE_ROCM)
+  // Returns true when ptr exactly matches an ncclMemAlloc segment base on this
+  // process group's device and len does not exceed the allocation size.
+  bool isNcclAllocatorSegment(const void* ptr, size_t len) const;
+#endif
   // Registers the segment containing ptr as a NCCL_WIN_COLL_SYMMETRIC window
   // if it is not one already. Collective: all ranks must call it together.
   ncclResult_t ensureSegmentWindow(const void* ptr);
@@ -700,9 +705,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // ncclCommMemPoolMap). The symm mode is not tracked: a segment carries its
   // own window handle, so teardown does not need to be told which mode to use.
   std::set<c10::cuda::MempoolId_t> registeredMemPools_;
-#if defined(USE_ROCM)
-  bool isNcclAllocatorSegment(const void* ptr, size_t len) const;
-#endif
   // Caller must hold memory_registration_mutex_ and have checked that `addr`
   // is not already registered.
   void registerAddressLocked(void* addr, size_t len);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -345,6 +345,10 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
 #endif
   // Registers the segment containing ptr as a NCCL_WIN_COLL_SYMMETRIC window
   // if it is not one already. Collective: all ranks must call it together.
+  // On ROCm the segment must be a live ncclMemAlloc/getMemAllocator range:
+  // an ineligible segment returns ncclInvalidArgument (caller should throw),
+  // while ncclInvalidUsage stays reserved for a missing symmetric transport
+  // (caller keeps the plain registration and warns).
   ncclResult_t ensureSegmentWindow(const void* ptr);
 
   bool supportsAbortHooks() const override {

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -338,6 +338,10 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);
+#if defined(USE_ROCM)
+  // Returns true when ptr belongs to a segment allocated by ncclMemAlloc.
+  bool isWindowRegistrationSegment(const void* ptr);
+#endif
   // Registers the segment containing ptr as a NCCL_WIN_COLL_SYMMETRIC window
   // if it is not one already. Collective: all ranks must call it together.
   ncclResult_t ensureSegmentWindow(const void* ptr);
@@ -696,6 +700,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // ncclCommMemPoolMap). The symm mode is not tracked: a segment carries its
   // own window handle, so teardown does not need to be told which mode to use.
   std::set<c10::cuda::MempoolId_t> registeredMemPools_;
+#if defined(USE_ROCM)
+  bool isNcclAllocatorSegment(const void* ptr, size_t len) const;
+#endif
   // Caller must hold memory_registration_mutex_ and have checked that `addr`
   // is not already registered.
   void registerAddressLocked(void* addr, size_t len);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -338,10 +338,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Returns {window handle, byte offset of ptr within the segment}, or
   // {nullptr, 0} if ptr is not inside a window-registered segment.
   std::pair<ncclWindow_t, size_t> lookupSegmentWindow(const void* ptr);
-#if defined(USE_ROCM)
-  // Returns true when ptr belongs to a segment allocated by ncclMemAlloc.
-  bool isWindowRegistrationSegment(const void* ptr);
-#endif
   // Registers the segment containing ptr as a NCCL_WIN_COLL_SYMMETRIC window
   // if it is not one already. Collective: all ranks must call it together.
   ncclResult_t ensureSegmentWindow(const void* ptr);
@@ -690,7 +686,11 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
     ncclWindow_t winHandle{nullptr};
     size_t len{0};
   };
-  std::map<void*, RegistrationHandle, std::less<>> memoryRegistrationHandles_;
+  using RegistrationMap = std::map<void*, RegistrationHandle, std::less<>>;
+  RegistrationMap memoryRegistrationHandles_;
+  // Caller must hold memory_registration_mutex_. Returns end() when ptr is not
+  // inside a registered segment.
+  RegistrationMap::iterator findContainingRegistrationLocked(const void* ptr);
   // Guards memoryRegistrationHandles_ and registeredMemPools_:
   // register/deregister_address run on allocator threads while window ops look
   // segments up on the main thread.

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -24,6 +24,36 @@ namespace c10d::nccl2 {
 
 namespace {
 
+#if defined(USE_ROCM)
+struct NcclAllocatorSegmentRegistry {
+  std::mutex mutex;
+  std::map<std::pair<int, uintptr_t>, size_t> segments;
+};
+
+NcclAllocatorSegmentRegistry& ncclAllocatorSegmentRegistry() {
+  static auto* registry = new NcclAllocatorSegmentRegistry();
+  return *registry;
+}
+
+void trackNcclAllocatorSegment(void* ptr, size_t size, int device) {
+  auto& registry = ncclAllocatorSegmentRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  const auto key = std::make_pair(device, reinterpret_cast<uintptr_t>(ptr));
+  TORCH_INTERNAL_ASSERT(
+      registry.segments.emplace(key, size).second,
+      "NCCL allocator returned an address that is already live");
+}
+
+void untrackNcclAllocatorSegment(void* ptr, int device) {
+  auto& registry = ncclAllocatorSegmentRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  const auto key = std::make_pair(device, reinterpret_cast<uintptr_t>(ptr));
+  TORCH_INTERNAL_ASSERT(
+      registry.segments.erase(key) == 1,
+      "NCCL allocator freed an address that was not tracked");
+}
+#endif
+
 std::vector<uint64_t> normalizeSplitSizes(
     const std::vector<int64_t>& split_sizes,
     const at::Tensor& tensor,
@@ -312,6 +342,9 @@ std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
               result == ncclSuccess,
               "ncclMemAlloc failed: ",
               nccl_api->getErrorString(result));
+#if defined(USE_ROCM)
+          trackNcclAllocatorSegment(ptr, size, device);
+#endif
           return ptr;
         },
         [nccl_api](void* ptr, size_t size, int device, cudaStream_t stream) {
@@ -321,10 +354,25 @@ std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
               result == ncclSuccess,
               "ncclMemFree failed: ",
               nccl_api->getErrorString(result));
+#if defined(USE_ROCM)
+          untrackNcclAllocatorSegment(ptr, device);
+#endif
         });
   }();
   return allocator;
 }
+
+#if defined(USE_ROCM)
+bool ProcessGroupNCCL::isNcclAllocatorSegment(const void* ptr, size_t len)
+    const {
+  auto& registry = ncclAllocatorSegmentRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  const auto key = std::make_pair(
+      static_cast<int>(device_.index()), reinterpret_cast<uintptr_t>(ptr));
+  auto it = registry.segments.find(key);
+  return it != registry.segments.end() && len <= it->second;
+}
+#endif
 
 bool ProcessGroupNCCL::supportsTensorAlloc(c10::DeviceIndex deviceIdx) {
   return ::c10d::cuda::deviceSupportsMulticast(deviceIdx);
@@ -382,9 +430,7 @@ at::Tensor ProcessGroupNCCL::allocateTensor(
 c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
     const std::optional<at::Tensor>& tensor) {
   TORCH_CHECK(
-      supportsWindow(),
-      "ProcessGroupNCCL windows require NCCL 2.29 or later and are not "
-      "supported on ROCm");
+      supportsWindow(), "ProcessGroupNCCL windows require NCCL 2.29 or later");
   checkInitialized();
   auto window = c10::make_intrusive<WindowNCCL>(
       c10::intrusive_ptr<ProcessGroupNCCL>::unsafe_reclaim_from_nonowning(
@@ -396,7 +442,7 @@ c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
 }
 
 bool ProcessGroupNCCL::supportsWindow() const {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0) && !defined(USE_ROCM)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   int runtime_version = 0;
   return ncclGetVersion(&runtime_version) == ncclSuccess &&
       runtime_version >= NCCL_VERSION(2, 29, 0);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -650,38 +650,33 @@ void ProcessGroupNCCL::deregister_address(
   memoryRegistrationHandles_.erase(it);
 }
 
-#if defined(USE_ROCM)
-bool ProcessGroupNCCL::isWindowRegistrationSegment(const void* ptr) {
-  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+ProcessGroupNCCL::RegistrationMap::iterator ProcessGroupNCCL::
+    findContainingRegistrationLocked(const void* ptr) {
   const auto target = reinterpret_cast<uintptr_t>(ptr);
+  // memoryRegistrationHandles_ is sorted by base address. upper_bound + step
+  // back finds the segment whose base is less than or equal to target.
   auto it = memoryRegistrationHandles_.upper_bound(ptr);
   if (it == memoryRegistrationHandles_.begin()) {
-    return false;
+    return memoryRegistrationHandles_.end();
   }
   --it;
   const auto base = reinterpret_cast<uintptr_t>(it->first);
   if (target < base || target - base >= it->second.len) {
-    return false;
+    return memoryRegistrationHandles_.end();
   }
-  return isNcclAllocatorSegment(it->first, it->second.len);
+  return it;
 }
-#endif
 
 std::pair<ncclWindow_t, size_t> ProcessGroupNCCL::lookupSegmentWindow(
     const void* ptr) {
   std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  auto it = findContainingRegistrationLocked(ptr);
+  if (it == memoryRegistrationHandles_.end() ||
+      it->second.winHandle == nullptr) {
+    return {nullptr, 0};
+  }
   const auto target = reinterpret_cast<uintptr_t>(ptr);
-  // memoryRegistrationHandles_ is sorted by base address; upper_bound + step
-  // back finds the segment whose base <= target.
-  auto it = memoryRegistrationHandles_.upper_bound(ptr);
-  if (it == memoryRegistrationHandles_.begin()) {
-    return {nullptr, 0};
-  }
-  --it;
   const auto base = reinterpret_cast<uintptr_t>(it->first);
-  if (target >= base + it->second.len || it->second.winHandle == nullptr) {
-    return {nullptr, 0};
-  }
   return {it->second.winHandle, target - base};
 }
 
@@ -690,16 +685,20 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
     return ncclInvalidUsage;
   }
   std::lock_guard<std::mutex> lock(memory_registration_mutex_);
-  const auto target = reinterpret_cast<uintptr_t>(ptr);
-  auto it = memoryRegistrationHandles_.upper_bound(ptr);
-  if (it == memoryRegistrationHandles_.begin()) {
+  auto it = findContainingRegistrationLocked(ptr);
+  if (it == memoryRegistrationHandles_.end()) {
     return ncclInvalidArgument;
   }
-  --it;
-  const auto base = reinterpret_cast<uintptr_t>(it->first);
-  if (target >= base + it->second.len) {
+#if defined(USE_ROCM)
+  // RCCL can create host-RMA windows for ordinary HIP allocations. Enforce the
+  // NCCL2 allocator contract for every path that creates a window. Return
+  // ncclInvalidArgument because registerMemPool reserves ncclInvalidUsage for
+  // unavailable transports and keeps those segments registered as plain
+  // buffers.
+  if (!isNcclAllocatorSegment(it->first, it->second.len)) {
     return ncclInvalidArgument;
   }
+#endif
   if (it->second.winHandle != nullptr) {
     return ncclSuccess;
   }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -650,6 +650,23 @@ void ProcessGroupNCCL::deregister_address(
   memoryRegistrationHandles_.erase(it);
 }
 
+#if defined(USE_ROCM)
+bool ProcessGroupNCCL::isWindowRegistrationSegment(const void* ptr) {
+  std::lock_guard<std::mutex> lock(memory_registration_mutex_);
+  const auto target = reinterpret_cast<uintptr_t>(ptr);
+  auto it = memoryRegistrationHandles_.upper_bound(ptr);
+  if (it == memoryRegistrationHandles_.begin()) {
+    return false;
+  }
+  --it;
+  const auto base = reinterpret_cast<uintptr_t>(it->first);
+  if (target < base || target - base >= it->second.len) {
+    return false;
+  }
+  return isNcclAllocatorSegment(it->first, it->second.len);
+}
+#endif
+
 std::pair<ncclWindow_t, size_t> ProcessGroupNCCL::lookupSegmentWindow(
     const void* ptr) {
   std::lock_guard<std::mutex> lock(memory_registration_mutex_);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -766,12 +766,35 @@ void ProcessGroupNCCL::registerMemPool(at::cuda::MemPool* pool, bool symm) {
   TC_LOG(INFO, this) << "Registering MemPool " << pool->id().first << ":"
                      << pool->id().second << " (symm=" << symm << ") on "
                      << device_;
+  // One snapshot for both the ROCm provenance pre-check and the registration
+  // loop: taking it twice would let a concurrent allocation change the segment
+  // set between validation and use.
+  const auto segments = poolSegments(pool->id());
+#if defined(USE_ROCM)
+  if (symm) {
+    // RCCL can window-register ordinary HIP allocations, but the NCCL2
+    // symmetric contract requires ncclMemAlloc provenance. Reject up front,
+    // before any state mutation, so a rejected pool never lands in
+    // registeredMemPools_ or leaves plain registrations behind.
+    for (const auto& segment : segments) {
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      void* addr = reinterpret_cast<void*>(segment.address);
+      TORCH_CHECK(
+          isNcclAllocatorSegment(addr, segment.total_size),
+          "register_mem_pool(symm=True) on ROCm requires a MemPool created "
+          "with the NCCL backend allocator: MemPool(backend.mem_allocator). "
+          "Segment ",
+          addr,
+          " was not allocated by ncclMemAlloc.");
+    }
+  }
+#endif
   {
     std::lock_guard<std::mutex> lock(memory_registration_mutex_);
     registeredMemPools_.insert(pool->id());
   }
   bool symmUnsupported = false;
-  for (const auto& segment : poolSegments(pool->id())) {
+  for (const auto& segment : segments) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* addr = reinterpret_cast<void*>(segment.address);
     {

--- a/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
@@ -92,15 +92,6 @@ void WindowNCCL::tensor_register(const at::Tensor& tensor, bool owning) {
   // Register the underlying segment as a NCCL_WIN_COLL_SYMMETRIC window
   // (collective). All ranks must reach this point with matching segments --
   // which holds for symmetric allocation patterns (the standard usage).
-#if defined(USE_ROCM)
-  // RCCL can accept ordinary HIP allocations where NCCL requires ncclMemAlloc.
-  // Preserve the nccl2 contract instead of making eligibility
-  // platform-dependent.
-  TORCH_CHECK(
-      pg_->isWindowRegistrationSegment(tensor.data_ptr()),
-      "WindowNCCL: tensor must be allocated from the NCCL mempool (e.g. ",
-      "torch.cuda.MemPool(backend.mem_allocator))");
-#endif
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,

--- a/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WindowNCCL.cpp
@@ -92,6 +92,15 @@ void WindowNCCL::tensor_register(const at::Tensor& tensor, bool owning) {
   // Register the underlying segment as a NCCL_WIN_COLL_SYMMETRIC window
   // (collective). All ranks must reach this point with matching segments --
   // which holds for symmetric allocation patterns (the standard usage).
+#if defined(USE_ROCM)
+  // RCCL can accept ordinary HIP allocations where NCCL requires ncclMemAlloc.
+  // Preserve the nccl2 contract instead of making eligibility
+  // platform-dependent.
+  TORCH_CHECK(
+      pg_->isWindowRegistrationSegment(tensor.data_ptr()),
+      "WindowNCCL: tensor must be allocated from the NCCL mempool (e.g. ",
+      "torch.cuda.MemPool(backend.mem_allocator))");
+#endif
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,


### PR DESCRIPTION
## Summary

This PR enables ProcessGroupNCCL2 windows on ROCm, which compile-time guards previously disabled, and enforces the existing allocation contract: window memory must come from `torch.cuda.MemPool(backend.mem_allocator)` (
`ncclMemAlloc`). The NCCL/RCCL 2.29 version check is unchanged.

## Problem

After the ROCm guards were removed, 10 of 11 window tests passed. `Nccl2WindowTest.test_register_errors` failed because RCCL accepted a tensor that should have been rejected, so the expected RuntimeError never fired.

NVIDIA NCCL requires compatible symmetric memory for this window path and has no fallback for ordinary cudaMalloc buffers. RCCL does: a host-side RMA fallback can register ordinary HIP allocations. A private-pool id is not a substitute for the right allocator, because `torch.cuda.MemPool()` also has a valid id. The unit test is what surfaced this, but the same hole exists for every ROCm window registration, including `register_mem_pool(pool, symm=True)`.

Leaving the fallback open is not a harmless extra. NCCL2 put and window lookup only check that a segment already has a window handle. If RCCL accepts ordinary HIP memory, those buffers become valid window sources. ROCm would then succeed on memory that the default path cannot use for this API, and the documented MemPool(backend.mem_allocator) contract would not actually be enforced.

## Solution

On ROCm, the backend records the address and size of each live 'ncclMemAlloc' allocation and drops the record after 
`ncclMemFree` succeeds. Before a symmetric window upgrade, it checks that the storage segment falls in a recorded range: default-allocator memory and unrelated private pools are rejected; `MemPool(backend.mem_allocator)` is accepted.

The check is ROCm-only. The shared allocator hook, ordinary collective registration, and NVIDIA behavior are unchanged.

## Design choices

**Windows are enabled on ROCm, but still gated on NCCL/RCCL 2.29.** supportsWindow() no longer has && !defined(USE_ROCM). The old guard was a feature kill switch, not a version check. RCCL 2.29+ can create windows; older RCCL should still fail with a version error.

**The host-RMA fallback is not a supported NCCL2 window.** The public contract is the NCCL allocator, and it should mean the same thing on CUDA and ROCm.

**Provenance is enforced in ensureSegmentWindow**, which both `tensor_register` and 
`register_mem_pool(..., symm=True)` call. Guarding only `tensor_register` leaves the `mempool` path open.

**Wrong allocator throws; missing transport does not.** Allocator violations return `ncclInvalidArgument` and become a Python RuntimeError. Missing symmetric transport stays `ncclInvalidUsage`: warn and keep plain `ncclCommRegister` registration, matching the stock NCCL backend. Those failures are different. A wrong allocator is a caller error and must not succeed. A missing transport is an environment limit. Mapping the allocator case onto `ncclInvalidUsage` would warn and leave the buffers registered as plain user buffers.

**`register_mem_pool(symm=True)` is rejected before any state is mutated.** On ROCm the pool snapshot is taken once and every segment is checked with `isNcclAllocatorSegment` before `registeredMemPools_.insert` or 
`registerAddressLocked. ensureSegmentWindow` keeps the same check as a second barrier for `tensor_register`. Checking only inside the upgrade loop recorded the pool first, so a throw left leftover state in a shared test worker.

**The extra tracking is #if defined(USE_ROCM).** NVIDIA NCCL already refuses ordinary allocations on this path; the extra check exists because RCCL is more permissive.

**Segment lookup is one helper**, `findContainingRegistrationLocked`, used by both `lookupSegmentWindow` and `ensureSegmentWindow`.

**The unsupported-window error no longer says windows are unavailable on ROCm.** It is now ProcessGroupNCCL windows require NCCL 2.29 or later. That is true after this PR; the old ROCm clause is not. Anything matching the old string will need an update.

## User-visible behavior on ROCm

| Call | Wrong allocator (default or unrelated `MemPool`) | No symmetric transport | RCCL < 2.29 |
| --- | --- | --- | --- |
| `register_mem_pool(pool, symm=True)` | Throws; the pool is not recorded | Warns; keeps plain registration | Windows stay disabled by the version check |
| `tensor_register` / `_new_window` | Throws (`mempool` / `MemPool` in the message) | Register can fail as unsupported | `supports_window` is false |

`register_mem_pool(symm=True)` on `torch.cuda.MemPool()` is a behavior change: RCCL host-RMA could previously succeed. This treats that as a bug, not as API. Docs already require `MemPool(backend.mem_allocator)` (`docs/source/symmetric_memory.md`).

## Tests

`Nccl2WindowTest.test_register_errors` rejects default-allocator tensors and unrelated private pools. Those cases run before `_probe_window_support` because they do not need a live symmetric transport. Double-registration still does, so it stays after the probe.

`ProcessGroupNCCL2MemPoolTest.test_register_mem_pool_symmetric_rejects_unrelated_allocator` expects a throw mentioning `mem_allocator` or `ncclMemAlloc`, then asserts that `deregister_mem_pool` fails with `not previously registered`. The second assert is the leftover-state regression.

## CI coverage

The limiter on current ROCm CI is GIN / symmetric transport, not RCCL 2.29. Trunk 7.14 and preview 10 both get past `supports_window`; `_probe_window_support` then tries a real `ncclCommWindowRegister`. On 7.14 CI that fails with `NCCL Last Error: GIN not supported`, so pytest reports the window file as skipped. The skip text also mentions mempool / `invalid usage`; that is PyTorch's mapping, not the RCCL reason.

On HEAD `36cdb3f`:

- **ciflow/rocm-preview** (this PR pins the preview image to ROCm 10.0.0rc4 / HIP Runtime 7.15.26333): live windows run. [distributed 2/3](https://github.com/pytorch/pytorch/actions/runs/32796615998/job/97673134522) is `Nccl2WindowTest` **11 passed**. [distributed 1/3](https://github.com/pytorch/pytorch/actions/runs/32796615998/job/97673134508) ran `ProcessGroupNCCL2MemPoolTest`, including `test_register_mem_pool_symmetric` and `test_register_mem_pool_symmetric_rejects_unrelated_allocator` (**PASSED**).
- **ciflow/trunk** jammy ROCm 7.14 MI350 (HIP Runtime 7.14.60850): mem-pool / provenance tests run ([distributed 1/3](https://github.com/pytorch/pytorch/actions/runs/32796614990/job/97659566299), `test_c10d_nccl2` successful). The window suite is selected but internally skipped: [distributed 2/3](https://github.com/pytorch/pytorch/actions/runs/32796614990/job/97659566372) is **11 skipped** with `GIN not supported`. Rank-local rejects in `test_register_errors` still execute before the probe; pytest then skips the test because double-registration needs a live GIN window.
- **ciflow/periodic-rocm-mi300** noble 7.14 is the same GIN skip for windows ([distributed 2/5](https://github.com/pytorch/pytorch/actions/runs/32796613834/job/97659332472), **11 skipped**). The shard reporting `test_c10d_window ... was successful` means the file completed with skips, not that put/signal ran.

Live window coverage in CI is the preview lane. Trunk / periodic 7.14 are not environments where RCCL initializes a usable GIN plugin.

## Validation

Manual run on MI355X with HIP 7.15 and RCCL 2.30.4: full NCCL2 window suite passed; mempool suite including the leftover-state reject test passed; reduction regression passed; targeted lint passed.

CI on `36cdb3f` repeats that split: preview executes the window suite; 7.14 trunk / MI300 periodic execute mem-pool provenance and skip live windows on GIN.

Authored with the assistance of an AI coding assistant.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
