### PR TITLE
[ROCm] Fix incorrect results in cross-CTA reductions (argmax/max)

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/DeviceUtils.cuh>
@@ -819,9 +819,9 @@ struct ReduceOp {
     if (is_last_block_done) {
       // complete the acquire pattern after atomic
       //
-      // On ROCm, committed stores [CMTSTRS] ensures the producer blocks writes are visbile to global memory.
+      // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
-      // before reading the staging buffer. A single fence here is far cheaper than per-element committed loads.
+      // before reading the staging buffer.
       __threadfence();
       for (auto &v : value) {
         v = ident;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -821,8 +821,7 @@ struct ReduceOp {
       __threadfence(); // complete the acquire pattern after atomic
 #else
       // complete the acquire pattern after atomic
-      //
-      // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
+      // On ROCm, committed stores [CMTSTRS] ensure the producer block's writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
       // before reading the staging buffer. An acquire-only fence at agent scope is sufficient
       // (and cheaper than a full seq_cst __threadfence()) since it pairs with the agent-scope

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/DeviceUtils.cuh>

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -817,9 +817,12 @@ struct ReduceOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
-      __threadfence(); // complete the acquire pattern after atomic
-#endif
+      // complete the acquire pattern after atomic
+      //
+      // On ROCm, committed stores [CMTSTRS] ensures the producer blocks writes are visbile to global memory.
+      // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
+      // before reading the staging buffer. A single fence here is far cheaper than per-element committed loads.
+      __threadfence();
       for (auto &v : value) {
         v = ident;
       }

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -817,12 +817,18 @@ struct ReduceOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
+#ifndef USE_ROCM
+      __threadfence(); // complete the acquire pattern after atomic
+#else
       // complete the acquire pattern after atomic
       //
       // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
-      // before reading the staging buffer.
-      __threadfence();
+      // before reading the staging buffer. An acquire-only fence at agent scope is sufficient
+      // (and cheaper than a full seq_cst __threadfence()) since it pairs with the agent-scope
+      // committed stores above.
+      __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+#endif
       for (auto &v : value) {
         v = ident;
       }

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -657,8 +657,7 @@ struct ReduceJitOp {
       __threadfence(); // complete the acquire pattern after atomic
 #else
       // complete the acquire pattern after atomic
-      //
-      // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
+      // On ROCm, committed stores [CMTSTRS] ensure the producer block's writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
       // before reading the staging buffer. An acquire-only fence at agent scope is sufficient
       // (and cheaper than a full seq_cst __threadfence()) since it pairs with the agent-scope

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -653,12 +653,18 @@ struct ReduceJitOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
+#ifndef USE_ROCM
+      __threadfence(); // complete the acquire pattern after atomic
+#else
       // complete the acquire pattern after atomic
       //
       // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
-      // before reading the staging buffer.
-      __threadfence();
+      // before reading the staging buffer. An acquire-only fence at agent scope is sufficient
+      // (and cheaper than a full seq_cst __threadfence()) since it pairs with the agent-scope
+      // committed stores above.
+      __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+#endif
       value = ident;
       if (config.should_block_x_reduce()) {
         uint32_t input_offset = threadIdx.x + threadIdx.y * blockDim.x;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -653,9 +653,12 @@ struct ReduceJitOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-  #ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
-      __threadfence(); //complete acquire pattern
-  #endif
+      // complete the acquire pattern after atomic
+      //
+      // On ROCm, committed stores [CMTSTRS] ensure the producer blocks' writes are visible to global memory.
+      // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
+      // before reading the staging buffer.
+      __threadfence();
       value = ident;
       if (config.should_block_x_reduce()) {
         uint32_t input_offset = threadIdx.x + threadIdx.y * blockDim.x;

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -653,9 +653,9 @@ struct ReduceJitOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-#ifndef USE_ROCM
+  #ifndef USE_ROCM
       __threadfence(); // complete the acquire pattern after atomic
-#else
+  #else
       // complete the acquire pattern after atomic
       // On ROCm, committed stores [CMTSTRS] ensure the producer block's writes are visible to global memory.
       // But the last block (consumer) still needs an acquire fence to invalidate its (non-coherent) L1,
@@ -663,7 +663,7 @@ struct ReduceJitOp {
       // (and cheaper than a full seq_cst __threadfence()) since it pairs with the agent-scope
       // committed stores above.
       __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
-#endif
+  #endif
       value = ident;
       if (config.should_block_x_reduce()) {
         uint32_t input_offset = threadIdx.x + threadIdx.y * blockDim.x;


### PR DESCRIPTION
## Summary
On ROCm, the cross-CTA reduction path (`global_reduce`) replaces the producer side `__threadfence()` calls with committed stores (`cmtdStore`) to avoid costly global fences. The committed store correctly handles the release/visibility side on the producer blocks; but the acquire side fence was missing on ROCm. The last block (`is_last_block_done`) read the staging buffer with ordinary loads and no fence. Because the per-CU L1 vector cache is not coherent across CUs, the last block could occasionally read a stale (or partially updated / torn) cache line for a staging slot and combine a garbage partial result. For index-carrying reductions (argmax/argmin, and max/min with indices) this surfaced as rare, out-of-range output indices. The failure was low-probability and independent of the input values, which is consistent with a memory-visibility race rather than a numerical bug.

## Fix
Issue a single acquire-only, agent-scope fence (`__builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent")`) in the last block, before it reads the staging buffer, to complete the acquire pattern and invalidate the L1. This pairs with the agent-scope committed stores on the producer side and is cheaper than a full seq_cst `__threadfence()`. The producer-side committed-store optimization is kept, so only the missing consumer-side acquire is added.
An earlier attempt used per-element committed loads of the staging buffer; that was correct but regressed performance. An earlier version of this fix used a full `__threadfence()`; the acquire-only fence restores correctness while keeping the committed-store fast path at lower cost.

## Impact
- Fixes rare incorrect indices from argmax/argmin/max/min on ROCm for large inner-dimension reductions that take the multi-CTA path.
- One extra fence per output on the final block only; common single-block reductions are unaffected.
- NVIDIA code path and behavior are unchanged.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @xinyazhang
