### PR TITLE
[inductor][cudagraphs] Prevent SIGSEGV for mutated outputs reused across generations

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -732,28 +732,35 @@ if HAS_CUDA_AND_TRITON:
                     return x + state, state
 
             compiled = torch.compile(Model().cuda().eval(), mode="reduce-overhead")
-            inputs = [torch.randn(1, 4, device="cuda") for _ in range(3)]
-            expected_state = torch.zeros_like(inputs[0])
+            priming_inputs = [torch.randn(1, 4, device="cuda") for _ in range(2)]
+            feedback_inputs = [torch.randn(1, 4, device="cuda") for _ in range(2)]
 
             with torch.no_grad():
-                state = None
-                for inp in inputs:
+                for inp in priming_inputs:
                     torch.compiler.cudagraph_mark_step_begin()
-                    prior_state_and_ptr = (
-                        (state, state.untyped_storage().data_ptr())
-                        if state is not None
-                        else None
-                    )
+                    out, state = compiled(inp, None)
+                    self.assertEqual(out, inp + inp)
+                    self.assertEqual(state, inp)
+
+                manager = self.get_manager()
+                self.assertEqual(manager.path_state, ExecutionState.EXECUTION)
+                self.assertTrue(
+                    manager._get_cuda_graph_recorded_tensor_checker()(state)
+                )
+                expected_state = priming_inputs[-1].clone()
+
+                for inp in feedback_inputs:
+                    torch.compiler.cudagraph_mark_step_begin()
+                    prior_state = state
+                    prior_state_ptr = state.untyped_storage().data_ptr()
                     expected_state.copy_(expected_state + inp)
                     expected_out = inp + expected_state
                     out, state = compiled(inp, state)
                     self.assertEqual(out, expected_out)
                     self.assertEqual(state, expected_state)
-                    if prior_state_and_ptr is not None:
-                        prior_state, prior_state_ptr = prior_state_and_ptr
-                        self.assertNotEqual(
-                            prior_state.untyped_storage().data_ptr(), prior_state_ptr
-                        )
+                    self.assertNotEqual(
+                        prior_state.untyped_storage().data_ptr(), prior_state_ptr
+                    )
             self.assertTrue("cudagraph_skips" not in counters["inductor"])
             self.assertEqual(self.get_manager().path_state, ExecutionState.EXECUTION)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -702,6 +702,8 @@ if HAS_CUDA_AND_TRITON:
                     out, state = compiled(inp, state)
                     self.assertEqual(out, expected_out)
                     self.assertEqual(state, expected_state)
+            self.assertTrue("cudagraph_skips" not in counters["inductor"])
+            self.assertEqual(self.get_manager().path_state, ExecutionState.EXECUTION)
 
         @parametrize("backend", ("inductor", "cudagraphs"))
         @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -674,6 +674,48 @@ if HAS_CUDA_AND_TRITON:
             ).check("Manually clone").check("cudagraph_trees_generation_cloning").run(
                 str(exc.exception)
             )
+            self.assertTrue("cudagraph_skips" not in counters["inductor"])
+
+        @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
+        @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)
+        @torch._inductor.config.patch("triton.cudagraph_support_input_mutation", True)
+        @parametrize("fallback_reason", ("mixed_mutation", "rerecord_limit"))
+        def test_prior_generation_mutated_input_eager_fallback(self, fallback_reason):
+            def produce(x):
+                return x + 1
+
+            def mutate(state, scratch):
+                state.add_(1)
+                if fallback_reason == "mixed_mutation":
+                    scratch.add_(1)
+                return state
+
+            produce = torch.compile(produce, mode="reduce-overhead")
+            mutate = torch.compile(mutate, mode="reduce-overhead")
+            state = produce(torch.randn(4, device="cuda"))
+            scratch = torch.randn_like(state)
+
+            # Register the mutation while the recorded state is still in the
+            # current generation.
+            state = mutate(state, scratch)
+            if fallback_reason == "rerecord_limit":
+                manager = self.get_manager()
+                node = manager.current_node
+                self.assertIsNotNone(node)
+                manager.num_rerecord[node.id][node.wrapped_function.id] = (
+                    torch._inductor.config.triton.cudagraph_unexpected_rerecord_limit
+                    + 1
+                )
+
+            expected_state = state + 1
+            expected_scratch = scratch + (fallback_reason == "mixed_mutation")
+            state_ptr = state.untyped_storage().data_ptr()
+            torch.compiler.cudagraph_mark_step_begin()
+            state = mutate(state, scratch)
+
+            self.assertEqual(state, expected_state)
+            self.assertEqual(scratch, expected_scratch)
+            self.assertEqual(state.untyped_storage().data_ptr(), state_ptr)
 
         @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
         @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)
@@ -697,11 +739,21 @@ if HAS_CUDA_AND_TRITON:
                 state = None
                 for inp in inputs:
                     torch.compiler.cudagraph_mark_step_begin()
+                    prior_state_and_ptr = (
+                        (state, state.untyped_storage().data_ptr())
+                        if state is not None
+                        else None
+                    )
                     expected_state.copy_(expected_state + inp)
                     expected_out = inp + expected_state
                     out, state = compiled(inp, state)
                     self.assertEqual(out, expected_out)
                     self.assertEqual(state, expected_state)
+                    if prior_state_and_ptr is not None:
+                        prior_state, prior_state_ptr = prior_state_and_ptr
+                        self.assertNotEqual(
+                            prior_state.untyped_storage().data_ptr(), prior_state_ptr
+                        )
             self.assertTrue("cudagraph_skips" not in counters["inductor"])
             self.assertEqual(self.get_manager().path_state, ExecutionState.EXECUTION)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -647,6 +647,62 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(mut_inp, non_mut(foo(inp)))
             self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
 
+        @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
+        @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)
+        @torch._inductor.config.patch("triton.cudagraph_support_input_mutation", True)
+        @parametrize("mark_step", (False, True))
+        def test_mutated_output_from_prior_generation_errors(self, mark_step):
+            class Model(nn.Module):
+                def forward(self, x, state=None):
+                    if state is None:
+                        state = torch.zeros_like(x)
+                    state.copy_(state + x)
+                    return x + state, state
+
+            compiled = torch.compile(Model().cuda().eval(), mode="reduce-overhead")
+            inp = torch.randn(1, 4, device="cuda")
+
+            with torch.no_grad():
+                _, state = compiled(inp)
+                if mark_step:
+                    torch.compiler.cudagraph_mark_step_begin()
+                with self.assertRaises(RuntimeError) as exc:
+                    compiled(torch.randn_like(inp), state)
+
+            FileCheck().check("tensor output of CUDAGraphs").check(
+                "mutated input"
+            ).check("Manually clone").check("cudagraph_trees_generation_cloning").run(
+                str(exc.exception)
+            )
+
+        @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
+        @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)
+        @torch._inductor.config.patch("triton.cudagraph_support_input_mutation", True)
+        @torch._inductor.config.patch(
+            "triton.cudagraph_trees_generation_cloning", "user_visible"
+        )
+        def test_clone_mutated_output_from_prior_generation(self):
+            class Model(nn.Module):
+                def forward(self, x, state=None):
+                    if state is None:
+                        state = torch.zeros_like(x)
+                    state.copy_(state + x)
+                    return x + state, state
+
+            compiled = torch.compile(Model().cuda().eval(), mode="reduce-overhead")
+            inputs = [torch.randn(1, 4, device="cuda") for _ in range(3)]
+            expected_state = torch.zeros_like(inputs[0])
+
+            with torch.no_grad():
+                state = None
+                for inp in inputs:
+                    torch.compiler.cudagraph_mark_step_begin()
+                    expected_state.copy_(expected_state + inp)
+                    expected_out = inp + expected_state
+                    out, state = compiled(inp, state)
+                    self.assertEqual(out, expected_out)
+                    self.assertEqual(state, expected_state)
+
         @parametrize("backend", ("inductor", "cudagraphs"))
         @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
         @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2521,6 +2521,19 @@ class CUDAGraphTreeManager:
         if self.in_warmup:
             self.try_end_curr_warmup(function_id)
 
+        node_id = self._get_node_id()
+        if function_id not in self.non_cudagraph_managed_mutation_hint[node_id]:
+            self._update_non_cudagraph_managed_mutation(function_id, new_inputs)
+
+        # Early exit if the function mutates inputs which are neither parameters/buffers nor
+        # cudagraph recorded tensors. This check should happen after `try_end_curr_recording`
+        # and `try_end_curr_warmup` which may change self.current_node, but before a
+        # user-visible generation transition clears the current path below.
+        if self.non_cudagraph_managed_mutation_hint[node_id][
+            function_id
+        ] or self.exceed_rerecord_limit(node_id, function_id):
+            return self.ids_to_funcs[function_id].model(new_inputs)
+
         if (
             self.has_live_user_visible_output_cloning
             and self.path_state == ExecutionState.EXECUTION
@@ -2534,18 +2547,6 @@ class CUDAGraphTreeManager:
                     curr_generation,
                     skip_dead_output_cleanup=True,
                 )
-
-        node_id = self._get_node_id()
-        if function_id not in self.non_cudagraph_managed_mutation_hint[node_id]:
-            self._update_non_cudagraph_managed_mutation(function_id, new_inputs)
-
-        # Early exit if the function mutates inputs which are neither parameters/buffers nor
-        # cudagraph recorded tensors. This check should happen after `try_end_curr_recording`
-        # and `try_end_curr_warmup` which may change self.current_node.
-        if self.non_cudagraph_managed_mutation_hint[node_id][
-            function_id
-        ] or self.exceed_rerecord_limit(node_id, function_id):
-            return self.ids_to_funcs[function_id].model(new_inputs)
 
         # warming up a function and subsequentally recording may use different memory addresses
         # because both depend on the state of the caching allocator. if we warm up graph A,

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2436,7 +2436,7 @@ class CUDAGraphTreeManager:
             return
 
         is_cuda_graph_recorded_tensor = self._get_cuda_graph_recorded_tensor_checker()
-        user_visible_storage_ptrs: set[int] = set()
+        user_visible_storage_ptrs: OrderedSet[int] = OrderedSet()
         if self.has_live_user_visible_output_cloning:
             for entries in self.current_node.path_user_visible_storage_groups:
                 for output_weakrefs, _tensor_weakrefs, _cached_tensors, idx in entries:

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2426,14 +2426,15 @@ class CUDAGraphTreeManager:
 
     def _check_for_mutated_input_from_prior_generation(
         self, function_id: FunctionID, inputs: list[InputType]
-    ) -> None:
+    ) -> bool:
+        """Return whether eager fallback must precede generation teardown."""
         mutated_input_idxs = self.ids_to_funcs[function_id].mutated_input_idxs
         if (
             not mutated_input_idxs
             or self.current_node is None
             or not self.can_start_new_generation()
         ):
-            return
+            return False
 
         is_cuda_graph_recorded_tensor = self._get_cuda_graph_recorded_tensor_checker()
         user_visible_storage_ptrs: OrderedSet[int] = OrderedSet()
@@ -2450,13 +2451,21 @@ class CUDAGraphTreeManager:
                 and is_cuda_graph_recorded_tensor(inp)
                 and inp.untyped_storage().data_ptr() not in user_visible_storage_ptrs
             ):
+                node_id = self._get_node_id()
+                if function_id not in self.non_cudagraph_managed_mutation_hint[node_id]:
+                    self._update_non_cudagraph_managed_mutation(function_id, inputs)
+                if self.non_cudagraph_managed_mutation_hint[node_id][
+                    function_id
+                ] or self.exceed_rerecord_limit(node_id, function_id):
+                    return True
                 raise RuntimeError(
                     "Error: a tensor output of CUDAGraphs from a previous invocation "
                     "is being passed back as a mutated input. Manually clone the tensor "
                     "outside torch.compile() before passing it back, or set "
                     "torch._inductor.config.triton.cudagraph_trees_generation_cloning "
-                    "= 'user_visible'."
+                    "= 'user_visible' before compiling the function."
                 )
+        return False
 
     def new_warmup_node_id(self) -> GraphID:
         return GraphID(next(self.warmup_node_counter))
@@ -2499,7 +2508,8 @@ class CUDAGraphTreeManager:
         # A graph-pool output is safe to mutate only while it remains on the same
         # tree path. At a generation boundary, ending the old path invalidates its
         # storage before an eager fallback or a new recording can consume it.
-        self._check_for_mutated_input_from_prior_generation(function_id, new_inputs)
+        if self._check_for_mutated_input_from_prior_generation(function_id, new_inputs):
+            return self.ids_to_funcs[function_id].model(new_inputs)
 
         # we will try to end the current execution lazily, since
         # we don't want to do unnecessary checking of the existing outputs

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -2424,6 +2424,40 @@ class CUDAGraphTreeManager:
             else lambda _: False
         )
 
+    def _check_for_mutated_input_from_prior_generation(
+        self, function_id: FunctionID, inputs: list[InputType]
+    ) -> None:
+        mutated_input_idxs = self.ids_to_funcs[function_id].mutated_input_idxs
+        if (
+            not mutated_input_idxs
+            or self.current_node is None
+            or not self.can_start_new_generation()
+        ):
+            return
+
+        is_cuda_graph_recorded_tensor = self._get_cuda_graph_recorded_tensor_checker()
+        user_visible_storage_ptrs: set[int] = set()
+        if self.has_live_user_visible_output_cloning:
+            for entries in self.current_node.path_user_visible_storage_groups:
+                for output_weakrefs, _tensor_weakrefs, _cached_tensors, idx in entries:
+                    output_ref = output_weakrefs[idx]
+                    if output_ref is not None:
+                        user_visible_storage_ptrs.add(output_ref.data_ptr())
+        for idx in mutated_input_idxs:
+            inp = inputs[idx]
+            if (
+                isinstance(inp, torch.Tensor)
+                and is_cuda_graph_recorded_tensor(inp)
+                and inp.untyped_storage().data_ptr() not in user_visible_storage_ptrs
+            ):
+                raise RuntimeError(
+                    "Error: a tensor output of CUDAGraphs from a previous invocation "
+                    "is being passed back as a mutated input. Manually clone the tensor "
+                    "outside torch.compile() before passing it back, or set "
+                    "torch._inductor.config.triton.cudagraph_trees_generation_cloning "
+                    "= 'user_visible'."
+                )
+
     def new_warmup_node_id(self) -> GraphID:
         return GraphID(next(self.warmup_node_counter))
 
@@ -2462,6 +2496,11 @@ class CUDAGraphTreeManager:
         )
 
     def _run(self, new_inputs: list[InputType], function_id: FunctionID) -> OutputType:
+        # A graph-pool output is safe to mutate only while it remains on the same
+        # tree path. At a generation boundary, ending the old path invalidates its
+        # storage before an eager fallback or a new recording can consume it.
+        self._check_for_mutated_input_from_prior_generation(function_id, new_inputs)
+
         # we will try to end the current execution lazily, since
         # we don't want to do unnecessary checking of the existing outputs
         # on the hot path, but both recording and warmup only happen once


### PR DESCRIPTION
## Summary

- reject a CUDAGraph output reused as a mutated input after its generation has ended, before the old graph path invalidates its storage
- preserve the opt-in user-visible output cloning path for feedback loops that need to carry mutated state across invocations
- cover both automatic generation changes and explicit `cudagraph_mark_step_begin()` calls

Fixes #192748

## Test plan

- added CUDA regression coverage for the prior-generation mutated-state error path
- added CUDA regression coverage for successful state feedback with user-visible generation cloning enabled
- PyFmt, Ruff, Flake8, Pyrefly, newline, and Python syntax checks

The CUDA regression tests require GPU CI coverage.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo