### PR TITLE
[inductor][xpu] Re-enable batch_linear_lhs with layout guards

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -23,6 +23,18 @@ except Exception:
     has_fbgemm = False
 
 
+@torch.library.custom_op("_batch_linear_lhs_test::require_contiguous", mutates_args=())
+def _require_contiguous(x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        raise RuntimeError(f"expected contiguous input, got stride={x.stride()}")
+    return x.clone()
+
+
+@_require_contiguous.register_fake
+def _(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
 class _TestHighwaySelfGating(torch.nn.Module):
     def __init__(
         self,
@@ -460,6 +472,62 @@ class TestGroupBatchFusion(TestCase):
             self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
             self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
             counters.clear()
+
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_layout_sensitive_users(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_small = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = self.proj_large(x)
+                small = self.proj_small(x)
+                return _require_contiguous(large), torch.sin(small)
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 0)
+
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_keeps_pointwise_fusion(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_small = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = torch.sin(self.proj_large(x))
+                small = torch.cos(self.proj_small(x))
+                return torch.cat((large, small), dim=1)
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
     @requires_gpu()
     def test_as_strided_storage_offset_after_mm_fusion(self):

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -598,6 +598,23 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    def test_batch_linear_lhs_treats_higher_order_ops_as_layout_sensitive(self):
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            triton_kernel_wrapper_mutation,
+        )
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        graph.call_function(
+            triton_kernel_wrapper_mutation,
+            kwargs={"kwargs": {"input": linear}},
+        )
+
+        self.assertTrue(_has_layout_sensitive_user(linear))
+
     @requires_gpu()
     def test_as_strided_storage_offset_after_mm_fusion(self):
         """

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -615,6 +615,40 @@ class TestGroupBatchFusion(TestCase):
 
         self.assertTrue(_has_layout_sensitive_user(linear))
 
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_view_users(self):
+        # A linear whose output feeds a view that needs the whole row contiguous
+        # (e.g. flattening across rows) would crash on the fused non-contiguous
+        # slice, so it must not be fused while the other pointwise-consumed
+        # linears still are.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = self.proj_large(x).view(-1)
+                a = torch.sin(self.proj_a(x))
+                b = torch.cos(self.proj_b(x))
+                return large, a, b
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
     @requires_gpu()
     def test_as_strided_storage_offset_after_mm_fusion(self):
         """

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -623,9 +623,11 @@ class TestGroupBatchFusion(TestCase):
     )
     def test_batch_linear_lhs_skips_view_users(self):
         # A linear whose output feeds a view that needs the whole row contiguous
-        # (e.g. flattening across rows) would crash on the fused non-contiguous
-        # slice, so it must not be fused while the other pointwise-consumed
-        # linears still are.
+        # (e.g. flattening across rows) crashes on the fused non-contiguous
+        # slice — torch.compile raises "Cannot view ... strides (224, 1)" below —
+        # so it must not be fused while the other pointwise-consumed linears
+        # still are. The counter is 1 either way (it counts fuse() groups, not
+        # nodes); the discriminator here is the compile not raising.
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -648,6 +650,22 @@ class TestGroupBatchFusion(TestCase):
 
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
+    def test_batch_linear_lhs_split_getitem_walked(self):
+        # split returns a tuple, so its users are operator.getitem nodes, which
+        # the guard must walk through to reach the downstream view.
+        import operator
+
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        split = graph.call_function(torch.ops.aten.split, args=(linear, 64, 1))
+        getitem = graph.call_function(operator.getitem, args=(split, 0))
+        graph.call_method("view", args=(getitem, -1))
+        self.assertTrue(_has_layout_sensitive_user(linear))
 
     @requires_gpu()
     def test_as_strided_storage_offset_after_mm_fusion(self):

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -624,7 +624,7 @@ class TestGroupBatchFusion(TestCase):
     def test_batch_linear_lhs_skips_view_users(self):
         # A linear whose output feeds a view that needs the whole row contiguous
         # (e.g. flattening across rows) crashes on the fused non-contiguous
-        # slice — torch.compile raises "Cannot view ... strides (224, 1)" below —
+        # slice (torch.compile raises "Cannot view ... strides (224, 1)" below),
         # so it must not be fused while the other pointwise-consumed linears
         # still are. The counter is 1 either way (it counts fuse() groups, not
         # nodes); the discriminator here is the compile not raising.
@@ -654,8 +654,6 @@ class TestGroupBatchFusion(TestCase):
     def test_batch_linear_lhs_split_getitem_walked(self):
         # split returns a tuple, so its users are operator.getitem nodes, which
         # the guard must walk through to reach the downstream view.
-        import operator
-
         from torch._inductor.fx_passes.group_batch_fusion import (
             _has_layout_sensitive_user,
         )

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -473,9 +473,10 @@ class TestGroupBatchFusion(TestCase):
             self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
             counters.clear()
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
@@ -498,8 +499,8 @@ class TestGroupBatchFusion(TestCase):
                 return torch.cat((large, a, b), dim=1)
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -507,9 +508,10 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
@@ -526,8 +528,8 @@ class TestGroupBatchFusion(TestCase):
                 return torch.cat((large, small), dim=1)
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -535,9 +537,10 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
@@ -554,8 +557,8 @@ class TestGroupBatchFusion(TestCase):
                 return self.proj_large(x), self.proj_small(x)
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -563,9 +566,10 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 0)
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
@@ -589,8 +593,8 @@ class TestGroupBatchFusion(TestCase):
                 return torch.cat((large, a, b), dim=1)
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -615,19 +619,21 @@ class TestGroupBatchFusion(TestCase):
 
         self.assertTrue(_has_layout_sensitive_user(linear))
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
     def test_batch_linear_lhs_skips_view_users(self):
         # A linear whose output feeds a view that needs the whole row contiguous
         # (e.g. flattening across rows) crashes on the fused non-contiguous
-        # slice (torch.compile raises "Cannot view ... strides (224, 1)" below),
-        # so it must not be fused while the other pointwise-consumed linears
-        # still are. The counter is 1 either way (it counts fuse() groups, not
-        # nodes); the discriminator here is the compile not raising.
+        # slice, so it must not be fused while the other pointwise-consumed
+        # linears still are. The view is routed through torch.sin so the guard
+        # reaches it via the "crash" branch rather than the graph-output branch;
+        # without the crash handling the fused slice would make view(-1) raise
+        # ("Cannot view ... strides").
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -636,14 +642,14 @@ class TestGroupBatchFusion(TestCase):
                 self.proj_b = torch.nn.Linear(64, 16, bias=False)
 
             def forward(self, x):
-                large = self.proj_large(x).view(-1)
+                large = torch.sin(self.proj_large(x).view(-1))
                 a = torch.sin(self.proj_a(x))
                 b = torch.cos(self.proj_b(x))
                 return large, a, b
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -651,15 +657,18 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
     def test_batch_linear_lhs_skips_view_as_users(self):
         # view_as is view in disguise (self.view_symint(other.sym_sizes())), so
         # it crashes on the fused non-contiguous slice exactly like .view(-1).
+        # Routed through torch.sin for the same crash-branch discriminator as
+        # the .view test above.
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -668,14 +677,14 @@ class TestGroupBatchFusion(TestCase):
                 self.proj_b = torch.nn.Linear(64, 16, bias=False)
 
             def forward(self, x):
-                large = self.proj_large(x).view_as(torch.empty(6144))
+                large = torch.sin(self.proj_large(x).view_as(x.new_empty(6144)))
                 a = torch.sin(self.proj_a(x))
                 b = torch.cos(self.proj_b(x))
                 return large, a, b
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -683,9 +692,46 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
-            "batch_linear_lhs": {"min_fuse_set_size": 2},
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_as_strided_users(self):
+        # as_strided observes the storage layout directly, so it is treated as
+        # a crash view and keeps its linear unfused while the other
+        # pointwise-consumed linears still fuse. Routed through torch.sin so the
+        # guard reaches it via the crash branch; without that, the fused
+        # non-contiguous slice would make as_strided read the wrong elements.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = torch.sin(self.proj_large(x).as_strided((6144,), (1,)))
+                a = torch.sin(self.proj_a(x))
+                b = torch.cos(self.proj_b(x))
+                return large, a, b
+
+        counters.clear()
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
         },
         post_grad_fusion_options={},
     )
@@ -709,8 +755,8 @@ class TestGroupBatchFusion(TestCase):
                 return torch.cat((large, a, b), dim=1)
 
         counters.clear()
-        module = M().eval()
-        x = torch.randn(32, 64)
+        module = M().eval().to("xpu")
+        x = torch.randn(32, 64, device="xpu")
         with torch.no_grad():
             expected = module(x)
             actual = torch.compile(module, fullgraph=True)(x)
@@ -1084,20 +1130,13 @@ class TestGroupBatchFusion(TestCase):
         counters.clear()
 
     @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
-    @torch._inductor.config.patch(
-        pre_grad_fusion_options={
-            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
-        },
-    )
-    def test_xpu_batch_linear_lhs(self):
-        # batch_linear_lhs is disabled by default; enabling it for XPU via mock
-        # config must make the fusion fire on XPU tensors.
+    def test_xpu_auto_enable_batch_linear_lhs(self):
         default_options = config.pre_grad_fusion_options
         self.assertIn("batch_linear_lhs", default_options)
         self.assertEqual(default_options["batch_linear_lhs"]["devices"], ("xpu",))
+        orig_fusion_options = dict(default_options)
         z = 10
         for has_bias in [True, False]:
-            orig_fusion_options = dict(config.pre_grad_fusion_options)
             counters.clear()
             module = MyModule4(z, "xpu", has_bias)
             input = [torch.randn(20, z, device="xpu")]
@@ -1105,7 +1144,7 @@ class TestGroupBatchFusion(TestCase):
             ref = module(*input)
             res = traced(*input)
             self.compare_pred(module, traced, input)
-            self.assertGreater(counters["inductor"]["batch_linear_lhs"], 0)
+            self.assertEqual(counters["inductor"]["batch_linear_lhs"], 2)
             self.assertEqual(ref, res)
             ref.sum().backward()
             res.sum().backward()

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -794,6 +794,97 @@ class TestGroupBatchFusion(TestCase):
         )
         self.assertTrue(_has_layout_sensitive_user(linear))
 
+    def test_batch_linear_lhs_layout_observers_are_sensitive(self):
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        cases = (
+            (torch.ops.aten.sym_stride.int, (0,)),
+            (torch.ops.aten.sym_storage_offset.default, ()),
+            (torch.ops.aten.sym_is_contiguous.default, ()),
+        )
+        for target, extra_args in cases:
+            with self.subTest(target=target):
+                graph = torch.fx.Graph()
+                linear = graph.placeholder("linear")
+                graph.call_function(target, args=(linear, *extra_args))
+                self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_unsafe_views_are_sensitive(self):
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        cases = (
+            (torch.ops.aten._unsafe_view.default, ((-1,),)),
+            (torch.ops.aten._reshape_alias.default, ((-1,), (1,))),
+            (torch.ops.aten.view_as_complex.default, ()),
+        )
+        for target, extra_args in cases:
+            with self.subTest(target=target):
+                graph = torch.fx.Graph()
+                linear = graph.placeholder("linear")
+                graph.call_function(target, args=(linear, *extra_args))
+                self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_preserve_format_contiguous_is_sensitive(self):
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        graph.call_method(
+            "contiguous",
+            args=(linear,),
+            kwargs={"memory_format": torch.preserve_format},
+        )
+        self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_mutation_through_view_is_sensitive(self):
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        transposed = graph.call_function(
+            torch.ops.aten.transpose.int, args=(linear, 0, 1)
+        )
+        graph.call_function(torch.ops.aten.add_.Tensor, args=(transposed, 1))
+        self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_storage_observers_are_sensitive(self):
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        other = graph.placeholder("other")
+        graph.call_function(
+            torch.ops.aten._has_same_storage_numel.default, args=(linear, other)
+        )
+        self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_rejects_broadcast_bias(self):
+        from torch._inductor.fx_passes.group_batch_fusion import BatchLinearLHSFusion
+
+        graph = torch.fx.Graph()
+        input = graph.placeholder("input")
+        weight = graph.placeholder("weight")
+        bias = graph.placeholder("bias")
+        input.meta["example_value"] = torch.randn(4, 8)
+        weight.meta["example_value"] = torch.randn(6, 8)
+        bias.meta["example_value"] = torch.randn(1, 6)
+        linear = graph.call_function(torch._C._nn.linear, args=(input, weight, bias))
+        linear.meta["example_value"] = torch.randn(4, 6)
+        rule = BatchLinearLHSFusion(
+            graph_search_options={"min_fuse_set_size": 2, "max_fuse_set_size": 300}
+        )
+        self.assertIsNone(rule.match(linear))
+
     @requires_gpu()
     def test_as_strided_storage_offset_after_mm_fusion(self):
         """

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -480,16 +480,22 @@ class TestGroupBatchFusion(TestCase):
         post_grad_fusion_options={},
     )
     def test_batch_linear_lhs_skips_layout_sensitive_users(self):
+        # Only one of three linears feeds the layout-sensitive custom op; the
+        # other two must still fuse (counter == 1) while the offending linear
+        # is skipped. _require_contiguous raises on a non-contiguous input, so
+        # the equality check also proves the custom op got a contiguous tensor.
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.proj_large = torch.nn.Linear(64, 192, bias=False)
-                self.proj_small = torch.nn.Linear(64, 16, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
 
             def forward(self, x):
-                large = self.proj_large(x)
-                small = self.proj_small(x)
-                return _require_contiguous(large), torch.sin(small)
+                large = _require_contiguous(self.proj_large(x))
+                a = torch.sin(self.proj_a(x))
+                b = torch.cos(self.proj_b(x))
+                return torch.cat((large, a, b), dim=1)
 
         counters.clear()
         module = M().eval()
@@ -499,7 +505,7 @@ class TestGroupBatchFusion(TestCase):
             actual = torch.compile(module, fullgraph=True)(x)
 
         self.assertEqual(actual, expected)
-        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 0)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
     @torch._inductor.config.patch(
         pre_grad_fusion_options={
@@ -518,6 +524,69 @@ class TestGroupBatchFusion(TestCase):
                 large = torch.sin(self.proj_large(x))
                 small = torch.cos(self.proj_small(x))
                 return torch.cat((large, small), dim=1)
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_output_users(self):
+        # The graph output can observe the fused stride directly, so linears
+        # returned straight from forward must not be fused.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_small = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                return self.proj_large(x), self.proj_small(x)
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 0)
+
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_packet_form_custom_op(self):
+        # Custom ops reached through the OpOverloadPacket call form
+        # (torch.ops.ns.op(x), no .default) must be treated as layout-sensitive
+        # too.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = torch.ops._batch_linear_lhs_test.require_contiguous(
+                    self.proj_large(x)
+                )
+                a = torch.sin(self.proj_a(x))
+                b = torch.cos(self.proj_b(x))
+                return torch.cat((large, a, b), dim=1)
 
         counters.clear()
         module = M().eval()

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -651,6 +651,73 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
 
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_skips_view_as_users(self):
+        # view_as is view in disguise (self.view_symint(other.sym_sizes())), so
+        # it crashes on the fused non-contiguous slice exactly like .view(-1).
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = self.proj_large(x).view_as(torch.empty(6144))
+                a = torch.sin(self.proj_a(x))
+                b = torch.cos(self.proj_b(x))
+                return large, a, b
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"min_fuse_set_size": 2},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_batch_linear_lhs_keeps_contiguous_fusion(self):
+        # contiguous() is alias-annotated but layout-breaking: its output is
+        # contiguous for any input, so the fused layout does not propagate
+        # through it. Feeding each linear through .contiguous() before the
+        # layout-sensitive custom op must not block the fusion; without the
+        # layout-breaking handling all three would be skipped (counter 0).
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj_large = torch.nn.Linear(64, 192, bias=False)
+                self.proj_a = torch.nn.Linear(64, 16, bias=False)
+                self.proj_b = torch.nn.Linear(64, 16, bias=False)
+
+            def forward(self, x):
+                large = _require_contiguous(self.proj_large(x).contiguous())
+                a = _require_contiguous(self.proj_a(x).contiguous())
+                b = _require_contiguous(self.proj_b(x).contiguous())
+                return torch.cat((large, a, b), dim=1)
+
+        counters.clear()
+        module = M().eval()
+        x = torch.randn(32, 64)
+        with torch.no_grad():
+            expected = module(x)
+            actual = torch.compile(module, fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(counters["inductor"]["batch_linear_lhs"], 1)
+
     def test_batch_linear_lhs_split_getitem_walked(self):
         # split returns a tuple, so its users are operator.getitem nodes, which
         # the guard must walk through to reach the downstream view.
@@ -663,6 +730,22 @@ class TestGroupBatchFusion(TestCase):
         split = graph.call_function(torch.ops.aten.split, args=(linear, 64, 1))
         getitem = graph.call_function(operator.getitem, args=(split, 0))
         graph.call_method("view", args=(getitem, -1))
+        self.assertTrue(_has_layout_sensitive_user(linear))
+
+    def test_batch_linear_lhs_transposed_view_walked(self):
+        # .T lowers to aten.numpy_T, a view that must be walked through to reach
+        # a downstream layout-sensitive custom op. This is the case that
+        # motivated deriving views from the schema instead of a list.
+        from torch._inductor.fx_passes.group_batch_fusion import (
+            _has_layout_sensitive_user,
+        )
+
+        graph = torch.fx.Graph()
+        linear = graph.placeholder("linear")
+        transposed = graph.call_function(torch.ops.aten.numpy_T, args=(linear,))
+        graph.call_function(
+            torch.ops._batch_linear_lhs_test.require_contiguous, args=(transposed,)
+        )
         self.assertTrue(_has_layout_sensitive_user(linear))
 
     @requires_gpu()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -372,7 +372,13 @@ batch_fusion = True
 # merge_splits_pass
 # mutate_cat_pass
 # split_cat_pass
-pre_grad_fusion_options: dict[str, dict[str, Any]] = {}
+# The "devices" key limits a fusion to matching input device types.
+pre_grad_fusion_options: dict[str, dict[str, Any]] = {
+    "batch_linear_lhs": {
+        "devices": ("xpu",),
+        "min_fuse_set_size": 2,
+    },
+}
 
 # Post grad fusion and options, set to empty dict to disable fusion.
 # Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions(False)` to see available fusions.

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -497,10 +497,32 @@ class BatchLinearLHSFusion(BatchFusion):
     We have a separate pass to eliminate contiguous transpose in a generic way.
     """
 
+    @staticmethod
+    def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
+        for user in node.users:
+            if user.op == "output":
+                return True
+            if user.op == "call_method" and user.target in (
+                "is_contiguous",
+                "storage_offset",
+                "stride",
+            ):
+                return True
+            if (
+                isinstance(user.target, torch._ops.OpOverload)
+                and user.target.namespace != "aten"
+            ):
+                return True
+        return False
+
     def match(self, node: torch.fx.Node) -> tuple[str, int | None, Any] | None:
         if CallFunctionVarArgs([torch.nn.functional.linear, torch._C._nn.linear]).match(
             node
         ) and is_linear_node_can_be_fused(node):
+            # Splitting a wide GEMM returns non-contiguous views. Avoid changing
+            # observable layout or passing those views to opaque custom operators.
+            if self._has_layout_sensitive_user(node):
+                return None
             input = get_arg_value(node, 0, "input")
             weight = get_arg_value(node, 1, "weight")
             bias = get_arg_value(node, 2, "bias")

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -503,9 +503,9 @@ class BatchLinearLHSFusion(BatchFusion):
         ) and is_linear_node_can_be_fused(node):
             # Splitting a wide GEMM returns non-contiguous views. Avoid changing
             # observable layout or passing those views to opaque custom operators.
-            # Note: this checks the linear node's direct users only; a layout
-            # change can also leak through aten view ops, but those are out of
-            # scope here (pre-existing limitation).
+            # The guard walks through view-producing users (including split /
+            # chunk / indexing via getitem) to find any consumer that can
+            # observe the layout or requires contiguity.
             if _has_layout_sensitive_user(node):
                 return None
             input = get_arg_value(node, 0, "input")
@@ -618,13 +618,15 @@ def _op_namespace(tgt) -> str | None:
     return None
 
 
-# aten ops that return a view of their input (no implicit copy), so the fused
-# non-contiguous layout propagates to their outputs and downstream consumers
-# still matter. view / as_strided additionally require a compatible layout and
+# aten ops whose output layout follows the input (views, or tuple-of-views for
+# split/chunk/unbind), so the fused non-contiguous layout propagates to their
+# consumers. reshape is included even though it may copy when the layout is
+# incompatible — a copy is contiguous, so walking through it is merely
+# conservative. view / as_strided additionally require a compatible layout and
 # can fail on the non-contiguous fused output. The same ops are traced either
 # as call_function[target=aten.view] or call_method[target="view"], so they are
 # matched by their op name.
-_VIEW_METHODS = OrderedSet(
+_VIEW_OP_NAMES = OrderedSet(
     [
         "view",
         "as_strided",
@@ -636,7 +638,11 @@ _VIEW_METHODS = OrderedSet(
         "expand",
         "select",
         "split",
+        "chunk",
+        "unbind",
         "slice",
+        "detach",
+        "t",
     ]
 )
 
@@ -649,15 +655,20 @@ def _view_op_kind(user: torch.fx.Node) -> str | None:
     # "crash" for view/as_strided (can fail on non-contiguous), "propagate" for
     # the other view-producing ops (layout flows through), None otherwise.
     if user.op == "call_function":
+        # operator.getitem unwraps the tuple returned by split/chunk/unbind and
+        # is itself an unguarded view producer (lin(x)[0]); walk through it.
+        if user.target is operator.getitem:
+            return "propagate"
         # Normalize OpOverload / OpOverloadPacket to the op name ("view").
-        name = getattr(
-            getattr(user.target, "overloadpacket", user.target), "__name__", None
-        )
+        tgt = user.target
+        if isinstance(tgt, torch._ops.OpOverload):
+            tgt = tgt.overloadpacket
+        name = getattr(tgt, "__name__", None)
     elif user.op == "call_method":
         name = user.target
     else:
         return None
-    if name in _VIEW_METHODS:
+    if name in _VIEW_OP_NAMES:
         return "crash" if name in _CRASH_VIEW_OPS else "propagate"
     return None
 
@@ -667,24 +678,30 @@ def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
     # output, stride/contiguity/storage-offset queries, an opaque custom op
     # (both OpOverload and OpOverloadPacket call forms), or a view/as_strided
     # that can fail on the non-contiguous fused output. View-producing ops
-    # (call_function aten.* or call_method x.view(...)) are walked through,
-    # since the layout propagates to their consumers.
-    for user in node.users:
-        if user.op == "output":
-            return True
-        if user.op == "call_method" and user.target in (
-            "is_contiguous",
-            "storage_offset",
-            "stride",
-        ):
-            return True
-        if _op_namespace(user.target) not in (None, "aten"):
-            return True
-        kind = _view_op_kind(user)
-        if kind == "crash":
-            return True
-        if kind == "propagate" and _has_layout_sensitive_user(user):
-            return True
+    # (call_function aten.* / call_method x.view(...) / getitem) are walked
+    # through since the layout propagates to their consumers. Iterative
+    # worklist with a seen set, so each node is visited at most once (view
+    # chains can form diamonds that a naive recursion would re-traverse).
+    queue = [node]
+    seen = OrderedSet([node])
+    while queue:
+        for user in queue.pop().users:
+            if user.op == "output":
+                return True
+            if user.op == "call_method" and user.target in (
+                "is_contiguous",
+                "storage_offset",
+                "stride",
+            ):
+                return True
+            if _op_namespace(user.target) not in (None, "aten"):
+                return True
+            kind = _view_op_kind(user)
+            if kind == "crash":
+                return True
+            if kind == "propagate" and user not in seen:
+                seen.add(user)
+                queue.append(user)
     return False
 
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -618,11 +618,63 @@ def _op_namespace(tgt) -> str | None:
     return None
 
 
+# aten ops that return a view of their input (no implicit copy), so the fused
+# non-contiguous layout propagates to their outputs and downstream consumers
+# still matter. view / as_strided additionally require a compatible layout and
+# can fail on the non-contiguous fused output.
+_VIEW_OPS = {
+    aten.view,
+    aten.as_strided,
+    aten.reshape,
+    aten.permute,
+    aten.transpose,
+    aten.slice,
+    aten.split,
+    aten.unsqueeze,
+    aten.squeeze,
+    aten.expand,
+    aten.select,
+}
+
+# Same ops traced as tensor methods (e.g. x.view(-1) is call_method[target="view"]).
+_VIEW_METHODS = {
+    "view",
+    "as_strided",
+    "reshape",
+    "permute",
+    "transpose",
+    "unsqueeze",
+    "squeeze",
+    "expand",
+    "select",
+    "split",
+    "slice",
+}
+
+# view / as_strided additionally require a compatible layout and can crash on
+# the non-contiguous fused output; the rest are layout-preserving and walked.
+_CRASH_VIEW_OPS = {"view", "as_strided"}
+
+
+def _view_op_kind(user: torch.fx.Node) -> str | None:
+    # "crash" for view/as_strided (can fail on non-contiguous), "propagate" for
+    # the other view-producing ops (layout flows through), None otherwise.
+    if user.op == "call_function":
+        packet = getattr(user.target, "overloadpacket", user.target)
+        if packet in _VIEW_OPS:
+            return "crash" if packet in (aten.view, aten.as_strided) else "propagate"
+    if user.op == "call_method" and user.target in _VIEW_METHODS:
+        return "crash" if user.target in _CRASH_VIEW_OPS else "propagate"
+    return None
+
+
 def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
     # A user that can observe the (possibly fused) output layout: the graph
-    # output, stride/contiguity/storage-offset queries, or an opaque custom op
-    # (both OpOverload and OpOverloadPacket call forms). aten ops are excluded
-    # because their layout-sensitive handlers are traced/folded elsewhere.
+    # output, stride/contiguity/storage-offset queries, an opaque custom op
+    # (both OpOverload and OpOverloadPacket call forms), or a view/as_strided
+    # that can fail on the non-contiguous fused output. View-producing ops
+    # (call_function aten.* or call_method x.view(...)) are walked through,
+    # since the layout propagates to their consumers.
     for user in node.users:
         if user.op == "output":
             return True
@@ -633,6 +685,11 @@ def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
         ):
             return True
         if _op_namespace(user.target) not in (None, "aten"):
+            return True
+        kind = _view_op_kind(user)
+        if kind == "crash":
+            return True
+        if kind == "propagate" and _has_layout_sensitive_user(user):
             return True
     return False
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import torch
 from torch._dynamo.utils import counters, is_node_meta_valid
+from torch._library.utils import get_layout_constraint_tag
 from torch._logging import trace_structured
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.symbolic_shapes import free_symbols
@@ -528,6 +529,8 @@ class BatchLinearLHSFusion(BatchFusion):
             bias_tensor = None
             if bias is not None:
                 bias_tensor = bias.meta.get("val", bias.meta.get("example_value"))
+                if bias_tensor is None or bias_tensor.ndim != 1:
+                    return None
             bias_dim = None if bias_tensor is None else bias_tensor.ndim  # type: ignore[union-attr]
             group_key = ("batch_linear_lhs", bias_dim, input)
         else:
@@ -637,47 +640,80 @@ def _is_aten_view_name(name: str) -> bool:
     return any(o.is_view for o in packet.op_overloads())
 
 
-# view / as_strided / view_as require a compatible layout and can crash on the
-# non-contiguous fused output; other views (permute, reshape, ...) work on any
-# layout and just propagate it. This is op semantics, not alias info, so it is
-# the one hand-maintained list.
-_CRASH_VIEW_OPS = OrderedSet(["view", "as_strided", "view_as"])
+# These ops require a compatible input layout or can reinterpret the fused
+# storage differently. This is op semantics, not alias info, so it cannot be
+# derived only from OpOverload.is_view.
+_CRASH_VIEW_OPS = OrderedSet(
+    [
+        "view",
+        "_unsafe_view",
+        "view_as",
+        "view_as_complex",
+        "as_strided",
+        "_reshape_alias",
+    ]
+)
 
-# contiguous is alias-annotated (so is_view is True) but its output layout is
-# determined by the call, not by the incoming strides: the result is contiguous
-# for any memory_format. The fused layout does not propagate through it, so the
-# walk stops there (otherwise custom_op(lin(x).contiguous()), the canonical
-# user-side fix, loses the fusion for no correctness benefit).
+# The unsafe split variants return aliases despite omitting alias annotations.
+_PROPAGATE_VIEW_OPS = OrderedSet(
+    ["unsafe_chunk", "unsafe_split", "unsafe_split_with_sizes"]
+)
+
+_LAYOUT_OBSERVING_OPS = OrderedSet(
+    [
+        "stride",
+        "sym_stride",
+        "storage_offset",
+        "sym_storage_offset",
+        "is_contiguous",
+        "sym_is_contiguous",
+        "_has_same_storage_numel",
+        "is_set_to",
+    ]
+)
+
+# Ordinary contiguous() is layout-breaking, so the fused layout does not
+# propagate through it. preserve_format is layout-sensitive and handled in
+# _view_op_kind.
 _LAYOUT_BREAKING_OPS = OrderedSet(["contiguous"])
 
 
+def _target_name(user: torch.fx.Node) -> str | None:
+    if user.op == "call_method":
+        return user.target if isinstance(user.target, str) else None
+    if user.op != "call_function":
+        return None
+    tgt = user.target
+    if isinstance(tgt, torch._ops.OpOverload):
+        tgt = tgt.overloadpacket
+    name = getattr(tgt, "__name__", None)
+    return name if isinstance(name, str) else None
+
+
 def _view_op_kind(user: torch.fx.Node) -> str | None:
-    # "crash" for view/as_strided/view_as (can fail on non-contiguous),
+    # "crash" for layout-sensitive views and observers,
     # "propagate" for the other view-producing ops (layout flows through),
-    # None otherwise. The caller (_has_layout_sensitive_user) checks the target
-    # namespace before this, so only aten ops reach the name lookup below.
+    # None otherwise.
     if user.op == "call_function":
         # operator.getitem unwraps the tuple returned by split/chunk/unbind and
         # is itself an unguarded view producer (lin(x)[0]); walk through it.
         if user.target is operator.getitem:
             return "propagate"
-        # Normalize OpOverload / OpOverloadPacket to the op name ("view").
-        tgt = user.target
-        if isinstance(tgt, torch._ops.OpOverload):
-            tgt = tgt.overloadpacket
-        name = getattr(tgt, "__name__", None)
-    elif user.op == "call_method":
-        name = user.target
-    else:
-        return None
-    # A call_function target without __name__ has no op name to look up; treat
-    # it as opaque and stop the walk rather than letting getattr on a non-string
-    # name raise inside _is_aten_view_name.
-    if not isinstance(name, str):
+    name = _target_name(user)
+    if name is None:
         return None
     if name in _CRASH_VIEW_OPS:
         return "crash"
+    if name in _PROPAGATE_VIEW_OPS:
+        return "propagate"
     if name in _LAYOUT_BREAKING_OPS:
+        memory_format = get_arg_value(user, 1, "memory_format")
+        if memory_format in (None, torch.contiguous_format):
+            return None
+        return "crash"
+    if name in _LAYOUT_OBSERVING_OPS:
+        return "crash"
+    if user.op == "call_function" and _op_namespace(user.target) != "aten":
         return None
     return "propagate" if _is_aten_view_name(name) else None
 
@@ -697,10 +733,14 @@ def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
         for user in queue.pop().users:
             if user.op == "output":
                 return True
-            if user.op == "call_method" and user.target in (
-                "is_contiguous",
-                "storage_offset",
-                "stride",
+            if _is_mutable_node(user.target):
+                return True
+            if isinstance(
+                user.target, torch._ops.OpOverload
+            ) and get_layout_constraint_tag(user.target, with_default=False) in (
+                torch.Tag.needs_exact_strides,
+                torch.Tag.needs_contiguous_strides,
+                torch.Tag.needs_fixed_stride_order,
             ):
                 return True
             if _op_namespace(user.target) not in (None, "aten"):
@@ -717,6 +757,10 @@ def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
 # Poor person's check for if a node in the graph mutates its input.
 # (the graph is torch IR, so we will see torch fns and python operators)
 def _is_mutable_node(tgt):
+    if isinstance(tgt, torch._ops.OpOverload):
+        return tgt._schema.is_mutable
+    if isinstance(tgt, torch._ops.OpOverloadPacket):
+        return any(op._schema.is_mutable for op in tgt.op_overloads())
     if str(tgt).endswith("_"):
         # e.g. torch.mul_, torch.Tensor.mul_
         return True

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -624,14 +624,17 @@ def _op_namespace(tgt) -> str | None:
 # same view op as call_method "view", as torch.split, or as
 # torch.ops.aten.numpy_T, so we match on the op name and ask aten's schema.
 # This tracks the aten table instead of a hand-maintained list (e.g. it covers
-# view_as / narrow / unfold / diagonal / .T without an edit).
+# view_as / narrow / unfold / diagonal / .T without an edit). The match is by
+# name only, so a non-aten python callable whose __name__ collides with an aten
+# view op is judged against aten's table; the caller rejects non-aten
+# namespaces first, which keeps that from firing on real third-party ops.
 @functools.lru_cache(None)
 def _is_aten_view_name(name: str) -> bool:
     packet = getattr(torch.ops.aten, name, None)
     if packet is None:
         return False
-    # Iterate overloads(): select/slice/transpose/unbind have no .default.
-    return any(getattr(packet, o).is_view for o in packet.overloads())
+    # Iterate op_overloads(): select/slice/transpose/unbind have no .default.
+    return any(o.is_view for o in packet.op_overloads())
 
 
 # view / as_strided / view_as require a compatible layout and can crash on the
@@ -639,6 +642,13 @@ def _is_aten_view_name(name: str) -> bool:
 # layout and just propagate it. This is op semantics, not alias info, so it is
 # the one hand-maintained list.
 _CRASH_VIEW_OPS = OrderedSet(["view", "as_strided", "view_as"])
+
+# contiguous is alias-annotated (so is_view is True) but its output layout is
+# determined by the call, not by the incoming strides: the result is contiguous
+# for any memory_format. The fused layout does not propagate through it, so the
+# walk stops there (otherwise custom_op(lin(x).contiguous()), the canonical
+# user-side fix, loses the fusion for no correctness benefit).
+_LAYOUT_BREAKING_OPS = OrderedSet(["contiguous"])
 
 
 def _view_op_kind(user: torch.fx.Node) -> str | None:
@@ -660,8 +670,15 @@ def _view_op_kind(user: torch.fx.Node) -> str | None:
         name = user.target
     else:
         return None
+    # A call_function target without __name__ has no op name to look up; treat
+    # it as opaque and stop the walk rather than letting getattr on a non-string
+    # name raise inside _is_aten_view_name.
+    if not isinstance(name, str):
+        return None
     if name in _CRASH_VIEW_OPS:
         return "crash"
+    if name in _LAYOUT_BREAKING_OPS:
+        return None
     return "propagate" if _is_aten_view_name(name) else None
 
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -608,10 +608,10 @@ class BatchLinearLHSFusion(BatchFusion):
 
 
 def _op_namespace(tgt) -> str | None:
-    # Both OpOverload and OpOverloadPacket can appear as call_function targets.
-    # OpOverload exposes .namespace; OpOverloadPacket does not (accessing it
-    # raises), so derive the namespace from the qualified op name ("ns::op").
-    if isinstance(tgt, torch._ops.OpOverload):
+    # OpOverload and HigherOrderOperator expose .namespace; OpOverloadPacket
+    # does not (accessing it raises), so derive its namespace from the
+    # qualified op name ("ns::op").
+    if isinstance(tgt, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
         return tgt.namespace
     if isinstance(tgt, torch._ops.OpOverloadPacket):
         return tgt._qualified_op_name.split("::")[0]

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -622,38 +622,42 @@ def _op_namespace(tgt) -> str | None:
 # non-contiguous layout propagates to their outputs and downstream consumers
 # still matter. view / as_strided additionally require a compatible layout and
 # can fail on the non-contiguous fused output.
-_VIEW_OPS = {
-    aten.view,
-    aten.as_strided,
-    aten.reshape,
-    aten.permute,
-    aten.transpose,
-    aten.slice,
-    aten.split,
-    aten.unsqueeze,
-    aten.squeeze,
-    aten.expand,
-    aten.select,
-}
+_VIEW_OPS = OrderedSet(
+    [
+        aten.view,
+        aten.as_strided,
+        aten.reshape,
+        aten.permute,
+        aten.transpose,
+        aten.slice,
+        aten.split,
+        aten.unsqueeze,
+        aten.squeeze,
+        aten.expand,
+        aten.select,
+    ]
+)
 
 # Same ops traced as tensor methods (e.g. x.view(-1) is call_method[target="view"]).
-_VIEW_METHODS = {
-    "view",
-    "as_strided",
-    "reshape",
-    "permute",
-    "transpose",
-    "unsqueeze",
-    "squeeze",
-    "expand",
-    "select",
-    "split",
-    "slice",
-}
+_VIEW_METHODS = OrderedSet(
+    [
+        "view",
+        "as_strided",
+        "reshape",
+        "permute",
+        "transpose",
+        "unsqueeze",
+        "squeeze",
+        "expand",
+        "select",
+        "split",
+        "slice",
+    ]
+)
 
 # view / as_strided additionally require a compatible layout and can crash on
 # the non-contiguous fused output; the rest are layout-preserving and walked.
-_CRASH_VIEW_OPS = {"view", "as_strided"}
+_CRASH_VIEW_OPS = OrderedSet(["view", "as_strided"])
 
 
 def _view_op_kind(user: torch.fx.Node) -> str | None:

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -621,24 +621,9 @@ def _op_namespace(tgt) -> str | None:
 # aten ops that return a view of their input (no implicit copy), so the fused
 # non-contiguous layout propagates to their outputs and downstream consumers
 # still matter. view / as_strided additionally require a compatible layout and
-# can fail on the non-contiguous fused output.
-_VIEW_OPS = OrderedSet(
-    [
-        aten.view,
-        aten.as_strided,
-        aten.reshape,
-        aten.permute,
-        aten.transpose,
-        aten.slice,
-        aten.split,
-        aten.unsqueeze,
-        aten.squeeze,
-        aten.expand,
-        aten.select,
-    ]
-)
-
-# Same ops traced as tensor methods (e.g. x.view(-1) is call_method[target="view"]).
+# can fail on the non-contiguous fused output. The same ops are traced either
+# as call_function[target=aten.view] or call_method[target="view"], so they are
+# matched by their op name.
 _VIEW_METHODS = OrderedSet(
     [
         "view",
@@ -664,11 +649,16 @@ def _view_op_kind(user: torch.fx.Node) -> str | None:
     # "crash" for view/as_strided (can fail on non-contiguous), "propagate" for
     # the other view-producing ops (layout flows through), None otherwise.
     if user.op == "call_function":
-        packet = getattr(user.target, "overloadpacket", user.target)
-        if packet in _VIEW_OPS:
-            return "crash" if packet in (aten.view, aten.as_strided) else "propagate"
-    if user.op == "call_method" and user.target in _VIEW_METHODS:
-        return "crash" if user.target in _CRASH_VIEW_OPS else "propagate"
+        # Normalize OpOverload / OpOverloadPacket to the op name ("view").
+        name = getattr(
+            getattr(user.target, "overloadpacket", user.target), "__name__", None
+        )
+    elif user.op == "call_method":
+        name = user.target
+    else:
+        return None
+    if name in _VIEW_METHODS:
+        return "crash" if name in _CRASH_VIEW_OPS else "propagate"
     return None
 
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -497,31 +497,16 @@ class BatchLinearLHSFusion(BatchFusion):
     We have a separate pass to eliminate contiguous transpose in a generic way.
     """
 
-    @staticmethod
-    def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
-        for user in node.users:
-            if user.op == "output":
-                return True
-            if user.op == "call_method" and user.target in (
-                "is_contiguous",
-                "storage_offset",
-                "stride",
-            ):
-                return True
-            if (
-                isinstance(user.target, torch._ops.OpOverload)
-                and user.target.namespace != "aten"
-            ):
-                return True
-        return False
-
     def match(self, node: torch.fx.Node) -> tuple[str, int | None, Any] | None:
         if CallFunctionVarArgs([torch.nn.functional.linear, torch._C._nn.linear]).match(
             node
         ) and is_linear_node_can_be_fused(node):
             # Splitting a wide GEMM returns non-contiguous views. Avoid changing
             # observable layout or passing those views to opaque custom operators.
-            if self._has_layout_sensitive_user(node):
+            # Note: this checks the linear node's direct users only; a layout
+            # change can also leak through aten view ops, but those are out of
+            # scope here (pre-existing limitation).
+            if _has_layout_sensitive_user(node):
                 return None
             input = get_arg_value(node, 0, "input")
             weight = get_arg_value(node, 1, "weight")
@@ -620,6 +605,36 @@ class BatchLinearLHSFusion(BatchFusion):
             new_node.meta.update(node.meta)
             graph.erase_node(node)  # type: ignore[operator]
         counters["inductor"]["batch_linear_lhs"] += 1
+
+
+def _op_namespace(tgt) -> str | None:
+    # Both OpOverload and OpOverloadPacket can appear as call_function targets.
+    # OpOverload exposes .namespace; OpOverloadPacket does not (accessing it
+    # raises), so derive the namespace from the qualified op name ("ns::op").
+    if isinstance(tgt, torch._ops.OpOverload):
+        return tgt.namespace
+    if isinstance(tgt, torch._ops.OpOverloadPacket):
+        return tgt._qualified_op_name.split("::")[0]
+    return None
+
+
+def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:
+    # A user that can observe the (possibly fused) output layout: the graph
+    # output, stride/contiguity/storage-offset queries, or an opaque custom op
+    # (both OpOverload and OpOverloadPacket call forms). aten ops are excluded
+    # because their layout-sensitive handlers are traced/folded elsewhere.
+    for user in node.users:
+        if user.op == "output":
+            return True
+        if user.op == "call_method" and user.target in (
+            "is_contiguous",
+            "storage_offset",
+            "stride",
+        ):
+            return True
+        if _op_namespace(user.target) not in (None, "aten"):
+            return True
+    return False
 
 
 # Poor person's check for if a node in the graph mutates its input.

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import collections
+import functools
 import logging
 import operator
 from collections import OrderedDict
@@ -618,42 +619,33 @@ def _op_namespace(tgt) -> str | None:
     return None
 
 
-# aten ops whose output layout follows the input (views, or tuple-of-views for
-# split/chunk/unbind), so the fused non-contiguous layout propagates to their
-# consumers. reshape is included even though it may copy when the layout is
-# incompatible — a copy is contiguous, so walking through it is merely
-# conservative. view / as_strided additionally require a compatible layout and
-# can fail on the non-contiguous fused output. The same ops are traced either
-# as call_function[target=aten.view] or call_method[target="view"], so they are
-# matched by their op name.
-_VIEW_OP_NAMES = OrderedSet(
-    [
-        "view",
-        "as_strided",
-        "reshape",
-        "permute",
-        "transpose",
-        "unsqueeze",
-        "squeeze",
-        "expand",
-        "select",
-        "split",
-        "chunk",
-        "unbind",
-        "slice",
-        "detach",
-        "t",
-    ]
-)
+# Whether an aten op is a view (its output aliases its input, per the schema's
+# alias annotations surfaced as OpOverload.is_view). Pre-grad graphs spell the
+# same view op as call_method "view", as torch.split, or as
+# torch.ops.aten.numpy_T, so we match on the op name and ask aten's schema.
+# This tracks the aten table instead of a hand-maintained list (e.g. it covers
+# view_as / narrow / unfold / diagonal / .T without an edit).
+@functools.lru_cache(None)
+def _is_aten_view_name(name: str) -> bool:
+    packet = getattr(torch.ops.aten, name, None)
+    if packet is None:
+        return False
+    # Iterate overloads(): select/slice/transpose/unbind have no .default.
+    return any(getattr(packet, o).is_view for o in packet.overloads())
 
-# view / as_strided additionally require a compatible layout and can crash on
-# the non-contiguous fused output; the rest are layout-preserving and walked.
-_CRASH_VIEW_OPS = OrderedSet(["view", "as_strided"])
+
+# view / as_strided / view_as require a compatible layout and can crash on the
+# non-contiguous fused output; other views (permute, reshape, ...) work on any
+# layout and just propagate it. This is op semantics, not alias info, so it is
+# the one hand-maintained list.
+_CRASH_VIEW_OPS = OrderedSet(["view", "as_strided", "view_as"])
 
 
 def _view_op_kind(user: torch.fx.Node) -> str | None:
-    # "crash" for view/as_strided (can fail on non-contiguous), "propagate" for
-    # the other view-producing ops (layout flows through), None otherwise.
+    # "crash" for view/as_strided/view_as (can fail on non-contiguous),
+    # "propagate" for the other view-producing ops (layout flows through),
+    # None otherwise. The caller (_has_layout_sensitive_user) checks the target
+    # namespace before this, so only aten ops reach the name lookup below.
     if user.op == "call_function":
         # operator.getitem unwraps the tuple returned by split/chunk/unbind and
         # is itself an unguarded view producer (lin(x)[0]); walk through it.
@@ -668,9 +660,9 @@ def _view_op_kind(user: torch.fx.Node) -> str | None:
         name = user.target
     else:
         return None
-    if name in _VIEW_OP_NAMES:
-        return "crash" if name in _CRASH_VIEW_OPS else "propagate"
-    return None
+    if name in _CRASH_VIEW_OPS:
+        return "crash"
+    return "propagate" if _is_aten_view_name(name) else None
 
 
 def _has_layout_sensitive_user(node: torch.fx.Node) -> bool:


### PR DESCRIPTION
I reviewed the implementation and test results. The AI-assisted summary below accurately describes the problem and intended fix.

> ## Summary
>
> `batch_linear_lhs` was enabled by default on XPU for PyTorch 2.14, then
> temporarily disabled by #194312 after it caused a Qwen3.5/Qwen3.8 regression
> in vLLM. The fusion replaces parallel `Linear(x, W_i)` operations with one
> wide GEMM and split views. Those views inherit the wide GEMM's row stride, so
> they can be non-contiguous even though the original linear outputs were
> contiguous.
>
> Layout-sensitive consumers can therefore observe unexpected strides, fail in
> `view`-like operations, or pass an incompatible layout to an opaque custom
> kernel.
>
> This PR adds a per-linear layout-safety guard and re-enables
> `batch_linear_lhs` by default on XPU. Safe pointwise consumers remain eligible
> for fusion, while unsafe consumers cause only the affected linear to be
> skipped.
>
> Fixes #193490.
> Alternative to #193264.
>
> ## Changes
>
> - Skip fusion when an output reaches the graph output, a layout or storage
>   observer, a mutable user, a non-ATen or higher-order operator, or an operator
>   with an exact-layout constraint.
> - Reject layout-sensitive views such as `view`, `view_as`, `as_strided`,
>   `_unsafe_view`, and `_reshape_alias`.
> - Walk through layout-preserving ATen views and `getitem` nodes from
>   `split`/`chunk`/`unbind`, using schema alias metadata instead of a
>   hand-maintained view list.
> - Stop propagation at ordinary `contiguous()`, while conservatively rejecting
>   layout-sensitive memory formats.
> - Reject unsupported non-1D or unknown bias layouts.
> - Re-enable `batch_linear_lhs` for XPU and add XPU regression coverage for
>   layout observers, view chains, custom operators, mutable consumers, layout
>   constraints, and safe pointwise consumers.
>
> ## Test Plan
>
> ```bash
> source ~/intel/oneapi/setvars.sh
> python test/inductor/test_group_batch_fusion.py -k batch_linear_lhs -v
> conda run -n pytorch_xpu_build_on spin quicklint
> conda run -n pytorch_xpu_build_on lintrunner -a \
>   test/inductor/test_group_batch_fusion.py \
>   torch/_inductor/config.py \
>   torch/_inductor/fx_passes/group_batch_fusion.py
> ```
>
> The focused run completed 23 tests successfully, and lint reported no issues.
>
> Authored with assistance from an AI assistant.
