### PR TITLE
[Testcase Refactoring]Make test_sac_estimator.py device-generic and add hw_classification label

### DIFF
--- a/test/distributed/_tools/test_sac_estimator.py
+++ b/test/distributed/_tools/test_sac_estimator.py
@@ -1,11 +1,13 @@
 # Owner(s): ["oncall: distributed"]
-import unittest
-
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.sac_estimator import SACEstimator
-from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -13,6 +15,8 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TestSACEstimator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _sac_estimation(
         self,
         estimate_mode: str,
@@ -25,10 +29,9 @@ class TestSACEstimator(TestCase):
         loss.backward()
         sace.pwlf_sac_tradeoff_curve(n_segments=2, save_tradeoff_graphs=False)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_transformer_sac_estimation(self):
+    def test_transformer_sac_estimation(self, device):
         """Runs a basic GPT-2 model"""
-        dev = torch.cuda.current_device()
+        dev = torch.device(device)
         vocab_size = 8192
         bsz, seq_len = 8, 1024
         model_args = ModelArgs(
@@ -49,8 +52,7 @@ class TestSACEstimator(TestCase):
             self._sac_estimation("operator-level-benchmark", model, inp)
             self._sac_estimation("operator-level-cost-model", model, inp)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_simple_model_sac_estimation(self):
+    def test_simple_model_sac_estimation(self, device):
         """This test checks the correctness of view_ops, random_ops and inplace_ops"""
 
         class Foo(torch.nn.Module):
@@ -66,7 +68,7 @@ class TestSACEstimator(TestCase):
                 x = torch.sin_(x)
                 return x
 
-        dev = torch.cuda.current_device()
+        dev = torch.device(device)
         with FakeTensorMode():
             with torch.device(dev):
                 model = Foo()
@@ -82,6 +84,9 @@ class TestSACEstimator(TestCase):
             self.assertEqual(
                 sac_estimator.sac_mod_stats["Foo"].inplace_ops, [(2, 1), (3, 1), (4, 1)]
             )
+
+
+instantiate_device_type_tests(TestSACEstimator, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Both tests in `test/distributed/_tools/test_sac_estimator.py`
(`test_transformer_sac_estimation` and `test_simple_model_sac_estimation`)
run under `FakeTensorMode` and use `SACEstimator` — a dispatch-level tool
that tracks operations regardless of the underlying device. The test
bodies are fully device-agnostic: they only need a device for fake-tensor
placement, not for actual hardware execution.

However, the admission gate is a hardcoded CUDA whitelist
(`@unittest.skipIf(not TEST_CUDA, "CUDA not available")`), and the device
is obtained via `torch.cuda.current_device()`. This wrongly skips the
tests on any other accelerator backend (e.g. out-of-tree PrivateUse1
backends) even though the test logic does not depend on CUDA-specific
functionality.

This PR replaces the whitelist with
`instantiate_device_type_tests(except_for="cpu")` to exclude CPU variants
at the instantiation layer (both test methods require an accelerator),
adds a `device` parameter to both test methods (framework-injected),
replaces `torch.cuda.current_device()` with `torch.device(device)`,
removes the unused `TEST_CUDA` / `unittest` imports, and adds a
`hw_classification = HardwareClassification.ACCELERATOR` label.

## Changes

- Replaced `@unittest.skipIf(not TEST_CUDA, "CUDA not available")` with
  `instantiate_device_type_tests(TestSACEstimator, globals(), except_for="cpu")`
  — both test methods require an accelerator, so CPU variants are excluded
  at the instantiation layer rather than per-method `@onlyAccelerator`.
- Removed the now-unused `TEST_CUDA` import from `common_cuda` and `import
  unittest`.
- Added `instantiate_device_type_tests` import from `common_device_type`;
  added `HardwareClassification` import from `common_utils`.
- Added `device` parameter to both test methods (injected by
  `instantiate_device_type_tests`).
- Changed device acquisition from `torch.cuda.current_device()` (returns
  `int`) to `torch.device(device)` (framework-injected `torch.device`
  object).
- Added `hw_classification = HardwareClassification.ACCELERATOR` class
  attribute.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

| Infrastructure | Source PR | Status | Hard dependency? |
|---|---|---|---|
| SACEstimator device-agnostic fallbacks (triton, Event, ZeroDivision) | #193301 | Submitted | Yes (test fails without it on non-CUDA) |
| SACEstimator `clear_user_hooks` bugfix | #194708 | Submitted | Yes (test calls SACEstimator twice, fails without fix) |

Without #193301, `test_simple_model_sac_estimation` fails on non-CUDA
accelerators due to triton driver dependency and Event timing issues.
Without #194708, the second `SACEstimator` call raises
`AssertionError: Only one pre_fw_hook can be registered at a time`.

## Not changed

- `_sac_estimation` private helper is unchanged — it receives `model` and
  `inp` as parameters and does not directly use the device.
- The operation-count assertions in `test_simple_model_sac_estimation`
  (`view_like_ops`, `rand_ops`, `inplace_ops`) are unchanged.
- The `FakeTensorMode()` context and `SACEstimator` usage pattern are
  unchanged.
- The `Transformer` model and `ModelArgs` configuration are unchanged.
- The `Foo` model in `test_simple_model_sac_estimation` is unchanged.

## Test plan

- `python test/distributed/_tools/test_sac_estimator.py` on CUDA (A100,
  PyTorch 2.13.0a0, CUDA 12.8):
  `TestSACEstimatorCUDA.test_simple_model_sac_estimation_cuda` and
  `TestSACEstimatorCUDA.test_transformer_sac_estimation_cuda` both pass
  (`Ran 2 tests, OK`, 2.106s). No skips — `except_for="cpu"` correctly
  excludes only CPU variants. This confirms the refactoring does not
  break existing CUDA behavior.
- `python test/distributed/_tools/test_sac_estimator.py` on an out-of-tree
  accelerator backend (PrivateUse1, torch_npu 2.13.0+git45fbeae on
  PyTorch 2.13.0a0+gitfad7424, Ascend 910B3):
  `TestSACEstimatorPRIVATEUSE1.test_simple_model_sac_estimation_npu`
  passes (with common PR #193301 applied);
  `TestSACEstimatorPRIVATEUSE1.test_transformer_sac_estimation_npu`
  fails due to a FakeTensorMode `native_dropout_backward` decomposition
  shape mismatch when backward runs outside the SACEstimator context.
  This is a separate NPU PyTorch implementation issue (C++ dispatch layer,
  not fixable via Python-level common PR); a `@unittest.expectedFailure`
  patch in the torch_npu adaptation repo marks this variant. With the
  patch: `OK (expected failures=1)`.
- `python test/distributed/_tools/test_sac_estimator.py` on CPU (no
  accelerator): `OK (skipped=2)` — CPU variants excluded by
  `except_for="cpu"`.## Summary

Both tests in `test/distributed/_tools/test_sac_estimator.py`
(`test_transformer_sac_estimation` and `test_simple_model_sac_estimation`)
run under `FakeTensorMode` and use `SACEstimator` — a dispatch-level tool
that tracks operations regardless of the underlying device. The test
bodies are fully device-agnostic: they only need a device for fake-tensor
placement, not for actual hardware execution.

However, the admission gate is a hardcoded CUDA whitelist
(`@unittest.skipIf(not TEST_CUDA, "CUDA not available")`), and the device
is obtained via `torch.cuda.current_device()`. This wrongly skips the
tests on any other accelerator backend (e.g. out-of-tree PrivateUse1
backends) even though the test logic does not depend on CUDA-specific
functionality. In fact, `torch.cuda.current_device()` returns an `int`
that is passed to `torch.device(dev)`, which creates a CPU device —
meaning the original tests were effectively placing fake tensors on CPU,
and `TEST_CUDA` was only needed because `torch.cuda.current_device()`
requires CUDA to be available.

This PR replaces the whitelist with `@onlyAccelerator` +
`instantiate_device_type_tests`, adds a `device` parameter to both test
methods (framework-injected), replaces `torch.cuda.current_device()` with
`torch.device(device)`, removes the unused `TEST_CUDA` / `unittest`
imports, and adds a `hw_classification` label so the tests are correctly
selected by the `--hw-classification` CI filter.

## Changes

- Replaced `@unittest.skipIf(not TEST_CUDA, "CUDA not available")` with
  `@onlyAccelerator` on `test_transformer_sac_estimation` and
  `test_simple_model_sac_estimation`.
- Removed the now-unused `TEST_CUDA` import from `common_cuda` and `import
  unittest`.
- Added `instantiate_device_type_tests` and `onlyAccelerator` imports from
  `common_device_type`; added `HardwareClassification` import from
  `common_utils`.
- Added `device` parameter to both test methods (injected by
  `instantiate_device_type_tests`).
- Changed device acquisition from `torch.cuda.current_device()` (returns
  `int`) to `torch.device(device)` (framework-injected `torch.device`
  object).
- Added `hw_classification = HardwareClassification.ACCELERATOR` class
  attribute.
- Added `instantiate_device_type_tests(TestSACEstimator, globals())` at
  file end.

## Depends on

This PR relies on the following upstream PR (submitted but not yet merged):

- **#193301**: — fixes 4 CUDA-specific issues in SACEstimator's dependency chain (`get_gpu_dram_gbps` triton dependency, `elapsed_time` Event timing, ZeroDivision guard, and missing `clear_user_hooks` in `__exit__`).

Without this common PR, `test_simple_model_sac_estimation` fails on
non-CUDA accelerators due to triton driver dependency and Event timing
issues.

## Not changed

- `_sac_estimation` private helper is unchanged — it receives `model` and
  `inp` as parameters and does not directly use the device.
- The operation-count assertions in `test_simple_model_sac_estimation`
  (`view_like_ops`, `rand_ops`, `inplace_ops`) are unchanged. These are
  dispatch-level tracking results that are device-independent under
  `FakeTensorMode`.
- The `FakeTensorMode()` context and `SACEstimator` usage pattern are
  unchanged.
- The `Transformer` model and `ModelArgs` configuration are unchanged.
- The `Foo` model in `test_simple_model_sac_estimation` is unchanged.

## Test plan

- `python test/distributed/_tools/test_sac_estimator.py` on an out-of-tree
  accelerator backend (PrivateUse1, torch_npu 2.13.0+git45fbeae on
  PyTorch 2.13.0a0+gitfad7424, Ascend 910B3):
  `TestSACEstimatorPRIVATEUSE1.test_simple_model_sac_estimation_npu`
  passes (with the common PR applied);
  `TestSACEstimatorPRIVATEUSE1.test_transformer_sac_estimation_npu`
  fails due to a FakeTensorMode `native_dropout_backward` decomposition
  shape mismatch when backward runs outside the SACEstimator context.
  This is a separate NPU PyTorch implementation issue tracked in a
  torch_npu issue; a `@skipPRIVATEUSE1If` patch in the torch_npu
  adaptation repo skips this variant. With the skip patch:
  `OK (skipped=3)`.
- `python test/distributed/_tools/test_sac_estimator.py` on CPU (no
  accelerator):
  Both accelerator test variants are correctly skipped via
  `@onlyAccelerator` (`OK (skipped=2)`).
- `python test/distributed/_tools/test_sac_estimator.py` on CUDA (A100,
  PyTorch 2.13.0a0, CUDA 12.8):
  `TestSACEstimatorCUDA.test_simple_model_sac_estimation_cuda` and
  `TestSACEstimatorCUDA.test_transformer_sac_estimation_cuda` both pass
  (`OK (skipped=2)`, 11.028s).
  This confirms the refactoring does not break existing CUDA behavior.