### PR TITLE
Fix _scoped_library masking Library construction errors

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -797,6 +797,17 @@ class TestPythonRegistration(TestCase):
             with self.assertRaisesRegex(ValueError, "reserved namespace"):
                 my_lib1 = Library("prim", kind)  # noqa: SCOPED_LIBRARY
 
+        # _scoped_library must report the constructor's error rather than
+        # masking it while unwinding.
+        with self.assertRaisesRegex(ValueError, "Unsupported kind"):
+            with _scoped_library("myns", "BLA"):
+                pass
+
+        for kind in ("DEF", "FRAGMENT"):
+            with self.assertRaisesRegex(ValueError, "reserved namespace"):
+                with _scoped_library("prim", kind):
+                    pass
+
     def test_dispatcher_error_filenames(self) -> None:
         # Test that dispatcher errors report correct Python filenames and line numbers
         # when defining duplicate libraries (which triggers the filename tracking)

--- a/torch/library.py
+++ b/torch/library.py
@@ -678,8 +678,8 @@ def _del_library(
 
 @contextlib.contextmanager
 def _scoped_library(*args, **kwargs):
+    lib = Library(*args, **kwargs)
     try:
-        lib = Library(*args, **kwargs)
         yield lib
     finally:
         lib._destroy()


### PR DESCRIPTION
`torch.library._scoped_library` constructs the `Library` inside the `try` block whose `finally` calls `lib._destroy()`. When the constructor raises, `lib` is never bound, so the cleanup fails with `UnboundLocalError`, and that replaces the error explaining what actually went wrong.

Two constructor paths reach this today: an unsupported `kind`, and a reserved namespace such as `aten` or `prim`.

```python
from torch.library import _scoped_library, Library

Library("myns", "BLA")
# ValueError: Unsupported kind: BLA

with _scoped_library("myns", "BLA"):
    pass
# UnboundLocalError: cannot access local variable 'lib' where it is not associated with a value

with _scoped_library("aten", "DEF"):
    pass
# UnboundLocalError, in place of:
# ValueError: aten is a reserved namespace. Please try creating a library with another name.
```

Losing the reserved namespace message is the more costly case, since it is the one that tells a custom op author exactly what to change.

This is also the path contributors are directed toward: the `SCOPED_LIBRARY` lint in `.lintrunner.toml` requires tests to use `_scoped_library` rather than `Library()` directly.

### Fix

Construct the `Library` before the `try`. If construction fails there is nothing to destroy, so the original exception propagates unchanged. The success path is unaffected, and the library is still destroyed when the context exits.

### Testing

`TestPythonRegistration.test_error_for_unsupported_ns_or_kind` already covers both constructor errors for `Library`, so this extends it to assert the same errors surface through `_scoped_library`. The added assertions fail on current main with `UnboundLocalError` and pass with the fix. `test_autograd_fallback.py`, which uses `_scoped_library` throughout, is unaffected (28/28 passing).

Same defect class as #191395.

> Disclosure per AI_POLICY.md: this patch was prepared with AI assistance. I have read and understand the change and take responsibility for it.
