### PR TITLE
Validate lambd and alpha in ASGD

### DIFF
--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -44,6 +44,10 @@ class ASGD(Optimizer):
             raise ValueError("Tensor lr must be 1-element")
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr}")
+        if not 0.0 <= lambd:
+            raise ValueError(f"Invalid lambd value: {lambd}")
+        if not 0.0 <= alpha:
+            raise ValueError(f"Invalid alpha value: {alpha}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -834,6 +834,24 @@ def optim_error_inputs_func_asgd(device, dtype):
                 error_type=ValueError,
                 error_regex="Invalid weight_decay value: -0.5",
             ),
+            ErrorOptimizerInput(
+                OptimizerInput(
+                    params=None,
+                    kwargs=dict(lr=1e-2, lambd=-0.5),
+                    desc="lambd should > 0",
+                ),
+                error_type=ValueError,
+                error_regex="Invalid lambd value: -0.5",
+            ),
+            ErrorOptimizerInput(
+                OptimizerInput(
+                    params=None,
+                    kwargs=dict(lr=1e-2, alpha=-0.5),
+                    desc="alpha should > 0",
+                ),
+                error_type=ValueError,
+                error_regex="Invalid alpha value: -0.5",
+            ),
         ]
     return error_inputs
 


### PR DESCRIPTION
`ASGD.__init__` validates `lr` and `weight_decay`, but not `lambd` or `alpha`. Both feed the eta schedule in `_single_tensor_asgd`:

```python
eta = lr / ((1 + lambd * lr * step) ** alpha)
```

so a negative value for either is accepted at construction and only surfaces later, during training.

### Negative `lambd` crashes mid-run

The base `1 + lambd * lr * step` decreases as steps accumulate and eventually reaches zero:

```python
import torch
from torch import optim

p = torch.nn.Parameter(torch.zeros(1))
opt = optim.ASGD([p], lr=0.1, lambd=-1.0)   # accepted today
for _ in range(400):
    opt.zero_grad()
    (p - 1).pow(2).sum().backward()
    opt.step()
```

```
ZeroDivisionError: float division by zero
  File "torch/optim/asgd.py", line 271, in _single_tensor_asgd
    new_eta = torch.as_tensor(lr / ((1 + lambd * lr * step) ** alpha))
```

The failure arrives at step 10 of 400, from inside the optimizer, with nothing pointing back to the constructor argument that caused it.

### Negative `alpha` inverts the schedule

A negative exponent turns the decay into growth, so eta rises with each step rather than decaying. Over 400 steps at `lr=0.1`, eta goes to `0.1004` where the default configuration gives `0.0997`. It never errors, it just quietly optimizes with a schedule that is the wrong shape.

### Fix

Reject both at construction, alongside the existing `lr` and `weight_decay` checks. `RMSprop` already validates `alpha` with exactly this pattern, so the wording matches its message:

```python
if not 0.0 <= alpha:
    raise ValueError(f"Invalid alpha value: {alpha}")
```

### Testing

Added two `ErrorOptimizerInput` entries to `optim_error_inputs_func_asgd`, matching the existing `weight_decay` entry, so `TestOptimRenewed.test_errors` covers them. Both new cases fail on current main (no error raised) and pass with the change, while the six pre-existing ASGD construction cases are unaffected.

No in-tree caller passes a negative `lambd` or `alpha` to ASGD, and the defaults (`lambd=1e-4`, `alpha=0.75`) are unchanged.

> Disclosure per AI_POLICY.md: this patch was prepared with AI assistance. I have read and understand the change and take responsibility for it.
