### PR TITLE
Mark the triage target when a PreToolUse hook blocks a mutation

### DIFF
--- a/.claude/skills/triaging-issues/scripts/triage_marker.py
+++ b/.claude/skills/triaging-issues/scripts/triage_marker.py
@@ -1,0 +1,67 @@
+"""Mark the triage target when a PreToolUse hook blocks a mutation.
+
+A blocked mutation never reaches the tool, so the PostToolUse hook that applies
+`bot-triaged` never runs and the issue is left looking untouched. This module
+lets the blocking hooks leave their own marker so a blocked run stays
+distinguishable from a run that never happened.
+"""
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+
+BLOCKED_LABEL = "bot-triage-blocked"
+DEBUG_LOG = os.environ.get("TRIAGE_HOOK_DEBUG_LOG", "/tmp/triage_hooks.log")
+REPOSITORY_ENV = "GITHUB_REPOSITORY"
+ISSUE_ENV = "TRIAGE_ISSUE_NUMBER"
+
+
+def _log(message: str) -> None:
+    formatted = f"[{datetime.now().isoformat()}] [BlockedMarker] {message}"
+    try:
+        with open(DEBUG_LOG, "a") as log:
+            log.write(formatted + "\n")
+    except OSError:
+        pass
+    if os.environ.get("TRIAGE_HOOK_VERBOSE"):
+        print(f"[DEBUG] {formatted}", file=sys.stderr)
+
+
+def mark_blocked(reason: str) -> None:
+    """Best-effort label of the workflow-selected issue. Never raises.
+
+    The target comes from the environment, never from tool_input: a mutation can
+    be blocked precisely because it named a target the workflow did not choose,
+    so the requested one is the one value here that cannot be trusted.
+    """
+    try:
+        repository = os.environ.get(REPOSITORY_ENV, "")
+        issue_number = os.environ.get(ISSUE_ENV, "")
+        if repository.count("/") != 1 or not issue_number.isdigit():
+            # Without a trusted target there is nothing safe to label.
+            _log(f"No trusted target to mark ({reason}); leaving log-only")
+            return
+
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "edit",
+                issue_number,
+                "--repo",
+                repository,
+                "--add-label",
+                BLOCKED_LABEL,
+            ],
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+        _log(
+            f"Marked {repository}#{issue_number} as blocked ({reason}); "
+            f"gh exit {result.returncode}: {result.stderr.decode().strip()}"
+        )
+    except Exception as error:  # never let marking change the block itself
+        _log(f"Could not mark blocked run: {type(error).__name__}: {error}")

--- a/.claude/skills/triaging-issues/scripts/validate_issue_target.py
+++ b/.claude/skills/triaging-issues/scripts/validate_issue_target.py
@@ -6,6 +6,8 @@ import os
 import sys
 from datetime import datetime
 
+from triage_marker import mark_blocked
+
 
 DEBUG_LOG = os.environ.get("TRIAGE_HOOK_DEBUG_LOG", "/tmp/triage_hooks.log")
 REPOSITORY_ENV = "GITHUB_REPOSITORY"
@@ -80,6 +82,7 @@ def main() -> None:
             )
     except Exception as error:
         debug_log(f"Blocked mutation: {type(error).__name__}: {error}")
+        mark_blocked(f"target hook: {type(error).__name__}")
         print(f"Blocked issue mutation: {error}", file=sys.stderr)
         sys.exit(2)
 

--- a/.claude/skills/triaging-issues/scripts/validate_labels.py
+++ b/.claude/skills/triaging-issues/scripts/validate_labels.py
@@ -22,6 +22,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from triage_marker import mark_blocked
+
 
 DEBUG_LOG = os.environ.get("TRIAGE_HOOK_DEBUG_LOG", "/tmp/triage_hooks.log")
 SCRIPT_DIR = Path(__file__).parent
@@ -228,6 +230,7 @@ def main():
 
     except json.JSONDecodeError as e:
         debug_log(f"JSON decode error: {e}")
+        mark_blocked("labels hook: invalid JSON input")
         print(f"Hook error: Invalid JSON input: {e}", file=sys.stderr)
         print(
             "Hook was unable to validate labels; stopping triage.",
@@ -236,6 +239,7 @@ def main():
         sys.exit(2)
     except Exception as e:
         debug_log(f"Unexpected error: {type(e).__name__}: {e}")
+        mark_blocked(f"labels hook: {type(e).__name__}")
         print(f"Hook error: {e}", file=sys.stderr)
         print(
             "Hook was unable to validate labels; stopping triage.",


### PR DESCRIPTION
Follow-up to #193060, per @bobrenjc93's suggestion there. **Draft: this needs a repo label created before it can work, and the shape is up for discussion — see "Open questions" below.**

### The remaining gap

#193060 removed the main path by which a triage run left no trace. What remains: a *blocked* mutation is still indistinguishable from a run that never happened. `add_bot_triaged.py` is a `PostToolUse` hook, so a call blocked by a `PreToolUse` hook never reaches the tool, the post-hook never fires, and the issue keeps no marker at all.

Simulating the hook chain showed something that changes the fix from the one sketched on #193060: **every remaining unmarked case is blocked by `validate_issue_target.py`, not the labels hook.** It runs first, so it catches malformed JSON and a missing `issue_number` before `validate_labels.py` ever sees them. The marker therefore has to be left by the blocking hooks — extending `add_bot_triaged.py` could not have covered these, because a `PostToolUse` hook cannot observe a call that never happened.

### The change

`triage_marker.mark_blocked()`, called from both `PreToolUse` hooks before they `exit(2)`.

**A distinct `bot-triage-blocked` label, not `bot-triaged`.** `bot-triaged` is carried by ~3,300 issues and is the signal used to audit what the bot decided. Stamping it on runs where the bot decided *nothing* would trade one blind spot for a noisier signal. A separate label keeps "ran and was blocked", "ran and succeeded", and "never ran" all distinguishable, following the precedent of `bot-mislabeled`.

**It labels the target from `GITHUB_REPOSITORY`/`TRIAGE_ISSUE_NUMBER`, never the one in `tool_input`.** A mutation can be blocked precisely because it named a target the workflow did not select, so the requested target is the one value here that cannot be trusted. When the environment carries no usable target there is nothing safe to label, so that case stays log-only rather than guessing.

Marking is best-effort and never raises, so it cannot turn a blocked call into a crash or change which calls are blocked.

### Test plan

The hooks read a tool call on stdin and signal through the exit code, so the chain can be simulated end to end, with `gh` stubbed on `PATH` so nothing mutates a real issue:

```
=== trusted target present ===
  successful triage              allowed         exit=0  marker=bot-triaged
  all labels invented            allowed         exit=0  marker=bot-triaged
  wrong issue targeted           BLOCKED(target) exit=2  marker=bot-triage-blocked
  wrong repo targeted            BLOCKED(target) exit=2  marker=bot-triage-blocked
  malformed JSON                 BLOCKED(target) exit=2  marker=bot-triage-blocked
  missing issue_number           BLOCKED(target) exit=2  marker=bot-triage-blocked

=== no trusted target in env (must stay log-only, never guess) ===
  wrong repo targeted            BLOCKED(target) exit=2  marker=NONE
  malformed JSON                 BLOCKED(target) exit=2  marker=NONE

=== marker must never label the REQUESTED target ===
  gh calls made while blocking a mutation aimed at evil/repo#191579:
    gh issue edit 191579 --repo pytorch/pytorch --add-label bot-triage-blocked
```

Every previously blocking path still exits 2, and the allowed paths are unchanged, including the fallback added in #193060.

### Open questions

1. **The `bot-triage-blocked` label has to be created in the repo** — I can't do that. Until it exists, `gh issue edit --add-label` will fail; that failure is caught and logged rather than crashing the hook, but the marker won't land. Happy to use a different name.
2. **Is a second label the right call at all**, or would you rather keep the vocabulary tight and accept the conflation with `bot-triaged`?
3. `add_bot_triaged.py` and `triage_marker.py` now both shell out to `gh` to add a label. I kept them separate to hold the diff down, but they could share one helper if you'd prefer.

---

This change was prepared with assistance from an AI coding assistant (Claude Code). I reviewed the diff and the test results before submitting.
