### PR TITLE
[testing] Honor unittest -k in subprocess test runs

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest.mock
 from typing import Any
 from collections.abc import Callable
@@ -559,6 +560,45 @@ instantiate_device_type_tests(TestTesting, globals())
 
 
 class TestFrameworkUtils(TestCase):
+
+    def test_subprocess_respects_unittest_k_filter(self):
+        test_source = """\
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class SubprocessFilterFixture(TestCase):
+    def test_selected(self):
+        pass
+
+    def test_other(self):
+        raise AssertionError("UNSELECTED_SENTINEL")
+
+
+if __name__ == "__main__":
+    run_tests()
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "subprocess_filter_fixture.py")
+            with open(test_file, "w", encoding="utf-8") as f:
+                f.write(test_source)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    test_file,
+                    "--subprocess",
+                    "-k",
+                    "test_selected",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(
+            "UNSELECTED_SENTINEL", result.stdout + result.stderr
+        )
 
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
     @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1409,6 +1409,16 @@ def get_pytest_test_cases(argv: list[str]) -> list[str]:
     return test_collector_plugin.tests
 
 
+def _get_unittest_test_name_patterns(argv: list[str]) -> list[str]:
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("-k", action="append", default=[])
+    args, _ = parser.parse_known_args(argv[1:])
+    return [
+        pattern if "*" in pattern else f"*{pattern}*"
+        for pattern in args.k
+    ]
+
+
 class HardwareClassificationTestLoader(unittest.TestLoader):
     """Unittest TestLoader that filters loaded tests by hw_classification."""
     def __init__(self, hw_classification):
@@ -1505,6 +1515,11 @@ def run_tests(argv=None):
         ]
 
     if TEST_IN_SUBPROCESS:
+        test_name_patterns = _get_unittest_test_name_patterns(argv)
+        if test_name_patterns:
+            if HW_CLASSIFICATION is None:
+                testLoader = unittest.TestLoader()
+            testLoader.testNamePatterns = test_name_patterns
         suite = testLoader.loadTestsFromModule(__main__)
         other_args = []
         if DISABLED_TESTS_FILE:


### PR DESCRIPTION
Fixes #88408.

`run_tests(--subprocess -k PATTERN)` currently builds its parent subprocess
suite without applying unittest's name patterns, so it launches unselected
tests. Apply the parsed `-k` patterns to the loader before constructing that
suite, preserving unittest's substring and wildcard behavior. Use a fresh
default loader so the filter cannot persist across runs.

The regression test creates a two-case fixture whose unselected case fails, and
verifies that `--subprocess -k test_selected` launches only the selected case.

- [x] The issue is linked.
- [x] Tests cover the changed behavior.
- [x] No backward-incompatible public API change.

> **AI assistance disclosure:** Codex helped prepare the change, tests, and this
> PR summary.

**Human commentary:** I reviewed and verified this contribution end to end before authorizing submission.
