### PR TITLE
[Testcase Refactoring] Add hw_classification=GENERIC to TestComplement

### DIFF
--- a/test/distributed/_pycute/test_complement.py
+++ b/test/distributed/_pycute/test_complement.py
@@ -40,13 +40,19 @@ Unit tests for _pycute.complement
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class TestComplement(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def helper_test_complement(self, layout):
         layoutR = complement(layout)
 


### PR DESCRIPTION
## Summary

`TestComplement` in `test/distributed/_pycute/test_complement.py` is a pure
layout algebra test — it verifies that `complement(layout)` produces a
layout whose codomain is disjoint from the original layout's codomain
across 10 different `Layout` configurations. The test has no device
dependency: no `torch.cuda.*` calls, no `device` parameter, no
`instantiate_device_type_tests`, and no accelerator admission gates.
The `Layout`, `complement`, and `size` functions imported from
`torch.distributed._pycute` are pure Python/CPU layout math with no
device-specific behavior.

This PR adds `hw_classification = HardwareClassification.GENERIC` so the
test class is correctly selected by the `--hw-classification` CI filter.
Without the label, the test is effectively dead code in the CI pipeline
(tests without `hw_classification` are not executed).

## Changes

- Imported `HardwareClassification` from
  `torch.testing._internal.common_utils`.
- Added `hw_classification = HardwareClassification.GENERIC` class
  attribute to `TestComplement`.

No test body, assertions, or instantiation mechanism modified.

## Test plan

- `python test/distributed/_pycute/test_complement.py` on an
  out-of-tree accelerator backend container (torch_npu 2.13.0+git45fbeae
  on PyTorch 2.13.0a0+gitfad7424, Ascend 910B3):
  `TestComplement.test_complement` passes
  (`OK`, 1 test in 0.005s).
  This is a pure layout algebra test with no device dependency; it runs
  identically on CPU, CUDA, and any out-of-tree accelerator backend.