### PR TITLE
[docs] Remove unsupported out argument from torch.linalg._powsum

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -3129,7 +3129,7 @@ Examples::
 _powsum = _add_docstr(
     _linalg.linalg__powsum,
     r"""
-linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
+linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None) -> Tensor
 
 Computes the sum of the absolute values raised to the power ``ord``.
 
@@ -3151,8 +3151,6 @@ Keyword args:
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
           If specified, the input tensor is cast to :attr:`dtype` before the operation
           is performed. Default: ``None``.
-    out (Tensor, optional): output tensor. Ignored if ``None``. Default: ``None``.
-
 Returns:
     A real-valued tensor, even when :attr:`x` is complex.
 


### PR DESCRIPTION
Fixes #180649

The public docstring for `torch.linalg._powsum` advertised an `out` keyword in both its displayed signature and keyword-argument section. The underlying `aten::linalg__powsum` schema does not define an out variant, so copying the documented call raises `TypeError`.

This docs-only change removes that unsupported keyword from the two authoritative docstring locations. Operator behavior and schemas are unchanged.

Validation:
- `python -m py_compile torch/linalg/__init__.py`
- focused docstring contract check confirms the `_powsum` block no longer advertises `out`
- `git diff --check`