### PR TITLE
[Testcase Refactoring] Add hardware classification to data scheduler tests

### DIFF
--- a/test/ao/sparsity/test_data_scheduler.py
+++ b/test/ao/sparsity/test_data_scheduler.py
@@ -7,7 +7,11 @@ import torch
 from torch import nn
 from torch.ao.pruning._experimental.data_scheduler import BaseDataScheduler
 from torch.ao.pruning._experimental.data_sparsifier import DataNormSparsifier
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ImplementedDataScheduler(BaseDataScheduler):
@@ -25,6 +29,8 @@ class ImplementedDataScheduler(BaseDataScheduler):
 
 
 class TestBaseDataScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_data(self):
         tensor1, param1, emb1 = (
             torch.randn(5, 5),


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestBaseDataScheduler` in `test/ao/sparsity/test_data_scheduler.py` covers data sparsifier scheduler construction and step behavior. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestBaseDataScheduler`.
- Keep all test methods and their behavior unchanged.

## Self-test

```bash
python -m pytest -vv -ra test/ao/sparsity/test_data_scheduler.py
python -m pytest -vv -ra test/ao/sparsity/test_data_scheduler.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_data_scheduler.py
```

Expected: all collected tests pass; GENERIC filter reports unclassified=0, mismatched=0; collected set unchanged.

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.

Made with [Cursor](https://cursor.com)