### PR TITLE
[Testcase Refactoring] Add hardware classification to sparsity parametrization tests

### DIFF
--- a/test/ao/sparsity/test_parametrization.py
+++ b/test/ao/sparsity/test_parametrization.py
@@ -5,7 +5,11 @@ import torch
 from torch import nn
 from torch.ao.pruning.sparsifier import utils
 from torch.nn.utils import parametrize
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ModelUnderTest(nn.Module):
@@ -32,6 +36,8 @@ class ModelUnderTest(nn.Module):
 
 
 class TestFakeSparsity(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_masking_logic(self):
         model = nn.Linear(16, 16, bias=False)
         model.weight = nn.Parameter(torch.eye(16))


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestFakeSparsity` in `test/ao/sparsity/test_parametrization.py` covers FakeSparsity masking and parametrization behavior. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestFakeSparsity`.
- Keep all test methods and their behavior unchanged.

## Self-test

```bash
python -m pytest -vv -ra test/ao/sparsity/test_parametrization.py
python -m pytest -vv -ra test/ao/sparsity/test_parametrization.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_parametrization.py
```

Expected: all collected tests pass; GENERIC filter reports unclassified=0, mismatched=0; collected set unchanged.

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.

Made with [Cursor](https://cursor.com)