### PR TITLE
[Testcase Refactoring] Add hardware classification to activation sparsifier tests

### DIFF
--- a/test/ao/sparsity/test_activation_sparsifier.py
+++ b/test/ao/sparsity/test_activation_sparsifier.py
@@ -10,6 +10,7 @@ from torch.ao.pruning._experimental.activation_sparsifier.activation_sparsifier 
 )
 from torch.ao.pruning.sparsifier.utils import module_to_fqn
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     raise_on_run_directly,
     skipIfTorchDynamo,
     TestCase,
@@ -43,6 +44,8 @@ class Model(nn.Module):
 
 
 class TestActivationSparsifier(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _check_constructor(self, activation_sparsifier, model, defaults, sparse_config):
         """Helper function to check if the model, defaults and sparse_config are loaded correctly
         in the activation sparsifier


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestActivationSparsifier` in `test/ao/sparsity/test_activation_sparsifier.py` covers activation sparsifier construction and apply behavior. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestActivationSparsifier`.
- Keep all test methods and their behavior unchanged.

## Self-test

```bash
python -m pytest -vv -ra test/ao/sparsity/test_activation_sparsifier.py
python -m pytest -vv -ra test/ao/sparsity/test_activation_sparsifier.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_activation_sparsifier.py
```

Expected: all collected tests pass; GENERIC filter reports unclassified=0, mismatched=0; collected set unchanged.

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.

Made with [Cursor](https://cursor.com)