### PR TITLE
[Testcase Refactoring] Add hardware classification to quantized sparse kernel tests

### DIFF
--- a/test/ao/sparsity/test_kernels.py
+++ b/test/ao/sparsity/test_kernels.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_quantized import (
     qengine_is_x86,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     raise_on_run_directly,
     skipIfTorchDynamo,
     TestCase,
@@ -32,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestQuantizedSparseKernels(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
     @override_qengines
     def test_sparse_qlinear(self):
@@ -262,6 +265,8 @@ class SparseQuantizedModel(nn.Module):
 
 
 class TestQuantizedSparseLayers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @override_qengines
     def test_sparse_qlinear(self):
         # Note: At the moment, for sparse kernels


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so that test selection can distinguish device-agnostic framework tests from accelerator or device-specific tests.

`TestQuantizedSparseKernels` and `TestQuantizedSparseLayers` in `test/ao/sparsity/test_kernels.py` cover quantized sparse linear kernels and layers. The tests do not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. Therefore, no hardware decoupling or class split is required, and both classes are classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestQuantizedSparseKernels` and `TestQuantizedSparseLayers`.
- Keep all test methods and their behavior unchanged.

## Self-test

```bash
python -m pytest -vv -ra test/ao/sparsity/test_kernels.py
python -m pytest -vv -ra test/ao/sparsity/test_kernels.py --hw-classification GENERIC
python -m pytest --collect-only -q test/ao/sparsity/test_kernels.py
```

Expected: all collected tests pass; GENERIC filter reports unclassified=0, mismatched=0; collected set unchanged.

## Risks

Low. This change only adds test metadata. It does not modify test logic, product code, device placement, or the collected test set.

Made with [Cursor](https://cursor.com)