### PR TITLE
[ROCm] Add acquire fence in the last block of cross-CTA reduction

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -817,8 +817,16 @@ struct ReduceOp {
     bool is_last_block_done = mark_block_finished();
 
     if (is_last_block_done) {
-#ifndef USE_ROCM // skip fence if store are committed [CMTSTRS]
+#ifndef USE_ROCM
       __threadfence(); // complete the acquire pattern after atomic
+#else
+      // On ROCm the producer blocks use committed stores (cmtdStore) instead of
+      // a __threadfence() to make their staging writes visible ([CMTSTRS]). That
+      // covers the release side, but the last block still needs an acquire fence
+      // to invalidate its (non-coherent) L1 before reading the staging buffer;
+      // otherwise it can observe stale/torn partial results. A single fence here
+      // is far cheaper than issuing per-element coherent loads.
+      __threadfence();
 #endif
       for (auto &v : value) {
         v = ident;


### PR DESCRIPTION
## Summary

On ROCm, the cross-CTA reduction path (`global_reduce` in `Reduce.cuh`) replaces the upstream `__threadfence()` calls with committed stores (`cmtdStore`) to avoid costly global fences (`[CMTSTRS]`). The committed store correctly handles the release/visibility side on the producer blocks, but the acquire side was also elided on ROCm: the last block (`is_last_block_done`) read the staging buffer with ordinary loads and no fence.

Because the per-CU L1 vector cache is not coherent across CUs, the last block could occasionally read a stale (or partially updated / torn) cache line for a staging slot and combine a garbage partial result. For index-carrying reductions (argmax/argmin, and max/min with indices) this surfaced as rare, out-of-range output indices. The failure was low-probability and independent of the input values, which is consistent with a memory-visibility race rather than a numerical bug.

## Fix

Issue a single `__threadfence()` in the last block, before it reads the staging buffer, to complete the acquire pattern and invalidate the L1. The producer-side committed-store optimization is retained, so only the missing consumer-side acquire is added.

An earlier attempt used per-element coherent (agent-scoped atomic) loads of the staging buffer; that was correct but regressed performance. A single fence in the last block restores correctness while keeping the committed-store fast path.

## Impact

- Fixes rare incorrect indices from argmax/argmin/max/min on ROCm for large inner-dimension reductions that take the multi-CTA path.
- One extra fence per output on the final block only; common single-block reductions are unaffected.
- NVIDIA code path and behavior are unchanged (the `#ifndef USE_ROCM` branch keeps the original fence and comment).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @xinyazhang
