### PR TITLE
[Testcase Refactoring]Add hw_classification label to test_composition.py

### DIFF
--- a/test/distributed/_pycute/test_composition.py
+++ b/test/distributed/_pycute/test_composition.py
@@ -40,13 +40,19 @@ Unit tests for _pycute.composition
 import logging
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class TestComposition(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def helper_test_composition(self, layoutA, layoutB):
         layoutR = composition(layoutA, layoutB)
 


### PR DESCRIPTION
## Summary

`test/distributed/_pycute/test_composition.py` contains unit tests for the `_pycute.composition` layout algebra function. The test class `TestComposition` is fully device-agnostic — it creates `Layout` objects and verifies the composition post-condition `R(c) = A(B(c))` using pure Python logic, with no tensor creation, no device API calls, and no `device` parameter.

However, the test class lacks a `hw_classification` label. Without this label, the test is not selected by the `--hw-classification` CI filter and is effectively dead code in the CI pipeline.

This PR adds `hw_classification = HardwareClassification.GENERIC` to `TestComposition`, making it correctly selected by the Nightly CI.

## Changes

- Added `HardwareClassification` to the imports from `torch.testing._internal.common_utils` (alphabetically ordered).
- Added `hw_classification = HardwareClassification.GENERIC` class attribute to `TestComposition`.

## Test plan

- NPU (Ascend 910B3, torch_npu 2.13.0): `OK` (1 test passed)
- CPU: `OK` (1 test passed)
- CUDA: pre-existing torch import issue (`bcomplex32` circular import) in the environment, unrelated to this change.