### PR TITLE
[Testcase Refactoring] Add hw_classification label to test_int_tuple.py

### DIFF
--- a/test/distributed/_pycute/test_int_tuple.py
+++ b/test/distributed/_pycute/test_int_tuple.py
@@ -38,10 +38,16 @@ Unit tests for _pycute.int_tuple
 """
 
 from torch.distributed._pycute import *
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestIntTuple(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_product(self):
         self.assertEqual(product(2), 2)
 


### PR DESCRIPTION
## Summary

`test/distributed/_pycute/test_int_tuple.py` contains 12 unit tests for the
`_pycute.int_tuple` module's pure-Python integer/tuple utility functions
(`product`, `inner_product`, `shape_div`, `suffix_product`, `crd2idx`,
`idx2crd`). These tests operate exclusively on Python `int` and `tuple`
objects — they create no tensors, reference no device, and depend on no
accelerator-specific behavior.

However, the class is missing a `hw_classification` label. Without this
label, the test class is not selected by the `--hw-classification` CI filter
and is effectively dead code in the CI pipeline.

This PR adds the `HardwareClassification.GENERIC` label to `TestIntTuple`,
making it correctly selectable by the nightly CI
(`--hw-classification ACCELERATOR,GENERIC`).

## Changes

- Added `HardwareClassification` to the import from
  `torch.testing._internal.common_utils`.
- Added `hw_classification = HardwareClassification.GENERIC` class attribute
  to `TestIntTuple`.

## Test plan

- `ruff check test/distributed/_pycute/test_int_tuple.py` on CPU: `All checks passed!`
- `python test/distributed/_pycute/test_int_tuple.py` on CPU: `Ran 12 tests ... OK`
EOF
)"