### PR TITLE
[Test] Add support for privateuse1 backend in C++ API parity tests

### DIFF
--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -343,7 +343,10 @@ def compute_arg_dict(test_params_dict, test_instance):
 def decorate_test_fn(test_fn, test_cuda, has_impl_parity, device):
     if device == "cuda":
         test_fn = unittest.skipIf(not TEST_CUDA, "CUDA unavailable")(test_fn)
-        test_fn = unittest.skipIf(not test_cuda, "Excluded from CUDA tests")(test_fn)
+    if device != "cpu":
+        test_fn = unittest.skipIf(
+            not test_cuda, "Excluded from accelerator tests"
+        )(test_fn)
 
     # If `Implementation Parity` entry in parity table for this module is `No`,
     # or `has_parity` entry in test params dict is `False`, we mark the test as

--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -344,9 +344,9 @@ def decorate_test_fn(test_fn, test_cuda, has_impl_parity, device):
     if device == "cuda":
         test_fn = unittest.skipIf(not TEST_CUDA, "CUDA unavailable")(test_fn)
     if device != "cpu":
-        test_fn = unittest.skipIf(
-            not test_cuda, "Excluded from accelerator tests"
-        )(test_fn)
+        test_fn = unittest.skipIf(not test_cuda, "Excluded from accelerator tests")(
+            test_fn
+        )
 
     # If `Implementation Parity` entry in parity table for this module is `No`,
     # or `has_parity` entry in test params dict is `False`, we mark the test as

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -21,6 +21,8 @@ import torch.testing._internal.common_utils as common
 PRINT_CPP_SOURCE = False
 
 devices = ["cpu", "cuda"]
+if torch._utils._is_privateuse1_backend_available():
+    devices.append(torch._C._get_privateuse1_backend_name())
 
 PARITY_TABLE_PATH = os.path.join(
     os.path.dirname(__file__), "cpp_api_parity", "parity-tracker.md"
@@ -75,19 +77,21 @@ if _test_torch_nn_count != _expected_count:
     )
 
 # Assert that there exists auto-generated tests for `SampleModule` and `sample_functional`.
-# 4 == 2 (number of test dicts that are not skipped) * 2 (number of devices)
+# 2 (number of test dicts that are not skipped) * len(devices)
 _sample_module_count = len(
     [name for name in TestCppApiParity.__dict__ if "SampleModule" in name]
 )
-if _sample_module_count != 4:
-    raise AssertionError(f"expected 4 SampleModule tests, got {_sample_module_count}")
-# 4 == 2 (number of test dicts that are not skipped) * 2 (number of devices)
+if _sample_module_count != 2 * len(devices):
+    raise AssertionError(
+        f"expected {2 * len(devices)} SampleModule tests, got {_sample_module_count}"
+    )
+# 2 (number of test dicts that are not skipped) * len(devices)
 _sample_functional_count = len(
     [name for name in TestCppApiParity.__dict__ if "sample_functional" in name]
 )
-if _sample_functional_count != 4:
+if _sample_functional_count != 2 * len(devices):
     raise AssertionError(
-        f"expected 4 sample_functional tests, got {_sample_functional_count}"
+        f"expected {2 * len(devices)} sample_functional tests, got {_sample_functional_count}"
     )
 
 module_impl_check.build_cpp_tests(TestCppApiParity, print_cpp_source=PRINT_CPP_SOURCE)

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -21,8 +21,8 @@ import torch.testing._internal.common_utils as common
 PRINT_CPP_SOURCE = False
 
 devices = ["cpu", "cuda"]
-if torch._utils._is_privateuse1_backend_available():
-    devices.append(torch._C._get_privateuse1_backend_name())
+if common.TEST_PRIVATEUSE1:
+    devices.append(common.TEST_PRIVATEUSE1_DEVICE_TYPE)
 
 PARITY_TABLE_PATH = os.path.join(
     os.path.dirname(__file__), "cpp_api_parity", "parity-tracker.md"
@@ -77,21 +77,21 @@ if _test_torch_nn_count != _expected_count:
     )
 
 # Assert that there exists auto-generated tests for `SampleModule` and `sample_functional`.
-# 2 (number of test dicts that are not skipped) * len(devices)
+# 2 == number of test dicts that are not skipped
+_expected_sample_count = 2 * len(devices)
 _sample_module_count = len(
     [name for name in TestCppApiParity.__dict__ if "SampleModule" in name]
 )
-if _sample_module_count != 2 * len(devices):
+if _sample_module_count != _expected_sample_count:
     raise AssertionError(
-        f"expected {2 * len(devices)} SampleModule tests, got {_sample_module_count}"
+        f"expected {_expected_sample_count} SampleModule tests, got {_sample_module_count}"
     )
-# 2 (number of test dicts that are not skipped) * len(devices)
 _sample_functional_count = len(
     [name for name in TestCppApiParity.__dict__ if "sample_functional" in name]
 )
-if _sample_functional_count != 2 * len(devices):
+if _sample_functional_count != _expected_sample_count:
     raise AssertionError(
-        f"expected {2 * len(devices)} sample_functional tests, got {_sample_functional_count}"
+        f"expected {_expected_sample_count} sample_functional tests, got {_sample_functional_count}"
     )
 
 module_impl_check.build_cpp_tests(TestCppApiParity, print_cpp_source=PRINT_CPP_SOURCE)


### PR DESCRIPTION
## Summary
Make test_cpp_api_parity.py device-agnostic so the C++ API parity tests also run on privateuse1 (out-of-tree) backends.

- `devices` now appends the privateuse1 backend name when one is registered and available (e.g. `["cpu", "cuda", "privateuseone"]`).
- Updated the auto-generated test count assertions to use `len(devices)` so they stay correct as the device list varies per machine.