### PR TITLE
Fix bytes_to_scalar for float/complex on RISC-V

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5977,27 +5977,19 @@ def bytes_to_scalar(byte_list: list[int], dtype: torch.dtype, device: torch.devi
             if not (0 <= byte <= 255):
                 raise AssertionError(f"byte value out of range: expected 0 <= byte <= 255, got {byte}")
 
-    if dtype.is_complex:
-        if len(byte_list) != (num_bytes * 2):
-            raise AssertionError(
-                f"expected len(byte_list) == {num_bytes * 2} for complex dtype, got {len(byte_list)}"
-            )
-        check_bytes(byte_list)
-        real = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list[:num_bytes])).value
-        imag = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list[num_bytes:])).value
-        res = real + 1j * imag
-    else:
-        if len(byte_list) != num_bytes:
-            raise AssertionError(
-                f"expected len(byte_list) == {num_bytes}, got {len(byte_list)}"
-            )
-        check_bytes(byte_list)
-        res = ctype.from_buffer((ctypes.c_byte * num_bytes)(
-            *byte_list)).value
+    expected_len = num_bytes * 2 if dtype.is_complex else num_bytes
+    if len(byte_list) != expected_len:
+        raise AssertionError(
+            f"expected len(byte_list) == {expected_len}"
+            f"{' for complex dtype' if dtype.is_complex else ''}, got {len(byte_list)}"
+        )
+    check_bytes(byte_list)
 
-    return torch.tensor(res, device=device, dtype=dtype)
+    # Reinterpret the raw bytes as the target dtype to preserve exact bit
+    # patterns (e.g. NaN payloads, which are not preserved when round-tripping
+    # through Python float/complex, especially on architectures like RISC-V
+    # that canonicalize NaNs).
+    return torch.tensor(byte_list, dtype=torch.uint8, device=device).view(dtype=dtype).squeeze(0)
 
 
 def copy_func(f):


### PR DESCRIPTION
bytes_to_scalar previously round-tripped raw bytes through Python float/complex values (via ctypes) before constructing the tensor. This loses NaN bit patterns on architectures (such as RISC-V) that canonicalize NaNs in floating-point loads/conversions, causing test_bytes_to_scalar_cpu_{float32,float64,complex64,complex128} to fail with mismatched storage bytes.

Construct the scalar tensor by writing the raw bytes directly into its untyped storage so all input bit patterns (including NaN payloads) are preserved exactly.

Tested python test/test_torch.py TestTorchDeviceTypeCPU.test_bytes_to_scalar_cpu_complex64 with sg2044, pass.