### PR TITLE
[ROCm][CI] Bring ROCm inductor benchmark jobs to parity with the CUDA ones

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -201,6 +201,22 @@ function install_torchvision() {
   fi
 }
 
+# Each ROCm CI build environment runs its tests on a single GPU family, so
+# companion wheels only need that one gfx target rather than the multi-arch
+# PYTORCH_ROCM_ARCH baked into the image. Prints nothing when the build
+# environment does not identify a target, in which case callers must keep the
+# image default -- a wheel missing the arch under test fails at kernel launch,
+# not at build time.
+function rocm_target_arch() {
+  case "${BUILD_ENVIRONMENT}" in
+    *mi200*|*mi210*) echo "gfx90a" ;;
+    *mi300*) echo "gfx942" ;;
+    *mi35*) echo "gfx950" ;;  # whole MI350 series, MI350X and MI355X alike
+    *navi31*) echo "gfx1100" ;;
+    *) echo "" ;;
+  esac
+}
+
 function install_fbgemm() {
   local build_variant=$1
 
@@ -240,11 +256,12 @@ function install_fbgemm() {
     # the CUID hash, giving each object a distinct __hip_cuid. Inline (not exported) and
     # scoped to the ROCm build so it does not affect the PyTorch build (already built).
     if [[ "${build_variant}" == "rocm" ]]; then
-      # The inductor-periodic ROCm benchmark job runs its tests only on MI350
-      # (gfx950), so build fbgemm for that single arch instead of the image's
-      # multi-arch default to cut build time.
-      if [[ "${GITHUB_WORKFLOW}" == "inductor-periodic" ]]; then
-        SCCACHE_RECACHE=1 PYTORCH_ROCM_ARCH="gfx950" python setup.py bdist_wheel --build-target=default --build-variant="${build_variant}"
+      # Build for just the arch this job tests on instead of the image's
+      # multi-arch default, to cut build time.
+      local target_arch
+      target_arch=$(rocm_target_arch)
+      if [[ -n "${target_arch}" ]]; then
+        SCCACHE_RECACHE=1 PYTORCH_ROCM_ARCH="${target_arch}" python setup.py bdist_wheel --build-target=default --build-variant="${build_variant}"
       else
         SCCACHE_RECACHE=1 python setup.py bdist_wheel --build-target=default --build-variant="${build_variant}"
       fi

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -193,6 +193,19 @@ function install_torchvision() {
     # Not sure if both are needed, but why not
     export FORCE_CUDA=1
     export WITH_CUDA=1
+  elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+    # Build jobs run on headless CPU runners, so torch.cuda.is_available() is
+    # false even with a ROCm PyTorch wheel. Without FORCE_CUDA, torchvision
+    # picks CppExtension while hipify still emits *_hip.cpp beside the
+    # originals, and both vision.cpp and vision_hip.cpp define
+    # vision::cuda_version() -> link failure. FORCE_CUDA selects
+    # CUDAExtension, which deduplicates hip sources. See pytorch/vision#9298.
+    export FORCE_CUDA=1
+    local target_arch
+    target_arch=$(rocm_target_arch)
+    if [[ -n "${target_arch}" ]]; then
+      export PYTORCH_ROCM_ARCH="${target_arch}"
+    fi
   fi
   retry pip_build_and_install "git+https://github.com/pytorch/vision.git@${commit}" dist/vision
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -63,6 +63,18 @@ on:
         required: false
         type: number
         default: 1
+      export-profiler-trace:
+        description: |
+          If set to "1", export Chrome profiler traces from performance benchmarks.
+        required: false
+        type: string
+        default: ""
+      enable-torch-trace:
+        description: |
+          If set to "1", enable TORCH_TRACE structured logging and collect tlparse output.
+        required: false
+        type: string
+        default: ""
     secrets:
       HUGGING_FACE_HUB_TOKEN:
         required: false
@@ -216,6 +228,8 @@ jobs:
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
+          EXPORT_PROFILER_TRACE: ${{ inputs.export-profiler-trace }}
+          ENABLE_TORCH_TRACE: ${{ inputs.enable-torch-trace }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           USE_ARC: "1"
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
@@ -270,6 +284,8 @@ jobs:
             -e HUGGING_FACE_HUB_TOKEN \
             -e DASHBOARD_TAG \
             -e USE_ARC \
+            -e EXPORT_PROFILER_TRACE \
+            -e ENABLE_TORCH_TRACE \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \
             --ulimit stack=10485760:83886080 \
             --ulimit core=0 \

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -134,6 +134,8 @@ jobs:
       disable-monitor: true
       monitor-log-interval: 10
       monitor-data-collect-interval: 2
+      export-profiler-trace: "1"
+      enable-torch-trace: "1"
     secrets: inherit
 
   test:
@@ -151,4 +153,6 @@ jobs:
       disable-monitor: true
       monitor-log-interval: 10
       monitor-data-collect-interval: 2
+      export-profiler-trace: "1"
+      enable-torch-trace: "1"
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -115,6 +115,7 @@ jobs:
           { config: "inductor_torchbench_perf_rocm_mi300", shard: 8, num_shards: 9, runner: "linux.rocm.gpu.mi300.1" },
           { config: "inductor_torchbench_perf_rocm_mi300", shard: 9, num_shards: 9, runner: "linux.rocm.gpu.mi300.1" },
         ]}
+      selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm"
     secrets: inherit
 

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -115,6 +115,7 @@ jobs:
           { config: "inductor_torchbench_perf_rocm_mi300", shard: 8, num_shards: 9, runner: "linux.rocm.gpu.mi300.1" },
           { config: "inductor_torchbench_perf_rocm_mi300", shard: 9, num_shards: 9, runner: "linux.rocm.gpu.mi300.1" },
         ]}
+      build-additional-packages: "vision audio fbgemm"
     secrets: inherit
 
   test-periodically:

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -117,6 +117,7 @@ jobs:
           { config: "inductor_torchbench_perf_rocm_mi350", shard: 8, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
           { config: "inductor_torchbench_perf_rocm_mi350", shard: 9, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
         ]}
+      selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm"
     secrets: inherit
 

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -136,6 +136,8 @@ jobs:
       disable-monitor: true
       monitor-log-interval: 10
       monitor-data-collect-interval: 2
+      export-profiler-trace: "1"
+      enable-torch-trace: "1"
     secrets: inherit
 
   test-weekly:
@@ -153,6 +155,8 @@ jobs:
       disable-monitor: true
       monitor-log-interval: 10
       monitor-data-collect-interval: 2
+      export-profiler-trace: "1"
+      enable-torch-trace: "1"
     secrets: inherit
 
   test:
@@ -170,4 +174,6 @@ jobs:
       disable-monitor: true
       monitor-log-interval: 10
       monitor-data-collect-interval: 2
+      export-profiler-trace: "1"
+      enable-torch-trace: "1"
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -117,6 +117,7 @@ jobs:
           { config: "inductor_torchbench_perf_rocm_mi350", shard: 8, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
           { config: "inductor_torchbench_perf_rocm_mi350", shard: 9, num_shards: 9, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
         ]}
+      build-additional-packages: "vision audio fbgemm"
     secrets: inherit
 
   test-periodically:

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -105,7 +105,7 @@ jobs:
           { config: "aot_inductor_torchbench", shard: 1, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
           { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },
         ]}
-      build-additional-packages: "fbgemm"
+      build-additional-packages: "vision audio fbgemm"
     secrets: inherit
 
   rocm-periodic-dynamo-benchmarks-test:

--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -58,4 +58,5 @@ jobs:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.docker-image }}
       test-matrix:  ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.test-matrix }}
+      enable-torch-trace: "1"
     secrets: inherit

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -61,4 +61,5 @@ jobs:
       build-environment: ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.docker-image }}
       test-matrix:  ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.test-matrix }}
+      enable-torch-trace: "1"
     secrets: inherit

--- a/.github/workflows/inductor-rocm-mi350.yml
+++ b/.github/workflows/inductor-rocm-mi350.yml
@@ -64,4 +64,5 @@ jobs:
       build-environment: ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.docker-image }}
       test-matrix:  ${{ needs.linux-noble-rocm-py3_12-inductor-build.outputs.test-matrix }}
+      enable-torch-trace: "1"
     secrets: inherit


### PR DESCRIPTION
The ROCm inductor benchmark jobs were missing a few things their CUDA
counterparts already do. This brings them in line.
- Prebuild `vision`, `audio` and `fbgemm` in the build job for the ROCm perf
  nightlies and inductor-periodic, instead of compiling them from source on
  every GPU test shard. ROCm test runners have no sccache write access, so
  this work was being repeated per shard at full cost.
- Build fbgemm for just the gfx target the job actually tests on, derived from
  `BUILD_ENVIRONMENT`, rather than the image's multi-arch default. Replaces a
  check that hardcoded gfx950 for `inductor-periodic` only.
- Wire up the `benchmark_configs` workflow_dispatch input on the ROCm perf
  nightlies. It was declared but never passed as `selected-test-configs`, so
  selecting configs on a manual run did nothing.
- Add `export-profiler-trace` and `enable-torch-trace` inputs to
  `_rocm-test.yml` and enable them on the perf nightlies, matching
  `inductor-perf-test-nightly.yml`. Also enable torch trace on the
  `inductor-rocm-*` jobs, matching `inductor.yml`.
  
  
  Coauthored by Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang