### PR TITLE
[ROCm] Add Context::tf32Supported() guard for hipBLASLt GEMMs

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -574,6 +574,25 @@ at::BlasBackend Context::blasPreferredBackend() {
   return blas_preferred_backend;
 }
 
+bool Context::tf32Supported() {
+#ifdef USE_ROCM
+  static const std::vector<std::string> supported_archs = {
+      "gfx942", "gfx950",
+  };
+  static const bool supported = []() {
+    for (auto index : c10::irange(detail::getCUDAHooks().deviceCount())) {
+      if (!detail::getCUDAHooks().isGPUArch(supported_archs, index)) {
+        return false;
+      }
+    }
+    return true;
+  }();
+  return supported;
+#else
+  return true;
+#endif
+}
+
 bool Context::ckSDPASupported() {
 #ifdef USE_ROCM
   // CK SDPA is only built for a subset of architectures to limit compile time.

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -160,6 +160,7 @@ class TORCH_API Context {
   static bool hasMKLDNN();
   static bool ckSDPASupported();
   static bool ckGemmSupported();
+  static bool tf32Supported();
   static bool hasEigenSparse();
   static bool hasMAGMA() {
     return detail::getCUDAHooks().hasMAGMA();

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -310,7 +310,8 @@ CublasLtTypeInfo<T, C_Dtype> getCublasLtTypeInfo() {
   } else if constexpr (std::is_same_v<T, float>) {
     if (at::globalContext().float32Precision(
             at::Float32Backend::CUDA,
-            at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+            at::Float32Op::MATMUL) == at::Float32Precision::TF32 &&
+        at::globalContext().tf32Supported()) {
       info.compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
     }
   } else if constexpr (std::is_same_v<T, c10::complex<double>>) {

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -523,7 +523,8 @@ class HipblasltGemmOp : public Callable<ParamsT> {
 
       hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
       if constexpr (std::is_same_v<CT, float>) {
-        if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+        if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32 &&
+            at::globalContext().tf32Supported()) {
           computeType = HIPBLAS_COMPUTE_32F_FAST_TF32;
         }
       }
@@ -651,7 +652,8 @@ auto GetHipBlasLtTypeStringAndOps() {
 
   hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
   if constexpr (std::is_same_v<CT, float>) {
-    if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+    if (at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32 &&
+        at::globalContext().tf32Supported()) {
       computeType = HIPBLAS_COMPUTE_32F_FAST_TF32;
     }
   }


### PR DESCRIPTION
## Description

Adds `Context::tf32Supported()`, following the existing `Context::ckGemmSupported()` idiom, and requires it alongside the fp32 precision setting before selecting `HIPBLAS_COMPUTE_32F_FAST_TF32`. Architectures without xf32 keep the `CUBLAS_COMPUTE_32F` default. Non-ROCm builds return `true` unconditionally.

## Reason

`Float32Precision::TF32` maps to hipBLASLt's xf32, a CDNA MFMA format that does not exist on RDNA. The compute type was chosen from the precision setting alone, with no check that the device supported it, so fp32 GEMMs on RDNA requested something hipBLASLt cannot service. It returns `HIPBLAS_STATUS_NOT_SUPPORTED`, and the recovery path emits a `TORCH_WARN` before retrying on the non-Lt path — under `warnings.simplefilter("error")` that warning is raised as an exception and the matmul dies before it can recover.

That is how `test_debug_flag_disables_internal_compilation` in `test/inductor/test_flex_attention.py` fails on gfx1201: the file sets `float32_matmul_precision("high")` at module scope, and the eager math fallback's fp32 bmm trips it.

```
UserWarning: bgemm_internal_cublaslt error: HIPBLAS_STATUS_NOT_SUPPORTED when calling
hipblasLtMatmul with ... abType 0 cType 0 computeType 6 scaleType 0.
```

## Test Plan

Requires masking off any integrated GPU — `blasPreferredBackend()` drops the whole process to rocBLAS if any visible device is unsupported by hipBLASLt, which hides the failure.

```bash
HIP_VISIBLE_DEVICES=0 python -m pytest test/inductor/test_flex_attention.py \
    -k "test_debug_flag_disables_internal_compilation_cuda" -v
```

Passes on gfx1201; fails without this change.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang