### PR TITLE
[Testcase Refactoring] Add NPU/PrivateUse1 support to common_fsdp.py

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -62,6 +62,7 @@ from torch.testing._internal.common_utils import (
     set_rng_seed,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
     TEST_WITH_ROCM,
     TEST_XPU,
 )
@@ -84,6 +85,10 @@ elif TEST_XPU:
     DEVICE_TYPE = "xpu"
     DISTRIBUTED_BACKEND = "xccl"
     DEVICE_COUNT = torch.xpu.device_count()
+elif TEST_PRIVATEUSE1:
+    DEVICE_TYPE = torch._C._get_privateuse1_backend_name()
+    DISTRIBUTED_BACKEND = "hccl"
+    DEVICE_COUNT = getattr(torch, DEVICE_TYPE).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -661,7 +666,7 @@ class ModuleWithDelay(FSDPTestModel):
     def get_loss(self, input, output):
         loss = self.module.get_loss(input, output)  # type: ignore[operator]
         if self.delay_after_loss_ms > 0:
-            if TEST_HPU or TEST_XPU:
+            if TEST_HPU or TEST_XPU or TEST_PRIVATEUSE1:
                 time.sleep(self.delay_after_loss_ms / 1000)
             elif TEST_CUDA:
                 torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
@@ -677,7 +682,7 @@ class ModuleWithDelay(FSDPTestModel):
                     torch.cuda._sleep(
                         int(self.delay_before_reduction_ms * get_cycles_per_ms())
                     )
-                elif TEST_HPU or TEST_XPU:
+                elif TEST_HPU or TEST_XPU or TEST_PRIVATEUSE1:
                     time.sleep(self.delay_before_reduction_ms / 1000)
             return orig_reduce_scatter(*args, **kwargs)
 
@@ -810,7 +815,7 @@ class MixtureOfExperts(NestedWrappedModule):
                         torch.cuda._sleep(
                             int(self.delay_before_free_ms * get_cycles_per_ms())
                         )
-                    elif TEST_HPU or TEST_XPU:
+                    elif TEST_HPU or TEST_XPU or TEST_PRIVATEUSE1:
                         time.sleep(self.delay_before_free_ms / 1000)
 
                     return orig_reshard(*args, **kwargs)
@@ -1245,7 +1250,7 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1593,7 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1640,7 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
## Summary
This PR adds NPU/PrivateUse1 backend support to `torch/testing/_internal/common_fsdp.py` to enable FSDP testing on NPU devices.

## Changes
- Import `TEST_PRIVATEUSE1` from `common_utils`
- Add NPU/PrivateUse1 case for `DEVICE_TYPE`, `DISTRIBUTED_BACKEND` (hccl), and `DEVICE_COUNT`
- Update device binding in `_init_pg` methods to use `torch.accelerator.is_available()` instead of checking specific device types, making it work for all accelerators (CUDA, XPU, NPU)
- Update delay timing checks in `ModuleWithDelay` and `MixtureOfExperts` to include `TEST_PRIVATEUSE1` (using `time.sleep` like HPU/XPU)

## Related PRs
- PR #192208: Migrate test_fsdp_tp_integration.py to capability gating
- PR #192694: Fix requires_world_size decorator for accelerator-agnostic device count
- PR #192043: Add _capabilities method to PrivateUse1TestBase

## Test Plan
```bash
# On NPU environment with 4 devices
cd test/distributed/fsdp
python test_fsdp_tp_integration.py
# All 3 tests pass:
# - TestFSDPTPIntegration::test_fsdp_tp_integration
# - TestFSDPTPIntegration::test_fsdp_tp_integration_with_fp8
# - TestFSDPTPIntegration::test_fsdp_tp_integration_with_activation_checkpointing
```

<details>
<summary>AI-assisted</summary>

This PR was created with the help of an AI assistant.
</details>