### PR TITLE
[Test] Make test_expanded_weights.py device-agnostic for OOT backends

### DIFF
--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_nn import (
     TestBase,
 )
 from torch.testing._internal.common_utils import (
+    ACCELERATOR_TYPE,
     freeze_rng_state,
     HardwareClassification,
     make_tensor,
@@ -880,8 +881,8 @@ class TestExpandedWeightModule(TestCase):
                 )
 
     def test_per_sample_api_failing(self, device):
-        module = nn.Linear(10, 10)
-        input = torch.randn(64, 10)
+        module = nn.Linear(10, 10).to(device)
+        input = torch.randn(64, 10, device=device)
         with self.assertRaisesRegex(RuntimeError, r"Module passed must be nn.Module"):
             call_for_per_sample_grads("fail")(input)
         with self.assertRaisesRegex(
@@ -895,7 +896,7 @@ class TestExpandedWeightModule(TestCase):
             loss.backward()  # populate grad_sample fields
             call_for_per_sample_grads(module)(input)
 
-        module = nn.Linear(10, 10)  # reset to not have grad_sample fields
+        module = nn.Linear(10, 10).to(device)  # reset to not have grad_sample fields
         with self.assertRaisesRegex(
             RuntimeError, r"Expected loss_reduction argument to be sum or mean"
         ):
@@ -910,9 +911,9 @@ class TestExpandedWeightModule(TestCase):
             def forward(self, input1, input2):
                 return self.linear(input1) + self.linear(input2)
 
-        module = CustomModule()
-        input1 = torch.randn(4, 5)
-        input2 = torch.randn(5, 5)
+        module = CustomModule().to(device)
+        input1 = torch.randn(4, 5, device=device)
+        input2 = torch.randn(5, 5, device=device)
 
         with self.assertRaisesRegex(
             RuntimeError,
@@ -920,13 +921,13 @@ class TestExpandedWeightModule(TestCase):
         ):
             call_for_per_sample_grads(module)(input1, input2)
 
-        input2 = torch.randn(4, 5)
+        input2 = torch.randn(4, 5, device=device)
         call_for_per_sample_grads(module)(input1, input2)
 
-        module = CustomModule()
+        module = CustomModule().to(device)
         call_for_per_sample_grads(module)(input1, input2=input2)
 
-        module = CustomModule()
+        module = CustomModule().to(device)
         call_for_per_sample_grads(module)(input1=input1, input2=input2)
 
     def test_per_sample_api_compute_batch_size_not_pytreeable(self, device):
@@ -943,8 +944,10 @@ class TestExpandedWeightModule(TestCase):
             def forward(self, input1, input2):
                 return self.linear(input1.elem1) + self.linear(input1.elem2)
 
-        input = NonPytreeableTuple(torch.randn(4, 5), torch.randn(4, 5))
-        model = CustomModule()
+        input = NonPytreeableTuple(
+            torch.randn(4, 5, device=device), torch.randn(4, 5, device=device)
+        )
+        model = CustomModule().to(device)
         with self.assertRaisesRegex(
             RuntimeError,
             "ExpandedWeights cannot compute the batch size from the inputs",
@@ -957,16 +960,18 @@ class TestExpandedWeightModule(TestCase):
         ):
             call_for_per_sample_grads(model)(input, torch.randn(5))
 
-        model = CustomModule()  # TODO: functional call bug, sam will fix
+        model = CustomModule().to(device)  # TODO: functional call bug, sam will fix
         call_for_per_sample_grads(model)(input, torch.randn(4, 5))
-        model = CustomModule()
+        model = CustomModule().to(device)
         call_for_per_sample_grads(model, batch_size=4)(input, torch.randn(5))
 
 
 class ContextManagerTests(TestBase):
     def __init__(self, *args, **kwargs):
         self.test_cpu = kwargs.get("test_cpu", True)
-        self.test_accelerator = kwargs.get("test_accelerator", True)
+        self.test_accelerator = kwargs.get(
+            "test_accelerator", kwargs.get("test_cuda", True)
+        )
         super().__init__(*args, **kwargs)
 
     @property
@@ -1023,6 +1028,7 @@ def filter_supported_tests(t):
 supported_tests = [
     t for t in module_tests + get_new_module_tests() if filter_supported_tests(t)
 ]
+accelerator = ACCELERATOR_TYPE._value
 for test_param in supported_tests:
     if "constructor" not in test_param:
         name = test_param.pop("module_name")
@@ -1051,13 +1057,14 @@ for test_param in supported_tests:
             ),
         )
     if TEST_ACCELERATOR and test.test_accelerator:
-        accelerator = torch.accelerator.current_accelerator().type
         # since this checks derivatives, only use double for precision
         setattr(
             TestExpandedWeightModule,
             test_name + f"_{accelerator}_double",
             decorator(
-                lambda self, test=test: test.test_context_manager(self, accelerator)
+                lambda self, test=test, acc=accelerator: test.test_context_manager(
+                    self, acc
+                )
             ),
         )
 

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -17,7 +17,7 @@ from torch.nn.utils._expanded_weights.expanded_weights_utils import (
     unpack_expanded_weight_or_tensor,
 )
 from torch.nn.utils._per_sample_grad import call_for_per_sample_grads
-from torch.testing._internal.common_cuda import TEST_CUDA, tf32_off
+from torch.testing._internal.common_cuda import tf32_off
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
@@ -32,20 +32,20 @@ from torch.testing._internal.common_nn import (
 )
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
+    HardwareClassification,
     make_tensor,
     parametrize,
     run_tests,
     skipIfTorchDynamo,
+    TEST_ACCELERATOR,
     TestCase,
 )
 from torch.utils._pytree import tree_map_only
 
 
-class TestContext:
-    pass
-
-
 class TestExpandedWeightHelperFunction(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_forward_helper(self, device):
         input = torch.randn(3, 4, device=device)
         weight = torch.randn(5, 4, device=device)
@@ -225,6 +225,8 @@ class TestExpandedWeightHelperFunction(TestCase):
 
 
 class TestExpandedWeightFunctional(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _compare_ew_and_for_loop_per_sample_grads(self, op, sample_input, reduction):
         input = sample_input.input
         args = sample_input.args
@@ -621,6 +623,8 @@ class TestExpandedWeightFunctional(TestCase):
 
 
 class TestExpandedWeightModule(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _do_test(
         self,
         module,
@@ -875,7 +879,7 @@ class TestExpandedWeightModule(TestCase):
                     rtol=rtol,
                 )
 
-    def test_per_sample_api_failing(self):
+    def test_per_sample_api_failing(self, device):
         module = nn.Linear(10, 10)
         input = torch.randn(64, 10)
         with self.assertRaisesRegex(RuntimeError, r"Module passed must be nn.Module"):
@@ -897,7 +901,7 @@ class TestExpandedWeightModule(TestCase):
         ):
             call_for_per_sample_grads(module, loss_reduction="")(input)
 
-    def test_per_sample_api_compute_batch_size(self):
+    def test_per_sample_api_compute_batch_size(self, device):
         class CustomModule(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -925,7 +929,7 @@ class TestExpandedWeightModule(TestCase):
         module = CustomModule()
         call_for_per_sample_grads(module)(input1=input1, input2=input2)
 
-    def test_per_sample_api_compute_batch_size_not_pytreeable(self):
+    def test_per_sample_api_compute_batch_size_not_pytreeable(self, device):
         @dataclass
         class NonPytreeableTuple:
             elem1: torch.Tensor
@@ -962,7 +966,7 @@ class TestExpandedWeightModule(TestCase):
 class ContextManagerTests(TestBase):
     def __init__(self, *args, **kwargs):
         self.test_cpu = kwargs.get("test_cpu", True)
-        self.test_cuda = kwargs.get("test_cuda", True)
+        self.test_accelerator = kwargs.get("test_accelerator", True)
         super().__init__(*args, **kwargs)
 
     @property
@@ -1046,12 +1050,15 @@ for test_param in supported_tests:
                 )
             ),
         )
-    if TEST_CUDA and test.test_cuda:
+    if TEST_ACCELERATOR and test.test_accelerator:
+        accelerator = torch.accelerator.current_accelerator().type
         # since this checks derivatives, only use double for precision
         setattr(
             TestExpandedWeightModule,
-            test_name + "_cuda_double",
-            decorator(lambda self, test=test: test.test_context_manager(self, "cuda")),
+            test_name + f"_{accelerator}_double",
+            decorator(
+                lambda self, test=test: test.test_context_manager(self, accelerator)
+            ),
         )
 
 # ------------- HELPER FUNCTIONS -----------------


### PR DESCRIPTION
- Tag the three device-parametrized classes
  (`TestExpandedWeightHelperFunction`, `TestExpandedWeightFunctional`,
  `TestExpandedWeightModule`) with
  `hw_classification = HardwareClassification.ACCELERATOR`, and add the
  `HardwareClassification` import (merged alphabetically into the common_utils
  block).
- Remove the empty dead `TestContext` class.
- Add a device parameter to `test_per_sample_api_failing`,
  `test_per_sample_api_compute_batch_size`, and
  `test_per_sample_api_compute_batch_size_not_pytreeable` so every ACCELERATOR
  test method accepts device.