### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard init

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -36,9 +36,7 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.distributed.tensor.placement_types import _StridedShard
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     FSDPTest,
@@ -73,7 +71,7 @@ class TestFullyShardDeviceTensor(FSDPTestMultiThread):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    def test_move_states_to_device_tensor(self):
+    def test_move_states_to_device_tensor(self, device):
         model = MLP(8, torch.device("cpu"), with_buffer=True)
         for tensor in itertools.chain(model.parameters(), model.buffers()):
             self.assertEqual(tensor.device, torch.device("cpu"))
@@ -85,7 +83,7 @@ class TestFullyShardDeviceTensor(FSDPTestMultiThread):
             self.assertEqual(tensor.device, accelerator_device)
 
     @skip_if_lt_x_gpu(1)
-    def test_move_states_to_device_ignored_param_device(self):
+    def test_move_states_to_device_ignored_param_device(self, device):
         cpu_device = torch.device("cpu")
         model = MLP(8, cpu_device, with_buffer=True)
         ignored_params = [model.out_proj.weight, model.out_proj.bias]
@@ -110,7 +108,7 @@ class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_move_states_to_device_dtensor_valid(self):
+    def test_move_states_to_device_dtensor_valid(self, device):
         if not (self.world_size >= 4):
             raise AssertionError(f"Expected world_size >= 4, but got {self.world_size}")
         dp_size = 2
@@ -143,7 +141,7 @@ class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
                 self.assertEqual(tensor._local_tensor.device, accelerator_device)
 
     @skip_if_lt_x_gpu(1)
-    def test_move_states_to_device_dtensor_invalid(self):
+    def test_move_states_to_device_dtensor_invalid(self, device):
         if not (self.world_size >= 4):
             raise AssertionError(f"Expected world_size >= 4, but got {self.world_size}")
         dp_size = 2
@@ -202,7 +200,7 @@ class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    def test_moduledict_subclass_with_forward(self):
+    def test_moduledict_subclass_with_forward(self, device):
         model = self.DictWithForward(8, 8)
         mesh = init_device_mesh(device_type.type, (self.world_size,))
         # Should not raise due to container type since forward() is implemented
@@ -211,7 +209,7 @@ class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
         _ = fsdp_model(x)
 
     @skip_if_lt_x_gpu(1)
-    def test_modulelist_subclass_with_forward(self):
+    def test_modulelist_subclass_with_forward(self, device):
         model = self.ListWithForward(8, 8)
         mesh = init_device_mesh(device_type.type, (self.world_size,))
         fsdp_model = fully_shard(model, mesh=mesh)
@@ -442,7 +440,7 @@ class TestFullyShardShardedParameterTensor(FSDPTestMultiThread):
         return 2
 
     @skip_if_lt_x_gpu(1)
-    def test_shard_tensor_parameters(self):
+    def test_shard_tensor_parameters(self, device):
         # Use odd dim sizes to test uneven shards
         model = nn.Sequential(*[MLP(3, dim_multiplier=3) for _ in range(3)])
         orig_params = [param.detach().clone() for param in model.parameters()]
@@ -506,7 +504,7 @@ class TestFullyShardShardedParameterDTensor(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_shard_dtensor_parameters(self):
+    def test_shard_dtensor_parameters(self, device):
         dp_size = 2 if self.world_size > 2 else 1
         global_mesh = init_device_mesh(
             device_type.type,
@@ -703,7 +701,7 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_meta_device_1d_init(self):
+    def test_meta_device_1d_init(self, device):
         default_pg = torch.distributed.distributed_c10d._get_default_group()
         mesh = init_device_mesh(device_type.type, mesh_shape=(default_pg.size(),))
         # Test both even sharding (8), uneven sharding (3), and empty local tensor (1)
@@ -743,7 +741,7 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
         self._test_to_empty_and_reset_parameters(model, mesh, mlp_dim)
 
     @skip_if_lt_x_gpu(1)
-    def test_meta_device_2d_init(self):
+    def test_meta_device_2d_init(self, device):
         if not (self.world_size >= 4):
             raise AssertionError(f"Expected world_size >= 4, but got {self.world_size}")
         dp_size = 2
@@ -806,7 +804,7 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
         optim.step()
 
     @skip_if_lt_x_gpu(1)
-    def test_invalid_meta_device_init(self):
+    def test_invalid_meta_device_init(self, device):
         default_pg = torch.distributed.distributed_c10d._get_default_group()
         mesh = init_device_mesh(device_type.type, mesh_shape=(default_pg.size(),))
         mlp_dim = 8
@@ -827,7 +825,7 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
             model(inp)
 
     @skip_if_lt_x_gpu(1)
-    def test_rank0_broadcast_meta_device_init(self):
+    def test_rank0_broadcast_meta_device_init(self, device):
         model_args = ModelArgs(dropout_p=0.0)
         # Assume we have a CPU full state dict on rank 0
         if self.rank == 0:
@@ -920,7 +918,7 @@ class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_1d_process_group_init(self):
+    def test_1d_process_group_init(self, device):
         if not (self.world_size == 4):
             raise AssertionError(f"Expected world_size == 4, but got {self.world_size}")
         # For convenience, use device mesh's infra to construct the DP PG
@@ -983,7 +981,7 @@ class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
             )
 
     @skip_if_lt_x_gpu(1)
-    def test_2d_process_group_init(self):
+    def test_2d_process_group_init(self, device):
         shard_mesh_dim_size = 2
         if not (self.world_size % shard_mesh_dim_size == 0):
             raise AssertionError(
@@ -1084,7 +1082,7 @@ class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
         return 4
 
     @skip_if_lt_x_gpu(1)
-    def test_hsdp_broadcast_across_replicas(self):
+    def test_hsdp_broadcast_across_replicas(self, device):
         shard_size, replicate_size = 2, 2
         mesh = init_device_mesh(
             device_type.type,
@@ -1159,7 +1157,7 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
         torch.set_default_device(device_type)
 
     @skip_if_lt_x_gpu(1)
-    def test_custom_hook_custom_stream(self):
+    def test_custom_hook_custom_stream(self, device):
         hsdp_mesh = init_device_mesh(
             device_type.type, (2, 2), mesh_dim_names=("replicate", "shard")
         )
@@ -1201,7 +1199,7 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
         self.assertEqual(hook_used_stream, custom_stream)
 
     @skip_if_lt_x_gpu(1)
-    def test_custom_hsdp_all_reduce_hook(self):
+    def test_custom_hsdp_all_reduce_hook(self, device):
         world_pg = dist.distributed_c10d._get_default_group()
         intra_pg = _init_intra_node_process_group(2)
         inter_pg = _init_inter_node_process_group(world_pg, 2)
@@ -1271,7 +1269,7 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
         return model, ref_model
 
     @skip_if_lt_x_gpu(1)
-    def test_init_1d_transformer_shard_largest_dim(self):
+    def test_init_1d_transformer_shard_largest_dim(self, device):
         model, ref_model = self._init_models()
 
         def shard_placement_fn(param: nn.Parameter) -> Shard | None:
@@ -1302,7 +1300,7 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
             self.assertEqual(full_param, ref_param)
 
     @skip_if_lt_x_gpu(1)
-    def test_init_1d_transformer_shard_dim_neg1(self):
+    def test_init_1d_transformer_shard_dim_neg1(self, device):
         model, ref_model = self._init_models()
 
         def shard_placement_fn(param: nn.Parameter) -> Shard | None:
@@ -1318,7 +1316,7 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
             self.assertEqual(full_param, ref_param)
 
     @skip_if_lt_x_gpu(1)
-    def test_init_2d_transformer_shard_diff_dim(self):
+    def test_init_2d_transformer_shard_diff_dim(self, device):
         model, ref_model = self._init_models()
 
         dp_size, tp_size = self.world_size // 2, 2
@@ -1371,7 +1369,7 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
             self.assertEqual(full_param, ref_param)
 
     @skip_if_lt_x_gpu(1)
-    def test_init_1d_uneven_shard_largest_dim(self):
+    def test_init_1d_uneven_shard_largest_dim(self, device):
         torch.manual_seed(42)
         model = nn.Sequential(nn.Linear(16, 17), nn.Linear(17, 8))
 
@@ -1446,7 +1444,7 @@ class TestFullyShardMixedDtypeParam(FSDPTestMultiThread):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    def test_mixed_dtypes_no_grad_param(self):
+    def test_mixed_dtypes_no_grad_param(self, device):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1488,7 +1486,7 @@ class TestFullyShardNonFloatParam(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    def test_non_float_param(self):
+    def test_non_float_param(self, device):
         """Non-float params (e.g. uint8, int64) are supported in all-gather,
         excluded from reduce-scatter, and not cast by mp_policy.param_dtype."""
         self.run_subtests(

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1471,9 +1471,15 @@ class TestFullyShardMixedDtypeParam(FSDPTestMultiThread):
 class TestFullyShardNonFloatParam(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
-    # asserts run in autograd worker threads (the all-gather/reduce-scatter
-    # callbacks); override with the plain `TestCase` defaults.
+    # `instantiate_device_type_tests` injects `DeviceTypeTestBase`, whose
+    # `precision`/`rel_tol` are thread-local properties populated only on the
+    # thread that imports the module. The all-gather/reduce-scatter callbacks
+    # in `test_non_float_param` run `assertEqual` from an autograd worker
+    # thread during backward; since `assertEqual` always reads `self.rel_tol`,
+    # that worker thread's empty thread-local raises `AttributeError`. Override
+    # with the plain `TestCase` defaults (0 = no tolerance override) to shadow
+    # the thread-local properties; this is safe because this test sets no
+    # custom tolerance.
     precision = TestCase._precision
     rel_tol = TestCase._rel_tol
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -36,6 +36,9 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.distributed.tensor.placement_types import _StridedShard
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     FSDPTest,
@@ -45,7 +48,11 @@ from torch.testing._internal.common_fsdp import (
     patch_all_gather,
     patch_reduce_scatter,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -58,6 +65,8 @@ device_type = torch.device(get_devtype())
 
 class TestFullyShardDeviceTensor(FSDPTestMultiThread):
     """Tests that tensor parameters are moved to the expected device."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -93,6 +102,8 @@ class TestFullyShardDeviceTensor(FSDPTestMultiThread):
 
 class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
     """Tests that DTensor parameters are moved to the expected device."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -167,6 +178,8 @@ class TestFullyShardDeviceDTensor(FSDPTestMultiThread):
 class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
     """Tests that fully_shard accepts ModuleDict/ModuleList subclasses that implement forward()."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     class DictWithForward(nn.ModuleDict):
         def __init__(self, in_features=8, out_features=8):
             super().__init__({"lin": nn.Linear(in_features, out_features)})
@@ -209,6 +222,8 @@ class TestFullyShardContainerSubclasses(FSDPTestMultiThread):
 class TestFullyShardMeshArg(FSDPTestMultiThread):
     """Tests the ``mesh`` argument."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 4
@@ -230,6 +245,8 @@ class TestFullyShardMeshArg(FSDPTestMultiThread):
 
 class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
     """Tests getting the managed modules/states for a ``fully_shard`` module."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     @property
     def world_size(self) -> int:
@@ -344,6 +361,8 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
 
 
 class TestFullyShardParamModuleInfos(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -416,6 +435,8 @@ class TestFullyShardParamModuleInfos(FSDPTestMultiThread):
 
 
 class TestFullyShardShardedParameterTensor(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
@@ -450,6 +471,10 @@ class TestFullyShardShardedParameterTensor(FSDPTestMultiThread):
             chunks = torch.chunk(orig_param, self.world_size, dim=0)
             self.assertEqual(sharded_param._local_tensor, chunks[self.rank])
 
+
+class TestFullyShardShardedParameterValidation(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_raise_scalar_parameter(self):
         """Tests raising an exception when the model has scalar parameters."""
         model = nn.Sequential(*[MLP(3, dim_multiplier=3) for _ in range(3)])
@@ -474,6 +499,8 @@ class TestFullyShardShardedParameterTensor(FSDPTestMultiThread):
 
 
 class TestFullyShardShardedParameterDTensor(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -519,6 +546,8 @@ class TestFullyShardShardedParameterDTensor(FSDPTestMultiThread):
 
 
 class TestFullyShardLazyInit(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -667,6 +696,8 @@ class TestFullyShardLazyInit(FSDPTestMultiThread):
 
 
 class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -882,6 +913,8 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
 
 
 class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -1044,6 +1077,8 @@ class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
 
 
 class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -1113,6 +1148,8 @@ class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
 
 
 class TestHSDPWithCustomHook(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
@@ -1218,6 +1255,8 @@ class TestHSDPWithCustomHook(FSDPTestMultiThread):
 
 
 class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 8
@@ -1358,6 +1397,10 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
         ):
             fully_shard(model, shard_placement_fn=shard_placement_fn)
 
+
+class TestFullyShardShardPlacementValidation(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_invalid_shard_dim(self):
         model = nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 8))
 
@@ -1374,6 +1417,8 @@ class TestFullyShardShardPlacementFn(FSDPTestMultiThread):
 # TODO: Remove this test class once we remove the old import path:
 # torch/distributed/_composable/fsdp
 class TestFullyShardOldImport(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -1394,6 +1439,8 @@ class TestFullyShardOldImport(FSDPTestMultiThread):
 
 
 class TestFullyShardMixedDtypeParam(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
@@ -1422,6 +1469,14 @@ class TestFullyShardMixedDtypeParam(FSDPTestMultiThread):
 
 
 class TestFullyShardNonFloatParam(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
+    # asserts run in autograd worker threads (the all-gather/reduce-scatter
+    # callbacks); override with the plain `TestCase` defaults.
+    precision = TestCase._precision
+    rel_tol = TestCase._rel_tol
+
     @property
     def world_size(self) -> int:
         return 2
@@ -1518,6 +1573,80 @@ class TestFullyShardNonFloatParam(FSDPTest):
         ):
             loss = model(x).sum()
             loss.backward()
+
+
+instantiate_device_type_tests(
+    TestFullyShardDeviceTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardDeviceDTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardContainerSubclasses,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardShardedParameterTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardShardedParameterDTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardMetaDeviceInit,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardProcessGroupInit,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardHSDPBroadcast,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestHSDPWithCustomHook,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardShardPlacementFn,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardMixedDtypeParam,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardNonFloatParam,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds hw_classification to the fully_shard init test classes: 12 classes are
ACCELERATOR (instantiated via instantiate_device_type_tests with
except_for=["cpu"]) and 7 are GENERIC.

The classification is driven by the test methods' hardware requirements rather
than the base class. Most classes here extend FSDPTestMultiThread (threaded
process group, which also runs on CPU), so the label follows whether a method is
guarded by @skip_if_lt_x_gpu: guarded methods exercise accelerator-device
behavior (moving params to the accelerator, sharding DTensors, training parity)
and are ACCELERATOR, while unguarded methods are device-agnostic logic
(_get_managed_modules/_get_managed_states, invalid-input validation) and are
GENERIC.

Two classes mixed guarded and unguarded methods, so the unguarded validation
methods are split into dedicated GENERIC classes (invalid shard dim, and the
scalar/non-contiguous parameter raises) so they keep running on CPU.

TestFullyShardNonFloatParam overrides precision/rel_tol with the plain TestCase
defaults. Its all-gather/reduce-scatter callbacks assert inside the autograd
backward, which runs on an autograd worker thread; instantiate_device_type_tests
injects DeviceTypeTestBase whose precision/rel_tol are thread-local, so reading
them from that worker thread raises AttributeError. Overriding with the plain
defaults restores the non-thread-local behavior.

Test Plan: Ran the two commands below; each executed only the tests matching the
requested `--hw-classification` value.
python test/distributed/_composable/fsdp/test_fully_shard_init.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_init.py --hw-classification GENERIC