### PR TITLE
[Testcase Refactoring] Add HardwareClassification to test_state_dict.py

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -42,11 +42,11 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import Optimizer
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_dist_composable import (
     CompositeParamModel,
     UnitModule,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -65,9 +65,6 @@ from torch.testing._internal.distributed.common_state_dict import (
     VerifyStateDictMixin,
 )
 from torch.utils._pytree import tree_all, tree_all_only
-
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 if not dist.is_available():
@@ -111,7 +108,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             for d_optim in _dist_optim:
                 d_optim.zero_grad()
 
-            batch = torch.rand(8, 100, device=device_type)
+            batch = torch.rand(8, 100, device=self.device_type)
             model(batch).sum().backward()
             dist_model(batch).sum().backward()
 
@@ -198,9 +195,9 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
         def init_model_optim():
             if use_dtensor:
-                device_mesh = init_device_mesh(device_type, (self.world_size,))
+                device_mesh = init_device_mesh(self.device_type, (self.world_size,))
 
-            orig_model = CompositeParamModel(device=torch.device(device_type))
+            orig_model = CompositeParamModel(device=torch.device(self.device_type))
             orig_optim = optimizer_class(orig_model.parameters(), lr=1e-4, foreach=True)
             copy_optim = optimizer_class(orig_model.parameters(), lr=1e-4, foreach=True)
             if wrapping:
@@ -208,7 +205,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             else:
                 strategy = {UnitModule}
             if use_dtensor:
-                device_mesh = init_device_mesh(device_type, (self.world_size,))
+                device_mesh = init_device_mesh(self.device_type, (self.world_size,))
                 dist_model = FSDP(
                     copy.deepcopy(orig_model),
                     auto_wrap_policy=ModuleWrapPolicy(strategy),
@@ -268,7 +265,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         foreach: bool = True,
     ):
         def init_model_optim():
-            orig_model = CompositeParamModel(device=torch.device(device_type))
+            orig_model = CompositeParamModel(device=torch.device(self.device_type))
             orig_optim = optimizer_class(
                 orig_model.parameters(), lr=1e-4, foreach=foreach
             )
@@ -305,7 +302,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     def _test_ddp(self, use_composable: bool, optimizer_class: type[Optimizer]) -> None:
         def init_model_optim():
-            orig_model = CompositeParamModel(device=torch.device(device_type))
+            orig_model = CompositeParamModel(device=torch.device(self.device_type))
             orig_optim = optimizer_class(orig_model.parameters(), lr=1e-4)
             copy_optim = optimizer_class(orig_model.parameters(), lr=1e-4)
             if use_composable:
@@ -339,7 +336,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         test_frozen: bool = False,
     ) -> None:
         def init_model_optim():
-            orig_model = CompositeParamModel(device=torch.device(device_type))
+            orig_model = CompositeParamModel(device=torch.device(self.device_type))
             if test_frozen:
                 for param in chain(
                     orig_model.u1.parameters(), orig_model.u2.parameters()
@@ -380,7 +377,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     def _test_single_gpu(self, optimizer_class: type[Optimizer]) -> None:
         def init_model_optim():
-            orig_model = CompositeParamModel(device=torch.device(device_type))
+            orig_model = CompositeParamModel(device=torch.device(self.device_type))
             orig_optim = optimizer_class(orig_model.parameters(), lr=1e-4)
             copy_optim = optimizer_class(orig_model.parameters(), lr=1e-4)
             model_copy = copy.deepcopy(orig_model)
@@ -395,7 +392,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self._test_single_gpu(torch.optim.AdamW)
 
     def _test_strict(self, parallelism: str) -> None:
-        model = CompositeParamModel(device=torch.device(device_type))
+        model = CompositeParamModel(device=torch.device(self.device_type))
         if parallelism == "DDP":
             model = DDP(model)
         else:
@@ -432,8 +429,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     def _test_cpu_offload_full_state_dict(
         self, optimizer_class: type[Optimizer]
     ) -> None:
-        orig_model = CompositeParamModel(device=torch.device(device_type))
-        device_mesh = init_device_mesh(device_type, (self.world_size,))
+        orig_model = CompositeParamModel(device=torch.device(self.device_type))
+        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
         dist_model = FSDP(
             copy.deepcopy(orig_model),
             auto_wrap_policy=ModuleWrapPolicy({UnitModule}),
@@ -509,6 +506,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @skip_if_lt_x_gpu(1)
     def test_activation_ckpt_fqns_ddp(self, device) -> None:
         """Tests that activation checkpointing prefixes are removed from module names"""
+        device_type = torch.device(device).type
         model = CompositeParamModel(device=torch.device(device_type))
         original_keys = get_model_state_dict(model).keys()
 
@@ -528,7 +526,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     def _test_activation_ckpt_fqns_fsdp1(self, use_orig_params: bool) -> None:
         """Tests that activation checkpointing prefixes are removed from module names"""
-        model = CompositeParamModel(device=torch.device(device_type))
+        model = CompositeParamModel(device=torch.device(self.device_type))
         original_keys = get_model_state_dict(model).keys()
 
         apply_activation_checkpointing(model)
@@ -539,6 +537,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @skip_if_lt_x_gpu(1)
     def test_extra_state(self, device) -> None:
+        device_type = torch.device(device).type
         model = CompositeParamModel(device=torch.device(device_type))
 
         def get_extra_state(self):
@@ -557,6 +556,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @skip_if_lt_x_gpu(1)
     def test_non_persistent_buffers(self, device) -> None:
+        device_type = torch.device(device).type
         model = CompositeParamModel(device=torch.device(device_type))
         model.register_buffer(
             "dont_save_me", torch.rand(100, device=device_type), persistent=False
@@ -566,12 +566,12 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self.assertEqual(model.state_dict(), get_model_state_dict(target_model))
 
     def _test_broadcast_from_rank0(self, wrapper) -> None:
-        model = CompositeParamModel(device=torch.device(device_type))
+        model = CompositeParamModel(device=torch.device(self.device_type))
         optim = torch.optim.Adam(model.parameters())
         fsdp_model = wrapper(copy.deepcopy(model))
         fsdp_optim = torch.optim.Adam(fsdp_model.parameters())
 
-        batch = torch.rand(8, 100, device=device_type)
+        batch = torch.rand(8, 100, device=self.device_type)
         model(batch).sum().backward()
         optim.step()
         states, optim_states = get_state_dict(model, optim)
@@ -641,6 +641,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(4)
     def test_broadcast_from_rank0(self, device) -> None:
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(device_type, (self.world_size,))
         hsdp_device_mesh = init_device_mesh(device_type, (2, self.world_size // 2))
         self.run_subtests(
@@ -664,6 +665,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         # This test verifies that FSDP root is not initialized but we should
         # still be able to  get the state_dict without errors because
         # fsdp_model.state_dict() will trigger the FSDP initialization.
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(device_type, (self.world_size,))
         model = CompositeParamModel(device=torch.device(device_type))
         fsdp_model = FSDP(copy.deepcopy(model), device_mesh=device_mesh)
@@ -678,6 +680,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         # "initial_lr" is added to optim_state_dict, but not to the new optim
         # We test whether "initial_lr" appear in optim after
         # set_optimizer_state_dict.
+        device_type = torch.device(device).type
         torch.manual_seed(0)
         model = nn.Sequential(
             *[nn.Linear(4, 4, device=device_type, bias=False) for _ in range(2)]
@@ -723,6 +726,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         2. We can load optimizer state dict with/without flattening
         3. The resulting optimizer state is equivalent regardless of flattening options
         """
+        device_type = torch.device(device).type
         for flatten_to_save, flatten_to_load in product([True, False], repeat=2):
             device_mesh = init_device_mesh(device_type, (self.world_size,))
             model = CompositeParamModel(device=torch.device(device_type))
@@ -753,7 +757,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             self.assertEqual(fsdp_optim.state_dict(), fsdp_optim2.state_dict())
 
     def _test_deprecate_partial(self) -> None:
-        model = CompositeParamModel(device=torch.device(device_type))
+        model = CompositeParamModel(device=torch.device(self.device_type))
 
         model_state_dict1 = get_model_state_dict(model)
         model_state_dict1 = copy.deepcopy(model_state_dict1)
@@ -806,8 +810,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self.assertEqual(model.l.bias, model_state_dict1["l.bias"])
 
     def _test_deprecate_fsdp_api(self) -> None:
-        device_mesh = init_device_mesh(device_type, (self.world_size,))
-        model = CompositeParamModel(device=torch.device(device_type))
+        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+        model = CompositeParamModel(device=torch.device(self.device_type))
         fsdp_model = FSDP(copy.deepcopy(model), device_mesh=device_mesh)
         with self.assertWarnsRegex(
             FutureWarning,
@@ -832,6 +836,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_shared_weight(self, device):
+        device_type = torch.device(device).type
+
         class TiedEmbeddingModel(nn.Module):
             def __init__(self, vocab_size, embedding_dim):
                 super().__init__()
@@ -897,6 +903,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         # This test verifies that we can set model state dict by a meta device model
         # With the correlated changes in state_dict, meta device model should be accepted
         # in broadcasting and get copied successfully.
+        device_type = torch.device(device).type
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_model = nn.Sequential(
@@ -967,6 +974,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_multi_device_load_model_state_dict(self, device) -> None:
+        device_type = torch.device(device).type
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_submodel = nn.Linear(4, 4, bias=False)
@@ -1002,6 +1010,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_state_dict_with_hook_on_keys(self, device) -> None:
+        device_type = torch.device(device).type
         with torch.device("meta"):
             metamodel = FusionEmbedding(4, 4, 4)
         with torch.device(device_type):
@@ -1016,6 +1025,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_multi_param_groups(self, device) -> None:
+        device_type = torch.device(device).type
+
         class TestModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1099,6 +1110,7 @@ class TestNoComm(MultiProcessTestCase):
 
     @skip_if_lt_x_gpu(1)
     def test_no_dist(self, device) -> None:
+        device_type = torch.device(device).type
         model = CompositeParamModel(device=torch.device(device_type))
         optim = torch.optim.AdamW(model.parameters(), lr=1e-4)
 
@@ -1119,8 +1131,10 @@ class TestNoComm(MultiProcessTestCase):
         set_optimizer_state_dict(model, optim, optim.state_dict())
 
 
-instantiate_device_type_tests(TestStateDict, globals(), except_for="cpu")
-instantiate_device_type_tests(TestNoComm, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestStateDict, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(TestNoComm, globals(), except_for="cpu", allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -46,8 +46,13 @@ from torch.testing._internal.common_dist_composable import (
     CompositeParamModel,
     UnitModule,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MultiProcessTestCase,
@@ -79,6 +84,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     """Tests state_dict and load_state_dict"""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -224,7 +231,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_fsdp(self) -> None:
+    def test_fsdp(self, device) -> None:
         self.run_subtests(
             {
                 "use_orig_params": [True, False],
@@ -241,7 +248,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_compiled_fsdp(self) -> None:
+    def test_compiled_fsdp(self, device) -> None:
         self.run_subtests(
             {
                 "use_orig_params": [True],
@@ -286,7 +293,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_fsdp2(self) -> None:
+    def test_fsdp2(self, device) -> None:
         self.run_subtests(
             {
                 "reshard_after_forward": [True, False],
@@ -312,7 +319,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_ddp(self) -> None:
+    def test_ddp(self, device) -> None:
         self.run_subtests(
             {
                 "use_composable": [True, False],
@@ -363,7 +370,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_fsdp_ddp(self) -> None:
+    def test_fsdp_ddp(self, device) -> None:
         self.run_subtests(
             {
                 "optimizer_class": [torch.optim.Adam, torch.optim.AdamW],
@@ -383,7 +390,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self._test_save_load(init_model_optim)
 
     @skip_if_lt_x_gpu(1)
-    def test_single_gpu(self) -> None:
+    def test_single_gpu(self, device) -> None:
         self._test_single_gpu(torch.optim.Adam)
         self._test_single_gpu(torch.optim.AdamW)
 
@@ -416,7 +423,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(1)
-    def test_strict(self) -> None:
+    def test_strict(self, device) -> None:
         self.run_subtests(
             {"parallelism": ["DDP", "fully_shard"]},
             self._test_strict,
@@ -492,7 +499,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_cpu_offload_full_state_dict(self) -> None:
+    def test_cpu_offload_full_state_dict(self, device) -> None:
         self.run_subtests(
             {"optimizer_class": [torch.optim.Adam, torch.optim.AdamW]},
             self._test_cpu_offload_full_state_dict,
@@ -500,7 +507,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(1)
-    def test_activation_ckpt_fqns_ddp(self) -> None:
+    def test_activation_ckpt_fqns_ddp(self, device) -> None:
         """Tests that activation checkpointing prefixes are removed from module names"""
         model = CompositeParamModel(device=torch.device(device_type))
         original_keys = get_model_state_dict(model).keys()
@@ -513,7 +520,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(1)
-    def test_activation_ckpt_fqns_fsdp1(self) -> None:
+    def test_activation_ckpt_fqns_fsdp1(self, device) -> None:
         self.run_subtests(
             {"use_orig_params": [True, False]},
             self._test_activation_ckpt_fqns_fsdp1,
@@ -531,7 +538,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self.assertEqual(original_keys, new_keys)
 
     @skip_if_lt_x_gpu(1)
-    def test_extra_state(self) -> None:
+    def test_extra_state(self, device) -> None:
         model = CompositeParamModel(device=torch.device(device_type))
 
         def get_extra_state(self):
@@ -549,7 +556,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self.assertEqual(model.state_dict(), get_model_state_dict(target_model))
 
     @skip_if_lt_x_gpu(1)
-    def test_non_persistent_buffers(self) -> None:
+    def test_non_persistent_buffers(self, device) -> None:
         model = CompositeParamModel(device=torch.device(device_type))
         model.register_buffer(
             "dont_save_me", torch.rand(100, device=device_type), persistent=False
@@ -633,7 +640,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_broadcast_from_rank0(self) -> None:
+    def test_broadcast_from_rank0(self, device) -> None:
         device_mesh = init_device_mesh(device_type, (self.world_size,))
         hsdp_device_mesh = init_device_mesh(device_type, (2, self.world_size // 2))
         self.run_subtests(
@@ -653,7 +660,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_fsdp_root_not_initialized(self) -> None:
+    def test_fsdp_root_not_initialized(self, device) -> None:
         # This test verifies that FSDP root is not initialized but we should
         # still be able to  get the state_dict without errors because
         # fsdp_model.state_dict() will trigger the FSDP initialization.
@@ -666,7 +673,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_optim_state_dict_param_matching(self) -> None:
+    def test_optim_state_dict_param_matching(self, device) -> None:
         # This test verifies parameters between optim and optim_state_dict
         # "initial_lr" is added to optim_state_dict, but not to the new optim
         # We test whether "initial_lr" appear in optim after
@@ -706,7 +713,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_flattened_osd(self) -> None:
+    def test_flattened_osd(self, device) -> None:
         """
         Test flattened optimizer state dictionaries with different combinations of
         flatten_optimizer_state_dict flag for saving and loading.
@@ -818,13 +825,13 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(1)
-    def test_deprecate_api(self) -> None:
+    def test_deprecate_api(self, device) -> None:
         self._test_deprecate_partial()
         self._test_deprecate_fsdp_api()
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_shared_weight(self):
+    def test_shared_weight(self, device):
         class TiedEmbeddingModel(nn.Module):
             def __init__(self, vocab_size, embedding_dim):
                 super().__init__()
@@ -858,7 +865,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_setting_meta_device_model(self) -> None:
+    def test_setting_meta_device_model(self, device) -> None:
         # This test verifies that we can set model state dict by a meta device model
         torch.manual_seed(0)
         with torch.device("meta"):
@@ -886,7 +893,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_setting_meta_device_model_broadcasting_and_memory(self) -> None:
+    def test_setting_meta_device_model_broadcasting_and_memory(self, device) -> None:
         # This test verifies that we can set model state dict by a meta device model
         # With the correlated changes in state_dict, meta device model should be accepted
         # in broadcasting and get copied successfully.
@@ -932,7 +939,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_set_cpu_model_state_dict_broadcast_from_rank0(self) -> None:
+    def test_set_cpu_model_state_dict_broadcast_from_rank0(self, device) -> None:
         torch.manual_seed(42)
         model = nn.Linear(2, 2)
         expected_state_dict = {
@@ -959,7 +966,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_multi_device_load_model_state_dict(self) -> None:
+    def test_multi_device_load_model_state_dict(self, device) -> None:
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_submodel = nn.Linear(4, 4, bias=False)
@@ -994,7 +1001,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_state_dict_with_hook_on_keys(self) -> None:
+    def test_state_dict_with_hook_on_keys(self, device) -> None:
         with torch.device("meta"):
             metamodel = FusionEmbedding(4, 4, 4)
         with torch.device(device_type):
@@ -1008,7 +1015,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_multi_param_groups(self) -> None:
+    def test_multi_param_groups(self, device) -> None:
         class TestModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1084,12 +1091,14 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
 
 class TestNoComm(MultiProcessTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
 
     @skip_if_lt_x_gpu(1)
-    def test_no_dist(self) -> None:
+    def test_no_dist(self, device) -> None:
         model = CompositeParamModel(device=torch.device(device_type))
         optim = torch.optim.AdamW(model.parameters(), lr=1e-4)
 
@@ -1098,7 +1107,7 @@ class TestNoComm(MultiProcessTestCase):
             model, options=StateDictOptions(full_state_dict=True, cpu_offload=True)
         )
         for v in msd.values():
-            self.assertFalse(v.is_cuda)
+            self.assertEqual(v.device.type, "cpu")
         self.assertEqual(model.state_dict(), msd)
         set_model_state_dict(model, model.state_dict())
         osd = get_optimizer_state_dict(
@@ -1109,6 +1118,9 @@ class TestNoComm(MultiProcessTestCase):
         set_optimizer_state_dict(model, optim, osd)
         set_optimizer_state_dict(model, optim, optim.state_dict())
 
+
+instantiate_device_type_tests(TestStateDict, globals(), except_for="cpu")
+instantiate_device_type_tests(TestNoComm, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Tags `TestNoComm` and `TestStateDict` in `test/distributed/checkpoint/test_state_dict.py` with
`hw_classification = HardwareClassification.ACCELERATOR`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in ``TestNoComm` and `TestStateDict``.
- Added `hw_classification = HardwareClassification.ACCELERATOR` as the first class attribute of `TestNoComm` and `TestStateDict`.
- Replaced a CUDA-specific `assertFalse(v.is_cuda)` assertion in `TestNoComm.test_no_dist` with a device-agnostic `assertEqual(v.device.type, "cpu")` check.


## Context

`TestStateDict` (`DTensorTestBase`) and `TestNoComm` (`MultiProcessTestCase`) are tagged with `hw_classification = HardwareClassification.ACCELERATOR`, since both require a hardware accelerator.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `test/distributed/checkpoint/test_state_dict.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
