### PR TITLE
[Testcase Refactoring] Add HardwareClassification to test_state_dict_stager.py

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_stager.py
+++ b/test/distributed/checkpoint/test_state_dict_stager.py
@@ -3,7 +3,6 @@
 import dataclasses
 import os
 import tempfile
-import unittest
 from datetime import timedelta
 
 import psutil
@@ -26,29 +25,27 @@ from torch.distributed.checkpoint.staging import (
 )
 from torch.distributed.checkpoint.state_dict_saver import async_save
 from torch.distributed.tensor import DeviceMesh, distribute_tensor
-from torch.testing._internal.common_distributed import (
-    HAS_ACCELERATOR,
-    requires_accelerator_dist_backend,
-    skip_if_lt_x_gpu,
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    onlyAccelerator,
+    requires_capabilities,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
 
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-
-
-def create_cpu_state_dict(state_dict):
-    cpu_state_dict = {}
-    for key, value in state_dict.items():
-        cpu_state_dict[key] = value.cpu()
-    return cpu_state_dict
-
-
-def compare_state_dicts(gpu_state_dict, cpu_state_dict, rtol=1e-5, atol=1e-8):
+def compare_state_dicts(
+    gpu_state_dict, cpu_state_dict, device_type, rtol=1e-5, atol=1e-8
+):
     """
     Compare if two state dictionaries (one on GPU, one on CPU) are otherwise the same.
 
@@ -213,8 +210,11 @@ class FrozenDataClass:
 
 
 class TestStateDictStager(TestCase):
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_views(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_views(self, device):
+        device_type = torch.device(device).type
         test_configs = [
             (False, False),  # pin_memory=False, share_memory=False,
             (True, False),  # pin_memory=True, share_memory=False
@@ -272,7 +272,9 @@ class TestStateDictStager(TestCase):
                         f"Expected {expected_bytes} bytes, got {num_bytes}"
                     )
                 # Verify that the CPU state dict is equivalent to the original GPU state dict
-                result, error = compare_state_dicts(state_dict, cpu_state_dict)
+                result, error = compare_state_dicts(
+                    state_dict, cpu_state_dict, device_type
+                )
                 if not result:
                     raise AssertionError(f"State dicts are not equivalent: {error}")
 
@@ -308,11 +310,12 @@ class TestStateDictStager(TestCase):
                         "tensor3 and type.tensor1 should share storage"
                     )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_caching(self):
+    @onlyAccelerator
+    def test_caching(self, device):
         """
         Test that the StateDictStager correctly caches and reuses storages.
         """
+        device_type = torch.device(device).type
         test_configs = [
             (False, False),  # pin_memory=False, share_memory=False,
             (True, False),  # pin_memory=True, share_memory=False
@@ -346,7 +349,9 @@ class TestStateDictStager(TestCase):
                 num_storages1 = len(stager._cached_storage_mapping)
 
                 # Verify the first result is correct
-                result, error = compare_state_dicts(state_dict, cpu_state_dict1)
+                result, error = compare_state_dicts(
+                    state_dict, cpu_state_dict1, device_type
+                )
                 if not result:
                     raise AssertionError(
                         f"First state dict is not equivalent to original: {error}"
@@ -363,7 +368,9 @@ class TestStateDictStager(TestCase):
                 num_storages2 = len(stager._cached_storage_mapping)
 
                 # Verify that the second CPU state dict is equivalent to the modified original state dict
-                result, error = compare_state_dicts(state_dict, cpu_state_dict2)
+                result, error = compare_state_dicts(
+                    state_dict, cpu_state_dict2, device_type
+                )
                 if not result:
                     raise AssertionError(
                         f"Second state dict is not equivalent to modified original: {error}"
@@ -408,11 +415,12 @@ class TestStateDictStager(TestCase):
                         "Updated values should be reflected in the cached state dict for tensor2"
                     )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_tensor_attrs(self):
+    @onlyAccelerator
+    def test_tensor_attrs(self, device):
         """
         Test that tensor attributes are preserved during stage with StateDictStager.
         """
+        device_type = torch.device(device).type
         tensor1 = torch.randn(4, 4).to(device_type)
         tensor2 = tensor1.view(16)
         tensor3 = torch.randn(4, 4).to(device_type)
@@ -454,11 +462,12 @@ class TestStateDictStager(TestCase):
                 f"Tensor attribute 'c' has incorrect value: {cpu_state_dict['recursive']['tensor3'].c}"
             )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_different_dtypes(self):
+    @onlyAccelerator
+    def test_different_dtypes(self, device):
         """
         Test that StateDictStager works correctly with tensors of different data types.
         """
+        device_type = torch.device(device).type
         # Create tensors with different dtypes
         tensors = {
             "float32": torch.randn(4, 4, dtype=torch.float32).to(device_type),
@@ -496,11 +505,12 @@ class TestStateDictStager(TestCase):
                 lambda msg: f"{msg}\nTensor {dtype_name} has incorrect values",
             )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_empty_tensors(self):
+    @onlyAccelerator
+    def test_empty_tensors(self, device):
         """
         Test that StateDictStager works correctly with empty tensors.
         """
+        device_type = torch.device(device).type
         test_configs = [
             (False, False),  # pin_memory=False, share_memory=False,
             (True, False),  # pin_memory=True, share_memory=False
@@ -551,11 +561,12 @@ class TestStateDictStager(TestCase):
                         lambda msg: f"{msg}\nTensor {tensor_name} has incorrect dtype",
                     )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_complex_storage_sharing(self):
+    @onlyAccelerator
+    def test_complex_storage_sharing(self, device):
         """
         Test that StateDictStager correctly handles complex storage sharing scenarios.
         """
+        device_type = torch.device(device).type
         # Create a base tensor
         base_tensor = torch.randn(10, 10).to(device_type)
 
@@ -578,7 +589,7 @@ class TestStateDictStager(TestCase):
         cpu_state_dict = StateDictStager().stage(state_dict)
 
         # Verify that all tensors have been correctly copied to CPU
-        result, error = compare_state_dicts(state_dict, cpu_state_dict)
+        result, error = compare_state_dicts(state_dict, cpu_state_dict, device_type)
         self.assertTrue(
             result, lambda msg: f"{msg}\nState dicts are not equivalent: {error}"
         )
@@ -635,8 +646,9 @@ class TestStateDictStager(TestCase):
             "slice3 should reflect changes to base",
         )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_dataclasses(self):
+    @onlyAccelerator
+    def test_dataclasses(self, device):
+        device_type = torch.device(device).type
         # Create tensors
         tensor1 = torch.randn(4, 4).to(device_type)
         tensor2 = torch.randn(8, 8).to(device_type)
@@ -693,66 +705,12 @@ class TestStateDictStager(TestCase):
         self.assertFalse(torch.allclose(nested_cpu.tensor, tensor3.cpu()))
         self.assertFalse(torch.allclose(frozen_cpu.tensor, tensor4.cpu()))
 
-    def test_cpu_storage_independence(self):
-        """
-        Test ensures CPU tensors passed to StateDictStager are actually cloned
-        """
-        # Create test tensors
-        tensor1 = torch.randn(4, 4)
-        tensor2 = torch.randn(8, 8)
-
-        # Create a state dict with these tensors
-        state_dict = {
-            "tensor1": tensor1,
-            "tensor2": tensor2,
-        }
-
-        cpu_state_dict = StateDictStager().stage(state_dict)
-        cpu_tensor1 = cpu_state_dict["tensor1"]
-        cpu_tensor2 = cpu_state_dict["tensor2"]
-
-        # Verify that the CPU tensors have different storage pointers than the original tensors
-        self.assertNotEqual(
-            tensor1.storage().data_ptr(),
-            cpu_tensor1.storage().data_ptr(),
-            "CPU tensor should have a different storage pointer than the original tensor",
-        )
-        self.assertNotEqual(
-            tensor2.storage().data_ptr(),
-            cpu_tensor2.storage().data_ptr(),
-            "CPU tensor should have a different storage pointer than the original tensor",
-        )
-
-        self.assertTrue(
-            torch.allclose(tensor1, cpu_tensor1),
-            "CPU tensor should have the same values as the original tensor",
-        )
-        self.assertTrue(
-            torch.allclose(tensor2, cpu_tensor2),
-            "CPU tensor should have the same values as the original tensor",
-        )
-
-        # Modify the original CPU tensors and validate staged tensors are not modified
-        cloned_orginial1 = tensor1.clone()
-        cloned_orginia2 = tensor2.clone()
-        tensor1.fill_(99.0)
-        tensor2.fill_(88.0)
-
-        self.assertFalse(torch.allclose(cloned_orginial1, tensor1))
-        self.assertTrue(
-            torch.allclose(cloned_orginial1, cpu_tensor1),
-            "CPU tensor should have the same values as the original tensor",
-        )
-        self.assertTrue(
-            torch.allclose(cloned_orginia2, cpu_tensor2),
-            "CPU tensor should have the same values as the original tensor",
-        )
-
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_tensor_pinned_and_shared(self):
+    @onlyAccelerator
+    def test_tensor_pinned_and_shared(self, device):
         """
         Test that verifies tensors are actually pinned and shared using tensor.is_pinned() and tensor.is_shared() methods.
         """
+        device_type = torch.device(device).type
         # Create test tensors
         tensor1 = torch.randn(4, 4).to(device_type)
         tensor2 = torch.randn(8, 8).to(device_type)
@@ -847,8 +805,9 @@ class TestStateDictStager(TestCase):
                         "When share_memory=False, tensor storage should not be shared",
                     )
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_async_save_can_reuse_default_stager(self):
+    @onlyAccelerator
+    def test_async_save_can_reuse_default_stager(self, device):
+        device_type = torch.device(device).type
         state_dict = {
             "weight": torch.randn(4, 4, device=device_type),
             "step": 42,
@@ -876,10 +835,12 @@ class TestStateDictStager(TestCase):
 
 
 class TestDTensorStateDictStager(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
-    @requires_accelerator_dist_backend()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(2)
-    def test_dtensor(self):
+    def test_dtensor(self, device):
         """
         Test that StateDictStager works correctly with DTensors.
         """
@@ -910,8 +871,9 @@ class TestDTensorStateDictStager(DTensorTestBase):
         self.assertEqual(cpu_state_dict["dtensor"]._spec, dtensor._spec)
         self.assertEqual(cpu_state_dict["dtensor"].size(), dtensor.size())
 
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
-    def test_async_save_no_memory_leak(self):
+    @onlyAccelerator
+    def test_async_save_no_memory_leak(self, device):
+        device_type = torch.device(device).type
         # repeatedly calling async_save should not cause memory to grow by
         # the checkpoint size each iteration
         model_size_mb = 128
@@ -956,9 +918,11 @@ class TestReplicationStager(DTensorTestBase):
     Tests replication of state_dict across training ranks using CPU tensors only.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self) -> str:
-        return "cpu:gloo,cuda:nccl"
+        return f"cpu:gloo,{self.device_type}:{super().backend}"
 
     def _create_simple_state_dict(self, rank: int) -> dict:
         """
@@ -1267,7 +1231,7 @@ class TestReplicationStager(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_replication_basic(self):
+    def test_replication_basic(self, device):
         """Test basic replication functionality with world_size=16"""
         world_size = dist.get_world_size()
 
@@ -1299,7 +1263,7 @@ class TestReplicationStager(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_replication_dtensors(self):
+    def test_replication_dtensors(self, device):
         """Test replication with DTensor and mixed tensor types"""
         world_size = dist.get_world_size()
 
@@ -1340,7 +1304,7 @@ class TestReplicationStager(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_replication_sharded_tensors(self):
+    def test_replication_sharded_tensors(self, device):
         """Test replication with ShardedTensor and mixed tensor types"""
         world_size = dist.get_world_size()
 
@@ -1380,7 +1344,7 @@ class TestReplicationStager(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_replication_persistence(self):
+    def test_replication_persistence(self, device):
         """Test persistence functionality in _ReplicationStager"""
         world_size = dist.get_world_size()
 
@@ -1478,6 +1442,75 @@ class TestReplicationStager(DTensorTestBase):
             # Clean up
             stager.close()
 
+
+class TestStateDictStagerCPUStorage(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_cpu_storage_independence(self):
+        """
+        Test ensures CPU tensors passed to StateDictStager are actually cloned
+        """
+        # Create test tensors
+        tensor1 = torch.randn(4, 4)
+        tensor2 = torch.randn(8, 8)
+
+        # Create a state dict with these tensors
+        state_dict = {
+            "tensor1": tensor1,
+            "tensor2": tensor2,
+        }
+
+        cpu_state_dict = StateDictStager().stage(state_dict)
+        cpu_tensor1 = cpu_state_dict["tensor1"]
+        cpu_tensor2 = cpu_state_dict["tensor2"]
+
+        # Verify that the CPU tensors have different storage pointers than the original tensors
+        self.assertNotEqual(
+            tensor1.storage().data_ptr(),
+            cpu_tensor1.storage().data_ptr(),
+            "CPU tensor should have a different storage pointer than the original tensor",
+        )
+        self.assertNotEqual(
+            tensor2.storage().data_ptr(),
+            cpu_tensor2.storage().data_ptr(),
+            "CPU tensor should have a different storage pointer than the original tensor",
+        )
+
+        self.assertTrue(
+            torch.allclose(tensor1, cpu_tensor1),
+            "CPU tensor should have the same values as the original tensor",
+        )
+        self.assertTrue(
+            torch.allclose(tensor2, cpu_tensor2),
+            "CPU tensor should have the same values as the original tensor",
+        )
+
+        # Modify the original CPU tensors and validate staged tensors are not modified
+        cloned_orginial1 = tensor1.clone()
+        cloned_orginia2 = tensor2.clone()
+        tensor1.fill_(99.0)
+        tensor2.fill_(88.0)
+
+        self.assertFalse(torch.allclose(cloned_orginial1, tensor1))
+        self.assertTrue(
+            torch.allclose(cloned_orginial1, cpu_tensor1),
+            "CPU tensor should have the same values as the original tensor",
+        )
+        self.assertTrue(
+            torch.allclose(cloned_orginia2, cpu_tensor2),
+            "CPU tensor should have the same values as the original tensor",
+        )
+
+
+instantiate_device_type_tests(
+    TestStateDictStager, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDTensorStateDictStager, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestReplicationStager, globals(), except_for="cpu", allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Tags `TestStateDictStager`, `TestDTensorStateDictStager`, and `TestReplicationStager` with
`hw_classification = HardwareClassification.ACCELERATOR`, extracts CPU-only `test_cpu_storage_independence` into a standalone testcase class and tags with `HardwareClassification.GENERIC` in `test/distributed/checkpoint/test_state_dict_stager.py`,
opting the class into the hardware-classification test selection introduced by `--hw-classification`,
replaces a hardcoded `"cpu:gloo,cuda:nccl"` backend string in `TestReplicationStager.backend` with a
device-agnostic resolution , so the distributed backend pair follows the active accelerator, and removes the import-time `device_type` module global in favor of a per-method local derived from the injected `device` argument.

## Changes

- Added `HardwareClassification` import in `test/distributed/checkpoint/test_state_dict_stager.py`.
- Added `hw_classification = HardwareClassification.ACCELERATOR` as the first class attribute of `TestStateDictStager`, `TestDTensorStateDictStager`, and `TestReplicationStager`.
- Replaced `@requires_accelerator_dist_backend()` with `@requires_capabilities(Capability.distributed.backend)` on `TestDTensorStateDictStager.test_dtensor`, reusing the capability registry that `instantiate_device_type_tests` injects via `DeviceTypeTestBase`.
- Extract the CPU-only `test_cpu_storage_independence` into a standalone `TestStateDictStagerCPUStorage` class labeled `HardwareClassification.GENERIC`.
- Replaced 10 `@unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")` decorators with `@onlyAccelerator`.
- Replaced the literal `"cpu:gloo,cuda:nccl"` with a device-agnostic resolution `f"cpu:gloo,{self.device_type}:{super().backend}"`, and added the `device` parameter to its four `test_replication_*` methods.
- Remove the import-time module global `device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"`. Each test method that needs a device string now derives it from the injected argument via `device_type = torch.device(device).type`.

## Context

The classes `TestStateDictStager`, `TestDTensorStateDictStager`, and `TestReplicationStager` are plain `TestCase` (accelerator-gated) or `DTensorTestBase` harness classes that obtain devices via the module-level `device_type` and `self.device_type`. Hence  classified as `ACCELERATOR` following `HardwareClassification` rules.

The testcase `test_cpu_storage_independence` exercises only CPU storage-cloning behavior and does not need accelerator instantiation, hence extract it into a standalone `TestStateDictStagerCPUStorage` class labeled `HardwareClassification.GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are unchanged; the tag only takes effect when the selection flag is used.

`HAS_ACCELERATOR` is `TEST_CUDA or TEST_HPU or TEST_XPU`, so it evaluated `False` on out-of-tree backends and skipped accelerator tests there; `@onlyAccelerator` skips only when `self.device_type` is `cpu`/`meta` and therefore runs on any registered accelerator.

In `TestReplicationStager.backend`, the hardcoded `"cpu:gloo,cuda:nccl"` caused failures while running tests on out-of-tree backends, hence replaced it with `"cpu:gloo,{self.device_type}:{super().backend}"`, mirroring the base `DTensorTestBase.backend` / `init_pg` pattern.  On CUDA the resolved string is identical (`"cpu:gloo,cuda:nccl"`); on other accelerators it now resolves the correct collective backend instead of forcing NCCL.

The import-time `device_type` module global is removed and replaced by a per-method local derived from the injected `device` argument, so the per-instance device no longer depends on a value computed once at import time. This makes the `device` parameter load-bearing rather than dead.


## Test plan

- Run the test file:
  `python test/distributed/checkpoint/test_state_dict_stager.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
