### PR TITLE
Fix typo in docs/source/notes/faq.md

### DIFF
--- a/docs/source/notes/faq.md
+++ b/docs/source/notes/faq.md
@@ -108,7 +108,7 @@ except RuntimeError: # Out of memory
 But find that when you do run out of memory, your recovery code can't allocate
 either. That's because the python exception object holds a reference to the
 stack frame where the error was raised. Which prevents the original tensor
-objects from being freed. The solution is to move you OOM recovery code outside
+objects from being freed. The solution is to move your OOM recovery code outside
 of the `except` clause.
 
 ```python


### PR DESCRIPTION
Fixes #193360

In `docs/source/notes/faq.md`, "move you OOM recovery code" -> "move your OOM recovery code".

> AI-generated content disclosure: The typo was identified with the help of an AI assistant (opencode). I reviewed the finding and confirmed it against the file before submitting this PR.