### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard memory

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -17,12 +17,15 @@ from torch.distributed.fsdp import (
     OffloadPolicy,
 )
 from torch.distributed.tensor import init_device_mesh
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
+    HardwareClassification,
     run_tests,
-    TEST_CUDA,
     TEST_HPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -36,6 +39,8 @@ device_type = torch.device(get_devtype())
 
 
 class TestFullyShardMemory(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(2, torch.get_device_module(device_type).device_count())
@@ -365,13 +370,14 @@ class TestFullyShardHSDPSyncCorrectness(FSDPTest):
     `foreach_reduce`.
     """
 
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
     # This test is CUDA-specific because it relies on torch.cuda._sleep.
     @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(not TEST_CUDA, "HSDP sync correctness test is CUDA-only")
     def test_ar_buffer_lifetime_mixed_dtype(self):
         """Regression guard for PR #140044 (`[FSDP2] Fix CUDA sync for bf16
         HSDP AR, fp32 params`).
@@ -499,6 +505,19 @@ class TestFullyShardHSDPSyncCorrectness(FSDPTest):
                         f"(see PR #140044, PR #180900)."
                     ),
                 )
+
+
+instantiate_device_type_tests(
+    TestFullyShardMemory,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardHSDPSyncCorrectness,
+    globals(),
+    only_for=["cuda"],
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -17,9 +17,7 @@ from torch.distributed.fsdp import (
     OffloadPolicy,
 )
 from torch.distributed.tensor import init_device_mesh
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import (
@@ -47,7 +45,7 @@ class TestFullyShardMemory(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_HPU, " 'empty_cache' is not supported on hpu")
-    def test_fully_shard_training_memory(self):
+    def test_fully_shard_training_memory(self, device):
         self.run_subtests(
             {
                 "reshard_after_forward": [True, False],
@@ -243,7 +241,7 @@ class TestFullyShardMemory(FSDPTest):
         self.assertLessEqual(mem_mb - base_mem_mb, expected_mem_mb)
 
     @skip_if_lt_x_gpu(2)
-    def test_fully_shard_training_memory_no_gc(self):
+    def test_fully_shard_training_memory_no_gc(self, device):
         """Memory should not grow across training steps when GC is disabled.
 
         Regression test: reference cycles in FSDP's autograd integration can
@@ -302,7 +300,7 @@ class TestFullyShardMemory(FSDPTest):
             gc.enable()
 
     @skip_if_lt_x_gpu(2)
-    def test_fully_shard_del_memory(self):
+    def test_fully_shard_del_memory(self, device):
         base_mem_mb = self._get_peak_active_memory_mb()
         vocab_size = 32
         model_args = ModelArgs(
@@ -378,7 +376,7 @@ class TestFullyShardHSDPSyncCorrectness(FSDPTest):
 
     # This test is CUDA-specific because it relies on torch.cuda._sleep.
     @skip_if_lt_x_gpu(4)
-    def test_ar_buffer_lifetime_mixed_dtype(self):
+    def test_ar_buffer_lifetime_mixed_dtype(self, device):
         """Regression guard for PR #140044 (`[FSDP2] Fix CUDA sync for bf16
         HSDP AR, fp32 params`).
 


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR / CUDA) to the fully_shard memory test classes and instantiates them via instantiate_device_type_tests, so they are discovered per device type under the hardware-classification selection. TestFullyShardMemory is classified as ACCELERATOR and instantiated for all supported device types (except_for=["cpu"], allow_xpu=True); TestFullyShardHSDPSyncCorrectness is classified as CUDA and instantiated with only_for=["cuda"]. The class-level @unittest.skipIf(not TEST_CUDA, ...) guard is removed since hw_classification + only_for=["cuda"] already restrict it to CUDA, making the guard redundant.

Test Plan: Ran the two commands below; each executed only the tests matching the requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_memory.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_memory.py --hw-classification GENERIC