### PR TITLE
Fix typo in docs/source/notes/libtorch_stable_abi.md

### DIFF
--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -64,7 +64,7 @@ acquire it first.
 
 ## Migrating your kernel to the LibTorch stable ABI
 
-If you'd like your kernel to be ABI stable with LibTorch, meaning you'd the ability to build for one version and run on another, your kernel must only use the limited stable ABI. This following section goes through some steps of migrating an existing kernel and APIs we imagine you would need to swap over.
+If you'd like your kernel to be ABI stable with LibTorch, meaning you'd have the ability to build for one version and run on another, your kernel must only use the limited stable ABI. This following section goes through some steps of migrating an existing kernel and APIs we imagine you would need to swap over.
 
 Firstly, instead of registering kernels through `TORCH_LIBRARY`, LibTorch ABI stable kernels must be registered via `STABLE_TORCH_LIBRARY`. Note that implementations registered via `STABLE_TORCH_LIBRARY` must be boxed unlike `TORCH_LIBRARY`. The `TORCH_BOX` macro handles this automatically for most use cases. See the simple example below or our docs on [Stack-based APIs](stack-based-apis) for more details. For kernels that are registered via `pybind`, before using the stable ABI, it would be useful to migrate to register them via `TORCH_LIBRARY`.
 


### PR DESCRIPTION
Fixes #193364

In `docs/source/notes/libtorch_stable_abi.md`, "you'd the ability" -> "you'd have the ability".

> AI-generated content disclosure: The typo was identified with the help of an AI assistant (opencode). I reviewed the finding and confirmed it against the file before submitting this PR.