### PR TITLE
Parallelize slow_conv3d across the batch dimension

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -23,7 +23,7 @@
 #include <ATen/ops/sum.h>
 #endif
 
-constexpr int64_t CONV3D_GRAIN_SALT = 20;
+constexpr int64_t CONV3D_GRAIN_SALT = 0;
 
 namespace at::native {
 


### PR DESCRIPTION
## Summary

`slow_conv3d` parallelizes over the batch dimension with `at::parallel_for`, but passed `CONV3D_GRAIN_SALT = 20` as the grain size. The grain size is the threshold below which at::parallel_for keeps the loop on a single thread. Since the loop runs once per batch item, any conv3d with a batch smaller than 21 fell below that threshold and ran the batch loop on a single thread.

## Changes

Set `CONV3D_GRAIN_SALT` to `0`, so the three batch loops in `ConvolutionMM3d.cpp` - the unfold in `compute_columns3d`, the forward GEMM, and backward grad-input - always parallelize across the batch, matching conv2d.

## Performance

Hardware: Windows ARM64, 12 cores, torch 2.14.0

**Benchmark:** `Conv3d_IC64_OC64_kernel3_stride1_N8_D4_H16_W16_cpu_dtypetorch.float32`

| Platform | Before (ms) | After (ms) | Speedup |
|----------|------------:|-----------:|--------:|
| Windows ARM64 | 8.429 | 1.335 | **6.3x** |

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01