### PR TITLE
FindAPL: Use _mp variant of APL when USE_OPENMP is enabled

### DIFF
--- a/cmake/Modules/FindAPL.cmake
+++ b/cmake/Modules/FindAPL.cmake
@@ -14,6 +14,12 @@ SET(APL_BIN_SEARCH_PATHS $ENV{ARMPL_DIR}/bin)
 
 SET(APL_FOUND ON)
 
+IF(USE_OPENMP)
+    SET(APL_THREADING_SUFFIX "_mp")
+ELSE()
+    SET(APL_THREADING_SUFFIX "")
+ENDIF()
+
 # Check include file
 FIND_PATH(APL_INCLUDE_DIR NAMES armpl.h PATHS ${APL_INCLUDE_SEARCH_PATHS})
 IF(NOT APL_INCLUDE_DIR)
@@ -22,14 +28,14 @@ IF(NOT APL_INCLUDE_DIR)
 ENDIF()
 
 # Check lib file
-FIND_PATH(APL_LIB_DIR NAMES armpl_lp64.dll.lib libarmpl_lp64.a PATHS ${APL_LIB_SEARCH_PATHS})
+FIND_PATH(APL_LIB_DIR NAMES armpl_lp64${APL_THREADING_SUFFIX}.dll.lib libarmpl_lp64${APL_THREADING_SUFFIX}.a PATHS ${APL_LIB_SEARCH_PATHS})
 IF(NOT APL_LIB_DIR)
     SET(APL_FOUND OFF)
     MESSAGE(STATUS "Could not verify APL lib directory. Turning APL_FOUND off")
 ENDIF()
 
 # Check bin file
-FIND_PATH(APL_BIN_DIR NAMES armpl_lp64.dll armpl-info PATHS ${APL_BIN_SEARCH_PATHS})
+FIND_PATH(APL_BIN_DIR NAMES armpl_lp64${APL_THREADING_SUFFIX}.dll armpl-info PATHS ${APL_BIN_SEARCH_PATHS})
 IF(NOT APL_BIN_DIR)
     SET(APL_FOUND OFF)
     MESSAGE(STATUS "Could not verify APL bin directory. Turning APL_FOUND off")
@@ -38,20 +44,20 @@ ENDIF()
 IF (APL_FOUND)
   IF(WIN32)
     set(APL_LIBRARIES
-      "${APL_LIB_DIR}/armpl_lp64.dll.lib"
+      "${APL_LIB_DIR}/armpl_lp64${APL_THREADING_SUFFIX}.dll.lib"
     )
     set(APL_DLLS
-      "${CMAKE_INSTALL_PREFIX}/lib/armpl_lp64.dll"
+      "${CMAKE_INSTALL_PREFIX}/lib/armpl_lp64${APL_THREADING_SUFFIX}.dll"
     )
     add_custom_command(
       OUTPUT ${APL_DLLS}
       COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_INSTALL_PREFIX}/lib"
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${APL_BIN_DIR}/armpl_lp64.dll" "${CMAKE_INSTALL_PREFIX}/lib/armpl_lp64.dll"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${APL_BIN_DIR}/armpl_lp64${APL_THREADING_SUFFIX}.dll" "${CMAKE_INSTALL_PREFIX}/lib/armpl_lp64${APL_THREADING_SUFFIX}.dll"
     )
     add_custom_target(copy_apl_dlls ALL DEPENDS ${APL_DLLS})
   ELSEIF(UNIX)
     set(APL_LIBRARIES
-      "${APL_LIB_DIR}/libarmpl_lp64.a"
+      "${APL_LIB_DIR}/libarmpl_lp64${APL_THREADING_SUFFIX}.a"
     )
   ENDIF()
   MESSAGE(STATUS "Found APL header: ${APL_INCLUDE_DIR}")


### PR DESCRIPTION
## Summary
 
`FindAPL.cmake` searches for serial Arm Performance Libraries build (`armpl_lp64`). APL ships both a serial and an OpenMP-threaded build of each interface, the latter carrying an `_mp` suffix, so any PyTorch built with `BLAS=APL` got a single-threaded BLAS regardless of `USE_OPENMP`.
 
## Changes
 
Derive an `APL_THREADING_SUFFIX` (`_mp` when `USE_OPENMP` is on, empty otherwise) and apply it consistently to the library and DLL names.
 
## Performance
 
Windows ARM64, `BLAS=APL`, benchmarks from `benchmarks/operator_benchmark`.
Hardware: Windows-ARM64, 12 cores, torch 2.14.0
 
| Operation | Shape | Before (ms) | After (ms) | Speedup |
|-----------|-------|------------:|-----------:|--------:|
| ConvTranspose3d | IC64 OC64 k3 s1 N8 D4 H16 W16 | 29.869 | 4.208 | **7.10x** |
| ConvTranspose1d | IC2016 OC1026 k1024 s256 N1 L224 | 9982.401 | 3898.417 | **2.56x** |
| ConvTranspose2d | IC256 OC256 k3 s1 N1 H16 W16 G1 pad0 | 3.573 | 1.665 | **2.15x** |
| Conv2d | IC256 OC256 k3 s1 N1 H16 W16 G1 pad0 | 2.381 | 1.769 | **1.35x** |