### PR TITLE
Enable a reference CPU MXFP scaled_mm path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@
 # /aten/src/ATen/native/TriangularOpsUtils.h
 /test/test_linalg.py @lezcano @nikitaved
 # /test/test_matmul_cuda.py
+# /test/test_scaled_matmul_cpu.py
 /test/test_scaled_matmul_cuda.py @drisspg @slayton58
 # /test/test_spectral_ops.py
 /torch/linalg/ @lezcano @nikitaved

--- a/aten/src/ATen/native/ScaledBlas.cpp
+++ b/aten/src/ATen/native/ScaledBlas.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/GroupedMMUtils.h>
 #include <ATen/BlasBackend.h>
 #include <ATen/native/ScaledBlasUtils.h>
+#include <ATen/native/cpu/mxfp_mm_kernel.h>
 #if !defined(__s390x__) && !defined(__powerpc__)
 #include <cpuinfo.h>
 #endif
@@ -78,6 +79,26 @@ TORCH_META_FUNC(_scaled_mm_v2)(
   TORCH_CHECK_VALUE(self.dim() == 2, "mat_a must be a matrix");
   TORCH_CHECK_VALUE(mat2.dim() == 2, "mat_b must be a matrix");
 
+  std::vector<Tensor> scale_a_vec(scale_a.begin(), scale_a.end());
+  std::vector<Tensor> scale_b_vec(scale_b.begin(), scale_b.end());
+  auto recipe_a_enum =
+      scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_a);
+  auto recipe_b_enum =
+      scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_b);
+  auto swizzle_a_enum =
+      scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_a);
+  auto swizzle_b_enum =
+      scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_b);
+  const bool is_cpu_mxfp = scaled_blas::validate_cpu_mxfp_v2_inputs(
+      self,
+      scale_a_vec,
+      recipe_a_enum,
+      swizzle_a_enum,
+      scale_b_vec,
+      recipe_b_enum,
+      swizzle_b_enum,
+      contraction_dim);
+
   if (!contraction_dim.empty()) {
     TORCH_CHECK_VALUE(contraction_dim.size() == 2, "contraction_dim must have exactly 2 elements");
     auto mat_a_dim = contraction_dim[0];
@@ -96,18 +117,17 @@ TORCH_META_FUNC(_scaled_mm_v2)(
       !bias.has_value() || bias->sym_numel() == mat2.sym_size(1),
       "Bias must be size ", mat2.sym_size(1), " but got ", bias->sym_numel());
 
-  // Layout / per-recipe scale-shape validation. Materialize the lists so the
-  // helper sees ArrayRef<Tensor> rather than ITensorListRef.
-  std::vector<Tensor> scale_a_vec(scale_a.begin(), scale_a.end());
-  std::vector<Tensor> scale_b_vec(scale_b.begin(), scale_b.end());
-  auto recipe_a_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_a);
-  auto recipe_b_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_b);
-  auto swizzle_a_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_a);
-  auto swizzle_b_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_b);
-  scaled_blas::validate_scaled_mm_v2_inputs(
-      self, mat2,
-      scale_a_vec, recipe_a_enum, swizzle_a_enum,
-      scale_b_vec, recipe_b_enum, swizzle_b_enum);
+  if (!is_cpu_mxfp) {
+    scaled_blas::validate_scaled_mm_v2_inputs(
+        self,
+        mat2,
+        scale_a_vec,
+        recipe_a_enum,
+        swizzle_a_enum,
+        scale_b_vec,
+        recipe_b_enum,
+        swizzle_b_enum);
+  }
 
   const auto out_dtype_ = out_dtype.value_or(self.scalar_type());
   set_output_raw_strided(
@@ -157,6 +177,8 @@ namespace at::native {
 
 using at::blas::ScalingType;
 using at::blas::SwizzleType;
+
+DEFINE_DISPATCH(mxfp_mm_stub);
 
 namespace {
 
@@ -240,6 +262,106 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
   }
   invalid_scaling_config(mat_a, mat_b, scale_a, scale_b);
   return {};
+}
+
+bool is_mxfp_scale(const Tensor& scale) {
+  return scale.scalar_type() == ScalarType::Float8_e8m0fnu;
+}
+
+void validate_mxfp_cpu(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    const Tensor& out) {
+  TORCH_CHECK_VALUE(
+      mat_a.dim() == 2 && mat_b.dim() == 2, "MXFP operands must be matrices");
+  TORCH_CHECK_VALUE(
+      is_mxfp_scale(scale_a) && is_mxfp_scale(scale_b),
+      "MXFP scales must both have dtype Float8_e8m0fnu");
+
+  const auto input_dtype = mat_a.scalar_type();
+  const bool is_mxfp4 = input_dtype == ScalarType::Float4_e2m1fn_x2;
+  TORCH_CHECK_VALUE(
+      mat_b.scalar_type() == input_dtype &&
+          (is_mxfp4 || input_dtype == ScalarType::Float8_e4m3fn),
+      "MXFP operands must both have dtype Float8_e4m3fn or Float4_e2m1fn_x2");
+
+  const int64_t packing = is_mxfp4 ? 2 : 1;
+  const int64_t logical_k = packing * mat_a.size(1);
+  TORCH_CHECK_VALUE(
+      mat_a.size(1) == mat_b.size(0),
+      "MXFP operand shapes cannot be multiplied: ",
+      mat_a.sizes(),
+      " and ",
+      mat_b.sizes());
+  const int64_t k_blocks = (logical_k + 31) / 32;
+  TORCH_CHECK_VALUE(
+      scale_a.dim() == 2 && scale_a.size(0) == mat_a.size(0) &&
+          scale_a.size(1) == k_blocks,
+      "MXFP scale_a must have shape (", mat_a.size(0), ", ", k_blocks,
+      "), got ", scale_a.sizes());
+  TORCH_CHECK_VALUE(
+      scale_b.dim() == 2 && scale_b.size(0) == mat_b.size(1) &&
+          scale_b.size(1) == k_blocks,
+      "MXFP scale_b must have shape (", mat_b.size(1), ", ", k_blocks,
+      "), got ", scale_b.sizes());
+  TORCH_CHECK_VALUE(
+      scale_a.is_contiguous(), "MXFP scale_a must be contiguous");
+  TORCH_CHECK_VALUE(
+      scale_b.is_contiguous(), "MXFP scale_b must be contiguous");
+  TORCH_CHECK_VALUE(mat_a.is_contiguous(), "MXFP mat_a must be row-major");
+  TORCH_CHECK_VALUE(
+      mat_b.numel() == 0 ||
+          (mat_b.size(0) == 1 && mat_b.stride(1) == 1) ||
+          (mat_b.size(1) == 1 && mat_b.stride(0) == 1) ||
+          (mat_b.stride(0) == 1 && mat_b.stride(1) == mat_b.size(0)),
+      "MXFP mat_b must be column-major");
+  TORCH_CHECK_VALUE(
+      out.scalar_type() == ScalarType::BFloat16 ||
+          out.scalar_type() == ScalarType::Float,
+      "CPU MXFP output must have dtype BFloat16 or Float32, got ",
+      out.scalar_type());
+  TORCH_CHECK_VALUE(out.is_contiguous(), "CPU MXFP output must be contiguous");
+  TORCH_CHECK_VALUE(
+      !bias.has_value() || bias->numel() == mat_b.size(1),
+      "Bias must be size ",
+      mat_b.size(1),
+      " but got ",
+      bias.has_value() ? bias->numel() : 0);
+  TORCH_CHECK_VALUE(
+      !bias.has_value() || bias->scalar_type() == ScalarType::Half ||
+          bias->scalar_type() == ScalarType::BFloat16 ||
+          bias->scalar_type() == ScalarType::Float,
+      "CPU MXFP bias must have dtype Float16, BFloat16, or Float32, got ",
+      bias.has_value() ? bias->scalar_type() : ScalarType::Undefined);
+}
+
+Tensor& _scaled_mm_mxfp_out_cpu(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<Tensor>& bias,
+    Tensor& out) {
+  validate_mxfp_cpu(mat_a, mat_b, scale_a, scale_b, bias, out);
+  at::native::resize_output(out, {mat_a.size(0), mat_b.size(1)});
+  if (out.numel() == 0) {
+    return out;
+  }
+  const Tensor bias_data = bias.has_value()
+      ? bias->contiguous().view({-1})
+      : Tensor{};
+  if (mat_a.size(1) == 0) {
+    out.zero_();
+    if (bias_data.defined()) {
+      out.add_(bias_data);
+    }
+    return out;
+  }
+  mxfp_mm_stub(kCPU, mat_a, mat_b, scale_a, scale_b, bias_data, out);
+  return out;
 }
 
 } // namespace
@@ -375,6 +497,20 @@ _scaled_mm_out_cpu(const Tensor& mat1, const Tensor& mat2,
           std::optional<c10::ScalarType> out_dtype,
           bool use_fast_accum,
           Tensor& out) {
+  if (is_mxfp_scale(scale_a) || is_mxfp_scale(scale_b)) {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        !scale_result.has_value(), "CPU MXFP does not support scale_result");
+    TORCH_CHECK_VALUE(
+        !out_dtype || *out_dtype == out.scalar_type(),
+        "out_dtype must match output matrix type");
+    return _scaled_mm_mxfp_out_cpu(
+        mat1,
+        mat2,
+        scale_a,
+        scale_b,
+        bias,
+        out);
+  }
 #if AT_MKLDNN_ENABLED() && !defined(__powerpc__)
   if (at::globalContext().userEnabledMkldnn() && scale_a.numel() == 1 && scale_b.numel() == 1) {
     bool mixed_dtype = mat1.scalar_type() != mat2.scalar_type();
@@ -469,6 +605,34 @@ TORCH_IMPL_FUNC(_scaled_mm_cpu_v2_out)(
   ArrayRef<Tensor> scale_a_ref(scale_a);
   ArrayRef<Tensor> scale_b_ref(scale_b);
 
+  // Conversion of implicitly-defined enums to explicit
+  auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
+  auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
+  auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
+  auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
+  std::optional<Tensor> bias_opt = bias.has_value()
+      ? std::optional<Tensor>{*bias}
+      : std::optional<Tensor>{std::nullopt};
+
+  if (scaled_blas::validate_cpu_mxfp_v2_inputs(
+          mat_a,
+          scale_a_ref,
+          scale_recipe_a_enum,
+          swizzle_a_enum,
+          scale_b_ref,
+          scale_recipe_b_enum,
+          swizzle_b_enum,
+          contraction_dim)) {
+    _scaled_mm_mxfp_out_cpu(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias_opt,
+        const_cast<Tensor&>(out));
+    return;
+  }
+
   // If any of M, K, N is 0 - return early (the tensorwise/rowwise float8 gemm kernels
   // do not support this case). The output has already been sized by the
   // structured-op meta function; we only need to zero-fill when K=0.
@@ -487,12 +651,6 @@ TORCH_IMPL_FUNC(_scaled_mm_cpu_v2_out)(
         "Bias must be Float32 or BFloat16 or Half, but got ",
         bias->scalar_type());
   }
-
-  // Conversion of implicitly-defined enums to explicit
-  auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
-  auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
-  auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
-  auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
   if (!swizzle_a_enum.empty() && !swizzle_b_enum.empty()) {
     TORCH_CHECK_VALUE(
@@ -521,10 +679,6 @@ TORCH_IMPL_FUNC(_scaled_mm_cpu_v2_out)(
 
     invalid_scaling_config(mat_a, mat_b, scale_a_opt, scale_b_opt);
   }
-
-  std::optional<Tensor> bias_opt = bias.has_value()
-      ? std::optional<Tensor>{*bias}
-      : std::optional<Tensor>{std::nullopt};
 
   if (gemm_impl == ScaledGemmImplementation::TENSORWISE_TENSORWISE ||
       gemm_impl == ScaledGemmImplementation::ROWWISE_ROWWISE) {

--- a/aten/src/ATen/native/ScaledBlasUtils.cpp
+++ b/aten/src/ATen/native/ScaledBlasUtils.cpp
@@ -296,6 +296,50 @@ bool is_two_level_nvfp4(
 
 } // namespace
 
+bool validate_cpu_mxfp_v2_inputs(
+    const Tensor& mat_a,
+    ArrayRef<Tensor> scale_a,
+    ArrayRef<ScalingType> recipe_a,
+    ArrayRef<SwizzleType> swizzle_a,
+    ArrayRef<Tensor> scale_b,
+    ArrayRef<ScalingType> recipe_b,
+    ArrayRef<SwizzleType> swizzle_b,
+    IntArrayRef contraction_dim) {
+  const auto has_mxfp_scale = [](ArrayRef<Tensor> scales) {
+    for (const auto& scale : scales) {
+      if (scale.scalar_type() == ScalarType::Float8_e8m0fnu) {
+        return true;
+      }
+    }
+    return false;
+  };
+  if (!mat_a.device().is_cpu() ||
+      (!has_mxfp_scale(scale_a) && !has_mxfp_scale(scale_b))) {
+    return false;
+  }
+  TORCH_CHECK_VALUE(
+      scale_a.size() == 1 && scale_b.size() == 1 &&
+          is_single_recipe(
+              recipe_a,
+              recipe_b,
+              ScalingType::BlockWise1x32,
+              ScalingType::BlockWise1x32),
+      "CPU MXFP requires one BlockWise1x32 scale per operand");
+  const auto is_no_swizzle = [](ArrayRef<SwizzleType> swizzle) {
+    return swizzle.empty() ||
+        (swizzle.size() == 1 && swizzle[0] == SwizzleType::NO_SWIZZLE);
+  };
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      is_no_swizzle(swizzle_a) && is_no_swizzle(swizzle_b),
+      "CPU MXFP only supports NO_SWIZZLE");
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      contraction_dim.empty() ||
+          (contraction_dim.size() == 2 && contraction_dim[0] == 1 &&
+           contraction_dim[1] == 0),
+      "CPU scaled_mm_v2 only supports contraction_dim=[] or [1, 0]");
+  return true;
+}
+
 // Eager-and-meta validation for `_scaled_mm_v2`. Mirrors a subset of the
 // kernel-side checks so torch.compile tracing fails fast with the same
 // messages users get in eager. We deliberately *don't* duplicate checks

--- a/aten/src/ATen/native/ScaledBlasUtils.h
+++ b/aten/src/ATen/native/ScaledBlasUtils.h
@@ -182,6 +182,18 @@ bool check_mxfp4_recipe(
     std::vector<ScalingType>& recipe_b,
     ArrayRef<Tensor>& scales_b);
 
+// Returns true when the configuration is handled as CPU MXFP.
+TORCH_API
+bool validate_cpu_mxfp_v2_inputs(
+    const Tensor& mat_a,
+    ArrayRef<Tensor> scale_a,
+    ArrayRef<ScalingType> recipe_a,
+    ArrayRef<SwizzleType> swizzle_a,
+    ArrayRef<Tensor> scale_b,
+    ArrayRef<ScalingType> recipe_b,
+    ArrayRef<SwizzleType> swizzle_b,
+    IntArrayRef contraction_dim);
+
 /**
  * Validate v2 _scaled_mm inputs and per-recipe scale shapes/dtypes.
  * Centralized here so it can be called from both TORCH_META_FUNC (so

--- a/aten/src/ATen/native/cpu/mxfp_mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/mxfp_mm_kernel.cpp
@@ -1,0 +1,152 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include <ATen/Parallel.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/cpu/mxfp_mm_kernel.h>
+#include <c10/util/bit_cast.h>
+#include <c10/util/irange.h>
+
+namespace at::native {
+
+#if defined(CPU_CAPABILITY_DEFAULT)
+const float* get_mxfp8_values() {
+  static const auto values = [] {
+    std::array<float, 256> result{};
+    for (int encoding = 0; encoding < 256; ++encoding) {
+      result[encoding] = static_cast<float>(c10::Float8_e4m3fn(
+          static_cast<uint8_t>(encoding), c10::Float8_e4m3fn::from_bits()));
+    }
+    return result;
+  }();
+  return values.data();
+}
+#endif
+
+namespace {
+
+constexpr std::array<float, 16> mxfp4_values = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f};
+C10_ALWAYS_INLINE float apply_mxfp_scale(
+    float value, uint8_t scale_a, uint8_t scale_b) {
+  if (scale_a == 0xff || scale_b == 0xff) {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+  const int exponent = static_cast<int>(scale_a) +
+      static_cast<int>(scale_b) - 254;
+  const int biased_exponent = exponent + 127;
+  if (biased_exponent > 0 && biased_exponent < 255) {
+    const auto bits = static_cast<uint32_t>(biased_exponent) << 23;
+    return value * c10::bit_cast<float>(bits);
+  }
+  return std::scalbn(value, exponent);
+}
+
+void mxfp_mm_emulated_kernel(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const Tensor& bias_data,
+    Tensor& out) {
+  const bool is_fp4 = mat_a.scalar_type() == ScalarType::Float4_e2m1fn_x2;
+  const int64_t m = mat_a.size(0);
+  const int64_t k = mat_a.size(1) * (is_fp4 ? 2 : 1);
+  const int64_t n = mat_b.size(1);
+  const int64_t groups = (k + 31) / 32;
+  const auto* scale_a_data = scale_a.const_data_ptr<c10::Float8_e8m0fnu>();
+  const auto* scale_b_data = scale_b.const_data_ptr<c10::Float8_e8m0fnu>();
+  const auto* bias_f32 =
+      bias_data.defined() && bias_data.scalar_type() == ScalarType::Float
+      ? bias_data.const_data_ptr<float>()
+      : nullptr;
+  const auto* bias_f16 =
+      bias_data.defined() && bias_data.scalar_type() == ScalarType::Half
+      ? bias_data.const_data_ptr<c10::Half>()
+      : nullptr;
+  const auto* bias_bf16 =
+      bias_data.defined() && bias_data.scalar_type() == ScalarType::BFloat16
+      ? bias_data.const_data_ptr<c10::BFloat16>()
+      : nullptr;
+  auto* out_f32 = out.scalar_type() == ScalarType::Float
+      ? out.mutable_data_ptr<float>()
+      : nullptr;
+  auto* out_bf16 = out.scalar_type() == ScalarType::BFloat16
+      ? out.mutable_data_ptr<c10::BFloat16>()
+      : nullptr;
+
+  auto run = [&](auto load_a, auto load_b) {
+    const int64_t grain_size =
+        std::max<int64_t>(1, at::internal::GRAIN_SIZE / k);
+    at::parallel_for(0, m * n, grain_size, [&](int64_t begin, int64_t end) {
+      for (const auto index : c10::irange(begin, end)) {
+        const int64_t row = index / n;
+        const int64_t column = index % n;
+        float result = 0.0f;
+        for (const auto group : c10::irange(groups)) {
+          float partial = 0.0f;
+          const int64_t group_start = group * 32;
+          const int64_t group_size = std::min<int64_t>(32, k - group_start);
+          for (const auto offset : c10::irange(group_size)) {
+            const int64_t inner = group_start + offset;
+            partial += load_a(row, inner) * load_b(inner, column);
+          }
+          result += apply_mxfp_scale(
+              partial,
+              scale_a_data[row * groups + group].x,
+              scale_b_data[column * groups + group].x);
+        }
+        if (bias_f32 != nullptr) {
+          result += bias_f32[column];
+        } else if (bias_f16 != nullptr) {
+          result += static_cast<float>(bias_f16[column]);
+        } else if (bias_bf16 != nullptr) {
+          result += static_cast<float>(bias_bf16[column]);
+        }
+        if (out_f32 != nullptr) {
+          out_f32[index] = result;
+        } else {
+          out_bf16[index] = c10::BFloat16(result);
+        }
+      }
+    });
+  };
+
+  if (is_fp4) {
+    const int64_t packed_k = k / 2;
+    const auto* a = static_cast<const uint8_t*>(mat_a.const_data_ptr());
+    const auto* b = static_cast<const uint8_t*>(mat_b.const_data_ptr());
+    run(
+        [&](int64_t row, int64_t inner) {
+          const uint8_t packed = a[row * packed_k + inner / 2];
+          return mxfp4_values[(packed >> (4 * (inner % 2))) & 0x0f];
+        },
+        [&](int64_t inner, int64_t column) {
+          const uint8_t packed = b[column * packed_k + inner / 2];
+          return mxfp4_values[(packed >> (4 * (inner % 2))) & 0x0f];
+        });
+  } else {
+    const auto* a = mat_a.const_data_ptr<c10::Float8_e4m3fn>();
+    const auto* b = mat_b.const_data_ptr<c10::Float8_e4m3fn>();
+    const auto* mxfp8_values = get_mxfp8_values();
+    run(
+        [&](int64_t row, int64_t inner) {
+          return mxfp8_values[a[row * k + inner].x];
+        },
+        [&](int64_t inner, int64_t column) {
+          return mxfp8_values[b[column * k + inner].x];
+        });
+  }
+}
+
+} // namespace
+
+REGISTER_DISPATCH(mxfp_mm_stub, &mxfp_mm_emulated_kernel)
+
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/mxfp_mm_kernel.h
+++ b/aten/src/ATen/native/cpu/mxfp_mm_kernel.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at::native {
+
+TORCH_API const float* get_mxfp8_values();
+
+// The default implementation emulates MXFP in FP32; future native CPU kernels can register with this stub.
+using mxfp_mm_fn = void (*)(
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    Tensor&);
+
+DECLARE_DISPATCH(mxfp_mm_fn, mxfp_mm_stub)
+
+} // namespace at::native

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1347,6 +1347,7 @@ aten_native_source_codegen_list = [
     "aten/src/ATen/native/cpu/int4mm_kernel.cpp",
     "aten/src/ATen/native/cpu/int8mm_kernel.cpp",
     "aten/src/ATen/native/cpu/layer_norm_kernel.cpp",
+    "aten/src/ATen/native/cpu/mxfp_mm_kernel.cpp",
     "aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp",
     "aten/src/ATen/native/cpu/scaled_modified_bessel_k0.cpp",
     "aten/src/ATen/native/cpu/scaled_modified_bessel_k1.cpp",

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1746,6 +1746,77 @@ class TestFP8Lowering(TestCase):
         self.assertEqual(y_compiled.dtype, dtype)
         torch.testing.assert_close(y_eager, y_compiled, rtol=1e-2, atol=0.07)
 
+    @onlyOn(["cpu"])
+    @parametrize("api", ("v1", "v2"))
+    @parametrize("mx_format", ("mxfp4", "mxfp8"))
+    def test_cpu_mxfp_fullgraph(self, device, api, mx_format):
+        m, n, k = 3, 5, 48
+        if mx_format == "mxfp4":
+            a = torch.randint(
+                0, 256, (m, k // 2), dtype=torch.uint8, device=device
+            ).view(torch.float4_e2m1fn_x2)
+            b = (
+                torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=device)
+                .view(torch.float4_e2m1fn_x2)
+                .t()
+            )
+        else:
+            a_raw = torch.randint(0, 256, (m, k), dtype=torch.uint8, device=device)
+            b_raw = torch.randint(0, 256, (n, k), dtype=torch.uint8, device=device)
+            a_raw[(a_raw & 0x7F) == 0x7F] = 0
+            b_raw[(b_raw & 0x7F) == 0x7F] = 0
+            a = a_raw.view(torch.float8_e4m3fn)
+            b = b_raw.view(torch.float8_e4m3fn).t()
+
+        groups = ceil_div(k, 32)
+        scale_a = torch.full((m, groups), 127, dtype=torch.uint8, device=device).view(
+            torch.float8_e8m0fnu
+        )
+        scale_b = torch.full((n, groups), 127, dtype=torch.uint8, device=device).view(
+            torch.float8_e8m0fnu
+        )
+        bias = torch.randn(n, dtype=torch.bfloat16, device=device)
+        recipe = [ScalingType.BlockWise1x32.value]
+
+        if api == "v1":
+
+            def fn(a, b, scale_a, scale_b, bias):
+                return torch._scaled_mm(
+                    a,
+                    b,
+                    scale_a,
+                    scale_b,
+                    bias=bias,
+                    out_dtype=torch.bfloat16,
+                )
+
+            args = (a, b, scale_a, scale_b, bias)
+            op_name = "extern_kernels._scaled_mm"
+        else:
+
+            def fn(a, b, scale_a, scale_b, bias):
+                return torch.ops.aten._scaled_mm_v2.default(
+                    a,
+                    b,
+                    [scale_a],
+                    recipe,
+                    [],
+                    [scale_b],
+                    recipe,
+                    [],
+                    bias,
+                    torch.bfloat16,
+                    [],
+                )
+
+            args = (a, b, scale_a, scale_b, bias)
+            op_name = "_scaled_mm_v2.default"
+
+        expected = fn(*args)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+        self.assertEqual(actual, expected)
+        FileCheck().check(op_name).run(code)
+
     @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_scaled_mm_v2_no_swizzle(self, device):

--- a/test/test_scaled_matmul_cpu.py
+++ b/test/test_scaled_matmul_cpu.py
@@ -1,0 +1,405 @@
+# Owner(s): ["module: linear algebra"]
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_quantized import _floatx_unpacked_to_f32
+from torch.testing._internal.common_utils import (
+    parametrize,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
+
+
+BLOCK_SIZE = 32
+MXFP_RECIPE = [torch._C._ScalingType.BlockWise1x32.value]
+NO_SWIZZLE = torch._C._SwizzleType.NO_SWIZZLE.value
+
+
+def _e8m0(data: torch.Tensor) -> torch.Tensor:
+    return data.to(torch.uint8).view(torch.float8_e8m0fnu)
+
+
+def _unpack_mxfp4(data: torch.Tensor) -> torch.Tensor:
+    packed = data.view(torch.uint8)
+    unpacked = torch.empty(*packed.shape[:-1], packed.shape[-1] * 2, dtype=torch.uint8)
+    unpacked[..., 0::2] = packed & 0x0F
+    unpacked[..., 1::2] = packed >> 4
+    return _floatx_unpacked_to_f32(unpacked, 2, 1)
+
+
+def _dequantize_mxfp(
+    data: torch.Tensor, scale: torch.Tensor, *, transposed: bool = False
+) -> torch.Tensor:
+    if transposed:
+        data = data.t().contiguous()
+    values = data.float() if data.dtype == torch.float8_e4m3fn else _unpack_mxfp4(data)
+    scales = scale.float().repeat_interleave(BLOCK_SIZE, dim=1)
+    result = values * scales[..., : values.size(1)]
+    return result.t() if transposed else result
+
+
+def _make_mxfp_inputs(
+    mx_format: str,
+    device: torch.device,
+    *,
+    m: int = 5,
+    n: int = 7,
+    k: int = 48,
+) -> tuple[torch.Tensor, ...]:
+    generator = torch.Generator(device=device).manual_seed(42)
+    if mx_format == "mxfp8":
+        a_raw = torch.randint(
+            0, 256, (m, k), dtype=torch.uint8, device=device, generator=generator
+        )
+        b_raw = torch.randint(
+            0, 256, (n, k), dtype=torch.uint8, device=device, generator=generator
+        )
+        a_raw[(a_raw & 0x7F) == 0x7F] = 0
+        b_raw[(b_raw & 0x7F) == 0x7F] = 0
+        a = a_raw.view(torch.float8_e4m3fn)
+        b = b_raw.view(torch.float8_e4m3fn).t()
+    else:
+        a_raw = torch.randint(
+            0,
+            256,
+            (m, k // 2),
+            dtype=torch.uint8,
+            device=device,
+            generator=generator,
+        )
+        b_raw = torch.randint(
+            0,
+            256,
+            (n, k // 2),
+            dtype=torch.uint8,
+            device=device,
+            generator=generator,
+        )
+        a = a_raw.view(torch.float4_e2m1fn_x2)
+        b = b_raw.view(torch.float4_e2m1fn_x2).t()
+
+    groups = (k + BLOCK_SIZE - 1) // BLOCK_SIZE
+    scale_a = _e8m0(
+        torch.randint(120, 135, (m, groups), device=device, generator=generator)
+    )
+    scale_b = _e8m0(
+        torch.randint(120, 135, (n, groups), device=device, generator=generator)
+    )
+    return a, b, scale_a, scale_b
+
+
+def _scaled_mm_v2(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype,
+    *,
+    recipe: list[int] | None = None,
+    swizzle: list[int] | None = None,
+    contraction_dim: list[int] | None = None,
+) -> torch.Tensor:
+    recipe = MXFP_RECIPE if recipe is None else recipe
+    swizzle = [] if swizzle is None else swizzle
+    contraction_dim = [] if contraction_dim is None else contraction_dim
+    return torch.ops.aten._scaled_mm_v2.default(
+        a,
+        b,
+        [scale_a],
+        recipe,
+        swizzle,
+        [scale_b],
+        recipe,
+        swizzle,
+        bias,
+        out_dtype,
+        contraction_dim,
+    )
+
+
+class TestScaledMatmulCPU(TestCase):
+    @parametrize("mx_format", ("mxfp4", "mxfp8"))
+    @parametrize("out_dtype", (torch.bfloat16, torch.float32))
+    @parametrize("bias_dtype", (torch.float16, torch.bfloat16, torch.float32))
+    def test_mxfp_numerics(self, device, mx_format, out_dtype, bias_dtype):
+        a, b, scale_a, scale_b = _make_mxfp_inputs(mx_format, device)
+        bias = torch.randn(b.size(1), device=device, dtype=bias_dtype)
+        expected = (
+            _dequantize_mxfp(a, scale_a) @ _dequantize_mxfp(b, scale_b, transposed=True)
+            + bias.float()
+        ).to(out_dtype)
+
+        v1 = torch._scaled_mm(a, b, scale_a, scale_b, bias=bias, out_dtype=out_dtype)
+        v2 = _scaled_mm_v2(a, b, scale_a, scale_b, bias, out_dtype)
+        v2_explicit = _scaled_mm_v2(
+            a,
+            b,
+            scale_a,
+            scale_b,
+            bias,
+            out_dtype,
+            swizzle=[NO_SWIZZLE],
+            contraction_dim=[1, 0],
+        )
+        if out_dtype == torch.float32:
+            self.assertEqual(v1, expected, atol=2e-5, rtol=2e-5)
+        else:
+            self.assertEqual(v1, expected)
+        self.assertEqual(v2, v1)
+        self.assertEqual(v2_explicit, v1)
+
+    def test_mxfp_nan_accumulation(self, device):
+        m, n, k = 2, 5, 64
+        a_storage = torch.full((m, k), 0x38, dtype=torch.uint8, device=device)
+        b_storage = torch.full((n, k), 0x38, dtype=torch.uint8, device=device)
+        a_storage[0, 40] = 0x7F
+        b_storage[0, 8] = 0x7F
+        b_storage[4, 8] = 0x7F
+        a = a_storage.view(torch.float8_e4m3fn)
+        b = b_storage.view(torch.float8_e4m3fn).t()
+        scale_a = _e8m0(torch.full((m, 2), 127, device=device))
+        scale_b = _e8m0(torch.full((n, 2), 127, device=device))
+        expected = torch.full((m, n), 64.0, device=device)
+        expected[0, :] = torch.nan
+        expected[:, 0] = torch.nan
+        expected[:, 4] = torch.nan
+
+        v1 = torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+        v2 = _scaled_mm_v2(a, b, scale_a, scale_b, None, torch.float32)
+        self.assertEqual(v1, expected)
+        self.assertEqual(v2, expected)
+
+    def test_mxfp_encodings(self, device):
+        fp8_encodings = torch.arange(256, dtype=torch.uint8, device=device)
+        a_storage = torch.zeros((256, BLOCK_SIZE), dtype=torch.uint8, device=device)
+        a_storage[:, 0] = fp8_encodings
+        a = a_storage.view(torch.float8_e4m3fn)
+        b_storage = torch.zeros((1, BLOCK_SIZE), dtype=torch.uint8, device=device)
+        b_storage[:, 0] = 0x38
+        b = b_storage.view(torch.float8_e4m3fn).t()
+        scale_a = _e8m0(torch.full((256, 1), 127, device=device))
+        scale_b = _e8m0(torch.full((1, 1), 127, device=device))
+        actual = torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+        expected = fp8_encodings.view(torch.float8_e4m3fn).float()
+        self.assertEqual(actual[:, 0], expected)
+
+        fp4_encodings = torch.arange(16, dtype=torch.uint8, device=device)
+        a_storage = torch.zeros((16, BLOCK_SIZE // 2), dtype=torch.uint8, device=device)
+        a_storage[:, 0] = fp4_encodings | (fp4_encodings << 4)
+        a = a_storage.view(torch.float4_e2m1fn_x2)
+        b_storage = torch.zeros((2, BLOCK_SIZE // 2), dtype=torch.uint8, device=device)
+        b_storage[0, 0] = 0x02
+        b_storage[1, 0] = 0x20
+        b = b_storage.view(torch.float4_e2m1fn_x2).t()
+        scale_a = _e8m0(torch.full((16, 1), 127, device=device))
+        scale_b = _e8m0(torch.full((2, 1), 127, device=device))
+        actual = torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+        expected = _floatx_unpacked_to_f32(fp4_encodings, 2, 1)
+        self.assertEqual(actual, expected[:, None].expand(16, 2))
+
+        scale_encodings = torch.tensor(
+            [0, 1, 126, 127, 128, 253, 254, 255],
+            dtype=torch.uint8,
+            device=device,
+        )
+        shape = (scale_encodings.numel(), BLOCK_SIZE)
+        a = torch.ones(shape, dtype=torch.float8_e4m3fn, device=device)
+        b = torch.ones(shape, dtype=torch.float8_e4m3fn, device=device).t()
+        scale_a = _e8m0(scale_encodings[:, None])
+        scale_b = _e8m0(scale_encodings[:, None])
+        actual = torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+        exponents = (
+            scale_encodings.int()[:, None] + scale_encodings.int()[None, :] - 254
+        )
+        expected = torch.ldexp(torch.full_like(actual, 32.0), exponents)
+        expected[-1, :] = torch.nan
+        expected[:, -1] = torch.nan
+        self.assertEqual(actual, expected)
+
+    @parametrize("mx_format", ("mxfp4", "mxfp8"))
+    @parametrize("m,n,k", ((0, 5, 48), (3, 0, 48), (3, 5, 0)))
+    def test_mxfp_empty_dimensions(self, device, mx_format, m, n, k):
+        a, b, scale_a, scale_b = _make_mxfp_inputs(mx_format, device, m=m, n=n, k=k)
+        bias = torch.randn(n, dtype=torch.bfloat16, device=device)
+        expected = (
+            _dequantize_mxfp(a, scale_a) @ _dequantize_mxfp(b, scale_b, transposed=True)
+            + bias.float()
+        ).to(torch.bfloat16)
+        v1 = torch._scaled_mm(
+            a, b, scale_a, scale_b, bias=bias, out_dtype=torch.bfloat16
+        )
+        v2 = _scaled_mm_v2(a, b, scale_a, scale_b, bias, torch.bfloat16)
+        self.assertEqual(v1, expected)
+        self.assertEqual(v2, expected)
+
+    @parametrize("mx_format", ("mxfp4", "mxfp8"))
+    @parametrize("degenerate_dim", ("k", "n"))
+    def test_mxfp_degenerate_mat_b_layout(self, device, mx_format, degenerate_dim):
+        n = 1 if degenerate_dim == "n" else 5
+        k = (2 if mx_format == "mxfp4" else 1) if degenerate_dim == "k" else 32
+        a, b, scale_a, scale_b = _make_mxfp_inputs(mx_format, device, m=3, n=n, k=k)
+        b_contiguous = torch.empty_like(b, memory_format=torch.contiguous_format)
+        b_contiguous.copy_(b)
+        expected = torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+        v1 = torch._scaled_mm(
+            a, b_contiguous, scale_a, scale_b, out_dtype=torch.float32
+        )
+        v2 = _scaled_mm_v2(a, b_contiguous, scale_a, scale_b, None, torch.float32)
+        self.assertEqual(v1, expected)
+        self.assertEqual(v2, expected)
+
+    @parametrize(
+        "case,error_type,error_regex",
+        (
+            ("v1_scale_b", ValueError, "MXFP scale_b must have shape"),
+            ("v2_scale_b", ValueError, "MXFP scale_b must have shape"),
+            ("layout", ValueError, "MXFP mat_b must be column-major"),
+            ("recipe", ValueError, "requires one BlockWise1x32 scale per operand"),
+            ("bias_shape", ValueError, "Bias must be size"),
+            ("bias_dtype", ValueError, "CPU MXFP bias must have dtype"),
+            ("swizzle", NotImplementedError, "CPU MXFP only supports NO_SWIZZLE"),
+            ("contraction", NotImplementedError, "only supports contraction_dim"),
+        ),
+    )
+    def test_mxfp_validation_parity(self, device, case, error_type, error_regex):
+        a, b, scale_a, scale_b = _make_mxfp_inputs("mxfp8", device, m=3, n=5, k=32)
+
+        def invoke(a, b, scale_a, scale_b):
+            if case == "v1_scale_b":
+                return torch._scaled_mm(
+                    a,
+                    b,
+                    scale_a,
+                    scale_b.t().contiguous(),
+                    out_dtype=torch.float32,
+                )
+            if case == "v2_scale_b":
+                return torch.ops.aten._scaled_mm_v2.default(
+                    a,
+                    b,
+                    [scale_a],
+                    MXFP_RECIPE,
+                    [],
+                    [scale_b.t().contiguous()],
+                    MXFP_RECIPE,
+                    [],
+                    None,
+                    torch.float32,
+                    [],
+                )
+            if case == "layout":
+                return _scaled_mm_v2(
+                    a,
+                    b.contiguous(),
+                    scale_a,
+                    scale_b,
+                    None,
+                    torch.float32,
+                )
+            if case == "recipe":
+                invalid_recipe = [torch._C._ScalingType.TensorWise.value]
+                return _scaled_mm_v2(
+                    a,
+                    b,
+                    scale_a,
+                    scale_b,
+                    None,
+                    torch.float32,
+                    recipe=invalid_recipe,
+                )
+            if case == "bias_shape":
+                bias = torch.zeros(b.size(1) - 1, dtype=torch.float32, device=device)
+                return _scaled_mm_v2(a, b, scale_a, scale_b, bias, torch.float32)
+            if case == "bias_dtype":
+                bias = torch.zeros(b.size(1), dtype=torch.float64, device=device)
+                return _scaled_mm_v2(a, b, scale_a, scale_b, bias, torch.float32)
+            if case == "swizzle":
+                return _scaled_mm_v2(
+                    a,
+                    b,
+                    scale_a,
+                    scale_b,
+                    None,
+                    torch.float32,
+                    swizzle=[1],
+                )
+            return _scaled_mm_v2(
+                a,
+                b,
+                scale_a,
+                scale_b,
+                None,
+                torch.float32,
+                contraction_dim=[0, 1],
+            )
+
+        expected_errors = (error_type, torch._dynamo.exc.TorchRuntimeError)
+        with self.assertRaisesRegex(expected_errors, error_regex):
+            invoke(a, b, scale_a, scale_b)
+
+        mode = FakeTensorMode()
+        fake_inputs = tuple(mode.from_tensor(t) for t in (a, b, scale_a, scale_b))
+        with mode, self.assertRaisesRegex(expected_errors, error_regex):
+            invoke(*fake_inputs)
+
+    @skipIfTorchDynamo(
+        "explicit CPU MXFP .out calls do not support FakeTensor/Dynamo tracing"
+    )
+    @parametrize("api", ("v1", "v2"))
+    def test_mxfp_out(self, device, api):
+        a, b, scale_a, scale_b = _make_mxfp_inputs("mxfp8", device, m=3, n=5, k=32)
+        expected = (
+            torch._scaled_mm(a, b, scale_a, scale_b, out_dtype=torch.float32)
+            if api == "v1"
+            else _scaled_mm_v2(a, b, scale_a, scale_b, None, torch.float32)
+        )
+        out = torch.empty(0, dtype=torch.float32, device=device)
+
+        def call_out(out, out_dtype):
+            if api == "v1":
+                return torch.ops.aten._scaled_mm.out(
+                    a,
+                    b,
+                    scale_a,
+                    scale_b,
+                    out_dtype=out_dtype,
+                    out=out,
+                )
+            return torch.ops.aten._scaled_mm_v2.out(
+                a,
+                b,
+                [scale_a],
+                MXFP_RECIPE,
+                [],
+                [scale_b],
+                MXFP_RECIPE,
+                [],
+                None,
+                out_dtype,
+                [],
+                out=out,
+            )
+
+        result = call_out(out, torch.float32)
+        self.assertIs(result, out)
+        self.assertEqual(out, expected)
+
+        invalid_dtype = torch.empty_like(out, dtype=torch.float16)
+        with self.assertRaisesRegex(ValueError, "CPU MXFP output must have dtype"):
+            call_out(invalid_dtype, torch.float16)
+
+        noncontiguous = torch.empty(
+            out.size(1), out.size(0), dtype=out.dtype, device=device
+        ).t()
+        with self.assertRaisesRegex(ValueError, "CPU MXFP output must be contiguous"):
+            call_out(noncontiguous, torch.float32)
+
+
+instantiate_device_type_tests(TestScaledMatmulCPU, globals(), only_for=("cpu",))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -51,6 +51,7 @@ DTYPE_TO_CPP = {
     torch.float8_e4m3fnuz: "at::Float8_e4m3fnuz",
     torch.float8_e5m2fnuz: "at::Float8_e5m2fnuz",
     torch.float8_e8m0fnu: "at::Float8_e8m0fnu",
+    torch.float4_e2m1fn_x2: "at::Float4_e2m1fn_x2",
 }
 
 DTYPE_TO_ATEN = {
@@ -78,6 +79,7 @@ DTYPE_TO_ATEN = {
     torch.float8_e4m3fnuz: "at::kFloat8_e4m3fnuz",
     torch.float8_e5m2fnuz: "at::kFloat8_e5m2fnuz",
     torch.float8_e8m0fnu: "at::kFloat8_e8m0fnu",
+    torch.float4_e2m1fn_x2: "at::kFloat4_e2m1fn_x2",
 }
 
 DEVICE_TO_ATEN = {

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4848,6 +4848,7 @@ def _infer_scale_swizzle_impl(
     scale_numel: Any,
     mat_dtype: torch.dtype,
     scale_dtype: torch.dtype,
+    device_type: str,
     eq_fn: Callable[[Any, Any], bool],
 ) -> tuple[Any | None, Any | None]:
     """
@@ -4910,7 +4911,7 @@ def _infer_scale_swizzle_impl(
 
     # MXFP8: BlockWise1x32 with float8_e8m0fnu scales
     if scale_dtype == torch.float8_e8m0fnu:
-        if not torch.version.hip and not torch.xpu._is_compiled():
+        if device_type == "cuda" and not torch.version.hip:
             # NVIDIA: uses swizzled 32x4x4 layout
             expected_numel_a = _round_up(mat_size[0], 128) * _round_up(
                 ceildiv(K_multiplier * mat_size[1], 32), 4
@@ -4923,7 +4924,7 @@ def _infer_scale_swizzle_impl(
             ):
                 return ScalingType.BlockWise1x32, SwizzleType.SWIZZLE_32_4_4
         else:
-            # AMD/XPU: no swizzle
+            # CPU/AMD/XPU: no swizzle
             expected_numel_a = ceildiv(mat_size[0], 32) * K_multiplier * mat_size[1]
             expected_numel_b = ceildiv(K_multiplier * mat_size[1], 32) * mat_size[0]
             if eq_fn(scale_numel, expected_numel_a) or eq_fn(
@@ -4944,7 +4945,7 @@ def infer_scale_swizzle(
     - TensorWise: Single scale for entire tensor
     - RowWise: One scale per row
     - BlockWise1x128/128x128: Block-scaled with float32 scales
-    - BlockWise1x32: MXFP8 with float8_e8m0fnu scales (swizzled on NVIDIA)
+    - BlockWise1x32: MXFP8 scales (swizzled on NVIDIA, unswizzled otherwise)
     - BlockWise1x16: NVFP4 with float8_e4m3fn scales (swizzled)
 
     Args:
@@ -4960,6 +4961,7 @@ def infer_scale_swizzle(
         scale_numel=scale.numel(),
         mat_dtype=mat.dtype,
         scale_dtype=scale.dtype,
+        device_type=mat.device.type,
         eq_fn=lambda a, b: a == b,
     )
 
@@ -4997,5 +4999,6 @@ def infer_scale_swizzle_ir(
         scale_numel=scale_numel,
         mat_dtype=mat.dtype,
         scale_dtype=scale.dtype,
+        device_type=mat.get_device_or_error().type,
         eq_fn=symbolic_eq,
     )

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7195,6 +7195,99 @@ def meta__efficient_attention_backward(
     return grad_query, grad_key, grad_value, grad_bias
 
 
+def _is_cpu_mxfp(self: torch.Tensor, *scales: torch.Tensor) -> bool:
+    return device_hint(self) == "cpu" and any(
+        scale.dtype == torch.float8_e8m0fnu for scale in scales
+    )
+
+
+def _check_cpu_mxfp(
+    self: torch.Tensor,
+    mat2: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype | None,
+    scale_result: torch.Tensor | None = None,
+) -> torch.Tensor:
+    torch._check_value(
+        self.dim() == 2 and mat2.dim() == 2,
+        lambda: "MXFP operands must be matrices",
+    )
+    is_mxfp8 = self.dtype == mat2.dtype == torch.float8_e4m3fn
+    is_mxfp4 = self.dtype == mat2.dtype == torch.float4_e2m1fn_x2
+    torch._check_value(
+        is_mxfp8 or is_mxfp4,
+        lambda: "MXFP operands must both have dtype Float8_e4m3fn or Float4_e2m1fn_x2",
+    )
+    torch._check_value(
+        scale_a.dtype == scale_b.dtype == torch.float8_e8m0fnu,
+        lambda: "MXFP scales must both have dtype Float8_e8m0fnu",
+    )
+
+    packing = 2 if is_mxfp4 else 1
+    logical_k = packing * self.size(1)
+    torch._check_value(
+        self.size(1) == mat2.size(0),
+        lambda: f"MXFP operand shapes cannot be multiplied: {self.shape} and {mat2.shape}",
+    )
+    k_blocks = ceil_div(logical_k, 32)
+    torch._check_value(
+        scale_a.dim() == 2,
+        lambda: f"MXFP scale_a must have shape ({self.size(0)}, {k_blocks}), got {scale_a.shape}",
+    )
+    torch._check_value(
+        (scale_a.size(0) == self.size(0)) & (scale_a.size(1) == k_blocks),
+        lambda: f"MXFP scale_a must have shape ({self.size(0)}, {k_blocks}), got {scale_a.shape}",
+    )
+    scale_b_shape = (mat2.size(1), k_blocks)
+    torch._check_value(
+        scale_b.dim() == 2,
+        lambda: f"MXFP scale_b must have shape {scale_b_shape}, got {scale_b.shape}",
+    )
+    torch._check_value(
+        (scale_b.size(0) == scale_b_shape[0]) & (scale_b.size(1) == scale_b_shape[1]),
+        lambda: f"MXFP scale_b must have shape {scale_b_shape}, got {scale_b.shape}",
+    )
+    torch._check_value(
+        scale_a.is_contiguous(), lambda: "MXFP scale_a must be contiguous"
+    )
+    torch._check_value(
+        scale_b.is_contiguous(), lambda: "MXFP scale_b must be contiguous"
+    )
+    torch._check_value(self.is_contiguous(), lambda: "MXFP mat_a must be row-major")
+    torch._check_value(
+        (mat2.numel() == 0)
+        | ((mat2.size(0) == 1) & (mat2.stride(1) == 1))
+        | ((mat2.size(1) == 1) & (mat2.stride(0) == 1))
+        | ((mat2.stride(0) == 1) & (mat2.stride(1) == mat2.size(0))),
+        lambda: "MXFP mat_b must be column-major",
+    )
+    torch._check_not_implemented(
+        scale_result is None,
+        lambda: "CPU MXFP does not support scale_result",
+    )
+    resolved_out_dtype = out_dtype if out_dtype is not None else self.dtype
+    torch._check_value(
+        resolved_out_dtype in (torch.bfloat16, torch.float32),
+        lambda: f"CPU MXFP output must have dtype BFloat16 or Float32, got {resolved_out_dtype}",
+    )
+    if bias is not None:
+        torch._check_value(
+            bias.numel() == mat2.size(1),
+            lambda: f"Bias must be size {mat2.size(1)} but got {bias.numel()}",
+        )
+        torch._check_value(
+            bias.dtype in (torch.float16, torch.bfloat16, torch.float32),
+            lambda: (
+                f"CPU MXFP bias must have dtype Float16, BFloat16, or Float32, got {bias.dtype}"
+            ),
+        )
+    return torch.empty(
+        self.size(0), mat2.size(1), dtype=resolved_out_dtype, device=self.device
+    )
+
+
 def _check_scaled_mm_sizes(
     self: torch.Tensor,
     mat2: torch.Tensor,
@@ -7222,6 +7315,11 @@ def _check_scaled_mm_sizes(
         is_fp8_or_fp4_type(self.dtype) and is_fp8_or_fp4_type(mat2.dtype),
         lambda: f"Expected both inputs to be fp8 or fp4 types but got self.dtype={self.dtype} and mat2.dtype={mat2.dtype}",
     )
+
+    if _is_cpu_mxfp(self, scale_a, scale_b):
+        return _check_cpu_mxfp(
+            self, mat2, scale_a, scale_b, bias, out_dtype, scale_result
+        )
 
     if (
         device_hint(self) == "cuda"
@@ -7439,6 +7537,33 @@ def meta_scaled_mm_v2(
     contraction_dim: list[int] | None = None,
     use_fast_accum: bool = False,
 ):
+    if _is_cpu_mxfp(self, *scale_a, *scale_b):
+        scaling_type = torch._C._ScalingType  # pyrefly: ignore [missing-attribute]
+        swizzle_type = torch._C._SwizzleType  # pyrefly: ignore [missing-attribute]
+        blockwise_1x32 = scaling_type.BlockWise1x32.value
+        no_swizzle = swizzle_type.NO_SWIZZLE.value
+        torch._check_value(
+            len(scale_a) == len(scale_b) == 1
+            and scale_recipe_a == scale_recipe_b == [blockwise_1x32],
+            lambda: "CPU MXFP requires one BlockWise1x32 scale per operand",
+        )
+        torch._check_not_implemented(
+            swizzle_a in ([], [no_swizzle]) and swizzle_b in ([], [no_swizzle]),
+            lambda: "CPU MXFP only supports NO_SWIZZLE",
+        )
+        torch._check_not_implemented(
+            not contraction_dim or contraction_dim == [1, 0],
+            lambda: "CPU scaled_mm_v2 only supports contraction_dim=[] or [1, 0]",
+        )
+        return _check_cpu_mxfp(
+            self,
+            mat2,
+            scale_a[0],
+            scale_b[0],
+            bias,
+            out_dtype,
+        )
+
     # Shape inference only; per-recipe scale validation lives in the C++
     # TORCH_META_FUNC (validate_scaled_mm_v2_inputs) and runs in eager. This
     # Python meta exists because the structured C++ meta sizes its output via


### PR DESCRIPTION
Adds a reference CPU MXFP kernel supporting MXFP4/MXFP8 inputs, E8M0 block scales, and BF16/FP32 outputs via both scaled_mm v1 and v2 APIs, with handling of unsupported configurations, and support for fullgraph CPU compilation. Essential tests were added that cover numerics, validation and compiled execution. The primary goal is to provide a viable compiled MXFP path without graph breaks for CPU-only reference.

Note that a reference style kernel implementation was chosen over dispatching to say oneDNN. This is because such dispatch would require dequantizing inputs first and then performing the matmul, but this approach does not produce accurate results across all of MXFP-supported domain (overflows with extreme value+scale combinations etc). Such implementations can still be added in the future, especially if support for MXFP-style scales directly in the matmul kernel is added. But until then this reference kernel aims to act as an accuracy-first CPU implementation.

Authored with assistance from GPT 5.6 Sol

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo