### PR TITLE
Remove debug-only CPU device index assert

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -178,10 +178,6 @@ struct C10_API Device final {
         index_ >= -1,
         "Device index must be -1 or non-negative, got ",
         static_cast<int>(index_));
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        !is_cpu() || index_ <= 0,
-        "CPU device index must be -1 or zero, got ",
-        static_cast<int>(index_));
   }
 };
 


### PR DESCRIPTION
### Description 
Removes the `TORCH_INTERNAL_ASSERT_DEBUG_ONLY` in `c10::Device::validate` that asserts CPU device must be -1 or 0. This assert is compiled out in release builds, so `torch.device("cpu:N")` always suceeds. 

This was exposed by #191509 which adds a debug-build CPU-only distributed CI job. About 30+ distributed test files exhibit the same pattern 

### Test Plan

```
DEBUG=1 python -m pip install -e . -v

#This no longer asserts 
python -c "import torch; print(torch.device('cpu:2'))"

#Failing tests in 191509 now pass 
python test/distributed/_shard/sharding_spec/test_sharding_spec.py TestShardingSpec.test_infer_sharding_spec_from_shards_metadata
python -m pytest test/distributed/test_device_mesh.py::InitDeviceMeshTest::test_backend_override_argument_dict_with_idx_and_backend_eager
```

cc: @d4l3k @atalman 