### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard mixed_precision

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -16,6 +16,9 @@ from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
 )
 from torch.distributed.tensor import Shard
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     SaveForwardInputsModel,
@@ -32,12 +35,14 @@ from torch.testing._internal.common_fsdp import (
     reduce_scatter_with_assert,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     MI300_ARCH,
     run_tests,
     skipIfRocmArch,
     skipIfRocmVersionLessThan,
     TEST_CUDA,
     TEST_XPU,
+    TestCase,
 )
 from torch.utils.checkpoint import checkpoint
 
@@ -46,6 +51,14 @@ device_type = torch.device(get_devtype())
 
 
 class TestFullyShardMixedPrecisionTraining(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
+    # asserts run in autograd worker threads (the reduce-scatter callbacks);
+    # override with the plain `TestCase` defaults.
+    precision = TestCase._precision
+    rel_tol = TestCase._rel_tol
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
@@ -632,6 +645,8 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
 
 class TestFullyShardMixedPrecisionJVP(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
@@ -704,6 +719,14 @@ class TestFullyShardMixedPrecisionJVP(FSDPTest):
 
 
 class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
+    # asserts run in autograd worker threads (the reduce-scatter callbacks);
+    # override with the plain `TestCase` defaults.
+    precision = TestCase._precision
+    rel_tol = TestCase._rel_tol
+
     @property
     def world_size(self) -> int:
         return 2
@@ -995,6 +1018,26 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
             inp = torch.randn((4, 32), device=device_type.type)
             loss = model(inp).sum()
             loss.backward()
+
+
+instantiate_device_type_tests(
+    TestFullyShardMixedPrecisionTraining,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardMixedPrecisionJVP,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardMixedPrecisionCasts,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -16,9 +16,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
 )
 from torch.distributed.tensor import Shard
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     SaveForwardInputsModel,
@@ -123,7 +121,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_compute_dtype(self):
+    def test_compute_dtype(self, device):
         use_shard_placement_fn_vals = (
             self._get_use_shard_placement_fn_vals_for_bf16_reduce()
         )
@@ -204,7 +202,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_reduce_dtype(self):
+    def test_reduce_dtype(self, device):
         self.run_subtests(
             {
                 "reshard_after_forward": [False, True, 2],
@@ -280,7 +278,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)
-    def test_reduce_dtype_after_frozen_first_forward(self):
+    def test_reduce_dtype_after_frozen_first_forward(self, device):
         class Model(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -373,7 +371,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
             check_sharded_parity(self, ref_model, model)
 
     @skip_if_lt_x_gpu(2)
-    def test_grad_acc_with_reduce_dtype(self):
+    def test_grad_acc_with_reduce_dtype(self, device):
         """
         Tests that gradient accumulation without reduce-scatter when using
         bf16 compute and fp32 reduction accumulates the unsharded gradients in
@@ -478,7 +476,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
                 param.grad.div_(group.size())
 
     @skip_if_lt_x_gpu(2)
-    def test_structured_input_output(self):
+    def test_structured_input_output(self, device):
         """
         Tests numeric parity between FSDP and a reference model when using
         structured (dataclass, nested dataclass, NamedTuple) activations
@@ -659,7 +657,7 @@ class TestFullyShardMixedPrecisionJVP(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_no_warmup_jvp_reshard_after_forward_false(self):
+    def test_no_warmup_jvp_reshard_after_forward_false(self, device):
         dtype = torch.bfloat16
         mesh = init_device_mesh(
             device_type.type,
@@ -744,7 +742,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
         return 2
 
     @skip_if_lt_x_gpu(1)
-    def test_float16_on_one_submodule(self):
+    def test_float16_on_one_submodule(self, device):
         x = torch.zeros(2, 100, device=device_type)
 
         # Subtest 1: use fp16 on the second child submodule -- does not require
@@ -798,7 +796,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
         self.assertEqual(forward_inputs[model.c2].dtype, torch.float32)
 
     @skip_if_lt_x_gpu(1)
-    def test_submodules_with_external_inputs(self):
+    def test_submodules_with_external_inputs(self, device):
         self.run_subtests(
             {"enable_submodule_cast": [False, True]},
             self._test_submodules_with_external_inputs,
@@ -854,14 +852,14 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     @skipIfRocmArch(MI300_ARCH)  # https://github.com/pytorch/pytorch/issues/182988
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_checkpoint_recompute_casts_forward_inputs(self):
+    def test_checkpoint_recompute_casts_forward_inputs(self, device):
         self._test_checkpoint_recompute_casts(
             recompute_cast="input",
         )
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_checkpoint_recompute_casts_outputs(self):
+    def test_checkpoint_recompute_casts_outputs(self, device):
         self._test_checkpoint_recompute_casts(
             recompute_cast="output",
         )
@@ -936,13 +934,13 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_norm_modules_bf16(self):
+    def test_norm_modules_bf16(self, device):
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
         self._test_norm_modules(mp_policy)
 
     @skip_if_lt_x_gpu(1)
     @skipIfRocmArch(MI300_ARCH)  # https://github.com/pytorch/pytorch/issues/182988
-    def test_norm_modules_fp16(self):
+    def test_norm_modules_fp16(self, device):
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.float16)
         self._test_norm_modules(mp_policy)
 
@@ -999,7 +997,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
         inner(model, torch.randn((3, 1, 9, 9)))
 
     @skip_if_lt_x_gpu(1)
-    def test_clamp_reduce_dtype(self):
+    def test_clamp_reduce_dtype(self, device):
         # Initialize the model directly in bf16
         init_dtype = torch.bfloat16
         model = nn.Sequential(

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -53,9 +53,15 @@ device_type = torch.device(get_devtype())
 class TestFullyShardMixedPrecisionTraining(FSDPTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
-    # asserts run in autograd worker threads (the reduce-scatter callbacks);
-    # override with the plain `TestCase` defaults.
+    # `instantiate_device_type_tests` injects `DeviceTypeTestBase`, whose
+    # `precision`/`rel_tol` are thread-local properties populated only on the
+    # thread that imports the module. The reduce-scatter callbacks in
+    # `test_compute_dtype`/`test_reduce_dtype`/`test_grad_acc_with_reduce_dtype`
+    # run `assertEqual` from an autograd worker thread during backward; since
+    # `assertEqual` always reads `self.rel_tol`, that worker thread's empty
+    # thread-local raises `AttributeError`. Override with the plain `TestCase`
+    # defaults (0 = no tolerance override) to shadow the thread-local
+    # properties; this is safe because this test sets no custom tolerance.
     precision = TestCase._precision
     rel_tol = TestCase._rel_tol
 
@@ -721,9 +727,15 @@ class TestFullyShardMixedPrecisionJVP(FSDPTest):
 class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    # `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some
-    # asserts run in autograd worker threads (the reduce-scatter callbacks);
-    # override with the plain `TestCase` defaults.
+    # `instantiate_device_type_tests` injects `DeviceTypeTestBase`, whose
+    # `precision`/`rel_tol` are thread-local properties populated only on the
+    # thread that imports the module. The reduce-scatter callback in
+    # `test_clamp_reduce_dtype` runs `assertEqual` from an autograd worker
+    # thread during backward; since `assertEqual` always reads `self.rel_tol`,
+    # that worker thread's empty thread-local raises `AttributeError`. Override
+    # with the plain `TestCase` defaults (0 = no tolerance override) to shadow
+    # the thread-local properties; this is safe because this test sets no
+    # custom tolerance.
     precision = TestCase._precision
     rel_tol = TestCase._rel_tol
 


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the fully_shard mixed_precision test classes and instantiates them via instantiate_device_type_tests, so they are discovered per device type under the hardware-classification selection. All three classes (TestFullyShardMixedPrecisionTraining, TestFullyShardMixedPrecisionJVP, TestFullyShardMixedPrecisionCasts) are classified as ACCELERATOR and instantiated with except_for=["cpu"], allow_xpu=True.

Two of the classes (Training, Casts) also override `precision` and `rel_tol` with the plain `TestCase` defaults. `DeviceTypeTestBase.precision`/`rel_tol` are thread-local, but some asserts run in autograd worker threads (the reduce-scatter callbacks); overriding them as plain class attributes fixes the resulting `AttributeError` when the tests are instantiated as device-type tests. The override does not affect the actual assertions: the values are the same `TestCase` defaults the non-instantiated tests already used, so precision/tolerance behavior is unchanged.

Test Plan: Ran the two commands below; each executed only the tests matching the requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py --hw-classification GENERIC