### PR TITLE
Fix FileStore rendezvous fd leak and find_free_port UnboundLocalError

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -274,6 +274,23 @@ class CreateBackendTest(TestCase):
         ):
             create_backend(self._params_filestore)
 
+    def test_create_backend_closes_mkstemp_file_descriptor(self) -> None:
+        # Set the endpoint to empty so the default path (mkstemp) is used.
+        self._params_filestore.endpoint = ""
+
+        fd, temp_path = tempfile.mkstemp()
+        # mkstemp() opens the file; we only need the path here, so close the
+        # descriptor we created before handing the path to the mocks below.
+        os.close(fd)
+        self.addCleanup(os.remove, temp_path)
+
+        with mock.patch("tempfile.mkstemp", return_value=(fd, temp_path)), mock.patch(
+            "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.os.close"
+        ) as os_close_mock:
+            create_backend(self._params_filestore)
+
+        os_close_mock.assert_called_once_with(fd)
+
     @mock.patch(
         "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
     )

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -11,7 +11,10 @@ import unittest
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import (
+    EtcdServer,
+    find_free_port,
+)
 
 
 if os.getenv("CIRCLECI"):
@@ -34,6 +37,15 @@ class EtcdServerTest(unittest.TestCase):
             self.assertIsNotNone(server.get_client().version)
         finally:
             server.stop()
+
+    def test_find_free_port_socket_failure_raises_runtime_error(self):
+        with unittest.mock.patch(
+            "socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 0))]
+        ), unittest.mock.patch(
+            "socket.socket", side_effect=OSError("socket failed")
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+                find_free_port()
 
     def test_etcd_server_with_rendezvous(self):
         server = EtcdServer()

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -47,6 +47,37 @@ class EtcdServerTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
                 find_free_port()
 
+    def test_find_free_port_retries_next_address(self):
+        addrs = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        second = unittest.mock.Mock()
+        with unittest.mock.patch(
+            "socket.getaddrinfo", return_value=addrs
+        ) as mock_getaddrinfo, unittest.mock.patch("socket.socket", side_effect=[
+            OSError("first address failed"),
+            second,
+        ]) as mock_socket:
+            result = find_free_port()
+        self.assertEqual(mock_getaddrinfo.call_count, 1)
+        self.assertEqual(mock_socket.call_count, 2)
+        self.assertIs(result, second)
+        second.bind.assert_called_once()
+        second.listen.assert_called_once()
+
+    def test_find_free_port_all_addresses_fail_raises_runtime_error(self):
+        addrs = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        with unittest.mock.patch(
+            "socket.getaddrinfo", return_value=addrs
+        ), unittest.mock.patch("socket.socket", side_effect=OSError("socket failed")) as mock_socket:
+            with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+                find_free_port()
+        self.assertEqual(mock_socket.call_count, len(addrs))
+
     def test_etcd_server_with_rendezvous(self):
         server = EtcdServer()
         server.start()

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,12 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            # FileStore reopens the path independently, so the descriptor
+            # returned by mkstemp() is never used by this code path. Close it
+            # right away to avoid leaking an open file descriptor for the
+            # lifetime of the process.
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -51,6 +51,7 @@ def find_free_port():
         host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
     )
 
+    s: socket.socket | None = None
     for addr in addrs:
         family, type, proto, _, _ = addr
         try:
@@ -59,7 +60,8 @@ def find_free_port():
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -51,19 +51,21 @@ def find_free_port():
         host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
     )
 
-    s: socket.socket | None = None
+    last_error: OSError | None = None
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
+            last_error = e
             if s is not None:
                 s.close()
             print(f"Socket creation attempt failed: {e}")
-    raise RuntimeError("Failed to create a socket")
+    raise RuntimeError("Failed to create a socket") from last_error
 
 
 def stop_etcd(subprocess, data_dir: str | None = None):


### PR DESCRIPTION
Fixes #191394 and #191395.

### Changes
- `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py`: `_create_file_store()` now closes the file descriptor returned by `tempfile.mkstemp()`. `FileStore` reopens the given path independently, so the original descriptor was leaked for the lifetime of the process.
- `torch/distributed/elastic/rendezvous/etcd_server.py`: `find_free_port()` now guards `s.close()` (previously `# type: ignore[possibly-undefined]`). When `socket.socket()` itself raised `OSError`, the `UnboundLocalError` masked the real `RuntimeError("Failed to create a socket")`.

### Tests
- `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py`: new `test_create_backend_closes_mkstemp_file_descriptor` asserts `os.close(fd)` is called for the descriptor returned by the mocked `tempfile.mkstemp()`.
- `test/distributed/elastic/rendezvous/etcd_server_test.py`: new `test_find_free_port_socket_failure_raises_runtime_error` reproduces the issue by mocking `socket.socket` to raise; asserts the `RuntimeError` (not `UnboundLocalError`) is raised.

Ran `python3 -m py_compile` on all four modified files; no local suite run requires a built torch, so CI on this branch is the authoritative check.