### PR TITLE
[Testcase Refactoring] 1. Add instantiate_device_type_tests to generalize device types. 2. Add proper hw_classification attribute to test classes. 

### DIFF
--- a/test/inductor/test_multi_kernel.py
+++ b/test/inductor/test_multi_kernel.py
@@ -13,21 +13,18 @@ from torch._inductor import config, test_operators
 from torch._inductor.codegen.multi_kernel import MultiKernelCall
 from torch._inductor.runtime.benchmarking import set_gpu_benchmark_lock_context
 from torch._inductor.test_case import TestCase
-from torch._inductor.utils import run_and_get_code
+from torch._inductor.utils import is_big_gpu, run_and_get_code
 from torch.nn import functional as F
 from torch.testing import make_tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     skipIfRocm,
     skipIfXpu,
 )
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_GPU,
-    IS_BIG_GPU,
-    requires_triton,
-)
+from torch.testing._internal.inductor_utils import requires_triton
+from torch.utils._triton import has_triton
 
 
 class TransformerSnippet(nn.Module):
@@ -42,8 +39,8 @@ class TransformerSnippet(nn.Module):
 
         return self.ln2(x1 + x2)
 
-    def example_inputs(self):
-        return (torch.randn(2, 64).to(GPU_TYPE), torch.randn(2, 64).to(GPU_TYPE))
+    def example_inputs(self, device):
+        return (torch.randn(2, 64).to(device), torch.randn(2, 64).to(device))
 
 
 def _contains_multi_kernel_code(wrapper_code: str):
@@ -74,27 +71,21 @@ def make_cpp_wrapper_test(orig_test, **extra_args):
 
     @config.patch("cpp_wrapper", True)
     @config.patch("triton.autotune_at_compile_time", True)
-    def fn(self):
+    def fn(self, device):
         # The same kernel may have been compiled by previous tests with
         # cpp_wrapper disabled. Clear the cache so we go ahead to re-compile
         # the kernel with cpp_wrapper enabled.
         from torch._inductor import codecache
 
         codecache.PyCodeCache.cache_clear()
-        return orig_test(self, **extra_args)
+        return orig_test(self, device=device, **extra_args)
 
     return fn
 
 
-@config.patch(
-    {
-        "triton.multi_kernel": int(os.environ.get("TORCHINDUCTOR_MULTI_KERNEL", "1")),
-        "benchmark_kernel": True,
-        "multi_kernel_hints": [64, 256, 4096],
-    }
-)
-@instantiate_parametrized_tests
-class MultiKernelTest(TestCase):
+class MultiKernelTestGENERIC(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @staticmethod
     def _benchmark_lock_call(events):
         def kernel(index):
@@ -180,8 +171,27 @@ class MultiKernelTest(TestCase):
 
         self.assertEqual(events, ["lock_enter", "lock_exit"])
 
-    def test_softmax(self, expect_multi_kernel=True):
-        x = torch.rand(2, 1024).to(GPU_TYPE)
+
+class MultiKernelTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._exit_stack.enter_context(
+            config.patch(
+                {
+                    "triton.multi_kernel": int(
+                        os.environ.get("TORCHINDUCTOR_MULTI_KERNEL", "1")
+                    ),
+                    "benchmark_kernel": True,
+                    "multi_kernel_hints": [64, 256, 4096],
+                }
+            )
+        )
+
+    def _softmax(self, device, expect_multi_kernel=True):
+        x = torch.rand(2, 1024).to(device)
         ref = torch.softmax(x, -1)
         compiled_fn = torch.compile(torch.softmax)
         act, wrapper_code = run_and_get_code(compiled_fn, x, -1)
@@ -196,12 +206,17 @@ class MultiKernelTest(TestCase):
         else:
             self.assertFalse(_contains_multi_kernel_code(wrapper_code))
 
+    def test_softmax(self, device, expect_multi_kernel=True):
+        self._softmax(device, expect_multi_kernel)
+
     @requires_triton()
     # TODO: bobrenjc93 to fix multi-kernel for ROCM
     @skipIfRocm
-    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
     @skipIfXpu(msg="driver issue, torch-xpu-ops: 2295")
-    def test_triton_gemm(self):
+    def test_triton_gemm(self, device):
+        if not is_big_gpu(device):
+            self.skipTest("templates require big gpu")
+
         def fn(x, y):
             return x @ y
 
@@ -212,8 +227,8 @@ class MultiKernelTest(TestCase):
                 "max_autotune_gemm_backends": "TRITON",
             },
         )
-        x = torch.randn(4096, 4096, device=GPU_TYPE)
-        y = torch.randn(4096, 4096, device=GPU_TYPE)
+        x = torch.randn(4096, 4096, device=device)
+        y = torch.randn(4096, 4096, device=device)
         torch._dynamo.mark_dynamic(x, 0)
         act, wrapper_code = run_and_get_code(compiled_fn, x, y)
         ref = fn(x, y)
@@ -229,8 +244,10 @@ class MultiKernelTest(TestCase):
     @requires_triton()
     # TODO: bobrenjc93 to fix multi-kernel for ROCM
     @skipIfRocm
-    @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
-    def test_triton_relu_fused_gemm(self):
+    def test_triton_relu_fused_gemm(self, device):
+        if not is_big_gpu(device):
+            self.skipTest("templates require big gpu")
+
         def fn(x, y):
             return (x @ y).relu()
 
@@ -241,8 +258,8 @@ class MultiKernelTest(TestCase):
                 "max_autotune_gemm_backends": "TRITON",
             },
         )
-        x = torch.randn(4096, 4096, device=GPU_TYPE)
-        y = torch.randn(4096, 4096, device=GPU_TYPE)
+        x = torch.randn(4096, 4096, device=device)
+        y = torch.randn(4096, 4096, device=device)
         torch._dynamo.mark_dynamic(x, 0)
         act, wrapper_code = run_and_get_code(compiled_fn, x, y)
         ref = fn(x, y)
@@ -258,11 +275,11 @@ class MultiKernelTest(TestCase):
     @unittest.mock.patch.dict(
         os.environ, {"TORCHINDUCTOR_DISABLE_MULTI_KERNEL_CACHE": "1"}
     )
-    def test_softmax_force_non_persistent_reduction(self, force_kernel):
+    def test_softmax_force_non_persistent_reduction(self, device, force_kernel):
         """
         Force a specific sub-kernel being picked by mocking the benchmark result.
         """
-        x = torch.rand(2, 1024).to(GPU_TYPE)
+        x = torch.rand(2, 1024).to(device)
         mock_latency = [0.2, 0.2]
         mock_latency[force_kernel] = 0.1  # this make sure force_kernel will be picked
 
@@ -290,21 +307,21 @@ class MultiKernelTest(TestCase):
         self.assertEqual(picked_kernel, force_kernel)
 
     @config.patch("warn_mix_layout", True)
-    def test_softmax_warn_mixed_layout(self):
-        self.test_softmax()
+    def test_softmax_warn_mixed_layout(self, device):
+        self._softmax(device)
 
     test_softmax_cpp_wrapper = make_cpp_wrapper_test(
         test_softmax, expect_multi_kernel=True
     )
 
-    def test_layernorm(self):
-        ln = nn.LayerNorm(1024).to(GPU_TYPE)
-        x = torch.rand(2, 1024).to(GPU_TYPE)
+    def test_layernorm(self, device):
+        ln = nn.LayerNorm(1024).to(device)
+        x = torch.rand(2, 1024).to(device)
         ref = ln(x)
         act = torch.compile(ln)(x)
         self.assertEqual(ref, act, atol=1e-4, rtol=1e-4)
 
-    def test_inplace_update(self):
+    def test_inplace_update(self, device):
         """
         Inductor generate inplace kernel for mul.
         """
@@ -312,15 +329,15 @@ class MultiKernelTest(TestCase):
         def f(x, y):
             return x.sum(dim=-1, keepdims=True) * (y @ y)
 
-        x = torch.rand(1024, 1024).to(GPU_TYPE)
-        y = torch.rand(1024, 1024).to(GPU_TYPE)
+        x = torch.rand(1024, 1024).to(device)
+        y = torch.rand(1024, 1024).to(device)
         ref = f(x, y)
         act = torch.compile(f)(x, y)
         self.assertEqual(ref, act)
 
-    def test_transformer_snippet(self):
-        model = TransformerSnippet().to(GPU_TYPE)
-        x = model.example_inputs()
+    def _transformer_snippet(self, device):
+        model = TransformerSnippet().to(device)
+        x = model.example_inputs(device=device)
 
         def f(*x):
             y = model(*x)
@@ -339,15 +356,18 @@ class MultiKernelTest(TestCase):
         if config.fallback_random:
             self.assertEqual(ref, act, atol=1e-4, rtol=1e-4)
 
-    def test_transformer_snippet_with_fallback_random(self):
+    def test_transformer_snippet(self, device):
+        self._transformer_snippet(device)
+
+    def test_transformer_snippet_with_fallback_random(self, device):
         """
         Same as test_transformer_snippet but fallback the random number
         generator to eager so we can check accuracy.
         """
         with config.patch("fallback_random", True):
-            self.test_transformer_snippet()
+            self._transformer_snippet(device)
 
-    def test_batchnorm_training(self):
+    def test_batchnorm_training(self, device):
         """
         For training, batchnorm will tracking running mean/variance during forward pass.
         The kernel generated by inductor currently will pass in those tensors twice as arguments:
@@ -358,18 +378,18 @@ class MultiKernelTest(TestCase):
         for a kernel. No matter if we change inductor behavior to assure that, it's better
         to make multi-kernel being able to handle those cases.
         """
-        bn = nn.BatchNorm2d(3).to(GPU_TYPE)
+        bn = nn.BatchNorm2d(3).to(device)
 
         @torch.compile
         def f(x):
             bn(x).sum().backward()
 
         _, (wrapper_code, _) = run_and_get_code(
-            f, torch.randn(2, 3, 8, 8, device=GPU_TYPE)
+            f, torch.randn(2, 3, 8, 8, device=device)
         )
         self.assertTrue(_contains_multi_kernel_code(wrapper_code))
 
-    def test_pass_same_arg_multi_times(self):
+    def test_pass_same_arg_multi_times(self, device):
         """
         A super simple example that simulate how BatchNorm update the running
         stats.
@@ -385,15 +405,15 @@ class MultiKernelTest(TestCase):
             x = x.sum(dim=1, keepdim=False)
             y.copy_(y * 0.9 + x * 0.1)
 
-        x = torch.randn(8, 16, device=GPU_TYPE)
-        y = torch.randn(8, device=GPU_TYPE)
+        x = torch.randn(8, 16, device=device)
+        y = torch.randn(8, device=device)
         y_ref = y.clone()
 
         ref = f(x, y_ref)  # noqa: F841
         act = torch.compile(f)(x, y)  # noqa: F841
         self.assertEqual(y_ref, y)
 
-    def test_reduction_scratch_buffer(self, force_multi_kernel=1):
+    def test_reduction_scratch_buffer(self, device, force_multi_kernel=1):
         """
         The explicitly realized buffer in the test function will be passed in
         as a scratch buffer for the non-persistent reduction kernel but
@@ -412,24 +432,24 @@ class MultiKernelTest(TestCase):
             x = x.sum(dim=-1, keepdim=True) + x
             return x
 
-        x = torch.rand(16, 16, device=GPU_TYPE)
+        x = torch.rand(16, 16, device=device)
         ref = f(x)
         with config.patch("triton.multi_kernel", force_multi_kernel):
             act = torch.compile(f)(x)
         self.assertEqual(ref, act)
 
-    def test_split_scan(self, force_multi_kernel=1):
+    def test_split_scan(self, device, force_multi_kernel=1):
         def f(x):
             x = x.view(-1)
             return torch.cumsum(x, 0)
 
-        x = make_tensor(10, 3, 352, 352, low=0, dtype=torch.float32, device=GPU_TYPE)
+        x = make_tensor(10, 3, 352, 352, low=0, dtype=torch.float32, device=device)
         expect = f(x)
         with config.patch("triton.multi_kernel", force_multi_kernel):
             actual = torch.compile(f)(x)
         self.assertEqual(expect, actual)
 
-    def test_sort_disables_multi_kernel(self, force_multi_kernel=1):
+    def test_sort_disables_multi_kernel(self, device, force_multi_kernel=1):
         """
         Sort currently requires a persistent kernel, so multi-kernel is not
         possible. Make sure this falls back gracefully.
@@ -438,7 +458,7 @@ class MultiKernelTest(TestCase):
         def f(x):
             return x.sort(-1).values
 
-        x = torch.rand(32, 32, device=GPU_TYPE)
+        x = torch.rand(32, 32, device=device)
         expect = f(x)
         with config.patch("triton.multi_kernel", force_multi_kernel):
             actual = torch.compile(f)(x)
@@ -460,8 +480,13 @@ class MultiKernelTest(TestCase):
     )
 
 
+instantiate_device_type_tests(
+    MultiKernelTest, globals(), except_for="cpu", allow_xpu=True
+)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU:
+    if has_triton():
         run_tests()


### PR DESCRIPTION
## Summary
1、This PR adds `instantiate_device_type_tests` is used to generate test classes for different devices.  
Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
2、Add `hw_classification `annotations to test classes and aligning test methods with their hardware classification.

## Changes
- Add `instantiate_device_type_tests` to the class. If functions within the class use `device`
- Add a device parameter to the function, and replace the usages of device within the function with the input parameter.
- Added `hw_classification` attribute to classes

## Motivation
HAS_GPU hardcodes CUDA/XPU/MTIA checks, excluding other accelerator backends.
Remove  `GPU_TYPE` / `HAS_GPU` and use `instantiate_device_type_tests` to generalize the device type tests.

## Test Plan
python test/inductor/test_multi_kernel.py
python test/inductor/test_multi_kernel.py -v --hw-classification ACCELERATOR

## Notes
Make CUDA/HPU/XPU device-generic in https://github.com/pytorch/pytorch/issues/189138
This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo