### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard overlap

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -16,9 +16,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import (
 )
 from torch.distributed.tensor import init_device_mesh, Shard
 from torch.distributed.tensor.experimental import implicit_replication
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
@@ -85,7 +83,7 @@ class TestFullyShardOverlap(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_fully_shard_training_overlap(self):
+    def test_fully_shard_training_overlap(self, device):
         torch.manual_seed(42)
 
         # Use non-trivial comm. time but still shorter than compute time
@@ -200,7 +198,7 @@ class TestFullyShardOverlap(FSDPTest):
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(2)
-    def test_fully_shard_backward_comm_overlap(self):
+    def test_fully_shard_backward_comm_overlap(self, device):
         """Exercise backward with reduce-scatter sharing the shard process
         group and with reduce-scatter opted in to a dedicated process group via
         set_separate_reduce_scatter_group.
@@ -282,7 +280,7 @@ class TestFullyShardOverlap(FSDPTest):
         _time_fn(fsdp_bwd)
 
     @skip_if_lt_x_gpu(2)
-    def test_set_separate_reduce_scatter_group(self):
+    def test_set_separate_reduce_scatter_group(self, device):
         """Reduce-scatter shares the shard PG by default; enabling gives it a
         dedicated PG (one communicator shared across same-rank-set meshes), and
         disabling resets to the shared PG."""
@@ -332,7 +330,7 @@ class TestFullyShardOverlap(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_fully_shard_post_optim_event_overlap(self):
+    def test_fully_shard_post_optim_event_overlap(self, device):
         torch.manual_seed(42)
 
         # Use non-trivial comm. time but still shorter than compute time
@@ -499,7 +497,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_fully_shard_per_param_mesh_training_overlap(self):
+    def test_fully_shard_per_param_mesh_training_overlap(self, device):
         self._test_per_param_mesh_overlap(simulate_no_grad_input=False)
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
@@ -508,7 +506,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_fully_shard_per_param_mesh_no_grad_input_overlap(self):
+    def test_fully_shard_per_param_mesh_no_grad_input_overlap(self, device):
         self._test_per_param_mesh_overlap(simulate_no_grad_input=True)
 
     def _test_per_param_mesh_overlap(self, simulate_no_grad_input: bool):

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -16,6 +16,9 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import (
 )
 from torch.distributed.tensor import init_device_mesh, Shard
 from torch.distributed.tensor.experimental import implicit_replication
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
@@ -28,6 +31,7 @@ from torch.testing._internal.common_fsdp import (
 )
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
+    HardwareClassification,
     IS_LINUX,
     MI200_ARCH,
     run_tests,
@@ -68,6 +72,8 @@ class TestFullyShardOverlap(FSDPTest):
     overlapped times are less than a non-overlapped baseline, but we do not
     test that the overlapped time is less than a precisely calculated time.
     """
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self) -> int:
@@ -422,6 +428,8 @@ class LinearWithSleep(nn.Module):
 
 
 class TestFullyShardPerParamMeshOverlap(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
@@ -647,6 +655,20 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             lambda msg: f"{msg}\nFSDP/replicate ratio {fsdp_time / rep_time:.2f} >= 1.5; "
             f"per-group RS state may not be preventing cross-group stalls",
         )
+
+
+instantiate_device_type_tests(
+    TestFullyShardOverlap,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardPerParamMeshOverlap,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the fully_shard overlap test classes and instantiates them via instantiate_device_type_tests, so they are discovered per device type under the hardware-classification selection. Both classes (TestFullyShardOverlap, TestFullyShardPerParamMeshOverlap) are classified as ACCELERATOR and instantiated with except_for=["cpu"], allow_xpu=True.

Test Plan: Ran the two commands below; each executed only the tests matching the requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_overlap.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_overlap.py --hw-classification GENERIC