### PR TITLE
[Metal][ops] Fix std/var for complex tensors on MPS (#135210)

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -40,6 +40,7 @@
 #include <ATen/ops/trace_native.h>
 #include <ATen/ops/var_mean_native.h>
 #include <ATen/ops/var_native.h>
+#include <ATen/ops/view_as_real.h>
 #endif
 
 namespace at::native {
@@ -360,6 +361,21 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       StdVarType stdVarType) {
   TORCH_CHECK_TYPE(input_t.is_floating_point() || input_t.is_complex(),
                    "std and var only support floating point and complex dtypes");
+
+  // MPSGraph does not support complex dtypes. Decompose: var(z) = var(real) + var(imag).
+  if (c10::isComplexType(input_t.scalar_type())) {
+    auto real_view = at::view_as_real(input_t.contiguous()); // shape [..., 2]; last dim is [real, imag]
+    auto real_part = real_view.select(-1, 0).contiguous();
+    auto imag_part = real_view.select(-1, 1).contiguous();
+    auto var_real = std_var_common_impl_mps(real_part, dim, correction, keepdim, STANDARD_VARIANCE);
+    auto var_imag = std_var_common_impl_mps(imag_part, dim, correction, keepdim, STANDARD_VARIANCE);
+    auto var_sum = var_real.add(var_imag);
+    if (stdVarType == STANDARD_DEVIATION) {
+      return var_sum.sqrt();
+    }
+    return var_sum;
+  }
+
   using CachedGraph = MPSUnaryCachedGraph;
 
   IntArrayRef input_shape = input_t.sizes();

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -364,9 +364,9 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
 
   // MPSGraph does not support complex dtypes. Decompose: var(z) = var(real) + var(imag).
   if (c10::isComplexType(input_t.scalar_type())) {
-    auto real_view = at::view_as_real(input_t.contiguous()); // shape [..., 2]; last dim is [real, imag]
-    auto real_part = real_view.select(-1, 0).contiguous();
-    auto imag_part = real_view.select(-1, 1).contiguous();
+    auto real_view = at::view_as_real(input_t); // shape [..., 2]; last dim is [real, imag]
+    auto real_part = real_view.select(-1, 0);
+    auto imag_part = real_view.select(-1, 1);
     auto var_real = std_var_common_impl_mps(real_part, dim, correction, keepdim, STANDARD_VARIANCE);
     auto var_imag = std_var_common_impl_mps(imag_part, dim, correction, keepdim, STANDARD_VARIANCE);
     auto var_sum = var_real.add(var_imag);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10447,50 +10447,6 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
-    def _check_var_std_complex(self, x_cpu, dim=None, correction=1, keepdim=False):
-        x_mps = x_cpu.to("mps")
-        var_cpu = torch.var(x_cpu, dim=dim, correction=correction, keepdim=keepdim)
-        var_mps = torch.var(x_mps, dim=dim, correction=correction, keepdim=keepdim)
-        std_cpu = torch.std(x_cpu, dim=dim, correction=correction, keepdim=keepdim)
-        std_mps = torch.std(x_mps, dim=dim, correction=correction, keepdim=keepdim)
-        self.assertFalse(var_cpu.is_complex(), "CPU var of complex should be real")
-        self.assertFalse(var_mps.is_complex(), "MPS var of complex should be real")
-        self.assertEqual(var_mps.cpu(), var_cpu, atol=1e-4, rtol=1e-4)
-        self.assertEqual(std_mps.cpu(), std_cpu, atol=1e-4, rtol=1e-4)
-
-    # https://github.com/pytorch/pytorch/issues/135210
-    def test_var_complex64_scalar(self):
-        x = torch.randn(1000, dtype=torch.complex64)
-        self._check_var_std_complex(x)
-
-    def test_var_complex64_unbiased(self):
-        x = torch.randn(1000, dtype=torch.complex64)
-        self._check_var_std_complex(x, correction=0)
-
-    def test_var_complex64_dim(self):
-        x = torch.randn(8, 64, dtype=torch.complex64)
-        self._check_var_std_complex(x, dim=1)
-        self._check_var_std_complex(x, dim=0)
-
-    def test_var_complex64_keepdim(self):
-        x = torch.randn(4, 16, dtype=torch.complex64)
-        self._check_var_std_complex(x, dim=0, keepdim=True)
-        self._check_var_std_complex(x, dim=1, keepdim=True)
-
-    def test_var_complex64_multi_dim(self):
-        x = torch.randn(4, 8, 16, dtype=torch.complex64)
-        self._check_var_std_complex(x, dim=(0, 2))
-
-    def test_std_complex64_known_value(self):
-        # torch.randn(complex64): real~N(0,1/sqrt(2)), imag~N(0,1/sqrt(2))
-        # var(real)+var(imag) ~= 0.5+0.5 = 1.0, so std ~= 1.0
-        torch.manual_seed(0)
-        x = torch.randn(100000, dtype=torch.complex64)
-        x_mps = x.to("mps")
-        std_cpu = torch.std(x).item()
-        std_mps = torch.std(x_mps).cpu().item()
-        self.assertFalse(isinstance(std_mps, complex), "std should be real")
-        self.assertAlmostEqual(std_mps, std_cpu, delta=0.01)
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10447,6 +10447,50 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
+    def _check_var_std_complex(self, x_cpu, dim=None, correction=1, keepdim=False):
+        x_mps = x_cpu.to("mps")
+        var_cpu = torch.var(x_cpu, dim=dim, correction=correction, keepdim=keepdim)
+        var_mps = torch.var(x_mps, dim=dim, correction=correction, keepdim=keepdim)
+        std_cpu = torch.std(x_cpu, dim=dim, correction=correction, keepdim=keepdim)
+        std_mps = torch.std(x_mps, dim=dim, correction=correction, keepdim=keepdim)
+        self.assertFalse(var_cpu.is_complex(), "CPU var of complex should be real")
+        self.assertFalse(var_mps.is_complex(), "MPS var of complex should be real")
+        self.assertEqual(var_mps.cpu(), var_cpu, atol=1e-4, rtol=1e-4)
+        self.assertEqual(std_mps.cpu(), std_cpu, atol=1e-4, rtol=1e-4)
+
+    # https://github.com/pytorch/pytorch/issues/135210
+    def test_var_complex64_scalar(self):
+        x = torch.randn(1000, dtype=torch.complex64)
+        self._check_var_std_complex(x)
+
+    def test_var_complex64_unbiased(self):
+        x = torch.randn(1000, dtype=torch.complex64)
+        self._check_var_std_complex(x, correction=0)
+
+    def test_var_complex64_dim(self):
+        x = torch.randn(8, 64, dtype=torch.complex64)
+        self._check_var_std_complex(x, dim=1)
+        self._check_var_std_complex(x, dim=0)
+
+    def test_var_complex64_keepdim(self):
+        x = torch.randn(4, 16, dtype=torch.complex64)
+        self._check_var_std_complex(x, dim=0, keepdim=True)
+        self._check_var_std_complex(x, dim=1, keepdim=True)
+
+    def test_var_complex64_multi_dim(self):
+        x = torch.randn(4, 8, 16, dtype=torch.complex64)
+        self._check_var_std_complex(x, dim=(0, 2))
+
+    def test_std_complex64_known_value(self):
+        # torch.randn(complex64): real~N(0,1/sqrt(2)), imag~N(0,1/sqrt(2))
+        # var(real)+var(imag) ~= 0.5+0.5 = 1.0, so std ~= 1.0
+        torch.manual_seed(0)
+        x = torch.randn(100000, dtype=torch.complex64)
+        x_mps = x.to("mps")
+        std_cpu = torch.std(x).item()
+        std_mps = torch.std(x_mps).cpu().item()
+        self.assertFalse(isinstance(std_mps, complex), "std should be real")
+        self.assertAlmostEqual(std_mps, std_cpu, delta=0.01)
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22244,16 +22244,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                 unittest.skip('Skipped!'), 'TestReductions', 'test_ref_small_input',
                 device_type='xpu',
                 dtypes=[torch.float64]),
-            # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # The operator 'aten::std.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22277,16 +22267,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             # FIXME: dim=[] reduces all dimensions
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
-            # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     ReductionOpInfo(
@@ -22315,16 +22295,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
             # NumPy is giving NaN for this
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_large_input'),
-            # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # NotImplementedError: The operator 'aten::var.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22348,9 +22318,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             # FIXME: dim=[] reduces all dimensions
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
-            # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
         ),
     ),
     ReductionOpInfo(
@@ -26198,13 +26165,6 @@ python_ref_db = [
                 unittest.skip('Skipped!'), 'TestReductions', 'test_ref_small_input',
                 device_type='xpu',
                 dtypes=[torch.float64]),
-            # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     # std_mean and var_mean are not ReductionInfos
@@ -26212,12 +26172,6 @@ python_ref_db = [
         "_refs.std_mean",
         torch_opinfo_name="std_mean",
         skips=(
-            # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     ReductionPythonRefInfo(
@@ -26312,12 +26266,6 @@ python_ref_db = [
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_small_input'),
             DecorateInfo(
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
-            # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     PythonRefInfo(
@@ -26325,12 +26273,6 @@ python_ref_db = [
         torch_opinfo_name="var_mean",
         validate_view_consistency=False,
         skips=(
-            # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     #

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -343,6 +343,12 @@ if torch.backends.mps.is_available():
             "short",
             "square",
             "stack",
+            # var(z) = var(real(z)) + var(imag(z)), see
+            # https://github.com/pytorch/pytorch/issues/135210
+            "std",
+            "stdunbiased",
+            "std_mean",
+            "std_meanunbiased",
             "stft",
             "sum",
             "sum_to_size",
@@ -350,6 +356,10 @@ if torch.backends.mps.is_available():
             "trace",
             "trapz",
             "trapezoid",
+            "var",
+            "varunbiased",
+            "var_mean",
+            "var_meanunbiased",
             "vdot",
             "vstack",
             "where",


### PR DESCRIPTION
Fixes #135210.

torch.var/torch.std (and var_mean/std_mean) on MPS returned incorrect results for complex tensors because the MPS reduction kernel computed variance directly on complex values instead of var(real) + var(imag). This mirrors the CPU/CUDA behavior.

Test plan:
```
python test/test_mps.py -v -k "complex64 and (var or std)"
```