### PR TITLE
Upload triton wheels per platform instead of waiting for all of them

### DIFF
--- a/.github/workflows/_build-triton-wheel-linux.yml
+++ b/.github/workflows/_build-triton-wheel-linux.yml
@@ -1,0 +1,139 @@
+name: Build Triton wheel (Linux)
+
+# Called once per build device so each device's wheels can be uploaded as soon
+# as that device is done, rather than waiting for every device and Windows.
+
+on:
+  workflow_call:
+    inputs:
+      device:
+        required: true
+        type: string
+      runs_on:
+        required: true
+        type: string
+      docker_image:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: "Build Triton Wheel"
+    runs-on: ${{ inputs.runs_on }}
+    # Run inside the manylinux builder on OSDC (ARC has no host docker daemon),
+    # instead of docker run/exec on an EC2 host.
+    container:
+      image: ${{ inputs.docker_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
+    timeout-minutes: 40
+    env:
+      PY_VERS: ${{ matrix.py_vers }}
+      BUILD_DEVICE: ${{ inputs.device }}
+      PLATFORM: 'manylinux_2_28_x86_64'
+    steps:
+      - name: Add sudo shim
+        shell: bash
+        # We run as root in the manylinux builder. It ships a gcc-toolset `sudo`
+        # wrapper that exec's /usr/bin/sudo (missing) with options like -E, so
+        # setup-linux's `sudo chmod` fails. Provide /usr/bin/sudo as a passthrough
+        # that drops leading sudo options and runs the command directly.
+        run: |
+          printf '%s\n' \
+            '#!/bin/sh' \
+            'while [ $# -gt 0 ]; do' \
+            '  case "$1" in' \
+            '    --) shift; break ;;' \
+            '    -*) shift ;;' \
+            '    *) break ;;' \
+            '  esac' \
+            'done' \
+            'exec "$@"' \
+            > /usr/bin/sudo
+          chmod +x /usr/bin/sudo
+
+      - name: Setup Linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          submodules: false
+          use-arc: true
+
+      - name: Build Triton wheel
+        env:
+          IS_RELEASE_TAG: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+        # Runs inside the manylinux builder container (matrix.docker_image), so the
+        # build commands run directly rather than via docker run/exec.
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+
+          # Determine python executable for given version
+          case $PY_VERS in
+          3.10)
+            PYTHON_EXECUTABLE=/opt/python/cp310-cp310/bin/python
+            ;;
+          3.11)
+            PYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python
+            ;;
+          3.12)
+            PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
+            ;;
+          3.13)
+            PYTHON_EXECUTABLE=/opt/python/cp313-cp313/bin/python
+            ;;
+          3.14)
+            PYTHON_EXECUTABLE=/opt/python/cp314-cp314/bin/python
+            ;;
+          3.14t)
+            PYTHON_EXECUTABLE=/opt/python/cp314-cp314t/bin/python
+            ;;
+          3.15)
+            PYTHON_EXECUTABLE=/opt/python/cp315-cp315/bin/python
+            ;;
+          3.15t)
+            PYTHON_EXECUTABLE=/opt/python/cp315-cp315t/bin/python
+            ;;
+          *)
+            echo "Unsupported python version ${PY_VERS}"
+            exit 1
+            ;;
+          esac
+
+          # Put the selected interpreter's bin dir on PATH so the pip-installed
+          # cmake (and python/pip) are found by triton's setup.py. In the original
+          # docker-exec env this was on PATH; in container: mode it is not.
+          export PATH="$(dirname "${PYTHON_EXECUTABLE}"):${PATH}"
+
+          RELEASE=""
+          WITH_CLANG_LDD=""
+          if [[ "${IS_RELEASE_TAG}" == true ]]; then
+            RELEASE="--release"
+          fi
+
+          yum install -y zlib-devel zip
+          "${PYTHON_EXECUTABLE}" -m pip install -U setuptools==78.1.0 pybind11==3.0.1 auditwheel wheel
+          "${PYTHON_EXECUTABLE}" -m pip install -U cmake --force-reinstall
+
+          if [[ ("${{ inputs.device }}" == "cuda" || "${{ inputs.device }}" == "rocm" || "${{ inputs.device }}" == "aarch64" ) ]]; then
+            # With this install, it gets clang 16.0.6.
+            dnf install clang lld -y
+            WITH_CLANG_LDD="--with-clang-ldd"
+          fi
+
+          cd "${RUNNER_TEMP}/artifacts"
+          "${PYTHON_EXECUTABLE}" "${GITHUB_WORKSPACE}/.github/scripts/build_triton_wheel.py" --device="${BUILD_DEVICE}" ${RELEASE} ${WITH_CLANG_LDD}
+
+          if [[ ("${{ inputs.device }}" == "cuda" || "${{ inputs.device }}" == "xpu") ]]; then
+            auditwheel repair --plat "${PLATFORM}" --exclude libtriton.so "${RUNNER_TEMP}/artifacts/"*.whl -w "${RUNNER_TEMP}/artifacts/wheelhouse"
+          else
+            mkdir -p "${RUNNER_TEMP}/artifacts/wheelhouse"
+            mv "${RUNNER_TEMP}/artifacts/"*.whl "${RUNNER_TEMP}/artifacts/wheelhouse/"
+          fi
+
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: triton-wheel-${{ matrix.py_vers }}-${{ inputs.device }}-${{ env.PLATFORM }}
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/wheelhouse/*

--- a/.github/workflows/_upload-triton-wheel.yml
+++ b/.github/workflows/_upload-triton-wheel.yml
@@ -1,0 +1,103 @@
+# Owner(s): ["oncall: releng"]
+name: Upload Triton wheel
+
+# Called once per published package (triton, pytorch-triton-rocm,
+# pytorch-triton-xpu) so each one uploads as soon as its own builds finish,
+# rather than waiting on every device and Windows.
+#
+# Only the artifact selection differs between callers, so everything else --
+# credentials, DRY_RUN/UPLOAD_CHANNEL gating and the upload itself -- lives here
+# instead of being copied per package.
+
+on:
+  workflow_call:
+    inputs:
+      artifact_pattern:
+        description: "download-artifact pattern for this package's wheels"
+        required: true
+        type: string
+      extra_artifact_pattern:
+        description: "Second pattern, for packages built on more than one platform"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  upload:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    container:
+      image: continuumio/miniconda3:4.12.0
+    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials(PyTorch account) for main
+        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials(PyTorch account) for RC builds
+        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
+          aws-region: us-east-1
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: ${{ inputs.artifact_pattern }}
+          path: ${{ runner.temp }}/artifacts-all
+
+      - name: Download Build Artifacts (second platform)
+        if: ${{ inputs.extra_artifact_pattern != '' }}
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: ${{ inputs.extra_artifact_pattern }}
+          path: ${{ runner.temp }}/artifacts-all
+
+      - name: Select Wheel Artifacts
+        shell: bash
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
+
+      - name: Set DRY_RUN (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
+        shell: bash
+        run: |
+          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
+
+      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          set -ex
+
+          # reference ends with an RC suffix
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
+            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
+          fi
+
+      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
+      - name: Upload binaries
+        env:
+          PACKAGE_TYPE: wheel
+          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
+          # to nightly or test
+          UPLOAD_SUBFOLDER: ""
+          PKG_DIR: ${{ runner.temp }}/artifacts
+          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          set -ex
+          bash .ci/pytorch/binary_upload.sh

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -265,16 +265,14 @@ jobs:
           mv ./*.whl "${RUNNER_TEMP}/artifacts/"
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}
+          name: triton-wheel-win-${{ matrix.py_vers }}-${{ matrix.device }}
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/*
 
 
-  upload-wheel:
+  upload-wheel-linux:
     runs-on: ubuntu-22.04
-    needs:
-      - build-wheel
-      - build-wheel-win
+    needs: build-wheel
     permissions:
       id-token: write
       contents: read
@@ -301,7 +299,80 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          # Download all available artifacts
+          pattern: triton-wheel-*-manylinux_2_28_x86_64
+          path: ${{ runner.temp }}/artifacts-all
+
+      - name: Select Wheel Artifacts
+        shell: bash
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
+
+      - name: Set DRY_RUN (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
+        shell: bash
+        run: |
+          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
+
+      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          set -ex
+
+          # reference ends with an RC suffix
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
+            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
+          fi
+
+      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
+      - name: Upload binaries
+        env:
+          PACKAGE_TYPE: wheel
+          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
+          # to nightly or test
+          UPLOAD_SUBFOLDER: ""
+          PKG_DIR: ${{ runner.temp }}/artifacts
+          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          set -ex
+          bash .ci/pytorch/binary_upload.sh
+
+  upload-wheel-win:
+    runs-on: ubuntu-22.04
+    needs: build-wheel-win
+    permissions:
+      id-token: write
+      contents: read
+    container:
+      image: continuumio/miniconda3:4.12.0
+    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials(PyTorch account) for main
+        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials(PyTorch account) for RC builds
+        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
+          aws-region: us-east-1
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: triton-wheel-win-*
           path: ${{ runner.temp }}/artifacts-all
 
       - name: Select Wheel Artifacts

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -34,51 +34,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-label-type:
+  select-runner:
     if: github.repository_owner == 'pytorch'
-    name: get-label-type
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-      check_experiments: lf
+    uses: ./.github/workflows/_select-release-runner.yml
 
   build-wheel-cuda:
     if: github.repository_owner == 'pytorch'
-    needs: get-label-type
+    needs: select-runner
     uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    secrets: inherit
     with:
       device: "cuda"
-      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      runs_on: ${{ needs.select-runner.outputs.x86 }}
       docker_image: "pytorch/manylinux2_28-builder:cpu"
 
   build-wheel-aarch64:
     if: github.repository_owner == 'pytorch'
-    needs: get-label-type
+    needs: select-runner
     uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    secrets: inherit
     with:
       device: "aarch64"
-      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
+      runs_on: ${{ needs.select-runner.outputs.arm64 }}
       docker_image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64"
 
   build-wheel-rocm:
     if: github.repository_owner == 'pytorch'
-    needs: get-label-type
+    needs: select-runner
     uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    secrets: inherit
     with:
       device: "rocm"
-      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      runs_on: ${{ needs.select-runner.outputs.x86 }}
       docker_image: "pytorch/manylinux2_28-builder:rocm7.2"
 
   build-wheel-xpu:
     if: github.repository_owner == 'pytorch'
-    needs: get-label-type
+    needs: select-runner
     uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    secrets: inherit
     with:
       device: "xpu"
-      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      runs_on: ${{ needs.select-runner.outputs.x86 }}
       docker_image: "pytorch/manylinux2_28-builder:cpu"
 
   build-wheel-win:
@@ -164,233 +161,26 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/*
 
+  # One upload job per published package, each gated only on its own builds.
   upload-wheel-triton:
-    runs-on: ubuntu-22.04
     needs: [build-wheel-cuda, build-wheel-aarch64]
-    permissions:
-      id-token: write
-      contents: read
-    container:
-      image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure AWS credentials(PyTorch account) for main
-        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
-          aws-region: us-east-1
-
-      - name: Configure AWS credentials(PyTorch account) for RC builds
-        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
-          aws-region: us-east-1
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          pattern: triton-wheel-*-cuda-manylinux_2_28_x86_64
-          path: ${{ runner.temp }}/artifacts-all
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          pattern: triton-wheel-*-aarch64-manylinux_2_28_x86_64
-          path: ${{ runner.temp }}/artifacts-all
-
-      - name: Select Wheel Artifacts
-        shell: bash
-        run: |
-          set -x
-          mkdir -p "${RUNNER_TEMP}/artifacts/"
-          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
-
-      - name: Set DRY_RUN (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
-        shell: bash
-        run: |
-          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
-
-      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          set -ex
-
-          # reference ends with an RC suffix
-          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
-            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
-          fi
-
-      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
-      - name: Upload binaries
-        env:
-          PACKAGE_TYPE: wheel
-          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
-          # to nightly or test
-          UPLOAD_SUBFOLDER: ""
-          PKG_DIR: ${{ runner.temp }}/artifacts
-          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        shell: bash
-        run: |
-          set -ex
-          bash .ci/pytorch/binary_upload.sh
+    uses: ./.github/workflows/_upload-triton-wheel.yml
+    secrets: inherit
+    with:
+      artifact_pattern: triton-wheel-*-cuda-manylinux_2_28_x86_64
+      extra_artifact_pattern: triton-wheel-*-aarch64-manylinux_2_28_x86_64
 
   upload-wheel-rocm:
-    runs-on: ubuntu-22.04
     needs: build-wheel-rocm
-    permissions:
-      id-token: write
-      contents: read
-    container:
-      image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure AWS credentials(PyTorch account) for main
-        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
-          aws-region: us-east-1
-
-      - name: Configure AWS credentials(PyTorch account) for RC builds
-        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
-          aws-region: us-east-1
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          pattern: triton-wheel-*-rocm-manylinux_2_28_x86_64
-          path: ${{ runner.temp }}/artifacts-all
-
-      - name: Select Wheel Artifacts
-        shell: bash
-        run: |
-          set -x
-          mkdir -p "${RUNNER_TEMP}/artifacts/"
-          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
-
-      - name: Set DRY_RUN (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
-        shell: bash
-        run: |
-          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
-
-      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          set -ex
-
-          # reference ends with an RC suffix
-          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
-            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
-          fi
-
-      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
-      - name: Upload binaries
-        env:
-          PACKAGE_TYPE: wheel
-          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
-          # to nightly or test
-          UPLOAD_SUBFOLDER: ""
-          PKG_DIR: ${{ runner.temp }}/artifacts
-          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        shell: bash
-        run: |
-          set -ex
-          bash .ci/pytorch/binary_upload.sh
+    uses: ./.github/workflows/_upload-triton-wheel.yml
+    secrets: inherit
+    with:
+      artifact_pattern: triton-wheel-*-rocm-manylinux_2_28_x86_64
 
   upload-wheel-xpu:
-    runs-on: ubuntu-22.04
     needs: [build-wheel-xpu, build-wheel-win]
-    permissions:
-      id-token: write
-      contents: read
-    container:
-      image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure AWS credentials(PyTorch account) for main
-        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
-          aws-region: us-east-1
-
-      - name: Configure AWS credentials(PyTorch account) for RC builds
-        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
-          aws-region: us-east-1
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          pattern: triton-wheel-*-xpu-manylinux_2_28_x86_64
-          path: ${{ runner.temp }}/artifacts-all
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          pattern: triton-wheel-win-*
-          path: ${{ runner.temp }}/artifacts-all
-
-      - name: Select Wheel Artifacts
-        shell: bash
-        run: |
-          set -x
-          mkdir -p "${RUNNER_TEMP}/artifacts/"
-          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
-
-      - name: Set DRY_RUN (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
-        shell: bash
-        run: |
-          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
-
-      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          set -ex
-
-          # reference ends with an RC suffix
-          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
-            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
-          fi
-
-      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
-      - name: Upload binaries
-        env:
-          PACKAGE_TYPE: wheel
-          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
-          # to nightly or test
-          UPLOAD_SUBFOLDER: ""
-          PKG_DIR: ${{ runner.temp }}/artifacts
-          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-        shell: bash
-        run: |
-          set -ex
-          bash .ci/pytorch/binary_upload.sh
+    uses: ./.github/workflows/_upload-triton-wheel.yml
+    secrets: inherit
+    with:
+      artifact_pattern: triton-wheel-*-xpu-manylinux_2_28_x86_64
+      extra_artifact_pattern: triton-wheel-win-*

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -45,146 +45,41 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: lf
 
-  build-wheel:
+  build-wheel-cuda:
     if: github.repository_owner == 'pytorch'
-    name: "Build Triton Wheel"
     needs: get-label-type
-    runs-on: ${{ matrix.runs_on }}
-    # Run inside the manylinux builder on OSDC (ARC has no host docker daemon),
-    # instead of docker run/exec on an EC2 host.
-    container:
-      image: ${{ matrix.docker_image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
-        device: ["cuda", "rocm", "xpu", "aarch64"]
-        include:
-          - device: "rocm"
-            rocm_version: "7.2"
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
-            docker_image: "pytorch/manylinux2_28-builder:rocm7.2"
-          - device: "cuda"
-            rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
-            docker_image: "pytorch/manylinux2_28-builder:cpu"
-          - device: "xpu"
-            rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
-            docker_image: "pytorch/manylinux2_28-builder:cpu"
-          - device: "aarch64"
-            rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
-            docker_image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64"
-    timeout-minutes: 40
-    env:
-      PY_VERS: ${{ matrix.py_vers }}
-      BUILD_DEVICE: ${{ matrix.device }}
-      PLATFORM: 'manylinux_2_28_x86_64'
-    steps:
-      - name: Add sudo shim
-        shell: bash
-        # We run as root in the manylinux builder. It ships a gcc-toolset `sudo`
-        # wrapper that exec's /usr/bin/sudo (missing) with options like -E, so
-        # setup-linux's `sudo chmod` fails. Provide /usr/bin/sudo as a passthrough
-        # that drops leading sudo options and runs the command directly.
-        run: |
-          printf '%s\n' \
-            '#!/bin/sh' \
-            'while [ $# -gt 0 ]; do' \
-            '  case "$1" in' \
-            '    --) shift; break ;;' \
-            '    -*) shift ;;' \
-            '    *) break ;;' \
-            '  esac' \
-            'done' \
-            'exec "$@"' \
-            > /usr/bin/sudo
-          chmod +x /usr/bin/sudo
+    uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    with:
+      device: "cuda"
+      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      docker_image: "pytorch/manylinux2_28-builder:cpu"
 
-      - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@main
-        with:
-          submodules: false
-          use-arc: true
+  build-wheel-aarch64:
+    if: github.repository_owner == 'pytorch'
+    needs: get-label-type
+    uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    with:
+      device: "aarch64"
+      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
+      docker_image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64"
 
-      - name: Build Triton wheel
-        env:
-          IS_RELEASE_TAG: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
-        # Runs inside the manylinux builder container (matrix.docker_image), so the
-        # build commands run directly rather than via docker run/exec.
-        run: |
-          set -x
-          mkdir -p "${RUNNER_TEMP}/artifacts/"
+  build-wheel-rocm:
+    if: github.repository_owner == 'pytorch'
+    needs: get-label-type
+    uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    with:
+      device: "rocm"
+      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      docker_image: "pytorch/manylinux2_28-builder:rocm7.2"
 
-          # Determine python executable for given version
-          case $PY_VERS in
-          3.10)
-            PYTHON_EXECUTABLE=/opt/python/cp310-cp310/bin/python
-            ;;
-          3.11)
-            PYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python
-            ;;
-          3.12)
-            PYTHON_EXECUTABLE=/opt/python/cp312-cp312/bin/python
-            ;;
-          3.13)
-            PYTHON_EXECUTABLE=/opt/python/cp313-cp313/bin/python
-            ;;
-          3.14)
-            PYTHON_EXECUTABLE=/opt/python/cp314-cp314/bin/python
-            ;;
-          3.14t)
-            PYTHON_EXECUTABLE=/opt/python/cp314-cp314t/bin/python
-            ;;
-          3.15)
-            PYTHON_EXECUTABLE=/opt/python/cp315-cp315/bin/python
-            ;;
-          3.15t)
-            PYTHON_EXECUTABLE=/opt/python/cp315-cp315t/bin/python
-            ;;
-          *)
-            echo "Unsupported python version ${PY_VERS}"
-            exit 1
-            ;;
-          esac
-
-          # Put the selected interpreter's bin dir on PATH so the pip-installed
-          # cmake (and python/pip) are found by triton's setup.py. In the original
-          # docker-exec env this was on PATH; in container: mode it is not.
-          export PATH="$(dirname "${PYTHON_EXECUTABLE}"):${PATH}"
-
-          RELEASE=""
-          WITH_CLANG_LDD=""
-          if [[ "${IS_RELEASE_TAG}" == true ]]; then
-            RELEASE="--release"
-          fi
-
-          yum install -y zlib-devel zip
-          "${PYTHON_EXECUTABLE}" -m pip install -U setuptools==78.1.0 pybind11==3.0.1 auditwheel wheel
-          "${PYTHON_EXECUTABLE}" -m pip install -U cmake --force-reinstall
-
-          if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "rocm" || "${{ matrix.device }}" == "aarch64" ) ]]; then
-            # With this install, it gets clang 16.0.6.
-            dnf install clang lld -y
-            WITH_CLANG_LDD="--with-clang-ldd"
-          fi
-
-          cd "${RUNNER_TEMP}/artifacts"
-          "${PYTHON_EXECUTABLE}" "${GITHUB_WORKSPACE}/.github/scripts/build_triton_wheel.py" --device="${BUILD_DEVICE}" ${RELEASE} ${WITH_CLANG_LDD}
-
-          if [[ ("${{ matrix.device }}" == "cuda" || "${{ matrix.device }}" == "xpu") ]]; then
-            auditwheel repair --plat "${PLATFORM}" --exclude libtriton.so "${RUNNER_TEMP}/artifacts/"*.whl -w "${RUNNER_TEMP}/artifacts/wheelhouse"
-          else
-            mkdir -p "${RUNNER_TEMP}/artifacts/wheelhouse"
-            mv "${RUNNER_TEMP}/artifacts/"*.whl "${RUNNER_TEMP}/artifacts/wheelhouse/"
-          fi
-
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-        with:
-          name: triton-wheel-${{ matrix.py_vers }}-${{ matrix.device }}-${{ env.PLATFORM }}
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/wheelhouse/*
+  build-wheel-xpu:
+    if: github.repository_owner == 'pytorch'
+    needs: get-label-type
+    uses: ./.github/workflows/_build-triton-wheel-linux.yml
+    with:
+      device: "xpu"
+      runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+      docker_image: "pytorch/manylinux2_28-builder:cpu"
 
   build-wheel-win:
     if: github.repository_owner == 'pytorch'
@@ -269,10 +164,9 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/*
 
-
-  upload-wheel-linux:
+  upload-wheel-triton:
     runs-on: ubuntu-22.04
-    needs: build-wheel
+    needs: [build-wheel-cuda, build-wheel-aarch64]
     permissions:
       id-token: write
       contents: read
@@ -299,7 +193,13 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          pattern: triton-wheel-*-manylinux_2_28_x86_64
+          pattern: triton-wheel-*-cuda-manylinux_2_28_x86_64
+          path: ${{ runner.temp }}/artifacts-all
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: triton-wheel-*-aarch64-manylinux_2_28_x86_64
           path: ${{ runner.temp }}/artifacts-all
 
       - name: Select Wheel Artifacts
@@ -343,9 +243,9 @@ jobs:
           set -ex
           bash .ci/pytorch/binary_upload.sh
 
-  upload-wheel-win:
+  upload-wheel-rocm:
     runs-on: ubuntu-22.04
-    needs: build-wheel-win
+    needs: build-wheel-rocm
     permissions:
       id-token: write
       contents: read
@@ -368,6 +268,85 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
           aws-region: us-east-1
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: triton-wheel-*-rocm-manylinux_2_28_x86_64
+          path: ${{ runner.temp }}/artifacts-all
+
+      - name: Select Wheel Artifacts
+        shell: bash
+        run: |
+          set -x
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
+          mv "${RUNNER_TEMP}"/artifacts-all/triton-wheel-*/* "${RUNNER_TEMP}/artifacts/"
+
+      - name: Set DRY_RUN (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) }}
+        shell: bash
+        run: |
+          echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
+
+      - name: Set UPLOAD_CHANNEL (only for tagged pushes)
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          set -ex
+
+          # reference ends with an RC suffix
+          if [[ "${GITHUB_REF_NAME}" = *-rc[0-9]* ]]; then
+            echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
+          fi
+
+      # NB: This step is gated by DRY_RUN, which is enabled everywhere except main and release branches
+      - name: Upload binaries
+        env:
+          PACKAGE_TYPE: wheel
+          # The UPLOAD_SUBFOLDER needs to be empty here so that triton wheels are uploaded
+          # to nightly or test
+          UPLOAD_SUBFOLDER: ""
+          PKG_DIR: ${{ runner.temp }}/artifacts
+          R2_UPLOAD: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'true' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          set -ex
+          bash .ci/pytorch/binary_upload.sh
+
+  upload-wheel-xpu:
+    runs-on: ubuntu-22.04
+    needs: [build-wheel-xpu, build-wheel-win]
+    permissions:
+      id-token: write
+      contents: read
+    container:
+      image: continuumio/miniconda3:4.12.0
+    environment: ${{ (github.event_name == 'push' && github.event.ref == 'refs/heads/main') && 'nightly-wheel-upload' || '' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials(PyTorch account) for main
+        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials(PyTorch account) for RC builds
+        if: ${{ github.event_name == 'push' &&  (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')) }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
+          aws-region: us-east-1
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: triton-wheel-*-xpu-manylinux_2_28_x86_64
+          path: ${{ runner.temp }}/artifacts-all
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -164,6 +164,9 @@ jobs:
   # One upload job per published package, each gated only on its own builds.
   upload-wheel-triton:
     needs: [build-wheel-cuda, build-wheel-aarch64]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/_upload-triton-wheel.yml
     secrets: inherit
     with:
@@ -172,6 +175,9 @@ jobs:
 
   upload-wheel-rocm:
     needs: build-wheel-rocm
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/_upload-triton-wheel.yml
     secrets: inherit
     with:
@@ -179,6 +185,9 @@ jobs:
 
   upload-wheel-xpu:
     needs: [build-wheel-xpu, build-wheel-win]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/_upload-triton-wheel.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Same problem as #193234, in `build-triton-wheel.yml`: `upload-wheel` needed **both** `build-wheel` and `build-wheel-win`, and `needs` is evaluated per job rather than per matrix leg, so nothing published until the slowest leg of either matrix finished.

## Measured cost

Windows is the long pole by a wide margin. From [run 31656988446](https://github.com/pytorch/pytorch/actions/runs/31656988446):

| group | last build finished | upload waited until | idle |
| --- | --- | --- | --- |
| aarch64 | 01:28:11 | 01:50:47 | **22.6 min** |
| cuda | 01:30:07 | 01:50:47 | 20.7 min |
| rocm | 01:32:37 | 01:50:47 | 18.2 min |
| xpu | 01:33:47 | 01:50:47 | 17.0 min |
| windows | 01:50:47 | 01:50:47 | 0.0 min |

Every Linux wheel sat finished for 17-23 minutes waiting on Windows.

## Change

Split into `upload-wheel-linux` (needs `build-wheel`) and `upload-wheel-win` (needs `build-wheel-win`), so each platform publishes as soon as its own builds are done.

This also decouples failures. In that same run a single leg failed (`Build Triton Wheel (3.14t, cuda)`), and because one upload job was gated on both matrices, **no wheels shipped at all** — including the 8 Windows wheels that had built fine.

Neither job sets `if:`, so the default "all needs succeeded" gate still applies. A failed build must not publish, and unlike #193234 this workflow never had a `!cancelled()` guard weakening that.

The Windows artifact is renamed `triton-wheel-${{ ... }}` -> `triton-wheel-win-${{ ... }}` so each upload job can select its own set with a `download-artifact` pattern. Verified the two globs are disjoint across every real artifact name:

```
triton-wheel-3.10-cuda-manylinux_2_28_x86_64   linux=True  win=False
triton-wheel-win-3.10-xpu                      linux=False win=True
```

Nothing outside this workflow references `triton-wheel-*` artifacts (grepped `.github/`), so the rename is safe.

## What this does not do

Upload is split **by platform**, not per device. Splitting Linux further (cuda / rocm / xpu / aarch64) would need `build-wheel` itself broken into four jobs, since `needs: build-wheel` waits for the whole matrix — the same restructuring #193234 did for manywheel.

The measured marginal gain is small: within Linux the spread is 01:28:11 (aarch64) to 01:33:47 (xpu), so per-device would save aarch64 a further ~5.6 min on top of the ~22 min this already recovers. Happy to do it as a follow-up if that is wanted — it is worth extracting the build into a reusable workflow at that point rather than duplicating a ~100-line job body four times.

## Test plan

Structural change to a workflow, so CI on this PR exercises it via the `pull_request` trigger (paths include this file). Verified locally: YAML parses, the job graph is `upload-wheel-linux -> build-wheel` and `upload-wheel-win -> build-wheel-win`, and `actionlint` reports no new findings versus base (the remaining SC2016/SC2155 are pre-existing on the build steps).