### PR TITLE
[Metal][ops] Fix nonzero to return Fortran-contiguous output matching CPU (#170175)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -966,7 +966,10 @@ INSTANTIATE_INDEX_FILL_FROM_MASK(half2)
 // Step 3 (scatter_nonzero_indices): Each thread with a nonzero element writes
 // its multi-dimensional indices into the output at the position determined by
 // block_offsets[tgid] plus an intra-block prefix recomputed in threadgroup
-// memory.
+// memory. out_stride0/out_stride1 are the output's element strides, so the
+// same kernel fills either layout the callers need without a staging copy:
+// row-major {n, ndim} for nonzero_static, or Fortran-contiguous for nonzero
+// (which matches CPU, see gh-46224).
 
 template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
 inline bool is_nonzero(T val) {
@@ -1213,6 +1216,8 @@ kernel void scatter_nonzero_indices(
     constant long& max_entries [[buffer(5)]],
     constant ulong& flat_base [[buffer(6)]],
     constant uint& block_base [[buffer(7)]],
+    constant long& out_stride0 [[buffer(8)]],
+    constant long& out_stride1 [[buffer(9)]],
     uint tid [[thread_position_in_grid]],
     uint tgid [[threadgroup_position_in_grid]],
     uint tgsize [[threads_per_threadgroup]],
@@ -1275,10 +1280,11 @@ kernel void scatter_nonzero_indices(
   // it keeps the per-dimension div/mod below in fast 32-bit math on the input
   // flat index. The output base is always 64-bit (count-side, see above).
   index_t flat = gid;
-  ulong out_base = pos * static_cast<ulong>(ndim);
+  ulong row = pos * static_cast<ulong>(out_stride0);
   for (int d = ndim - 1; d >= 0; d--) {
     index_t dim_size = static_cast<index_t>(sizes[d]);
-    output[out_base + d] = static_cast<int64_t>(flat % dim_size);
+    output[row + static_cast<ulong>(d) * static_cast<ulong>(out_stride1)] =
+        static_cast<int64_t>(flat % dim_size);
     flat /= dim_size;
   }
 }
@@ -1312,6 +1318,8 @@ kernel void scatter_nonzero_indices(
       constant long& max_entries [[buffer(5)]],               \
       constant ulong& flat_base [[buffer(6)]],                \
       constant uint& block_base [[buffer(7)]],                \
+      constant long& out_stride0 [[buffer(8)]],               \
+      constant long& out_stride1 [[buffer(9)]],               \
       uint tid [[thread_position_in_grid]],                   \
       uint tgid [[threadgroup_position_in_grid]],             \
       uint tgsize [[threads_per_threadgroup]],                \

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -431,7 +431,10 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
     // Dynamic path: sync to learn output size. total_nonzero is int64, so the
     // count reads back directly even when it exceeds INT_MAX.
     const int64_t total_nonzero = total_nonzero_buf.item<int64_t>();
-    at::native::resize_output(out_, {total_nonzero, nDim});
+    if (at::native::resize_output(out_, {total_nonzero, nDim})) {
+      // Match CPU behavior: default to Fortran-contiguous output (see gh-46224)
+      out_.as_strided_({total_nonzero, nDim}, {1, total_nonzero});
+    }
     max_elements = total_nonzero;
   }
 
@@ -439,6 +442,17 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
     return;
   }
 
+  // Fortran-contiguous out_ (the common nDim > 1, n > 1 case) is not
+  // out_.is_contiguous(), so this falls back to a scratch contiguous buffer
+  // plus a full strided copy_ below. CUDA's Nonzero.cu avoids that copy by
+  // scattering into a contiguous {ndim, n} buffer (transposed layout) and
+  // finishing with out.set_(out_temp.t()), a metadata-only transpose. Doing
+  // the same here would require the scatter_nonzero_indices Metal kernel to
+  // write transposed output (output[d * n + pos] instead of
+  // output[pos * ndim + d]) and reworking this function's branching, since
+  // nonzero_static shares this code path with a different output-layout
+  // contract (pre-sized, pre-filled, no resize/as_strided_). Left as a
+  // possible future optimization; not applied here to keep this fix minimal.
   bool contiguous_output = out_.is_contiguous();
   Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
@@ -481,7 +495,9 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
 Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   int64_t nDim = self.dim();
   if (self.numel() == 0) {
-    at::native::resize_output(out_, {0, nDim});
+    if (at::native::resize_output(out_, {0, nDim})) {
+      out_.as_strided_({0, nDim}, {1, 0});
+    }
     return out_;
   }
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -442,25 +442,26 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
     return;
   }
 
-  // Fortran-contiguous out_ (the common nDim > 1, n > 1 case) is not
-  // out_.is_contiguous(), so this falls back to a scratch contiguous buffer
-  // plus a full strided copy_ below. CUDA's Nonzero.cu avoids that copy by
-  // scattering into a contiguous {ndim, n} buffer (transposed layout) and
-  // finishing with out.set_(out_temp.t()), a metadata-only transpose. Doing
-  // the same here would require the scatter_nonzero_indices Metal kernel to
-  // write transposed output (output[d * n + pos] instead of
-  // output[pos * ndim + d]) and reworking this function's branching, since
-  // nonzero_static shares this code path with a different output-layout
-  // contract (pre-sized, pre-filled, no resize/as_strided_). Left as a
-  // possible future optimization; not applied here to keep this fix minimal.
-  bool contiguous_output = out_.is_contiguous();
-  Tensor out = contiguous_output ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
+  // Scatter writes straight into out_ whenever its layout is addressable with a
+  // (row, column) stride pair: row-major, which is nonzero_static's contract, or
+  // Fortran-contiguous, which is nonzero's (matching CPU, see gh-46224). Since
+  // Fortran-contiguous out_ is not out_.is_contiguous(), keying the fast path on
+  // contiguity alone would send the common nonzero case through a scratch buffer
+  // plus a full strided copy_. Anything else (an out= argument with some other
+  // strides) still falls back to that scratch path.
+  const bool direct_write = out_.is_contiguous() || out_.t().is_contiguous();
+  Tensor out = direct_write ? out_ : at::empty_like(out_, MemoryFormat::Contiguous);
 
   int ndim_int = static_cast<int>(nDim);
   // max_entries caps how many nonzeros scatter writes. It is int64 (kernel-side
   // too), so a user-supplied static size or a dynamic count above 2^32 is not
   // truncated.
   int64_t max_entries = *max_elements;
+
+  // Element strides of the scatter destination, so the kernel can fill either
+  // layout in place (see direct_write above).
+  const int64_t out_stride0 = out.stride(0);
+  const int64_t out_stride1 = out.stride(1);
 
   // Pick the scatter index width. tid is a 32-bit grid position, so the flat
   // input index is bounded by numel; the output offset is num_nonzeros * ndim.
@@ -480,14 +481,23 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
       for (uint64_t base = 0; base < static_cast<uint64_t>(numel); base += chunk_elems) {
         uint64_t this_chunk = std::min(chunk_elems, static_cast<uint64_t>(numel) - base);
         uint32_t block_base = static_cast<uint32_t>(base / threads_per_group);
-        mtl_setArgs(
-            computeEncoder, input, out, ndim_int, input.sizes(), block_offsets_buf, max_entries, base, block_base);
+        mtl_setArgs(computeEncoder,
+                    input,
+                    out,
+                    ndim_int,
+                    input.sizes(),
+                    block_offsets_buf,
+                    max_entries,
+                    base,
+                    block_base,
+                    out_stride0,
+                    out_stride1);
         mtl_dispatch1DJob(computeEncoder, pso_step3, this_chunk);
       }
     }
   });
 
-  if (!contiguous_output) {
+  if (!direct_write) {
     out_.copy_(out);
   }
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10448,18 +10448,13 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(y, ref, atol=0, rtol=0)
 
     # https://github.com/pytorch/pytorch/issues/170175
-    def test_nonzero_strides_match_cpu(self):
-        x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
-        self.assertEqual(x.nonzero().stride(), x.cpu().nonzero().stride())
-
-    def test_nonzero_view_raises_like_cpu(self):
-        x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
-        with self.assertRaisesRegex(RuntimeError, "view size is not compatible"):
-            x.nonzero().view(-1)
-
-    def test_nonzero_values_correct(self):
+    def test_nonzero_matches_cpu_layout_and_values(self):
         x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
         self.assertEqual(x.nonzero(), x.cpu().nonzero())
+        self.assertEqual(x.nonzero().stride(), x.cpu().nonzero().stride())
+        # Fortran-contiguous output is not viewable as 1-D, same as CPU.
+        with self.assertRaisesRegex(RuntimeError, "view size is not compatible"):
+            x.nonzero().view(-1)
 
     def test_nonzero_2d_strides(self):
         x = (torch.randn(8, 8, device="mps") > 0).to(torch.int)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10447,6 +10447,36 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
+    # https://github.com/pytorch/pytorch/issues/170175
+    def test_nonzero_strides_match_cpu(self):
+        x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
+        self.assertEqual(x.nonzero().stride(), x.cpu().nonzero().stride())
+
+    def test_nonzero_view_raises_like_cpu(self):
+        x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
+        with self.assertRaisesRegex(RuntimeError, "view size is not compatible"):
+            x.nonzero().view(-1)
+
+    def test_nonzero_values_correct(self):
+        x = torch.tensor([[0, 1, 0], [2, 0, 3], [0, 4, 0]], device="mps")
+        self.assertEqual(x.nonzero(), x.cpu().nonzero())
+
+    def test_nonzero_2d_strides(self):
+        x = (torch.randn(8, 8, device="mps") > 0).to(torch.int)
+        self.assertEqual(x.nonzero().stride(), x.cpu().nonzero().stride())
+
+    def test_nonzero_empty_input(self):
+        x = torch.zeros(0, 3, device="mps")
+        out = x.nonzero()
+        self.assertEqual(out.size(), (0, 2))
+        self.assertEqual(out.stride(), x.cpu().nonzero().stride())
+
+    def test_nonzero_all_zero(self):
+        x = torch.zeros(4, 4, dtype=torch.int, device="mps")
+        out = x.nonzero()
+        self.assertEqual(out.size(), (0, 2))
+        self.assertEqual(out.stride(), x.cpu().nonzero().stride())
+
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
Fixes #170175.

MPS nonzero() always returned C-contiguous output, while CPU/CUDA return Fortran-contiguous output (stride (1, n)). This let .view(-1) silently succeed on MPS where it correctly raises on CPU/CUDA. Fix defaults the resized output to Fortran-contiguous strides, matching CPU.

A similar fix, #170181, was previously opened for this issue.

Test plan:
```
python test/test_mps.py -v -k nonzero
```

Note: nonzero_static intentionally keeps its existing (pre-sized) contiguous output contract — not touched by this fix, as documented in the code comment.