### PR TITLE
[MPS] Fix mm/addmm/bmm producing garbage when out= is a tensor slice on macOS 14

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -547,6 +547,12 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
   if (!output.is_contiguous() && !is_macos_26_0_or_newer) {
     return true;
   }
+  // Before macOS 15, an output with a storage offset is gathered into a
+  // temporary that the graph writes and nothing scatters back; the metal
+  // kernels honor the offset.
+  if (needsGather(output)) {
+    return true;
+  }
   // multiplicationWithPrimaryTensor: returns incorrect results if inner size exceeds 2048
   // See https://github.com/pytorch/pytorch/issues/167727#issuecomment-3529308548
   if (c10::isComplexType(self.scalar_type()) && self.size(1) > max_complex_inner_size) {
@@ -1474,6 +1480,11 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // kernel honors the output strides.
   static const bool is_macos_26_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_26_0);
   if (!result.is_contiguous() && !is_macos_26_0_or_newer) {
+    return do_metal_bmm(batch1, batch2, result);
+  }
+  // Same pre-macOS-15 crack as use_metal_mm: an output with a storage offset
+  // is gathered into a temporary that nothing scatters back.
+  if (needsGather(result)) {
     return do_metal_bmm(batch1, batch2, result);
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14410,17 +14410,6 @@ class TestConvolutionMPS(TestCaseMPS):
             x_gpu = conv_gpu(y_gpu)
             self.assertEqual(x_cpu, x_gpu.cpu(), rtol=1e-03, atol=1e-05)
 
-    @parametrize("with_bias", [False, True], name_fn=lambda with_bias: "bias" if with_bias else "no_bias")
-    def test_conv3d_pointwise_batched(self, with_bias):
-        # 1x1x1 stride-1 convs run as per-batch matmuls; outputs of batch > 0
-        # are views at a storage offset, which macOS 14 miscomputed
-        x = torch.randn(2, 48, 5, 10, 5)
-        weight = torch.randn(96, 48, 1, 1, 1)
-        bias = torch.randn(96) if with_bias else None
-        expected = F.conv3d(x, weight, bias)
-        actual = F.conv3d(x.to("mps"), weight.to("mps"), bias.to("mps") if with_bias else None)
-        self.assertEqual(actual.cpu(), expected, atol=1e-4, rtol=1e-4)
-
     @parametrize("case", ["catalog", "simd_miss"])
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("with_bias", [False, True])

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1612,7 +1612,6 @@ class TestMPS(TestCaseMPS):
         tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
         self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
 
-    @unittest.skipIf(MACOS_VERSION >= 15.0, "Exercises the pre-macOS-15 gather path")
     def test_matmul_offset_output(self):
         # Contiguous out= views at a nonzero storage offset; macOS < 15 dropped the write.
         a = torch.randn(2, 16, 16, device="mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1612,6 +1612,18 @@ class TestMPS(TestCaseMPS):
         tol = 1e-2 if dtype in (torch.float16, torch.bfloat16) else 1e-4
         self.assertEqual(out.cpu(), ref, atol=tol, rtol=tol)
 
+    @unittest.skipIf(MACOS_VERSION >= 15.0, "Exercises the pre-macOS-15 gather path")
+    def test_matmul_offset_output(self):
+        # Contiguous out= views at a nonzero storage offset; macOS < 15 dropped the write.
+        a = torch.randn(2, 16, 16, device="mps")
+        out = torch.zeros(4, 16, 16, device="mps")
+        torch.mm(a[0], a[1], out=out[1])
+        torch.addmm(a[0], a[0], a[1], out=out[2])
+        expected = torch.stack([a[0].cpu() @ a[1].cpu(), a[0].cpu() + a[0].cpu() @ a[1].cpu()])
+        self.assertEqual(out[1:3].cpu(), expected, atol=1e-5, rtol=1e-5)
+        torch.bmm(a, a, out=out.view(2, 2, 16, 16)[1])
+        self.assertEqual(out[2:].cpu(), a.cpu() @ a.cpu(), atol=1e-5, rtol=1e-5)
+
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("case", [
         ((1, 64, 12), "inner"),

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14398,6 +14398,17 @@ class TestConvolutionMPS(TestCaseMPS):
             x_gpu = conv_gpu(y_gpu)
             self.assertEqual(x_cpu, x_gpu.cpu(), rtol=1e-03, atol=1e-05)
 
+    @parametrize("with_bias", [False, True], name_fn=lambda with_bias: "bias" if with_bias else "no_bias")
+    def test_conv3d_pointwise_batched(self, with_bias):
+        # 1x1x1 stride-1 convs run as per-batch matmuls; outputs of batch > 0
+        # are views at a storage offset, which macOS 14 miscomputed
+        x = torch.randn(2, 48, 5, 10, 5)
+        weight = torch.randn(96, 48, 1, 1, 1)
+        bias = torch.randn(96) if with_bias else None
+        expected = F.conv3d(x, weight, bias)
+        actual = F.conv3d(x.to("mps"), weight.to("mps"), bias.to("mps") if with_bias else None)
+        self.assertEqual(actual.cpu(), expected, atol=1e-4, rtol=1e-4)
+
     @parametrize("case", ["catalog", "simd_miss"])
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("with_bias", [False, True])


### PR DESCRIPTION
On macOS 14, `torch.mm(a, b, out=buf[1])` never writes the result, this PR routes these outputs to the metal matmul kernels, which write the slice directly.

Since most of us don't have macOS 14, I used the CI Runners to run the test initially before making the change and it was failing:
<img width="1511" height="633" alt="Screenshot 2026-08-14 at 00 05 39" src="https://github.com/user-attachments/assets/59dd06a8-67d8-4b23-80da-417bda00f6f7" />

Found this out when implementing conv1d