### PR TITLE
[Testcase Refactoring] [DTensor] Classify strategy tests by hardware

### DIFF
--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    build_fake_device_mesh,
+    build_mesh_for_fake_pg,
 )
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
@@ -46,7 +46,7 @@ class CommonRulesTest(TestCase):
 
     def test_einop_basic_propagation(self):
         # plain einsum, mm
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         mm_call = aten.mm.default
         # propagate col-wise sharding
@@ -98,7 +98,7 @@ class CommonRulesTest(TestCase):
         self.assertTrue(output_spec.placements[0].is_partial())
 
     def test_einop_pointwise_propagation(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         add_call = aten.add.Tensor
         # addition
@@ -153,7 +153,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -177,7 +177,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -243,7 +243,7 @@ class CommonRulesTest(TestCase):
     def test_einop_multi_sharding_on_mesh_dim(self):
         # einop prop with multi sharding on same mesh dim
         mesh_shape = torch.arange(self.world_size)
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         mm_call = aten.mm.default
         mat1, mat2 = [0, -1], [0, -1]
@@ -272,7 +272,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         add_call = aten.add.Tensor
         mat1, mat2 = [0, -1], [1, -1]
@@ -289,7 +289,7 @@ class CommonRulesTest(TestCase):
             einop_rule("ij,ij->ij", OpSchema(add_call, (mat1_spec, mat2_spec), {}))
 
     def test_pointwise_rules_broadcasting(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         where_call = aten.where.self
         inp1, inp2, inp3 = [0], [], [-1, -1]
@@ -314,7 +314,7 @@ class CommonRulesTest(TestCase):
         self.assertEqual(output_spec.dim_map, [-1, 0])
 
     def test_pointwise_rules_suggestion(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         lerp_call = aten.lerp.Scalar
         # propagate point-wise sharding
@@ -345,7 +345,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         add_call = aten.add.Tensor
 
@@ -390,7 +390,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_fake_device_mesh(mesh_shape)
+        mesh = build_mesh_for_fake_pg(mesh_shape)
 
         add_call = aten.add_.Tensor
 

--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -2,23 +2,39 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
-from torch.distributed.tensor import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor._ops._common_rules import einop_rule, pointwise_rule
-from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorContinuousTestBase,
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
 )
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    build_fake_device_mesh,
+)
+from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 aten = torch.ops.aten
 
 
-class CommonRulesTest(DTensorContinuousTestBase):
+class CommonRulesTest(TestCase):
     # hard code world size to 4 as we need to test
     # at least with 2d mesh
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 4
+
+    def setUp(self):
+        super().setUp()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=FakeStore()
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
 
     def _gen_tensor_meta(self, shape):
         empty_tensor = torch.empty(shape)
@@ -30,7 +46,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
 
     def test_einop_basic_propagation(self):
         # plain einsum, mm
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         mm_call = aten.mm.default
         # propagate col-wise sharding
@@ -82,7 +98,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         self.assertTrue(output_spec.placements[0].is_partial())
 
     def test_einop_pointwise_propagation(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         add_call = aten.add.Tensor
         # addition
@@ -137,7 +153,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -161,7 +177,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -227,7 +243,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
     def test_einop_multi_sharding_on_mesh_dim(self):
         # einop prop with multi sharding on same mesh dim
         mesh_shape = torch.arange(self.world_size)
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         mm_call = aten.mm.default
         mat1, mat2 = [0, -1], [0, -1]
@@ -256,7 +272,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         add_call = aten.add.Tensor
         mat1, mat2 = [0, -1], [1, -1]
@@ -273,7 +289,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
             einop_rule("ij,ij->ij", OpSchema(add_call, (mat1_spec, mat2_spec), {}))
 
     def test_pointwise_rules_broadcasting(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         where_call = aten.where.self
         inp1, inp2, inp3 = [0], [], [-1, -1]
@@ -298,7 +314,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         self.assertEqual(output_spec.dim_map, [-1, 0])
 
     def test_pointwise_rules_suggestion(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         lerp_call = aten.lerp.Scalar
         # propagate point-wise sharding
@@ -329,7 +345,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         add_call = aten.add.Tensor
 
@@ -374,7 +390,7 @@ class CommonRulesTest(DTensorContinuousTestBase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = DeviceMesh(self.device_type, mesh_shape)
+        mesh = build_fake_device_mesh(mesh_shape)
 
         add_call = aten.add_.Tensor
 

--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -2,39 +2,25 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
+from torch.distributed.tensor import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor._ops._common_rules import einop_rule, pointwise_rule
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-    TestCase,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    build_mesh_for_fake_pg,
+    DTensorContinuousTestBase,
 )
-from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 aten = torch.ops.aten
 
 
-class CommonRulesTest(TestCase):
-    # hard code world size to 4 as we need to test
-    # at least with 2d mesh
+class CommonRulesTest(DTensorContinuousTestBase):
     hw_classification = HardwareClassification.GENERIC
 
+    # hard code world size to 4 as we need to test
+    # at least with 2d mesh
     world_size = 4
-
-    def setUp(self):
-        super().setUp()
-        torch.distributed.init_process_group(
-            backend="fake", rank=0, world_size=self.world_size, store=FakeStore()
-        )
-
-    def tearDown(self):
-        super().tearDown()
-        torch.distributed.destroy_process_group()
 
     def _gen_tensor_meta(self, shape):
         empty_tensor = torch.empty(shape)
@@ -46,7 +32,7 @@ class CommonRulesTest(TestCase):
 
     def test_einop_basic_propagation(self):
         # plain einsum, mm
-        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
         mm_call = aten.mm.default
         # propagate col-wise sharding
@@ -98,7 +84,7 @@ class CommonRulesTest(TestCase):
         self.assertTrue(output_spec.placements[0].is_partial())
 
     def test_einop_pointwise_propagation(self):
-        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
         add_call = aten.add.Tensor
         # addition
@@ -153,7 +139,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -177,7 +163,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         mm_call = aten.mm.default
 
@@ -243,7 +229,7 @@ class CommonRulesTest(TestCase):
     def test_einop_multi_sharding_on_mesh_dim(self):
         # einop prop with multi sharding on same mesh dim
         mesh_shape = torch.arange(self.world_size)
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         mm_call = aten.mm.default
         mat1, mat2 = [0, -1], [0, -1]
@@ -272,7 +258,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         add_call = aten.add.Tensor
         mat1, mat2 = [0, -1], [1, -1]
@@ -289,7 +275,7 @@ class CommonRulesTest(TestCase):
             einop_rule("ij,ij->ij", OpSchema(add_call, (mat1_spec, mat2_spec), {}))
 
     def test_pointwise_rules_broadcasting(self):
-        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
         where_call = aten.where.self
         inp1, inp2, inp3 = [0], [], [-1, -1]
@@ -314,7 +300,7 @@ class CommonRulesTest(TestCase):
         self.assertEqual(output_spec.dim_map, [-1, 0])
 
     def test_pointwise_rules_suggestion(self):
-        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
         lerp_call = aten.lerp.Scalar
         # propagate point-wise sharding
@@ -345,7 +331,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         add_call = aten.add.Tensor
 
@@ -390,7 +376,7 @@ class CommonRulesTest(TestCase):
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
-        mesh = build_mesh_for_fake_pg(mesh_shape)
+        mesh = DeviceMesh(self.device_type, mesh_shape)
 
         add_call = aten.add_.Tensor
 

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -34,8 +34,14 @@ from torch.distributed.tensor._ops._math_ops import common_reduction_strategy
 from torch.distributed.tensor._ops.utils import replicate_op_strategy
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
+    build_fake_device_mesh,
     create_local_tensor_test_class,
     DTensorOpTestBase,
     DTensorTestBase,
@@ -56,6 +62,8 @@ def extract_tensor_meta(t) -> TensorMeta:
 
 
 class TestEinsumDims(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_batch_dims(self):
         equation = "abc,abc->abc"
         input_dims, output_dim = EinsumDims.parse_equation(equation)
@@ -115,47 +123,57 @@ class TestEinsumDims(TestCase):
         self.assertEqual(edims.rhs_out_only_dims, ["f"])
 
 
-class TestEinsumStrategies(DTensorOpTestBase):
-    @property
-    def world_size(self) -> int:
-        return 4
+class TestEinsumStrategies(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+    world_size = 4
+
+    def setUp(self):
+        super().setUp()
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
 
     def test_mm_1d_mesh(self):
-        mesh = self.build_device_mesh()
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("mk,kn->mn", mesh)
         self.assertEqual(len(all_strats.strategies), 4)
 
     def test_mm_2d_mesh(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
 
         all_strats = gen_einsum_strategies("mk,kn->mn", mesh)
         self.assertEqual(len(all_strats.strategies), 16)
 
     def test_bmm_1d_mesh(self):
-        mesh = self.build_device_mesh()
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("bmk,bkn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 5)
 
     def test_bmm_diffinndim_2d_mesh(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
         all_strats = gen_einsum_strategies("bmk,kn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 25)
 
     def test_bmm_diffoutndim_2d_mesh(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
         all_strats = gen_einsum_strategies("bmk,k->bm", mesh)
         self.assertEqual(len(all_strats.strategies), 16)
 
     def test_bmm_2d_mesh(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
 
         all_strats = gen_einsum_strategies("bmk,bkn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 25)
 
     def test_pointwise_1d_mesh(self):
-        mesh = self.build_device_mesh()
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         simple_strats = gen_einsum_strategies("abcd,abcd->abcd", mesh)
         self.assertEqual(len(simple_strats.strategies), 5)
@@ -164,19 +182,29 @@ class TestEinsumStrategies(DTensorOpTestBase):
         self.assertEqual(len(broadcast_strats.strategies), 5)
 
     def test_linearity_1d_mesh(self):
-        mesh = self.build_device_mesh()
+        mesh = build_fake_device_mesh(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("abcd,abcd->abcd", mesh, linearity=True)
         self.assertEqual(len(all_strats.strategies), 6)
 
 
-class TestCostModel(DTensorOpTestBase):
-    @property
-    def world_size(self) -> int:
-        return 4
+class TestCostModel(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+    world_size = 4
+
+    def setUp(self):
+        super().setUp()
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
 
     def test_redistribute_cost_mesh_1d(self):
-        mesh_1d = self.build_device_mesh()
+        mesh_1d = DeviceMesh("cpu", torch.arange(self.world_size))
         shard_placement = (Shard(0),)
         replica_placement = (Replicate(),)
         partial_placement = (Partial(),)
@@ -210,7 +238,7 @@ class TestCostModel(DTensorOpTestBase):
 
     def test_redistribute_cost_strided_shard(self):
         """_StridedShard specs get inf cost (shard_order is None bail-out)."""
-        mesh_1d = self.build_device_mesh()
+        mesh_1d = DeviceMesh("cpu", torch.arange(self.world_size))
 
         global_tensor_meta = extract_tensor_meta(torch.randn(10, 10))
 
@@ -227,39 +255,8 @@ class TestCostModel(DTensorOpTestBase):
         # reaching the shard_order check
         self.assertEqual(redistribute_cost(replica_spec, strided_shard_spec), 0.0)
 
-    def test_addmm_partial_redistribute(self):
-        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
-        # bias/mat1/mat2 are the GLOBAL (unsharded) tensors, distributed below;
-        # the final assert checks full_tensor() against the global addmm. Every
-        # rank must therefore draw identical values: distribute_tensor broadcasts
-        # from rank 0, and the Partial() mat1 reconstruction sums mat1/world_size
-        # across ranks, which only recovers the global mat1 if all ranks match.
-        # This class is a MultiThreadedTestCase, so ranks are threads sharing the
-        # process-global default generator; a per-thread local Generator gives
-        # each rank its own state seeded identically, avoiding interleaved draws.
-        gen = torch.Generator().manual_seed(0)
-        bias = torch.randn(8, generator=gen)
-        mat1 = torch.randn(50, 6, generator=gen)
-        mat2 = torch.randn(6, 8, generator=gen)
-
-        dist_bias = distribute_tensor(bias, mesh, [Shard(0)])
-        dist_mat1 = DTensor.from_local(
-            mat1 / self.world_size,
-            mesh,
-            [Partial()],
-            run_check=False,
-        )
-        dist_mat2 = distribute_tensor(mat2, mesh, [Shard(1)])
-
-        dist_out = torch.addmm(dist_bias, dist_mat1, dist_mat2)
-
-        self.assertEqual(dist_out.placements, (Shard(1),))
-        self.assertEqual(dist_out.full_tensor(), torch.addmm(bias, mat1, mat2))
-
     def test_redistribute_cost_mesh_2d(self):
-        mesh_2d = DeviceMesh(
-            self.device_type, torch.arange(self.world_size).reshape(2, 2)
-        )
+        mesh_2d = DeviceMesh("cpu", torch.arange(self.world_size).reshape(2, 2))
         shard_placement = (Shard(0), Shard(0))
         replica_placement = (Replicate(), Replicate())
         partial_placement = (Partial(), Partial())
@@ -289,7 +286,7 @@ class TestCostModel(DTensorOpTestBase):
         self.assertTrue(allreduce_cost > reduce_scatter_cost)
 
     def test_mm_strategies(self):
-        mesh = self.build_device_mesh()
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
         lhs_tensor = torch.randn(6, 8)
         rhs_tensor = torch.randn(8, 12)
         lhs_tensor_meta = extract_tensor_meta(lhs_tensor)
@@ -369,7 +366,7 @@ class TestCostModel(DTensorOpTestBase):
         )
 
     def test_bmm_strategies(self):
-        mesh = self.build_device_mesh()
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size))
         lhs_tensor = torch.randn(8, 6, 8)
         rhs_tensor = torch.randn(8, 8, 12)
         lhs_tensor_meta = extract_tensor_meta(lhs_tensor)
@@ -403,7 +400,7 @@ class TestCostModel(DTensorOpTestBase):
         Converting between different Partial types (e.g., sum -> avg) is not supported,
         so the redistribute cost should be infinite to prevent this strategy from being chosen.
         """
-        mesh_1d = self.build_device_mesh()
+        mesh_1d = DeviceMesh("cpu", torch.arange(self.world_size))
         global_tensor = torch.randn(10, 10)
         global_tensor_meta = extract_tensor_meta(global_tensor)
 
@@ -415,9 +412,7 @@ class TestCostModel(DTensorOpTestBase):
         self.assertEqual(cost, float("inf"))
 
     def test_redistribute_cost_with_order(self):
-        mesh_2d = DeviceMesh(
-            self.device_type, torch.arange(self.world_size).reshape(2, 2)
-        )
+        mesh_2d = DeviceMesh("cpu", torch.arange(self.world_size).reshape(2, 2))
 
         # Source: Shard on dim 0 across all three mesh dimensions
         source_placement = (Shard(0), Shard(0))
@@ -446,7 +441,47 @@ class TestCostModel(DTensorOpTestBase):
         self.assertGreater(cost_mesh_dim0, cost_mesh_dim1)
 
 
+class TestCostModelLatency(DTensorOpTestBase):
+    hw_classification = HardwareClassification.CPU
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_addmm_partial_redistribute(self, device):
+        device_type = torch.device(device).type
+        mesh = DeviceMesh(device_type, torch.arange(self.world_size))
+        # bias/mat1/mat2 are the GLOBAL (unsharded) tensors, distributed below;
+        # the final assert checks full_tensor() against the global addmm. Every
+        # rank must therefore draw identical values: distribute_tensor broadcasts
+        # from rank 0, and the Partial() mat1 reconstruction sums mat1/world_size
+        # across ranks, which only recovers the global mat1 if all ranks match.
+        # This class is a MultiThreadedTestCase, so ranks are threads sharing the
+        # process-global default generator; a per-thread local Generator gives
+        # each rank its own state seeded identically, avoiding interleaved draws.
+        gen = torch.Generator().manual_seed(0)
+        bias = torch.randn(8, generator=gen, device=device_type)
+        mat1 = torch.randn(50, 6, generator=gen, device=device_type)
+        mat2 = torch.randn(6, 8, generator=gen, device=device_type)
+
+        dist_bias = distribute_tensor(bias, mesh, [Shard(0)])
+        dist_mat1 = DTensor.from_local(
+            mat1 / self.world_size,
+            mesh,
+            [Partial()],
+            run_check=False,
+        )
+        dist_mat2 = distribute_tensor(mat2, mesh, [Shard(1)])
+
+        dist_out = torch.addmm(dist_bias, dist_mat1, dist_mat2)
+
+        self.assertEqual(dist_out.placements, (Shard(1),))
+        self.assertEqual(dist_out.full_tensor(), torch.addmm(bias, mat1, mat2))
+
+
 class TestReductionStrategy(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 4
@@ -598,9 +633,12 @@ def detect_exists_identical_opspec(*args, op, mesh, strategy_function) -> bool:
 
 
 class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
     @patch("torch.distributed.tensor._sharding_prop._select_min_cost_strategy")
-    def test_replicate_strategy_placement(self, mock_select_strategy):
+    def test_replicate_strategy_placement(self, mock_select_strategy, device):
+        device_type = torch.device(device).type
         costs_from__select_strategy = []
 
         def mock_select_func(strategy, op_schema=None):
@@ -620,11 +658,11 @@ class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
             return strategy.strategies[op_spec_costs.index(min(op_spec_costs))]
 
         mock_select_strategy.side_effect = mock_select_func
-        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        mesh = init_device_mesh(device_type, (2, self.world_size // 2))
         comm_mode = CommDebugMode()
         test_op = torch.ops.mylib.numpy_sin
-        input_x = torch.randn([8, 16, 32], device=self.device_type)
-        input_y = torch.randn([8, 16, 32], device=self.device_type)
+        input_x = torch.randn([8, 16, 32], device=device_type)
+        input_y = torch.randn([8, 16, 32], device=device_type)
         output = test_op(input_x, input_y)
         input_x_dt = distribute_tensor(input_x, mesh, [Shard(0), Shard(1)])
         input_y_dt = distribute_tensor(input_y, mesh, [Shard(0), Shard(1)])
@@ -663,19 +701,18 @@ class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
                 )
 
     @with_comms
-    def test_tuple_replicate_strategy_placement(self):
-        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+    def test_tuple_replicate_strategy_placement(self, device):
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (2, self.world_size // 2))
         test_op = torch.ops.mylib.numpy_tuple_sin
         with op_strategy_context(
             test_op.default,
             replicate_op_strategy,
             schema_info=RuntimeSchemaInfo(needs_pytree=True),
         ):
-            input_x = torch.randn([8, 16, 8], device=self.device_type)
-            input_y = [
-                torch.randn([8, 16, 8], device=self.device_type) for _ in range(3)
-            ]
-            input_z = torch.randn([8, 16, 8], device=self.device_type)
+            input_x = torch.randn([8, 16, 8], device=device_type)
+            input_y = [torch.randn([8, 16, 8], device=device_type) for _ in range(3)]
+            input_z = torch.randn([8, 16, 8], device=device_type)
             output = test_op(input_x, input_y, input_z)
             input_x_dt = distribute_tensor(input_x, mesh, [Shard(0), Shard(1)])
             input_y_dt = [
@@ -688,9 +725,12 @@ class DistTensorReplicateStrategyRegistrationTest(DTensorTestBase):
 
 
 class TestStrategyHashing(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
-    def test_call_with_different_nontensor_args(self):
-        mesh = self.build_device_mesh()
+    def test_call_with_different_nontensor_args(self, device):
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         global_tensor = torch.tensor(
             [
                 [29.0, 45.0, 3.0, 61.0],
@@ -711,16 +751,19 @@ class TestStrategyHashing(DTensorTestBase):
 
 
 class TestStrategyOperation(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
 
     @with_comms
-    def test_cache_clean(self):
-        mesh = self.build_device_mesh()
+    def test_cache_clean(self, device):
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         test_op = torch.ops.mylib.numpy_sin
-        x = torch.randn(2, device=self.device_type)
-        y = torch.randn(2, device=self.device_type)
+        x = torch.randn(2, device=device_type)
+        y = torch.randn(2, device=device_type)
         x_dt = distribute_tensor(x, mesh, [Shard(0)])
         y_dt = distribute_tensor(y, mesh, [Shard(0)])
         with op_strategy_context(test_op.default, replicate_op_strategy):
@@ -730,6 +773,19 @@ class TestStrategyOperation(DTensorTestBase):
             f"Operator {test_op.default} does not have a sharding strategy registered",
         ):
             self._test_op_on_dtensor(test_op, x_dt, y_dt)
+
+
+instantiate_device_type_tests(
+    TestCostModelLatency,
+    globals(),
+    only_for=["cpu"],
+)
+instantiate_device_type_tests(
+    TestStrategyOperation,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 DistTensorReplicateStrategyRegistrationTestWithLocalTensor = (
@@ -742,8 +798,35 @@ TestStrategyHashingWithLocalTensor = create_local_tensor_test_class(
     TestStrategyHashing,
 )
 
+instantiate_device_type_tests(
+    DistTensorReplicateStrategyRegistrationTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    DistTensorReplicateStrategyRegistrationTestWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestStrategyHashing,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestStrategyHashingWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
 
 class TestOpSchemaMetaProperties(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 8
@@ -1532,6 +1615,8 @@ class TestOpSchemaMetaProperties(TestCase):
 class TestOpSpecMesh(TestCase):
     """Tests for OpSpec.mesh property handling of None specs."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         store = FakeStore()
@@ -1611,9 +1696,9 @@ class TestExpandToFullMeshOpStrategy(TestCase):
     like grad_bias in SDPA backward when attn_bias is not used).
     """
 
-    def setUp(self):
-        from torch.testing._internal.distributed.fake_pg import FakeStore
+    hw_classification = HardwareClassification.GENERIC
 
+    def setUp(self):
         super().setUp()
         self.world_size = 4
         self.fake_store = FakeStore()
@@ -1848,6 +1933,8 @@ def _unsupported_cat_fake(tensors, dim=0):
 
 
 class TestUnsupportedDTensorOp(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 4

--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -41,7 +41,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    build_fake_device_mesh,
+    build_mesh_for_fake_pg,
     create_local_tensor_test_class,
     DTensorOpTestBase,
     DTensorTestBase,
@@ -139,41 +139,41 @@ class TestEinsumStrategies(TestCase):
         torch.distributed.destroy_process_group()
 
     def test_mm_1d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("mk,kn->mn", mesh)
         self.assertEqual(len(all_strats.strategies), 4)
 
     def test_mm_2d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size).reshape(2, 2))
 
         all_strats = gen_einsum_strategies("mk,kn->mn", mesh)
         self.assertEqual(len(all_strats.strategies), 16)
 
     def test_bmm_1d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("bmk,bkn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 5)
 
     def test_bmm_diffinndim_2d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size).reshape(2, 2))
         all_strats = gen_einsum_strategies("bmk,kn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 25)
 
     def test_bmm_diffoutndim_2d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size).reshape(2, 2))
         all_strats = gen_einsum_strategies("bmk,k->bm", mesh)
         self.assertEqual(len(all_strats.strategies), 16)
 
     def test_bmm_2d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size).reshape(2, 2))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size).reshape(2, 2))
 
         all_strats = gen_einsum_strategies("bmk,bkn->bmn", mesh)
         self.assertEqual(len(all_strats.strategies), 25)
 
     def test_pointwise_1d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         simple_strats = gen_einsum_strategies("abcd,abcd->abcd", mesh)
         self.assertEqual(len(simple_strats.strategies), 5)
@@ -182,7 +182,7 @@ class TestEinsumStrategies(TestCase):
         self.assertEqual(len(broadcast_strats.strategies), 5)
 
     def test_linearity_1d_mesh(self):
-        mesh = build_fake_device_mesh(torch.arange(self.world_size))
+        mesh = build_mesh_for_fake_pg(torch.arange(self.world_size))
 
         all_strats = gen_einsum_strategies("abcd,abcd->abcd", mesh, linearity=True)
         self.assertEqual(len(all_strats.strategies), 6)

--- a/test/distributed/tensor/test_optimizers.py
+++ b/test/distributed/tensor/test_optimizers.py
@@ -13,9 +13,11 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -53,7 +55,18 @@ def output_fn(mod, outputs, device_mesh):
     return outputs.redistribute(placements=[Replicate()] * device_mesh.ndim).to_local()
 
 
-class TestDTensorOptimizer(DTensorTestBase):
+class TestDTensorOptimizerGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_optimizer_foreach_supported_types_include_DTensor(self):
+        from torch.optim.optimizer import _foreach_supported_types
+
+        self.assertTrue(DTensor in _foreach_supported_types)
+
+
+class TestDTensorOptimizerAccelerator(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _assert_optimizer(
         self,
         mesh,
@@ -86,11 +99,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 p2 = p2.full_tensor()
                 # Default 'rtol' and 'atol' for attr:`~torch.float32` are ``1.3e-6`` and ``1e-5``
                 self.assertEqual(p1, p2, atol=atol, rtol=rtol)
-
-    def test_optimizer_foreach_supported_types_include_DTensor(self):
-        from torch.optim.optimizer import _foreach_supported_types
-
-        self.assertTrue(DTensor in _foreach_supported_types)
 
     @with_comms
     def test_adam_1d_sharding(self):
@@ -776,11 +784,11 @@ class TestDTensorOptimizer(DTensorTestBase):
         )
 
 
-instantiate_parametrized_tests(TestDTensorOptimizer)
-
+instantiate_parametrized_tests(TestDTensorOptimizerAccelerator)
 TestDTensorOptimizerWithLocalTensor = create_local_tensor_test_class(
-    TestDTensorOptimizer,
+    TestDTensorOptimizerAccelerator,
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -87,7 +87,10 @@ else:
     NUM_DEVICES = 4
 
 
-def build_fake_device_mesh(mesh: torch.Tensor) -> DeviceMesh:
+def build_mesh_for_fake_pg(mesh: torch.Tensor) -> DeviceMesh:
+    if not dist.is_initialized() or dist.get_backend() != "fake":
+        raise RuntimeError("An initialized fake process group is required")
+    # DeviceMesh requires a logical device type, but FakePG performs no device work.
     return DeviceMesh("cpu", mesh)
 
 

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -86,6 +86,11 @@ if TEST_WITH_ROCM:
 else:
     NUM_DEVICES = 4
 
+
+def build_fake_device_mesh(mesh: torch.Tensor) -> DeviceMesh:
+    return DeviceMesh("cpu", mesh)
+
+
 # We use this as a proxy for "multiple GPUs exist"
 if (TEST_CUDA or TEST_XPU or TEST_HPU or TEST_PRIVATEUSE1) and DEVICE_COUNT > 1:
     # when we actually have multiple GPUs, relax the requirement to smaller counts.


### PR DESCRIPTION
## Summary

This PR classifies DTensor strategy tests according to whether they are device-independent, CPU-only, or accelerator-dependent, while preserving the original real-backend lifecycle where the tests require it.

## Changes

- Mark device-independent propagation-rule tests as generic without device-type instantiation.
- Split operator-strategy tests into generic, CPU-only, and accelerator classes and instantiate each class with the corresponding device rules.
- Add generated `device` arguments to accelerator-dependent test methods.
- Add a shared helper for building a CPU mesh only when a fake process group is active.
- Separate the generic optimizer registration check from accelerator-dependent optimizer numerical tests.

## Scope

This PR changes:

- `test/distributed/tensor/test_common_rules.py`
- `test/distributed/tensor/test_op_strategy.py`
- `test/distributed/tensor/test_optimizers.py`
- `torch/testing/_internal/distributed/_tensor/common_dtensor.py`

## Test plan

- `python -m py_compile test/distributed/tensor/test_common_rules.py` - passed.
- `spin quicklint` - passed.
- `spin lint -a` - applicable Python checks passed; clang-tidy could not run without a local build.
- Runtime tests could not start because the lint environment does not contain an installed PyTorch runtime.

Prepared with assistance from an AI coding assistant.
