### PR TITLE
[Testcase Refactoring] Classify debug and parallel tests by hardware

### DIFF
--- a/test/distributed/tensor/debug/test_comm_mode.py
+++ b/test/distributed/tensor/debug/test_comm_mode.py
@@ -7,20 +7,27 @@ import torch.nn as nn
 from torch.distributed.tensor import DeviceMesh, DTensor, Shard
 from torch.distributed.tensor._redistribute import use_min_cost_redistribution_plan
 from torch.distributed.tensor.debug import CommDebugMode
+from torch.testing._internal.common_device_type import (
+    DeviceTypeTestBase,
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import MLPModule
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 c10d_functional = torch.ops.c10d_functional
 c10d_ops = torch.ops.c10d
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 
 
-class TestCommMode(TestCase):
+class TestCommModeGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         super().tearDown()
         dist.destroy_process_group()
@@ -32,15 +39,7 @@ class TestCommMode(TestCase):
         dist.init_process_group(
             backend="fake", rank=1, world_size=self.world_size, store=store
         )
-        self.device_type = device_type
         self.world_pg = dist.distributed_c10d._get_default_group()
-
-    def checksAssert(self, comm_mode, key, expected_value, expected_total_value):
-        comm_counts = comm_mode.get_comm_counts()
-        self.assertEqual(comm_mode.get_total_counts(), expected_total_value)
-        self.assertEqual(comm_counts[key], expected_value)
-
-        return
 
     def test_comm_mode(self):
         world_pg = self.world_pg
@@ -56,11 +55,11 @@ class TestCommMode(TestCase):
                 out = self.model(x)
                 return funcol.all_reduce(out, "sum", world_pg)
 
-        model = WrapperModel(self.device_type)
+        model = WrapperModel("cpu")
 
         comm_mode = CommDebugMode()
         with comm_mode:
-            model(torch.randn(20, 10, device=self.device_type))
+            model(torch.randn(20, 10, device="cpu"))
 
         comm_counts = comm_mode.get_comm_counts()
         self.assertEqual(comm_mode.get_total_counts(), 3)
@@ -82,11 +81,11 @@ class TestCommMode(TestCase):
                 out = self.model(x)
                 return funcol.all_reduce_coalesced([out], "sum", world_pg)
 
-        model = WrapperModelCoalesced(self.device_type)
+        model = WrapperModelCoalesced("cpu")
 
         comm_mode = CommDebugMode()
         with comm_mode:
-            model(torch.randn(20, 10, device=self.device_type))
+            model(torch.randn(20, 10, device="cpu"))
 
         comm_counts = comm_mode.get_comm_counts()
         self.assertEqual(comm_mode.get_total_counts(), 3)
@@ -95,7 +94,7 @@ class TestCommMode(TestCase):
         self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 1)
 
     def test_comm_mode_with_dtensor(self):
-        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        mesh = DeviceMesh("cpu", list(range(self.world_size)))
 
         def f(x, y):
             return torch.mm(x, y)
@@ -115,12 +114,36 @@ class TestCommMode(TestCase):
         self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 1)
         self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 0)
 
+
+class TestCommMode(DeviceTypeTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def tearDown(self):
+        super().tearDown()
+        dist.destroy_process_group()
+
+    def setUp(self):
+        super().setUp()
+        self.world_size = 2
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake", rank=1, world_size=self.world_size, store=store
+        )
+        self.world_pg = dist.distributed_c10d._get_default_group()
+
+    def checksAssert(self, comm_mode, key, expected_value, expected_total_value):
+        comm_counts = comm_mode.get_comm_counts()
+        self.assertEqual(comm_mode.get_total_counts(), expected_total_value)
+        self.assertEqual(comm_counts[key], expected_value)
+
+        return
+
     @requires_accelerator_dist_backend(["nccl", "xccl"])
-    def test_comm_mode_with_c10d(self):
+    def test_comm_mode_with_c10d(self, device):
         if not torch.accelerator.is_available():
             return
 
-        inp = torch.rand(2, 8, 16).to(device_type)
+        inp = torch.rand(2, 8, 16).to(device)
         all_gather_out = inp.new_empty(self.world_size * 2, 8, 16)
 
         comm_mode = CommDebugMode()
@@ -226,6 +249,8 @@ class TestCommMode(TestCase):
 class TestCommModeModuleReuse(TestCase):
     """Tests that do not require a process group."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_comm_mode_repeated_module_forward(self):
         m = torch.nn.Linear(2, 2)
         with CommDebugMode():
@@ -266,6 +291,14 @@ class TestCommModeModuleReuse(TestCase):
         m(torch.ones(1, 2))
         self.assertEqual(len(m.fc1._forward_hooks), 0)
         self.assertEqual(len(m.fc2._forward_hooks), 0)
+
+
+instantiate_device_type_tests(
+    TestCommMode,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/debug/test_comm_mode_features.py
+++ b/test/distributed/tensor/debug/test_comm_mode_features.py
@@ -11,14 +11,18 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests, skipIfHpu, TEST_XPU, xfailIf
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfHpu,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MLPModule,
     MLPStacked,
     ModelArgs,
     NUM_DEVICES,
-    skip_unless_torch_gpu,
     Transformer,
     with_comms,
 )
@@ -28,6 +32,8 @@ c10d_functional = torch.ops.c10d_functional
 
 
 class TestCommModeFeatures(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # checks if parameter / sharding info is the same as ground truth
     def check_same_set_of_keys(self, dict1, dict2):
         """
@@ -76,19 +82,17 @@ class TestCommModeFeatures(DTensorTestBase):
         return module_parameters_dict, module_sharding_dict
 
     @with_comms
-    def test_MLP_distributed_sharding_display(self):
+    def test_MLP_distributed_sharding_display(self, device):
         """
         tests parameters and sharding on a module level
         """
-        device_mesh = DeviceMesh(
-            self.device_type,
-            torch.arange(0, NUM_DEVICES),
-        )
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, torch.arange(0, NUM_DEVICES))
 
         inp_size = [8, 10]
         torch.manual_seed(0)
-        inp = torch.rand(*inp_size, device=self.device_type)
-        model = MLPModule(self.device_type)
+        inp = torch.rand(*inp_size, device=device_type)
+        model = MLPModule(device_type)
 
         parallelize_plan = {
             "net1": ColwiseParallel(),
@@ -113,20 +117,18 @@ class TestCommModeFeatures(DTensorTestBase):
 
     @skipIfHpu
     @with_comms
-    def test_MLPStacked_distributed_sharding_display(self):
+    def test_MLPStacked_distributed_sharding_display(self, device):
         """
         tests model with nested modules and makes sure comm_mode correctly resets parameter and sharding information
         """
 
-        device_mesh = DeviceMesh(
-            self.device_type,
-            torch.arange(0, NUM_DEVICES),
-        )
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, torch.arange(0, NUM_DEVICES))
 
         inp_size = [8, 10]
         torch.manual_seed(0)
-        inp = torch.rand(*inp_size, device=self.device_type)
-        model = MLPModule(self.device_type)
+        inp = torch.rand(*inp_size, device=device_type)
+        model = MLPModule(device_type)
 
         parallelize_plan = {
             "net1": ColwiseParallel(),
@@ -141,7 +143,7 @@ class TestCommModeFeatures(DTensorTestBase):
             output_tp = model(inp)
             output_tp.sum().backward()
 
-        model2 = MLPStacked(self.device_type)
+        model2 = MLPStacked(device_type)
 
         parallelize_plan = {
             "layers.0.net1": ColwiseParallel(),
@@ -168,19 +170,17 @@ class TestCommModeFeatures(DTensorTestBase):
         self.assertEqual(len(comm_mode.get_sharding_info()), 8)
 
     @with_comms
-    def test_MLP_module_tracing(self):
+    def test_MLP_module_tracing(self, device):
         """
         tests module-level tracing for MLP module
         """
 
-        device_mesh = DeviceMesh(
-            self.device_type,
-            torch.arange(0, NUM_DEVICES),
-        )
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, torch.arange(0, NUM_DEVICES))
         inp_size = [8, 10]
         torch.manual_seed(0)
-        inp = torch.rand(*inp_size, device=self.device_type)
-        model = MLPModule(self.device_type)
+        inp = torch.rand(*inp_size, device=device_type)
+        model = MLPModule(device_type)
 
         parallelize_plan = {
             "net1": ColwiseParallel(),
@@ -219,23 +219,22 @@ class TestCommModeFeatures(DTensorTestBase):
             1,
         )
 
-    @skipIfHpu
-    @skip_unless_torch_gpu
-    @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1555
+
+class TestCommModeTransformerCUDA(DTensorTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     @with_comms
-    def test_transformer_module_tracing(self, is_seq_parallel=False):
+    def test_transformer_module_tracing(self, device, is_seq_parallel=False):
         """
         tests module-level tracing for more complicated transformer module and
         ensures that comm_module depth and tracing dictionaries correctly reset
         """
-        device_mesh = DeviceMesh(
-            self.device_type,
-            torch.arange(0, NUM_DEVICES),
-        )
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, torch.arange(0, NUM_DEVICES))
         inp_size = [8, 10]
         torch.manual_seed(0)
-        inp = torch.rand(*inp_size, device=self.device_type)
-        model = MLPModule(self.device_type)
+        inp = torch.rand(*inp_size, device=device_type)
+        model = MLPModule(device_type)
 
         parallelize_plan = {
             "net1": ColwiseParallel(),
@@ -256,12 +255,12 @@ class TestCommModeFeatures(DTensorTestBase):
             model(inp)
 
         model_args = ModelArgs(dropout_p=0.0)
-        model2 = Transformer(model_args).to(device=self.device_type)
+        model2 = Transformer(model_args).to(device=device_type)
         model2 = Transformer.parallelize(model2, device_mesh, is_seq_parallel)
 
         inp_size = [8, 8]
 
-        inp = torch.randint(model_args.vocab_size, inp_size, device=self.device_type)
+        inp = torch.randint(model_args.vocab_size, inp_size, device=device_type)
         inp = distribute_tensor(inp, device_mesh=device_mesh)
 
         comm_mode = CommDebugMode()
@@ -371,6 +370,19 @@ class TestCommModeFeatures(DTensorTestBase):
             ],
             1,
         )
+
+
+instantiate_device_type_tests(
+    TestCommModeFeatures,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestCommModeTransformerCUDA,
+    globals(),
+    only_for=["cuda"],
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/parallel/test_parallelize_api.py
+++ b/test/distributed/tensor/parallel/test_parallelize_api.py
@@ -13,7 +13,7 @@ from torch.distributed.tensor.parallel.style import (
     PrepareModuleOutput,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -33,6 +33,8 @@ class DummyModule(torch.nn.Module):
 
 
 class TensorParallelAPITests(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         gpu_num = torch.accelerator.device_count()

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -32,6 +32,7 @@ from torch.distributed.tensor.parallel.input_reshard import input_reshard
 from torch.testing._internal.common_device_type import skipXPUIf
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -63,6 +64,8 @@ class ExpCommCounts(NamedTuple):
 
 
 class DistTensorParallelExampleTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
         for name, param_m2 in m2.named_parameters():
@@ -866,10 +869,10 @@ class DistTensorParallelExampleTest(DTensorTestBase):
 
 
 instantiate_parametrized_tests(DistTensorParallelExampleTest)
-
 DistTensorParallelExampleTestWithLocalTensor = create_local_tensor_test_class(
     DistTensorParallelExampleTest,
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/parallel/test_tp_random_state.py
+++ b/test/distributed/tensor/parallel/test_tp_random_state.py
@@ -8,7 +8,7 @@ from torch.distributed.tensor import Replicate
 from torch.distributed.tensor.parallel.api import parallelize_module
 from torch.distributed.tensor.parallel.style import ColwiseParallel
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +18,8 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TensorParallelRandomStateTests(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def get_tensor_slice(self, idx, n, large_tensor):
         shape = large_tensor.shape
         if shape[0] % n != 0:
@@ -137,6 +139,7 @@ class TensorParallelRandomStateTests(DTensorTestBase):
 TensorParallelRandomStateTestsWithLocalTensor = create_local_tensor_test_class(
     TensorParallelRandomStateTests
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor.parallel.style import (
     SequenceParallel,
 )
 from torch.distributed.tensor.placement_types import _Partial
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -31,6 +31,8 @@ c10d_functional = torch.ops.c10d_functional
 
 
 class TensorParallelStyleTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return NUM_DEVICES
@@ -464,6 +466,7 @@ class TensorParallelStyleTest(DTensorTestBase):
 TensorParallelStyleTestWithLocalTensor = create_local_tensor_test_class(
     TensorParallelStyleTest,
 )
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

This PR adds hardware classifications to focused DTensor communication-debugging and tensor-parallel test classes, and converts the classes that already follow the device-type test pattern.

## Changes

- Keep fake-process-group communication-mode checks in a generic test class.
- Classify real communication-mode and communication-feature tests as accelerator tests, add generated device arguments, and instantiate them for non-CPU devices.
- Keep the transformer communication-mode test CUDA-specific and instantiate it only for CUDA.
- Add accelerator classification metadata to the affected tensor-parallel API, example, random-state, and style test classes.

## Scope

This PR changes six files under `test/distributed/tensor/debug` and `test/distributed/tensor/parallel`. It does not claim NPU runtime coverage or change backend capabilities.

## Test plan

- `git diff --check`
- TODO: Run `lintrunner -a` for the six changed files.
- TODO: Run the affected debug and tensor-parallel tests on supported accelerator hardware.

Prepared with assistance from an AI coding assistant.
