### PR TITLE
[Metal][ops] Fix softplus/softplus_backward on non-contiguous MPS inputs (#131736)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -329,6 +329,12 @@ TORCH_IMPL_FUNC(softplus_out_mps)
   MPSScalar beta_scalar = getMPSScalar(beta, self.scalar_type());
   MPSScalar threshold_scalar = getMPSScalar(threshold, self.scalar_type());
 
+  bool executeGatherOp = needsGather(self);
+  Tensor result_;
+  if (executeGatherOp) {
+    result_ = at::empty_like(self, MemoryFormat::Contiguous);
+  }
+
   @autoreleasepool {
     std::string key = "softplus_out_mps:" + getTensorsStringKey({self}) + ":" + std::to_string(beta.to<double>()) +
         ":" + std::to_string(threshold.to<double>());
@@ -364,8 +370,9 @@ TORCH_IMPL_FUNC(softplus_out_mps)
       newCachedGraph->thresholdTensor_ = thresholdTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
+    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
+    Placeholder outputPlaceholder =
+        Placeholder(cachedGraph->outputTensor_, executeGatherOp ? result_ : result, nil, false);
 
     // Create dictionary of inputs and outputs
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
@@ -374,6 +381,9 @@ TORCH_IMPL_FUNC(softplus_out_mps)
       cachedGraph->thresholdTensor_ : getMPSGraphTensorFromScalar(stream, threshold_scalar),
     };
     runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+  }
+  if (executeGatherOp) {
+    result.copy_(result_);
   }
 }
 
@@ -399,6 +409,12 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
   };
 
   MPSStream* stream = getCurrentMPSStream();
+
+  bool executeGatherOp = needsGather(grad_output) || needsGather(self);
+  Tensor grad_input_;
+  if (executeGatherOp) {
+    grad_input_ = at::empty_like(self, MemoryFormat::Contiguous);
+  }
 
   @autoreleasepool {
     std::string key = "softplus_backward_out_mps:" + getTensorsStringKey({grad_output, self}) + ":" +
@@ -439,9 +455,10 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
       newCachedGraph->thresholdTensor_ = thresholdTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->outputTensor_, grad_input);
+    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output, nil, executeGatherOp);
+    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, nil, executeGatherOp);
+    Placeholder gradInputPlaceholder =
+        Placeholder(cachedGraph->outputTensor_, executeGatherOp ? grad_input_ : grad_input, nil, false);
 
     // Create dictionary of inputs and outputs
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
@@ -451,6 +468,9 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps)
       cachedGraph->thresholdTensor_ : getMPSGraphTensorFromScalar(stream, threshold_scalar),
     };
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
+  }
+  if (executeGatherOp) {
+    grad_input.copy_(grad_input_);
   }
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10555,6 +10555,30 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
+    # https://github.com/pytorch/pytorch/issues/131736
+    def test_softplus_after_moveaxis_matches_cpu(self):
+        x_cpu = torch.linspace(-1, 1, 6).view(2, 3)
+        x_mps = x_cpu.to("mps")
+        self.assertEqual(torch.nn.functional.softplus(x_mps.moveaxis(0, 1)).cpu(),
+                         torch.nn.functional.softplus(x_cpu).moveaxis(0, 1))
+
+    def test_softplus_backward_after_moveaxis_matches_cpu(self):
+        x_cpu = torch.linspace(-1, 1, 12).view(3, 4).requires_grad_(True)
+        x_mps = x_cpu.detach().to("mps").requires_grad_(True)
+        torch.nn.functional.softplus(x_cpu.moveaxis(0, 1)).sum().backward()
+        torch.nn.functional.softplus(x_mps.moveaxis(0, 1)).sum().backward()
+        self.assertEqual(x_mps.grad.cpu(), x_cpu.grad)
+
+    def test_softplus_channels_last_matches_cpu(self):
+        x_cpu = torch.randn(2, 3, 4, 4).to(memory_format=torch.channels_last).requires_grad_(True)
+        x_mps = x_cpu.detach().to("mps").requires_grad_(True)
+        out_cpu = torch.nn.functional.softplus(x_cpu)
+        out_mps = torch.nn.functional.softplus(x_mps)
+        self.assertEqual(out_mps.cpu(), out_cpu)
+        out_cpu.sum().backward()
+        out_mps.sum().backward()
+        self.assertEqual(x_mps.grad.cpu(), x_cpu.grad)
+
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
Fixes #131736.

softplus on MPS produced wrong values when its input was non-contiguous (e.g. from moveaxis or permute), because the MPSGraph placeholder was created without a gather, so strides were ignored. Gated the fix behind needsGather() (matching the pattern used by every sibling op with this class of MPSGraph native-stride bug) so the extra gather/copy only runs pre-macOS-15, where it's actually needed.

Added coverage for the non-contiguous forward+backward case and for channels_last, which softplus_backward special-cases separately.

Test plan:
```
python test/test_mps.py -v -k softplus
```