### PR TITLE
[Testcase Refactoring] [DTensor] Classify core operator tests by hardware

### DIFF
--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
 from torch.testing._internal.common_distributed import run_subtests
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -45,6 +45,8 @@ def _conv_fn(
 
 
 class DistConvolutionOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 2
@@ -486,6 +488,7 @@ DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
         "test_conv3d_batch_shard",
     ],
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_convolution_ops.py
+++ b/test/distributed/tensor/test_convolution_ops.py
@@ -16,6 +16,7 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import with_tf32_off
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import run_subtests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -53,19 +54,18 @@ class DistConvolutionOpsTest(DTensorTestBase):
         return 2
 
     @with_comms
-    def test_downsampling_convolution(self):
+    def test_downsampling_convolution(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(3)]
 
         input_list = torch.rand(ITER_TIME, 7, 3, 512, 1024)
         grad_output_list = torch.rand(ITER_TIME, 7, 256, 128, 256) * 1e-3
 
-        model = nn.Conv2d(3, 256, kernel_size=4, stride=4, padding=0).to(
-            self.device_type
-        )
+        model = nn.Conv2d(3, 256, kernel_size=4, stride=4, padding=0).to(device_type)
         nn.init.ones_(model.weight)
         nn.init.zeros_(model.bias)
-        model_gt = copy.deepcopy(model).to(self.device_type)
+        model_gt = copy.deepcopy(model).to(device_type)
 
         # training with dtensor
         model = distribute_module(
@@ -74,10 +74,10 @@ class DistConvolutionOpsTest(DTensorTestBase):
         optimizer = torch.optim.SGD(model.parameters(), lr=LR)
         for i in range(ITER_TIME):
             optimizer.zero_grad()
-            inp = input_list[i].to(self.device_type).requires_grad_()
+            inp = input_list[i].to(device_type).requires_grad_()
             inp_dtensor = distribute_tensor(inp, device_mesh, shard_spec)
             output = model(inp_dtensor)
-            grad_output = grad_output_list[i].to(self.device_type)
+            grad_output = grad_output_list[i].to(device_type)
             grad_output_dtensor = distribute_tensor(
                 grad_output, device_mesh, shard_spec
             )
@@ -88,9 +88,9 @@ class DistConvolutionOpsTest(DTensorTestBase):
         optimizer_gt = torch.optim.SGD(model_gt.parameters(), lr=LR)
         for i in range(ITER_TIME):
             optimizer_gt.zero_grad()
-            inp = input_list[i].to(self.device_type).requires_grad_()
+            inp = input_list[i].to(device_type).requires_grad_()
             output = model_gt(inp)
-            grad_output = grad_output_list[i].to(self.device_type)
+            grad_output = grad_output_list[i].to(device_type)
             output.backward(grad_output)
             optimizer_gt.step()
 
@@ -123,7 +123,8 @@ class DistConvolutionOpsTest(DTensorTestBase):
     # Temporarily disable it to unblock CI.
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_depthwise_convolution(self):
+    def test_depthwise_convolution(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(3)]
 
@@ -131,11 +132,11 @@ class DistConvolutionOpsTest(DTensorTestBase):
         grad_output_list = torch.rand(ITER_TIME, 7, 256, 128, 256) * 1e-3
 
         model = nn.Conv2d(256, 256, kernel_size=7, padding=3, groups=256).to(
-            self.device_type
+            device_type
         )
         nn.init.ones_(model.weight)
         nn.init.zeros_(model.bias)
-        model_gt = copy.deepcopy(model).to(self.device_type)
+        model_gt = copy.deepcopy(model).to(device_type)
 
         # training with dtensor
         model = distribute_module(
@@ -144,10 +145,10 @@ class DistConvolutionOpsTest(DTensorTestBase):
         optimizer = torch.optim.SGD(model.parameters(), lr=LR)
         for i in range(ITER_TIME):
             optimizer.zero_grad()
-            inp = input_list[i].to(self.device_type).requires_grad_()
+            inp = input_list[i].to(device_type).requires_grad_()
             inp_dtensor = distribute_tensor(inp, device_mesh, shard_spec)
             output = model(inp_dtensor)
-            grad_output = grad_output_list[i].to(self.device_type)
+            grad_output = grad_output_list[i].to(device_type)
             grad_output_dtensor = distribute_tensor(
                 grad_output, device_mesh, shard_spec
             )
@@ -158,9 +159,9 @@ class DistConvolutionOpsTest(DTensorTestBase):
         optimizer_gt = torch.optim.SGD(model_gt.parameters(), lr=LR)
         for i in range(ITER_TIME):
             optimizer_gt.zero_grad()
-            inp = input_list[i].to(self.device_type).requires_grad_()
+            inp = input_list[i].to(device_type).requires_grad_()
             output = model_gt(inp)
-            grad_output = grad_output_list[i].to(self.device_type)
+            grad_output = grad_output_list[i].to(device_type)
             output.backward(grad_output)
             optimizer_gt.step()
 
@@ -191,7 +192,7 @@ class DistConvolutionOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_conv_backward_none_grad_inp(self):
+    def test_conv_backward_none_grad_inp(self, device):
         device_mesh = self.build_device_mesh()
         conv = nn.Conv2d(64, 64, 3, padding=1).train()
         x = torch.randn(1, 64, 32, 32)
@@ -210,39 +211,44 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertTrue(x_dt.grad is None)
 
     def _run_single_arg_fwd(
-        self, model, arg, placements=None
+        self, model, arg, placements=None, *, device_type
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Given model and arg, runs fwd model local and distbuted given device_mesh"""
         device_mesh = self.build_device_mesh()
-        model_copy = copy.deepcopy(model).to(device=self.device_type)
+        model_copy = copy.deepcopy(model).to(device=device_type)
         dist_model = distribute_module(model, device_mesh, _conv_fn)
         arg_dt = DTensor.from_local(arg, device_mesh, placements)
-        out_dt = dist_model(arg_dt.to(device=self.device_type))
+        out_dt = dist_model(arg_dt.to(device=device_type))
         out = model_copy(arg_dt.full_tensor())
         return (out_dt.full_tensor(), out)
 
     @with_comms
-    def test_conv1d(self):
+    def test_conv1d(self, device):
+        device_type = torch.device(device).type
         model = nn.Conv1d(64, 64, 3, padding=1)
-        x = torch.randn(1, 64, 8, device=self.device_type)
-        out_dt, out = self._run_single_arg_fwd(model, x)
+        x = torch.randn(1, 64, 8, device=device_type)
+        out_dt, out = self._run_single_arg_fwd(model, x, device_type=device_type)
         self.assertEqual(out_dt, out)
 
     @with_comms
-    def test_conv3d(self):
+    def test_conv3d(self, device):
+        device_type = torch.device(device).type
         model = nn.Conv3d(64, 64, 3, padding=1)
-        x = torch.randn(1, 64, 8, 8, 8, device=self.device_type)
-        out_dt, out = self._run_single_arg_fwd(model, x, [Shard(0)])
+        x = torch.randn(1, 64, 8, 8, 8, device=device_type)
+        out_dt, out = self._run_single_arg_fwd(
+            model, x, [Shard(0)], device_type=device_type
+        )
         self.assertEqual(out_dt, out)
 
     @with_tf32_off
     @with_comms
-    def test_conv2d_no_bias_compile(self):
+    def test_conv2d_no_bias_compile(self, device):
         """Test Conv2d with bias=False in compile mode (Issue #167091)
 
         Regression test: Previously this would fail during torch.compile
         tracing with AssertionError when bias_spec was None.
         """
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         def conv_fn(x, w):
@@ -251,8 +257,8 @@ class DistConvolutionOpsTest(DTensorTestBase):
         compiled_fn = torch.compile(conv_fn)
 
         # Create tensors
-        x = torch.randn(1, 4, 5, 5, device=self.device_type)
-        w = torch.randn(8, 4, 3, 3, device=self.device_type)
+        x = torch.randn(1, 4, 5, 5, device=device_type)
+        w = torch.randn(8, 4, 3, 3, device=device_type)
 
         # Distribute tensors
         x_dt = distribute_tensor(x, device_mesh, [Replicate()])
@@ -271,17 +277,18 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertEqual(result_compiled.to_local(), result_eager.to_local())
 
     @with_comms
-    def test_conv2d_no_bias_backward(self):
+    def test_conv2d_no_bias_backward(self, device):
         """Test Conv2d backward pass with bias=False (Issue #167091)
 
         Regression test: Previously backward pass would fail when
         grad_bias_spec was None.
         """
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # Create tensors with requires_grad
-        x = torch.randn(1, 4, 5, 5, device=self.device_type)
-        w = torch.randn(8, 4, 3, 3, device=self.device_type, requires_grad=True)
+        x = torch.randn(1, 4, 5, 5, device=device_type)
+        w = torch.randn(8, 4, 3, 3, device=device_type, requires_grad=True)
 
         # Distribute tensors
         x_dt = distribute_tensor(x, device_mesh, [Replicate()])
@@ -301,15 +308,16 @@ class DistConvolutionOpsTest(DTensorTestBase):
     @with_tf32_off
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_conv2d_batch_shard_strided(self):
+    def test_conv2d_batch_shard_strided(self, device):
         """Batch-dim sharding with stride != 1 should not hit _is_supported."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
-        model = nn.Conv2d(3, 8, kernel_size=7, stride=2, padding=3).to(self.device_type)
-        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = nn.Conv2d(3, 8, kernel_size=7, stride=2, padding=3).to(device_type)
+        model_ref = copy.deepcopy(model).to(device_type)
         model = distribute_module(model, device_mesh, _conv_fn)
 
-        x = torch.randn(4, 3, 16, 16, device=self.device_type, requires_grad=True)
+        x = torch.randn(4, 3, 16, 16, device=device_type, requires_grad=True)
         x_ref = x.detach().clone().requires_grad_(True)
         x_dt = distribute_tensor(x, device_mesh, [Shard(0)])
 
@@ -332,14 +340,16 @@ class DistConvolutionOpsTest(DTensorTestBase):
 
     @with_tf32_off
     @with_comms
-    def test_convolution_last_dim_shard(self):
+    def test_convolution_last_dim_shard(self, device):
+        device_type = torch.device(device).type
         run_subtests(
             self,
             {"conv_dim": [1, 2, 3]},
             self._test_convolution_last_dim_shard,
+            device_type=device_type,
         )
 
-    def _test_convolution_last_dim_shard(self, conv_dim):
+    def _test_convolution_last_dim_shard(self, conv_dim, *, device_type):
         device_mesh = self.build_device_mesh()
         conv_cls = (nn.Conv1d, nn.Conv2d, nn.Conv3d)[conv_dim - 1]
         spatial_shape = (8,) * (conv_dim - 1) + (16,)
@@ -349,13 +359,11 @@ class DistConvolutionOpsTest(DTensorTestBase):
 
         model = conv_cls(
             3, 8, kernel_size=kernel_size, stride=stride, padding=padding
-        ).to(self.device_type)
-        model_ref = copy.deepcopy(model).to(self.device_type)
+        ).to(device_type)
+        model_ref = copy.deepcopy(model).to(device_type)
         model = distribute_module(model, device_mesh, _conv_fn)
 
-        x = torch.randn(
-            4, 3, *spatial_shape, device=self.device_type, requires_grad=True
-        )
+        x = torch.randn(4, 3, *spatial_shape, device=device_type, requires_grad=True)
         placements = (Shard(x.ndim - 1),)
         x_ref = x.detach().clone().requires_grad_(True)
         x_dt = distribute_tensor(x, device_mesh, placements)
@@ -376,24 +384,23 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 
     @with_comms
-    def test_conv2d_module_no_bias(self):
+    def test_conv2d_module_no_bias(self, device):
         """Test nn.Conv2d module with bias=False (Issue #167091)
 
         Regression test: Ensures nn.Conv2d with bias=False works with DTensor.
         """
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # Create model with bias=False
-        model = nn.Conv2d(4, 8, kernel_size=3, padding=1, bias=False).to(
-            self.device_type
-        )
+        model = nn.Conv2d(4, 8, kernel_size=3, padding=1, bias=False).to(device_type)
         nn.init.ones_(model.weight)
 
         # Distribute model
         model_dt = distribute_module(model, device_mesh, _conv_fn)
 
         # Create input
-        x = torch.randn(1, 4, 5, 5, device=self.device_type)
+        x = torch.randn(1, 4, 5, 5, device=device_type)
         x_dt = distribute_tensor(x, device_mesh, [Replicate()])
 
         # Forward pass - this should not crash
@@ -408,14 +415,15 @@ class DistConvolutionOpsTest(DTensorTestBase):
     @with_tf32_off
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_conv1d_batch_shard(self):
+    def test_conv1d_batch_shard(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
-        model = nn.Conv1d(3, 8, kernel_size=3, padding=1).to(self.device_type)
-        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = nn.Conv1d(3, 8, kernel_size=3, padding=1).to(device_type)
+        model_ref = copy.deepcopy(model).to(device_type)
         model = distribute_module(model, device_mesh, _conv_fn)
 
-        x = torch.randn(4, 3, 16, device=self.device_type, requires_grad=True)
+        x = torch.randn(4, 3, 16, device=device_type, requires_grad=True)
         x_ref = x.detach().clone().requires_grad_(True)
         x_dt = distribute_tensor(x, device_mesh, [Shard(0)])
 
@@ -441,14 +449,15 @@ class DistConvolutionOpsTest(DTensorTestBase):
     @with_tf32_off
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def test_conv3d_batch_shard(self):
+    def test_conv3d_batch_shard(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
-        model = nn.Conv3d(3, 8, kernel_size=3, padding=1).to(self.device_type)
-        model_ref = copy.deepcopy(model).to(self.device_type)
+        model = nn.Conv3d(3, 8, kernel_size=3, padding=1).to(device_type)
+        model_ref = copy.deepcopy(model).to(device_type)
         model = distribute_module(model, device_mesh, _conv_fn)
 
-        x = torch.randn(4, 3, 8, 8, 8, device=self.device_type, requires_grad=True)
+        x = torch.randn(4, 3, 8, 8, 8, device=device_type, requires_grad=True)
         x_ref = x.detach().clone().requires_grad_(True)
         x_dt = distribute_tensor(x, device_mesh, [Shard(0)])
 
@@ -472,21 +481,31 @@ class DistConvolutionOpsTest(DTensorTestBase):
         self.assertEqual(x_dt.grad.full_tensor(), x_ref.grad)
 
 
+local_tensor_skips = [
+    # Send / recv ops are not supported
+    "test_conv_backward_none_grad_inp",
+    "test_depthwise_convolution",
+    "test_downsampling_convolution",
+    "test_conv2d_batch_shard_strided",
+    # New tests for Issue #167091 - use send/recv via tp_convolution
+    "test_conv2d_no_bias_compile",
+    "test_conv2d_no_bias_backward",
+    "test_conv2d_module_no_bias",
+    "test_conv1d_batch_shard",
+    "test_conv3d_batch_shard",
+]
 DistConvolutionOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistConvolutionOpsTest,
-    # Send / recv ops are not supported
-    skipped_tests=[
-        "test_conv_backward_none_grad_inp",
-        "test_depthwise_convolution",
-        "test_downsampling_convolution",
-        "test_conv2d_batch_shard_strided",
-        # New tests for Issue #167091 - use send/recv via tp_convolution
-        "test_conv2d_no_bias_compile",
-        "test_conv2d_no_bias_backward",
-        "test_conv2d_module_no_bias",
-        "test_conv1d_batch_shard",
-        "test_conv3d_batch_shard",
-    ],
+    skipped_tests=local_tensor_skips,
+)
+instantiate_device_type_tests(
+    DistConvolutionOpsTest, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    DistConvolutionOpsTestWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_dynamic.py
+++ b/test/distributed/tensor/test_dynamic.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributed.tensor import distribute_tensor, DTensor
 from torch.distributed.tensor.placement_types import Replicate
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -16,11 +17,12 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE
 from torch.testing._internal.triton_utils import requires_gpu
 
 
 class TestDynamic(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @requires_gpu
     @with_comms
     @parametrize("fake_tensor_cache_enabled", [False, True])
@@ -38,7 +40,7 @@ class TestDynamic(DTensorTestBase):
                 torch.rand(
                     [num_embeddings, embedding_dim],
                     dtype=torch.float32,
-                    device=GPU_TYPE,
+                    device=self.device_type,
                     requires_grad=True,
                 ),
                 device_mesh,
@@ -51,7 +53,11 @@ class TestDynamic(DTensorTestBase):
                 return emb
 
             arg0 = torch.randint(
-                low=0, high=100, size=(2, 512), dtype=torch.int64, device=GPU_TYPE
+                low=0,
+                high=100,
+                size=(2, 512),
+                dtype=torch.int64,
+                device=self.device_type,
             )
             arg0 = DTensor.from_local(arg0, device_mesh, placements)
 
@@ -60,7 +66,6 @@ class TestDynamic(DTensorTestBase):
 
 
 instantiate_parametrized_tests(TestDynamic)
-
 TestDynamicWithLocalTensor = create_local_tensor_test_class(
     TestDynamic,
     # LocalTensorMode is a non-infra dispatch mode that causes Dynamo to skip
@@ -70,6 +75,7 @@ TestDynamicWithLocalTensor = create_local_tensor_test_class(
         "test_embedding_fake_tensor_cache_enabled_True",
     ],
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_dynamic.py
+++ b/test/distributed/tensor/test_dynamic.py
@@ -6,9 +6,9 @@ from unittest.mock import patch
 import torch
 from torch.distributed.tensor import distribute_tensor, DTensor
 from torch.distributed.tensor.placement_types import Replicate
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
 )
@@ -26,7 +26,8 @@ class TestDynamic(DTensorTestBase):
     @requires_gpu
     @with_comms
     @parametrize("fake_tensor_cache_enabled", [False, True])
-    def test_embedding(self, fake_tensor_cache_enabled):
+    def test_embedding(self, device, fake_tensor_cache_enabled):
+        device_type = torch.device(device).type
         with patch.object(
             torch._dynamo.config, "fake_tensor_cache_enabled", fake_tensor_cache_enabled
         ):
@@ -40,7 +41,7 @@ class TestDynamic(DTensorTestBase):
                 torch.rand(
                     [num_embeddings, embedding_dim],
                     dtype=torch.float32,
-                    device=self.device_type,
+                    device=device_type,
                     requires_grad=True,
                 ),
                 device_mesh,
@@ -57,7 +58,7 @@ class TestDynamic(DTensorTestBase):
                 high=100,
                 size=(2, 512),
                 dtype=torch.int64,
-                device=self.device_type,
+                device=device_type,
             )
             arg0 = DTensor.from_local(arg0, device_mesh, placements)
 
@@ -65,15 +66,20 @@ class TestDynamic(DTensorTestBase):
             _out = compiled_forward(arg0)
 
 
-instantiate_parametrized_tests(TestDynamic)
 TestDynamicWithLocalTensor = create_local_tensor_test_class(
     TestDynamic,
     # LocalTensorMode is a non-infra dispatch mode that causes Dynamo to skip
     # frames, which is incompatible with fullgraph=True.
-    skipped_tests=[
-        "test_embedding_fake_tensor_cache_enabled_False",
-        "test_embedding_fake_tensor_cache_enabled_True",
-    ],
+    skipped_tests=["test_embedding"],
+)
+instantiate_device_type_tests(
+    TestDynamic, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDynamicWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -11,7 +11,11 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -31,6 +35,8 @@ funcol = torch.ops.c10d_functional
 
 
 class TestEmbeddingOp(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _apply_sharding(self, embedding_mod, shard_dim, device_mesh):
         def shard_embedding_fn(name, module, device_mesh):
             for name, param in module.named_parameters():
@@ -263,6 +269,7 @@ class TestEmbeddingOp(DTensorTestBase):
 TestEmbeddingOpWithLocalTensor = create_local_tensor_test_class(
     TestEmbeddingOp,
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_embedding_ops.py
+++ b/test/distributed/tensor/test_embedding_ops.py
@@ -11,6 +11,7 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -57,6 +58,8 @@ class TestEmbeddingOp(DTensorTestBase):
         input_size,
         num_embeddings,
         embedding_dim,
+        *,
+        device_type,
         **kwargs,
     ):
         # Use same seed.
@@ -64,13 +67,13 @@ class TestEmbeddingOp(DTensorTestBase):
         local_embedding = torch.nn.Embedding(
             num_embeddings,
             embedding_dim,
-            device=self.device_type,
+            device=device_type,
             **kwargs,
         )
         sharded_embedding = torch.nn.Embedding(
             num_embeddings,
             embedding_dim,
-            device=self.device_type,
+            device=device_type,
             **kwargs,
         )
 
@@ -85,11 +88,9 @@ class TestEmbeddingOp(DTensorTestBase):
 
         # Run sharded computation
         torch.manual_seed(10)
-        inp = torch.randint(
-            0, num_embeddings, tuple(input_size), device=self.device_type
-        )
+        inp = torch.randint(0, num_embeddings, tuple(input_size), device=device_type)
         target = torch.empty(
-            *inp.size(), embedding_dim, dtype=torch.float, device=self.device_type
+            *inp.size(), embedding_dim, dtype=torch.float, device=device_type
         ).random_(0, 1)
         dist_inp = distribute_tensor(inp, device_mesh, [Replicate()])
 
@@ -145,41 +146,61 @@ class TestEmbeddingOp(DTensorTestBase):
         self.assertEqual(local_output, sharded_output.full_tensor())
 
     @with_comms
-    def test_sharded_embedding_colwise(self):
+    def test_sharded_embedding_colwise(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
-        self._run_embedding_op_test(mesh, 1, [5, 4], 17, 12)
-        self._run_embedding_op_test(mesh, 1, [6, 7, 6], 21, 11)
-        self._run_embedding_op_test(mesh, 1, [8, 6, 5, 4], 23, 13)
-        self._run_embedding_op_test(mesh, 1, [8, 6, 5, 4, 7], 23, 16)
-        self._run_embedding_op_test(mesh, 1, [4], 15, 14)
-        self._run_embedding_op_test(mesh, 1, [34], 15, 14, padding_idx=10)
-        self._run_embedding_op_test(mesh, 1, [8, 6, 5, 4], 23, 13, padding_idx=12)
+        self._run_embedding_op_test(mesh, 1, [5, 4], 17, 12, device_type=device_type)
+        self._run_embedding_op_test(mesh, 1, [6, 7, 6], 21, 11, device_type=device_type)
+        self._run_embedding_op_test(
+            mesh, 1, [8, 6, 5, 4], 23, 13, device_type=device_type
+        )
+        self._run_embedding_op_test(
+            mesh, 1, [8, 6, 5, 4, 7], 23, 16, device_type=device_type
+        )
+        self._run_embedding_op_test(mesh, 1, [4], 15, 14, device_type=device_type)
+        self._run_embedding_op_test(
+            mesh, 1, [34], 15, 14, padding_idx=10, device_type=device_type
+        )
+        self._run_embedding_op_test(
+            mesh, 1, [8, 6, 5, 4], 23, 13, padding_idx=12, device_type=device_type
+        )
 
     @with_comms
-    def test_sharded_embedding_colwise_max_norm_errors(self):
+    def test_sharded_embedding_colwise_max_norm_errors(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         with self.assertRaisesRegex(
             NotImplementedError,
             "aten.embedding_renorm_.default does not have a sharding strategy registered.",
         ):
             self._run_embedding_op_test(
-                mesh, 1, [8, 6, 5, 4], 23, 13, padding_idx=12, max_norm=2.0
+                mesh,
+                1,
+                [8, 6, 5, 4],
+                23,
+                13,
+                padding_idx=12,
+                max_norm=2.0,
+                device_type=device_type,
             )
 
     @with_comms
-    def test_sharded_embedding_rowwise(self):
+    def test_sharded_embedding_rowwise(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         # test correctness
-        self._run_embedding_op_test(mesh, 0, [5, 12], 16, 22)
-        self._run_embedding_op_test(mesh, 0, [6, 7, 6], 13, 22)
-        self._run_embedding_op_test(mesh, 0, [34], 15, 14, padding_idx=10)
+        self._run_embedding_op_test(mesh, 0, [5, 12], 16, 22, device_type=device_type)
+        self._run_embedding_op_test(mesh, 0, [6, 7, 6], 13, 22, device_type=device_type)
+        self._run_embedding_op_test(
+            mesh, 0, [34], 15, 14, padding_idx=10, device_type=device_type
+        )
 
         from torch.distributed.tensor.placement_types import _MaskPartial
 
         # test collectives
-        embedding_mod = torch.nn.Embedding(10, 20, device=self.device_type)
+        embedding_mod = torch.nn.Embedding(10, 20, device=device_type)
         sharded_embedding = self._apply_sharding(embedding_mod, 0, mesh)
-        inp = torch.randint(0, 10, (8, 8), device=self.device_type)
+        inp = torch.randint(0, 10, (8, 8), device=device_type)
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
         output = sharded_embedding(replicated_inp)
         self.assertIsInstance(output.placements[0], _MaskPartial)
@@ -192,10 +213,11 @@ class TestEmbeddingOp(DTensorTestBase):
             self.assertEqual(comm_mode.get_comm_counts()[funcol.all_reduce], 1)
 
     @with_comms
-    def test_multiple_embeddings_rowwise(self):
+    def test_multiple_embeddings_rowwise(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
 
-        inp = torch.randint(0, 10, (4, 4), device=self.device_type)
+        inp = torch.randint(0, 10, (4, 4), device=device_type)
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
 
         from torch.distributed.tensor.placement_types import _MaskPartial
@@ -203,11 +225,11 @@ class TestEmbeddingOp(DTensorTestBase):
         # case 1: two embeddings with the same shape, thus sharing the underlying _MaskPartial
         # and MaskBuffer, because of cache hit from sharding propagation
 
-        emb1 = torch.nn.Embedding(10, 23, device=self.device_type)
+        emb1 = torch.nn.Embedding(10, 23, device=device_type)
         sharded_emb1 = self._apply_sharding(emb1, 0, mesh)
         output1 = sharded_emb1(replicated_inp)
 
-        emb2 = torch.nn.Embedding(10, 23, device=self.device_type)
+        emb2 = torch.nn.Embedding(10, 23, device=device_type)
         sharded_emb2 = self._apply_sharding(emb2, 0, mesh)
         output2 = sharded_emb2(replicated_inp)
 
@@ -224,7 +246,7 @@ class TestEmbeddingOp(DTensorTestBase):
         # case 2: two embeddings with the same logical_dim_size, but different logical_shape
         # thus they will have different _MaskPartial placements (with no cache hit)
 
-        emb3 = torch.nn.Embedding(10, 29, device=self.device_type)
+        emb3 = torch.nn.Embedding(10, 29, device=device_type)
         sharded_emb3 = self._apply_sharding(emb3, 0, mesh)
         output3 = sharded_emb3(replicated_inp)
         partial_placement3 = output3.placements[0]
@@ -235,21 +257,22 @@ class TestEmbeddingOp(DTensorTestBase):
         self.assertNotEqual(partial_placement1, partial_placement3)
 
     @with_comms
-    def test_embedding_backward_different_num_embeddings(self):
+    def test_embedding_backward_different_num_embeddings(self, device):
         # Regression test: embedding_dense_backward op strategy must include
         # num_weights in its cache key. Without this, multiple embeddings with
         # different num_embeddings share a cached strategy, producing gradients
         # with the wrong shape.
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         torch.manual_seed(0)
 
-        emb_small = torch.nn.Embedding(16, 12, device=self.device_type)
-        emb_large = torch.nn.Embedding(32, 12, device=self.device_type)
+        emb_small = torch.nn.Embedding(16, 12, device=device_type)
+        emb_large = torch.nn.Embedding(32, 12, device=device_type)
         sharded_emb_small = self._apply_sharding(emb_small, 1, mesh)
         sharded_emb_large = self._apply_sharding(emb_large, 1, mesh)
 
-        inp_small = torch.randint(0, 16, (4, 4), device=self.device_type)
-        inp_large = torch.randint(0, 32, (4, 4), device=self.device_type)
+        inp_small = torch.randint(0, 16, (4, 4), device=device_type)
+        inp_large = torch.randint(0, 32, (4, 4), device=device_type)
         dist_inp_small = DTensor.from_local(
             inp_small, mesh, [Replicate()], run_check=False
         )
@@ -268,6 +291,16 @@ class TestEmbeddingOp(DTensorTestBase):
 
 TestEmbeddingOpWithLocalTensor = create_local_tensor_test_class(
     TestEmbeddingOp,
+)
+
+instantiate_device_type_tests(
+    TestEmbeddingOp, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestEmbeddingOpWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_experimental_ops.py
+++ b/test/distributed/tensor/test_experimental_ops.py
@@ -5,7 +5,7 @@
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import distribute_tensor, Replicate
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -18,6 +18,8 @@ LR = 0.001
 
 
 class DistOtherOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 2
@@ -194,6 +196,7 @@ DistOtherOpsTestWithLocalTensor = create_local_tensor_test_class(
     # Send / recv ops are not supported
     skipped_tests=["test_bernoulli"],
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_experimental_ops.py
+++ b/test/distributed/tensor/test_experimental_ops.py
@@ -5,6 +5,7 @@
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import distribute_tensor, Replicate
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -26,7 +27,8 @@ class DistOtherOpsTest(DTensorTestBase):
         return 2
 
     @with_comms
-    def test_slice(self):
+    def test_slice(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Replicate()]
 
@@ -34,8 +36,8 @@ class DistOtherOpsTest(DTensorTestBase):
         grad_output_list = torch.rand(ITER_TIME, 1024, 5) * 1e-3
 
         for i in range(ITER_TIME):
-            inp = input_list[i].to(self.device_type).requires_grad_()
-            grad_output = grad_output_list[i].to(self.device_type)
+            inp = input_list[i].to(device_type).requires_grad_()
+            grad_output = grad_output_list[i].to(device_type)
 
             # droppath  with dtensor
             inp_dtensor = distribute_tensor(inp, device_mesh, shard_spec)
@@ -77,7 +79,8 @@ class DistOtherOpsTest(DTensorTestBase):
             )
 
     @with_comms
-    def test_bernoulli(self):
+    def test_bernoulli(self, device):
+        device_type = torch.device(device).type
         rank = dist.get_rank()
         device_mesh = self.build_device_mesh()
         shard_spec = [Replicate()]
@@ -86,8 +89,8 @@ class DistOtherOpsTest(DTensorTestBase):
         grad_output_list = torch.rand(ITER_TIME, 1024, 10) * 1e-3
 
         for i in range(ITER_TIME):
-            inp = input_list[i].to(self.device_type).requires_grad_()
-            grad_output = grad_output_list[i].to(self.device_type)
+            inp = input_list[i].to(device_type).requires_grad_()
+            grad_output = grad_output_list[i].to(device_type)
 
             # bernoulli  with dtensor
             inp_dtensor = distribute_tensor(inp, device_mesh, shard_spec)
@@ -140,7 +143,8 @@ class DistOtherOpsTest(DTensorTestBase):
             )
 
     @with_comms
-    def test_nll(self):
+    def test_nll(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         shard_spec = [Replicate()]
 
@@ -150,8 +154,8 @@ class DistOtherOpsTest(DTensorTestBase):
         criterion = torch.nn.CrossEntropyLoss()
 
         for i in range(ITER_TIME):
-            pred = pred_list[i].to(self.device_type).requires_grad_()
-            target = target_list[i].to(self.device_type)
+            pred = pred_list[i].to(device_type).requires_grad_()
+            target = target_list[i].to(device_type)
 
             # nll with dtensor
             pred_dtensor = distribute_tensor(pred, device_mesh, shard_spec)
@@ -195,6 +199,15 @@ DistOtherOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistOtherOpsTest,
     # Send / recv ops are not supported
     skipped_tests=["test_bernoulli"],
+)
+instantiate_device_type_tests(
+    DistOtherOpsTest, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    DistOtherOpsTestWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_init.py
+++ b/test/distributed/tensor/test_init.py
@@ -3,6 +3,7 @@
 
 import torch
 from torch.distributed._local_tensor import maybe_run_for_local_tensor
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import (
     DeviceMesh,
     DTensor,
@@ -12,7 +13,8 @@ from torch.distributed.tensor import (
     Shard,
     zeros,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -21,11 +23,13 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class DTensorInitOpsTest(DTensorTestBase):
-    def _run_init_op(self, init_op, *args, **kwargs):
-        device_mesh = self.build_device_mesh()
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _run_init_op(self, init_op, device_type, *args, **kwargs):
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
         shard_spec = [Shard(0)]
         input_size = (8, 4)
-        input_tensor = torch.randn(*input_size, device=self.device_type)
+        input_tensor = torch.randn(*input_size, device=device_type)
         dtensor = DTensor.from_local(input_tensor, device_mesh, shard_spec)
         local_tensor_clone = torch.clone(input_tensor)
         torch.manual_seed(self.rank)
@@ -35,27 +39,31 @@ class DTensorInitOpsTest(DTensorTestBase):
         self.assertEqual(local_tensor_clone, dtensor.to_local())
 
     @with_comms
-    def test_init_ops(self):
+    def test_init_ops(self, device):
         # NOTE: random init tests are moved to test_random_ops.py
-        self._run_init_op(torch.nn.init.constant_, 2.4)
+        device_type = torch.device(device).type
+        self._run_init_op(torch.nn.init.constant_, device_type, 2.4)
 
     @with_comms
-    def test_eye_init(self):
+    def test_eye_init(self, device):
         # Test nn.init.eye_() with DTensor (issue #173357)
-        device_mesh = self.build_device_mesh()
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
         shard_spec = [Replicate()]
         input_size = (8, 8)
 
-        input_tensor = torch.randn(*input_size, device=self.device_type)
+        input_tensor = torch.randn(*input_size, device=device_type)
         dtensor = DTensor.from_local(input_tensor, device_mesh, shard_spec)
 
         torch.nn.init.eye_(dtensor)
 
-        expected = torch.eye(*input_size, device=self.device_type)
+        expected = torch.eye(*input_size, device=device_type)
         self.assertEqual(expected, dtensor.to_local())
 
 
 class DTensorConstructorTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 4
@@ -414,6 +422,15 @@ DTensorConstructorTestWithLocalTensor = create_local_tensor_test_class(
         "test_zeros_submesh",
     ],
 )
+
+
+instantiate_device_type_tests(
+    DTensorInitOpsTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_init.py
+++ b/test/distributed/tensor/test_init.py
@@ -129,7 +129,7 @@ class DTensorConstructorTest(DTensorTestBase):
         eq_op(expected_tensor, local_tensor)
 
     @with_comms
-    def test_ones(self):
+    def test_ones(self, device):
         self._run_init_op(
             torch.ones,
             torch.distributed.tensor.ones,
@@ -138,7 +138,7 @@ class DTensorConstructorTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_empty(self):
+    def test_empty(self, device):
         self._run_init_op(
             torch.empty,
             torch.distributed.tensor.empty,
@@ -149,7 +149,7 @@ class DTensorConstructorTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_full(self):
+    def test_full(self, device):
         self._run_init_op(
             torch.full,
             torch.distributed.tensor.full,
@@ -159,7 +159,8 @@ class DTensorConstructorTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_linspace(self):
+    def test_linspace(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         steps = 8
 
@@ -196,10 +197,10 @@ class DTensorConstructorTest(DTensorTestBase):
             self.assertEqual(dist_tensor.full_tensor(), torch.linspace(2.0, -2.0, 5))
 
             start = DTensor.from_local(
-                torch.tensor(1.0, device=self.device_type), mesh, [Replicate()]
+                torch.tensor(1.0, device=device_type), mesh, [Replicate()]
             )
             end = DTensor.from_local(
-                torch.tensor(2.0, device=self.device_type), mesh, [Replicate()]
+                torch.tensor(2.0, device=device_type), mesh, [Replicate()]
             )
             dist_tensor = linspace(
                 start, end, steps, device_mesh=mesh, placements=placements
@@ -211,7 +212,7 @@ class DTensorConstructorTest(DTensorTestBase):
                 "linspace only supports 0-dimensional start and end tensors",
             ):
                 linspace(
-                    torch.tensor([1.0, 2.0], device=self.device_type),
+                    torch.tensor([1.0, 2.0], device=device_type),
                     2.0,
                     steps,
                     device_mesh=mesh,
@@ -219,7 +220,8 @@ class DTensorConstructorTest(DTensorTestBase):
                 )
 
     @with_comms
-    def test_logspace(self):
+    def test_logspace(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         steps = 8
 
@@ -258,10 +260,10 @@ class DTensorConstructorTest(DTensorTestBase):
             self.assertEqual(dist_tensor.full_tensor(), torch.logspace(2.0, -2.0, 5))
 
             start = DTensor.from_local(
-                torch.tensor(1.0, device=self.device_type), mesh, [Replicate()]
+                torch.tensor(1.0, device=device_type), mesh, [Replicate()]
             )
             end = DTensor.from_local(
-                torch.tensor(2.0, device=self.device_type), mesh, [Replicate()]
+                torch.tensor(2.0, device=device_type), mesh, [Replicate()]
             )
             dist_tensor = logspace(
                 start, end, steps, device_mesh=mesh, placements=placements
@@ -273,7 +275,7 @@ class DTensorConstructorTest(DTensorTestBase):
                 "logspace only supports 0-dimensional start and end tensors",
             ):
                 logspace(
-                    torch.tensor([1.0, 2.0], device=self.device_type),
+                    torch.tensor([1.0, 2.0], device=device_type),
                     2.0,
                     steps,
                     device_mesh=mesh,
@@ -281,7 +283,7 @@ class DTensorConstructorTest(DTensorTestBase):
                 )
 
     @with_comms
-    def test_zeros(self):
+    def test_zeros(self, device):
         self._run_init_op(
             torch.zeros,
             torch.distributed.tensor.zeros,
@@ -290,8 +292,9 @@ class DTensorConstructorTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_zeros_full_mesh(self):
+    def test_zeros_full_mesh(self, device):
         # construct a gpu device 1d mesh
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         placements = [Shard(0)]
         size = [32, 3]
@@ -303,7 +306,7 @@ class DTensorConstructorTest(DTensorTestBase):
         local_tensor = torch.zeros(8, 3)
         self.assertEqual(dist_tensor.to_local(), local_tensor)
 
-        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(dist_tensor.device.type, device_type)
 
         # 1d sharded unevenly
         size = [31, 3]
@@ -323,7 +326,7 @@ class DTensorConstructorTest(DTensorTestBase):
         check_per_rank_tensors(self.rank, local_tensor)
 
         # construct a gpu device mesh with 2d: shard, replicate
-        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
+        mesh = DeviceMesh(device_type, torch.arange(self.world_size).reshape(2, 2))
         placements = [Shard(0), Replicate()]
         size = [32, 4]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -360,11 +363,12 @@ class DTensorConstructorTest(DTensorTestBase):
             self.assertEqual(local_tensor, torch.zeros([15, 1]))
 
     @with_comms
-    def test_zeros_submesh(self):
+    def test_zeros_submesh(self, device):
         # default world_size is 4
         # construct a gpu device 1d mesh, with no sub pg initialized
+        device_type = torch.device(device).type
         sub_mesh_list = [0, 3]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list)
+        mesh = DeviceMesh(device_type, sub_mesh_list)
         placements = [Shard(0)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -380,7 +384,7 @@ class DTensorConstructorTest(DTensorTestBase):
 
         # construct a gpu device 1d mesh: unevenly, with subpg initialized
         sub_mesh_list = [0, 1, 3]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list)
+        mesh = DeviceMesh(device_type, sub_mesh_list)
         placements = [Shard(0)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -400,7 +404,7 @@ class DTensorConstructorTest(DTensorTestBase):
 
         # construct a gpu device 2d mesh, with no subpg initialized
         sub_mesh_list = [[0], [3]]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list)
+        mesh = DeviceMesh(device_type, sub_mesh_list)
         placements = [Shard(0), Shard(1)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -422,10 +426,17 @@ DTensorConstructorTestWithLocalTensor = create_local_tensor_test_class(
         "test_zeros_submesh",
     ],
 )
-
-
 instantiate_device_type_tests(
     DTensorInitOpsTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    DTensorConstructorTest, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    DTensorConstructorTestWithLocalTensor,
     globals(),
     except_for=["cpu"],
     allow_xpu=True,

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -27,7 +27,11 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfRocm,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -41,6 +45,8 @@ funcol = torch.ops.c10d_functional
 
 
 class DistMathOpsTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
         for name, param_m2 in m2.named_parameters():
@@ -2034,6 +2040,7 @@ class DistMathOpsTest(DTensorTestBase):
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,
 )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -26,6 +26,7 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
     SequenceParallel,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -46,6 +47,7 @@ funcol = torch.ops.c10d_functional
 
 class DistMathOpsTest(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
+    norm_types = (torch.nn.LayerNorm,)
 
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
@@ -95,7 +97,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dt_full_reduced, full_reduced_tensor)
 
     @with_comms
-    def test_linear_op_reductions(self):
+    def test_linear_op_reductions(self, device):
         for op_str in (
             "all",
             "sum",
@@ -112,12 +114,13 @@ class DistMathOpsTest(DTensorTestBase):
             self.linear_op_reductions(op_str)
 
     @with_comms
-    def test_nansum_with_nan(self):
+    def test_nansum_with_nan(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         # Tensor with NaN values sharded across the reduction dim
         tensor = torch.tensor(
             [[1.0, float("nan"), 3.0], [float("nan"), 5.0, 6.0]],
-            device=self.device_type,
+            device=device_type,
         )
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
 
@@ -137,9 +140,10 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dt_dim1.placements, (Shard(0),))
 
     @with_comms
-    def test_prims_amax_amin(self):
+    def test_prims_amax_amin(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        tensor = torch.randn(12, 8, 8, device=self.device_type)
+        tensor = torch.randn(12, 8, 8, device=device_type)
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
 
         for op in (torch.ops.prims.amax.default, torch.ops.prims.amin.default):
@@ -161,15 +165,16 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_mean(self):
+    def test_mean(self, device):
         self.linear_op_reductions("mean")
 
     # TODO: forward test can be removed once test_softmax_with_bwd passes on CPU
     @with_comms
-    def test_softmax_fwd(self):
+    def test_softmax_fwd(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
-        x = torch.rand(8, 12, 16, device=self.device_type)
+        x = torch.rand(8, 12, 16, device=device_type)
         dims = range(3)  # used to convert -1 to the actual dim
         softmax_dims = [-1, 0, 1, 2]
         shard_dims = [-1, 0, 1, 2]
@@ -196,7 +201,8 @@ class DistMathOpsTest(DTensorTestBase):
     # fail_on_cpu_list = [(0, -1), (1, -1)]
     @with_comms
     @skip_unless_torch_gpu
-    def test_softmax_with_bwd(self):
+    def test_softmax_with_bwd(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         dims = range(3)  # used to convert -1 to the actual dim
@@ -206,7 +212,7 @@ class DistMathOpsTest(DTensorTestBase):
 
         for params in test_list:
             softmax_dim, shard_dim = params
-            x = torch.rand(8, 12, 16, device=self.device_type, requires_grad=True)
+            x = torch.rand(8, 12, 16, device=device_type, requires_grad=True)
             self.assertTrue(x.requires_grad)
             local_y = torch.nn.functional.softmax(
                 x, dim=softmax_dim, dtype=torch.float32
@@ -239,7 +245,8 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_nll_loss_and_cross_entropy(self):
+    def test_nll_loss_and_cross_entropy(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -249,8 +256,8 @@ class DistMathOpsTest(DTensorTestBase):
             (3, (8, channel_size, 12), (8, 12)),  # calling aten.nll_loss2d_forward
         ]
         for input_ndim, input_size, target_size in test_setup:
-            x = torch.rand(*input_size, device=self.device_type, requires_grad=True)
-            target = torch.randint(channel_size, target_size, device=self.device_type)
+            x = torch.rand(*input_size, device=device_type, requires_grad=True)
+            target = torch.randint(channel_size, target_size, device=device_type)
             dist_target = distribute_tensor(target, device_mesh, [Replicate()])
 
             shard_dims = list(range(input_ndim))
@@ -309,15 +316,16 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_nll_loss_weighted_mean_with_even_target_counts(self):
+    def test_nll_loss_weighted_mean_with_even_target_counts(self, device):
+        device_type = torch.device(device).type
         if self.world_size < 2:
             self.skipTest("requires at least 2 ranks")
 
         device_mesh = self.build_device_mesh()
         samples_per_rank = 2
         batch = self.world_size * samples_per_rank
-        x = torch.zeros(batch, 2, device=self.device_type)
-        target = torch.empty(batch, device=self.device_type, dtype=torch.long)
+        x = torch.zeros(batch, 2, device=device_type)
+        target = torch.empty(batch, device=device_type, dtype=torch.long)
 
         for rank in range(self.world_size):
             start = rank * samples_per_rank
@@ -326,7 +334,7 @@ class DistMathOpsTest(DTensorTestBase):
             target[start : start + samples_per_rank] = cls
             x[start : start + samples_per_rank, cls] = -loss
 
-        weight = torch.tensor([1.0, 10.0], device=self.device_type)
+        weight = torch.tensor([1.0, 10.0], device=device_type)
         dist_x = distribute_tensor(x, device_mesh, [Shard(0)])
         dist_target = distribute_tensor(target, device_mesh, [Replicate()])
         dist_weight = distribute_tensor(weight, device_mesh, [Replicate()])
@@ -347,10 +355,11 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dist_y.to_local(), y)
 
     @with_comms
-    def test_shard_math_ops(self):
+    def test_shard_math_ops(self, device):
+        device_type = torch.device(device).type
         mesh_shape = (2, self.world_size // 2)
         mesh = DeviceMesh(
-            self.device_type,
+            device_type,
             torch.arange(self.world_size).reshape(*mesh_shape),
         )
         global_tensor = torch.ones(4, 4)
@@ -371,25 +380,24 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(fully_shard_full_tensor, expect_rs)
 
     @with_comms
-    def test_layer_norm_fwd(self):
+    def test_layer_norm_fwd(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # NLP example from pytorch docs
         # https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html
         batch, sentence_length, embedding_dim = 20, 5, 10
-        x = torch.rand(batch, sentence_length, embedding_dim, device=self.device_type)
+        x = torch.rand(batch, sentence_length, embedding_dim, device=device_type)
         norm_shape_idx_list = list(range(x.ndim))
         shard_dims = [-1, 0, 1, 2]
         elementwise_affine_list = [False, True]
 
-        # Test RMSNorm as well if CUDA
-        norm_types = [torch.nn.LayerNorm]
-        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
-            norm_types.append(torch.nn.RMSNorm)
-
         test_config_list = list(
             itertools.product(
-                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+                self.norm_types,
+                shard_dims,
+                norm_shape_idx_list,
+                elementwise_affine_list,
             )
         )
 
@@ -399,9 +407,9 @@ class DistMathOpsTest(DTensorTestBase):
             layer_norm = norm_type(
                 normalized_shape,
                 elementwise_affine=elementwise_affine,
-                device=self.device_type,
+                device=device_type,
             )
-            layer_norm_local = copy.deepcopy(layer_norm).to(self.device_type)
+            layer_norm_local = copy.deepcopy(layer_norm).to(device_type)
 
             def _replicate_fn(name, module, device_mesh):
                 for name, param in module.named_parameters():
@@ -440,7 +448,8 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(y_local, y_dist.full_tensor())
 
     @with_comms
-    def test_layer_norm_bwd(self):
+    def test_layer_norm_bwd(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # NLP example from pytorch docs
@@ -450,14 +459,12 @@ class DistMathOpsTest(DTensorTestBase):
         shard_dims = [0, 1, 2]
         elementwise_affine_list = [False, True]
 
-        # Test both LayerNorm and RMSNorm (if CUDA)
-        norm_types = [torch.nn.LayerNorm]
-        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
-            norm_types.append(torch.nn.RMSNorm)
-
         test_config_list = list(
             itertools.product(
-                norm_types, shard_dims, norm_shape_idx_list, elementwise_affine_list
+                self.norm_types,
+                shard_dims,
+                norm_shape_idx_list,
+                elementwise_affine_list,
             )
         )
 
@@ -467,16 +474,16 @@ class DistMathOpsTest(DTensorTestBase):
                 batch,
                 sentence_length,
                 embedding_dim,
-                device=self.device_type,
+                device=device_type,
                 requires_grad=True,
             )
             normalized_shape = x.shape[norm_idx:]
             layer_norm = norm_type(
                 normalized_shape,
                 elementwise_affine=elementwise_affine,
-                device=self.device_type,
+                device=device_type,
             )
-            layer_norm_local = copy.deepcopy(layer_norm).to(self.device_type)
+            layer_norm_local = copy.deepcopy(layer_norm).to(device_type)
 
             def _replicate_fn(name, module, device_mesh):
                 for name, param in module.named_parameters():
@@ -562,14 +569,10 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(x_local.grad, x_dist.grad.full_tensor())
 
     @with_comms
-    def test_layer_norm_bwd_req_grad(self):
+    def test_layer_norm_bwd_req_grad(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         batch, seq_len, embedding_dim, vocab_size = 8, 8, 10, 32
-
-        # Test both LayerNorm and RMSNorm (if CUDA)
-        norm_types = [torch.nn.LayerNorm]
-        if self.device_type == "cuda" and hasattr(torch.nn, "RMSNorm"):
-            norm_types.append(torch.nn.RMSNorm)
 
         # build our subtest configurations and filter out invalid ones
         class SubTest(NamedTuple):
@@ -590,7 +593,7 @@ class DistMathOpsTest(DTensorTestBase):
                 valid_filter,
                 [
                     SubTest(norm_type, *cfg)
-                    for norm_type in norm_types
+                    for norm_type in self.norm_types
                     for cfg in itertools.product(*(((False, True),) * 5))
                 ],
             )
@@ -642,7 +645,7 @@ class DistMathOpsTest(DTensorTestBase):
                 }
 
                 model = LnTpBlock()
-                model_local = copy.deepcopy(model).to(device=self.device_type)
+                model_local = copy.deepcopy(model).to(device=device_type)
                 model_dist = parallelize_module(model, device_mesh, parallel_plan)
                 req_grad_map = {
                     "preln_embeddings": emb_req_grad,
@@ -666,7 +669,7 @@ class DistMathOpsTest(DTensorTestBase):
                                 )
 
                 # forward step for both local and distributed models
-                x = torch.randint(vocab_size, (batch, seq_len), device=self.device_type)
+                x = torch.randint(vocab_size, (batch, seq_len), device=device_type)
                 x_local = x.detach().clone()
                 output_local = model_local(x_local)
 
@@ -734,7 +737,7 @@ class DistMathOpsTest(DTensorTestBase):
             )
 
     @with_comms
-    def test_topk(self):
+    def test_topk(self, device):
         device_mesh = self.build_device_mesh()
         placement_combs = [Shard(0), Shard(1), Shard(2), Replicate()]
 
@@ -757,7 +760,8 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(global_topk.values, out_full_values)
 
     @with_comms
-    def test_topk_backward(self):
+    def test_topk_backward(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         # Test backward for topk with various shard_dim / topk_dim combinations.
         # The fix in value_selecting_reduction_backward ensures that the zeros
@@ -767,7 +771,7 @@ class DistMathOpsTest(DTensorTestBase):
         shard_dims = [0, 1, 2]
         for topk_dim, shard_dim in itertools.product(topk_dims, shard_dims):
             # Reference: plain (non-distributed) backward
-            x = torch.randn(12, 8, 8, device=self.device_type, requires_grad=True)
+            x = torch.randn(12, 8, 8, device=device_type, requires_grad=True)
             ref_topk = x.topk(3, dim=topk_dim)
             ref_topk.values.sum().backward()
 
@@ -793,10 +797,11 @@ class DistMathOpsTest(DTensorTestBase):
             x.grad.zero_()
 
     @with_comms
-    def test_shard0_svd(self):
+    def test_shard0_svd(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         torch.manual_seed(42)
-        replicated_x = torch.randn((8, 8), device=self.device_type)
+        replicated_x = torch.randn((8, 8), device=device_type)
         sharded_x = distribute_tensor(replicated_x, device_mesh, (Shard(0),))
         with CommDebugMode() as comm_mode:
             U, S, V = torch.linalg.svd(sharded_x, full_matrices=False)
@@ -809,7 +814,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(comm_counts[funcol.all_gather_into_tensor], 1)
 
     @with_comms
-    def test_vector_norm(self):
+    def test_vector_norm(self, device):
         device_mesh = self.build_device_mesh()
 
         grad = torch.randn(12, 8)
@@ -825,7 +830,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(sharded_out.full_tensor(), out)
 
     @with_comms
-    def test_vector_norm_partial(self):
+    def test_vector_norm_partial(self, device):
         device_mesh = self.build_device_mesh()
 
         all_ranks = list(range(self.world_size))
@@ -845,7 +850,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(partial_out.full_tensor(), out)
 
     @with_comms
-    def test_foreach_norm(self):
+    def test_foreach_norm(self, device):
         device_mesh = self.build_device_mesh()
 
         grad0 = torch.randn(12, 8)
@@ -864,13 +869,14 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(so.full_tensor(), o)
 
     @with_comms
-    def test_foreach_max_sharded(self):
+    def test_foreach_max_sharded(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         torch.manual_seed(42)
         tensors = [
-            torch.randn(12, 8, device=self.device_type),
-            torch.randn(8, 8, device=self.device_type),
+            torch.randn(12, 8, device=device_type),
+            torch.randn(8, 8, device=device_type),
         ]
         sharded_tensors = [
             distribute_tensor(tensor, device_mesh, [Shard(0)]) for tensor in tensors
@@ -884,7 +890,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(actual_max.full_tensor(), expected_max)
 
     @with_comms
-    def test_foreach_norm_partial(self):
+    def test_foreach_norm_partial(self, device):
         device_mesh = self.build_device_mesh()
 
         all_ranks = list(range(self.world_size))
@@ -914,7 +920,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(po.full_tensor(), o)
 
     @with_comms
-    def test_powsum_sharded(self):
+    def test_powsum_sharded(self, device):
         """Test that linalg__powsum produces Partial(sum) placement for sharded input."""
         device_mesh = self.build_device_mesh()
 
@@ -935,7 +941,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(sharded_out.full_tensor(), expected)
 
     @with_comms
-    def test_vector_norm_special_norms_placement(self):
+    def test_vector_norm_special_norms_placement(self, device):
         """Test that inf/-inf/0/1 norms produce correct Partial placements."""
         device_mesh = self.build_device_mesh()
 
@@ -968,7 +974,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(out_0.placements[0].reduce_op, "sum")
 
     @with_comms
-    def test_foreach_powsum_sharded(self):
+    def test_foreach_powsum_sharded(self, device):
         """Test that _foreach_powsum produces correct values and placements for sharded input."""
         device_mesh = self.build_device_mesh()
 
@@ -997,11 +1003,10 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(sharded_out[1].full_tensor(), expected1)
 
     @with_comms
-    def test_foreach_norm_different_mesh(self):
+    def test_foreach_norm_different_mesh(self, device):
+        device_type = torch.device(device).type
         mesh_shape = (2, self.world_size // 2)
-        mesh_2d = init_device_mesh(
-            self.device_type, mesh_shape, mesh_dim_names=("x", "y")
-        )
+        mesh_2d = init_device_mesh(device_type, mesh_shape, mesh_dim_names=("x", "y"))
 
         mesh_x = mesh_2d["x"]
         mesh_y = mesh_2d["y"]
@@ -1023,20 +1028,22 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(grad1_norm.device_mesh, mesh_y)
 
     @with_comms
-    def test_norm_0_on_psum(self):
+    def test_norm_0_on_psum(self, device):
         # L0 norm on P(sum) should not propagate -> P(sum), should replicate
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        t = torch.tensor([0, 1, 0, 3, 0, 5], device=self.device_type).float()
+        t = torch.tensor([0, 1, 0, 3, 0, 5], device=device_type).float()
         dt = distribute_tensor(t, device_mesh, [Partial()])
         out = torch.ops.aten.linalg_vector_norm(dt, 0)
         self.assertEqual(out.full_tensor().item(), 3.0)
         self.assertEqual(out.placements, (Replicate(),))
 
     @with_comms
-    def test_max_min_dim_sharded(self):
+    def test_max_min_dim_sharded(self, device):
         """max.dim/min.dim on sharded tensors produce correct values and indices."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        t = torch.randn(128, 64, device=self.device_type)
+        t = torch.randn(128, 64, device=device_type)
 
         for op in [torch.max, torch.min]:
             expected_vals, expected_idx = op(t, dim=1)
@@ -1061,11 +1068,10 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_foreach_add_different_mesh(self):
+    def test_foreach_add_different_mesh(self, device):
+        device_type = torch.device(device).type
         mesh_shape = (2, self.world_size // 2)
-        mesh_2d = init_device_mesh(
-            self.device_type, mesh_shape, mesh_dim_names=("x", "y")
-        )
+        mesh_2d = init_device_mesh(device_type, mesh_shape, mesh_dim_names=("x", "y"))
 
         mesh_x = mesh_2d["x"]
         mesh_y = mesh_2d["y"]
@@ -1095,7 +1101,7 @@ class DistMathOpsTest(DTensorTestBase):
             )
 
     @with_comms
-    def test_foreach_compose(self):
+    def test_foreach_compose(self, device):
         """Test composing multiple foreach operations."""
         device_mesh = self.build_device_mesh()
         local_shards = tuple(torch.randn(4, 8) for _ in range(3))
@@ -1112,7 +1118,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(max_val.full_tensor(), expected)
 
     @with_comms
-    def test_linalg_eigh(self):
+    def test_linalg_eigh(self, device):
         A = torch.randn(2, 2, dtype=torch.float64)
         mesh = self.build_device_mesh()
         dtensor_A = distribute_tensor(A, device_mesh=mesh, placements=[Replicate()])
@@ -1130,7 +1136,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(distance.item(), 0.0)
 
     @with_comms
-    def test_upsampling(self):
+    def test_upsampling(self, device):
         input = torch.arange(1, 5, dtype=torch.float32).view(1, 1, 2, 2)
         mesh = self.build_device_mesh()
         input_dtensor = distribute_tensor(
@@ -1148,10 +1154,11 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(result, dtensor_result.full_tensor())
 
     @with_comms
-    def test_cumsum(self):
+    def test_cumsum(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.rand(3, 5, device=device_type)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1176,10 +1183,11 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(output_dtensor.full_tensor(), output)
 
     @with_comms
-    def test_scan_ops(self):
+    def test_scan_ops(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.rand(3, 5, device=device_type)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1198,7 +1206,8 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(output_dtensor.full_tensor(), output)
 
     @with_comms
-    def test_scan_ops_backward(self):
+    def test_scan_ops_backward(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         for op, placements in itertools.product(
@@ -1214,7 +1223,7 @@ class DistMathOpsTest(DTensorTestBase):
                         dim=dim,
                         has_zero=has_zero,
                     ):
-                        x = torch.rand(12, 8, device=self.device_type).add_(0.1)
+                        x = torch.rand(12, 8, device=device_type).add_(0.1)
                         if has_zero:
                             x.select(dim, x.size(dim) // 2).zero_()
                         x.requires_grad_()
@@ -1233,10 +1242,11 @@ class DistMathOpsTest(DTensorTestBase):
                         self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
-    def test_cumprod_backward_higher_order(self):
+    def test_cumprod_backward_higher_order(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         dim = 0
-        x = torch.rand(4, 3, device=self.device_type).add_(0.1)
+        x = torch.rand(4, 3, device=device_type).add_(0.1)
         x.select(dim, x.size(dim) // 2).zero_()
         x.requires_grad_()
 
@@ -1258,10 +1268,11 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
-    def test_masked_cumprod_backward(self):
+    def test_masked_cumprod_backward(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        row_idx = torch.arange(12, device=self.device_type).unsqueeze(1)
-        col_idx = torch.arange(8, device=self.device_type).unsqueeze(0)
+        row_idx = torch.arange(12, device=device_type).unsqueeze(1)
+        col_idx = torch.arange(8, device=device_type).unsqueeze(0)
         mask = (row_idx + col_idx) % 2 == 0
 
         for placements, dim in itertools.product(
@@ -1269,7 +1280,7 @@ class DistMathOpsTest(DTensorTestBase):
             [0, 1],
         ):
             with self.subTest(placements=placements, dim=dim):
-                x = torch.rand(12, 8, device=self.device_type).add_(0.1)
+                x = torch.rand(12, 8, device=device_type).add_(0.1)
                 x.requires_grad_()
                 ref_out = torch.masked.cumprod(x, mask=mask, dim=dim)
                 ref_out.sum().backward()
@@ -1287,10 +1298,11 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
-    def test_scan_ops_with_indices(self):
+    def test_scan_ops_with_indices(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.rand(12, 8, device=self.device_type)
+        inp = torch.rand(12, 8, device=device_type)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1309,7 +1321,8 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(dt_values.full_tensor(), values)
 
     @with_comms
-    def test_scan_ops_with_indices_backward(self):
+    def test_scan_ops_with_indices_backward(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         for op, placements in itertools.product(
@@ -1318,7 +1331,7 @@ class DistMathOpsTest(DTensorTestBase):
         ):
             for dim in [0, 1]:
                 with self.subTest(op=op.__name__, placements=placements, dim=dim):
-                    x = torch.randn(12, 8, device=self.device_type, requires_grad=True)
+                    x = torch.randn(12, 8, device=device_type, requires_grad=True)
                     ref_values, ref_indices = op(x, dim=dim)
                     ref_values.sum().backward()
 
@@ -1335,9 +1348,10 @@ class DistMathOpsTest(DTensorTestBase):
                     self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
-    def test_median(self):
+    def test_median(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        tensor = torch.randn(12, 8, device=self.device_type)
+        tensor = torch.randn(12, 8, device=device_type)
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
 
         # Global median
@@ -1349,9 +1363,10 @@ class DistMathOpsTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_dim_reductions_with_indices(self):
+    def test_dim_reductions_with_indices(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        tensor = torch.randn(12, 8, device=self.device_type)
+        tensor = torch.randn(12, 8, device=device_type)
         shard_dim = 0
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(shard_dim)])
 
@@ -1389,12 +1404,13 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertTrue(dt_vals.placements[0].is_shard(shard_dim))
 
     @with_comms
-    def test_conj_complex_dtensor(self):
+    def test_conj_complex_dtensor(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
         freqs_cis = torch.randn(
-            1, 1, dtype=torch.complex64, requires_grad=False, device=self.device_type
+            1, 1, dtype=torch.complex64, requires_grad=False, device=device_type
         )
         freqs_cis_dt = distribute_tensor(
             freqs_cis, device_mesh=mesh, placements=[Replicate()]
@@ -1408,7 +1424,8 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(local_result, dtensor_result.full_tensor())
 
     @with_comms
-    def test_rotary_embedding_complex_ops(self):
+    def test_rotary_embedding_complex_ops(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -1417,9 +1434,9 @@ class DistMathOpsTest(DTensorTestBase):
             xq_out = torch.view_as_real(xq_ * freqs_cis)
             return xq_out
 
-        xq = torch.randn(1, 1, 2, requires_grad=True, device=self.device_type)
+        xq = torch.randn(1, 1, 2, requires_grad=True, device=device_type)
         freqs_cis = torch.randn(
-            1, 1, dtype=torch.complex64, requires_grad=False, device=self.device_type
+            1, 1, dtype=torch.complex64, requires_grad=False, device=device_type
         )
 
         xq_dt = distribute_tensor(xq, device_mesh=mesh, placements=[Replicate()])
@@ -1441,7 +1458,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dtensor_grad, xq.grad)
 
     @with_comms
-    def test_histc(self):
+    def test_histc(self, device):
         # TODO - nicer to use parametrize here so its easy to run one sub-test by name,
         # but its too slow (10sec per process-group init) -> switch to MultiProcessContinuousTest
         device_mesh = self.build_device_mesh()
@@ -1477,10 +1494,11 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(global_bins, out_full)
 
     @with_comms
-    def test_logsumexp(self):
+    def test_logsumexp(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.rand(3, 5, device=device_type)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1505,12 +1523,13 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(output_dtensor.full_tensor(), output)
 
     @with_comms
-    def test_partial_reduction_ops(self):
+    def test_partial_reduction_ops(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         rank = dist.get_rank()
 
         torch.manual_seed(rank)
-        local_tensor = torch.rand(3, dtype=torch.float32, device=self.device_type)
+        local_tensor = torch.rand(3, dtype=torch.float32, device=device_type)
         dt = DTensor.from_local(
             local_tensor, device_mesh=mesh, placements=[Partial("sum")]
         )
@@ -1523,7 +1542,7 @@ class DistMathOpsTest(DTensorTestBase):
             out_without_redistribute.full_tensor(), out_with_redistribute.full_tensor()
         )
 
-        local_tensor = torch.rand(3, dtype=torch.float32, device=self.device_type)
+        local_tensor = torch.rand(3, dtype=torch.float32, device=device_type)
         dt = DTensor.from_local(
             local_tensor, device_mesh=mesh, placements=[Partial("sum")]
         )
@@ -1536,7 +1555,7 @@ class DistMathOpsTest(DTensorTestBase):
             out_without_redistribute.full_tensor(), out_with_redistribute.full_tensor()
         )
 
-        local_tensor = torch.rand(3, dtype=torch.float32, device=self.device_type)
+        local_tensor = torch.rand(3, dtype=torch.float32, device=device_type)
         dt = DTensor.from_local(
             local_tensor, device_mesh=mesh, placements=[Partial("sum")]
         )
@@ -1550,12 +1569,13 @@ class DistMathOpsTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_matching_partial_reduction_ops(self):
+    def test_matching_partial_reduction_ops(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
         rank = dist.get_rank()
 
         torch.manual_seed(rank)
-        local_tensor = torch.rand(3, dtype=torch.float32, device=self.device_type)
+        local_tensor = torch.rand(3, dtype=torch.float32, device=device_type)
         dt = DTensor.from_local(
             local_tensor, device_mesh=mesh, placements=[Partial("max")]
         )
@@ -1572,8 +1592,9 @@ class DistMathOpsTest(DTensorTestBase):
 
     @skip_if_lt_x_gpu(4)
     @with_comms
-    def test_std(self):
-        mesh = DeviceMesh(self.device_type, torch.arange(4).reshape(2, 2))
+    def test_std(self, device):
+        device_type = torch.device(device).type
+        mesh = DeviceMesh(device_type, torch.arange(4).reshape(2, 2))
         rank = self.rank
         comm_mode = CommDebugMode()
 
@@ -1596,7 +1617,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(res.full_tensor(), expected_answer)
 
     @with_comms
-    def test_prims_pointwise_ops(self):
+    def test_prims_pointwise_ops(self, device):
         device_mesh = self.build_device_mesh()
         x = torch.randn(12, 8)
         y = torch.randn(12, 8)
@@ -1635,7 +1656,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertEqual(dtensor_result.full_tensor(), local_result)
 
     @with_comms
-    def test_prims_fma(self):
+    def test_prims_fma(self, device):
         from torch._inductor import inductor_prims
 
         device_mesh = self.build_device_mesh()
@@ -1668,7 +1689,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(dtensor_result.placements[0].is_replicate())
 
     @with_comms
-    def test_prims_view_of(self):
+    def test_prims_view_of(self, device):
         device_mesh = self.build_device_mesh()
         x = torch.randn(12, 8)
         dtensor = distribute_tensor(x, device_mesh, [Shard(0)])
@@ -1678,11 +1699,12 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(result.full_tensor(), x)
 
     @with_comms
-    def test_pooling_ops(self):
+    def test_pooling_ops(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # Single-output pooling
-        inp_4d = torch.randn(8, 3, 16, 16, device=self.device_type)
+        inp_4d = torch.randn(8, 3, 16, 16, device=device_type)
         dt_4d = distribute_tensor(inp_4d, device_mesh, [Shard(0)])
 
         for op, args in [
@@ -1708,7 +1730,7 @@ class DistMathOpsTest(DTensorTestBase):
             self.assertTrue(dt_val.placements[0].is_shard(0))
 
         # 3D pooling
-        inp_5d = torch.randn(8, 3, 8, 8, 8, device=self.device_type)
+        inp_5d = torch.randn(8, 3, 8, 8, 8, device=device_type)
         dt_5d = distribute_tensor(inp_5d, device_mesh, [Shard(0)])
 
         expected = torch.nn.functional.avg_pool3d(inp_5d, 3)
@@ -1718,7 +1740,7 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_nll_loss_backward_comm_counts(self):
+    def test_nll_loss_backward_comm_counts(self, device):
         """Test backward comm counts for nll_loss/cross_entropy with Shard(0) inputs.
 
         When inputs are Shard(0), nll_loss_forward produces total_weight as
@@ -1728,6 +1750,7 @@ class DistMathOpsTest(DTensorTestBase):
         the backward kernel). This test verifies that the unnecessary all-reduce
         is avoided for 'sum' and 'none' reductions.
         """
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -1739,8 +1762,8 @@ class DistMathOpsTest(DTensorTestBase):
         expected_backward_allreduce = {"sum": 0, "none": 0, "mean": 0}
 
         for reduction, expected_allreduce_count in expected_backward_allreduce.items():
-            x = torch.rand(8, channel_size, device=self.device_type, requires_grad=True)
-            target = torch.randint(channel_size, (8,), device=self.device_type)
+            x = torch.rand(8, channel_size, device=device_type, requires_grad=True)
+            target = torch.randint(channel_size, (8,), device=device_type)
 
             dist_x = distribute_tensor(x, device_mesh, [Shard(0)])
             dist_target = distribute_tensor(target, device_mesh, [Shard(0)])
@@ -1776,12 +1799,13 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_linalg_ops(self):
-        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+    def test_linalg_ops(self, device):
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, list(range(self.world_size)))
 
         # Batched positive-definite matrix for ops that require it (cholesky, inv)
-        A = torch.randn(8, 4, 4, device=self.device_type)
-        spd = A @ A.mT + 4 * torch.eye(4, device=self.device_type)
+        A = torch.randn(8, 4, 4, device=device_type)
+        spd = A @ A.mT + 4 * torch.eye(4, device=device_type)
         dt_spd = distribute_tensor(spd, device_mesh, [Shard(0)])
 
         # cholesky
@@ -1797,7 +1821,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(result.placements[0].is_shard(0))
 
         # lu_factor
-        B = torch.randn(8, 4, 4, device=self.device_type)
+        B = torch.randn(8, 4, 4, device=device_type)
         dt_B = distribute_tensor(B, device_mesh, [Shard(0)])
         exp_LU, exp_piv = torch.linalg.lu_factor(B)
         res_LU, res_piv = torch.linalg.lu_factor(dt_B)
@@ -1811,7 +1835,7 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(result_vals.placements[0].is_shard(0))
 
         # solve
-        rhs = torch.randn(8, 4, 2, device=self.device_type)
+        rhs = torch.randn(8, 4, 2, device=device_type)
         dt_rhs = distribute_tensor(rhs, device_mesh, [Shard(0)])
         expected = torch.linalg.solve(spd, rhs)
         result = torch.linalg.solve(dt_spd, dt_rhs)
@@ -1820,10 +1844,11 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_linalg_cross(self):
-        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        a = torch.randn(8, 4, 3, device=self.device_type)
-        b = torch.randn(8, 4, 3, device=self.device_type)
+    def test_linalg_cross(self, device):
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, list(range(self.world_size)))
+        a = torch.randn(8, 4, 3, device=device_type)
+        b = torch.randn(8, 4, 3, device=device_type)
 
         # Shard on batch dim (dim=0), cross on default dim=-1
         dt_a = distribute_tensor(a, device_mesh, [Shard(0)])
@@ -1842,11 +1867,12 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_linalg_solve_partial(self):
-        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        A = torch.randn(4, 4, device=self.device_type, dtype=torch.float64)
-        A = A @ A.mT + 4 * torch.eye(4, device=self.device_type, dtype=torch.float64)
-        B = torch.randn(4, 2, device=self.device_type, dtype=torch.float64)
+    def test_linalg_solve_partial(self, device):
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, list(range(self.world_size)))
+        A = torch.randn(4, 4, device=device_type, dtype=torch.float64)
+        A = A @ A.mT + 4 * torch.eye(4, device=device_type, dtype=torch.float64)
+        B = torch.randn(4, 2, device=device_type, dtype=torch.float64)
 
         dt_A = distribute_tensor(A, device_mesh, [Replicate()])
         dt_B = distribute_tensor(B, device_mesh, [Partial()])
@@ -1855,13 +1881,14 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(result.full_tensor(), expected)
 
     @with_comms
-    def test_interpolation_upsample_ops(self):
+    def test_interpolation_upsample_ops(self, device):
         """Test forward and backward for F.interpolate with DTensor.
 
         Verifies output and gradient correctness for all interpolation modes
         across batch-shard, channel-shard, and replicate placements. Also
         checks that no communication occurs during forward or backward.
         """
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         F = torch.nn.functional
         comm_mode = CommDebugMode()
@@ -1886,7 +1913,7 @@ class DistMathOpsTest(DTensorTestBase):
         ]
 
         # lanczos is CPU-only; this branch is exercised when running without GPUs
-        if self.device_type == "cpu":
+        if device_type == "cpu":
             test_configs.append(
                 ((8, 4, 8, 8), dict(size=(16, 16), mode="lanczos", antialias=True)),
             )
@@ -1897,9 +1924,7 @@ class DistMathOpsTest(DTensorTestBase):
             for placements in placements_to_test:
                 with self.subTest(shape=shape, placements=placements, **kwargs):
                     # Reference: plain tensor forward + backward
-                    inp_ref = torch.randn(
-                        shape, device=self.device_type, requires_grad=True
-                    )
+                    inp_ref = torch.randn(shape, device=device_type, requires_grad=True)
                     out_ref = F.interpolate(inp_ref, **kwargs)
                     out_ref.sum().backward()
 
@@ -1921,7 +1946,7 @@ class DistMathOpsTest(DTensorTestBase):
                     self.assertEqual(dt_inp.grad.full_tensor(), inp_ref.grad)
 
         # Forward-only tests for pooling ops (backward uses different ops)
-        inp = torch.randn(8, 3, 16, 16, device=self.device_type)
+        inp = torch.randn(8, 3, 16, 16, device=device_type)
         dt_inp = distribute_tensor(inp, device_mesh, [Shard(0)])
 
         # F.interpolate with area mode
@@ -1938,16 +1963,17 @@ class DistMathOpsTest(DTensorTestBase):
 
     @skipIfRocm
     @with_comms
-    def test_normalization_ops(self):
+    def test_normalization_ops(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         F = torch.nn.functional
 
         N, C, H, W = 8, 6, 4, 4
-        inp = torch.randn(N, C, H, W, device=self.device_type)
-        weight = torch.randn(C, device=self.device_type)
-        bias = torch.randn(C, device=self.device_type)
-        running_mean = torch.zeros(C, device=self.device_type)
-        running_var = torch.ones(C, device=self.device_type)
+        inp = torch.randn(N, C, H, W, device=device_type)
+        weight = torch.randn(C, device=device_type)
+        bias = torch.randn(C, device=device_type)
+        running_mean = torch.zeros(C, device=device_type)
+        running_var = torch.ones(C, device=device_type)
 
         replicate = [Replicate()]
         dt_inp = distribute_tensor(inp, device_mesh, [Shard(0)])
@@ -1967,9 +1993,9 @@ class DistMathOpsTest(DTensorTestBase):
         # batch_norm with channel-dim sharding — forward + backward
         # Use C divisible by world_size for even channel sharding across ranks
         C_s = self.world_size * 2
-        inp_s = torch.randn(N, C_s, H, W, device=self.device_type)
-        weight_s = torch.randn(C_s, device=self.device_type)
-        bias_s = torch.randn(C_s, device=self.device_type)
+        inp_s = torch.randn(N, C_s, H, W, device=device_type)
+        weight_s = torch.randn(C_s, device=device_type)
+        bias_s = torch.randn(C_s, device=device_type)
 
         ref_inp = inp_s.clone().detach().requires_grad_(True)
         ref_w = weight_s.clone().detach().requires_grad_(True)
@@ -1984,16 +2010,16 @@ class DistMathOpsTest(DTensorTestBase):
             bias_s.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
         )
         dt_rmean = distribute_tensor(
-            torch.zeros(C_s, device=self.device_type), device_mesh, [Shard(0)]
+            torch.zeros(C_s, device=device_type), device_mesh, [Shard(0)]
         )
         dt_rvar = distribute_tensor(
-            torch.ones(C_s, device=self.device_type), device_mesh, [Shard(0)]
+            torch.ones(C_s, device=device_type), device_mesh, [Shard(0)]
         )
 
         expected_out = F.batch_norm(
             ref_inp,
-            torch.zeros(C_s, device=self.device_type),
-            torch.ones(C_s, device=self.device_type),
+            torch.zeros(C_s, device=device_type),
+            torch.ones(C_s, device=device_type),
             ref_w,
             ref_b,
             training=True,
@@ -2037,8 +2063,35 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(result_no_affine.placements[0].is_shard(0))
 
 
+class DistMathOpsCUDATest(DTensorTestBase):
+    hw_classification = HardwareClassification.CUDA
+    norm_types = (torch.nn.RMSNorm,)
+
+    _check_module = DistMathOpsTest._check_module
+    test_rms_norm_fwd = DistMathOpsTest.test_layer_norm_fwd
+    test_rms_norm_bwd = DistMathOpsTest.test_layer_norm_bwd
+    test_rms_norm_bwd_req_grad = DistMathOpsTest.test_layer_norm_bwd_req_grad
+
+
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,
+)
+DistMathOpsCUDATestWithLocalTensor = create_local_tensor_test_class(
+    DistMathOpsCUDATest,
+)
+
+instantiate_device_type_tests(
+    DistMathOpsTest, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    DistMathOpsTestWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(DistMathOpsCUDATest, globals(), only_for=["cuda"])
+instantiate_device_type_tests(
+    DistMathOpsCUDATestWithLocalTensor, globals(), only_for=["cuda"]
 )
 
 

--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -22,6 +22,7 @@ from torch.distributed.tensor._ops._math_ops import _NormPartial
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -83,6 +84,8 @@ def deepcopy_convert_from_dtensor(val: Any) -> Any:
 
 
 class DistElementwiseOpsTest(DTensorOpTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _compare_pairwise_ops(
         self,
         *,
@@ -1337,11 +1340,10 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             self.assertEqual(op(dx, dn).to_local(), op(x, n))
 
 
-instantiate_parametrized_tests(DistElementwiseOpsTest)
-
-
 class TestPointwiseRuleValidation(TestCase):
     """Validate registered partial-placement rules via OpInfo samples."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     world_size = 2
 
@@ -1432,6 +1434,7 @@ class TestPointwiseRuleValidation(TestCase):
                 self._with_even_sizes(run)
 
 
+instantiate_parametrized_tests(DistElementwiseOpsTest)
 DistElementwiseOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistElementwiseOpsTest, base_class=LocalDTensorOpTestBase
 )

--- a/test/distributed/tensor/test_pointwise_ops.py
+++ b/test/distributed/tensor/test_pointwise_ops.py
@@ -21,9 +21,9 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor._ops._math_ops import _NormPartial
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
     TestCase,
@@ -131,6 +131,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
     def _run_sharded_elementwise_ops(
         self,
         *,
+        device_type,
         device_mesh: DeviceMesh,
         placements: Sequence[Placement],
         pre_op_fn: Callable | None = None,
@@ -143,7 +144,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         input_tensor = torch.randn(
             *input_size,
-            device=self.device_type,
+            device=device_type,
             requires_grad=True,
         )
 
@@ -158,7 +159,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
     @with_comms
     @skip("This test will sometimes hang and a timeout error will be thrown")
-    def test_partial_add(self):
+    def test_partial_add(self, device):
         device_mesh = self.build_device_mesh()
         d_1 = DTensor.from_local(torch.rand(2, 2), device_mesh, [Partial()])
         d_2 = DTensor.from_local(torch.rand(2, 2), device_mesh, [Partial()])
@@ -166,7 +167,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertTrue(d_3._spec.placements[0].is_partial())
 
     @with_comms
-    def test_partial_replicate_add(self):
+    def test_partial_replicate_add(self, device):
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -191,50 +192,58 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             self.assertEqual(d_3.full_tensor(), d_1.full_tensor() + d_2.full_tensor())
 
     @with_comms
-    def test_activations(self):
+    def test_activations(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Shard(0)],
             input_size=(8, 5),
             op=torch.nn.functional.gelu,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Replicate()],
             input_size=(8, 5),
             op=torch.nn.functional.gelu,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Shard(1)],
             input_size=(3, 12),
             op=torch.nn.functional.relu,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Replicate()],
             input_size=(8, 5),
             op=torch.nn.functional.relu,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Shard(0)],
             input_size=(8, 5),
             op=torch.sigmoid,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
             placements=[Replicate()],
             input_size=(8, 5),
             op=torch.sigmoid,
+            device_type=device_type,
         )
 
     @with_comms
     @skip(
         "testing RNG based ops is broken: https://github.com/pytorch/PiPPy/issues/494"
     )
-    def test_dropout(self):
+    def test_dropout(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         def _reset_random_seed():
@@ -248,6 +257,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             pre_op_fn=_reset_random_seed,
             p=0.4,
             training=False,
+            device_type=device_type,
         )
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
@@ -257,11 +267,13 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             pre_op_fn=_reset_random_seed,
             p=0.5,
             training=True,
+            device_type=device_type,
         )
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_dropout_backward(self):
+    def test_dropout_backward(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         placements = [Shard(0)]
 
@@ -269,13 +281,13 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         grad_output = torch.rand(
             input_size,
-            device=self.device_type,
+            device=device_type,
             requires_grad=True,
         )
         mask = (
             torch.rand(
                 input_size,
-                device=self.device_type,
+                device=device_type,
                 requires_grad=False,
             )
             < 0.8
@@ -294,28 +306,30 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_dropout_partial_redistributes(self):
+    def test_dropout_partial_redistributes(self, device):
         """Dropout on Partial input redistributes to Replicate first (no error)."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
-        input_tensor = torch.randn(8, 5, device=self.device_type)
+        input_tensor = torch.randn(8, 5, device=device_type)
         dt = DTensor.from_local(input_tensor, device_mesh, [Partial("sum")])
         result = torch.nn.functional.dropout(dt, training=True)
         self.assertIsInstance(result, DTensor)
         self.assertEqual(result.placements, (Replicate(),))
 
     @with_comms
-    def test_mul_out(self):
+    def test_mul_out(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         torch.manual_seed(self.rank)
         shard_spec = [Shard(0)]
         input_size = (8, 4)
-        input_tensor = torch.randn(*input_size, device=self.device_type)
+        input_tensor = torch.randn(*input_size, device=device_type)
         dtensor = DTensor.from_local(input_tensor, device_mesh, shard_spec)
 
-        other_tensor = torch.randn(*input_size, device=self.device_type)
+        other_tensor = torch.randn(*input_size, device=device_type)
         other_dtensor = DTensor.from_local(other_tensor, device_mesh, shard_spec)
 
-        output_tensor = torch.randn(*input_size, device=self.device_type)
+        output_tensor = torch.randn(*input_size, device=device_type)
         output_dtensor = DTensor.from_local(output_tensor, device_mesh, shard_spec)
         dt = torch.mul(dtensor, other_dtensor, out=output_dtensor)
         expected = torch.mul(input_tensor, other_tensor, out=output_tensor)
@@ -323,23 +337,24 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(expected, dt.to_local())
 
     @with_comms
-    def test_mul_out_partial(self):
+    def test_mul_out_partial(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         input_size = (8, 4)
         # P(sum) * R -> P(sum), with out= kwarg
         partial_tensor = DTensor.from_local(
-            torch.ones(*input_size, device=self.device_type),
+            torch.ones(*input_size, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
         replicate_tensor = DTensor.from_local(
-            torch.full(input_size, 2.0, device=self.device_type),
+            torch.full(input_size, 2.0, device=device_type),
             device_mesh,
             [Replicate()],
             run_check=False,
         )
         output_tensor = DTensor.from_local(
-            torch.empty(*input_size, device=self.device_type),
+            torch.empty(*input_size, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
@@ -348,9 +363,10 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(output_tensor.placements, (Partial("sum"),))
 
     @with_comms
-    def test_mul_partial(self):
+    def test_mul_partial(self, device):
         # we only test the partial behavior for mul op as other placement
         # behaviors should be well tested in test_dtensor_ops.py
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
         # 1. simple test for partial * partial
@@ -365,13 +381,13 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(d_3.to_local(), torch.ones(2, 2) * (self.world_size))
 
         # 2. test the partial input DTensor * scalar/replicate input
-        input = torch.full((8, 8), 1.0, device=self.device_type)
+        input = torch.full((8, 8), 1.0, device=device_type)
 
         # test for different types of other inputs
         other_inps = (
             2.0,  # scalar
-            torch.tensor(2.0, device=self.device_type),  # scalar tensor
-            torch.full((8, 8), 2.0, device=self.device_type),  # tensor
+            torch.tensor(2.0, device=device_type),  # scalar tensor
+            torch.full((8, 8), 2.0, device=device_type),  # tensor
         )
 
         for partial_op in ["sum", "avg"]:
@@ -405,21 +421,22 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(z.to_local(), input)
 
     @with_comms
-    def test_div_partial(self):
+    def test_div_partial(self, device):
         # we only test the partial behavior for div op as other placement
         # behaviors should be well tested in test_dtensor_ops.py
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
         # 1. test the partial input DTensor / scalar/replicate input
         # This is mathematically sound: (a1 + a2) / b = a1/b + a2/b
-        input = torch.full((8, 8), 2.0, device=self.device_type)
+        input = torch.full((8, 8), 2.0, device=device_type)
 
         # test for different types of other inputs
         other_inps = (
             2.0,  # scalar
-            torch.tensor(2.0, device=self.device_type),  # scalar tensor
-            torch.full((8, 8), 2.0, device=self.device_type),  # tensor
+            torch.tensor(2.0, device=device_type),  # scalar tensor
+            torch.full((8, 8), 2.0, device=device_type),  # tensor
         )
 
         for partial_op in ["sum", "avg"]:
@@ -447,7 +464,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         # test other partial to assert the partial not getting propagated
         d_input = DTensor.from_local(input, device_mesh, [Partial("max")])
         d_other = distribute_tensor(
-            torch.full((8, 8), 2.0, device=self.device_type), device_mesh, [Replicate()]
+            torch.full((8, 8), 2.0, device=device_type), device_mesh, [Replicate()]
         )
 
         z = d_input / d_other
@@ -455,14 +472,15 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(z.to_local(), input / 2.0)
 
     @with_comms
-    def test_masked_fill_scalar(self):
+    def test_masked_fill_scalar(self, device):
         """Test masked_fill_ with scalar value."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         # Test with deterministic values to avoid random seed issues in threaded tests
         # Test with Shard(0) placement
         input_tensor = torch.arange(
-            40, dtype=torch.float32, device=self.device_type
+            40, dtype=torch.float32, device=device_type
         ).reshape(8, 5)
         mask = input_tensor > 20
         fill_value = -999.0
@@ -480,8 +498,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         # Test with Replicate placement
         input_tensor2 = (
-            torch.arange(40, dtype=torch.float32, device=self.device_type).reshape(8, 5)
-            - 20
+            torch.arange(40, dtype=torch.float32, device=device_type).reshape(8, 5) - 20
         )
         mask2 = input_tensor2 < 0
         fill_value2 = 42.0
@@ -496,7 +513,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         # Test with Shard(1) placement
         input_tensor3 = torch.arange(
-            48, dtype=torch.float32, device=self.device_type
+            48, dtype=torch.float32, device=device_type
         ).reshape(4, 12)
         mask3 = input_tensor3 % 2 == 0  # even numbers
         fill_value3 = 0.0
@@ -510,12 +527,13 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(input_tensor3, dt_input3.full_tensor())
 
     @with_comms
-    def test_inplace_op_partial_to_replicate(self):
+    def test_inplace_op_partial_to_replicate(self, device):
         # test that in-place operations that require redistribution raise an error
         # to preserve aliasing semantics (issue #163374)
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
-        input_tensor = torch.tensor(64.0, device=self.device_type)
+        input_tensor = torch.tensor(64.0, device=device_type)
         partial_dt = DTensor.from_local(
             input_tensor, device_mesh, placements=(Partial(),)
         )
@@ -530,7 +548,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             partial_dt.clamp_(max=10)
 
     @with_comms
-    def test_mul_div_scalar_partial(self):
+    def test_mul_div_scalar_partial(self, device):
         aten = torch.ops.aten
         mesh = self.build_device_mesh()
 
@@ -564,7 +582,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(res.full_tensor(), expected)
 
     @with_comms
-    def test_mul_div_scalar_norm_partial(self):
+    def test_mul_div_scalar_norm_partial(self, device):
         mesh = self.build_device_mesh()
         aten = torch.ops.aten
         local_tensor = torch.tensor([1.0, 1.0, 7.0, 7.0])
@@ -579,7 +597,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(aten.div.Scalar(norm, -2).full_tensor(), -5)
 
     @with_comms
-    def test_add_sub_scalar_partial(self):
+    def test_add_sub_scalar_partial(self, device):
         mesh = self.build_device_mesh()
 
         rank = self.rank
@@ -629,7 +647,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(res.full_tensor(), 0)
 
     @with_comms
-    def test_add_sub_scalar_norm_partial(self):
+    def test_add_sub_scalar_norm_partial(self, device):
         mesh = self.build_device_mesh()
 
         # norm partial + scalar
@@ -654,7 +672,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
     @with_comms
     @parametrize("op,reduce_op", [(torch.maximum, "max"), (torch.minimum, "min")])
-    def test_partial_propagation(self, op, reduce_op):
+    def test_partial_propagation(self, device, op, reduce_op):
         # Test that torch.maximum/minimum preserves Partial("max"/"min") placements
         # since max(max(a), max(b)) == max(a, b) and min(min(a), min(b)) == min(a, b)
         device_mesh = self.build_device_mesh()
@@ -675,19 +693,20 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(result.placements, (Partial(reduce_op),))
 
     @with_comms
-    def test_neg_partial(self):
+    def test_neg_partial(self, device):
         # test that neg preserves Partial placement without communication
         # math: -(A1 + A2) = -A1 + -A2
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
-        input = torch.full((8, 8), 2.0, device=self.device_type)
+        input = torch.full((8, 8), 2.0, device=device_type)
 
         for partial_op in ["sum", "avg"]:
             expected_full = (
-                torch.full((8, 8), -2.0 * self.world_size, device=self.device_type)
+                torch.full((8, 8), -2.0 * self.world_size, device=device_type)
                 if partial_op == "sum"
-                else torch.full((8, 8), -2.0, device=self.device_type)
+                else torch.full((8, 8), -2.0, device=device_type)
             )
 
             d_input = DTensor.from_local(input, device_mesh, [Partial(partial_op)])
@@ -722,7 +741,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(z.placements, (Partial("max"),))
 
     @with_comms
-    def test_maximum_mixed_partials_redistribution(self):
+    def test_maximum_mixed_partials_redistribution(self, device):
         # Test that mixing Partial("max") with Partial("sum") correctly
         # redistributes the incompatible partial before computing maximum
         device_mesh = self.build_device_mesh()
@@ -752,15 +771,16 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(result.full_tensor()[0, 0].item(), expected_value)
 
     @with_comms
-    def test_add_partial_with_replicate_rules(self):
+    def test_add_partial_with_replicate_rules(self, device):
         # P(x) + R -> P(x) for x in {avg, max, min}: adding a replicated constant
         # preserves the partial reduce type (constant is the same on all ranks)
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
         other_val = 3.0
         d_other = distribute_tensor(
-            torch.full((8, 8), other_val, device=self.device_type),
+            torch.full((8, 8), other_val, device=device_type),
             device_mesh,
             [Replicate()],
         )
@@ -772,7 +792,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         }
 
         for reduce_op in ("avg", "max", "min"):
-            input_tensor = torch.ones(8, 8, device=self.device_type) * (self.rank + 1)
+            input_tensor = torch.ones(8, 8, device=device_type) * (self.rank + 1)
             d_input = DTensor.from_local(
                 input_tensor, device_mesh, [Partial(reduce_op)]
             )
@@ -784,22 +804,23 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             self.assertEqual(result.placements, (Partial(reduce_op),))
             self.assertEqual(
                 result.full_tensor(),
-                torch.full((8, 8), expected_full[reduce_op], device=self.device_type),
+                torch.full((8, 8), expected_full[reduce_op], device=device_type),
             )
 
     @with_comms
-    def test_add_replicate_with_partial_avg(self):
+    def test_add_replicate_with_partial_avg(self, device):
         # R + P(avg) -> P(avg): avg is linear, so this holds for any alpha
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
         replicate_val = 3.0
         d_input = distribute_tensor(
-            torch.full((8, 8), replicate_val, device=self.device_type),
+            torch.full((8, 8), replicate_val, device=device_type),
             device_mesh,
             [Replicate()],
         )
-        other_tensor = torch.ones(8, 8, device=self.device_type) * (self.rank + 1)
+        other_tensor = torch.ones(8, 8, device=device_type) * (self.rank + 1)
         d_other = DTensor.from_local(other_tensor, device_mesh, [Partial("avg")])
 
         with comm_mode:
@@ -811,14 +832,15 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected = torch.full(
             (8, 8),
             replicate_val + (self.world_size + 1) / 2.0,
-            device=self.device_type,
+            device=device_type,
         )
         self.assertEqual(result.full_tensor(), expected)
 
     @with_comms
-    def test_mul_div_replicate_partial_asymmetry(self):
+    def test_mul_div_replicate_partial_asymmetry(self, device):
         # mul is bilinear: r * (p1 + p2) = r*p1 + r*p2, so R * P(sum) -> P(sum).
         # div is only linear in the numerator: r / (p1 + p2) != r/p1 + r/p2.
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -826,14 +848,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         partial_local_val = 2.0
 
         d_replicate = distribute_tensor(
-            torch.full((8, 8), replicate_val, device=self.device_type),
+            torch.full((8, 8), replicate_val, device=device_type),
             device_mesh,
             [Replicate()],
         )
 
         # R * P(sum) -> P(sum): valid, zero communication
         d_partial = DTensor.from_local(
-            torch.full((8, 8), partial_local_val, device=self.device_type),
+            torch.full((8, 8), partial_local_val, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
@@ -846,13 +868,13 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected_mul = torch.full(
             (8, 8),
             replicate_val * partial_local_val * self.world_size,
-            device=self.device_type,
+            device=device_type,
         )
         self.assertEqual(mul_result.full_tensor(), expected_mul)
 
         # R / P(sum) -> requires communication (not linear in denominator)
         d_partial2 = DTensor.from_local(
-            torch.full((8, 8), partial_local_val, device=self.device_type),
+            torch.full((8, 8), partial_local_val, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
@@ -864,21 +886,22 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected_div = torch.full(
             (8, 8),
             replicate_val / (partial_local_val * self.world_size),
-            device=self.device_type,
+            device=device_type,
         )
         self.assertEqual(div_result.full_tensor(), expected_div)
 
     @with_comms
-    def test_inplace_add_partial_avg_with_replicate(self):
+    def test_inplace_add_partial_avg_with_replicate(self, device):
         # P(avg) += R -> P(avg): self is P(avg), other is R, valid inplace
         # because the rule P(avg)+R->P(avg) keeps output == self placement.
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
-        self_tensor = torch.ones(8, 8, device=self.device_type) * (self.rank + 1)
+        self_tensor = torch.ones(8, 8, device=device_type) * (self.rank + 1)
         d_self = DTensor.from_local(self_tensor, device_mesh, [Partial("avg")])
         d_other = distribute_tensor(
-            torch.full((8, 8), 3.0, device=self.device_type),
+            torch.full((8, 8), 3.0, device=device_type),
             device_mesh,
             [Replicate()],
         )
@@ -892,21 +915,22 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected = torch.full(
             (8, 8),
             (self.world_size + 1) / 2.0 + 3.0,
-            device=self.device_type,
+            device=device_type,
         )
         self.assertEqual(d_self.full_tensor(), expected)
 
     @with_comms
-    def test_inplace_add_replicate_with_partial_avg_requires_comm(self):
+    def test_inplace_add_replicate_with_partial_avg_requires_comm(self, device):
         # R += P(avg): the out-of-place rule R+P(avg)->P(avg) is valid, but
         # inplace requires output == self == R, so P(avg) output is rejected.
         # The runtime must redistribute P(avg) to R first (communication).
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
-        self_tensor = torch.full((8, 8), 3.0, device=self.device_type)
+        self_tensor = torch.full((8, 8), 3.0, device=device_type)
         d_self = distribute_tensor(self_tensor, device_mesh, [Replicate()])
-        other_tensor = torch.ones(8, 8, device=self.device_type) * (self.rank + 1)
+        other_tensor = torch.ones(8, 8, device=device_type) * (self.rank + 1)
         d_other = DTensor.from_local(other_tensor, device_mesh, [Partial("avg")])
 
         with comm_mode:
@@ -918,7 +942,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         expected = torch.full(
             (8, 8),
             3.0 + (self.world_size + 1) / 2.0,
-            device=self.device_type,
+            device=device_type,
         )
         self.assertEqual(d_self.full_tensor(), expected)
 
@@ -937,8 +961,9 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         ],
     )
     def test_foreach_placement_propagation(
-        self, op_fn, second_arg, placement, expected
+        self, device, op_fn, second_arg, placement, expected
     ):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
@@ -946,14 +971,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         if placement.is_shard():
             dts = [
                 distribute_tensor(
-                    torch.rand(s, device=self.device_type), device_mesh, [placement]
+                    torch.rand(s, device=device_type), device_mesh, [placement]
                 )
                 for s in shapes
             ]
         else:
             dts = [
                 DTensor.from_local(
-                    torch.rand(s, device=self.device_type), device_mesh, [placement]
+                    torch.rand(s, device=device_type), device_mesh, [placement]
                 )
                 for s in shapes
             ]
@@ -962,7 +987,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             if placement.is_shard():
                 args = [
                     distribute_tensor(
-                        torch.rand(s, device=self.device_type),
+                        torch.rand(s, device=device_type),
                         device_mesh,
                         [placement],
                     )
@@ -971,7 +996,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             else:
                 args = [
                     DTensor.from_local(
-                        torch.rand(s, device=self.device_type),
+                        torch.rand(s, device=device_type),
                         device_mesh,
                         [placement],
                     )
@@ -993,26 +1018,27 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             self.assertEqual(r.placements, (expected,))
 
     @with_comms
-    def test_foreach_mixed_placements(self):
+    def test_foreach_mixed_placements(self, device):
         """Each element in a foreach list independently preserves its placement."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
 
         dt1 = DTensor.from_local(
-            torch.rand(8, 8, device=self.device_type),
+            torch.rand(8, 8, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
         ds1 = DTensor.from_local(
-            torch.rand(8, 8, device=self.device_type),
+            torch.rand(8, 8, device=device_type),
             device_mesh,
             [Partial("sum")],
         )
         dt2 = distribute_tensor(
-            torch.rand(8, 4, device=self.device_type), device_mesh, [Shard(0)]
+            torch.rand(8, 4, device=device_type), device_mesh, [Shard(0)]
         )
         ds2 = distribute_tensor(
-            torch.rand(8, 4, device=self.device_type), device_mesh, [Shard(0)]
+            torch.rand(8, 4, device=device_type), device_mesh, [Shard(0)]
         )
 
         with comm_mode:
@@ -1023,11 +1049,12 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(result[1].placements, (Shard(0),))
 
     @with_comms
-    def test_auto_registered_foreach_unary(self):
+    def test_auto_registered_foreach_unary(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         inputs = [
-            torch.linspace(0.05, 0.95, 32, device=self.device_type).reshape(8, 4),
-            torch.linspace(0.1, 0.9, 32, device=self.device_type).reshape(4, 8),
+            torch.linspace(0.05, 0.95, 32, device=device_type).reshape(8, 4),
+            torch.linspace(0.1, 0.9, 32, device=device_type).reshape(4, 8),
         ]
         dtensors = [
             distribute_tensor(input, device_mesh, [Shard(0)]) for input in inputs
@@ -1067,13 +1094,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             ("cross", False),
         ],
     )
-    def test_fused_adam(self, mesh_type, amsgrad):
+    def test_fused_adam(self, device, mesh_type, amsgrad):
+        device_type = torch.device(device).type
         if mesh_type == "same":
             param_mesh = self.build_device_mesh()
             step_mesh = param_mesh
         else:
             mesh_2d = init_device_mesh(
-                self.device_type,
+                device_type,
                 (2, self.world_size // 2),
                 mesh_dim_names=("dp", "tp"),
             )
@@ -1082,28 +1110,28 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         d_params = [
             distribute_tensor(
-                torch.rand(8, 8, device=self.device_type), param_mesh, [Shard(0)]
+                torch.rand(8, 8, device=device_type), param_mesh, [Shard(0)]
             )
         ]
         d_grads = [
             distribute_tensor(
-                torch.rand(8, 8, device=self.device_type), param_mesh, [Shard(0)]
+                torch.rand(8, 8, device=device_type), param_mesh, [Shard(0)]
             )
         ]
         d_exp_avgs = [
             distribute_tensor(
-                torch.zeros(8, 8, device=self.device_type), param_mesh, [Shard(0)]
+                torch.zeros(8, 8, device=device_type), param_mesh, [Shard(0)]
             )
         ]
         d_exp_avg_sqs = [
             distribute_tensor(
-                torch.zeros(8, 8, device=self.device_type), param_mesh, [Shard(0)]
+                torch.zeros(8, 8, device=device_type), param_mesh, [Shard(0)]
             )
         ]
         d_max_exp_avg_sqs = (
             [
                 distribute_tensor(
-                    torch.zeros(8, 8, device=self.device_type),
+                    torch.zeros(8, 8, device=device_type),
                     param_mesh,
                     [Shard(0)],
                 )
@@ -1113,7 +1141,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         )
         d_state_steps = [
             distribute_tensor(
-                torch.tensor(1.0, device=self.device_type), step_mesh, [Replicate()]
+                torch.tensor(1.0, device=device_type), step_mesh, [Replicate()]
             )
         ]
 
@@ -1139,11 +1167,12 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
     @with_comms
     @skip_unless_torch_gpu
-    def test_fused_adamw_strided_shard_cross_mesh(self):
+    def test_fused_adamw_strided_shard_cross_mesh(self, device):
         """Reproduce the torchtitan pattern: params with _StridedShard on a 2D
         mesh, state_steps with Replicate on a 1D DP sub-mesh."""
+        device_type = torch.device(device).type
         mesh_2d = init_device_mesh(
-            self.device_type,
+            device_type,
             (2, self.world_size // 2),
             mesh_dim_names=("dp", "tp"),
         )
@@ -1152,7 +1181,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
 
         d_params = [
             DTensor.from_local(
-                torch.randn(4, 8, device=self.device_type),
+                torch.randn(4, 8, device=device_type),
                 mesh_2d,
                 placements,
                 run_check=False,
@@ -1160,7 +1189,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         ]
         d_grads = [
             DTensor.from_local(
-                torch.randn(4, 8, device=self.device_type),
+                torch.randn(4, 8, device=device_type),
                 mesh_2d,
                 placements,
                 run_check=False,
@@ -1168,7 +1197,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         ]
         d_exp_avgs = [
             DTensor.from_local(
-                torch.zeros(4, 8, device=self.device_type),
+                torch.zeros(4, 8, device=device_type),
                 mesh_2d,
                 placements,
                 run_check=False,
@@ -1176,7 +1205,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         ]
         d_exp_avg_sqs = [
             DTensor.from_local(
-                torch.zeros(4, 8, device=self.device_type),
+                torch.zeros(4, 8, device=device_type),
                 mesh_2d,
                 placements,
                 run_check=False,
@@ -1184,7 +1213,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         ]
         d_state_steps = [
             DTensor.from_local(
-                torch.tensor(1.0, device=self.device_type),
+                torch.tensor(1.0, device=device_type),
                 dp_mesh,
                 [Replicate()],
                 run_check=False,
@@ -1212,39 +1241,40 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(d_params[0].device_mesh, mesh_2d)
 
     @with_comms
-    def test_fused_adamw_tensor_lr(self):
+    def test_fused_adamw_tensor_lr(self, device):
         """Test _fused_adamw_ with tensor lr kwarg."""
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
 
         d_params = [
             distribute_tensor(
-                torch.rand(8, 8, device=self.device_type), device_mesh, [Shard(0)]
+                torch.rand(8, 8, device=device_type), device_mesh, [Shard(0)]
             )
         ]
         d_grads = [
             distribute_tensor(
-                torch.rand(8, 8, device=self.device_type), device_mesh, [Shard(0)]
+                torch.rand(8, 8, device=device_type), device_mesh, [Shard(0)]
             )
         ]
         d_exp_avgs = [
             distribute_tensor(
-                torch.zeros(8, 8, device=self.device_type), device_mesh, [Shard(0)]
+                torch.zeros(8, 8, device=device_type), device_mesh, [Shard(0)]
             )
         ]
         d_exp_avg_sqs = [
             distribute_tensor(
-                torch.zeros(8, 8, device=self.device_type), device_mesh, [Shard(0)]
+                torch.zeros(8, 8, device=device_type), device_mesh, [Shard(0)]
             )
         ]
         d_state_steps = [
             distribute_tensor(
-                torch.tensor(1.0, device=self.device_type),
+                torch.tensor(1.0, device=device_type),
                 device_mesh,
                 [Replicate()],
             )
         ]
         d_lr = distribute_tensor(
-            torch.tensor(0.001, device=self.device_type),
+            torch.tensor(0.001, device=device_type),
             device_mesh,
             [Replicate()],
         )
@@ -1270,13 +1300,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         self.assertEqual(d_params[0].placements, (Shard(0),))
 
     @with_comms
-    def test_new_pointwise_ops(self):
+    def test_new_pointwise_ops(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         torch.manual_seed(self.rank)
         shard_spec = [Shard(0)]
 
         # hardshrink: non-decreasing unary, decomp-blocked
-        inp = torch.randn(8, 5, device=self.device_type)
+        inp = torch.randn(8, 5, device=device_type)
         dt = DTensor.from_local(inp, device_mesh, shard_spec)
         self.assertEqual(
             torch.nn.functional.hardshrink(dt).to_local(),
@@ -1284,14 +1315,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         )
 
         # lcm: binary integer pointwise
-        a = torch.randint(1, 100, (8, 5), device=self.device_type)
-        b = torch.randint(1, 100, (8, 5), device=self.device_type)
+        a = torch.randint(1, 100, (8, 5), device=device_type)
+        b = torch.randint(1, 100, (8, 5), device=device_type)
         da = DTensor.from_local(a, device_mesh, shard_spec)
         db = DTensor.from_local(b, device_mesh, shard_spec)
         self.assertEqual(torch.lcm(da, db).to_local(), torch.lcm(a, b))
 
         # special_xlog1py and special_entr
-        pos = torch.rand(8, 5, device=self.device_type) + 0.1
+        pos = torch.rand(8, 5, device=device_type) + 0.1
         dp = DTensor.from_local(pos, device_mesh, shard_spec)
         self.assertEqual(
             torch.special.xlog1py(dp, dp).to_local(),
@@ -1303,13 +1334,14 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         )
 
     @with_comms
-    def test_new_special_pointwise_ops(self):
+    def test_new_special_pointwise_ops(self, device):
+        device_type = torch.device(device).type
         device_mesh = self.build_device_mesh()
         torch.manual_seed(self.rank)
         shard_spec = [Shard(0)]
 
         # Unary special functions
-        inp = torch.rand(8, 5, device=self.device_type) + 0.1
+        inp = torch.rand(8, 5, device=device_type) + 0.1
         dt = DTensor.from_local(inp, device_mesh, shard_spec)
         for op in [
             torch.special.airy_ai,
@@ -1325,8 +1357,8 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
             self.assertEqual(op(dt).to_local(), op(inp))
 
         # Binary special polynomial ops
-        x = torch.rand(8, 5, device=self.device_type)
-        n = torch.randint(0, 5, (8, 5), device=self.device_type, dtype=x.dtype)
+        x = torch.rand(8, 5, device=device_type)
+        n = torch.randint(0, 5, (8, 5), device=device_type, dtype=x.dtype)
         dx = DTensor.from_local(x, device_mesh, shard_spec)
         dn = DTensor.from_local(n, device_mesh, shard_spec)
         for op in [
@@ -1434,9 +1466,18 @@ class TestPointwiseRuleValidation(TestCase):
                 self._with_even_sizes(run)
 
 
-instantiate_parametrized_tests(DistElementwiseOpsTest)
 DistElementwiseOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistElementwiseOpsTest, base_class=LocalDTensorOpTestBase
+)
+
+instantiate_device_type_tests(
+    DistElementwiseOpsTest, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    DistElementwiseOpsTestWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -33,7 +33,7 @@ from torch.distributed.tensor._ops._view_ops import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorContinuousTestBase,
@@ -43,6 +43,8 @@ from torch.utils import _pytree as pytree
 
 
 class TestViewOps(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     world_size = 6
 
     @staticmethod

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -33,6 +33,7 @@ from torch.distributed.tensor._ops._view_ops import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -72,7 +73,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         return [f for f in get_sorted_factorizations(n) if len(f) >= 2]
 
-    def test_view_groups(self):
+    def test_view_groups(self, device):
         self.assertEqual(
             view_groups([2, 3], [3, 2]),
             (
@@ -253,7 +254,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(rules, expected_rule_output)
         self.call_dt_test(op, args, {}, self.device_mesh)
 
-    def test_illegal_views(self):
+    def test_illegal_views(self, device):
         device_mesh = self.build_device_mesh()
         # 1D mesh [6] (see above)
         tensor = torch.randn((6, 256))
@@ -282,7 +283,7 @@ class TestViewOps(DTensorContinuousTestBase):
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             shard.view(8, 2, -1)
 
-    def test_split_flatten_non_first_shard_falls_back_to_replicate(self):
+    def test_split_flatten_non_first_shard_falls_back_to_replicate(self, device):
         rule = view_groups((32, 4), (4, 32))
         input_tgt, output = propagate_shape_and_sharding(
             [Shard(1)],
@@ -294,7 +295,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(input_tgt, [Replicate()])
         self.assertEqual(output, [Replicate()])
 
-    def test_double_shard_split_validation(self):
+    def test_double_shard_split_validation(self, device):
         """[Shard(0), Shard(0)] through Split correctly validates divisibility."""
         # Compatible: reshape (24,)→(6,4) with [Shard(0), Shard(0)] on mesh (2,3)
         # submesh_size = 2*3 = 6, split_id=0 out_size=6, 6%6==0 → passes
@@ -322,10 +323,11 @@ class TestViewOps(DTensorContinuousTestBase):
                 strict_view=True,
             )
 
-    def test_view_ops(self):
+    def test_view_ops(self, device):
+        device_type = torch.device(device).type
         mesh_shape = (dist.get_world_size() // 2, 2)
         self.device_mesh = init_device_mesh(
-            self.device_type, mesh_shape=mesh_shape, mesh_dim_names=("outer", "inner")
+            device_type, mesh_shape=mesh_shape, mesh_dim_names=("outer", "inner")
         )
         self.dimmap_test(torch.atleast_1d, (randn(()),), (Singleton(),))
         self.dimmap_test(torch.atleast_1d, (randn(24),), (InputDim(0),))
@@ -619,9 +621,10 @@ class TestViewOps(DTensorContinuousTestBase):
     #     ),
     # )
 
-    def test_complex_view_ops(self):
+    def test_complex_view_ops(self, device):
+        device_type = torch.device(device).type
         self.device_mesh = DeviceMesh(
-            self.device_type, torch.arange(dist.get_world_size()).view(-1, 2)
+            device_type, torch.arange(dist.get_world_size()).view(-1, 2)
         )
         inp = randn(24, 13, 2)
         intermediate = torch.view_as_complex(inp)
@@ -663,13 +666,14 @@ class TestViewOps(DTensorContinuousTestBase):
             )
             self.assertEqual(out, out_dt.full_tensor())
 
-    def test_view_as_complex_no_pmax_pmin(self):
+    def test_view_as_complex_no_pmax_pmin(self, device):
         """
         view_as_complex converts real tensors to complex. Complex numbers don't
         have a total ordering, so P(max) and P(min) placements are invalid.
         This test verifies that these placements are not propagated.
         """
-        device_mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        device_type = torch.device(device).type
+        device_mesh = DeviceMesh(device_type, torch.arange(self.world_size))
         inp = torch.randn(8, 2)
 
         # Create input with P(sum) - this should work
@@ -689,7 +693,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # P(max) should NOT propagate - output should be Replicate
         self.assertIsInstance(result_pmax.placements[0], Replicate)
 
-    def test_dtensor_view_op_uneven(self):
+    def test_dtensor_view_op_uneven(self, device):
         """
         When the sharded dimension is unchanged, the view op should not trigger any communication.
         And the behavior should be the same as operating under single-device.
@@ -699,10 +703,11 @@ class TestViewOps(DTensorContinuousTestBase):
             2) the sharded tensor dim is uneven such that some ranks have full shards,
                 smaller non-empty shards, and empty shards.
         """
+        device_type = torch.device(device).type
         dim0_sizes = [1, self.world_size + 1]
         for dim0_size in dim0_sizes:
             p = torch.randn(dim0_size, 2, 2, 2)
-            mesh = init_device_mesh(self.device_type, (self.world_size,))
+            mesh = init_device_mesh(device_type, (self.world_size,))
             dtensor = distribute_tensor(p, mesh, [Shard(0)])
 
             with CommDebugMode() as comm_mode:
@@ -810,7 +815,7 @@ class TestViewOps(DTensorContinuousTestBase):
         else:
             self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    def test_dtensor_flatten_split_multi_mesh(self):
+    def test_dtensor_flatten_split_multi_mesh(self, device):
         """Test views producing Split(Flatten) rules.
 
         Complements test_dtensor_flatten_multi_mesh (pure Flatten rules) and
@@ -822,10 +827,11 @@ class TestViewOps(DTensorContinuousTestBase):
         mesh dim) to cover even/uneven divisibility, following the same
         pattern as _run_flatten_single_shard.
         """
+        device_type = torch.device(device).type
         for mesh_shape in [(self.world_size,), (3, 2)]:
             if self.world_size < math.prod(mesh_shape):
                 continue
-            mesh = init_device_mesh(self.device_type, mesh_shape)
+            mesh = init_device_mesh(device_type, mesh_shape)
             for shard_mesh_dim in range(mesh.ndim):
                 M = mesh.size(shard_mesh_dim)
                 dim_vals = [2 * M - 1, 2 * M, 2 * M + 1]
@@ -863,12 +869,13 @@ class TestViewOps(DTensorContinuousTestBase):
                                     mesh,
                                 )
 
-    def test_dtensor_flatten_multi_mesh(self):
+    def test_dtensor_flatten_multi_mesh(self, device):
         """Test flatten operations across 1D and 2D meshes with all placement patterns.
 
         Iterates over 1D and 2D mesh configurations to test single-shard (S, SR, RS),
         multi-shard (SS), and replicate (R, RR) patterns with even/uneven tensor dim sizes.
         """
+        device_type = torch.device(device).type
         cases = [
             ((6,), [("S",), ("R",)]),
             ((3, 2), [("S", "R"), ("R", "S"), ("S", "S"), ("R", "R")]),
@@ -876,7 +883,7 @@ class TestViewOps(DTensorContinuousTestBase):
         for mesh_shape, patterns in cases:
             if self.world_size < math.prod(mesh_shape):
                 continue
-            mesh = init_device_mesh(self.device_type, mesh_shape)
+            mesh = init_device_mesh(device_type, mesh_shape)
             mesh_ndim = len(mesh_shape)
             for pattern in patterns:
                 shard_mesh_dims = [i for i, p in enumerate(pattern) if p == "S"]
@@ -1167,7 +1174,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(inps_viewed._local_tensor, expected_local_tensor)
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    def test_dtensor_flatten_shard_outside_range(self):
+    def test_dtensor_flatten_shard_outside_range(self, device):
         """Test that Shard on a dim outside the flatten range passes through correctly.
 
         When flattening dims [flatten_start, flatten_end), a Shard on a dim outside
@@ -1175,7 +1182,8 @@ class TestViewOps(DTensorContinuousTestBase):
         - Shard before range: dim unchanged
         - Shard after range: dim shifts by -(flatten_end - flatten_start - 1)
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         # Use sizes divisible by mesh size to avoid uneven-shard complications
         dim_size = mesh.size(0) * 2
         test_cases = [
@@ -1228,7 +1236,7 @@ class TestViewOps(DTensorContinuousTestBase):
                 self.assertEqual(comm_mode.get_total_counts(), 0)
 
         # 2D mesh: test shard outside range with (Shard, Replicate) and (Replicate, Shard)
-        mesh_2d = init_device_mesh(self.device_type, (3, self.world_size // 3))
+        mesh_2d = init_device_mesh(device_type, (3, self.world_size // 3))
         dim_size_2d = mesh_2d.size(0) * mesh_2d.size(1) * 2
         test_cases_2d = [
             # (tensor_dims, flatten_start, flatten_end, shard_dim)
@@ -1278,14 +1286,15 @@ class TestViewOps(DTensorContinuousTestBase):
                     self.assertEqual(dt_flat._local_tensor, expected_local)
                     self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    def test_dtensor_flatten_unflatten_roundtrip(self):
+    def test_dtensor_flatten_unflatten_roundtrip(self, device):
         """Flatten then unflatten should recover the original placements and data.
 
         Tests the full round-trip: DTensor -> flatten -> unflatten -> compare with original.
         Covers sharding on dims before, within, and after the flatten range.
         Also tests unflatten -> flatten direction.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         dim_size = mesh.size(0) * 2  # evenly divisible
 
         # flatten -> unflatten round-trip
@@ -1417,8 +1426,9 @@ class TestViewOps(DTensorContinuousTestBase):
                 tensor_dims[shard_dim] = shard_dim_value
                 yield list(tensor_dims)
 
-    def test_dtensor_unflatten_1d(self):
-        mesh: DeviceMesh = init_device_mesh(self.device_type, (self.world_size,))
+    def test_dtensor_unflatten_1d(self, device):
+        device_type = torch.device(device).type
+        mesh: DeviceMesh = init_device_mesh(device_type, (self.world_size,))
 
         # flatten -> view -> unflatten
         for tensor_ndim in [2, 3, 4]:
@@ -1600,13 +1610,14 @@ class TestViewOps(DTensorContinuousTestBase):
                 )._local_tensor
                 self.assertEqual(inps_viewed._local_tensor, expected_local)
 
-    def test_dtensor_unflatten_multi_mesh(self):
+    def test_dtensor_unflatten_multi_mesh(self, device):
         """Test unflatten across 2D and 3D meshes with all placement patterns.
 
         Iterates over 2D and 3D mesh configurations to test multi-shard (SS, SSS),
         mixed (R+SS, RR+SS), and replicate (RR, RRR) patterns.
         """
         # (mesh_shape, num_replicate_dims)
+        device_type = torch.device(device).type
         cases = [
             ((3, 2), 0),  # (SS, SS)
             ((3, 2), 1),  # (R, SS)
@@ -1619,7 +1630,7 @@ class TestViewOps(DTensorContinuousTestBase):
         for mesh_shape, num_rep in cases:
             if self.world_size < math.prod(mesh_shape):
                 continue
-            mesh = init_device_mesh(self.device_type, mesh_shape)
+            mesh = init_device_mesh(device_type, mesh_shape)
             mesh_ndim = len(mesh_shape)
             num_shard = mesh_ndim - num_rep
             flattened_size = math.prod(mesh_shape) * 12
@@ -1773,10 +1784,11 @@ class TestViewOps(DTensorContinuousTestBase):
         )._local_tensor
         self.assertEqual(inps_viewed._local_tensor, expected_local_tensor)
 
-    def test_dtensor_flatten_unflatten_2d_reversed_mesh(self):
+    def test_dtensor_flatten_unflatten_2d_reversed_mesh(self, device):
         """Test flatten/unflatten with reversed mesh shape (2, 3) to catch ordering bugs."""
+        device_type = torch.device(device).type
         self.assertEqual(self.world_size, 6)
-        mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        mesh = init_device_mesh(device_type, (2, self.world_size // 2))
         dim_size = mesh.size(0) * mesh.size(1) * 2  # divisible by both mesh dims
 
         # Flatten with (S, S) pattern
@@ -1829,9 +1841,10 @@ class TestViewOps(DTensorContinuousTestBase):
                                 mesh,
                             )
 
-    def test_dtensor_unflatten_ss_and_s_same_dim(self):
+    def test_dtensor_unflatten_ss_and_s_same_dim(self, device):
         """Test unflatten when _StridedShard and Shard both shard the same tensor dim."""
-        mesh = init_device_mesh(self.device_type, (3, self.world_size // 3))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (3, self.world_size // 3))
 
         global_tensor = torch.arange(4 * 6 * 3).view(4, 6, 3)
         inps = distribute_tensor(global_tensor, mesh, [Shard(1), Shard(0)])
@@ -1861,16 +1874,17 @@ class TestViewOps(DTensorContinuousTestBase):
         )._local_tensor
         self.assertEqual(unflattened._local_tensor, expected_local)
 
-    def test_flatten_then_sum_non_shard_dim(self):
+    def test_flatten_then_sum_non_shard_dim(self, device):
         """Verify _StridedShard correctness through sum on a non-shard dim.
 
         sum uses map_placements_after_reduction which must preserve
         _StridedShard (with split_factor) when remapping dims after
         the reduced dim is removed.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)  # _StridedShard(dim=0)
         flat_full = full.flatten(0, 1)
@@ -1893,7 +1907,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # _StridedShard on higher dim: reduce a dim below it to trigger remap
         shape2 = (3, 5, self.world_size * 2)
-        full2 = torch.randn(*shape2, device=self.device_type)
+        full2 = torch.randn(*shape2, device=device_type)
         dt2 = distribute_tensor(full2, mesh, [Shard(2)])
         dt2_flat = dt2.flatten(1, 2)  # _StridedShard(dim=1)
         flat_full2 = full2.flatten(1, 2)
@@ -1910,15 +1924,16 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(result3.full_tensor(), flat_full2.sum(dim=0))
 
-    def test_flatten_then_softmax(self):
+    def test_flatten_then_softmax(self, device):
         """Verify _StridedShard correctness through softmax.
 
         softmax uses replicate_reduction_dims which only checks isinstance(p, Shard).
         _StridedShard on the softmax dim may not be replicated, producing wrong results.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -1933,15 +1948,16 @@ class TestViewOps(DTensorContinuousTestBase):
         result = torch.softmax(dt_flat, dim=-1)
         self.assertEqual(result.full_tensor(), torch.softmax(flat_full, dim=-1))
 
-    def test_flatten_then_layer_norm(self):
+    def test_flatten_then_layer_norm(self, device):
         """Verify _StridedShard correctness through layer_norm.
 
         layer_norm uses _replicate_dims_start_at which only checks isinstance(p, Shard).
         _StridedShard on normalized dims may not be replicated.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -1962,16 +1978,17 @@ class TestViewOps(DTensorContinuousTestBase):
             torch.nn.functional.layer_norm(flat_full, list(flat_full.shape)),
         )
 
-    def test_flatten_then_transpose(self):
+    def test_flatten_then_transpose(self, device):
         """Verify _StridedShard correctness through transpose.
 
         aten.transpose.int goes through view op propagation which handles
         _StridedShard. aten.t uses a single-dim strategy in _matrix_ops.py
         which swaps the dim for both Shard and _StridedShard.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -1995,7 +2012,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # t() with _StridedShard(dim=1) → _StridedShard(dim=0)
         # Shard(2) on (4, 6, ws*2) + flatten(1,2) → _StridedShard(dim=1)
         shape1 = (4, 6, self.world_size * 2)
-        full1 = torch.randn(*shape1, device=self.device_type)
+        full1 = torch.randn(*shape1, device=device_type)
         dt1 = distribute_tensor(full1, mesh, [Shard(2)])
         dt1_flat = dt1.flatten(1, 2)  # (4, 6*ws*2) with _StridedShard(dim=1)
         self.assertIsInstance(dt1_flat.placements[0], _StridedShard)
@@ -2016,7 +2033,7 @@ class TestViewOps(DTensorContinuousTestBase):
             self.world_size * 2,
             5,
         )  # flatten(0,1) gives (3*ws*2, 5), uneven in dim 0
-        full2 = torch.randn(*shape2, device=self.device_type)
+        full2 = torch.randn(*shape2, device=device_type)
         dt2 = distribute_tensor(full2, mesh, [Shard(1)])
         dt2_flat = dt2.flatten(0, 1)
         self.assertIsInstance(dt2_flat.placements[0], _StridedShard)
@@ -2035,7 +2052,7 @@ class TestViewOps(DTensorContinuousTestBase):
             3,
             self.world_size * 2,
         )  # flatten(1,2) gives (5, 3*ws*2), uneven in dim 1
-        full3 = torch.randn(*shape3, device=self.device_type)
+        full3 = torch.randn(*shape3, device=device_type)
         dt3 = distribute_tensor(full3, mesh, [Shard(2)])
         dt3_flat = dt3.flatten(1, 2)
         self.assertIsInstance(dt3_flat.placements[0], _StridedShard)
@@ -2049,20 +2066,21 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(result3.full_tensor(), full3.flatten(1, 2).t())
 
-    def test_flatten_then_nll_loss(self):
+    def test_flatten_then_nll_loss(self, device):
         """Verify _StridedShard correctness through nll_loss.
 
         nll_loss_forward_strategy uses replicate_reduction_dims on the channel
         dim and _skip_dim to build target placements.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         num_classes = 10
 
         # 2D input: (N, C) — _StridedShard on batch dim (dim 0), which is
         # below channel_dim (dim 1), so _skip_dim preserves it unchanged.
         shape = (4, self.world_size * 2)
-        full_input = torch.randn(*shape, num_classes, device=self.device_type)
-        full_target = torch.randint(0, num_classes, shape, device=self.device_type)
+        full_input = torch.randn(*shape, num_classes, device=device_type)
+        full_target = torch.randint(0, num_classes, shape, device=device_type)
         dist.broadcast(full_target, src=0)
 
         dt_input = distribute_tensor(full_input, mesh, [Shard(1)])
@@ -2087,8 +2105,8 @@ class TestViewOps(DTensorContinuousTestBase):
         # is above channel_dim (dim 1), so _skip_dim must shift it from
         # dim 2 to dim 1 while preserving split_factor.
         N, C, D1, D2 = 2, num_classes, 3, self.world_size * 2
-        full_input_3d = torch.randn(N, C, D1, D2, device=self.device_type)
-        full_target_3d = torch.randint(0, C, (N, D1, D2), device=self.device_type)
+        full_input_3d = torch.randn(N, C, D1, D2, device=device_type)
+        full_target_3d = torch.randint(0, C, (N, D1, D2), device=device_type)
         dist.broadcast(full_target_3d, src=0)
 
         dt_input_3d = distribute_tensor(full_input_3d, mesh, [Shard(3)])
@@ -2110,16 +2128,17 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(result_3d.full_tensor(), expected_3d)
 
-    def test_flatten_then_select(self):
+    def test_flatten_then_select(self, device):
         """Verify _StridedShard correctness through select.
 
         select removes a dim, so select_int_strategy must detect
         _StridedShard (which is_sharded() misses) and call
         shift_shard_dims_after_remove to adjust the shard dim.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (2, 3, 4, self.world_size * 2)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(3)])
         dt_flat = dt.flatten(2, 3)  # (2, 3, 4*ws*2) with _StridedShard(dim=2)
 
@@ -2148,15 +2167,16 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertNotIsInstance(result2.placements[0], _StridedShard)
         self.assertEqual(result2.full_tensor(), expected2)
 
-    def test_flatten_then_unbind(self):
+    def test_flatten_then_unbind(self, device):
         """Verify _StridedShard correctness through unbind.
 
         unbind removes a dim via shift_shard_dims_after_remove, which
         must preserve split_factor when shifting _StridedShard dims.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (2, 3, 4, self.world_size * 2)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(3)])
         dt_flat = dt.flatten(2, 3)  # (2, 3, 4*ws*2) with _StridedShard(dim=2)
 
@@ -2183,7 +2203,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # unbind on dim above shard dim: _StridedShard dim stays unchanged
         shape2 = (4, self.world_size * 2, 3, 5)
-        full2 = torch.randn(*shape2, device=self.device_type)
+        full2 = torch.randn(*shape2, device=device_type)
         dt2 = distribute_tensor(full2, mesh, [Shard(1)])
         dt2_flat = dt2.flatten(0, 1)  # (4*ws*2, 3, 5) with _StridedShard(dim=0)
         self.assertIsInstance(dt2_flat.placements[0], _StridedShard)
@@ -2198,15 +2218,16 @@ class TestViewOps(DTensorContinuousTestBase):
             self.assertEqual(r.placements[0].split_factor, orig_split_factor2)
             self.assertEqual(r.full_tensor(), e)
 
-    def test_flatten_then_stack(self):
+    def test_flatten_then_stack(self, device):
         """Verify _StridedShard correctness through stack.
 
         stack inserts a new dim via shift_shard_dims_after_insert, which
         must preserve split_factor when shifting _StridedShard dims.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
 
@@ -2229,7 +2250,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(result2.placements[0].split_factor, orig_split_factor)
         self.assertEqual(result2.full_tensor(), expected2)
 
-    def test_flatten_then_slice(self):
+    def test_flatten_then_slice(self, device):
         """Verify _StridedShard correctness through slice.
 
         aten.slice.Tensor goes through gen_slice_strategy which uses
@@ -2237,9 +2258,10 @@ class TestViewOps(DTensorContinuousTestBase):
         matches the _StridedShard dim, the strategy should redistribute
         to Replicate first, otherwise results are silently wrong.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -2256,7 +2278,7 @@ class TestViewOps(DTensorContinuousTestBase):
         expected2 = flat_full[:, :3]
         self.assertEqual(result2.full_tensor(), expected2)
 
-    def test_flatten_then_slice_scatter(self):
+    def test_flatten_then_slice_scatter(self, device):
         """Verify _StridedShard correctness through slice_scatter.
 
         gen_slice_scatter_strategy uses replicate_tensor_dim which only
@@ -2264,9 +2286,10 @@ class TestViewOps(DTensorContinuousTestBase):
         scatter dim matches the _StridedShard dim and all strategies are
         filtered, replicate_tensor_dim should replicate it but doesn't.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -2288,16 +2311,17 @@ class TestViewOps(DTensorContinuousTestBase):
         expected2 = flat_full.slice_scatter(src2_full, dim=1, start=0, end=3)
         self.assertEqual(result2.full_tensor(), expected2)
 
-    def test_flatten_then_slice_backward(self):
+    def test_flatten_then_slice_backward(self, device):
         """Verify _StridedShard correctness through slice backward.
 
         slice_backward_rules only checks isinstance(p, Shard), missing
         _StridedShard. When the slice dim matches the _StridedShard dim,
         gradients are computed on the wrong local shards.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         full_req = full.clone().requires_grad_(True)
 
         dt = distribute_tensor(full, mesh, [Shard(1)])
@@ -2313,16 +2337,17 @@ class TestViewOps(DTensorContinuousTestBase):
         (flat_full[:half].sum()).backward()
         self.assertEqual(dt_flat.grad.full_tensor(), full_req.grad.flatten(0, 1))
 
-    def test_flatten_then_cat_on_strided_shard_dim(self):
+    def test_flatten_then_cat_on_strided_shard_dim(self, device):
         """Verify _StridedShard correctness through cat on the shard dim.
 
         cat_strategy uses is_tensor_dim_sharded which calls is_shard(),
         missing _StridedShard. When cat dim == _StridedShard dim, the
         strategy won't unshard first, producing wrong results.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -2342,7 +2367,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # _StridedShard on a higher dim (dim=1), cat on that dim
         shape2 = (3, 5, self.world_size * 2)
-        full2 = torch.randn(*shape2, device=self.device_type)
+        full2 = torch.randn(*shape2, device=device_type)
         dt2 = distribute_tensor(full2, mesh, [Shard(2)])
         dt2_flat = dt2.flatten(1, 2)  # (3, 5*ws*2) with _StridedShard(dim=1)
         flat_full2 = full2.flatten(1, 2)
@@ -2354,16 +2379,17 @@ class TestViewOps(DTensorContinuousTestBase):
         expected3 = torch.cat([flat_full2, flat_full2], dim=1)
         self.assertEqual(result3.full_tensor(), expected3)
 
-    def test_flatten_then_split_on_strided_shard_dim(self):
+    def test_flatten_then_split_on_strided_shard_dim(self, device):
         """Verify _StridedShard correctness through split on the shard dim.
 
         split_strategy uses is_tensor_dim_sharded which calls is_shard(),
         missing _StridedShard. When split dim == _StridedShard dim, the
         strategy won't unshard first, producing wrong results.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
         flat_full = full.flatten(0, 1)
@@ -2386,7 +2412,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # _StridedShard on a higher dim (dim=1), split on that dim
         shape2 = (3, 5, self.world_size * 2)
-        full2 = torch.randn(*shape2, device=self.device_type)
+        full2 = torch.randn(*shape2, device=device_type)
         dt2 = distribute_tensor(full2, mesh, [Shard(2)])
         dt2_flat = dt2.flatten(1, 2)  # (3, 5*ws*2) with _StridedShard(dim=1)
         flat_full2 = full2.flatten(1, 2)
@@ -2400,16 +2426,17 @@ class TestViewOps(DTensorContinuousTestBase):
         for r, e in zip(results3, expected3):
             self.assertEqual(r.full_tensor(), e)
 
-    def test_flatten_then_unbind_on_strided_shard_dim(self):
+    def test_flatten_then_unbind_on_strided_shard_dim(self, device):
         """Verify _StridedShard is detected by unbind on the shard dim.
 
         gen_unbind_strategy uses is_tensor_dim_sharded which calls is_shard(),
         missing _StridedShard. Unbinding on a _StridedShard dim should raise
         RuntimeError (same as unbinding on a regular Shard dim).
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (2, self.world_size * 2, 3)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
 
@@ -2420,7 +2447,7 @@ class TestViewOps(DTensorContinuousTestBase):
         with self.assertRaises(RuntimeError):
             torch.unbind(dt_flat, dim=0)
 
-    def test_flatten_then_add_strided_shard_inputs(self):
+    def test_flatten_then_add_strided_shard_inputs(self, device):
         """Verify _StridedShard is treated as shard in placement merge.
 
         Binary ops (e.g. add) with two _StridedShard inputs go through
@@ -2429,10 +2456,11 @@ class TestViewOps(DTensorContinuousTestBase):
         causing it to fall through to the Replicate branch and triggering
         an unnecessary all-gather before the elementwise op.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full_a = torch.randn(*shape, device=self.device_type)
-        full_b = torch.randn(*shape, device=self.device_type)
+        full_a = torch.randn(*shape, device=device_type)
+        full_b = torch.randn(*shape, device=device_type)
 
         dt_a = distribute_tensor(full_a, mesh, [Shard(1)])
         dt_b = distribute_tensor(full_b, mesh, [Shard(1)])
@@ -2453,7 +2481,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # all-gather would be emitted here.
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    def test_flatten_then_redistribute_backward_partial(self):
+    def test_flatten_then_redistribute_backward_partial(self, device):
         """Verify backward normalize handles _StridedShard → Partial.
 
         In the backward pass of Redistribute, the code normalizes
@@ -2462,9 +2490,10 @@ class TestViewOps(DTensorContinuousTestBase):
         so _StridedShard → Partial would keep the Partial placement
         instead of normalizing to Replicate.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
 
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1).requires_grad_(True)
@@ -2480,18 +2509,19 @@ class TestViewOps(DTensorContinuousTestBase):
         expected_grad = torch.ones_like(full.flatten(0, 1))
         self.assertEqual(dt_flat.grad.full_tensor(), expected_grad)
 
-    def test_unpack_hook_tp_with_strided_shard(self):
+    def test_unpack_hook_tp_with_strided_shard(self, device):
         """_unpack_hook_tp must redistribute _StridedShard to Replicate.
 
         _unpack_hook_tp restores activations before recomputation in BWD.
         If it only checks .is_shard() it misses _StridedShard, returning the
         tensor still sharded and producing wrong gradients.
         """
+        device_type = torch.device(device).type
         from torch.distributed.tensor.parallel.input_reshard import _unpack_hook_tp
 
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        mesh = init_device_mesh(device_type, (self.world_size,))
         shape = (4, self.world_size * 2, 6)
-        full = torch.randn(*shape, device=self.device_type)
+        full = torch.randn(*shape, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
         dt_flat = dt.flatten(0, 1)
 
@@ -2502,22 +2532,24 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertTrue(result.placements[0].is_replicate())
         self.assertEqual(result.full_tensor(), full.flatten(0, 1))
 
-    def test_view_redistribution(self):
+    def test_view_redistribution(self, device):
         """
         This test is added to demonstrate "incorrect" view ops behavior if redistribution happens.
         """
 
+        device_type = torch.device(device).type
         x = torch.randn(4, 4)
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        mesh = init_device_mesh(device_type, (self.world_size,))
         dtensor_x = distribute_tensor(x, mesh, (Shard(0),))
 
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             dtensor_x.view(-1, 8)
 
-    def test_squeeze_(self):
-        mesh_2d = init_device_mesh(self.device_type, (3, 2), mesh_dim_names=("a", "b"))
+    def test_squeeze_(self, device):
+        device_type = torch.device(device).type
+        mesh_2d = init_device_mesh(device_type, (3, 2), mesh_dim_names=("a", "b"))
         self.init_manual_seed_for_rank()
-        x = torch.randn((1, 4), device=self.device_type)
+        x = torch.randn((1, 4), device=device_type)
         dist_x = DTensor.from_local(x, mesh_2d, [Partial(), Shard(1)])
         self._test_op_on_dtensor(
             torch.ops.aten.squeeze_.dim,
@@ -2533,19 +2565,20 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(dist_x.placements, [Partial(), Shard(0)])
 
         # squeeze_ should not trigger any communication
-        y = torch.randn((1, 4), device=self.device_type)
+        y = torch.randn((1, 4), device=device_type)
         dist_y = DTensor.from_local(y, mesh_2d, [Partial(), Shard(1)])
         with CommDebugMode() as comm_mode:
             torch.ops.aten.squeeze_.dim(dist_y, 0)
         self.assertEqual(comm_mode.get_total_counts(), 0)
 
-    def test_squeeze_variants(self):
+    def test_squeeze_variants(self, device):
         """Test squeeze.default, squeeze.dim, and squeeze.dims with DTensor."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         # squeeze.dims on sharded tensor - squeeze non-sharded dims
         with self.subTest("dims_sharded"):
-            x = torch.randn(self.world_size, 1, 1, 8, device=self.device_type)
+            x = torch.randn(self.world_size, 1, 1, 8, device=device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze((1, 2))
@@ -2556,7 +2589,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # squeeze.dim on sharded tensor - squeeze non-sharded dim
         with self.subTest("dim_sharded"):
-            x = torch.randn(self.world_size, 1, 8, device=self.device_type)
+            x = torch.randn(self.world_size, 1, 8, device=device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze(1)
@@ -2567,7 +2600,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # squeeze.default on replicated tensor
         with self.subTest("default_replicated"):
-            x = torch.randn(4, 1, 1, 8, device=self.device_type)
+            x = torch.randn(4, 1, 1, 8, device=device_type)
             dt = distribute_tensor(x, mesh, [Replicate()])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze()
@@ -2577,7 +2610,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # squeeze.dims on replicated tensor
         with self.subTest("dims_replicated"):
-            x = torch.randn(2, 1, 3, 1, device=self.device_type)
+            x = torch.randn(2, 1, 3, 1, device=device_type)
             dt = distribute_tensor(x, mesh, [Replicate()])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze((1, 3))
@@ -2587,7 +2620,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # squeeze non-singleton dim is a no-op
         with self.subTest("non_singleton_noop"):
-            x = torch.randn(self.world_size, 4, device=self.device_type)
+            x = torch.randn(self.world_size, 4, device=device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze(1)
@@ -2597,7 +2630,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # Partial passes through squeeze unchanged
         with self.subTest("partial_max_passthrough"):
-            x = torch.randn(1, 4, device=self.device_type)
+            x = torch.randn(1, 4, device=device_type)
             dt = DTensor.from_local(x, mesh, [Partial("max")])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze(0)
@@ -2607,7 +2640,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # Partial("sum") also passes through
         with self.subTest("partial_sum_passthrough"):
-            x = torch.randn(1, device=self.device_type)
+            x = torch.randn(1, device=device_type)
             dt = DTensor.from_local(x, mesh, [Partial("sum")])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze()
@@ -2618,7 +2651,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # squeeze must not remove sharded dim (local size 1, global size > 1)
         with self.subTest("preserve_sharded_dim_default"):
             x = (
-                torch.arange(self.world_size * 8, device=self.device_type)
+                torch.arange(self.world_size * 8, device=device_type)
                 .reshape(self.world_size, 8)
                 .float()
             )
@@ -2634,7 +2667,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # same as above but via squeeze.dim (single int arg)
         with self.subTest("preserve_sharded_dim_explicit"):
             x = (
-                torch.arange(self.world_size * 8, device=self.device_type)
+                torch.arange(self.world_size * 8, device=device_type)
                 .reshape(self.world_size, 8)
                 .float()
             )
@@ -2649,7 +2682,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # squeeze.dims with mixed singleton/non-singleton dims
         with self.subTest("mixed_dims"):
-            x = torch.randn(1, 4, 1, device=self.device_type)
+            x = torch.randn(1, 4, 1, device=device_type)
             dt = distribute_tensor(x, mesh, [Replicate()])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze((0, 1, 2))
@@ -2660,7 +2693,7 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # sharded non-singleton dim preserved, shard index shifts
         with self.subTest("shard_index_shift"):
-            x = torch.randn(1, self.world_size, 1, device=self.device_type)
+            x = torch.randn(1, self.world_size, 1, device=device_type)
             dt = distribute_tensor(x, mesh, [Shard(1)])
             with CommDebugMode() as comm_mode:
                 result = dt.squeeze((0, 1, 2))
@@ -2673,7 +2706,7 @@ class TestViewOps(DTensorContinuousTestBase):
         # Squeezing a sharded singleton dim requires redistribution and
         # must error rather than silently allgathering (#174136).
         with self.subTest("squeeze_sharded_dim_errors"):
-            x = torch.randn(1, 4, device=self.device_type)
+            x = torch.randn(1, 4, device=device_type)
             dt = distribute_tensor(x, mesh, [Shard(0)])
             # All 6 squeeze ATen ops must error:
             for op, args in [
@@ -2687,12 +2720,13 @@ class TestViewOps(DTensorContinuousTestBase):
                 with self.assertRaisesRegex(RuntimeError, "requires redistribution"):
                     op(*args)
 
-    def test_squeeze_comm_free_cases(self):
+    def test_squeeze_comm_free_cases(self, device):
         """Squeeze is comm-free when no sharded dim is removed."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         # Non-sharded singleton removed (out-of-place), shard dim reindexes
-        x = torch.randn(1, self.world_size, device=self.device_type)
+        x = torch.randn(1, self.world_size, device=device_type)
         dt = distribute_tensor(x, mesh, [Shard(1)])
         with CommDebugMode() as comm_mode:
             result = dt.squeeze(0)
@@ -2702,7 +2736,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(result.full_tensor(), x.squeeze(0))
 
         # Same but inplace — exercises the dispatch reindex path
-        x_inp = torch.randn(1, self.world_size, device=self.device_type)
+        x_inp = torch.randn(1, self.world_size, device=device_type)
         dt_inp = distribute_tensor(x_inp, mesh, [Shard(1)])
         with CommDebugMode() as comm_mode:
             dt_inp.squeeze_(0)
@@ -2712,7 +2746,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(dt_inp.full_tensor(), x_inp.squeeze(0))
 
         # Explicit redistribute first, then squeeze
-        x2 = torch.randn(1, 4, device=self.device_type)
+        x2 = torch.randn(1, 4, device=device_type)
         dt2 = distribute_tensor(x2, mesh, [Shard(0)])
         dt2_rep = dt2.redistribute(mesh, [Replicate()])
         with CommDebugMode() as comm_mode:
@@ -2724,9 +2758,9 @@ class TestViewOps(DTensorContinuousTestBase):
 
         # 2D mesh: both shard dims reindex
         mesh_2d = init_device_mesh(
-            self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+            device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
         )
-        x3 = torch.randn(1, 2, self.world_size // 2, device=self.device_type)
+        x3 = torch.randn(1, 2, self.world_size // 2, device=device_type)
         dt3 = distribute_tensor(x3, mesh_2d, [Shard(1), Shard(2)])
         with CommDebugMode() as comm_mode:
             result3 = dt3.squeeze(0)
@@ -2735,15 +2769,16 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(result3.placements, (Shard(0), Shard(1)))
         self.assertEqual(result3.full_tensor(), x3.squeeze(0))
 
-    def test_storage_offset_slice(self):
+    def test_storage_offset_slice(self, device):
         """
         Test that storage_offset is properly tracked on DTensor when slicing
         a replicated tensor.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         # Create a replicated DTensor
-        tensor = torch.randn(10, device=self.device_type)
+        tensor = torch.randn(10, device=device_type)
         dtensor = distribute_tensor(tensor, mesh, [Replicate()])
 
         # Perform a slice operation [1:]
@@ -2765,15 +2800,16 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = tensor[1:]
         self.assertEqual(sliced_dtensor.full_tensor(), expected)
 
-    def test_storage_offset_shard_dim0_slice_dim1(self):
+    def test_storage_offset_shard_dim0_slice_dim1(self, device):
         """
         Test that storage_offset is properly tracked when tensor is sharded on dim 0
         and sliced on dim 1.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         # Create a 2D tensor and shard on dim 0
-        tensor = torch.randn(12, 8, device=self.device_type)
+        tensor = torch.randn(12, 8, device=device_type)
         dtensor = distribute_tensor(tensor, mesh, [Shard(0)])
 
         # Perform a slice operation [:, 2:]
@@ -2796,15 +2832,16 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = tensor[:, 2:]
         self.assertEqual(sliced_dtensor.full_tensor(), expected)
 
-    def test_storage_offset_shard_dim1_slice_dim0(self):
+    def test_storage_offset_shard_dim1_slice_dim0(self, device):
         """
         Test that storage_offset is properly tracked when tensor is sharded on dim 1
         and sliced on dim 0.
         """
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         # Create a 2D tensor and shard on dim 1
-        tensor = torch.randn(10, 12, device=self.device_type)
+        tensor = torch.randn(10, 12, device=device_type)
         dtensor = distribute_tensor(tensor, mesh, [Shard(1)])
 
         # Perform a slice operation [2:, :]
@@ -2827,7 +2864,7 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = tensor[2:, :]
         self.assertEqual(sliced_dtensor.full_tensor(), expected)
 
-    def test_view_groups_unbacked_symint(self):
+    def test_view_groups_unbacked_symint(self, device):
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
         shape_env = ShapeEnv()
@@ -2914,7 +2951,7 @@ class TestViewOps(DTensorContinuousTestBase):
             ),
         )
 
-    def test_view_groups_unbacked_sharding_propagation(self):
+    def test_view_groups_unbacked_sharding_propagation(self, device):
         """Test that sharding is correctly propagated through view_groups with symbolic shapes."""
         from torch.fx.experimental.symbolic_shapes import (
             free_symbols,
@@ -3029,7 +3066,7 @@ class TestViewOps(DTensorContinuousTestBase):
         )
         self.assertEqual(out_plc, [Replicate(), Replicate()])
 
-    def test_input_dim_rejects_int_comparison(self):
+    def test_input_dim_rejects_int_comparison(self, device):
         """InputDim.__eq__ should raise TypeError when compared with int.
 
         Regression guard: shard.dim == in_dim (int == InputDim) silently
@@ -3054,13 +3091,14 @@ class TestViewOps(DTensorContinuousTestBase):
         """Assert use_strided_shard_as_shard_order matches expected_flag."""
         self.assertEqual(dt._spec.use_strided_shard_as_shard_order, expected_flag)
 
-    def test_strided_shard_propagates_through_chained_ops(self):
+    def test_strided_shard_propagates_through_chained_ops(self, device):
         """Verify use_strided_shard_as_shard_order=False propagates through
         chained pointwise ops after flatten produces _StridedShard."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         torch.manual_seed(42)
         B, num_heads, S, head_dim = 2, 6, 4, 8
-        full = torch.randn(B, num_heads, S, head_dim, device=self.device_type)
+        full = torch.randn(B, num_heads, S, head_dim, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
 
         # flatten(0,1): Shard(1) on non-first flatten dim -> _StridedShard(0)
@@ -3085,14 +3123,15 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = full.flatten(0, 1).relu().add(1.0).mul(0.5).abs()
         self.assertEqual(result.full_tensor(), expected)
 
-    def test_strided_shard_propagates_through_reduction(self):
+    def test_strided_shard_propagates_through_reduction(self, device):
         """Verify use_strided_shard_as_shard_order=False propagates through
         reduction ops that don't reduce the _StridedShard dim."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         torch.manual_seed(42)
         # shape: (2, 6, 4, 8), shard on dim 1
         B, num_heads, S, head_dim = 2, 6, 4, 8
-        full = torch.randn(B, num_heads, S, head_dim, device=self.device_type)
+        full = torch.randn(B, num_heads, S, head_dim, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
 
         # flatten(0,1) -> (12, 4, 8) with _StridedShard(0)
@@ -3107,13 +3146,14 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = full.flatten(0, 1).sum(dim=-1)
         self.assertEqual(reduced.full_tensor(), expected)
 
-    def test_strided_shard_propagates_through_matmul(self):
+    def test_strided_shard_propagates_through_matmul(self, device):
         """Verify use_strided_shard_as_shard_order=False propagates when a
         _StridedShard tensor participates in matmul."""
-        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
         torch.manual_seed(42)
         B, num_heads, S, head_dim = 2, 6, 4, 8
-        full = torch.randn(B, num_heads, S, head_dim, device=self.device_type)
+        full = torch.randn(B, num_heads, S, head_dim, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(1)])
 
         # flatten(0,1) -> (12, 4, 8) with _StridedShard(0)
@@ -3122,7 +3162,7 @@ class TestViewOps(DTensorContinuousTestBase):
         self._assert_strided_shard_flag(flat, False)
 
         # matmul with a replicated weight: (12, 4, 8) @ (8, 16) -> (12, 4, 16)
-        weight = torch.randn(head_dim, 16, device=self.device_type)
+        weight = torch.randn(head_dim, 16, device=device_type)
         weight_dt = distribute_tensor(weight, mesh, [Replicate()])
         result = torch.matmul(flat, weight_dt)
         self._assert_strided_shard_flag(result, False)
@@ -3130,12 +3170,13 @@ class TestViewOps(DTensorContinuousTestBase):
         expected = torch.matmul(full.flatten(0, 1), weight)
         self.assertEqual(result.full_tensor(), expected)
 
-    def test_strided_shard_propagates_2d_mesh(self):
+    def test_strided_shard_propagates_2d_mesh(self, device):
         """Verify use_strided_shard_as_shard_order=False propagates on a 2D mesh."""
-        mesh = init_device_mesh(self.device_type, (self.world_size // 2, 2))
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size // 2, 2))
         torch.manual_seed(42)
         # shape: (3, 4, 8), shard dim 0 on mesh dim 0, replicate on mesh dim 1
-        full = torch.randn(3, 4, 8, device=self.device_type)
+        full = torch.randn(3, 4, 8, device=device_type)
         dt = distribute_tensor(full, mesh, [Shard(0), Replicate()])
 
         # flatten(0,1) -> (12, 8); Shard(0) stays Shard(0), Replicate stays
@@ -3149,21 +3190,31 @@ class TestViewOps(DTensorContinuousTestBase):
         self.assertEqual(result.full_tensor(), expected)
 
 
+local_tensor_skips = [
+    # Comparing data pointers is not supported for local tensor
+    "test_dtensor_view_op_uneven",
+    # These tests use ShapeEnv directly, not local tensor tests
+    "test_view_groups_unbacked_symint",
+    "test_view_groups_unbacked_sharding_propagation",
+    # Too many test cases for LocalTensorMode dispatch overhead
+    "test_dtensor_flatten_1d",
+    "test_dtensor_flatten_2d",
+    "test_dtensor_flatten_multi_mesh",
+    "test_dtensor_flatten_split_multi_mesh",
+]
 TestViewOpsWithLocalTensor = create_local_tensor_test_class(
     TestViewOps,
-    skipped_tests=[
-        # Comparing data pointers is not supported for local tensor
-        "test_dtensor_view_op_uneven",
-        # These tests use ShapeEnv directly, not local tensor tests
-        "test_view_groups_unbacked_symint",
-        "test_view_groups_unbacked_sharding_propagation",
-        # Too many test cases for LocalTensorMode dispatch overhead
-        "test_dtensor_flatten_1d",
-        "test_dtensor_flatten_2d",
-        "test_dtensor_flatten_multi_mesh",
-        "test_dtensor_flatten_split_multi_mesh",
-    ],
+    skipped_tests=local_tensor_skips,
     base_class=LocalDTensorContinuousTestBase,
+)
+instantiate_device_type_tests(
+    TestViewOps, globals(), except_for=["cpu"], allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestViewOpsWithLocalTensor,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
 )
 
 

--- a/test/distributed/tensor/test_xla_integration.py
+++ b/test/distributed/tensor/test_xla_integration.py
@@ -18,7 +18,11 @@ from torch.distributed.tensor import (
     Replicate,
     Shard,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # wrapper to check xla test requirements
@@ -46,6 +50,8 @@ def with_xla(func: Callable) -> Callable:
 
 
 class DTensorXLAIntegrationTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     class SimpleLinear(nn.Module):
         def __init__(self) -> None:
             super(DTensorXLAIntegrationTest.SimpleLinear, self).__init__()

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -696,8 +696,13 @@ class DTensorTestMixin:
 
 class DTensorContinuousTestBase(DTensorTestMixin, MultiProcContinuousTest):
     @classmethod
+    def _selected_device_type(cls) -> str:
+        device_type = cls.device_type
+        return device_type if isinstance(device_type, str) else DEVICE_TYPE
+
+    @classmethod
     def backend_str(cls) -> str:
-        backend = dist.get_default_backend_for_device(DEVICE_TYPE)
+        backend = dist.get_default_backend_for_device(cls._selected_device_type())
         return backend
 
     @classmethod
@@ -705,7 +710,7 @@ class DTensorContinuousTestBase(DTensorTestMixin, MultiProcContinuousTest):
         # Set device before initializing process group to ensure
         # each rank is bound to the correct GPU. However, if world_size > device_count,
         # we skip the test.
-        if torch.accelerator.is_available():
+        if cls._selected_device_type() != "cpu":
             if world_size > torch.accelerator.device_count():
                 sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
             else:
@@ -1223,7 +1228,7 @@ class LocalDTensorTestBase(DTensorTestBase):
 
 def make_wrapped(fn, ctxs):
     @functools.wraps(fn)
-    def wrapped(self):
+    def wrapped(self, *args, **kwargs):
         torch._dynamo.reset()
         stack = contextlib.ExitStack()
         for ctx in ctxs:
@@ -1232,12 +1237,20 @@ def make_wrapped(fn, ctxs):
             else:
                 stack.enter_context(ctx)
         try:
-            out = fn(self)
+            out = fn(self, *args, **kwargs)
         finally:
             stack.close()
         return out
 
     return wrapped
+
+
+def make_skipped(fn):
+    @functools.wraps(fn)
+    def skipped(self, *args, **kwargs):
+        self.skipTest("Skipped test")
+
+    return skipped
 
 
 def create_local_tensor_test_class(
@@ -1252,7 +1265,7 @@ def create_local_tensor_test_class(
         if not callable(fn):
             continue
         elif name in skipped_tests:
-            dct[name] = lambda self: self.skipTest("Skipped test")
+            dct[name] = make_skipped(fn)
         elif name.startswith("test_"):
             ctxs = [
                 lambda test: test._get_local_tensor_mode(),


### PR DESCRIPTION
## Summary

This PR classifies DTensor operator tests by hardware responsibility and removes fixed-device assumptions from the accelerator-dependent paths.

## Changes

- Classify and instantiate the affected convolution, dynamic-shape, embedding, experimental, initialization, math, pointwise, and view operator tests as accelerator tests.
- Pass generated device arguments into device-specific test methods and use the selected device module where needed.
- Keep CUDA-specific RMSNorm coverage in a dedicated CUDA test class instantiated only for CUDA.
- Mark the XLA integration test as generic while preserving its existing XLA availability gate.
- Update shared DTensor test helpers to select the generated device type and to forward generated arguments through LocalTensor wrappers.

## Scope

This PR changes nine focused test files plus `torch/testing/_internal/distributed/_tensor/common_dtensor.py`. It does not claim that all operators are implemented by every accelerator backend.

## Test plan

- `spin quicklint -a` - passed.
- `python -m compileall -q` for the changed Python test and helper files - passed.
- `spin lint -a` was attempted; changed-file checks passed, while clang-tidy could not run without a local build.
- Device runtime tests were not run locally.

Prepared with assistance from an AI coding assistant.
