### PR TITLE
Stop profiler OVERHEAD activities from claiming device time

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3019,6 +3019,47 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
                 "Error: No kernel events in trace contained grid/block metadata",
             )
 
+    @onlyAccelerator
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_overhead_activities_own_no_device_time(self, device):
+        """OVERHEAD rows account for host-side profiler cost, never device time.
+
+        Overhead activities (CUPTI "Lazy Function Loading" / "Activity Buffer
+        Request", XPU "Instrumentation") carry no correlation id of their own, so
+        they inherit the enclosing op's. They must stay out of the kernel
+        association, otherwise each overhead record claims that op's kernels and
+        the reported device time is multiplied by the number of records.
+        """
+        device_type = device.split(":")[0]
+        # No warm-up iteration: the first traced launches are the ones that emit
+        # overhead records.
+        with profile(activities=get_profiler_activities(device_type)) as prof:
+            self.payload(device=device)
+
+        events = prof.events()
+        device_time_total = sum(
+            e.self_device_time_total for e in events if e.device_type != DeviceType.CPU
+        )
+        for e in events:
+            if e.activity_type == "overhead":
+                self.assertEqual(
+                    e.self_device_time_total,
+                    0,
+                    lambda msg: f"{msg}\noverhead row '{e.name}' claims self device time",
+                )
+                self.assertEqual(
+                    e.device_time_total,
+                    0,
+                    lambda msg: f"{msg}\noverhead row '{e.name}' claims device time",
+                )
+            # A single row can never own more device time than the whole trace
+            # spent on device.
+            self.assertLessEqual(
+                e.self_device_time_total,
+                device_time_total,
+                lambda msg: f"{msg}\nrow '{e.name}' over-reports device time",
+            )
+
 
 instantiate_device_type_tests(TestProfilerDevice, globals())
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -57,6 +57,10 @@ __all__ = [
     "MemRecordsAcc",
 ]
 
+# libkineto's name for ActivityType::OVERHEAD, as returned by
+# KinetoEvent.activity_type().
+_OVERHEAD_ACTIVITY_TYPE = "overhead"
+
 try:
     # Available in Python >= 3.2
     from contextlib import ContextDecorator as _ContextDecorator
@@ -764,7 +768,18 @@ class profile:
                     device_corr_map[corr_id] = []
                 device_corr_map[corr_id].append(fe)
             elif corr_id == 0:
-                frontend_function_events.append(fe)
+                # Profiler OVERHEAD activities (e.g. CUPTI "Buffer Flush" /
+                # "Lazy Function Loading", XPU "Instrumentation") account for the
+                # profiler's own host-side cost. They are reported with no device
+                # (deviceId is hardcoded to -1 by both the CUPTI and XPU handlers),
+                # so they never own device time. They do carry no correlation id of
+                # their own though, so they inherit the enclosing op's id, and
+                # associating them below would hand each of them that op's kernels,
+                # multiplying the reported device time by the number of overhead
+                # records. Reported at
+                # https://github.com/intel/torch-xpu-ops/issues/4824
+                if fe.activity_type != _OVERHEAD_ACTIVITY_TYPE:
+                    frontend_function_events.append(fe)
             else:
                 raise RuntimeError(
                     f"Got negative correlation id {corr_id} in profiler post processing"


### PR DESCRIPTION
Profiler OVERHEAD activities (CUPTI "Lazy Function Loading" / "Activity Buffer Request", XPU "Instrumentation") account for the profiler's own host-side cost and never execute device work: both the CUPTI and the XPU handler hardcode their `deviceId` to `-1`, and `kineto_shim` maps `OVERHEAD` to `DeviceType::CPU`. They were nevertheless being credited with device time in the `key_averages` table.

Root cause: overhead records are emitted without a correlation id of their own, so `kinetoEventCorrelationID()` lets them inherit the correlation id of the op they are nested in. `parse_kineto_results()` then treats every event whose linked correlation id is 0 as a frontend aten/torch op and attaches to it every device event in `device_corr_map[fe.id]`. Each overhead record therefore claims the enclosing op's kernels, and the reported device time is multiplied by the number of overhead records emitted. The kernel-launch runtime row and the parent operator inherit that inflated total through their children. On Intel Arc Pro B-Series Graphics a three-element add reported aten::add "XPU time avg" of 710.981us and Instrumentation "Self XPU %" of 16415% against 13.019us of real kernel time; on an A100 the same workload reported an aten::add CUDA total of 16.831us against 8.063us. The inflation factor is simply the number of overhead records, which is why it is glaring on XPU (a few hundred records, during a kernel launch) and easy to miss on CUDA (a few, before).

The fix keeps `OVERHEAD` activities out of `frontend_function_events`, restoring the invariant that list already documents ("the events in aten or torch frontend level"). Real device time was never wrong, so Self <device> time total is unchanged; only the inflated per-row device columns are corrected. Overhead records keep their host time in the CPU columns and in the Chrome trace.

An alternative was to stop the inheritance in `kinetoEventCorrelationID()` in C++, which is closer to where the misleading id originates. That was not taken because the incorrect *use* of the id is here, as this list's documented contract is what is being violated.

Reported at https://github.com/intel/torch-xpu-ops/issues/4824.

Test Plan:

New regression test `test_overhead_activities_own_no_device_time` asserts that `OVERHEAD` rows report no device time and that no row owns more device time than the whole trace spent on device:

```
python test/profiler/test_profiler.py -k test_overhead_activities_own_no_device_time
```

This change is pure post-processing, so it was also verified against released nightly wheels (no rebuild) by applying the same edit to the installed `torch/autograd/profiler.py` and running an identical workload before and after on both XPU and CUDA devices. After the change, on every device the overhead rows report 0.000us of device time, the kernel-launch row returns to 0.000us, `aten::add`'s device total equals `Self <device> time total` exactly, and the kernel percentages sum to 100% instead of overshooting. The assertions of the new test were mirrored in a standalone script and run against those wheels with the fix toggled: they fail without it ("overhead row `Instrumentation` claims self device time") and pass with it.