### PR TITLE
[Metal][ops] Fix lerp NaN for infinite inputs (#111374)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -35,7 +35,31 @@ struct sub_alpha_functor {
 struct lerp_alpha_functor {
   template <typename T>
   inline T operator()(const T a, const T b, const T alpha) {
-    return static_cast<T>(a + c10::metal::mul(alpha, b - a));
+    // Mirror CPU (aten/src/ATen/native/Lerp.h): two-branch formula to preserve
+    // infinities. |alpha| < 0.5: a + alpha*(b-a)        [accurate for small
+    // weight] otherwise:     b - (b-a)*(1-alpha)    [avoids (-inf)+inf = NaN
+    // for large weight]
+    if (::metal::abs(float(alpha)) < 0.5f) {
+      return static_cast<T>(a + c10::metal::mul(alpha, b - a));
+    }
+    return static_cast<T>(b - c10::metal::mul(b - a, T(1) - alpha));
+  }
+  // float2/half2 are complex types; magnitude check is |alpha|^2 < 0.25.
+  inline float2 operator()(float2 a, float2 b, float2 alpha) {
+    float2 diff = b - a;
+    if (alpha.x * alpha.x + alpha.y * alpha.y < 0.25f) {
+      return a + c10::metal::mul(alpha, diff);
+    }
+    return b - c10::metal::mul(float2{1.0f - alpha.x, -alpha.y}, diff);
+  }
+  inline half2 operator()(half2 a, half2 b, half2 alpha) {
+    float2 fa{float(a.x), float(a.y)}, fb{float(b.x), float(b.y)},
+        fw{float(alpha.x), float(alpha.y)};
+    float2 diff = fb - fa;
+    float2 result = fw.x * fw.x + fw.y * fw.y < 0.25f
+        ? fa + c10::metal::mul(fw, diff)
+        : fb - c10::metal::mul(float2{1.0f - fw.x, -fw.y}, diff);
+    return half2{half(result.x), half(result.y)};
   }
 };
 
@@ -769,22 +793,41 @@ REGISTER_BINARY_ALPHA_OP(sub_alpha, half2, half2, half2);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, float2, float2, float2);
 REGISTER_BINARY_ALPHA_OP(lerp_alpha, half2, half2, half2);
 
-// lerp with tensor weight: lerp(s, e, w) = fma(w, e - s, s)
+// lerp with tensor weight: two-branch formula matching CPU
+// (aten/src/ATen/native/Lerp.h) |w| < 0.5: fma(w, e-s, s)          [accurate
+// for small weight] |w| >= 0.5: e - (e-s)*(1-w)        [avoids (-inf)+inf = NaN
+// for large weight]
 template <typename T>
 inline T lerp_op(T s, T e, T w) {
-  return fma(w, e - s, s);
+  if (::metal::abs(float(w)) < 0.5f) {
+    return fma(w, e - s, s);
+  }
+  return e - (e - s) * (T(1) - w);
 }
 
 inline bfloat lerp_op(bfloat s, bfloat e, bfloat w) {
-  return static_cast<bfloat>(fma(float(w), float(e) - float(s), float(s)));
+  if (::metal::abs(float(w)) < 0.5f) {
+    return static_cast<bfloat>(fma(float(w), float(e) - float(s), float(s)));
+  }
+  return static_cast<bfloat>(
+      float(e) - (float(e) - float(s)) * (1.0f - float(w)));
 }
 
 inline long lerp_op(long s, long e, long w) {
   return s + w * (e - s);
 }
 
+// float2 is a complex type; magnitude check is |w|^2 < 0.25, matching
+// lerp_alpha_functor's complex overloads above. Same NaN-avoidance rationale
+// as the real-valued overloads: for large |w|, s + w*(e-s) can compute
+// (-inf)+inf = NaN component-wise even when the mathematically correct
+// result is finite, so the large-weight branch approaches from e instead.
 inline float2 lerp_op(float2 s, float2 e, float2 w) {
-  return s + mul(w, e - s);
+  float2 diff = e - s;
+  if (w.x * w.x + w.y * w.y < 0.25f) {
+    return s + c10::metal::mul(w, diff);
+  }
+  return e - c10::metal::mul(diff, float2{1.0f - w.x, -w.y});
 }
 
 template <typename T>

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10555,6 +10555,70 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
+    # https://github.com/pytorch/pytorch/issues/111374
+    def test_lerp_neg_inf_scalar_weight(self):
+        # Without the two-branch formula, weight >= 0.5 with one operand at -inf
+        # produces NaN on MPS while CPU returns the correct value.
+        x = torch.tensor([float("-inf"), 0.0, 1.0], device="mps")
+        y = torch.tensor([0.0, 1.0, 2.0], device="mps")
+        for w in (0.1, 0.5, 0.7, 0.99):
+            self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w))
+
+    def test_lerp_pos_inf_scalar_weight(self):
+        x = torch.tensor([float("inf"), 0.0, 1.0], device="mps")
+        y = torch.tensor([0.0, 1.0, 2.0], device="mps")
+        for w in (0.1, 0.5, 0.7, 0.99):
+            self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w))
+
+    def test_lerp_tensor_weight(self):
+        x = torch.tensor([float("-inf"), float("inf"), 0.0, 1.0], device="mps")
+        y = torch.tensor([0.0, 0.0, 1.0, 2.0], device="mps")
+        w = torch.tensor([0.7, 0.7, 0.3, 0.8], device="mps")
+        self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w.cpu()))
+
+    def test_lerp_tensor_weight_end_inf(self):
+        # Same as test_lerp_tensor_weight but with the infinity in `end`
+        # instead of `start`, since the two-branch formula is not symmetric
+        # in its operands.
+        x = torch.tensor([0.0, 0.0, 1.0, 2.0], device="mps")
+        y = torch.tensor([float("-inf"), float("inf"), 0.0, 1.0], device="mps")
+        w = torch.tensor([0.7, 0.7, 0.3, 0.8], device="mps")
+        self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w.cpu()))
+
+    def test_lerp_complex_tensor_weight_inf(self):
+        # The tensor-weight path for complex dtypes (lerp_op(float2, ...) in
+        # BinaryKernel.metal) had its own unconditional formula, separate
+        # from lerp_alpha_functor's scalar-weight overload, and reproduced
+        # the same (-inf)+inf = NaN failure mode #111374 was filed for.
+        # complex128 is not exercised: MPS has no float64 support at all.
+        x_vals = [complex(float("-inf"), 3.0), complex(float("inf"), 3.0), 1.0 + 1j]
+        x = torch.tensor(x_vals, dtype=torch.complex64, device="mps")
+        y = torch.tensor([0.0 + 0j, 0.0 + 0j, 2.0 + 2j], dtype=torch.complex64, device="mps")
+        w = torch.tensor([0.7 + 0.1j, 0.7 + 0.1j, 0.3 + 0.05j], dtype=torch.complex64, device="mps")
+        self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w.cpu()))
+
+    def test_lerp_weight_zero(self):
+        x = torch.tensor([float("-inf"), float("inf"), 1.5], device="mps")
+        y = torch.tensor([0.0, 0.0, 2.5], device="mps")
+        self.assertEqual(torch.lerp(x, y, 0.0), torch.lerp(x.cpu(), y.cpu(), 0.0))
+
+    def test_lerp_weight_one(self):
+        x = torch.tensor([float("-inf"), float("inf"), 1.5], device="mps")
+        y = torch.tensor([0.0, 0.0, 2.5], device="mps")
+        self.assertEqual(torch.lerp(x, y, 1.0), torch.lerp(x.cpu(), y.cpu(), 1.0))
+
+    def test_lerp_normal_values_unchanged(self):
+        x = torch.randn(64, device="mps")
+        y = torch.randn(64, device="mps")
+        for w in (0.1, 0.3, 0.5, 0.7, 0.9):
+            self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w))
+
+    def test_lerp_half(self):
+        x = torch.tensor([float("-inf"), float("inf"), 0.0, 1.0], dtype=torch.half, device="mps")
+        y = torch.tensor([0.0, 0.0, 1.0, 2.0], dtype=torch.half, device="mps")
+        for w in (0.1, 0.7):
+            self.assertEqual(torch.lerp(x, y, w), torch.lerp(x.cpu(), y.cpu(), w))
+
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
Fixes #111374.

torch.lerp on MPS produced NaN for infinite inputs with weight >= 0.5, because the unconditional formula s + w*(e-s) computes (-inf)+inf = NaN component-wise even when the mathematically correct result is finite. Mirrors CPU's two-branch formula (aten/src/ATen/native/Lerp.h): small weight uses the direct formula, large weight approaches from the end operand instead.

Applied to both the scalar-weight and tensor-weight paths, including the complex64 overloads, since the tensor-weight path had a separate, unconditional lerp_op(float2, ...) overload that reproduced the same bug independently.

Test plan:
```
python test/test_mps.py -v -k lerp
```