### PR TITLE
Let expandable segments reuse free blocks larger than max_split_size

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3748,15 +3748,29 @@ class DeviceCachingAllocator {
       }
     }
 
-    // Do not return an oversized block for a large request
-    if ((p.size() < AcceleratorAllocatorConfig::max_split_size()) &&
-        ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()))
-      return false;
-    // Allow oversized block size to be rounded up but within a limit
-    if ((p.size() >= AcceleratorAllocatorConfig::max_split_size()) &&
-        ((*it)->size >=
-         p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
-      return false;
+    // The oversize rules below exist because splitting a standalone
+    // cudaMalloc'ed block keeps the whole block pinned until every piece of it
+    // is free again. A block inside an expandable segment is not a standalone
+    // allocation: the segment's pages are mapped and unmapped independently, so
+    // handing out part of a large free block there does not pin the rest of the
+    // segment. Applying these rules to expandable blocks only rejects memory
+    // that is reusable and forces the segment to grow instead; with
+    // max_split_size_mb set, reserved memory then climbs until the device is
+    // full while the live set stays small. should_split() already ignores
+    // max_split_size when expandable segments are active; this keeps
+    // get_free_block() consistent with it.
+    if (!(*it)->expandable_segment_) {
+      // Do not return an oversized block for a large request
+      if ((p.size() < AcceleratorAllocatorConfig::max_split_size()) &&
+          ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()))
+        return false;
+      // Allow oversized block size to be rounded up but within a limit
+      if ((p.size() >= AcceleratorAllocatorConfig::max_split_size()) &&
+          ((*it)->size >=
+           p.size() +
+               AcceleratorAllocatorConfig::max_non_split_rounding_size()))
+        return false;
+    }
     p.block = *it;
     pool.erase_from_blocks(p.block);
     return true;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6768,6 +6768,99 @@ class TestCudaAllocator(TestCase):
             )
 
     @serialTest()
+    @parametrize("big_request", [False, True])
+    def test_max_split_expandable_reuses_interior_blocks(self, big_request):
+        # An expandable segment must not keep growing just because a free block
+        # inside it is larger than max_split_size. Each iteration frees a pair
+        # of blocks whose merged size exceeds max_split_size, while a small
+        # allocation made after them stays alive and keeps the merged block
+        # away from the segment's unmapped tail. If get_free_block() rejects
+        # that block, every iteration maps fresh pages instead of reusing it and
+        # reserved memory grows without bound.
+        #
+        # get_free_block() has two separate oversize rules and the sizes here
+        # pick which one the reused request hits:
+        #   big_request=False  request 24MB < max_split_size 32MB, merged block
+        #                      36MB >= max_split_size -> first rule
+        #   big_request=True   request 64MB >= max_split_size, merged block 96MB
+        #                      >= 64MB + max_non_split_rounding_size -> second rule
+        mb = 1024 * 1024
+        max_split_mb = 32
+        # Pinned rather than left at its default: the second rule's threshold is
+        # request + max_non_split_rounding_size, so a change to the default would
+        # silently stop big_request=True from reaching that rule.
+        rounding_mb = 20
+        a_mb, b_mb = (64, 32) if big_request else (24, 12)
+        merged_mb = a_mb + b_mb
+        fence_mb = 2
+        cycles = 5
+        fences = []
+        try:
+            torch.cuda.memory.empty_cache()
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:True,max_split_size_mb:{max_split_mb},"
+                f"max_non_split_rounding_mb:{rounding_mb}"
+            )
+
+            def alloc(n):
+                return torch.empty(n * mb, dtype=torch.int8, device="cuda")
+
+            def cycle():
+                a = alloc(a_mb)
+                b = alloc(b_mb)  # a + b merge above max_split_size when freed
+                fences.append(alloc(fence_mb))
+                del a, b
+
+            def reserved():
+                torch.cuda.synchronize()
+                return torch.cuda.memory_reserved()
+
+            cycle()  # warm up: the first iteration has to map its pages
+
+            # Guard against silently testing the ordinary allocator: if
+            # expandable segments were not actually enabled, none of this
+            # exercises the code path under test and the assertions below could
+            # pass for the wrong reason.
+            self.assertTrue(
+                any(
+                    seg.get("is_expandable")
+                    for seg in torch.cuda.memory.memory_snapshot()
+                ),
+                "expandable segments are not active; test would not cover "
+                "get_free_block()'s expandable path",
+            )
+
+            baseline = reserved()
+            per_cycle = []
+            for _ in range(cycles):
+                before = reserved()
+                cycle()
+                per_cycle.append(reserved() - before)
+            growth = reserved() - baseline
+
+            # After the warm-up the merged block is already mapped, so a cycle
+            # that reuses it needs at most another fence. A cycle that rejects
+            # it has to map the whole merged block again, so no single cycle may
+            # grow by as much as the merged block.
+            self.assertLess(
+                max(per_cycle),
+                merged_mb * mb,
+                f"per-cycle reserved growth {per_cycle} (bytes) indicates the "
+                f"{merged_mb}MB interior block is being remapped, not reused",
+            )
+            # Over every cycle combined, the segment must still not have grown
+            # by even one merged block; only the fences are genuinely new.
+            self.assertLess(growth, merged_mb * mb)
+        finally:
+            del fences
+            # Test toggles expandable_segments internally; restore the
+            # suite's baseline so subsequent tests see consistent state.
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+            )
+            torch.cuda.memory.empty_cache()
+
+    @serialTest()
     def test_garbage_collect_expandable(self):
         try:
             orig = torch.cuda.get_per_process_memory_fraction(0)


### PR DESCRIPTION
Fixes #123548.

### The problem

With `max_split_size_mb` and `expandable_segments:True` set together, `reserved` memory
grows without bound while the live set stays small, until the device is full and the
allocator has to release and retry.

Reproducer using nothing but `torch.empty`, on a 16 GiB card:

```
PYTORCH_ALLOC_CONF=max_split_size_mb:128,expandable_segments:True
```

| cycle | 0 | 20 | 40 | 60 | 80 | 100 |
|---|---|---|---|---|---|---|
| `allocated` (MiB) | 66 | 106 | 146 | 186 | 226 | 266 |
| `reserved` (MiB) | 220 | 2,980 | 5,760 | 8,520 | 11,300 | 14,060 |

Each cycle allocates A = 91 MiB and B = 45.5 MiB, then a 2 MiB block that stays alive,
then frees A and B. Either option on its own, or the same allocation pattern without the
small block that stays alive, keeps `reserved` under 500 MiB.

### Why it happens

`get_free_block()` applies the `max_split_size` oversize rules to every candidate block,
including blocks that live inside an expandable segment:

```c++
    // Do not return an oversized block for a large request
    if ((p.size() < AcceleratorAllocatorConfig::max_split_size()) &&
        ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()))
      return false;
```

In the reproducer, freeing A and B leaves a merged 136.5 MiB free block. The 2 MiB block
allocated after them is still alive, so that merged block sits in the interior of the
segment and is not adjacent to its unmapped tail. The next 91 MiB request is smaller than
`max_split_size` while the block is larger than it, so the block is rejected, the
expandable-segment path cannot reach it either, and the segment is grown instead.

These rules exist because splitting a standalone `cudaMalloc`ed block keeps the whole
block pinned until every piece of it is free again. That does not apply inside an
expandable segment, where pages are mapped and unmapped independently: handing out part of
a large free block there does not pin the rest of the segment. So the rules reject memory
that is in fact reusable, and force the segment to grow instead.

### The change

Both oversize checks in `get_free_block()` are skipped for blocks that belong to an
expandable segment.

The condition tests the *block* (`(*it)->expandable_segment_`), not the current setting
(`p.is_expandable_segments_active`). Testing the setting would also lift the rules for
ordinary blocks that were created before expandable segments were switched on, which is
not intended — the reason the rules do not apply is a property of the block, not of the
configuration in effect at the time of the request.

This makes `get_free_block()` consistent with the two other places in the same file that
already treat expandable segments as an exception:

- `should_split()` ignores `max_split_size` when expandable segments are active
- `release_available_cached_blocks()` does not release expandable segments (#134338)

`get_free_block()` was the remaining one.

### Test

`test_max_split_expandable_reuses_interior_blocks` in `test/test_cuda.py` runs the same
pattern at reduced scale. It is parametrized over the two oversize rules the change
touches, since sizes decide which one a request hits:

| case | request | merged free block | rule reached |
|---|---|---|---|
| `big_request=False` | 24 MiB (< `max_split_size` 32 MiB) | 36 MiB (>= 32 MiB) | first |
| `big_request=True` | 64 MiB (>= `max_split_size`) | 96 MiB (>= 64 + 20 MiB) | second |

`max_non_split_rounding_mb` is set explicitly by the test rather than left at its default,
so a change to that default cannot silently stop the second case from reaching the rule it
targets. The assertions are derived from the mechanism rather than a fixed number: no
single cycle may grow `reserved` by as much as the merged block, and the cycles combined
may not grow by one merged block either. The test also asserts that an expandable segment
exists before it measures, so it cannot pass by falling back to the ordinary allocator.
It peaks at a few hundred MiB, so it does not need a large card.

### Before/after

Measured on two clean local builds of this PR's parent (`04de8a6b2a`), ROCm 7.2.4 /
gfx1201, differing only in this PR's allocator change:

| | before | after |
|---|---|---|
| `..._big_request_False` | FAILED | PASSED |
| `..._big_request_True` | FAILED | PASSED |
| `TestCudaAllocator -k "expandable or max_split"` | 3 passed, 1 skipped | 5 passed, 1 skipped |
| reserved growth, first rule, 5 cycles | 200 MiB | 20 MiB |
| reserved growth, second rule, 5 cycles | 500 MiB | 20 MiB |

An auxiliary measurement using the same allocation sequence also records addresses: before
the change, the request landed inside the free range it should have reused in 0 of 5
cycles; after, in 5 of 5, with the whole requested interval contained in that range. The
full provenance of the two builds and the raw numbers are in a comment below.

### Verification status

Verified locally only on ROCm 7.2.4 / gfx1201 (Radeon RX 9070 XT, single GPU). The edit is
in `c10/cuda/CUDACachingAllocator.cpp`; what ran on this machine is the hipified copy of
the same conditional, so the source edit is shared but the generated code and the runtime
underneath are not. I do not have a CUDA device, so the CUDA path is unverified locally
and I am relying on CI for it.

CI has not run on this PR yet: the workflow runs are sitting at `action_required`, which I
believe needs a maintainer to approve them for a first-time contributor. I would
appreciate that approval — the CUDA side of this change is exactly what I cannot check
myself.

### Notes

I found this while chasing a ROCm-specific problem where the resulting map/unmap churn
also loses the contents of a live allocation (ROCm/ROCm#6603). That part is not addressed
here and is not what this PR claims to fix. The evidence in this PR covers block selection
in `get_free_block()` and the resulting reserved-memory growth, and says nothing about
data integrity.
