### PR TITLE
[Windows] Fix non-ASCII file paths serialization (#157624)

### DIFF
--- a/caffe2/serialize/file_adapter.cc
+++ b/caffe2/serialize/file_adapter.cc
@@ -4,12 +4,19 @@
 #include <cstdio>
 #include <string>
 #include "caffe2/core/common.h"
+#ifdef _WIN32
+#include <c10/util/Unicode.h>
+#endif
 
 namespace caffe2 {
 namespace serialize {
 
 FileAdapter::RAIIFile::RAIIFile(const std::string& file_name) {
+#ifdef _WIN32
+  fp_ = _wfopen(c10::u8u16(file_name).c_str(), L"rb");
+#else
   fp_ = fopen(file_name.c_str(), "rb");
+#endif
   if (fp_ == nullptr) {
     auto old_errno = errno;
 #if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_VER))

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -4,6 +4,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <istream>
 #include <ostream>
@@ -722,9 +723,9 @@ void PyTorchStreamWriter::setup(const string& file_name) {
 
   const std::string dir_name = parentdir(file_name);
   if (!dir_name.empty()) {
-    struct stat st;
-    bool dir_exists =
-        (stat(dir_name.c_str(), &st) == 0 && (st.st_mode & S_IFDIR));
+    std::error_code ec;
+    bool dir_exists = std::filesystem::is_directory(
+        std::filesystem::path(reinterpret_cast<const char8_t*>(dir_name.c_str())), ec);
     TORCH_CHECK(
         dir_exists, "Parent directory ", dir_name, " does not exist.");
   }
@@ -735,9 +736,8 @@ void PyTorchStreamWriter::setup(const string& file_name) {
     try {
       file_stream_.exceptions(std::ios_base::failbit | std::ios_base::badbit);
       file_stream_.open(
-          file_name,
-          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary
-        );
+          std::filesystem::path(reinterpret_cast<const char8_t*>(file_name.c_str())),
+          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
     } catch (const std::ios_base::failure&) {
 #ifdef _WIN32
       // Windows have verbose error code, we prefer to use it than std errno.

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -11,9 +11,11 @@ import torch
 from torch import Tensor
 from torch.testing._internal.common_cuda import SM120OrLater
 from torch.testing._internal.common_utils import (
+    IS_FILESYSTEM_UTF8_ENCODING,
     IS_WINDOWS,
     raise_on_run_directly,
     skipIfTorchDynamo,
+    TemporaryDirectoryName,
     TemporaryFileName,
 )
 
@@ -403,6 +405,40 @@ class TestSaveLoad(JitTestCase):
 
         x = torch.tensor([1.0, 2.0, 3.0, 4.0])
         self.assertTrue(torch.equal(m(x), m2(x)))
+
+    @unittest.skipIf(
+        not IS_FILESYSTEM_UTF8_ENCODING,
+        "requires UTF-8 filesystem encoding",
+    )
+    def test_save_load_non_ascii_path(self):
+        payload = b"hello non-ascii world"
+        for suffix in ["用户_流星", "ユーザー", "данные", "données_réseau"]:
+            with self.subTest(suffix=suffix):
+                with TemporaryDirectoryName(suffix=suffix) as dname:
+                    path = os.path.join(dname, "archive.zip")
+                    writer = torch._C.PyTorchFileWriter(path)
+                    writer.write_record("data.pkl", payload, len(payload))
+                    writer.write_end_of_file()
+                    reader = torch._C.PyTorchFileReader(path)
+                    self.assertEqual(reader.get_record("data.pkl"), payload)
+                    del reader
+
+    @unittest.skipIf(
+        not IS_FILESYSTEM_UTF8_ENCODING,
+        "requires UTF-8 filesystem encoding",
+    )
+    def test_save_load_non_ascii_nested_path(self):
+        payload = b"nested non-ascii"
+        with TemporaryDirectoryName(suffix="非ASCII") as dname:
+            nested = os.path.join(dname, "データ", "モデル")
+            os.makedirs(nested)
+            path = os.path.join(nested, "archive.zip")
+            writer = torch._C.PyTorchFileWriter(path)
+            writer.write_record("data.pkl", payload, len(payload))
+            writer.write_end_of_file()
+            reader = torch._C.PyTorchFileReader(path)
+            self.assertEqual(reader.get_record("data.pkl"), payload)
+            del reader
 
     def test_save_nonexit_file(self):
         class Foo(torch.nn.Module):

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -32,6 +32,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/qualified_name.h>
 #include <cerrno>
+#include <filesystem>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -864,7 +865,9 @@ void ExportModule(
     return;
   }
   std::ofstream ofile;
-  ofile.open(filename, std::ios::binary | std::ios::out);
+  ofile.open(
+      std::filesystem::path(reinterpret_cast<const char8_t*>(filename.c_str())),
+      std::ios::binary | std::ios::out);
   if (ofile.fail()) {
     std::stringstream message;
     if (errno == ENOENT) {


### PR DESCRIPTION
Fixes:
- #157624

On Windows, the C++ serialization layer fails to open files whose paths contain non-ASCII characters. 
The root cause is that calls like `fopen()`, `stat()` interpret paths using the system's ANSI code page.

Test Plan:
```
python -m pytest test/jit/test_save_load.py -xvs -k "non_ascii"
```

