### PR TITLE
[docs] Clarify index_add_ destination indices

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2362,7 +2362,7 @@ Note:
 
 Args:
     dim (int): dimension along which to index
-    index (Tensor): indices of ``source`` to select from,
+    index (Tensor): indices of :attr:`self` to add to,
             should have dtype either `torch.int64` or `torch.int32`
     source (Tensor): the tensor containing values to add
 


### PR DESCRIPTION
Fixes #180119.

The `Tensor.index_add_` argument documentation currently says `index` selects
from `source`. Its values actually identify the positions in `self` that
receive the corresponding source slices. Describe `index` as destination
indices, consistent with the operation and the neighboring `index_reduce_`
documentation.

I verified the behavior with reordered destination indices. PYFMT, Ruff, the
Python compile check, and `git diff --check` pass.

> **AI assistance disclosure:** Codex helped prepare the change, verification,
> and this PR summary.

**Human commentary:** I reviewed and verified this contribution end to end before authorizing submission.
