### PR TITLE
[profiler] Scope PM sampling to trace windows

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -3591,6 +3591,130 @@ class TestWindowFinalizer(TestCase):
         self.assertIsNone(w._poll_thread)
 
 
+@unittest.skipIf(not TEST_CUPTI_PYTHON, "requires cupti-python")
+class TestProfilerObserverPmWindow(TestCase):
+    class _FakeMonitor:
+        def __init__(self) -> None:
+            self.now = 0
+            self.release_now = None
+            self.release_frame = None
+            self.requests = []
+            self.releases = 0
+            self.pm_sink = None
+            self.unregistered = False
+
+        def register(self, activities, callback):
+            self.callback = callback
+            return object()
+
+        def unregister(self, obs):
+            self.unregistered = True
+
+        def now_record_ns(self):
+            return self.now
+
+        def convert_time(self, value):
+            return value
+
+        def convert_time_array(self, values):
+            return values
+
+        def request_pm_sampling(self, sink, metrics):
+            self.requests.append(list(metrics))
+            self.pm_sink = sink
+
+        def release_pm_sampling(self, sink):
+            if self.pm_sink != sink:
+                return
+            self.pm_sink = None
+            self.releases += 1
+            if self.release_now is not None:
+                self.now = self.release_now
+            if self.release_frame is not None:
+                sink(self.release_frame)
+
+        def flush(self, *, sync=False):
+            pass
+
+    def _observer(self, monitor, *, defer_export):
+        from torch.profiler._cupti import monitor as cupti_monitor
+        from torch.profiler._cupti.observers.base import CuptiMonitorObserver
+        from torch.profiler._cupti.observers.profiler import ProfilerObserver
+
+        with (
+            patch.object(cupti_monitor, "CuptiMonitor", return_value=monitor),
+            patch.object(
+                CuptiMonitorObserver, "_register_graph_destroy_hooks", return_value=None
+            ),
+            patch.object(torch.cuda, "is_available", return_value=True),
+        ):
+            observer = ProfilerObserver(
+                enable_pm_sampling=True,
+                pm_metrics=["metric"],
+                defer_export=defer_export,
+            )
+        self.addCleanup(observer.join)
+        return observer
+
+    def test_pm_sampling_follows_window_lifetime(self):
+        monitor = self._FakeMonitor()
+        observer = self._observer(monitor, defer_export=True)
+        self.assertEqual(monitor.requests, [])
+
+        monitor.now = 100
+        observer.open_window()
+        self.assertEqual(monitor.requests, [["metric"]])
+        self.assertIsNotNone(monitor.pm_sink)
+
+        monitor.now = 200
+        window_id = observer.close_window()
+        self.assertEqual(window_id, 0)
+        self.assertEqual(monitor.releases, 1)
+        self.assertIsNone(monitor.pm_sink)
+        with observer._win_lock:
+            self.assertEqual(list(observer._boundaries), [(0, 200)])
+        self.assertIsNotNone(observer._obs)
+        self.assertFalse(monitor.unregistered)
+
+        observer.join()
+        self.assertEqual(monitor.releases, 1)
+        self.assertTrue(monitor.unregistered)
+
+    def test_close_keeps_pm_tail_with_prestamped_boundary(self):
+        import numpy as np
+
+        monitor = self._FakeMonitor()
+        observer = self._observer(monitor, defer_export=False)
+
+        def frame(*timestamps):
+            ts = np.asarray(timestamps, dtype=np.int64)
+            return {
+                "start_ns": ts,
+                "device_id": np.zeros(len(ts), dtype=np.int64),
+                "metric": ts.copy(),
+            }
+
+        observer.on_pm_samples(frame(50))
+        monitor.now = 100
+        observer.open_window()
+        observer.on_pm_samples(frame(150))
+        monitor.release_frame = frame(190, 210)
+        monitor.release_now = 900
+
+        monitor.now = 200
+        window_id = observer.close_window()
+        with observer._win_lock:
+            self.assertEqual(list(observer._boundaries), [(0, 200)])
+
+        observer._poll_once()
+        self.assertIsNone(observer._windows[window_id]["built"])
+
+        observer.join()
+        pm = observer._windows[window_id]["built"]["columns"]["pm_sampling"]
+        self.assertEqual(pm["start_ns"].tolist(), [150, 190])
+        self.assertEqual(pm["metric"].tolist(), [150, 190])
+
+
 @unittest.skipIf(IS_WINDOWS, "Test is flaky on Windows")
 @unittest.skipIf(not TEST_CUDA, "CUDA is required")
 class TestCuptiMonitorProfiler(TestCase):

--- a/torch/profiler/_cupti/observers/observation_window.py
+++ b/torch/profiler/_cupti/observers/observation_window.py
@@ -68,12 +68,13 @@ class WindowFinalizerMixin:
         self._poll_thread: _PollThread | None = None
         self._poll_thread_name = thread_name
 
-    def mark_boundary(self) -> int:
+    def mark_boundary(self, *, boundary_ns: int | None = None) -> int:
         """Stamp the native record clock as a window boundary and queue it for finalization
         once delivered records cover it. Returns the window id. Lazily starts the poller on
         the first call (unless auto_start_poller is False). Does NOT flush -- the caller
-        decides whether to nudge a flush so the poller sees the records."""
-        boundary = self._boundary_clock_ns()
+        decides whether to nudge a flush so the poller sees the records. Pass ``boundary_ns``
+        to enqueue a boundary captured before synchronous close work."""
+        boundary = self._boundary_clock_ns() if boundary_ns is None else boundary_ns
         with self._win_lock:
             window_id = self._next_window_id
             self._next_window_id += 1

--- a/torch/profiler/_cupti/observers/profiler.py
+++ b/torch/profiler/_cupti/observers/profiler.py
@@ -330,9 +330,9 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
                     register_graph_destroy_hook(recorder.purge_exec_ids)
                 )
         # Opt-in PM sampling (true SM-active % + DRAM-throughput %) is a feature of the CUPTI
-        # monitor: it registers us as a consumer (with our metrics) of the current device's shared
-        # session, delivering decoded frames to on_pm_samples (they render as GPU counter tracks).
-        # Off by default; also a no-op when no metrics are configured (pm_metrics).
+        # monitor. Each open window registers us as a consumer (with our metrics) of the current
+        # device's shared session, delivering decoded frames to on_pm_samples (they render as GPU
+        # counter tracks). Off by default; also a no-op when no metrics are configured (pm_metrics).
         self._pm_metrics = list(pm_metrics or [])
         self._pm_enabled = (
             enable_pm_sampling
@@ -344,8 +344,6 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
         # records (via _timed_frames); no separate buffer. Per-device max start_ns delivered:
         # a monotonic guard so each sample is enqueued at most once.
         self._pm_last_ns: dict[int, int] = {}
-        if self._pm_enabled and self._monitor is not None:
-            self._monitor.request_pm_sampling(self.on_pm_samples, self._pm_metrics)
 
     def _boundary_clock_ns(self) -> int:
         # Stamp the boundary in the converted clock the events' start_ns use (convert_time
@@ -466,12 +464,17 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
         self._record_calling_thread()
         with self._lock:
             self._open_start = self._boundary_clock_ns()
+        if self._pm_enabled and self._monitor is not None:
+            self._monitor.request_pm_sampling(self.on_pm_samples, self._pm_metrics)
 
     def close_window(self) -> int | None:
         """End the open window and queue it for deferred export; snapshots its annotations +
         thread map now. Pair with :meth:`set_export` for the paths. Returns the window id."""
         if not self.available:
             return None
+        boundary = self._boundary_clock_ns()
+        if self._pm_enabled and self._monitor is not None:
+            self._monitor.release_pm_sampling(self.on_pm_samples)
         with self._lock:
             start = self._open_start if self._open_start is not None else 0
             self._open_start = None
@@ -479,7 +482,7 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
             thread_map = {
                 pid: dict(mapping) for pid, mapping in self._thread_resource_map.items()
             }
-        window_id = self.mark_boundary()
+        window_id = self.mark_boundary(boundary_ns=boundary)
         with self._lock:
             self._windows[window_id] = {
                 "start": start,
@@ -515,8 +518,7 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
         (default) sync-flushes the tail, for use on the training thread. ``force=False`` (an
         off-thread finalize) must NOT flush, so it waits up to ``timeout_s`` for the poller to
         cover the windows, force-draining only if it stalls."""
-        # Release PM sampling first: its final tail decode must land in _timed_frames BEFORE the
-        # windows finalize, so those samples can be sliced into the closing window.
+        # Idempotent fallback for callers that join without closing the window first.
         if self._pm_enabled and self._monitor is not None:
             self._monitor.release_pm_sampling(self.on_pm_samples)
         if getattr(self, "_boundaries", None) is not None:
@@ -547,12 +549,13 @@ class ProfilerObserver(WindowFinalizerMixin, CuptiMonitorObserver):
             self._monitor.flush(sync=True)
 
     def _window_watermark_ns(self) -> int:
+        # PM samples use a separate ring and cannot prove activity-buffer coverage.
         with self._lock:
             return max(
                 (
                     int(frame["start_ns"].max())
-                    for _, frame in self._timed_frames
-                    if len(frame["start_ns"])
+                    for kind, frame in self._timed_frames
+                    if kind != "pm_sampling" and len(frame["start_ns"])
                 ),
                 default=-1,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193405

ProfilerObserver registered PM sampling during prepare_trace but did not release it until join. With deferred CUPTI monitor export, that left PM active after stop_trace, so the next monitor drain could synchronously decode a large backlog on a replay-end callback.

Start PM sampling when open_window establishes the profile window and release it synchronously at close_window before queuing the boundary. Capture the close boundary first so PM teardown latency does not extend the trace, preserve final PM tail delivery, and exclude PM frames from the activity-delivery watermark because they use a separate ring. Keep the join release as an idempotent fallback.

Splitting producer stop from final PM decode would require a PmSampler state machine that safely handles shared consumers and restart. This change retains the existing final-poll/detach semantics while correcting lifetime ownership.

Authored with assistance from an AI coding assistant.

Test Plan:

4 tests passed.