### PR TITLE
Fix CUDA illegal memory access in embedding_bag per_sample_weights backward

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -485,6 +485,7 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
     const index_t* offset2bag,  // contiguous
     int64_t num_samples,
     int64_t embedding_features,
+    int64_t num_embeddings,
     scalar_t* output,
     index_t padding_idx) {
   using accscalar_t = acc_type<scalar_t, true>;
@@ -498,7 +499,8 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
   for (int sample_idx = warp; sample_idx < num_samples; sample_idx += num_warps) {
     accscalar_t result = 0.;
     const int bag_idx = (int)offset2bag[sample_idx];
-    const int embedding_idx = (int)indices[sample_idx];
+    const index_t embedding_idx = indices[sample_idx];
+    CUDA_KERNEL_ASSERT((embedding_idx >= 0 && embedding_idx < num_embeddings) && "Invalid input index in EmbeddingBag: index out of range [0, numRows)");
     if (embedding_idx != padding_idx) {
       for (int feature_idx = thread_in_warp; feature_idx < embedding_features;
           feature_idx += C10_WARP_SIZE) {
@@ -562,6 +564,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
             offset2bag.const_data_ptr<index_t>(),
             num_samples,
             embedding_features,
+            weight.size(0),
             output.mutable_data_ptr<scalar_t>(),
             padding_idx);
         C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -485,6 +485,7 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
     const index_t* offset2bag,  // contiguous
     int64_t num_samples,
     int64_t embedding_features,
+    int64_t num_bags,
     int64_t num_embeddings,
     scalar_t* output,
     index_t padding_idx) {
@@ -498,8 +499,11 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
   // This involves doing one dot product between grad[bag_idx] and weight[embedding_idx].
   for (int sample_idx = warp; sample_idx < num_samples; sample_idx += num_warps) {
     accscalar_t result = 0.;
-    const int bag_idx = (int)offset2bag[sample_idx];
+    const index_t bag_idx = offset2bag[sample_idx];
     const index_t embedding_idx = indices[sample_idx];
+    CUDA_KERNEL_ASSERT(
+        (bag_idx >= 0 && bag_idx < num_bags) &&
+        "Invalid offset2bag value in EmbeddingBag: value out of range [0, numBags)");
     CUDA_KERNEL_ASSERT((embedding_idx >= 0 && embedding_idx < num_embeddings) && "Invalid input index in EmbeddingBag: index out of range [0, numRows)");
     if (embedding_idx != padding_idx) {
       for (int feature_idx = thread_in_warp; feature_idx < embedding_features;
@@ -564,6 +568,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
             offset2bag.const_data_ptr<index_t>(),
             num_samples,
             embedding_features,
+            grad.size(0),
             weight.size(0),
             output.mutable_data_ptr<scalar_t>(),
             padding_idx);

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1198,9 +1198,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
     # https://github.com/pytorch/pytorch/issues/192445
     @onlyOn(["cuda"])
     @dtypes(torch.int32, torch.int64)
-    def test_embedding_bag_per_sample_weights_mutated_indices(
-        self, device, dtype
-    ):
+    def test_embedding_bag_per_sample_weights_mutated_indices(self, device, dtype):
         stderr = self.runWithPytorchAPIUsageStderr(f"""\
 #!/usr/bin/env python3
 

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: nn"]
 import itertools
 import random
+import subprocess
+import sys
 import unittest
 from itertools import product
 
@@ -31,6 +33,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     set_default_dtype,
     skipIfTorchDynamo,
+    slowTest,
     TEST_CUDA,
     TEST_XPU,
 )
@@ -1197,43 +1200,92 @@ class TestEmbeddingNNDeviceType(NNTestCase):
 
     # https://github.com/pytorch/pytorch/issues/192445
     @onlyOn(["cuda"])
+    @slowTest
     @dtypes(torch.int32, torch.int64)
-    def test_embedding_bag_per_sample_weights_mutated_indices(self, device, dtype):
-        stderr = self.runWithPytorchAPIUsageStderr(f"""\
-#!/usr/bin/env python3
-
+    @parametrize_test("target", ("indices", "offset2bag"))
+    @parametrize_test("bound", ("negative", "upper"))
+    def test_embedding_bag_per_sample_weights_rejects_invalid_saved_indices(
+        self, device, dtype, target, bound
+    ):
+        script = f"""
 import torch
-import torch.nn.functional as F
-from torch.testing._internal.common_utils import run_tests, TestCase
 
-class TestEmbeddingBagMutatedIndices(TestCase):
-    def test_mutated_indices(self):
-        weight = torch.ones((5, 2), device="{device}")
-        indices = torch.zeros(1024, dtype={dtype}, device="{device}")
-        indices_alias = torch.from_dlpack(indices)
-        offsets = torch.tensor([0], dtype={dtype}, device="{device}")
-        per_sample_weights = torch.ones(1024, device="{device}", requires_grad=True)
+weight = torch.ones((5, 2), device={device!r})
+indices = torch.zeros(1024, dtype={dtype}, device={device!r})
+indices_alias = torch.from_dlpack(indices)
+offsets = torch.tensor([0], dtype={dtype}, device={device!r})
+per_sample_weights = torch.ones(1024, device={device!r}, requires_grad=True)
 
-        output = F.embedding_bag(
+output, offset2bag, _, _ = torch._embedding_bag(
+    weight,
+    indices,
+    offsets,
+    False,
+    0,
+    False,
+    per_sample_weights,
+)
+if {target!r} == "indices":
+    invalid_value = -1 if {bound!r} == "negative" else weight.size(0)
+    indices_alias.fill_(invalid_value)
+else:
+    invalid_value = -1 if {bound!r} == "negative" else output.size(0)
+    torch.from_dlpack(offset2bag).fill_(invalid_value)
+
+output.sum().backward()
+torch.cuda.synchronize()
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
+        stderr = proc.stderr
+        expected_assert = (
+            "embedding_idx >= 0 && embedding_idx < num_embeddings"
+            if target == "indices"
+            else "bag_idx >= 0 && bag_idx < num_bags"
+        )
+        has_cuda_assert = (
+            "device-side assert triggered" in stderr
+            and "EmbeddingBag.cu" in stderr
+            and expected_assert in stderr
+        )
+        has_hip_assert = (
+            "hipErrorLaunchFailure" in stderr
+            or "unspecified launch failure" in stderr
+            or "HSA_STATUS_ERROR_EXCEPTION" in stderr
+        )
+        self.assertTrue(
+            has_cuda_assert or has_hip_assert,
+            lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
+        )
+
+    # https://github.com/pytorch/pytorch/issues/192445
+    @onlyOn(["cuda"])
+    @largeTensorTest("5GB", device="cuda")
+    def test_embedding_bag_per_sample_weights_large_index(self, device):
+        large_index = 2**31
+        weight = torch.empty((large_index + 1, 1), device=device, dtype=torch.float16)
+        weight[large_index] = 3.0
+        indices = torch.tensor([large_index], device=device, dtype=torch.int64)
+        offsets = torch.tensor([0], device=device, dtype=torch.int64)
+        per_sample_weights = torch.ones(
+            1, device=device, dtype=torch.float16, requires_grad=True
+        )
+
+        torch.nn.functional.embedding_bag(
             indices,
             weight,
             offsets,
             mode="sum",
             per_sample_weights=per_sample_weights,
-        )
-        indices_alias.fill_(weight.size(0))
-        output.sum().backward()
-        torch.cuda.synchronize()
+        ).sum().backward()
 
-if __name__ == "__main__":
-    run_tests()
-""")
-        has_cuda_assert = "device-side assert triggered" in stderr
-        has_hip_assert = "launch failure" in stderr
-        has_hip_assert = has_hip_assert or "HSA_STATUS_ERROR_EXCEPTION" in stderr
-        self.assertTrue(
-            has_cuda_assert or has_hip_assert,
-            lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
+        self.assertEqual(
+            per_sample_weights.grad,
+            torch.tensor([3.0], device=device, dtype=torch.float16),
         )
 
     def test_embedding_bag_dimension_errors(self, device):

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1195,6 +1195,49 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                     mode=mode,
                 )
 
+    # https://github.com/pytorch/pytorch/issues/192445
+    @onlyOn(["cuda"])
+    @dtypes(torch.int32, torch.int64)
+    def test_embedding_bag_per_sample_weights_mutated_indices(
+        self, device, dtype
+    ):
+        stderr = self.runWithPytorchAPIUsageStderr(f"""\
+#!/usr/bin/env python3
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+class TestEmbeddingBagMutatedIndices(TestCase):
+    def test_mutated_indices(self):
+        weight = torch.ones((5, 2), device="{device}")
+        indices = torch.zeros(1024, dtype={dtype}, device="{device}")
+        indices_alias = torch.from_dlpack(indices)
+        offsets = torch.tensor([0], dtype={dtype}, device="{device}")
+        per_sample_weights = torch.ones(1024, device="{device}", requires_grad=True)
+
+        output = F.embedding_bag(
+            indices,
+            weight,
+            offsets,
+            mode="sum",
+            per_sample_weights=per_sample_weights,
+        )
+        indices_alias.fill_(weight.size(0))
+        output.sum().backward()
+        torch.cuda.synchronize()
+
+if __name__ == "__main__":
+    run_tests()
+""")
+        has_cuda_assert = "device-side assert triggered" in stderr
+        has_hip_assert = "launch failure" in stderr
+        has_hip_assert = has_hip_assert or "HSA_STATUS_ERROR_EXCEPTION" in stderr
+        self.assertTrue(
+            has_cuda_assert or has_hip_assert,
+            lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
+        )
+
     def test_embedding_bag_dimension_errors(self, device):
         funcs = (
             lambda x, y, z: torch.nn.functional.embedding_bag(y, x, z),

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1241,25 +1241,25 @@ torch.cuda.synchronize()
             text=True,
             errors="replace",
         )
-        stderr = proc.stderr
+        output = proc.stdout + "\n" + proc.stderr
         expected_assert = (
             "embedding_idx >= 0 && embedding_idx < num_embeddings"
             if target == "indices"
             else "bag_idx >= 0 && bag_idx < num_bags"
         )
         has_cuda_assert = (
-            "device-side assert triggered" in stderr
-            and "EmbeddingBag.cu" in stderr
-            and expected_assert in stderr
+            "device-side assert triggered" in output
+            and "EmbeddingBag.cu" in output
+            and expected_assert in output
         )
         has_hip_assert = (
-            "hipErrorLaunchFailure" in stderr
-            or "unspecified launch failure" in stderr
-            or "HSA_STATUS_ERROR_EXCEPTION" in stderr
+            "hipErrorLaunchFailure" in output
+            or "unspecified launch failure" in output
+            or "HSA_STATUS_ERROR_EXCEPTION" in output
         )
         self.assertTrue(
             has_cuda_assert or has_hip_assert,
-            lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
+            lambda msg: f"{msg}\nExpected device assert error in output, got: {output}",
         )
 
     # https://github.com/pytorch/pytorch/issues/192445


### PR DESCRIPTION
Fixes #192445.

## Root cause

`_embedding_bag_per_sample_weights_backward_kernel` in
`aten/src/ATen/native/cuda/EmbeddingBag.cu` indexed the embedding `weight` by
`embedding_idx = indices[sample_idx]` with no bounds check, unlike the forward
`EmbeddingBag` kernels in the same file which validate the index against
`numRows`. When an index is out of range, the kernel reads past the `weight`
allocation, causing an illegal global memory access (undefined behavior /
potential silent corruption). This can be triggered when `indices` is mutated in
place after the forward pass (e.g. via a DLPack alias), so the bad value is only
seen at backward time.

A secondary defect was the lossy `const int embedding_idx = (int)indices[...]`
cast: for int64 indices this truncates to 32 bits, so a large in-range int64
index could alias the wrong row or defeat a naive check.

## Fix

Thread `weight.size(0)` into the kernel as `num_embeddings`, read the index with
its native `index_t` type (no truncation), and add a `CUDA_KERNEL_ASSERT` bounds
check against `[0, num_embeddings)` before the weight read, using the same
message convention as the forward kernels. This converts the illegal access into
a deterministic device-side assert.

## Impact

The change is confined to the CUDA per-sample-weights backward path. In-range
indices behave exactly as before (the assert is a no-op on the valid range); the
only behavioral change is that a previously-illegal out-of-range read now fails
fast with a device-side assert instead of reading out of bounds.

## Validation

New device-generic test `test_embedding_bag_per_sample_weights_mutated_indices`
reproduces the issue out-of-process (a device-side assert corrupts the CUDA
context) by mutating `indices` via a DLPack alias after the forward pass, then
running backward, and asserts the device-side assert markers appear in stderr.
It is gated `@onlyOn(["cuda"])` for both int32 and int64.

```
python test/nn/test_embedding.py -k test_embedding_bag_per_sample_weights_mutated_indices -v
```

Validation limitation: the CUDA test and `lintrunner -a` could not be run in the
authoring environment (macOS, no CUDA/GPU, PyTorch not built, lintrunner/spin
unavailable). These need to be run on a CUDA box; CI is expected to exercise them
here.

---

This pull request was prepared with the assistance of an AI coding assistant. The
author has reviewed and understands the code change and takes responsibility for
it.
