### PR TITLE
[aot_autograd] Fix event passthrough versioning across waits

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -23,7 +23,6 @@ from torch._dynamo.testing import extract_graph, remove_trailing_space
 from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
@@ -1654,16 +1653,17 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
-    @requires_cuda
-    def test_control_deps_multiple_waiters_thread_latest_passthrough(self) -> None:
-        consumer1 = torch.Stream(device="cuda")
-        consumer2 = torch.Stream(device="cuda")
-        fork = torch.Event()
-        join1 = torch.Event()
-        join2 = torch.Event()
+    def test_control_deps_multiple_waiters_thread_latest_passthrough(
+        self, device
+    ) -> None:
+        consumer1 = torch.Stream(device=device)
+        consumer2 = torch.Stream(device=device)
+        fork = torch.Event(device=device)
+        join1 = torch.Event(device=device)
+        join2 = torch.Event(device=device)
 
         def fn(x) -> torch.Tensor:
-            default_stream = torch.cuda.current_stream()
+            default_stream = torch.accelerator.current_stream(device)
             y = x + 1
             fork.record(default_stream)
 
@@ -1681,7 +1681,7 @@ class <lambda>(torch.nn.Module):
             default_stream.wait_event(join2)
             return out1 + out2
 
-        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device="cuda"))
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device=device))
         gm = fw_graphs[0]
 
         from torch._functorch._aot_autograd.streams import (
@@ -1714,9 +1714,10 @@ class <lambda>(torch.nn.Module):
         self.assertIs(muls[1].args[0].args[0], fork_waits[1])
         gm.graph.lint()
 
-    @requires_cuda
     @parametrize("sync_kind", ("wait_stream", "full_barrier"))
-    def test_intervening_sync_updates_event_passthrough(self, sync_kind) -> None:
+    def test_intervening_sync_updates_event_passthrough(
+        self, device, sync_kind
+    ) -> None:
         import operator
 
         from torch._functorch._aot_autograd.streams import (
@@ -1724,13 +1725,13 @@ class <lambda>(torch.nn.Module):
         )
         from torch._inductor.fx_passes.control_dependencies import control_deps
 
-        intervening_stream = torch.Stream(device="cuda")
-        consumer_stream = torch.Stream(device="cuda")
-        fork = torch.Event()
-        intervening_event = torch.Event()
+        intervening_stream = torch.Stream(device=device)
+        consumer_stream = torch.Stream(device=device)
+        fork = torch.Event(device=device)
+        intervening_event = torch.Event(device=device)
 
         def fn(x) -> torch.Tensor:
-            default_stream = torch.cuda.current_stream()
+            default_stream = torch.accelerator.current_stream(device)
             y = x + 1
             fork.record(default_stream)
 
@@ -1744,7 +1745,7 @@ class <lambda>(torch.nn.Module):
                 fork.wait()
                 return y * 2
 
-        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device="cuda"))
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device=device))
         gm = fw_graphs[0]
         wrap_all_sync_nodes_with_control_deps(gm)
         event_waits = []
@@ -1765,7 +1766,6 @@ class <lambda>(torch.nn.Module):
         self.assertIs(consumers[0].args[0].args[0], event_waits[0])
         gm.graph.lint()
 
-    @requires_cuda
     def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
@@ -3193,9 +3193,6 @@ class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_s1, expected_s1)
         self.assertEqual(actual_s2, expected_s2)
         self.assertEqual(actual_default, default_s.sycl_queue)
-
-
-instantiate_parametrized_tests(TestStreams)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1652,6 +1652,67 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
+    @requires_cuda
+    def test_control_deps_multiple_waiters_thread_latest_passthrough(self) -> None:
+        consumer1 = torch.Stream(device="cuda")
+        consumer2 = torch.Stream(device="cuda")
+        fork = torch.Event()
+        join1 = torch.Event()
+        join2 = torch.Event()
+
+        def fn(x) -> torch.Tensor:
+            default_stream = torch.cuda.current_stream()
+            y = x + 1
+            fork.record(default_stream)
+
+            with consumer1:
+                fork.wait()
+                out1 = y * 2
+                join1.record()
+
+            with consumer2:
+                fork.wait()
+                out2 = y * 3
+                join2.record()
+
+            default_stream.wait_event(join1)
+            default_stream.wait_event(join2)
+            return out1 + out2
+
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device="cuda"))
+        gm = fw_graphs[0]
+
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        import operator
+
+        wait_ctrls = []
+        for ctrl in gm.graph.find_nodes(op="call_function", target=control_deps):
+            subgraph = getattr(gm, ctrl.args[1].target)
+            waits = subgraph.graph.find_nodes(
+                op="call_function", target=torch.ops.streams.wait_event.default
+            )
+            if waits:
+                wait_ctrls.append((waits[0].args[0], ctrl))
+
+        event_ids = [event_id for event_id, _ in wait_ctrls]
+        fork_waits = [
+            ctrl for event_id, ctrl in wait_ctrls if event_ids.count(event_id) == 2
+        ]
+        muls = gm.graph.find_nodes(op="call_function", target=torch.ops.aten.mul.Tensor)
+
+        self.assertEqual(len(fork_waits), 2)
+        self.assertEqual(len(muls), 2)
+        self.assertIs(muls[1].args[0].target, operator.getitem)
+        self.assertIs(muls[1].args[0].args[0], fork_waits[1])
+        gm.graph.lint()
+
+    @requires_cuda
     def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -23,9 +23,11 @@ from torch._dynamo.testing import extract_graph, remove_trailing_space
 from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
+    parametrize,
     requires_accelerator,
     requires_cuda,
     requires_xpu,
@@ -1713,6 +1715,57 @@ class <lambda>(torch.nn.Module):
         gm.graph.lint()
 
     @requires_cuda
+    @parametrize("sync_kind", ("wait_stream", "full_barrier"))
+    def test_intervening_sync_updates_event_passthrough(self, sync_kind) -> None:
+        import operator
+
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        intervening_stream = torch.Stream(device="cuda")
+        consumer_stream = torch.Stream(device="cuda")
+        fork = torch.Event()
+        intervening_event = torch.Event()
+
+        def fn(x) -> torch.Tensor:
+            default_stream = torch.cuda.current_stream()
+            y = x + 1
+            fork.record(default_stream)
+
+            if sync_kind == "wait_stream":
+                intervening_stream.wait_stream(default_stream)
+            else:
+                default_stream.synchronize()
+                intervening_event.record(intervening_stream)
+
+            with consumer_stream:
+                fork.wait()
+                return y * 2
+
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, 2, device="cuda"))
+        gm = fw_graphs[0]
+        wrap_all_sync_nodes_with_control_deps(gm)
+        event_waits = []
+        for ctrl in gm.graph.find_nodes(op="call_function", target=control_deps):
+            subgraph = getattr(gm, ctrl.args[1].target)
+            waits = subgraph.graph.find_nodes(
+                op="call_function", target=torch.ops.streams.wait_event.default
+            )
+            if waits:
+                event_waits.append(ctrl)
+
+        consumers = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.mul.Tensor
+        )
+        self.assertEqual(len(event_waits), 1)
+        self.assertEqual(len(consumers), 1)
+        self.assertIs(consumers[0].args[0].target, operator.getitem)
+        self.assertIs(consumers[0].args[0].args[0], event_waits[0])
+        gm.graph.lint()
+
+    @requires_cuda
     def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
@@ -3140,6 +3193,9 @@ class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_s1, expected_s1)
         self.assertEqual(actual_s2, expected_s2)
         self.assertEqual(actual_default, default_s.sycl_queue)
+
+
+instantiate_parametrized_tests(TestStreams)
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -432,12 +432,12 @@ def _wrap_sync_node(
     deps_before_sync: list[Node],
     visited: set[Node],
     partition_scoped_deps: set[Node] | None = None,
-) -> tuple[Node, list[Node]]:
+) -> tuple[Node, dict[Node, Node]]:
     """
     Core logic: wrap a single sync node in control_deps.
 
-    Returns (control_deps_node, passthrough_getitems) where passthrough_getitems
-    are the getitem nodes that thread dependencies through the control_deps node.
+    Returns (control_deps_node, replacements), where replacements maps each
+    dependency to the getitem that threads it through the control_deps node.
     ``visited`` is the set of nodes at or before the sync node in graph order,
     used to distinguish pre-sync vs post-sync users.
     """
@@ -575,7 +575,7 @@ def _wrap_sync_node(
     # Remove original sync node
     sync_node.replace_all_uses_with(control_deps_node)
     graph.erase_node(sync_node)
-    return control_deps_node, list(replacements.values())
+    return control_deps_node, replacements
 
 
 def _collect_sync_forward_deps(
@@ -765,9 +765,10 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                             existing_deps.add(dep)
                     if all_stream_deps:
                         found_sync = True
-                        ctrl_node_sync, passthrough_sync = _wrap_sync_node(
+                        ctrl_node_sync, replacements = _wrap_sync_node(
                             gm, node, all_stream_deps, visited
                         )
+                        passthrough_sync = list(replacements.values())
                     else:
                         ctrl_node_sync = None
                         passthrough_sync: list[Node] = []
@@ -817,9 +818,10 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                             existing_deps.add(dep)
                     if deps_before_sync:
                         found_sync = True
-                        ctrl_node_ws, passthrough_ws = _wrap_sync_node(
+                        ctrl_node_ws, replacements = _wrap_sync_node(
                             gm, node, deps_before_sync, visited
                         )
+                        passthrough_ws = list(replacements.values())
                     else:
                         ctrl_node_ws = None
                         passthrough_ws: list[Node] = []
@@ -932,7 +934,7 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
 
                 if deps_before_sync:
                     found_sync = True
-                    ctrl_node, passthrough = _wrap_sync_node(
+                    ctrl_node, replacements = _wrap_sync_node(
                         gm,
                         node,
                         deps_before_sync,
@@ -941,6 +943,12 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         if node.target is torch.ops.streams.wait_event.default
                         else None,
                     )
+                    # Keep recorded event data on its latest SSA version.
+                    for event, passthroughs in event_to_passthrough.items():
+                        event_to_passthrough[event] = [
+                            replacements.get(dep, dep) for dep in passthroughs
+                        ]
+                    passthrough = list(replacements.values())
                 else:
                     ctrl_node = None
                     passthrough: list[torch.fx.Node] = []

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -578,6 +578,16 @@ def _wrap_sync_node(
     return control_deps_node, replacements
 
 
+def _update_event_passthroughs(
+    event_to_passthrough: dict[int, list[Node]],
+    replacements: dict[Node, Node],
+) -> None:
+    for event, passthroughs in event_to_passthrough.items():
+        event_to_passthrough[event] = [
+            replacements.get(dep, dep) for dep in passthroughs
+        ]
+
+
 def _collect_sync_forward_deps(
     graph: torch.fx.Graph,
 ) -> tuple[dict[Node, OrderedSet[Node]], dict[Node, OrderedSet[Node]]]:
@@ -768,6 +778,7 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         ctrl_node_sync, replacements = _wrap_sync_node(
                             gm, node, all_stream_deps, visited
                         )
+                        _update_event_passthroughs(event_to_passthrough, replacements)
                         passthrough_sync = list(replacements.values())
                     else:
                         ctrl_node_sync = None
@@ -821,6 +832,7 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         ctrl_node_ws, replacements = _wrap_sync_node(
                             gm, node, deps_before_sync, visited
                         )
+                        _update_event_passthroughs(event_to_passthrough, replacements)
                         passthrough_ws = list(replacements.values())
                     else:
                         ctrl_node_ws = None
@@ -944,10 +956,7 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         else None,
                     )
                     # Keep recorded event data on its latest SSA version.
-                    for event, passthroughs in event_to_passthrough.items():
-                        event_to_passthrough[event] = [
-                            replacements.get(dep, dep) for dep in passthroughs
-                        ]
+                    _update_event_passthroughs(event_to_passthrough, replacements)
                     passthrough = list(replacements.values())
                 else:
                     ctrl_node = None


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/193409
The graph before the fix (correspond to the repro in https://github.com/pytorch/pytorch/issues/193409 ):
```
# No stacktrace found for following nodes
        subgraph_wait_event_1 = self.subgraph_wait_event_1
        control_deps_3 = torch.ops.higher_order.control_deps((control_deps, getitem), subgraph_wait_event_1);  subgraph_wait_event_1 = None

        # Annotation: {'stream': 4} File: /opt/pytorch/pytorch/repro.py:24 in fn, code: out2 = y * 3
        mul_1: "f32[2, 2]" = torch.ops.aten.mul.Tensor(getitem_3, 3)

        # No stacktrace found for following nodes
        subgraph_record_event_2 = self.subgraph_record_event_2
        control_deps_4 = torch.ops.higher_order.control_deps((mul_1, control_deps_3), subgraph_record_event_2, mul_1);  mul_1 = control_deps_3 = subgraph_record_event_2 = None
```
mul_1 doen't depend on the wait_event.
The graph after:
```
# No stacktrace found for following nodes
        subgraph_wait_event_1 = self.subgraph_wait_event_1
        control_deps_3 = torch.ops.higher_order.control_deps((control_deps, getitem_3), subgraph_wait_event_1, getitem_3);  getitem_3 = subgraph_wait_event_1 = None

        # File: /opt/pytorch/pytorch/repro.py:14 in fn, code: y = x + 1
        getitem_4: "f32[2, 2]" = control_deps_3[1]

        # Annotation: {'stream': 4} File: /opt/pytorch/pytorch/repro.py:24 in fn, code: out2 = y * 3
        mul_1: "f32[2, 2]" = torch.ops.aten.mul.Tensor(getitem_4, 3)

        # No stacktrace found for following nodes
        subgraph_record_event_2 = self.subgraph_record_event_2
        control_deps_4 = torch.ops.higher_order.control_deps((mul_1, control_deps_3, getitem_4), subgraph_record_event_2, mul_1);  mul_1 = control_deps_3 = subgraph_record_event_2 = None
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98