### PR TITLE
[inductor] Cache statically_known_equals

### DIFF
--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -286,6 +286,16 @@ class SizeVarAllocator:
         # expressions) and each miss runs sympy substitution plus heuristics,
         # none of which sympy caches. _lru_cache drops the cache whenever
         # replacements change.
+        # Lowering asks whether two sizes are equal over and over: 31k calls
+        # covering a few hundred distinct pairs on one model, a quarter of all
+        # lowering time. Caching statically_known_true does not help, because
+        # the caller has already paid to build the sympy.Eq - constructing a
+        # relational evaluates it, which drags in assumption queries - so the
+        # cache has to sit above that. _lru_cache drops it whenever
+        # replacements change.
+        self._statically_known_equals_cache = self._lru_cache(
+            self._statically_known_equals_uncached
+        )
         self._optimization_hint_cache = self._lru_cache(
             self._optimization_hint_uncached
         )
@@ -554,6 +564,11 @@ class SizeVarAllocator:
         """
         Returns a bool indicating if it is sound to optimize as if left and right are equal.
         """
+        return self._statically_known_equals_cache(left, right)
+
+    def _statically_known_equals_uncached(
+        self, left: Expr | int, right: Expr | int
+    ) -> bool:
         return self.statically_known_true(sympy.Eq(left, right))  # type: ignore[arg-type]
 
     def statically_known_list_equals(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193416
* __->__ #193415
* #193289
* #193227
* #193220
* #193219
* #193157
* #193161
* #193160
* #193159
* #193158
* #192009
* #193162

Lowering asks whether two sizes are equal constantly: 30,901 calls covering a few
hundred distinct pairs on a UMA cold compile, a quarter of all time spent in
GraphLowering.run.

Caching statically_known_true does not help, and that is worth explaining
because it looks like it should. By the time that function is called the caller
has already built the sympy.Eq, and constructing a relational evaluates it,
which drags in sympy's assumption machinery. The expensive part is therefore
paid before any cache on statically_known_true can be consulted, so the cache
has to sit one level up, on (left, right).

_lru_cache is the existing idiom in this class - it is what
_optimization_hint_cache uses - and drops the cache whenever replacements
change, which is exactly when an answer could differ.

Time inside statically_known_equals over the same 30.9k calls drops from 0.67s
to 0.18s. End to end, as the union of top-level chromium events, over
interleaved pairs:

  pair 1:  baseline 41.06s   cached 40.08s
  pair 2:  baseline 40.34s   cached 39.93s
  pair 3:  baseline 40.72s   cached 40.21s

40.71s -> 40.07s, -1.6%.

Test plan:

```
python test/inductor/test_torchinductor_dynamic_shapes.py -k cuda
```

1493 tests; failure set identical to a run with the change reverted (4 failures
and 73 errors, pre-existing on this aarch64 host).

This PR was authored with the assistance of an AI coding agent.