### PR TITLE
Fix test_comprehensive__softmax_backward_data_cpu_float16

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -419,6 +419,8 @@ inductor_override_kwargs["cpu"] = {
         "atol": 3e-4,
         "rtol": 0.003,
     },
+    # The CPU kernel cannot handle different input and grad types
+    ("_softmax_backward_data", f16): {"reference_in_float": False},
     ("softmax", f16): {"atol": 1e-4, "rtol": 0.02},
     ("polygamma.polygamma_n_0", f32): {"atol": 1e-3, "rtol": 1e-4},
     ("polygamma.polygamma_n_1", f32): {"atol": 1e-3, "rtol": 1e-4},


### PR DESCRIPTION
The test fails with `Exception: expected scalar type Float but found Half` as the inputs are converted to Float but the `input_dtype` argument is `float16`.

There is a comment referencing #63057 at https://github.com/pytorch/pytorch/blob/41d7be3f48df402837ba1bd1e436a99df448ae7d/aten/src/ATen/native/SoftMax.cpp#L92-L105

I'm not fully sure at which point things break: The inputs (grad and output) are converted to Float, input_dtype is passed as-is, but `softmax_backward_cpu_out` ignores `input_dtype`

This might be a regression introduced by 7255847ca2f272aa761ea8692c2b4826e53ef47b which (re)enabled reference_in_float for CPU possibly with some conflict with a newly added test or code change that used to rely on that.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo