### PR TITLE
Canonicalize set/frozenset iteration order in _stabilize_tensor_subclass_metadata

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -28,6 +28,7 @@ from torch._dynamo import config as dynamo_config
 from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import (
+    _CanonicalSetMetadata,
     AOTAutogradCache,
     AOTAutogradCachePickler,
     autograd_cache_key,
@@ -4095,6 +4096,60 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
             r"AOTAutogradCachePicklerTests.test_pickle_entry_strict_mode_raises.<locals>.<lambda>",
         ):
             AOTAutogradCache._pickle_entry(entry, remote=False)
+
+    def test_stabilize_set_deterministic_order(self):
+        """set/frozenset must produce a deterministic canonical form with
+        container type preserved, so cache keys are stable across processes
+        and set/frozenset don't collide."""
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        pickler = AOTAutogradCachePickler(gm)
+
+        dtype_set = {"float32", "bfloat16", "float16", "int8", "uint8"}
+        result = pickler._stabilize_tensor_subclass_metadata(dtype_set)
+        expected_elements = tuple(sorted(pickle.dumps(x) for x in dtype_set))
+        self.assertEqual(
+            result,
+            _CanonicalSetMetadata(container_type=set, elements=expected_elements),
+        )
+
+        # frozenset preserves its own type
+        result_fs = pickler._stabilize_tensor_subclass_metadata(frozenset(dtype_set))
+        self.assertEqual(
+            result_fs,
+            _CanonicalSetMetadata(container_type=frozenset, elements=expected_elements),
+        )
+
+        # set and frozenset must NOT collide
+        self.assertNotEqual(result, result_fs)
+
+    def test_stabilize_set_in_dict_deterministic(self):
+        """set nested inside metadata returned by __tensor_flatten__
+        must be converted to a canonical form."""
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        pickler = AOTAutogradCachePickler(gm)
+
+        metadata = {
+            "ragged_idx": 1,
+            "allowed_ops": {"add", "mul", "sub"},
+        }
+        result = pickler._stabilize_tensor_subclass_metadata(metadata)
+        expected_ops = tuple(sorted(pickle.dumps(x) for x in metadata["allowed_ops"]))
+        self.assertEqual(
+            result["allowed_ops"],
+            _CanonicalSetMetadata(container_type=set, elements=expected_ops),
+        )
+        self.assertEqual(result["ragged_idx"], 1)
+
+    def test_stabilize_nested_frozenset_in_set(self):
+        """frozenset elements inside a set must be recursively stabilized."""
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        pickler = AOTAutogradCachePickler(gm)
+
+        nested = {frozenset({"a", "b"}), frozenset({"c"})}
+        result = pickler._stabilize_tensor_subclass_metadata(nested)
+        self.assertIsInstance(result, _CanonicalSetMetadata)
+        self.assertEqual(result.container_type, set)
+        self.assertEqual(result.elements, tuple(sorted(result.elements)))
 
     @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4091")
     @requires_gpu_and_triton

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -5,6 +5,7 @@ Utils for caching the outputs of AOTAutograd
 from __future__ import annotations
 
 import base64
+import collections
 import contextlib
 import dataclasses
 import functools
@@ -92,6 +93,10 @@ from .schemas import (
     ViewAndMutationMeta,
 )
 
+
+_CanonicalSetMetadata = collections.namedtuple(
+    "_CanonicalSetMetadata", ["container_type", "elements"]
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
@@ -735,6 +740,16 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
             return {
                 k: self._stabilize_tensor_subclass_metadata(v) for k, v in obj.items()
             }
+        if isinstance(obj, (set, frozenset)):
+            return _CanonicalSetMetadata(
+                container_type=type(obj),
+                elements=tuple(
+                    sorted(
+                        pickle.dumps(self._stabilize_tensor_subclass_metadata(x))
+                        for x in obj
+                    )
+                ),
+            )
         return obj
 
     def _default_stable_hash_for_caching(self, tensor: torch.Tensor) -> str:


### PR DESCRIPTION
Fixes #193418

## Summary

`_stabilize_tensor_subclass_metadata` did not handle `set` or `frozenset`. They fell through to `return obj` unchanged. When pickled for cache key generation, `pickle.dumps()` serializes set elements in hash-table iteration order, which is randomized per process by `PYTHONHASHSEED`. This causes the same tensor subclass metadata to produce different cache keys in different processes, resulting in silent cache misses in the persistent AOTAutograd cache.

The fix canonicalizes set/frozenset by individually pickling each recursively stabilized element and sorting the resulting byte strings. This produces a deterministic `list[bytes]` regardless of hash seed or process.

Flagged by @aorenste during review of PR #190080.

## Test plan

Standalone reproducer confirms identical cache hashes across 3 different PYTHONHASHSEED values:

```
PYTHONHASHSEED=42   cache_hash=d474a5deeeb7bfbe0e04a629c5f4dc68
PYTHONHASHSEED=123  cache_hash=d474a5deeeb7bfbe0e04a629c5f4dc68
PYTHONHASHSEED=999  cache_hash=d474a5deeeb7bfbe0e04a629c5f4dc68
PASS: cache hash is stable across all 3 processes (fix works!)
```

Three new unit tests in `AOTAutogradCachePicklerTests`:
- `test_stabilize_set_deterministic_order`
- `test_stabilize_set_in_dict_deterministic`
- `test_stabilize_nested_frozenset_in_set`

All three pass with the fix and fail without it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98