### PR TITLE
[inductor] Skip pointless cumsum optimization for scalars

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     parametrize,
+    subtest,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_BIG_GPU
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
@@ -964,6 +965,22 @@ class TestPatternMatcher(TestCase):
             self.assertEqual(result, fn())
             self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
             counters.clear()
+
+    @parametrize(
+        "fn",
+        [
+            subtest(lambda: torch.tensor(5.0).cumsum(0), name="float"),
+            subtest(lambda: torch.tensor(5).cumsum(0), name="integer"),
+            subtest(lambda: torch.tensor(True).cumsum(0), name="boolean"),
+            subtest(lambda: torch.zeros(()).cumsum(0), name="zeros"),
+            subtest(lambda: torch.full((), 5.0).cumsum(0), name="full"),
+            subtest(lambda: torch.tensor(5.0).cumsum(-1), name="negative_dim"),
+        ],
+    )
+    def test_pointless_cumsum_scalar(self, fn):
+        expected = fn()
+        result = torch.compile(fn, fullgraph=True)()
+        self.assertEqual(result, expected)
 
     def test_reciprocal_sqrt_to_rsqrt(self):
         # reciprocal(sqrt(x)) should fuse into a single rsqrt in the kernel.

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1017,6 +1017,11 @@ def mm_plus_mm(match: Match, mat1, mat2, mat3, mat4):
     return inductor.kernel.mm_plus_mm.tuned_mm_plus_mm(mat1, mat2, mat3, mat4)
 
 
+def pointless_cumsum_non_scalar_check(match: Match) -> bool:
+    # Scalar cumsum is already handled directly by lowering.cumsum.
+    return len(match.kwargs["shape"]) > 0
+
+
 @register_graph_pattern(
     CallFunction(
         aten.cumsum.default,
@@ -1033,6 +1038,7 @@ def mm_plus_mm(match: Match, mat1, mat2, mat3, mat4):
         KeywordArg("dim"),
         _users=MULTIPLE,
     ),
+    extra_check=pointless_cumsum_non_scalar_check,
     # pyrefly: ignore [bad-argument-type]
     pass_dict=pass_patterns[1],
 )


### PR DESCRIPTION
Fixes #193265.

## Summary

`pointless_cumsum_replacement` assumes rank >= 1 because it indexes `shape[dim]`.

Rank-0 constants are intentionally excluded from this optimization. Scalar `cumsum` is already handled by normal Inductor lowering, so duplicating scalar dtype and dimension semantics here is unnecessary.

Rank-1 and higher constants remain eligible for the existing optimization.

## Testing

- `spin quicklint` - passed with no lint issues.
- `lintrunner -a` - passed with no lint issues and applied no source patches.
- `pytest test/inductor/test_pattern_matcher.py -k pointless_cumsum -v` - 7 passed, 115 deselected.
- `python -m py_compile torch/_inductor/fx_passes/post_grad.py test/inductor/test_pattern_matcher.py` - passed.
- `git diff --check` - passed.

Focused testing was run on CPU on macOS.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo