### PR TITLE
Make nightly Metamates PR auto-merge and auto-triaged

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,6 +194,9 @@
 - .github/actions/binary-docker-build/**
 - .lintrunner.toml
 
+"triaged":
+- .github/merge_rules.yaml
+
 "ciflow/torchtitan":
 # torchtitan commit pin updates
 - .github/ci_commit_pins/torchtitan.txt

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,9 +194,6 @@
 - .github/actions/binary-docker-build/**
 - .lintrunner.toml
 
-"triaged":
-- .github/merge_rules.yaml
-
 "ciflow/torchtitan":
 # torchtitan commit pin updates
 - .github/ci_commit_pins/torchtitan.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,7 @@ jobs:
           if [ -n "$EXISTING" ]; then
             BRANCH=$(gh pr view "$EXISTING" --json headRefName --jq '.headRefName')
           fi
-          git checkout -B "$BRANCH"
+          git checkout -b "$BRANCH"
           git add .github/merge_rules.yaml
           git commit -m "Update Metamates merge rule"
           git push --set-upstream origin "$BRANCH" -f

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,7 @@ jobs:
           if [ -n "$EXISTING" ]; then
             BRANCH=$(gh pr view "$EXISTING" --json headRefName --jq '.headRefName')
           fi
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add .github/merge_rules.yaml
           git commit -m "Update Metamates merge rule"
           git push --set-upstream origin "$BRANCH" -f
@@ -128,8 +128,11 @@ jobs:
 
           Updates the Metamates merge rule with active team members.
           EOF
-            )"
+            )" \
+              --label "triaged"
+            GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr review "${BRANCH}" --approve
           fi
+          GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr comment "${BRANCH}" --body "@pytorchbot merge"
 
   update-commit-hashes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,7 +128,8 @@ jobs:
 
           Updates the Metamates merge rule with active team members.
           EOF
-            )"
+            )" \
+              --label "triaged"
             GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr review "${BRANCH}" --approve
           fi
           GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr comment "${BRANCH}" --body "@pytorchbot merge"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,8 +128,7 @@ jobs:
 
           Updates the Metamates merge rule with active team members.
           EOF
-            )" \
-              --label "triaged"
+            )"
             GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr review "${BRANCH}" --approve
           fi
           GH_TOKEN="${PYTORCHBOT_TOKEN}" gh pr comment "${BRANCH}" --body "@pytorchbot merge"


### PR DESCRIPTION
Human review requested: This draft PR makes the nightly `update-metamates-rule` PRs self-approving and self-merging (like `update-triton-commit-hash` pin bumps) and auto-labels them `triaged`.

> AI-generated summary (please review before merging):
> ```
> Make nightly Metamates PR auto-merge and auto-triaged
>
> The update-metamates-rule job in nightly.yml previously created PRs
> like #191412 that stayed open without approval or labels, unlike
> nightly pin updates like #193245 or the Triton pin job which
> self-approve and merge via pytorchbot.
>
> Changes (minimal diff, no labeler.yml):
> - nightly.yml: add --label "triaged" on gh pr create,
>   approve with GH_TOKEN=PYTORCHBOT_TOKEN gh pr review --approve,
>   and always comment @pytorchbot merge (mirrors update-triton-commit-hash)
> ```

Changes:
- `.github/workflows/nightly.yml` — `update-metamates-rule` job (add `--label "triaged"`, approve + `@pytorchbot merge`)

Co-authored with Muse Code powered by Meta Muse Spark
