### PR TITLE
[dynamo] Type opaque global and FunctionType values as object

### DIFF
--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -474,9 +474,9 @@ class ModelInput:
 
     """
 
-    args: tuple[Any]
-    kwargs: dict[str, Any]
-    contexts: list[AbstractContextManager[Any]]
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+    contexts: Sequence[AbstractContextManager[object]]
 
 
 @dataclass

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1022,8 +1022,8 @@ class DynamoOutput:
 
     def graph_capture_output(
         self,
-        argdefs: tuple[Any, ...] | None = None,
-        kwdefaults: dict[str, Any] | None = None,
+        argdefs: tuple[object, ...] | None = None,
+        kwdefaults: dict[str, object] | None = None,
     ) -> GraphCaptureOutput:
         output_graph = self.tracer_output.output_graph
         if output_graph is None:
@@ -1072,10 +1072,10 @@ class GraphRuntimeEnv:
     bytecode: types.CodeType
     pycode: list[list[str] | None]
     import_sources: dict[str, str]
-    used_globals: dict[str, Any]
+    used_globals: dict[str, object]
     closure: tuple[Any, ...] | None
-    argdefs: tuple[Any, ...] | None
-    kwdefaults: dict[str, Any] | None = None
+    argdefs: tuple[object, ...] | None
+    kwdefaults: dict[str, object] | None = None
     external_refs: set[str] = dataclasses.field(default_factory=set)
 
     def forward_callable(
@@ -1083,7 +1083,7 @@ class GraphRuntimeEnv:
         backend_id: str,
         compiled_fn: Callable[..., Any],
         *,
-        extra_globals: dict[str, Any] | None = None,
+        extra_globals: dict[str, object] | None = None,
         use_python_codegen: bool = False,
     ) -> Callable[..., Any]:
         import_sources = {
@@ -1189,8 +1189,8 @@ class GraphCaptureOutput:
     bytecode: CodeType
     pycode: list[list[str] | None]
     closure: tuple[Any, ...] | None
-    argdefs: tuple[Any, ...] | None
-    kwdefaults: dict[str, Any] | None
+    argdefs: tuple[object, ...] | None
+    kwdefaults: dict[str, object] | None
     f_globals: dict[str, Any]
 
     def build_guards(
@@ -1289,7 +1289,7 @@ class CaptureOutput:
         self,
         *,
         compiled_fn: Callable[..., Any] | None = None,
-        extra_globals: dict[str, Any] | None = None,
+        extra_globals: dict[str, object] | None = None,
         use_python_codegen: bool = False,
     ) -> Callable[..., Any]:
         runtime_env = self.graph_capture_output.get_runtime_env()
@@ -1447,8 +1447,8 @@ class FrameInfo:
     locals: dict[str, object]
     builtins: dict[str, object]
     closure: tuple[CellType]
-    argdefs: tuple[Any, ...] | None
-    kwdefaults: dict[str, Any] | None
+    argdefs: tuple[object, ...] | None
+    kwdefaults: dict[str, object] | None
 
 
 def _fullgraph_capture_frame(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1581,7 +1581,7 @@ class OutputGraph(OutputGraphCommon):
         return name
 
     def register_static_attr_and_return_proxy(
-        self, attr_prefix: str, attr_value: Any
+        self, attr_prefix: str, attr_value: object
     ) -> fx.Proxy:
         # Check if the module already exists, if it does, return the already
         # added proxy. This is important for executorch tests.
@@ -3533,7 +3533,7 @@ class OutputGraph(OutputGraphCommon):
                 types.FunctionType(code, f_globals, name),
             )
 
-    def install_global_unsafe(self, name: str, value: Any) -> None:
+    def install_global_unsafe(self, name: str, value: object) -> None:
         """
         WARNING: prefer the safer `install_global_by_id/install_global`.
         torch.compile instances should be independent of each other;
@@ -3546,7 +3546,7 @@ class OutputGraph(OutputGraphCommon):
         self.installed_globals.add(name)
         self.cleanups.append(CleanupHook.create(self.global_scope, name, value))
 
-    def install_global_by_id(self, prefix: str, value: Any) -> str:
+    def install_global_by_id(self, prefix: str, value: object) -> str:
         """
         Installs a global if it hasn't been installed already.
         This is determined by (prefix, id(value)) pair.
@@ -3561,7 +3561,7 @@ class OutputGraph(OutputGraphCommon):
         self.install_global_unsafe(name, value)
         return name
 
-    def install_global(self, prefix: str, value: Any) -> str:
+    def install_global(self, prefix: str, value: object) -> str:
         """
         Installs a global, generating a unique name for it.
 

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -853,7 +853,9 @@ class CompilePackage:
                 "First code entry does not match _innermost_fn.__code__"
             )
 
-    def _install_global(self, module: types.ModuleType, name: str, value: Any) -> None:
+    def _install_global(
+        self, module: types.ModuleType, name: str, value: object
+    ) -> None:
         # A pre-reset compile in this process may still own `name` via a
         # CleanupHook that hasn't fired yet. We're taking over the binding now,
         # so that hook must not delete it once its code object is collected.

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5182,7 +5182,7 @@ class InstructionTranslatorBase(
         nn_modules_pattern = re.compile(r".*torch/nn/modules.*")
         return nn_modules_pattern.match(filename) is not None
 
-    def store_global_weakref_by_id(self, prefix: str, value: Any) -> str:
+    def store_global_weakref_by_id(self, prefix: str, value: object) -> str:
         global_name = self.output.install_global_by_id(prefix, weakref.ref(value))
         install_guard(
             GlobalWeakRefSource(global_name).make_guard(GuardBuilder.WEAKREF_ALIVE)


### PR DESCRIPTION
## Summary

- annotate opaque values installed into runtime globals as `object` instead of `Any`
- use `object` for the runtime metadata passed into `types.FunctionType` and for `ModelInput` payloads
- leave closure fields unchanged for a separate precise `CellType` migration

This is annotation-only and adds no casts or runtime behavior changes.

## Test plan

```
lintrunner --take PYFMT,RUFF,CODESPELL,FLAKE8 \
  torch/_dynamo/output_graph.py \
  torch/_dynamo/symbolic_convert.py \
  torch/_dynamo/convert_frame.py \
  torch/_dynamo/aot_compile.py \
  torch/_dynamo/package.py
```

```
python test/dynamo/test_global.py
python test/dynamo/test_package.py
python test/dynamo/test_aot_compile.py \
  -k test_aot_compile_module \
  -k test_aot_compile_with_default_args \
  -k test_aot_compile_with_global_tensor
```

The full `lintrunner -a` check was also attempted. Its changed-file formatting
was applied, but the repository-wide run could not complete because PYREFLY
reported unrelated local build-stub errors and an external dependency fetch
initially hit the proxy certificate.

Authored with assistance from OpenAI Codex.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98