### PR TITLE
Separate allocator-internal trace tags from user metadata

### DIFF
--- a/c10/core/CachingDeviceAllocator.h
+++ b/c10/core/CachingDeviceAllocator.h
@@ -179,6 +179,10 @@ struct TraceEntry {
   trace_time_ time_{};
   std::string compile_context_;
   std::string user_metadata_;
+  // Tag attached by allocator internals (e.g. "mallocWithAddress" on the
+  // synthetic prefix-block malloc/free pair), kept separate so
+  // user_metadata_ stays verbatim what the user set.
+  std::string internal_metadata_;
 };
 
 inline TraceEntry::Action parseTraceEntryAction(std::string_view action) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1533,6 +1533,11 @@ class DeviceCachingAllocator {
   // intentional: metadata labels a region of source code, not a device.
   static thread_local std::string user_metadata;
 
+  // Tag recorded as internal_metadata_ on trace entries emitted while it is
+  // set (see malloc_with_address). Guarded by mutex, which the setter holds
+  // across the tagged region.
+  std::string internal_metadata_tag;
+
  public:
   explicit DeviceCachingAllocator(c10::DeviceIndex id)
       : device_id(id),
@@ -1996,17 +2001,12 @@ class DeviceCachingAllocator {
     const size_t prefix_size = requested_addr - block_begin;
 
     // mallocWithAddress may allocate both prefix block and requested block,
-    // and free prefix block later. This adds a fake malloc/free pair for prefix
-    // block. A metadata is added for better memory visualization.
-    const auto original_user_metadata = getUserMetadata();
-    const auto malloc_with_address_metadata = original_user_metadata.empty()
-        ? std::string("mallocWithAddress")
-        : original_user_metadata + "\nmallocWithAddress";
-    setUserMetadata(malloc_with_address_metadata);
-    auto restore_user_metadata =
-        c10::make_scope_exit([this, original_user_metadata]() {
-          setUserMetadata(original_user_metadata);
-        });
+    // and free prefix block later. This adds a fake malloc/free pair for
+    // prefix block. Tag the resulting trace entries for better memory
+    // visualization, without touching the user-set metadata.
+    internal_metadata_tag = "mallocWithAddress";
+    auto clear_internal_metadata =
+        c10::make_scope_exit([this]() { internal_metadata_tag.clear(); });
 
     Block* prefix_block = nullptr;
     Block* requested_source = containing_block;
@@ -4456,6 +4456,7 @@ class DeviceCachingAllocator {
         record_context_ >= RecordContext::ALLOC ? std::move(context) : nullptr,
         compile_string,
         metadata_override ? std::move(*metadata_override) : user_metadata);
+    te.internal_metadata_ = internal_metadata_tag;
 
     // Callbacks should not include any Pytorch call
     for (const auto& cb : trace_trackers_) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -545,6 +545,22 @@ print(t.is_pinned())
             torch.cuda.memory._set_memory_metadata("metadata test")
         self.assertEqual(torch.cuda.memory._get_memory_metadata(), "")
 
+    def test_memory_metadata_dict(self):
+        if not torch._C._cuda_memoryMetadataSupported():
+            self.skipTest("backend does not support user metadata")
+        try:
+            # dicts are serialized to compact JSON; get returns the string form
+            torch.cuda.memory._set_memory_metadata({"step": 3, "phase": "fwd"})
+            got = torch.cuda.memory._get_memory_metadata()
+            self.assertEqual(json.loads(got), {"step": 3, "phase": "fwd"})
+            # get/set round-trips the string form unchanged
+            torch.cuda.memory._set_memory_metadata(got)
+            self.assertEqual(torch.cuda.memory._get_memory_metadata(), got)
+            with self.assertRaises(TypeError):
+                torch.cuda.memory._set_memory_metadata({"bad": object()})
+        finally:
+            torch.cuda.memory._set_memory_metadata("")
+
     def test_memory_stats(self):
         gc.collect()
         torch.cuda.empty_cache()
@@ -5808,6 +5824,39 @@ class TestResizeStorageWithAddr(TestCase):
         self.assertEqual(t.untyped_storage().nbytes(), original_size)
         self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
         self.assertNotEqual(other.untyped_storage().data_ptr(), original_ptr)
+
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC,
+        "CUDAMallocAsync does not support exact-address allocation",
+    )
+    def test_resize_storage_with_addr_metadata_tag(self):
+        # mallocWithAddress tags its trace entries via internal_metadata,
+        # leaving the user-set metadata (possibly JSON) verbatim
+        pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool):
+            other = torch.empty(294, dtype=torch.uint8, device="cuda")
+            t = torch.empty(4096, dtype=torch.uint8, device="cuda")
+        original_ptr = t.untyped_storage().data_ptr()
+        original_size = t.untyped_storage().nbytes()
+        t.untyped_storage().resize_(0)
+        other.untyped_storage().resize_(0)
+        try:
+            torch.cuda.memory._record_memory_history(context=None)
+            torch.cuda.memory._set_memory_metadata({"phase": "resize"})
+            with torch.cuda.use_mem_pool(pool):
+                t.untyped_storage()._resize_with_addr_(original_size, original_ptr)
+            device = torch.cuda.current_device()
+            trace = torch.cuda.memory._snapshot()["device_traces"][device]
+            tag = "mallocWithAddress"
+            tagged = [e for e in trace if e.get("internal_metadata") == tag]
+            self.assertTrue(tagged)
+            for e in tagged:
+                self.assertEqual(json.loads(e["user_metadata"]), {"phase": "resize"})
+            for e in trace:
+                self.assertNotIn("mallocWithAddress", e["user_metadata"])
+        finally:
+            torch.cuda.memory._set_memory_metadata("")
+            torch.cuda.memory._record_memory_history(None)
 
     def test_resize_storage_negative_size_raises(self):
         # A negative requested storage size must be rejected, not silently

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -794,6 +794,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
   py::str time_us_s = "time_us";
   py::str compile_context_s = "compile_context";
   py::str user_metadata_s = "user_metadata";
+  py::str internal_metadata_s = "internal_metadata";
   py::str pool_id_s = "pool_id";
 
   py::list empty_frames;
@@ -914,6 +915,9 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
     trace_entry[time_us_s] = te.time_.t_;
     trace_entry[compile_context_s] = te.compile_context_;
     trace_entry[user_metadata_s] = te.user_metadata_;
+    if (!te.internal_metadata_.empty()) {
+      trace_entry[internal_metadata_s] = te.internal_metadata_;
+    }
     trace_entry[pool_id_s] = te.mempool_;
     return trace_entry;
   };

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -336,6 +336,7 @@ std::string _memory_snapshot_pickled() {
   IValue time_us_s = "time_us";
   IValue compile_contexts_s = "compile_context";
   IValue user_metadata_s = "user_metadata";
+  IValue internal_metadata_s = "internal_metadata";
   IValue pool_id_s = "pool_id";
 
   auto empty_frames = new_list();
@@ -456,6 +457,9 @@ std::string _memory_snapshot_pickled() {
     trace_entry.insert(stream_s, int64_t(te.stream_));
     trace_entry.insert(compile_contexts_s, te.compile_context_);
     trace_entry.insert(user_metadata_s, te.user_metadata_);
+    if (!te.internal_metadata_.empty()) {
+      trace_entry.insert(internal_metadata_s, te.internal_metadata_);
+    }
     if (te.context_) {
       auto sc = getCapturedTracebackFromContext(te.context_);
       frame_tracebacks.push_back(sc);

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -4,6 +4,7 @@ r"""This package adds support for device memory management implemented in CUDA."
 import collections
 import contextlib
 import ctypes
+import json
 import pickle
 import sys
 import threading
@@ -1126,6 +1127,12 @@ def _snapshot(device: "Device" = None, augment_with_fx_traces=False):
             frames: List[Frame]
             size: int
             stream: int
+            user_metadata: str  # the calling thread's metadata at the time of
+            # the event, as set via _set_memory_metadata (dicts appear as
+            # their JSON serialization)
+            internal_metadata: str  # only present when allocator internals
+            # tagged the event (e.g. "mallocWithAddress" on the synthetic
+            # prefix-block malloc/free pair)
             device_free: int  # only present for OOM, the amount of
             # memory cuda still reports to be free
             pool_id: Tuple[int, int]  # id of the memory pool for this entry
@@ -1183,7 +1190,7 @@ def _memory_metadata_supported() -> bool:
     return torch._C._cuda_memoryMetadataSupported()
 
 
-def _set_memory_metadata(metadata: str):
+def _set_memory_metadata(metadata: str | dict[str, Any]):
     """
     Set custom metadata to be recorded on memory history trace entries.
 
@@ -1204,10 +1211,19 @@ def _set_memory_metadata(metadata: str):
     backends (e.g. ``cudaMallocAsync`` or a pluggable allocator) it is
     silently ignored.
 
+    A dict is accepted as a convenience and is serialized to a compact JSON
+    string; trace entries always carry the string form (the allocator stores a
+    single string, which is what :func:`_snapshot` and the visualizer show).
+    Consequently :func:`_get_memory_metadata` returns the JSON string, not the
+    original dict, and serialization errors (e.g. non-JSON-serializable
+    values) raise at call time.
+
     Args:
-        metadata (str): Custom metadata string to record on trace entries.
-                       Pass an empty string to clear the metadata.
+        metadata (str or dict): Custom metadata to record on trace entries.
+                               Pass an empty string to clear the metadata.
     """
+    if isinstance(metadata, dict):
+        metadata = json.dumps(metadata, separators=(",", ":"))
     # pyrefly: ignore [missing-attribute]
     torch._C._cuda_setMemoryMetadata(metadata)
 
@@ -1218,7 +1234,10 @@ def _get_memory_metadata() -> str:
 
     See :func:`_set_memory_metadata`. Note that with allocator backends that
     do not support metadata this always returns the empty string, which is
-    indistinguishable from no metadata being set.
+    indistinguishable from no metadata being set. Metadata set as a dict is
+    returned as its JSON serialization; passing the returned string back to
+    :func:`_set_memory_metadata` restores the same metadata, which makes
+    save/set/restore patterns work without special-casing.
 
     Returns:
         str: The current metadata string, or empty string if no metadata is set.

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -201,7 +201,11 @@ function eventStack(e, allocated, reserved) {
       reserved,
     )} reserved)\n${event}`;
   }
-  const user_metadata_str = format_user_metadata(e.user_metadata);
+  let user_metadata_str = format_user_metadata(e.user_metadata);
+  if (e.internal_metadata) {
+    const internal_str = `Internal Metadata:\n  ${e.internal_metadata}`;
+    user_metadata_str += (user_metadata_str ? '\n' : '') + internal_str;
+  }
   const frames_str = format_frames(e.frames);
   const forward_frames_str = format_forward_frames(e.forward_frames);
   return event + '\n' + (user_metadata_str ? user_metadata_str + '\n' : '') + frames_str + forward_frames_str;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #193432

Previously `mallocWithAddress` recorded its provenance on the synthetic
prefix-block malloc/free pair by temporarily overwriting the calling
thread's `user_metadata` (appending `"\nmallocWithAddress"` and restoring
on scope exit). This conflated two distinct things: the user-set metadata
and an allocator-internal tag. It also corrupted structured metadata --
if the user set JSON via `_set_memory_metadata`, the appended text made
the recorded string no longer parse as JSON.

This adds a dedicated `internal_metadata_` field on `TraceEntry`. The
allocator sets an `internal_metadata_tag` (guarded by the allocator mutex,
which is held across the tagged region) and stamps it onto trace entries
in `record_trace`, leaving `user_metadata_` verbatim. The field is only
emitted in the snapshot (both pybind and pickled paths) when non-empty,
and the visualizer renders it under a separate "Internal Metadata" label.

`_set_memory_metadata` now also accepts a dict, serialized to compact JSON,
so callers can record structured metadata; `_get_memory_metadata` returns
the JSON string form, which round-trips back through `_set_memory_metadata`.

Test Plan:

```
python test/test_cuda.py -k test_memory_metadata_dict
python test/test_cuda.py -k test_resize_storage_with_addr_metadata_tag
```

Authored-with: Claude (Opus 4.8)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>