### PR TITLE
Fix fp32 non-associative gradient summation test threshold

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
+    split_backward_grad_tolerances,
     TestCase,
 )
 
@@ -160,7 +161,9 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                torch.testing.assert_close(
+                    p.grad, ref_p.grad, **split_backward_grad_tolerances()
+                )
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -211,7 +214,9 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                torch.testing.assert_close(
+                    p.grad, ref_p.grad, **split_backward_grad_tolerances()
+                )
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5781,6 +5781,30 @@ class BytesIOContext(io.BytesIO):
 # For more information see https://github.com/pytorch/pytorch/issues/56202
 GRADCHECK_NONDET_TOL = 1e-12
 
+# Default tolerances for comparing gradients produced by a split backward
+# against a monolithic .backward() reference. The two reduce in a different
+# order, so non-associative summation makes them diverge by more than the dtype
+# default on hardware whose matmul accumulates below full float32 width. None
+# means use the torch.testing.assert_close default for the dtype. Backends that
+# need wider bounds override these in their test overlay.
+SPLIT_BACKWARD_GRAD_ATOL: float | None = None
+SPLIT_BACKWARD_GRAD_RTOL: float | None = None
+
+
+def split_backward_grad_tolerances() -> dict:
+    """Keyword args for assert_close when comparing a split backward to a reference.
+
+    Reads the constants above at call time rather than import time, so a backend
+    overlay can set them after the test module has been imported. Both are passed
+    together because assert_close rejects one without the other. When both are
+    None, falls back to the per-dtype default.
+    """
+    return {
+        "atol": SPLIT_BACKWARD_GRAD_ATOL,
+        "rtol": SPLIT_BACKWARD_GRAD_RTOL,
+    }
+
+
 TEST_WITH_SLOW_GRADCHECK: bool = TestEnvironment.def_flag(
     "TEST_WITH_SLOW_GRADCHECK",
     env_var="PYTORCH_TEST_WITH_SLOW_GRADCHECK",


### PR DESCRIPTION
## Issue

The default float32 precision for assert_close (rtol=1.3e-6,
atol=1e-5) assumes both sides of the comparison reduce in the same order and
accumulate in full-width float32. The stage_backward_weight tests compare
split backward (stage_backward_input + stage_backward_weight) against a
monolithic .backward(), i.e. a different reduction order. On CPU/CUDA
that is hidden by full-float32 matmul accumulation; on hardware with
lower-precision matmul accumulation, this assert_close fails and the gradients diverge at
~1e-5. The results are still correct to float32 hardware epsilon.

Merged PR for amazing-contributing fork: https://github.com/amazon-contributing/upstream-to-pytorch/pull/90.

## Summary

Updated float32 tolerance for fp32 non-associative summation precision limits on hardware whose matmul accumulates below full float32 width. This enables the two stage_backward_weight tests pass without weakening precision checks anywhere else.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No