### PR TITLE
Fix world size for PP custom schedule test

### DIFF
--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -1451,7 +1451,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
         "schedule_class",
         [ScheduleVShaped, ScheduleUnbalanced],
     )
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_gpu(2)
     def test_non_symmetric_stage_ids(self, schedule_class):
         n_stages = schedule_class.n_stages
         rank_stages = schedule_class.rank_stages
@@ -1501,7 +1501,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
     @parametrize("ScheduleClass", [ScheduleWithReorderedB])
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_gpu(2)
     def test_pipeline_schedule_runtime_custom_sched(self, ScheduleClass):
         n_stages = 2
         stages_per_rank = 1
@@ -1565,7 +1565,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
     @parametrize("ScheduleClass", [ScheduleWithW])
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_gpu(2)
     def test_schedule_with_native_zero_bubble(self, ScheduleClass):
         n_stages = ScheduleClass.n_stages
         num_microbatches = ScheduleClass.num_microbatches


### PR DESCRIPTION
## Issue

`test_non_symmetric_stage_ids`, `test_pipeline_schedule_runtime_custom_sched`,
and `test_schedule_with_native_zero_bubble` were gated behind
`@skip_if_lt_x_gpu(4)`, but each only builds a 2-rank pipeline (2 stages,
1 stage per rank). The `4` requirement was overly strict and caused these
tests to be skipped on 2-device hosts that can run them fine. Lowered the
gate to `@skip_if_lt_x_gpu(2)` to match the actual world size the tests use.

Merged PR to amazon-contributing branch: https://github.com/amazon-contributing/upstream-to-pytorch/pull/69

## Summary

Fix world size for custom schedule tests.

Necessary for running the pipelining schedule tests on non-CUDA
accelerators (e.g. Neuron / PrivateUse1) with fewer than 4 devices.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No