### PR TITLE
[custom ops] Normalize non-Tensor PyObject dispatch returns

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -834,17 +834,102 @@ class TestCustomOp(CustomOpTestCaseBase):
             mutates_args=(),
         )
         def f(x: Tensor) -> Tuple[Tensor, float, bool]:
-            return x.clone(), 2, 1  # type: ignore[return-value]
+            return x.clone(), 2.0, True
 
         op = self.ns().pyobject_dispatch_non_tensor_output.default
         self.assertTrue(op._is_pyobj_dispatcher_enabled())
 
         x = torch.randn(3)
-        y, scalar, predicate = f(x)
+        op._enable_pyobj_dispatch(False)
+        expected = f(x)
+        op._enable_pyobj_dispatch(True)
+        actual = f(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            tuple(type(x) for x in actual), tuple(type(x) for x in expected)
+        )
+        y, scalar, predicate = actual
         self.assertEqual(y, x)
         self.assertIsInstance(scalar, float)
         self.assertEqual(scalar, 2.0)
         self.assertIs(predicate, True)
+
+    @skipIfTorchDynamo("PyObject dispatch test is eager-only")
+    def test_pyobject_dispatch_normalizes_single_scalar_output(self):
+        @torch.library.custom_op(
+            f"{self.test_ns}::pyobject_dispatch_scalar_output",
+            mutates_args=(),
+        )
+        def f(x: Tensor) -> float:
+            return 2  # type: ignore[return-value]
+
+        op = self.ns().pyobject_dispatch_scalar_output.default
+        x = torch.randn(3)
+
+        op._enable_pyobj_dispatch(False)
+        expected = f(x)
+        op._enable_pyobj_dispatch(True)
+        actual = f(x)
+
+        self.assertIsInstance(actual, float)
+        self.assertEqual(actual, expected)
+
+    @skipIfTorchDynamo("PyObject dispatch test is eager-only")
+    def test_pyobject_dispatch_validates_no_return(self):
+        lib = self.lib()
+        lib.define("pyobject_dispatch_no_return(Tensor x) -> ()")
+        return_value = None
+
+        def cpu_impl(x):
+            return return_value
+
+        lib.impl("pyobject_dispatch_no_return", cpu_impl, "CPU")
+        op = self.ns().pyobject_dispatch_no_return.default
+        op._enable_pyobj_dispatch(True)
+
+        x = torch.randn(3)
+        self.assertIsNone(op(x))
+        return_value = 1
+        with self.assertRaisesRegex(ValueError, "to return None"):
+            op(x)
+
+    @skipIfTorchDynamo("PyObject dispatch test is eager-only")
+    def test_pyobject_dispatch_validates_return_arity(self):
+        @torch.library.custom_op(
+            f"{self.test_ns}::pyobject_dispatch_return_arity",
+            mutates_args=(),
+        )
+        def f(x: Tensor) -> Tuple[Tensor, float]:
+            return x.clone(), 2.0, True  # type: ignore[return-value]
+
+        with self.assertRaisesRegex(ValueError, "expected 2 returns but got 3"):
+            f(torch.randn(3))
+
+    @skipIfTorchDynamo("PyObject dispatch test is eager-only")
+    def test_pyobject_dispatch_prims_item_parity(self):
+        op = torch.ops.prims.item.default
+        was_enabled = op._is_pyobj_dispatcher_enabled()
+        self.assertTrue(was_enabled)
+        values = (
+            torch.tensor(True),
+            torch.tensor(3),
+            torch.tensor(2.5),
+            torch.tensor(2 + 3j),
+        )
+
+        try:
+            op._enable_pyobj_dispatch(False)
+            expected = tuple(op(x) for x in values)
+            op._enable_pyobj_dispatch(True)
+            actual = tuple(op(x) for x in values)
+        finally:
+            op._enable_pyobj_dispatch(was_enabled)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            tuple(type(x) for x in actual), tuple(type(x) for x in expected)
+        )
 
     @skipIfTorchDynamo("PyObject dispatch test is eager-only")
     def test_pyobject_dispatch_normalizes_tensor_list_input(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -768,7 +768,7 @@ class TestCustomOp(CustomOpTestCaseBase):
         f.register_autograd(backward, setup_context=setup_context)
 
         op = self.ns().pyobject_dispatch_tensor_list_output.default
-        self.assertFalse(op._is_pyobj_dispatcher_enabled())
+        self.assertTrue(op._is_pyobj_dispatcher_enabled())
 
         x = torch.randn(6, 2, requires_grad=True)
         sizes = torch.tensor([1, 2, 3])
@@ -818,7 +818,7 @@ class TestCustomOp(CustomOpTestCaseBase):
                 return self.list_module([input_embs[0]])[0]
 
         op = self.ns().pyobject_dispatch_module_tensor_list_output.default
-        self.assertFalse(op._is_pyobj_dispatcher_enabled())
+        self.assertTrue(op._is_pyobj_dispatcher_enabled())
 
         x = torch.randn(6, 2)
         sizes = torch.tensor([1, 2, 3])
@@ -826,6 +826,25 @@ class TestCustomOp(CustomOpTestCaseBase):
         self.assertIsInstance(y, list)
         self.assertEqual(passthrough, x)
         self.assertEqual(Consumer()(y), y[0])
+
+    @skipIfTorchDynamo("PyObject dispatch test is eager-only")
+    def test_pyobject_dispatch_normalizes_non_tensor_output(self):
+        @torch.library.custom_op(
+            f"{self.test_ns}::pyobject_dispatch_non_tensor_output",
+            mutates_args=(),
+        )
+        def f(x: Tensor) -> Tuple[Tensor, float, bool]:
+            return x.clone(), 2, 1  # type: ignore[return-value]
+
+        op = self.ns().pyobject_dispatch_non_tensor_output.default
+        self.assertTrue(op._is_pyobj_dispatcher_enabled())
+
+        x = torch.randn(3)
+        y, scalar, predicate = f(x)
+        self.assertEqual(y, x)
+        self.assertIsInstance(scalar, float)
+        self.assertEqual(scalar, 2.0)
+        self.assertIs(predicate, True)
 
     @skipIfTorchDynamo("PyObject dispatch test is eager-only")
     def test_pyobject_dispatch_normalizes_tensor_list_input(self):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -979,21 +979,12 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
     def _is_pyobj_dispatcher_enabled(self) -> bool:
         return self._pyobj_dispatcher is not None
 
-    def _can_enable_pyobj_dispatch(self) -> bool:
-        # TODO(#187974): Support non-Tensor returns by normalizing Python kernel
-        # returns against the operator schema in the PyObject fast path.
-        return all(
-            isinstance(ret.type, torch.TensorType) for ret in self._schema.returns
-        )
-
     def _enable_pyobj_dispatch(self, enabled: bool = True) -> None:
         if self._is_pyobj_dispatcher_enabled() == enabled:
             return
         if not enabled:
             self._pyobj_dispatcher = None
             self._op = self._cpp_dispatch_handle
-            return
-        if not self._can_enable_pyobj_dispatch():
             return
         dispatch, redispatch = torch._C._dispatch_make_pyobj_dispatch_fns(
             self._handle,

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -435,6 +435,16 @@ static PyObject* pyobject_dispatch_normalize_result(
     const c10::FunctionSchema& schema,
     PyObject* result) {
   const auto& returns = schema.returns();
+  if (returns.empty()) {
+    py::object out = py::reinterpret_steal<py::object>(result);
+    TORCH_CHECK_VALUE(
+        out.is_none(),
+        "Expected Python kernel for ",
+        schema.operator_name(),
+        " to return None but it returned something else instead.");
+    return out.release().ptr();
+  }
+
   bool needs_normalization = false;
   for (const auto& ret : returns) {
     if (ret.real_type()->kind() != c10::TypeKind::TensorType) {
@@ -443,6 +453,9 @@ static PyObject* pyobject_dispatch_normalize_result(
     }
   }
   if (!needs_normalization) {
+    // Tensor-only schemas were already eligible for PyObject dispatch before
+    // result normalization was added. Preserve their zero-copy return path:
+    // converting through IValues would reintroduce the cost this path avoids.
     return result;
   }
 

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -431,6 +431,49 @@ static PyObject* pyobject_dispatch_call_python_with_keyset(
       kwnames);
 }
 
+static PyObject* pyobject_dispatch_normalize_result(
+    const c10::FunctionSchema& schema,
+    PyObject* result) {
+  const auto& returns = schema.returns();
+  bool needs_normalization = false;
+  for (const auto& ret : returns) {
+    if (ret.real_type()->kind() != c10::TypeKind::TensorType) {
+      needs_normalization = true;
+      break;
+    }
+  }
+  if (!needs_normalization) {
+    return result;
+  }
+
+  py::object out = py::reinterpret_steal<py::object>(result);
+  if (returns.size() == 1) {
+    return torch::jit::toPyObject(
+               torch::jit::toIValue(out, returns[0].real_type()))
+        .release()
+        .ptr();
+  }
+
+  auto outs = py::cast<py::sequence>(out);
+  TORCH_CHECK_VALUE(
+      outs.size() == returns.size(),
+      schema.name(),
+      "() expected ",
+      returns.size(),
+      " returns but got ",
+      outs.size());
+  py::tuple normalized(returns.size());
+  for (const auto i : c10::irange(returns.size())) {
+    if (returns[i].real_type()->kind() == c10::TypeKind::TensorType) {
+      normalized[i] = outs[i];
+    } else {
+      normalized[i] = torch::jit::toPyObject(
+          torch::jit::toIValue(outs[i], returns[i].real_type()));
+    }
+  }
+  return normalized.release().ptr();
+}
+
 template <typename Func>
 static PyObject* pyobject_dispatch_with_keyset(
     Func* self,
@@ -484,7 +527,7 @@ static PyObject* pyobject_dispatch_with_keyset(
   if (result == nullptr) {
     return nullptr;
   }
-  return result;
+  return pyobject_dispatch_normalize_result(self->handle->schema(), result);
 }
 
 static PyObject* pyobject_dispatch_vectorcall(


### PR DESCRIPTION
Related to #187974

PyObject dispatch currently skips custom operators with non-Tensor returns because direct Python kernel calls bypass dispatcher schema normalization.

This change:
- schema-normalizes only non-Tensor Python kernel results
- preserves the existing zero-copy return path for all-Tensor schemas
- removes the return-type gate so custom operators can use PyObject dispatch
- adds coverage for Tensor-list, mixed Tensor-list/Tensor, and scalar returns, including autograd and module hooks

Tested:
- PyTorch Python formatting and Ruff checks
- C++ clang-format check
- compiled schema-normalization probe for Tensor identity, Tensor-list normalization, and mixed Tensor/scalar/device returns

AI assistance was used in preparing this change.
