### PR TITLE
[FSDP] Make fsdp/ tests device-agnostic           

### DIFF
--- a/test/distributed/fsdp/test_distributed_checkpoint.py
+++ b/test/distributed/fsdp/test_distributed_checkpoint.py
@@ -11,7 +11,11 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataP
 from torch.distributed.fsdp.wrap import enable_wrap, wrap
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, SkipModel
+from torch.testing._internal.common_fsdp import (
+    FSDP_DEVICES,
+    FSDPTestContinuous,
+    SkipModel,
+)
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     parametrize,
@@ -110,7 +114,7 @@ class TestDistributedCheckpoint(FSDPTestContinuous):
         # TODO: add resharding test case.
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestDistributedCheckpoint, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_apply.py
+++ b/test/distributed/fsdp/test_fsdp_apply.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTestContinuous,
     get_devtype,
@@ -117,7 +118,7 @@ class TestApply(FSDPTestContinuous):
                 transformer.apply(self._init_linear_weights)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(TestApply, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _maybe_wrap_fsdp,
+    FSDP_DEVICES,
     FSDPTest,
     FSDPTestContinuous,
     get_devtype,
@@ -344,7 +345,7 @@ class TestFSDPCheckpointSubmodule(FSDPTestContinuous):
             self.assertTrue(p1.grad.allclose(p2.grad))
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestFSDPCheckpointSubmodule, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTestContinuous,
     get_devtype,
@@ -380,7 +381,7 @@ class TestClipGradNorm(FSDPTestContinuous):
         self.assertEqual(total_norm.dtype, torch.float32)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestClipGradNorm, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTestContinuous,
     get_devtype,
@@ -419,7 +420,7 @@ class TestExplicitUnshard(FSDPTestContinuous):
             self.assertTrue(param.numel() > 0)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestCommunication, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -12,6 +12,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecis
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_distributed import (
+    BFLOAT16_AVAILABLE,
     requires_accelerator_dist_backend,
     requires_nccl_version,
     skip_but_pass_in_sandcastle_if,
@@ -32,8 +33,6 @@ if not dist.is_available():
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
 )
-
-BFLOAT16_AVAILABLE = torch.cuda.is_bf16_supported() or torch.xpu.is_bf16_supported()
 
 
 class Net(nn.Module):

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_fsdp import (
     AlwaysWrapNestedWrappedModule,
     DEVICEInitMode,
     DummyDDP,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTest,
     get_devtype,
@@ -518,7 +519,7 @@ class TestAutograd(FSDPTest):
             FlatParamHandle._use_unsharded_views = orig_use_unsharded_views
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(TestHooks, globals(), only_for=devices, allow_xpu=True)
 instantiate_device_type_tests(
     TestParityWithDDP, globals(), only_for=devices, allow_xpu=True

--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -14,7 +14,7 @@ from torch.distributed.fsdp.api import (
 )
 from torch.distributed.tensor import DTensor, Shard
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_fsdp import get_devtype
+from torch.testing._internal.common_fsdp import FSDP_DEVICES, get_devtype
 from torch.testing._internal.common_utils import parametrize, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
@@ -285,7 +285,7 @@ class TestFSDPWithDeviceMeshAndDTensor(DTensorContinuousTestBase):
                 FSDP.optim_state_dict(model, optim)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestFSDPWithDeviceMeshAndDTensor, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -10,7 +10,11 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
+from torch.testing._internal.common_fsdp import (
+    FSDP_DEVICES,
+    FSDPTestContinuous,
+    get_devtype,
+)
 from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
@@ -211,7 +215,7 @@ class TestFSDPExecOrder(FSDPTestContinuous):
         # an `AssertionError` will be raised above for both sharding strategies
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestFSDPExecOrder, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -17,7 +17,11 @@ from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
+from torch.testing._internal.common_fsdp import (
+    FSDP_DEVICES,
+    FSDPTestContinuous,
+    get_devtype,
+)
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_CUDA,
@@ -404,7 +408,7 @@ class TestFSDPFineTune(FSDPTestContinuous):
                     self.assertEqual(param, ref_param)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestFSDPFineTune, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_fx.py
+++ b/test/distributed/fsdp/test_fsdp_fx.py
@@ -2,6 +2,7 @@
 import torch
 from torch.distributed.fsdp._trace_utils import _ExecOrderTracer
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_fsdp import FSDP_DEVICES
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -113,7 +114,7 @@ class TestSymbolicTracing(TestCase):
         self.assertEqual(exec_info.visited_params, set(exec_info.param_forward_order))
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestSymbolicTracing, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_grad_acc.py
+++ b/test/distributed/fsdp/test_fsdp_grad_acc.py
@@ -15,6 +15,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
+    DEVICE_TYPE,
     DEVICEInitMode,
     FSDPInitMode,
     FSDPTestContinuous,
@@ -133,7 +134,7 @@ class TestGradAcc(FSDPTestContinuous):
             deterministic=True,
             add_bn=False,  # disable BN since the test uses varying batch sizes
         )
-        device = torch.device("cuda")
+        device = torch.device(DEVICE_TYPE)
         optim = torch.optim.SGD(
             fsdp_model.parameters(),
             lr=0.01,

--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -8,7 +8,7 @@ from torch.nn import Linear, Module
 from torch.optim import SGD
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous
+from torch.testing._internal.common_fsdp import FSDP_DEVICES, FSDPTestContinuous
 from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
@@ -114,7 +114,7 @@ class TestInput(FSDPTestContinuous):
             self.assertIn("added", in_data)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(TestInput, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -35,6 +35,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _assert_module_states,
+    DEVICE_TYPE,
     DEVICEInitMode,
     FSDPInitMode,
     FSDPTestContinuous,
@@ -969,7 +970,8 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
         context = (
             (
                 self.assertRaisesRegex(
-                    ValueError, f"Inconsistent.*cuda:{self.rank} vs cuda:0"
+                    ValueError,
+                    f"Inconsistent.*{DEVICE_TYPE}:{self.rank} vs {DEVICE_TYPE}:0",
                 )
             )
             if self.rank != 0
@@ -1151,7 +1153,7 @@ class TestFSDPMiscWorldSize1(FSDPTestMultiThread):
         with self.assertRaisesRegex(
             RuntimeError,
             "An FSDP-managed module unexpectedly has parameters on cpu. Make "
-            "sure to move the module to cuda:0 before training.",
+            f"sure to move the module to {DEVICE_TYPE}:0 before training.",
         ):
             fsdp_model(inp)
 
@@ -1163,7 +1165,7 @@ class TestFSDPMiscWorldSize1(FSDPTestMultiThread):
         with self.assertRaisesRegex(
             RuntimeError,
             "An FSDP-managed module with parameter CPU offloading enabled has "
-            "parameters on cuda:0. Make sure to not move the module from CPU "
+            f"parameters on {DEVICE_TYPE}:0. Make sure to not move the module from CPU "
             "when offloading parameters.",
         ):
             fsdp_model(inp)

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -9,7 +9,11 @@ from itertools import product
 from typing import Any
 
 import torch
-import torch.cuda.nccl as nccl
+
+
+if torch.cuda.is_available():
+    import torch.cuda.nccl as nccl
+
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import distributed as dist
@@ -89,7 +93,9 @@ mp_only_param_and_buf = MixedPrecision(
 # Nothing is cast (thus param, comm, grad, and buffer should be in the full precision)
 mp_no_mixed_precision = MixedPrecision()
 
-nccl_supports_bf16 = dist.is_nccl_available() and nccl.version() >= (2, 10)
+nccl_supports_bf16 = (
+    dist.is_nccl_available() and torch.cuda.is_available() and nccl.version() >= (2, 10)
+)
 
 mp_configs = [default_mp, mp_only_reduce, mp_only_param_and_buf, mp_no_mixed_precision]
 if nccl_supports_bf16:

--- a/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
@@ -8,7 +8,11 @@ from torch.nn import Linear, Module, Sequential
 from torch.optim import SGD
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
+from torch.testing._internal.common_fsdp import (
+    FSDP_DEVICES,
+    FSDPTestContinuous,
+    get_devtype,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
 
@@ -61,7 +65,7 @@ class TestMultipleWrapping(FSDPTestContinuous):
         self.assertEqual(output, rewrapped_output)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestMultipleWrapping, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -12,7 +12,7 @@ from torch import distributed as dist, Event
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous
+from torch.testing._internal.common_fsdp import FSDP_DEVICES, FSDPTestContinuous
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
@@ -53,8 +53,8 @@ class Layer(nn.Module):
         # Record the fake forward compute time.
         self.e1.record()
         if self.sleep_cycles > 0:
-            if torch.cuda.is_available():
-                torch.cuda._sleep(self.sleep_cycles)
+            if torch.accelerator.is_available():
+                torch.get_device_module(device_type)._sleep(self.sleep_cycles)
         if self.optional_param is not None:
             x = x + self.optional_param  # force the param to be part of the graph
         self.e2.record()
@@ -141,8 +141,8 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 def _delayed_all_gather(*args, **kwargs):
                     nonlocal all_gather_called
                     all_gather_called = True
-                    if torch.cuda.is_available():
-                        torch.cuda._sleep(all_gather_cycles)
+                    if torch.accelerator.is_available():
+                        torch.get_device_module(device_type)._sleep(all_gather_cycles)
                     if not orig_all_gather:
                         raise AssertionError("Expected orig_all_gather to be truthy")
                     return orig_all_gather(*args, **kwargs)
@@ -261,7 +261,7 @@ class TestForwardOverlapWorldSizeTwo(TestForwardOverlapWorldSizeOne):
         return 2
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestForwardOverlapWorldSizeOne, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_pure_fp16.py
+++ b/test/distributed/fsdp/test_fsdp_pure_fp16.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTestContinuous,
     get_devtype,
@@ -151,7 +152,7 @@ class TestPureFP16(FSDPTestContinuous):
                 self.assertEqual(param.grad.dtype, torch.float16)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(TestPureFP16, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
+    FSDP_DEVICES,
     FSDPInitMode,
     FSDPTestContinuous,
     NestedWrappedModule,
@@ -61,7 +62,7 @@ class TestTraversal(FSDPTestContinuous):
         )
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestTraversal, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_uneven.py
+++ b/test/distributed/fsdp/test_fsdp_uneven.py
@@ -9,7 +9,11 @@ from torch.nn import Linear
 from torch.optim import SGD
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
+from torch.testing._internal.common_fsdp import (
+    FSDP_DEVICES,
+    FSDPTestContinuous,
+    get_devtype,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
 
@@ -68,7 +72,7 @@ class TestUnevenParamShard(FSDPTestContinuous):
             self.assertEqual(ref_weight_out, weight_out)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestUnevenParamShard, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -28,7 +28,6 @@ from torch.distributed.fsdp._init_utils import NO_RESHARD_AFTER_FORWARD_STRATEGI
 from torch.distributed.fsdp.wrap import always_wrap_policy, ModuleWrapPolicy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -41,7 +40,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
-    TEST_XPU,
     TestCase,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
@@ -1404,7 +1402,7 @@ class TestMultiTensorApply(TestCase):
         # Check that this does not segfault
         torch._foreach_mul_(size0_tensors, 0.1)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "no cuda and no xpu")
+    @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
     def test_multi_tensor_apply_size0_tensors_cuda(self):
         size0_tensors = [
             torch.empty(0, device=device_type) for _ in range(NUM_SIZE0_TENSORS)

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -17,7 +17,7 @@ from torch.distributed.fsdp.api import (
 )
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_fsdp import get_devtype
+from torch.testing._internal.common_fsdp import FSDP_DEVICES, get_devtype
 from torch.testing._internal.common_utils import parametrize, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
@@ -324,7 +324,7 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorContinuousTestBase):
                 self.assertIsInstance(state["exp_avg_sq"], torch.Tensor)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(
     TestHSDPWithDeviceMeshAndDTensor, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -14,11 +14,13 @@ from torch.distributed.fsdp._common_utils import _get_param_to_fqns
 from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDP_DEVICES
 from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     subtest,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_XPU,
     TestCase,
@@ -40,6 +42,8 @@ if TEST_HPU:
     list_device = "hpu"
 elif TEST_XPU:
     list_device = "xpu"
+elif TEST_PRIVATEUSE1:
+    list_device = torch._C._get_privateuse1_backend_name()
 else:
     list_device = "cuda"
 
@@ -203,7 +207,7 @@ class TestUtils(TestCase):
         )
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = FSDP_DEVICES
 instantiate_device_type_tests(TestUtils, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -49,8 +49,6 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TEST_CUDA,
-    TEST_XPU,
     TestCase,
 )
 
@@ -467,7 +465,7 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Test requires accelerator")
     def test_always_wrap(self):
         """
         Test to ensure that if `always_wrap_policy` is
@@ -732,7 +730,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[1], nn.ModuleList))
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test Requires CUDA or XPU")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Test requires accelerator")
     @parametrize(
         "device_init_mode", [DEVICEInitMode.DEVICE_BEFORE, DEVICEInitMode.DEVICE_AFTER]
     )

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -742,6 +742,16 @@ def create_device(interface=None, lazy_init: bool = False):
         )
 
 
+def _is_bf16_supported() -> bool:
+    if torch.accelerator.is_available():
+        device_module = torch.get_device_module(torch.accelerator.current_accelerator())
+        return getattr(device_module, "is_bf16_supported", lambda: False)()
+    return False
+
+
+BFLOAT16_AVAILABLE = _is_bf16_supported()
+
+
 def get_timeout(test_id) -> int:
     return TIMEOUT_OVERRIDE.get(test_id.split(".")[-1], TIMEOUT_DEFAULT)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -62,6 +62,8 @@ from torch.testing._internal.common_utils import (
     set_rng_seed,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TEST_WITH_ROCM,
     TEST_XPU,
 )
@@ -88,6 +90,11 @@ else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
     DEVICE_COUNT = 1
+
+# Device types supported by FSDP device-type-parameterized tests.
+FSDP_DEVICES = ("cuda", "hpu", "xpu")
+if TEST_PRIVATEUSE1:
+    FSDP_DEVICES = FSDP_DEVICES + (TEST_PRIVATEUSE1_DEVICE_TYPE,)
 
 
 class FSDPInitMode(Enum):


### PR DESCRIPTION
Make the tests under `test/distributed/fsdp/` device-agnostic so they can run on accelerator backends beyond CUDA/HPU/XPU.

  **Depends on #193445 ** (adds `FSDP_DEVICES` and `BFLOAT16_AVAILABLE`).
  
  - replace hardcoded `("cuda", "hpu", "xpu")` device tuples with `FSDP_DEVICES`
  - replace hardcoded `"cuda"` device strings with `DEVICE_TYPE`
  - replace inline bf16-support checks with `BFLOAT16_AVAILABLE`
  - replace `torch.cuda.is_available()` guards with `torch.accelerator.is_available()`
    where the code is not truly CUDA-only, and gate the `torch.cuda.nccl` import
    behind `TEST_CUDA` where it is
  - gate `nccl_supports_bf16` on `torch.cuda.is_available()` so it does not crash on
    non-CUDA accelerators
    
  Test-only; no library behavior changes.
  
  ### Test plan
```
  python test/distributed/fsdp/test_fsdp_core.py
  python test/distributed/fsdp/test_fsdp_comm_hooks.py
  python test/distributed/fsdp/test_fsdp_misc.py
  python test/distributed/fsdp/test_fsdp_mixed_precision.py
  python test/distributed/fsdp/test_fsdp_overlap.py
  python test/distributed/fsdp/test_utils.py
  (All 24 modified files should be exercised on CUDA and the target accelerator.)
  ```
