### PR TITLE
[FSDP] Make composable FSDP tests device-agnostic

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -1773,6 +1773,7 @@ class TestFullyShardAllocFromPG(FSDPTest):
         super()._run(*args, **kwargs)
 
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not TEST_CUDA, "NCCL log parsing requires CUDA")
     # The NCCL PG refuses to allocate tensors if multicast is unavailable, see
     # https://github.com/pytorch/pytorch/blob/503362d019b3782581492af7767945dbd75ca1c9/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L5634
     def test_fully_shard_alloc_from_pg(self):
@@ -1793,13 +1794,13 @@ class TestFullyShardAllocFromPG(FSDPTest):
         fully_shard(model)
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertNotRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1813,7 +1814,7 @@ class TestFullyShardAllocFromPG(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1858,13 +1859,13 @@ class TestFullyShardSymmMem(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device("cuda", self.rank)
+        return torch.device(device_type, self.rank)
 
     @parametrize("sum_reduction", [True, False])
     def test_fully_shard_symm_mem(self, sum_reduction: bool):
         torch.manual_seed(42 + self.rank)
-        device = torch.device("cuda", self.rank)
-        torch.cuda.set_device(device)
+        device = torch.device(device_type, self.rank)
+        torch.get_device_module(device_type).set_device(device)
         seq_len = 64
         model_args = ModelArgs()
         model_args.dim = 4096
@@ -1887,7 +1888,7 @@ class TestFullyShardSymmMem(MultiProcContinuousTest):
             loss.sum().backward()
 
         run()
-        torch.cuda.synchronize(device)
+        torch.accelerator.synchronize()
 
 
 instantiate_parametrized_tests(TestFullyShardSymmMem)
@@ -1946,13 +1947,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1969,7 +1970,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -2012,13 +2013,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -2037,7 +2038,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -106,7 +106,7 @@ class TestFullyShardOverlap(FSDPTest):
             )
             with torch.get_device_module(device_type).stream(comm_stream):
                 torch.get_device_module(device_type)._sleep(
-                    int(comm_sleep_ms * get_cycles_per_ms())
+                    int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
                 )
             torch.get_device_module(device_type).current_stream().wait_stream(
                 comm_stream
@@ -343,7 +343,7 @@ class TestFullyShardOverlap(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(comm_sleep_ms * get_cycles_per_ms())
+                int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_all_gather_into_tensor(*args, **kwargs)
 
@@ -397,14 +397,16 @@ class Matmul(torch.autograd.Function):
     def forward(ctx, input: torch.Tensor, weight: torch.Tensor, sleep_ms: int):
         ctx.save_for_backward(input, weight)
         ctx.sleep_ms = sleep_ms
-        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms()))
+        torch.get_device_module(device_type)._sleep(
+            int(sleep_ms * get_cycles_per_ms(device_type.type))
+        )
         return input @ weight
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (input, weight) = ctx.saved_tensors
         torch.get_device_module(device_type)._sleep(
-            int(2 * ctx.sleep_ms * get_cycles_per_ms())
+            int(2 * ctx.sleep_ms * get_cycles_per_ms(device_type.type))
         )
         grad_input = grad_output @ weight.T
         grad_weight = input.T @ grad_output
@@ -473,7 +475,9 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             ds = delay_streams[reduce_scatter_group]
             ds.wait_event(rs_event)
             with device_module.stream(ds):
-                device_module._sleep(int(sleep_ms * get_cycles_per_ms()))
+                device_module._sleep(
+                    int(sleep_ms * get_cycles_per_ms(device_type.type))
+                )
                 delayed_event = ds.record_event()
             return (rs_input, delayed_event, post_reduce_stream, *rest)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -114,7 +114,7 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
         return 2
 
     def test_root_move_forward_input_to_device(self):
-        device = torch.device(device_type.type, 0)
+        device = torch.device(device_type.type, self.rank)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):
@@ -514,7 +514,12 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             and offload_policy.pin_memory
         ):
             return
-        if test_device_type not in ("cuda", "hpu", "xpu", "cpu"):
+        valid_device_types = ("cuda", "hpu", "xpu", "cpu")
+        if hasattr(torch._C, "_get_privateuse1_backend_name"):
+            backend_name = torch._C._get_privateuse1_backend_name()
+            if backend_name != "privateuseone":
+                valid_device_types = valid_device_types + (backend_name,)
+        if test_device_type not in valid_device_types:
             raise AssertionError(f"Unexpected device type: {test_device_type}")
         torch.manual_seed(42)
         vocab_size = 1024


### PR DESCRIPTION
Replace hardcoded CUDA usage in test/distributed/_composable/fsdp with device-agnostic accelerator APIs so these tests can run on accelerator backends beyond CUDA:

- `device="cuda"` -> `device=device_type`
- `torch.cuda.synchronize()` -> `torch.accelerator.synchronize()`
- `torch.cuda.set_device(...)` -> `torch.get_device_module(device_type).set_device(...)`
- pass the device to `get_cycles_per_ms(device_type.type)`
- gate the NCCL-debug-log tests that are inherently CUDA-specific behind `@unittest.skipIf(not TEST_CUDA, ...)`
- allow the configured PrivateUse1 backend in the valid device-type check

These tests already define `device_type` and the helpers used here already support a device argument upstream, so this is test-only and does not change any library behavior.

Test plan:
```
python test/distributed/_composable/fsdp/test_fully_shard_comm.py
python test/distributed/_composable/fsdp/test_fully_shard_overlap.py
python test/distributed/_composable/fsdp/test_fully_shard_training.py
```

This PR was authored with the assistance of an AI coding assistant (Claude).