### PR TITLE
make DDP tests backend agnostic

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -25,11 +25,16 @@ import torch.distributed as c10d
 import torch.distributed._functional_collectives as _functional_collectives
 from torch.distributed.distributed_c10d import SHRINK_ABORT as NCCL_SHRINK_ABORT
 
-
-if not c10d.is_available() or not c10d.is_nccl_available():
-    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+if not c10d.is_available():
+    print("c10d not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+if torch.accelerator.current_accelerator() is None:
+    print("No accelerator available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+DEVICE_TYPE = torch.accelerator.current_accelerator().type
+BACKEND = c10d.get_default_backend_for_device(DEVICE_TYPE)
 
 import test_c10d_common
 from test_c10d_common import (
@@ -56,6 +61,7 @@ from torch.testing._internal.common_distributed import (
     init_multigpu_helper,
     MultiProcessTestCase,
     PLATFORM_SUPPORTS_SYMM_MEM,
+    requires_accelerator_dist_backend,
     requires_multicast_support,
     requires_nccl,
     requires_nccl_shrink,
@@ -91,9 +97,11 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-BFLOAT16_AVAILABLE = torch.cuda.is_available() and (
-    torch.version.cuda is not None or torch.version.hip is not None
-)
+BFLOAT16_AVAILABLE = False
+if (acc := torch.accelerator.current_accelerator()):
+    device_module = getattr(torch, acc.type, None)
+    if device_module and hasattr(device_module, 'is_bf16_supported'):
+        BFLOAT16_AVAILABLE = device_module.is_bf16_supported()
 
 _start_time = time.time()
 _logger = logging.getLogger(__name__)
@@ -1139,7 +1147,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @skip_but_pass_in_sandcastle_if(
-        torch.cuda.nccl.version()[-1] == "x", "NCCL test not for NCCLX"
+        DEVICE_TYPE == "cuda" and torch.cuda.nccl.version()[-1] == "x", "NCCL test not for NCCLX"
     )
     def test_comm_split_subgroup(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
@@ -2227,17 +2235,18 @@ class DistributedDataParallelTest(
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
         # that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
-        os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
+        if DEVICE_TYPE == "cuda" and c10d.is_nccl_available():
+            os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
         self._spawn_processes()
 
     def _get_process_group(self):
         store = self._get_store()
         c10d.init_process_group(
-            "nccl", store=store, rank=self.rank, world_size=self.world_size
+            BACKEND, store=store, rank=self.rank, world_size=self.world_size
         )
         return c10d.distributed_c10d._get_default_group()
 
-    def _test_nccl_backend(
+    def _test_backend(
         self, devices, device_ids, multi_device=False, gradient_as_bucket_view=False
     ):
         process_group = self._get_process_group()
@@ -2245,13 +2254,13 @@ class DistributedDataParallelTest(
             process_group, devices, device_ids, multi_device, gradient_as_bucket_view
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_complex_params_and_grads(self):
         # test ddp with complex parameters and gradients
         process_group = self._get_process_group()
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        device = torch.device(f"cuda:{device_id}")
+        device = torch.device(f"{DEVICE_TYPE}:{device_id}")
 
         torch.manual_seed(42 + self.rank)
         model = nn.Sequential(
@@ -2362,13 +2371,13 @@ class DistributedDataParallelTest(
                 "Final model parameters don't match after training",
             )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_mixed_real_and_complex_params(self):
         # test ddp with mixed real and complex parameters and gradients
         process_group = self._get_process_group()
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
-        device = torch.device(f"cuda:{device_id}")
+        device = torch.device(f"{DEVICE_TYPE}:{device_id}")
 
         class MixedModule(nn.Module):
             def __init__(self):
@@ -2495,7 +2504,7 @@ class DistributedDataParallelTest(
 
             # Now when nonzero rank attempts to use communicator, original failure reason should be logged.
             try:
-                pg.allreduce([torch.ones(2).cuda(self.rank)]).wait()
+                pg.allreduce([torch.ones(2).to(f"{DEVICE_TYPE}:{self.rank}")]).wait()
             except dist.DistBackendError as e:
                 self.assertTrue("aborted" in str(e))
             else:
@@ -2510,75 +2519,75 @@ class DistributedDataParallelTest(
         # the watchdog has run on the rank, and there is no reliable way
         # to confirm it has run.
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_multi_device_ids_not_allowed(self):
-        int_devices = list(range(torch.cuda.device_count()))
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+    def test_backend_multi_device_ids_not_allowed(self):
+        int_devices = list(range(torch.accelerator.device_count()))
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
         with self.assertRaisesRegex(
             ValueError, "device_ids can only be None or contain a single element."
         ):
-            self._test_nccl_backend(devices, int_devices)
+            self._test_backend(devices, int_devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_single_device_module_device_ids_None(self):
-        self._test_nccl_backend(None, None)
+    def test_backend_single_device_module_device_ids_None(self):
+        self._test_backend(None, None)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_single_device_module_empty_device_ids(self):
+    def test_backend_single_device_module_empty_device_ids(self):
         # This tests the backward compatibility of accepting an empty list as `device_ids`,
         # although we no longer document this in favor of the default value of `None`,
         # which is consistent with multi-device modules and CPU modules.
-        self._test_nccl_backend(None, [])
+        self._test_backend(None, [])
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    def test_nccl_backend_multi_device_module_device_ids_None(self):
+    def test_backend_multi_device_module_device_ids_None(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_1gpu_module_device_ids_integer_list(self):
+    def test_backend_1gpu_module_device_ids_integer_list(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, int_devices)
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, int_devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_nccl_backend_1gpu_module_device_ids_torch_device_list(self):
+    def test_backend_1gpu_module_device_ids_torch_device_list(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, devices)
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, devices)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    def test_nccl_backend_2gpu_module(self):
+    def test_backend_2gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(8)
-    def test_nccl_backend_4gpu_module(self):
+    def test_backend_4gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        self._test_nccl_backend(devices, None, multi_device=True)
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
+        self._test_backend(devices, None, multi_device=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
     def test_ddp_multi_device_module_config(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
+        device_ids = gpus_for_rank(self.world_size)[self.rank]
 
-        self.assertTrue(len(gpus) >= 2, "expecting at least 2 gpus per process")
+        self.assertTrue(len(device_ids) >= 2, "expecting at least 2 devices per process")
 
         process_group = self._get_process_group()
 
-        gpus = gpus[:2]
-        model = DoubleGpuNet(gpus)
+        device_ids = device_ids[:2]
+        model = DoubleGpuNet(device_ids)
 
         with self.assertRaisesRegex(
             ValueError,
@@ -2586,13 +2595,13 @@ class DistributedDataParallelTest(
             "single-device/multiple-device GPU modules or CPU modules",
         ):
             DistributedDataParallel(
-                model, output_device=gpus[1], process_group=process_group
+                model, output_device=device_ids[1], process_group=process_group
             )
 
         with self.assertRaisesRegex(
             ValueError, "device_ids can only be None or contain a single element."
         ):
-            DistributedDataParallel(model, device_ids=gpus, process_group=process_group)
+            DistributedDataParallel(model, device_ids=device_ids, process_group=process_group)
 
         with self.assertRaisesRegex(
             ValueError, "input module must be on the same type of devices"
@@ -2604,17 +2613,18 @@ class DistributedDataParallelTest(
         with self.assertRaisesRegex(
             ValueError, "device_ids can only be None or contain a single element."
         ):
-            DistributedDataParallel(model, device_ids=gpus, process_group=process_group)
+            DistributedDataParallel(model, device_ids=device_ids, process_group=process_group)
 
     def _test_fp16(self, gradient_as_bucket_view=False):
         process_group = self._get_process_group()
 
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        model = nn.Linear(1, 1, bias=False).cuda(gpus[0]).half()
+        dev_ids = gpus_for_rank(self.world_size)[self.rank]
+        device = torch.device(DEVICE_TYPE, dev_ids[0])
+        model = nn.Linear(1, 1, bias=False).to(device).half()
         nn.init.constant_(model.weight, 1)
         ddp_model = DistributedDataParallel(
             model,
-            device_ids=[gpus[0]],
+            device_ids=[dev_ids[0]],
             process_group=process_group,
             bucket_cap_mb=0.001,
             gradient_as_bucket_view=gradient_as_bucket_view,
@@ -2623,7 +2633,7 @@ class DistributedDataParallelTest(
         # Input 2**15, so that the gradients will overflow with a
         # world_size of 2, unless we normalize the gradient by the
         # world_size before the reduction
-        input = torch.tensor([[2**15]]).cuda(gpus[0]).half()
+        input = torch.tensor([[2**15]]).to(device).half()
 
         # Step model
         ddp_model.train()
@@ -2633,12 +2643,12 @@ class DistributedDataParallelTest(
 
         self.assertFalse(any(torch.isinf(p.grad).any() for p in ddp_model.parameters()))
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16(self):
         self._test_fp16()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16_grad_is_view(self):
         self._test_fp16(gradient_as_bucket_view=True)
@@ -2733,17 +2743,17 @@ class DistributedDataParallelTest(
             unbox=lambda obj: obj["list"][3],
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_arbitrary_forward_return_value(self):
         self._test_arbitrary_forward_return_value()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_arbitrary_forward_return_value_grad_is_view(self):
         self._test_arbitrary_forward_return_value(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_with_lazy_parameters(self):
         process_group = self._get_process_group()
@@ -2759,9 +2769,9 @@ class DistributedDataParallelTest(
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        torch.cuda.set_device(self.rank)
+        torch.accelerator.set_device_index(self.rank)
         dist.init_process_group(
-            backend="nccl",
+            backend=BACKEND,
             world_size=self.world_size,
             rank=self.rank,
             init_method=f"file://{self.file_name}",
@@ -2871,37 +2881,37 @@ class DistributedDataParallelTest(
 
     # TODO: Combine the following tests once https://github.com/pytorch/pytorch/issues/55967
     # is resolved.
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_find_unused_parameters_kwarg_debug_detail(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["INFO"])
     def test_find_unused_parameters_kwarg_debug_info(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["OFF"])
     def test_find_unused_parameters_kwarg_debug_off(self):
         self._test_find_unused_parameters_kwarg()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_detail(self):
         self._test_find_unused_parameters_kwarg(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["INFO"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_info(self):
         self._test_find_unused_parameters_kwarg(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     @with_dist_debug_levels(levels=["OFF"])
     def test_find_unused_parameters_kwarg_grad_is_view_debug_off(self):
@@ -2957,17 +2967,17 @@ class DistributedDataParallelTest(
         loss2 = criterion(output2, target)
         loss2.backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_multiple_outputs_multiple_backward(self):
         self._test_multiple_outputs_multiple_backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_multiple_outputs_multiple_backward_grad_is_view(self):
         self._test_multiple_outputs_multiple_backward(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_no_grad(self):
         """
@@ -3019,7 +3029,7 @@ class DistributedDataParallelTest(
         # we would like to make sure DDP does not mess up with the underlying
         # module.
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
-        devices = [torch.device("cuda:" + str(i)) for i in int_devices]
+        devices = [torch.device(f"{DEVICE_TYPE}:" + str(i)) for i in int_devices]
         process_group = self._get_process_group()
         global_batch_size = self.world_size
 
@@ -3066,17 +3076,17 @@ class DistributedDataParallelTest(
             torch.manual_seed(1337 + iteration)
             input = input[torch.randperm(global_batch_size)]
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_accumulate_gradients_module(self):
         self._test_accumulate_gradients_module()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_accumulate_gradients_module_with_grad_is_view(self):
         self._test_accumulate_gradients_module(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_failure_recovery(self):
         process_group = self._get_process_group()
@@ -3128,7 +3138,7 @@ class DistributedDataParallelTest(
 
         store = c10d.FileStore(recovery_filename, self.world_size)
         c10d.init_process_group(
-            "nccl", store=store, rank=self.rank, world_size=self.world_size
+            BACKEND, store=store, rank=self.rank, world_size=self.world_size
         )
         process_group = c10d.distributed_c10d._get_default_group()
         ddp = DistributedDataParallel(
@@ -3146,11 +3156,11 @@ class DistributedDataParallelTest(
             loss = criterion(output, target)
             loss.backward()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_pass_default_pg(self):
         dist.init_process_group(
-            "nccl",
+            BACKEND,
             init_method=f"file://{self.file_name}",
             world_size=self.world_size,
             rank=self.rank,
@@ -3282,10 +3292,10 @@ class DistributedDataParallelTest(
                             )
                             raise
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_grad_layout_1devicemodule_1replicaperprocess(self):
-        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
         # Tells DDP to use just one device.
         replica_devices = [dev0]
         # Tells _test_grad_layout to construct ConvNet with all layers on this process's first assigned device.
@@ -3293,12 +3303,12 @@ class DistributedDataParallelTest(
         local_batch_size = 16
         self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
     def test_grad_layout_2devicemodule(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
-        dev0 = torch.device("cuda:" + str(int_devices[0]))
-        dev1 = torch.device("cuda:" + str(int_devices[1]))
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(int_devices[0]))
+        dev1 = torch.device(f"{DEVICE_TYPE}:" + str(int_devices[1]))
         # DDP's default behavior for a multi-device module is "don't replicate."
         replica_devices = None
         # Tells _test_grad_layout to constructs this process's ConvNet on 2 devices, with 2 layers on each device.
@@ -3306,12 +3316,12 @@ class DistributedDataParallelTest(
         local_batch_size = 16
         self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_param_layout_mismatch_error(self):
         process_group = self._get_process_group()
 
-        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        dev0 = torch.device(f"{DEVICE_TYPE}:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
         layer_devs = dev0
         layer_formats = (
             [torch.contiguous_format] * 4
@@ -3355,11 +3365,11 @@ class DistributedDataParallelTest(
 
         return gpu_model
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_future_passing_gpu_nccl(self):
+    def test_ddp_comm_hook_future_passing(self):
         """
-        This unit test verifies whether the Future object is passed properly using nccl backend.
+        This unit test verifies whether the Future object is passed properly using accelerator backend.
         The hook callback function creates a Future object and sets a value to it.
         """
         process_group = self._get_process_group()
@@ -3371,7 +3381,7 @@ class DistributedDataParallelTest(
         # without the comm_hook, result would be 0.25 * torch.ones(2, 2).
         self._run_and_verify_hook(gpu_model, 8, 2 * torch.ones(2, 2))
 
-    def _test_ddp_comm_hook_allreduce_hook_nccl(
+    def _test_ddp_comm_hook_allreduce_hook(
         self, gradient_as_bucket_view=False, static_graph=False
     ):
         """
@@ -3400,7 +3410,7 @@ class DistributedDataParallelTest(
         # check whether the grads are equal to what DDP without hook would return.
         self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_default_ddp_comm_hooks_nccl(self, gradient_as_bucket_view=False):
+    def _test_default_ddp_comm_hooks(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether default Python DDP communication hooks ALLREDUCE, FP16_COMPRESS
         and BF16_COMPRESS, can give the same result with the case of no hook registered.
@@ -3414,6 +3424,7 @@ class DistributedDataParallelTest(
             not TEST_WITH_ROCM
             and BFLOAT16_AVAILABLE
             and c10d.is_nccl_available()
+            and DEVICE_TYPE == "cuda"
             and torch.cuda.nccl.version() >= (2, 10)
         ):
             hook_options.append(default.bf16_compress_hook)
@@ -3476,7 +3487,7 @@ class DistributedDataParallelTest(
             # check whether the grads are equal to what DDP without hook would return.
             self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_powerSGD_ddp_comm_hook_nccl(self, gradient_as_bucket_view=False):
+    def _test_powerSGD_ddp_comm_hook(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether Python DDP communication hook POWER_SGD
         can give the same result with the case of no hook registered.
@@ -3505,7 +3516,7 @@ class DistributedDataParallelTest(
                 # check whether the grads are equal to what DDP without hook would return.
                 self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    def _test_builtin_ddp_comm_hooks_nccl(self, gradient_as_bucket_view=False):
+    def _test_builtin_ddp_comm_hooks(self, gradient_as_bucket_view=False):
         """
         This unit test verifies whether built-in C++ DDP communication hooks ALLREDUCE and FP16_COMPRESS
         can give the same result with the case of no hook registered.
@@ -3524,62 +3535,62 @@ class DistributedDataParallelTest(
             # check whether the grads are equal to what DDP without hook would return.
             self._run_and_verify_hook(gpu_model, 8, 0.25 * torch.ones(2, 2))
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl()
+    def test_ddp_comm_hook_allreduce_with_future(self):
+        self._test_ddp_comm_hook_allreduce_hook()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_default_ddp_comm_hooks_nccl(self):
-        self._test_default_ddp_comm_hooks_nccl()
+    def test_default_ddp_comm_hooks(self):
+        self._test_default_ddp_comm_hooks()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_fp16_compress_wrapper_nccl(self):
+    def test_fp16_compress_hook_wrapper(self):
         self._test_fp16_compress_wrapper()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
     @skip_but_pass_in_sandcastle_if(
         not BFLOAT16_AVAILABLE,
         "BFloat16 is only supported by CUDA 11+",
     )
     @skip_if_lt_x_gpu(2)
-    def test_bf16_compress_wrapper_nccl(self):
+    def test_bf16_compress_hook_wrapper(self):
         self._test_bf16_compress_wrapper()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_builtin_ddp_comm_hooks_nccl(self):
-        self._test_builtin_ddp_comm_hooks_nccl()
+    def test_builtin_ddp_comm_hooks(self):
+        self._test_builtin_ddp_comm_hooks()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_powerSGD_ddp_comm_hook_nccl(self):
-        self._test_powerSGD_ddp_comm_hook_nccl()
+    def test_powerSGD_ddp_comm_hook(self):
+        self._test_powerSGD_ddp_comm_hook()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl_grad_is_view(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl(gradient_as_bucket_view=True)
+    def test_ddp_comm_hook_allreduce_with_future_grad_is_view(self):
+        self._test_ddp_comm_hook_allreduce_hook(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_hook_nccl_static_graph(self):
-        self._test_ddp_comm_hook_allreduce_hook_nccl(static_graph=True)
+    def test_ddp_comm_hook_allreduce_with_future_static_graph(self):
+        self._test_ddp_comm_hook_allreduce_hook(static_graph=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_default_ddp_comm_hooks_nccl_is_view(self):
-        self._test_default_ddp_comm_hooks_nccl(gradient_as_bucket_view=True)
+    def test_default_ddp_comm_hooks_is_view(self):
+        self._test_default_ddp_comm_hooks(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_fp16_compress_wrapper_is_view(self):
         self._test_fp16_compress_wrapper(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for BF16_COMPRESS")
     @skip_but_pass_in_sandcastle_if(
         not BFLOAT16_AVAILABLE,
@@ -3589,19 +3600,19 @@ class DistributedDataParallelTest(
     def test_bf16_compress_wrapper_is_view(self):
         self._test_bf16_compress_wrapper(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_builtin_ddp_comm_hooks_nccl_grad_is_view(self):
-        self._test_builtin_ddp_comm_hooks_nccl(gradient_as_bucket_view=True)
+    def test_builtin_ddp_comm_hooks_grad_is_view(self):
+        self._test_builtin_ddp_comm_hooks(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_powerSGD_ddp_comm_hook_nccl_grad_is_view(self):
-        self._test_powerSGD_ddp_comm_hook_nccl(gradient_as_bucket_view=True)
+    def test_powerSGD_ddp_comm_hook_grad_is_view(self):
+        self._test_powerSGD_ddp_comm_hook(gradient_as_bucket_view=True)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
-    def test_ddp_comm_hook_allreduce_with_then_hook_nccl(self):
+    def test_comm_hook_allreduce_with_then(self):
         """
         This unit test verifies whether a DDP communication hook that calls allreduce and then
         multiplies the result by ten and divides by two gives the expected result.
@@ -3642,7 +3653,7 @@ class DistributedDataParallelTest(
         def forward(self, input):
             return input + self.a * self.f
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_weight_sharing(self):
         process_group = self._get_process_group()
@@ -3656,7 +3667,7 @@ class DistributedDataParallelTest(
         for try_set_to_none, use_bucket_view in product((False, True), (False, True)):
             m = torch.nn.Sequential(
                 self.AcceptsParam(p, dev + 1), self.AcceptsParam(p, dev + 1)
-            ).cuda(dev)
+            ).to(torch.device(DEVICE_TYPE, dev))
 
             m = torch.nn.parallel.DistributedDataParallel(
                 m,
@@ -3686,7 +3697,7 @@ class DistributedDataParallelTest(
                         + f"set_to_none = {try_set_to_none}, use_bucket_view = {use_bucket_view}",
                     )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_packed_sequence(self):
         """
@@ -3696,7 +3707,7 @@ class DistributedDataParallelTest(
         """
         store = c10d.FileStore(self.file_name, self.world_size)
         process_group = dist.init_process_group(
-            "nccl",
+            BACKEND,
             world_size=self.world_size,
             rank=self.rank,
             store=store,
@@ -3747,17 +3758,17 @@ class DistributedDataParallelTest(
         for p1, p2 in zip(lstm.parameters(), lstm_ddp.parameters()):
             self.assertEqual(p1.grad, p2.grad)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_channels_last_contig(self):
         process_group = self._get_process_group()
-        device = torch.device(f"cuda:{self.rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{self.rank}")
         tensor = torch.ones((2, 16, 768, 1152), dtype=torch.float32, device=device).to(
             memory_format=torch.channels_last
         )
         process_group.broadcast([tensor]).wait()
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_ddp_complex_params(self):
         process_group = self._get_process_group()
@@ -3778,9 +3789,9 @@ class DistributedDataParallelTest(
         loss.backward()
         optimizer.step()
 
-        torch.cuda.synchronize(device=device_id)
+        torch.accelerator.synchronize(device_id)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_list_initialization(self):
         """Test that bucket_cap_mb_list is properly converted to bucket_bytes_cap_list"""
@@ -3821,7 +3832,7 @@ class DistributedDataParallelTest(
             lambda msg: f"{msg}\nbucket_bytes_cap should be {expected_bucket_bytes_cap}",
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_list_default_behavior(self):
         """Test that default bucket_cap_mb is used when neither parameter is provided"""
@@ -3856,7 +3867,7 @@ class DistributedDataParallelTest(
             "bucket_bytes_cap_list should be empty when not provided",
         )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(2)
     def test_bucket_cap_mb_alone(self):
         """Test that bucket_cap_mb works correctly when provided alone"""
@@ -3892,7 +3903,6 @@ class DistributedDataParallelTest(
             [],
             "bucket_bytes_cap_list should be empty when bucket_cap_mb_list not provided",
         )
-
 
 class WorkHookTest(MultiProcessTestCase):
     @property

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -686,7 +686,8 @@ class _LocalOffsetBasedRNGTracker:
 
     @property
     def _device(self):
-        return torch.device(self._device_type, torch.accelerator.current_device_index())
+        device_module = torch.get_device_module(self._device_type)
+        return torch.device(self._device_type, device_module.current_device())
 
     def _set_pre_op_offset(self, state, spec) -> None:
         """Compute and set per-rank offsets before the random operation."""

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -2484,6 +2484,11 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         if hook.__name__ in ["bf16_compress_hook", "bf16_compress_wrapper_hook"]:
+            bf16_supported = False
+            if torch.accelerator.is_available():
+                device_module = torch.get_device_module(torch.accelerator.current_accelerator())
+                bf16_supported = getattr(device_module, 'is_bf16_supported', lambda: False)()
+
             cuda_supported = (
                 torch.version.cuda is not None
             ) or torch.version.hip is not None
@@ -2498,10 +2503,11 @@ class DistributedDataParallel(Module, Joinable):
                 and torch.xpu.is_available()
             )
 
-            if not ((cuda_supported and nccl_supported) or xpu_xccl_supported):
+            if not (bf16_supported or (cuda_supported and nccl_supported) or xpu_xccl_supported):
                 self._log_and_throw(
                     TypeError,
-                    "BF16 all reduce communication hook required CUDA 11+ and NCCL 2.10+ or XPU and XCCL",
+                    "BF16 all reduce communication hook requires CUDA 11+ and NCCL 2.10+, "
+                    "XPU and XCCL, or an accelerator with BF16 support",
                 )
 
     @property

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -47,6 +47,7 @@ from torch.testing._internal.common_utils import (
     skip_but_pass_in_sandcastle_if,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
@@ -296,6 +297,8 @@ def at_least_x_gpu(x):
         return True
     if TEST_XPU and torch.xpu.device_count() >= x:
         return True
+    if TEST_PRIVATEUSE1 and torch.accelerator.device_count() >= x:
+        return True
     return False
 
 
@@ -324,7 +327,9 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
                 return func(*args, **kwargs)
             if TEST_XPU and torch.xpu.device_count() >= x:
                 return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
+            if TEST_PRIVATEUSE1 and torch.accelerator.device_count() >= x:
+                return func(*args, **kwargs)
+            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU or TEST_PRIVATEUSE1):
                 return func(*args, **kwargs)
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
@@ -549,8 +554,11 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
-                                       If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
+        backends (Optional[List[str]]): Specific accelerator backends to check
+            (e.g., ["nccl", "xccl", "hccl"]). Any registered PrivateUse1 backend
+            is always checked in addition to the listed backends.
+            If None, checks all known accelerator backends (NCCL, XCCL, HCCL)
+            plus any registered PrivateUse1 backend.
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
@@ -558,14 +566,21 @@ def requires_accelerator_dist_backend(backends=None):
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
 
+    _backend_availability_checks = {
+        "nccl": c10d.is_nccl_available,
+        "xccl": c10d.is_xccl_available,
+        "hccl": lambda: TEST_HPU,
+    }
+
+    def _is_privateuse1_backend_available() -> bool:
+        """Check if a PrivateUse1 backend is registered."""
+        pu1_device = torch._C._get_privateuse1_backend_name()
+        return c10d.Backend.default_device_backend_map.get(pu1_device) is not None
+
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
+        _backend_availability_checks.get(backend, lambda: False)()
         for backend in backends
-    )
+    ) or _is_privateuse1_backend_available()
 
     return skip_but_pass_in_sandcastle_if(
         not backend_available,
@@ -1303,14 +1318,8 @@ class DistributedTestBase(MultiProcessTestCase):
             pass
 
     def backend(self, device) -> str:
-        if "cuda" in device:
-            return "nccl"
-        elif "hpu" in device:  # intel gaudi
-            return "hccl"
-        elif "xpu" in device:
-            return "xccl"
-        else:
-            return "gloo"
+        device_type = torch.device(device).type if isinstance(device, str) else device.type
+        return c10d.Backend.default_device_backend_map.get(device_type, "gloo")
 
     def create_pg(self, device, world_size=None):
         if world_size is None:

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -806,7 +806,7 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
 
         curr_backend = dist.get_default_backend_for_device(self.device_type)
 
-        if backend not in [
+        _known = [
             "nccl",
             "gloo",
             "mpi",
@@ -817,7 +817,12 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
             "xccl",
             "fake",
             "cpu:gloo,xpu:xccl",
-        ]:
+        ]
+        # Dynamically accept the current device's registered backend.
+        if curr_backend:
+            _known.append(curr_backend)
+
+        if backend not in _known:
             raise RuntimeError(f"Backend {backend} not supported!")
 
         device_id = None


### PR DESCRIPTION
This PR is part of a series to refactor distributed tests to be completely device-agnostic.

### Changes

Includes changes from https://github.com/pytorch/pytorch/pull/193438 along with update to
**Tests:**
- `test_c10d_nccl.py`:
  - Use `torch.accelerator.current_accelerator()` to derive `DEVICE_TYPE` and `BACKEND` instead of hardcoding `"cuda"` / `"nccl"`
  - Replace `@requires_nccl()` with `@requires_accelerator_dist_backend()` on all distributed tests
  - Replace `f"cuda:{id}"` with `f"{DEVICE_TYPE}:{id}"` for device placement
  - Replace `torch.cuda.synchronize()` with `torch.accelerator.synchronize()`
  - Replace `"nccl"` in `init_process_group` calls with `BACKEND`
  - Remove `_nccl` suffix from test method names (e.g., `test_nccl_backend_1gpu_module_device_ids_None` → `test_backend_single_device_module_device_ids_None`)
  - Guard CUDA-specific checks (e.g., `torch.cuda.nccl.version()`) behind `DEVICE_TYPE == "cuda"`
  
This PR is refactored from https://github.com/pytorch/pytorch/pull/178336

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD