### PR TITLE
[testing] Add FSDP_DEVICES and BFLOAT16_AVAILABLE test helpers

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -742,6 +742,16 @@ def create_device(interface=None, lazy_init: bool = False):
         )
 
 
+def _is_bf16_supported() -> bool:
+    if torch.accelerator.is_available():
+        device_module = torch.get_device_module(torch.accelerator.current_accelerator())
+        return getattr(device_module, "is_bf16_supported", lambda: False)()
+    return False
+
+
+BFLOAT16_AVAILABLE = _is_bf16_supported()
+
+
 def get_timeout(test_id) -> int:
     return TIMEOUT_OVERRIDE.get(test_id.split(".")[-1], TIMEOUT_DEFAULT)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -62,6 +62,8 @@ from torch.testing._internal.common_utils import (
     set_rng_seed,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TEST_WITH_ROCM,
     TEST_XPU,
 )
@@ -88,6 +90,11 @@ else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
     DEVICE_COUNT = 1
+
+# Device types supported by FSDP device-type-parameterized tests.
+FSDP_DEVICES = ("cuda", "hpu", "xpu")
+if TEST_PRIVATEUSE1:
+    FSDP_DEVICES = FSDP_DEVICES + (TEST_PRIVATEUSE1_DEVICE_TYPE,)
 
 
 class FSDPInitMode(Enum):


### PR DESCRIPTION
 Add `FSDP_DEVICES` and `BFLOAT16_AVAILABLE` test helpers as a small prerequisite
  for making the distributed FSDP tests device-agnostic.

  - `torch/testing/_internal/common_fsdp.py`: add `FSDP_DEVICES`, a tuple of the
    device types the FSDP device-type-parameterized tests run against. Defaults to
    `("cuda", "hpu", "xpu")` and appends the configured PrivateUse1 backend name
    when `TEST_PRIVATEUSE1` is set, so an out-of-tree accelerator backend can join
    the same test matrix without patching each test file.
  - `torch/testing/_internal/common_distributed.py`: add `BFLOAT16_AVAILABLE`,
    computed from the current accelerator's `is_bf16_supported()`, to replace
    per-file inline `torch.cuda.is_bf16_supported() or torch.xpu.is_bf16_supported()`
    checks.

  Test-only; no library behavior changes. `TEST_PRIVATEUSE1` /
  `TEST_PRIVATEUSE1_DEVICE_TYPE` already exist in `common_utils`.
  
  ### Test plan
  Exercised by the follow-up PR that converts the FSDP tests to use these helpers;
  no behavior to test in isolation beyond import correctness.
