### PR TITLE
[DO NOT LAND] gpu-coverage probe: TMA-gated test where the predicate is unobservable

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -1115,6 +1115,12 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
             self.run_model("mm", tensors)
 
 
+class TestGpuCoverageProbe(TestCase):
+    @unittest.skipIf(not has_triton_tma_device(), "needs device-side TMA")
+    def test_gpu_coverage_probe(self):
+        self.assertTrue(True)
+
+
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu
 


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

Covers the unobservable-predicate path deliberately. The green-control probe hit it
only incidentally, when its `test.sh` edit pulled inductor files into the second
trigger; this fires it through the **changed-file** trigger, which is how a real
author would meet it.

`test/inductor/test_lookup_table.py` is the real-world shape rather than a synthetic
one: it already has three `@skipIf(not has_triton_tma_device(), ...)` tests and is in
neither smoke list. This appends a fourth.

**This probe is expected to behave differently locally and in CI, which is the
point.**

With triton installed, `has_triton_tma_device()` is True at sm90+ and False at sm86,
so the tests classify and the check goes red. Locally:

```
GPU coverage gap: test/inductor/test_lookup_table.py
    test_gpu_coverage_probe                 -- runs on b200, not on a10g
    test_mixed_template_configs             -- runs on b200, not on a10g
    test_multiple_configs_same_template     -- runs on b200, not on a10g
    test_tma_lookup_table_entry             -- runs on b200, not on a10g
  not selected by test_python_smoke_b200() in .ci/pytorch/test.sh
2 gap(s).
```

No `pull.yml` image ships triton -- `install_triton.sh` builds it into the image and
only the hardcoded `TRITON=yes` images get it, none of which `pull.yml` uses. So in CI
the predicate reads False at *every* simulated capability, nothing classifies, and the
check is expected to **pass with a warning** naming the file as incomplete.

Two things that makes concrete:

1. The three pre-existing tests above are a real gap in main, invisible in CI today.
2. The gap between the two runs is exactly what the missing triton costs us, and the
   warning is the only thing that surfaces it. Without it the file reports a clean
   bill of health.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo