### PR TITLE
Fix C++ warning propagation for torch.ops and custom ops

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2870,36 +2870,12 @@ TORCH_LIBRARY(test_autograd_function_backed_op, m) {
         loss.backward()
         self.assertEqual(x.grad, temp)
 
-    @scoped_load_inline
-    def test_custom_op_warning_propagation(self, load_inline):
-        import warnings
-        cpp_source = """
-#include <torch/csrc/Exceptions.h>
-#include <c10/util/Exception.h>
-
-torch::Tensor custom_op_with_warning(const torch::Tensor& x) {
-  TORCH_WARN("Warning from custom C++ op!");
-  return x;
-}
-
-TORCH_LIBRARY(test_custom_op_warning, m) {
-    m.def("custom_op_with_warning", custom_op_with_warning);
-}
-        """
-
-        module = load_inline(
-            name="test_custom_op_warning",
-            cpp_sources=cpp_source,
-            functions="custom_op_with_warning",
-            verbose=True,
-        )
-
-        x = torch.ones(2, 2)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            torch.ops.test_custom_op_warning.custom_op_with_warning(x)
-            self.assertEqual(len(w), 1)
-            self.assertIn("Warning from custom C++ op!", str(w[0].message))
+    def test_torch_ops_warning_propagation(self):
+        x = torch.ones(2)
+        y = torch.ones(2)
+        out = torch.empty(2, 2)
+        with self.assertWarnsRegex(UserWarning, "torch.ger is deprecated"):
+            torch.ops.aten.ger.out(x, y, out=out)
 
     # Using a non-existent DSO is a quick way to trigger an OSError,
     # which can be used to not break BC.

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2870,6 +2870,37 @@ TORCH_LIBRARY(test_autograd_function_backed_op, m) {
         loss.backward()
         self.assertEqual(x.grad, temp)
 
+    @scoped_load_inline
+    def test_custom_op_warning_propagation(self, load_inline):
+        import warnings
+        cpp_source = """
+#include <torch/csrc/Exceptions.h>
+#include <c10/util/Exception.h>
+
+torch::Tensor custom_op_with_warning(const torch::Tensor& x) {
+  TORCH_WARN("Warning from custom C++ op!");
+  return x;
+}
+
+TORCH_LIBRARY(test_custom_op_warning, m) {
+    m.def("custom_op_with_warning", custom_op_with_warning);
+}
+        """
+
+        module = load_inline(
+            name="test_custom_op_warning",
+            cpp_sources=cpp_source,
+            functions="custom_op_with_warning",
+            verbose=True,
+        )
+
+        x = torch.ones(2, 2)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            torch.ops.test_custom_op_warning.custom_op_with_warning(x)
+            self.assertEqual(len(w), 1)
+            self.assertIn("Warning from custom C++ op!", str(w[0].message))
+
     # Using a non-existent DSO is a quick way to trigger an OSError,
     # which can be used to not break BC.
     def test_load_library(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2877,6 +2877,14 @@ TORCH_LIBRARY(test_autograd_function_backed_op, m) {
         with self.assertWarnsRegex(UserWarning, "torch.ger is deprecated"):
             torch.ops.aten.ger.out(x, y, out=out)
 
+    def test_dispatch_call_boxed_warning_propagation(self):
+        op = torch._C._dispatch_find_schema_or_throw("aten::ger", "out")
+        x = torch.ones(2)
+        y = torch.ones(2)
+        out = torch.empty(2, 2)
+        with self.assertWarnsRegex(UserWarning, "torch.ger is deprecated"):
+            torch._C._dispatch_call_boxed(op, x, y, out=out)
+
     # Using a non-existent DSO is a quick way to trigger an OSError,
     # which can be used to not break BC.
     def test_load_library(self):

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -900,7 +900,7 @@ py::object invokeOperatorFromPython(
     const py::args& args,
     const py::kwargs& kwargs,
     std::optional<c10::DispatchKey> dk) {
-  torch::PyWarningHandler warning_handler;
+  HANDLE_TH_ERRORS
   auto [found_op, stack] = getOpWithStack(operations, args, kwargs);
   {
     pybind11::gil_scoped_release no_gil_guard;
@@ -912,6 +912,7 @@ py::object invokeOperatorFromPython(
   }
 
   return createPyObjectForStack(std::move(stack));
+  END_HANDLE_TH_ERRORS_PYBIND
 }
 
 std::optional<py::object> _maybe_handle_torch_function(

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -13,6 +13,7 @@
 #include <ATen/ScalarOps.h>
 
 #include <c10/util/irange.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 
 #include <limits>
@@ -899,6 +900,7 @@ py::object invokeOperatorFromPython(
     const py::args& args,
     const py::kwargs& kwargs,
     std::optional<c10::DispatchKey> dk) {
+  torch::PyWarningHandler warning_handler;
   auto [found_op, stack] = getOpWithStack(operations, args, kwargs);
   {
     pybind11::gil_scoped_release no_gil_guard;

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -14,6 +14,7 @@
 
 #include <c10/core/SafePyObject.h>
 #include <c10/util/SmallVector.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/autograd/autograd_not_implemented_fallback.h>
 #include <torch/csrc/autograd/python_variable.h>
@@ -202,6 +203,7 @@ static py::object ophandle_call_boxed(
     const c10::OperatorHandle& handle,
     const py::args& args,
     const py::kwargs& kwargs) {
+  HANDLE_TH_ERRORS
   auto stack = torch::jit::createStackForSchema(
       handle.schema(),
       args,
@@ -212,6 +214,7 @@ static py::object ophandle_call_boxed(
     handle.callBoxed(stack);
   }
   return torch::jit::createPyObjectForStack(std::move(stack));
+  END_HANDLE_TH_ERRORS_PYBIND
 }
 
 // Function that performs PyObject dispatch
@@ -720,6 +723,7 @@ void initDispatchBindings(PyObject* module) {
              c10::DispatchKeySet keyset,
              const py::args& args,
              const py::kwargs& kwargs) {
+            HANDLE_TH_ERRORS
             auto& handle = self.cast<c10::OperatorHandle&>();
             auto stack = torch::jit::createStackForSchema(
                 handle.schema(),
@@ -731,6 +735,7 @@ void initDispatchBindings(PyObject* module) {
               handle.redispatchBoxed(keyset, &stack);
             }
             return torch::jit::createPyObjectForStack(std::move(stack));
+            END_HANDLE_TH_ERRORS_PYBIND
           });
 
   m.def("_dispatch_call_boxed", &ophandle_call_boxed);


### PR DESCRIPTION
### Summary
Currently, when custom operators (or JIT-dispatched operators) are invoked from Python, C++ warnings emitted via `TORCH_WARN` or `TORCH_WARN_ONCE` are not intercepted by Python. Instead, they fall back to raw C++ stderr. As a result, Python users cannot catch them using `warnings.catch_warnings()` or suppress them using `warnings.filterwarnings()`.

### Fix
Instantiate `torch::PyWarningHandler` in `invokeOperatorFromPython`. This ensures that when custom operators (or JIT-dispatched operators) are invoked from Python, C++ warnings (emitted via `TORCH_WARN` / `TORCH_WARN_ONCE`) are correctly intercepted and routed to Python's `warnings` module as `UserWarning`s, rather than falling back to C++ stderr.

### Test Added
Added a new unit test `test_custom_op_warning_propagation` in `test/test_custom_ops.py` that dynamically compiles a custom C++ operator emitting a `TORCH_WARN` and asserts it is caught in Python.

BC-breaking note: we make torch.ops.* call go through the same exception and warning translation as the rest of the library. This means that some exception translation that used to be handle by pybind is now handled natively. User-defined pybind exception translation is thus lost here. Restoring it can be done in a follow up as part of a broader exception handler improvement.