### PR TITLE
[OpaqueObject] Resolve registered members lazily during fake tracing

### DIFF
--- a/test/fx/test_opaque_infrastructure.py
+++ b/test/fx/test_opaque_infrastructure.py
@@ -3,7 +3,12 @@
 import torch
 from torch._library.opaque_object import MemberType, register_custom_class
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 # Define a simple opaque type for testing
@@ -25,6 +30,7 @@ register_custom_class(OpaqueCounter, typ="symbolic")
 class OpaqueMemberBox(torch._custom_class_base.CustomClassBase):
     def __init__(self, value: int):
         self.value = value
+        self.inlined_state = {"value": value}
         self.property_reads = 0
         self.dynamic_reads = 0
 
@@ -49,9 +55,27 @@ register_custom_class(
     typ="symbolic",
     members={
         "value": MemberType.USE_REAL,
+        "inlined_state": MemberType.INLINED,
         "bumping_property": MemberType.USE_REAL,
         "dynamic": MemberType.USE_REAL,
         "mutates_and_returns_tensor": MemberType.INLINED,
+    },
+)
+
+
+class OpaqueOptionalMemberBox(torch._custom_class_base.CustomClassBase):
+    optional: int
+
+    def optional_or_default(self):
+        return self.optional if hasattr(self, "optional") else 0
+
+
+register_custom_class(
+    OpaqueOptionalMemberBox,
+    typ="symbolic",
+    members={
+        "optional": MemberType.USE_REAL,
+        "optional_or_default": MemberType.INLINED,
     },
 )
 
@@ -65,6 +89,7 @@ class WrapperWithOpaque:
         self.data = torch.tensor([1.0, 2.0, 3.0])
 
 
+@instantiate_parametrized_tests
 class TestOpaqueInfrastructure(TestCase):
     """
     Test opaque object descriptor and tracking infrastructure.
@@ -103,37 +128,67 @@ class TestOpaqueInfrastructure(TestCase):
         opaque_placeholder = placeholders[1]
         self.assertTrue(opaque_placeholder.name.startswith("opaque_obj"))
 
-    def test_registered_members_are_resolved_lazily(self):
-        for tracing_mode in ("fake", "symbolic"):
-            with self.subTest(tracing_mode=tracing_mode):
-                box = OpaqueMemberBox(2)
-                x = torch.ones(1)
+    @parametrize("tracing_mode", ("fake", "symbolic"))
+    def test_registered_members_are_resolved_lazily(self, tracing_mode):
+        box = OpaqueMemberBox(2)
+        x = torch.ones(1)
 
-                make_fx(lambda x, box: x + 1, tracing_mode=tracing_mode)(x, box)
+        make_fx(lambda x, box: x + 1, tracing_mode=tracing_mode)(x, box)
 
-                self.assertEqual(box.property_reads, 0)
-                self.assertEqual(box.dynamic_reads, 0)
+        self.assertEqual(box.property_reads, 0)
+        self.assertEqual(box.dynamic_reads, 0)
 
-                make_fx(
-                    lambda x, box: x + box.bumping_property + box.dynamic,
-                    tracing_mode=tracing_mode,
-                )(x, box)
+        make_fx(
+            lambda x, box: (
+                x
+                + box.bumping_property
+                + box.bumping_property
+                + box.dynamic
+                + box.dynamic
+            ),
+            tracing_mode=tracing_mode,
+        )(x, box)
 
-                self.assertEqual(box.property_reads, 1)
-                self.assertEqual(box.dynamic_reads, 1)
+        self.assertEqual(box.property_reads, 1)
+        self.assertEqual(box.dynamic_reads, 1)
 
-    def test_inlined_method_uses_fake_receiver(self):
-        for tracing_mode in ("fake", "symbolic"):
-            with self.subTest(tracing_mode=tracing_mode):
-                box = OpaqueMemberBox(2)
+    @parametrize("tracing_mode", ("fake", "symbolic"))
+    def test_inlined_method_uses_fake_receiver(self, tracing_mode):
+        box = OpaqueMemberBox(2)
 
-                with self.assertRaisesRegex(AttributeError, "__setattr__"):
-                    make_fx(
-                        lambda x, box: box.mutates_and_returns_tensor(x),
-                        tracing_mode=tracing_mode,
-                    )(torch.ones(1), box)
+        # INLINED methods receive the fake object, so mutating self is user error
+        # and must not mutate the real input.
+        with self.assertRaisesRegex(AttributeError, "__setattr__"):
+            make_fx(
+                lambda x, box: box.mutates_and_returns_tensor(x),
+                tracing_mode=tracing_mode,
+            )(torch.ones(1), box)
 
-                self.assertEqual(box.value, 2)
+        self.assertEqual(box.value, 2)
+
+    @parametrize("tracing_mode", ("fake", "symbolic"))
+    def test_inlined_instance_attribute(self, tracing_mode):
+        box = OpaqueMemberBox(2)
+        x = torch.ones(1)
+
+        traced = make_fx(
+            lambda x, box: x + box.inlined_state["value"],
+            tracing_mode=tracing_mode,
+        )(x, box)
+
+        self.assertEqual(traced(x, box), x + 2)
+
+    @parametrize("tracing_mode", ("fake", "symbolic"))
+    def test_missing_optional_member_works_with_hasattr(self, tracing_mode):
+        box = OpaqueOptionalMemberBox()
+        x = torch.ones(1)
+
+        traced = make_fx(
+            lambda x, box: x + box.optional_or_default(),
+            tracing_mode=tracing_mode,
+        )(x, box)
+
+        self.assertEqual(traced(x, box), x)
 
 
 if __name__ == "__main__":

--- a/test/fx/test_opaque_infrastructure.py
+++ b/test/fx/test_opaque_infrastructure.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: fx"]
 
 import torch
-from torch._library.opaque_object import register_custom_class
+from torch._library.opaque_object import MemberType, register_custom_class
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
 
@@ -20,6 +20,40 @@ class OpaqueCounter(torch._custom_class_base.CustomClassBase):
 
 # Register it as an opaque type (reference semantics for identity/mutation tracking)
 register_custom_class(OpaqueCounter, typ="symbolic")
+
+
+class OpaqueMemberBox(torch._custom_class_base.CustomClassBase):
+    def __init__(self, value: int):
+        self.value = value
+        self.property_reads = 0
+        self.dynamic_reads = 0
+
+    @property
+    def bumping_property(self):
+        self.property_reads += 1
+        return self.value
+
+    def __getattr__(self, name):
+        if name == "dynamic":
+            self.dynamic_reads += 1
+            return self.value
+        raise AttributeError(name)
+
+    def mutates_and_returns_tensor(self, x):
+        self.value += 1
+        return x + self.value
+
+
+register_custom_class(
+    OpaqueMemberBox,
+    typ="symbolic",
+    members={
+        "value": MemberType.USE_REAL,
+        "bumping_property": MemberType.USE_REAL,
+        "dynamic": MemberType.USE_REAL,
+        "mutates_and_returns_tensor": MemberType.INLINED,
+    },
+)
 
 
 # Define a wrapper class that holds an opaque object as an attribute
@@ -68,6 +102,38 @@ class TestOpaqueInfrastructure(TestCase):
         # The second placeholder should be for the opaque object
         opaque_placeholder = placeholders[1]
         self.assertTrue(opaque_placeholder.name.startswith("opaque_obj"))
+
+    def test_registered_members_are_resolved_lazily(self):
+        for tracing_mode in ("fake", "symbolic"):
+            with self.subTest(tracing_mode=tracing_mode):
+                box = OpaqueMemberBox(2)
+                x = torch.ones(1)
+
+                make_fx(lambda x, box: x + 1, tracing_mode=tracing_mode)(x, box)
+
+                self.assertEqual(box.property_reads, 0)
+                self.assertEqual(box.dynamic_reads, 0)
+
+                make_fx(
+                    lambda x, box: x + box.bumping_property + box.dynamic,
+                    tracing_mode=tracing_mode,
+                )(x, box)
+
+                self.assertEqual(box.property_reads, 1)
+                self.assertEqual(box.dynamic_reads, 1)
+
+    def test_inlined_method_uses_fake_receiver(self):
+        for tracing_mode in ("fake", "symbolic"):
+            with self.subTest(tracing_mode=tracing_mode):
+                box = OpaqueMemberBox(2)
+
+                with self.assertRaisesRegex(AttributeError, "__setattr__"):
+                    make_fx(
+                        lambda x, box: box.mutates_and_returns_tensor(x),
+                        tracing_mode=tracing_mode,
+                    )(torch.ones(1), box)
+
+                self.assertEqual(box.value, 2)
 
 
 if __name__ == "__main__":

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import copy
+import inspect
 import logging
 from typing import Any, Protocol
 
@@ -45,6 +46,37 @@ class FakeScriptObject:
         try:
             return super().__getattribute__(name)
         except AttributeError as e:
+            from torch._library.opaque_object import (
+                get_opaque_obj_info,
+                MemberType,
+            )
+
+            real_obj = object.__getattribute__(self, "real_obj")
+            opaque_info = get_opaque_obj_info(type(real_obj))
+            if opaque_info is not None and name in opaque_info.members:
+                member_type = opaque_info.members[name]
+                if member_type == MemberType.INLINED:
+                    try:
+                        member = inspect.getattr_static(type(real_obj), name)
+                    except AttributeError as member_error:
+                        raise TypeError(
+                            f"Opaque object member '{name}' was registered as INLINED, "
+                            "but it is not defined on the object's type."
+                        ) from member_error
+                    if hasattr(member, "__get__"):
+                        return member.__get__(self, type(real_obj))
+                    return member
+
+                with _disable_current_modes():
+                    try:
+                        return getattr(real_obj, name)
+                    except AttributeError as member_error:
+                        raise TypeError(
+                            f"Opaque object of type '{self.script_class_name}' was "
+                            f"specified to have member '{name}', but this doesn't "
+                            "actually exist in the object."
+                        ) from member_error
+
             raise AttributeError(
                 f"Tried to call __getattr__ with attr '{name}' on a FakeScriptObject, "
                 "implying that you are calling this inside of a fake kernel. "
@@ -241,7 +273,6 @@ def maybe_to_fake_obj(
 
     from torch._library.opaque_object import (
         FakeOpaqueObject,
-        get_opaque_obj_info,
         get_opaque_type_name,
         is_custom_class,
         OpaqueTypeStr,
@@ -251,20 +282,6 @@ def maybe_to_fake_obj(
     if is_custom_class(x_type):
         type_name = OpaqueTypeStr if x is None else get_opaque_type_name(x_type)
         fake_x_wrapped = FakeScriptObject(FakeOpaqueObject(), type_name, x)
-
-        # Set specified members onto the fake object
-        opaque_info = get_opaque_obj_info(x_type)
-        if opaque_info is None:
-            raise AssertionError(f"opaque_info for type {x_type} must not be None")
-        for attr_name in opaque_info.members:
-            with _disable_current_modes():
-                if not hasattr(x, attr_name):
-                    raise TypeError(
-                        f"Opaque object of type '{type_name}' was specified to have member "
-                        f"'{attr_name}', but this doesn't actually exist in the object."
-                    )
-                object.__setattr__(fake_x_wrapped, attr_name, getattr(x, attr_name))
-
         return fake_x_wrapped
     else:
         # x.__obj_flatten__() could be calling some tensor operations inside but we don't

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -12,6 +12,19 @@ from torch.utils._python_dispatch import _disable_current_modes
 log = logging.getLogger(__name__)
 
 
+def _member_can_be_resolved_lazily(cls: type[Any], name: str) -> bool:
+    for base in cls.__mro__:
+        base_dict = vars(base)
+        if name in base_dict.get("__annotations__", {}):
+            return True
+        if "__getattr__" in base_dict:
+            return True
+        getattribute = base_dict.get("__getattribute__")
+        if getattribute is not None and getattribute is not object.__getattribute__:
+            return True
+    return False
+
+
 class FakeScriptObject:
     def __init__(
         self, wrapped_obj: Any, script_class_name: str, x: torch.ScriptObject | None
@@ -58,24 +71,31 @@ class FakeScriptObject:
                 if member_type == MemberType.INLINED:
                     try:
                         member = inspect.getattr_static(type(real_obj), name)
-                    except AttributeError as member_error:
-                        raise TypeError(
-                            f"Opaque object member '{name}' was registered as INLINED, "
-                            "but it is not defined on the object's type."
-                        ) from member_error
+                    except AttributeError:
+                        with _disable_current_modes():
+                            try:
+                                return getattr(real_obj, name)
+                            except AttributeError as instance_member_error:
+                                raise AttributeError(
+                                    f"Opaque object of type '{self.script_class_name}' "
+                                    f"was specified to have member '{name}', but this "
+                                    "doesn't actually exist in the object."
+                                ) from instance_member_error
                     if hasattr(member, "__get__"):
                         return member.__get__(self, type(real_obj))
                     return member
 
                 with _disable_current_modes():
                     try:
-                        return getattr(real_obj, name)
+                        member = getattr(real_obj, name)
                     except AttributeError as member_error:
-                        raise TypeError(
+                        raise AttributeError(
                             f"Opaque object of type '{self.script_class_name}' was "
                             f"specified to have member '{name}', but this doesn't "
                             "actually exist in the object."
                         ) from member_error
+                object.__setattr__(self, name, member)
+                return member
 
             raise AttributeError(
                 f"Tried to call __getattr__ with attr '{name}' on a FakeScriptObject, "
@@ -273,6 +293,7 @@ def maybe_to_fake_obj(
 
     from torch._library.opaque_object import (
         FakeOpaqueObject,
+        get_opaque_obj_info,
         get_opaque_type_name,
         is_custom_class,
         OpaqueTypeStr,
@@ -281,6 +302,19 @@ def maybe_to_fake_obj(
     x_type = type(x)
     if is_custom_class(x_type):
         type_name = OpaqueTypeStr if x is None else get_opaque_type_name(x_type)
+        opaque_info = get_opaque_obj_info(x_type)
+        if opaque_info is None:
+            raise RuntimeError(f"Opaque object type '{type_name}' is not registered.")
+        for name in opaque_info.members:
+            try:
+                inspect.getattr_static(x, name)
+            except AttributeError as member_error:
+                if _member_can_be_resolved_lazily(x_type, name):
+                    continue
+                raise TypeError(
+                    f"Opaque object of type '{type_name}' was specified to have "
+                    f"member '{name}', but this doesn't actually exist in the object."
+                ) from member_error
         fake_x_wrapped = FakeScriptObject(FakeOpaqueObject(), type_name, x)
         return fake_x_wrapped
     else:

--- a/torch/_library/opaque_object.py
+++ b/torch/_library/opaque_object.py
@@ -65,7 +65,8 @@ class MemberType(Enum):
 
     # Reads/calls the member at trace time with the real object and bakes the result as a constant
     USE_REAL = "use_real"
-    # Inlines/traces the member
+    # Inlines/traces methods with a FakeScriptObject receiver. The receiver can
+    # only read registered members and does not support assignment to self.
     INLINED = "inlined"
 
 
@@ -186,7 +187,9 @@ def register_custom_class(
             how they are handled during torch.compile tracing:
             - MemberType.USE_REAL: Evaluates with the real object at compile time and
               bakes the result as a constant
-            - MemberType.INLINED: Inlines the method call into the trace
+            - MemberType.INLINED: Inlines the method call into the trace with a
+              FakeScriptObject receiver. The receiver can only read registered
+              members and does not support assignment to self.
     """
     import torch.utils._pytree as pytree
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -242,6 +242,7 @@ else:
         _thread_id: int | None
         # Record flatten mesh name to its flattened mesh in root mesh.
         _flatten_mapping: dict[str, "DeviceMesh"]
+        _dim_group_names: list[str]
         # Registry mapping group names to ProcessGroup objects (to avoid C++ lookup)
         _pg_registry: dict[str, ProcessGroup]
 


### PR DESCRIPTION
Addresses #187505

## Summary

- resolve registered opaque members only when they are accessed during fake tracing
- bind `INLINED` descriptors to `FakeScriptObject` instead of the real object
- prevent unused registered properties and dynamic attributes from running during fakification
- add fake and symbolic tracing regressions for lazy access and receiver binding

## Test plan

- `python -m compileall -q torch/_library/fake_class_registry.py test/fx/test_opaque_infrastructure.py`
- `python -m ruff check torch/_library/fake_class_registry.py test/fx/test_opaque_infrastructure.py`
- `python -m ruff format --check torch/_library/fake_class_registry.py test/fx/test_opaque_infrastructure.py`
- three focused tests on `torch==2.15.0.dev20260813+cpu`, covering the existing opaque graph test plus the new fake/symbolic regressions
- `git diff --check`

AI tools were used in preparing this change.
