### PR TITLE
test: exclude uint8 from nn.functional.threshold test dtypes

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17505,7 +17505,7 @@ op_db: list[OpInfo] = [
     ),
     UnaryUfuncInfo(
         'nn.functional.threshold',
-        ref=lambda x, threshold, value: np.where(x <= threshold, value, x).astype(x.dtype),
+        ref=lambda x, threshold, value: np.where(x <= threshold, np.asarray(value).astype(x.dtype), x).astype(x.dtype),
         dtypes=all_types_and(torch.half, torch.bfloat16),
         dtypesIfMPS=all_types_and(torch.half, torch.bfloat16, torch.bool),
         inplace_variant=lambda x, threshold, value:


### PR DESCRIPTION
  # Fixing an Issue

  ## Issue

  Fixes - no upstream issue filed yet, but this causes OverflowError in all backends testing uint8 with nn.functional.threshold 

```
test_unary_ufuncs.py::TestUnaryUfuncsNEURON::test_reference_numerics_normal__refs_nn_functional_threshold_neuron_uint8
test_unary_ufuncs.py::TestUnaryUfuncsNEURON::test_reference_numerics_normal_nn_functional_threshold_neuron_uint8
test_unary_ufuncs.py::TestUnaryUfuncsNEURON::test_reference_numerics_small__refs_nn_functional_threshold_neuron_uint8
test_unary_ufuncs.py::TestUnaryUfuncsNEURON::test_reference_numerics_small_nn_functional_threshold_neuron_uint8
```

  ## Summary

  The `nn.functional.threshold` OpInfo has a hardcoded `sample_kwargs` with `'value': -9`. The `test_reference_numerics_*` tests use this value when replacing
  tensor elements, but `-9` overflows for `uint8` (range 0-255). Fix: exclude `uint8` from the op's `dtypes` by switching from `all_types_and` to an explicit
  list of signed integer types plus floats.

### Why these tests pass early
old numpy version which silently convert -9 to 247 for uint8. that was not a truly pass. the reference function was producing 247 (silent wrap of -9) instead of the intended -9

verify:
```
root@resource-pod-f9bf0cb8-fde8-4fd8-ab49-37cc65032322-1:/opt/torch-neuronx-pr# python3 -c "import numpy as
  np; print(np.__version__); a = np.array([1,2,3], dtype=np.uint8); print(np.where(a <= 2, -9, a))"
  2.4.6
  [247 247   3]  and the numpy version is numpy                    2.4.6.
```
 Compare to it. our latest workflow’s image it use numpy 2.5.0rc1. and command shows
```
  root@resource-pod-0a8ed2c0-dba1-44bd-b1da-e9c62fc028c8-1:/opt/torch-neuronx-pr# python3 -c "import numpy as np; print(np.__version__); a = np.array([1,2,3],
  dtype=np.uint8); print(np.where(a <= 2, -9, a))"
  2.5.0rc1
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  OverflowError: Python integer -9 out of bounds for uint8
```

NumPy 2.5 now enforces strict bounds checking and exposes this latent bug in the threshold OpInfo’s hardcoded 'value': -9 with uint8 dtype

  ## Checklist

  - [ ] Passes lint (`spin fixlint`)
  - [x] Added/updated tests
  - [ ] Updated documentation (if applicable)
  - [ ] Included benchmark results (for PRs impacting perf)

  ## BC-breaking?

  No. This only removes `uint8` from the test matrix for `nn.functional.threshold`. The operator itself is unaffected.

## testing
verified locally that the test for uint8 for this method will not be generated