### PR TITLE
Support inline_asm_elementwise in flex_attention score/mask mods

### DIFF
--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -544,6 +544,31 @@ class TestInlineAsmElementwiseEdgeCases(TestCase):
         self.assertEqual(eager_result.shape, fake_result.shape)
         self.assertEqual(eager_result.stride(), fake_result.stride())
 
+    def test_vmap(self):
+        asm_str = "v_add_f32 $0, $1, $2" if torch.version.hip else "add.f32 $0, $1, $2;"
+        constraints = "=v, v, v" if torch.version.hip else "=f,f,f"
+
+        def add(a, b):
+            return inline_asm_elementwise(
+                a, b, asm_str=asm_str, constraints=constraints, dtype=torch.float32
+            )
+
+        bias = torch.randn(64, device="cuda")
+        x = torch.randn(8, 64, device="cuda")
+        # batched vector + unbatched vector
+        self.assertEqual(torch.vmap(add, in_dims=(0, None))(x, bias), x + bias)
+        # batched scalar + unbatched vector: batch dim must not be consumed by
+        # trailing-dim broadcasting
+        y = torch.randn(8, device="cuda")
+        self.assertEqual(torch.vmap(add, in_dims=(0, None))(y, bias), y[:, None] + bias)
+        # non-zero batch dim
+        self.assertEqual(
+            torch.vmap(add, in_dims=(1, None))(x, bias[:8]), x.t() + bias[:8]
+        )
+        # nested vmap down to scalars
+        nested = torch.vmap(torch.vmap(add))(x, x)
+        self.assertEqual(nested, x + x)
+
     @xfailIfNoAcceleratorTriton
     def test_dynamic_shapes(self):
         def fn(x, y):

--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -117,6 +117,11 @@ class TestCuteDSLTemplate(TestCase):
         lines = imports.strip().split("\n")
         self.assertEqual(len(lines), 8)
 
+        asm_imports = kernel.gen_imports(uses_inline_asm=True)
+        self.assertIn("inline_asm_elementwise_intrinsic", asm_imports)
+        self.assertNotIn("inline_asm_elementwise_intrinsic", imports)
+        self.assertEqual(len(asm_imports.strip().split("\n")), 9)
+
     def test_render_includes_imports(self):
         template_source = """@cute.kernel
 def {{kernel_name}}_kernel():

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import torch
 import torch.nn as nn
 from torch._dynamo.testing import CompileCounterWithBackend, normalize_gm
+from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch._inductor import config, metrics
 from torch._inductor.exc import InductorError
 from torch._inductor.runtime.triton_compat import HAS_WARP_SPEC
@@ -2066,6 +2067,114 @@ class TestFlexAttention(InductorTestCase):
 
         self.run_test(all_bias, dtype, device=device)
         self.run_test_with_paged_attention(all_bias, dtype, device=device)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps
+    @skip_on_rocm
+    def test_inline_asm_score_mod(self, device):
+        """score_mod using the inline_asm_elementwise HOP lowers to
+        tl.inline_asm_elementwise inside the flex kernel. Forward only:
+        the HOP has no autograd formula."""
+        bias = torch.randn(S, device=device)
+
+        def asm_score_mod(score, b, h, q, kv):
+            return inline_asm_elementwise(
+                score,
+                bias[kv],
+                asm_str="fma.rn.f32 $0, $1, 0f40000000, $2;",
+                constraints="=f,f,f",
+                dtype=torch.float32,
+            )
+
+        def ref_score_mod(score, b, h, q, kv):
+            return score * 2.0 + bias[kv]
+
+        q, k, v = [
+            torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+            for _ in range(3)
+        ]
+        compiled = torch.compile(flex_attention)
+        out = compiled(q, k, v, score_mod=asm_score_mod)
+        ref = compiled(q, k, v, score_mod=ref_score_mod)
+        self.assertEqual(out, ref)
+
+        # The eager (unfused) path applies score_mod under vmap and runs the
+        # asm via the Jiterator.
+        eager_out = flex_attention(q, k, v, score_mod=asm_score_mod)
+        eager_ref = flex_attention(q, k, v, score_mod=ref_score_mod)
+        self.assertEqual(eager_out, eager_ref)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps
+    @skip_on_rocm
+    def test_inline_asm_score_mod_pack2(self, device):
+        def asm_score_mod(score, b, h, q, kv):
+            return inline_asm_elementwise(
+                score,
+                asm_str="add.f32 $0, $2, $2; add.f32 $1, $3, $3;",
+                constraints="=f,=f,f,f",
+                dtype=torch.float32,
+                pack=2,
+            )
+
+        def ref_score_mod(score, b, h, q, kv):
+            return score * 2.0
+
+        q, k, v = [
+            torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+            for _ in range(3)
+        ]
+        compiled = torch.compile(flex_attention)
+        out = compiled(q, k, v, score_mod=asm_score_mod)
+        ref = compiled(q, k, v, score_mod=ref_score_mod)
+        self.assertEqual(out, ref)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps
+    @skip_on_rocm
+    def test_inline_asm_mask_mod(self, device):
+        """mask_mod using the inline_asm_elementwise HOP: the multi-line PTX
+        predicate is exercised both when building the block mask (eager vmap +
+        Jiterator, and compiled) and inside the kernel on partial blocks."""
+        asm_str = "{\n.reg .pred p;\nsetp.ge.s32 p, $1, $2;\nselp.u32 $0, 1, 0, p;\n}"
+
+        def asm_causal_mask(b, h, q_idx, kv_idx):
+            pred = inline_asm_elementwise(
+                q_idx.to(torch.int32),
+                kv_idx.to(torch.int32),
+                asm_str=asm_str,
+                constraints="=r,r,r",
+                dtype=torch.int32,
+            )
+            return pred != 0
+
+        def ref_causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        bm = create_block_mask(asm_causal_mask, B, H, S, S, device=device)
+        bm_ref = create_block_mask(ref_causal_mask, B, H, S, S, device=device)
+        self.assertEqual(bm.kv_num_blocks, bm_ref.kv_num_blocks)
+        self.assertEqual(bm.kv_indices, bm_ref.kv_indices)
+
+        bm_compiled = torch.compile(create_block_mask)(
+            asm_causal_mask, B, H, S, S, device=device
+        )
+        self.assertEqual(bm_compiled.kv_num_blocks, bm_ref.kv_num_blocks)
+
+        q, k, v = [
+            torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+            for _ in range(3)
+        ]
+        compiled = torch.compile(flex_attention)
+        out = compiled(q, k, v, block_mask=bm)
+        ref = compiled(q, k, v, block_mask=bm_ref)
+        self.assertEqual(out, ref)
 
     @supported_platform
     @skip_on_cpu

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -10,6 +10,7 @@ from unittest import mock
 import torch
 import torch._inductor.kernel.flex.flex_flash_attention as flex_flash_attention_module
 from torch._dynamo.testing import CompileCounterWithBackend, EagerAndRecordGraphs
+from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 from torch._inductor.kernel.flex.flex_flash_attention import (
     _flash_attention_unavailable_message,
     _hierarchical_indexer_cute,
@@ -980,6 +981,72 @@ class TestFlexFlash(InductorTestCase):
 
         q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
         flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
+    def test_inline_asm_score_mod(self):
+        """score_mod using the inline_asm_elementwise HOP lowers to a PTX call
+        inside the generated CuteDSL score_mod."""
+        seq_len = 512
+        bias = torch.randn(seq_len, device="cuda")
+
+        def score_mod(score, _b, _h, _q, kv_idx):
+            return inline_asm_elementwise(
+                score,
+                bias[kv_idx],
+                asm_str="fma.rn.f32 $0, $1, 0f40000000, $2;",
+                constraints="=f,f,f",
+                dtype=torch.float32,
+            )
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
+    def test_inline_asm_score_mod_pack2(self):
+        """pack=2 inline asm requires compile, so compare flash against the
+        compiled Triton backend directly."""
+
+        def score_mod(score, _b, _h, _q, _kv):
+            return inline_asm_elementwise(
+                score,
+                asm_str="add.f32 $0, $2, $2; add.f32 $1, $3, $3;",
+                constraints="=f,=f,f,f",
+                dtype=torch.float32,
+                pack=2,
+            )
+
+        q, k, v = create_test_tensors(seq_len=512, device="cuda")
+        compiled_fn = torch.compile(flex_attention)
+        out_flash = compiled_fn(
+            q, k, v, score_mod=score_mod, kernel_options={"BACKEND": "FLASH"}
+        )
+        out_triton = compiled_fn(
+            q, k, v, score_mod=score_mod, kernel_options={"BACKEND": "TRITON"}
+        )
+        torch.testing.assert_close(out_flash, out_triton, atol=2e-3, rtol=2e-3)
+
+    @xfailIfSM120OrLater
+    def test_inline_asm_mask_mod(self):
+        """mask_mod using the inline_asm_elementwise HOP: multi-line PTX
+        predicate runs in block-mask construction and on partial blocks."""
+        seq_len = 512
+        asm_str = "{\n.reg .pred p;\nsetp.ge.s32 p, $1, $2;\nselp.u32 $0, 1, 0, p;\n}"
+
+        def asm_causal_mask(_b, _h, q_idx, kv_idx):
+            pred = inline_asm_elementwise(
+                q_idx.to(torch.int32),
+                kv_idx.to(torch.int32),
+                asm_str=asm_str,
+                constraints="=r,r,r",
+                dtype=torch.int32,
+            )
+            return pred != 0
+
+        block_mask = _create_block_mask_for_device(
+            asm_causal_mask, 2, 4, seq_len, seq_len, device="cuda"
+        )
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, block_mask=block_mask)
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -238,6 +238,41 @@ inline_asm_elementwise.py_autograd_impl(
 )
 
 
+@inline_asm_elementwise.py_impl(torch._C._functorch.TransformType.Vmap)
+def _(interpreter, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    from torch._functorch.vmap import unwrap_batched, wrap_batched
+
+    op = functools.partial(
+        inline_asm_elementwise,
+        asm_str=asm_str,
+        constraints=constraints,
+        dtype=dtype,
+        is_pure=is_pure,
+        pack=pack,
+    )
+    unwrapped, bdims = unwrap_batched(list(inputs), interpreter.level())
+    if all(bdim is None for bdim in bdims):
+        # No input is batched at this level (e.g. this vmap level batches only
+        # tensors that are not asm inputs); the result has no batch dim to wrap.
+        with interpreter.lower():
+            return op(*unwrapped)
+    # The op is elementwise, so batching is a broadcast: move each batch dim to
+    # the front and pad the logical dims so they stay right-aligned across all
+    # inputs while the batch dim broadcasts only against other batch dims.
+    logical_ndim = max(
+        t.ndim - (0 if bdim is None else 1) for t, bdim in zip(unwrapped, bdims)
+    )
+    moved = []
+    for t, bdim in zip(unwrapped, bdims):
+        if bdim is not None:
+            t = t.movedim(bdim, 0)
+            t = t[(slice(None), *([None] * (logical_ndim - (t.ndim - 1))))]
+        moved.append(t)
+    with interpreter.lower():
+        res = op(*moved)
+    return wrap_batched((res,), (0,), interpreter.level())[0]
+
+
 def _elementwise_output_like(*inputs, dtype):
     from torch._prims_common import compute_elementwise_output_logical_to_physical_perm
 

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -260,6 +260,7 @@ class CuteDSLTemplateKernel(Kernel):
             from cutlass._mlir.dialects import math as mlir_math
             import operator
             from torch._inductor.codegen.cutedsl._cutedsl_utils import result_to_ssa, ssa_to_fragment, ssa_to_indexable
+            from torch._inductor.codegen.cutedsl._inline_asm import inline_asm_elementwise_intrinsic
             """
         )
         return imports.getvalue()

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -247,7 +247,7 @@ class CuteDSLTemplateKernel(Kernel):
     def create_cse_var(self, *args, **kwargs):
         return CuteDSLCSEVariable(*args, **kwargs)
 
-    def gen_imports(self) -> str:
+    def gen_imports(self, uses_inline_asm: bool = False) -> str:
         """Generate common imports for CuteDSL templates."""
         imports = IndentedBuffer()
         imports.splice(
@@ -260,9 +260,12 @@ class CuteDSLTemplateKernel(Kernel):
             from cutlass._mlir.dialects import math as mlir_math
             import operator
             from torch._inductor.codegen.cutedsl._cutedsl_utils import result_to_ssa, ssa_to_fragment, ssa_to_indexable
-            from torch._inductor.codegen.cutedsl._inline_asm import inline_asm_elementwise_intrinsic
             """
         )
+        if uses_inline_asm:
+            imports.splice(
+                "from torch._inductor.codegen.cutedsl._inline_asm import inline_asm_elementwise_intrinsic"
+            )
         return imports.getvalue()
 
     def gen_defines(self, **kwargs) -> str:
@@ -303,8 +306,11 @@ class CuteDSLTemplateKernel(Kernel):
             **kwargs,
         )
 
-        # Always prepend the common imports
-        imports = self.gen_imports()
+        # Always prepend the common imports. The inline-asm intrinsic import is
+        # conditional so kernels without asm do not load the MLIR llvm dialects.
+        imports = self.gen_imports(
+            uses_inline_asm="inline_asm_elementwise_intrinsic(" in rendered_code
+        )
         full_code = imports + rendered_code
 
         return PartialRender(full_code, self.render_hooks)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1832,20 +1832,16 @@ class TritonOverrides(OpOverrides):
             else:
                 cast_inputs.append(str(inp))
 
-        if torch.version.hip:
-            # AMDGCN asm strings may contain real newlines (instructions are
-            # newline-separated, unlike PTX which uses semicolons).  The
-            # generated code is nested inside two Python string layers:
-            #   Layer 1 : the cached wrapper .py file
-            #   Layer 2 : the Triton kernel source (a triple-quoted string
-            #             inside that wrapper, exec'd / JIT-compiled)
-            # repr() escapes \n -> \\n, then we double the backslashes so
-            # they survive both layers: \\\\n -> (L1 parse) \\n -> (L2 parse) \n.
-            asm_literal = repr(asm).replace("\\", "\\\\")
-            constraints_literal = repr(constraints).replace("\\", "\\\\")
-        else:
-            asm_literal = f"'{asm}'"
-            constraints_literal = f"'{constraints}'"
+        # Asm strings may contain real newlines (AMDGCN instructions are
+        # newline-separated; multi-line PTX blocks with .reg declarations
+        # too).  The generated code is nested inside two Python string layers:
+        #   Layer 1 : the cached wrapper .py file
+        #   Layer 2 : the Triton kernel source (a triple-quoted string
+        #             inside that wrapper, exec'd / JIT-compiled)
+        # repr() escapes \n -> \\n, then we double the backslashes so
+        # they survive both layers: \\\\n -> (L1 parse) \\n -> (L2 parse) \n.
+        asm_literal = repr(asm).replace("\\", "\\\\")
+        constraints_literal = repr(constraints).replace("\\", "\\\\")
 
         def asm_call(args):
             return (

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1135,16 +1135,13 @@ def get_kernel_metadata(
 
         for node in inductor_nodes:
             formatted_node = node.format_node(include_tensor_metadata=True)
-            if formatted_node is not None and torch.version.hip:
-                # AMDGCN asm strings can contain newlines, which propagate
-                # into format_node() output.  Split so every line gets the
-                # comment prefix; otherwise bare newlines break the wrapper.
-                detailed_metadata.extend(
-                    f"{wrapper.comment}   {line}"
-                    for line in formatted_node.splitlines()
-                )
-            else:
-                detailed_metadata.append(f"{wrapper.comment}   {formatted_node}")
+            # Asm strings can contain newlines, which propagate into
+            # format_node() output.  Split so every line gets the comment
+            # prefix; otherwise bare newlines break the wrapper.
+            detailed_metadata.extend(
+                f"{wrapper.comment}   {line}"
+                for line in str(formatted_node).splitlines()
+            )
 
         detailed_metadata.append(f"{wrapper.comment}   return {','.join(all_writes)}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193468
* __->__ #193459

## Human Note

## Agent note

Extends the inline_asm_elementwise HOP (previously wired up for flex_gemm) to work inside
flex_attention score_mods and mask_mods on both the Triton and FLASH (CuTeDSL) backends. The Triton
backend already worked end to end via the existing HOP lowering and PointwiseSubgraphLowering; the
rest needed three small fixes rather than new lowering machinery:

- The generated CuteDSL flash kernels emitted calls to inline_asm_elementwise_intrinsic but never
  imported it, so any asm score_mod failed with a NameError at DSL compile time. The import is now
  part of CuteDSLTemplateKernel.gen_imports().
- The eager (unfused) flex_attention path and create_block_mask apply mods under nested vmap, and
  the HOP had no batching rule. Since the op is elementwise, batching is a broadcast: move each
  batch dim to the front and pad the logical dims so a batched scalar is not consumed by
  trailing-dim broadcasting. Vmap levels that batch none of the asm inputs (e.g. the b/h levels of
  a causal mask_mod) return the result unwrapped.
- Multi-line PTX (needed for .reg predicate blocks in mask_mods) broke Triton codegen in two places
  where newline escaping was HIP-only: the tl.inline_asm_elementwise literal was emitted as a raw
  single-quoted string on CUDA, and the Graph-fragment provenance comments only split multi-line
  format_node() output on HIP. Both paths now use the same escaping unconditionally.

Backward is unchanged: the HOP has no autograd formula, so a score_mod using it fails with the
existing "output of score_mod must depend on score" error, matching the flex_gemm contract. One
user-facing note captured in the tests: eager create_block_mask passes int64 indices while compiled
kernels use int32, so asm with 32-bit "r" constraints needs an explicit q_idx.to(torch.int32).

This PR was authored with an AI assistant (Pi).

## Test Plan

All green on B200 (SM100); lintrunner clean on the changed files.

```bash
python -m pytest test/higher_order_ops/test_inline_asm_elementwise.py -n 8
python -m pytest test/inductor/test_flex_attention.py -k "cuda and (score_mod or mask_mod or inline_asm or block_mask)" -n 30
python -m pytest test/inductor/test_flex_flash.py -n 30
python -m pytest test/inductor/test_flex_gemm.py test/inductor/test_custom_lowering.py -k "not cpu" -n 30
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo