### PR TITLE
Update docs and stubs for foreach to be honest

### DIFF
--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -933,10 +933,6 @@ This API is in beta and subject to future changes.
 Forward-mode AD is not supported.
 :::
 
-Foreach operations accept a list or tuple of tensors. Out-of-place operations
-return the results as a tuple of tensors. In-place operations mutate each tensor
-and return the exact Python list or tuple passed as input, rather than `None`.
-
 ```{eval-rst}
 .. autosummary::
     :toctree: generated

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -933,6 +933,10 @@ This API is in beta and subject to future changes.
 Forward-mode AD is not supported.
 :::
 
+Foreach operations accept a list or tuple of tensors. Out-of-place operations
+return the results as a tuple of tensors. In-place operations mutate each tensor
+and return the exact Python list or tuple passed as input, rather than `None`.
+
 ```{eval-rst}
 .. autosummary::
     :toctree: generated

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -243,6 +243,10 @@ class TestForeach(TestCase):
             expect_fastpath = not (
                 noncontiguous or sample.disable_fastpath or div_slowpath
             )
+            # In-place ops return the exact list or tuple passed as input.
+            foreach_input = (
+                tuple(sample.input) if inplace and noncontiguous else sample.input
+            )
             ref_input, ctxmgr = sample.input, nullcontext()
             if inplace:
                 with torch.no_grad():
@@ -251,7 +255,7 @@ class TestForeach(TestCase):
             try:
                 with ctxmgr:
                     actual = func(
-                        [sample.input, *sample.args],
+                        [foreach_input, *sample.args],
                         self.is_cuda,
                         expect_fastpath,
                         **sample.kwargs,

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -243,7 +243,7 @@ class TestForeach(TestCase):
             expect_fastpath = not (
                 noncontiguous or sample.disable_fastpath or div_slowpath
             )
-            # In-place ops return the exact list or tuple passed as input.
+            # test both tuple and list (contiguous and inplace) inputs
             foreach_input = (
                 tuple(sample.input) if inplace and noncontiguous else sample.input
             )

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -47,7 +47,7 @@ from torchgen.api.python import (
     returns_structseq_pyi,
 )
 from torchgen.gen import parse_native_yaml, parse_tags_yaml
-from torchgen.model import _TorchDispatchModeKey, DispatchKey, Variant
+from torchgen.model import _TorchDispatchModeKey, DispatchKey, SchemaKind, Variant
 from torchgen.utils import FileManager
 
 
@@ -318,6 +318,23 @@ def generate_type_hints(sig_group: PythonSignatureGroup) -> list[str]:
     )
     if type_hint_vararg:
         type_hints.append(type_hint_vararg)
+
+    # Keep this in sync with the Python binding return-self special case in
+    # tools/autograd/gen_python_functions.py:emit_single_dispatch.
+    if (
+        str(sig_group.base.func.name).startswith("_foreach_")
+        and sig_group.base.func.kind() == SchemaKind.inplace
+    ):
+        old_suffix = " -> None: ..."
+        return_type = "tuple[Tensor, ...] | list[Tensor]"
+        if not all(hint.endswith(old_suffix) for hint in type_hints):
+            raise AssertionError(
+                "Expected generated in-place foreach hints to return None"
+            )
+        type_hints = [
+            f"{hint.removesuffix(old_suffix)} -> {return_type}: ..."
+            for hint in type_hints
+        ]
 
     return type_hints
 

--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -7,8 +7,10 @@ from collections import defaultdict
 
 import yaml
 from tools.autograd import gen_autograd_functions, load_derivatives
+from tools.pyi.gen_pyi import generate_type_hints
 
 from torchgen import dest
+from torchgen.api.python import PythonSignatureGroup, signature
 from torchgen.api.types import CppSignatureGroup, DispatcherSignature
 from torchgen.context import native_function_manager
 from torchgen.gen import (
@@ -28,6 +30,32 @@ from torchgen.model import (
 )
 from torchgen.native_function_generation import add_generated_native_functions
 from torchgen.selective_build.selector import SelectiveBuilder
+
+
+class TestGenPyi(unittest.TestCase):
+    def test_inplace_foreach_returns_input_container(self) -> None:
+        native_function, _ = NativeFunction.from_yaml(
+            {
+                "func": "_foreach_add_.Scalar(Tensor(a!)[] self, Scalar scalar) -> ()",
+                "variants": "function",
+                "device_check": "NoCheck",
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+        group = PythonSignatureGroup(
+            signature=signature(native_function, pyi=True),
+            base=native_function,
+            outplace=None,
+        )
+
+        hints = generate_type_hints(group)
+
+        self.assertEqual(len(hints), 1)
+        self.assertIn(
+            ") -> tuple[Tensor, ...] | list[Tensor]: ...",
+            hints[0],
+        )
 
 
 class TestCreateDerivative(unittest.TestCase):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14941,9 +14941,10 @@ for unary_base_func_name in (
         add_docstr(
             getattr(torch, unary_foreach_func_name),
             rf"""
-{unary_foreach_func_name}(self: List[Tensor]) -> List[Tensor]
+{unary_foreach_func_name}(self: tuple[Tensor, ...] | list[Tensor]) -> tuple[Tensor, ...]
 
-Apply :func:`torch.{unary_base_func_name}` to each Tensor of the input list.
+Applies :func:`torch.{unary_base_func_name}` to each tensor in ``self`` and returns the
+results as a tuple.
             """,
         )
     unary_inplace_foreach_func_name = f"{unary_foreach_func_name}_"
@@ -14951,9 +14952,10 @@ Apply :func:`torch.{unary_base_func_name}` to each Tensor of the input list.
         add_docstr(
             getattr(torch, unary_inplace_foreach_func_name),
             rf"""
-{unary_inplace_foreach_func_name}(self: List[Tensor]) -> None
+{unary_inplace_foreach_func_name}(self: tuple[Tensor, ...] | list[Tensor]) -> tuple[Tensor, ...] | list[Tensor]
 
-Apply :func:`torch.{unary_base_func_name}` to each Tensor of the input list.
+Applies :func:`torch.{unary_base_func_name}` in-place to each tensor in ``self`` and
+returns ``self``. The returned object is the exact list or tuple passed as input.
         """,
         )
 


### PR DESCRIPTION
Update stubs and docs to return List/Tuple instead of None for python foreach funcs. While the aten foreach inplace ops return None, we have our python binding codegen do the right thing and emit torch functions that return the input. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #193607
* #193472
* __->__ #193466

