### PR TITLE
[CUDA] cache `torch.cuda.get_device_properties`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -623,6 +623,38 @@ print(t.is_pinned())
         device_properties_no_argument = torch.cuda.get_device_properties()
         self.assertEqual(current_device_properties, device_properties_no_argument)
 
+    def test_cuda_get_device_properties_cache(self):
+        torch.cuda._get_device_properties_cached.cache_clear()
+        self.addCleanup(torch.cuda._get_device_properties_cached.cache_clear)
+        get_device_properties = torch.cuda._get_device_properties
+
+        with patch.object(
+            torch.cuda, "_get_device_properties", wraps=get_device_properties
+        ) as get_device_properties_mock:
+            with torch.cuda.device(0):
+                properties = torch.cuda.get_device_properties()
+                self.assertIs(properties, torch.cuda.get_device_properties(None))
+                self.assertIs(properties, torch.cuda.get_device_properties("cuda"))
+                self.assertIs(properties, torch.cuda.get_device_properties(0))
+                self.assertIs(
+                    properties,
+                    torch.cuda.get_device_properties(torch.device("cuda", 0)),
+                )
+            get_device_properties_mock.assert_called_once_with(0)
+
+            if torch.cuda.device_count() > 1:
+                with torch.cuda.device(1):
+                    other_properties = torch.cuda.get_device_properties()
+                    self.assertIs(
+                        other_properties, torch.cuda.get_device_properties("cuda")
+                    )
+                self.assertEqual(get_device_properties_mock.call_count, 2)
+                get_device_properties_mock.assert_called_with(1)
+
+                with torch.cuda.device(0):
+                    self.assertIs(properties, torch.cuda.get_device_properties())
+                self.assertEqual(get_device_properties_mock.call_count, 2)
+
     @unittest.skipIf(
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -20,7 +20,7 @@ import threading
 import traceback
 import warnings
 from collections.abc import Callable
-from functools import lru_cache
+from functools import cache, lru_cache
 from typing import Any, cast, NewType, Optional, TYPE_CHECKING
 
 import torch
@@ -783,6 +783,11 @@ def get_device_capability(device: Device = None) -> tuple[int, int]:
     return prop.major, prop.minor
 
 
+@cache
+def _get_device_properties_cached(device: int) -> _CudaDeviceProperties:
+    return _get_device_properties(device)  # type: ignore[name-defined]
+
+
 # pyrefly: ignore [not-a-type]
 def get_device_properties(device: Device = None) -> _CudaDeviceProperties:
     r"""Get the properties of a device.
@@ -800,7 +805,7 @@ def get_device_properties(device: Device = None) -> _CudaDeviceProperties:
     device = _get_device_index(device, optional=True)
     if device < 0 or device >= device_count():
         raise AssertionError("Invalid device id")
-    return _get_device_properties(device)  # type: ignore[name-defined]
+    return _get_device_properties_cached(device)
 
 
 def can_device_access_peer(device: Device, peer_device: Device) -> bool:


### PR DESCRIPTION
by popular demand
~400ns per call -> ~200ns

note that `get_device_properties` without specifying a device will still be slow, the bulk of time here seems to be due to the context lookups rather than underlying API calls
authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia