### PR TITLE
Fix CuteDSL shifts and Triton pack>1 asm in flex mask/score mods

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2178,6 +2178,46 @@ class TestFlexAttention(InductorTestCase):
 
     @supported_platform
     @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_mps
+    @skip_on_rocm
+    def test_inline_asm_mask_mod_pack2(self, device):
+        """pack>1 with multiple inputs: the (M, 1) q_idx and (1, N) kv_idx
+        blocks must be broadcast to a common shape before packing."""
+        asm_str = "{\n.reg .pred p;\nsetp.ge.s32 p, $2, $4; selp.u32 $0, 1, 0, p;\nsetp.ge.s32 p, $3, $5; selp.u32 $1, 1, 0, p;\n}"
+
+        def asm_causal_mask(b, h, q_idx, kv_idx):
+            pred = inline_asm_elementwise(
+                q_idx.to(torch.int32),
+                kv_idx.to(torch.int32),
+                asm_str=asm_str,
+                constraints="=r,=r,r,r,r,r",
+                dtype=torch.int32,
+                pack=2,
+            )
+            return pred != 0
+
+        def ref_causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        # pack > 1 requires compile, including for block-mask construction
+        bm = torch.compile(create_block_mask)(
+            asm_causal_mask, B, H, S, S, device=device
+        )
+        bm_ref = create_block_mask(ref_causal_mask, B, H, S, S, device=device)
+        self.assertEqual(bm.kv_indices, bm_ref.kv_indices)
+
+        q, k, v = [
+            torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+            for _ in range(3)
+        ]
+        compiled = torch.compile(flex_attention)
+        out = compiled(q, k, v, block_mask=bm)
+        ref = compiled(q, k, v, block_mask=bm_ref)
+        self.assertEqual(out, ref)
+
+    @supported_platform
+    @skip_on_cpu
     @expected_not_implemented_on_mps
     def test_bf16_score_mod_captured_grad_dtype(self, device):
         """

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1048,6 +1048,23 @@ class TestFlexFlash(InductorTestCase):
         q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
         flash_vs_triton(q, k, v, block_mask=block_mask)
 
+    def test_mask_mod_bitwise_shift(self):
+        """TensorSSA has no shift operators; codegen must emit MLIR arith
+        shifts or vectorized masks with >>/<< fail to compile (Morton-style
+        bit-manipulation masks)."""
+        seq_len = 512
+
+        def deint_mask(_b, _h, q_idx, kv_idx):
+            x = kv_idx & 0x55555555
+            x = (x | (x >> 1)) & 0x33333333
+            return ((x << 1) >= 0) & (q_idx >= kv_idx)
+
+        block_mask = _create_block_mask_for_device(
+            deint_mask, 2, 4, seq_len, seq_len, device="cuda"
+        )
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, block_mask=block_mask)
+
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", SCORE_MOD_CASES, name_fn=score_case_name)

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -43,6 +43,12 @@ class InlineAsmElementwiseOp(HigherOrderOperator):
         pack: Number of elements processed per asm invocation.  When
             ``pack > 1``, the constraint string must list ``pack`` outputs
             and ``pack`` copies of each input.  Requires ``torch.compile``.
+            Register conventions for elements smaller than 32 bits differ by
+            backend: Triton packs them into 32-bit registers, so a 16-bit
+            result uses one ``=r`` output holding ``pack`` halves (e.g.
+            ``add.rn.f16x2``), and per-element ``=h,=h`` outputs are invalid
+            (and currently abort compilation). CuTeDSL backends instead keep
+            one 16-bit register per element, so they use the ``=h,=h`` form.
 
     Returns:
         A tensor with the broadcast shape of the inputs and the given dtype.

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -899,14 +899,27 @@ class CuteDSLOpOverrides(OpOverrides):
         return CuteDSLOpOverrides._apply_unary_op(x, "(~{x})")
 
     @staticmethod
+    def _shift_op(x: CuteDSLArg, y: CuteDSLArg, py_op: str, op_name: str) -> CuteDSLArg:
+        """TensorSSA lacks __lshift__/__rshift__ (unlike __and__/__or__), so
+        vectorized shifts route through its _apply_op, which handles promotion,
+        scalar splatting, and signedness-aware arith dispatch."""
+        if CuteDSLOpOverrides._is_tensor_like(x) or CuteDSLOpOverrides._is_tensor_like(
+            y
+        ):
+            return CuteDSLOpOverrides._apply_binary_op(
+                x, y, f"{{a}}._apply_op(operator.{op_name}, {{b}})"
+            )
+        return CuteDSLOpOverrides._apply_binary_op(x, y, f"({{a}} {py_op} {{b}})")
+
+    @staticmethod
     # pyrefly: ignore [bad-override]
     def bitwise_left_shift(x: CuteDSLArg, y: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_binary_op(x, y, "({a} << {b})")
+        return CuteDSLOpOverrides._shift_op(x, y, "<<", "lshift")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def bitwise_right_shift(x: CuteDSLArg, y: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_binary_op(x, y, "({a} >> {b})")
+        return CuteDSLOpOverrides._shift_op(x, y, ">>", "rshift")
 
     @staticmethod
     def logical_not(a):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1809,6 +1809,15 @@ class TritonOverrides(OpOverrides):
         pack=1,
         input_dtypes=None,
     ):
+        """Emit a tl.inline_asm_elementwise call.
+
+        With pack > 1 the asm block is stamped once per `pack` adjacent
+        elements: the constraint string lists `pack` outputs and `pack` copies
+        of each input, with sub-32-bit elements packed into 32-bit registers.
+        Inputs are broadcast to a common shape, then raveled and zero-padded
+        via triton_helpers.inline_asm_pack; the result is restored with
+        inline_asm_unpack.
+        """
         # Use the actual dtype, not the compute type — the asm operates on
         # specific register types and Triton needs to know the real output type.
         asm_triton_type = triton_type(dtype)
@@ -1855,13 +1864,37 @@ class TritonOverrides(OpOverrides):
         first_input = inputs[0]
         compute = V.kernel.compute
         cse = V.kernel.cse
-        result = cse.newvar(dtype=dtype, shape=first_input.shape)
+        # inline_asm_pack ravels each input separately, so unlike the pack=1
+        # call (where tl.inline_asm_elementwise broadcasts internally) inputs
+        # with different block shapes (e.g. flex attention's (M, 1) q_idx vs
+        # (1, N) kv_idx) must be broadcast to a common shape before packing.
+        ref = first_input
+        if len(cast_inputs) > 1:
+            shape = first_input.shape
+            for inp in inputs[1:]:
+                if shape is None or inp.shape is None:
+                    shape = None
+                    break
+                shape = get_broadcasted_shape(tuple(shape), tuple(inp.shape))
+            if shape is None:
+                # TritonCSEVariable requires a shape; first input's is the
+                # best available approximation when propagation lost track.
+                shape = first_input.shape
+            ref = cse.newvar(dtype=dtype, shape=shape)
+            tmp = cse.newvar(dtype=dtype, shape=shape)
+            compute.writeline(f"{ref} = {cast_inputs[0]}")
+            for inp in cast_inputs[1:]:
+                compute.writeline(f"{ref}, {tmp} = tl.broadcast({ref}, {inp})")
+            cast_inputs = [
+                f"tl.broadcast_to({inp}, {ref}.shape)" for inp in cast_inputs
+            ]
+        result = cse.newvar(dtype=dtype, shape=ref.shape)
         packed_args = ", ".join(
             f"triton_helpers.inline_asm_pack({inp}, {pack})" for inp in cast_inputs
         )
         compute.writeline(f"{result} = {asm_call(packed_args)}")
         compute.writeline(
-            f"{result} = triton_helpers.inline_asm_unpack({result}, {first_input}, {pack})"
+            f"{result} = triton_helpers.inline_asm_unpack({result}, {ref}, {pack})"
         )
         return result
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193468
* #193459

## Human Note
Uno mas bug

## Agent note

Two independent codegen bugs hit by mask_mods/score_mods, found while fuzzing the inline-asm flex
support:

CuteDSL bitwise shifts: any mod containing `>>` or `<<` failed to compile on the FLASH backend with
`DSLRuntimeError: Unsupported DSL type: vector<32xi32>` (hit in practice by Morton/Z-order layout
masks, whose bit deinterleave is shift-heavy). The op override emitted plain Python `{a} >> {b}`,
assuming operator parity with `&`/`|`, but `cute.TensorSSA` never defined `__rshift__`/`__lshift__`,
so Python falls through to the inherited scalar-only `ArithValue` operator, which rejects vector
operands. The fix routes tensor shifts through `TensorSSA._apply_op(operator.rshift/lshift, ...)` --
the same body an upstream `TensorSSA.__rshift__` would have -- which provides type promotion, scalar
splatting, and signedness-aware `shrsi`/`shrui`/`shli` dispatch that `ArithValue` already implements.
Scalar operands keep the Python operator. An alternative emitting `arith.shrsi` directly was
rejected: it duplicated the signedness policy in Inductor, skipped `_apply_op`'s type promotion, and
needed extra dialect imports in generated kernels. The proper long-term fix is a one-line
`__rshift__`/`__lshift__` on `TensorSSA` upstream in CUTLASS.

Triton pack>1 with multiple inputs: `triton_helpers.inline_asm_pack` ravels each input separately,
so mod inputs with different block shapes (flex passes q_idx as (M, 1) and kv_idx as (1, N)) could
never broadcast and failed with `Cannot make_shape_compatible`. The pack=1 path was unaffected
because `tl.inline_asm_elementwise` broadcasts its inputs internally. The fix folds a broadcast
reference across the inputs with `tl.broadcast` and wraps each packed input in `tl.broadcast_to`
before raveling. Plain pointwise kernels never hit this because the HOP lowering broadcasts at the
IR level first.

Fuzzing also surfaced that backends disagree on sub-32-bit pack>1 register conventions: Triton packs
16-bit elements into one 32-bit register (one `=r` output, f16x2-style asm; the per-element
`=h,=h` form is invalid and currently aborts LLVM upstream), while CuTeDSL keeps one 16-bit register
per element and accepts `=h,=h`. This is documented on the HOP's `pack` argument rather than guarded
in the lowering, since the `=h,=h` spelling is the correct one on CuTeDSL.

This PR was authored with an AI assistant (Pi).

## Test Plan

New regression tests cover `>>`/`<<` and a Morton-style deinterleave step in a vectorized FLASH
mask_mod, and a pack=2 multi-input mask_mod on the Triton backend. Full flash, flex_gemm, and
inline-asm HOP suites pass on B200 (SM100), plus a 39-case fuzz sweep over dtypes, constraint
classes, pack widths, captured buffers, GQA, decoding, and dynamic shapes:

```bash
python -m pytest test/inductor/test_flex_flash.py -k "bitwise_shift" -q
python -m pytest test/inductor/test_flex_attention.py -k "inline_asm and cuda" -q
python -m pytest test/inductor/test_flex_flash.py test/inductor/test_flex_gemm.py -n 30 -q
python -m pytest test/higher_order_ops/test_inline_asm_elementwise.py -n 16 -q
```