### PR TITLE
[experimental] A/B the test retry policy in unstable

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -9,6 +9,17 @@ set -ex -o pipefail
 # Suppress ANSI color escape sequences
 export TERM=vt100
 
+# Retry-policy A/B experiment (see unstable.yml). The test config name is the only
+# per-job channel available without changing the shared _linux-test.yml, so the
+# suffix is stripped back to the real config here: everything downstream then sees
+# the same TEST_CONFIG as the trunk arm we are comparing against, and the only
+# difference is the retry policy.
+if [[ "${TEST_CONFIG}" == *_retry_experiment ]]; then
+  export TEST_CONFIG="${TEST_CONFIG%_retry_experiment}"
+  export PYTORCH_NUM_PYTEST_RERUNS=0
+  export PYTORCH_NUM_PROCESS_RETRIES=1
+fi
+
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 # shellcheck source=./common-build.sh

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -16,6 +16,10 @@ concurrency:
 permissions:
   id-token: write
   contents: read
+  # _linux-build.yml and _linux-test.yml both request actions: read, and a nested
+  # job cannot be granted more than its caller has. Omitting it here means
+  # actions: none, which fails the whole workflow at startup.
+  actions: read
 
 jobs:
   # There must be at least one job here to satisfy GitHub action workflow syntax
@@ -54,3 +58,108 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+
+  # Retry-policy A/B experiment against trunk's linux-jammy-cuda13.0-py3.10-gcc11
+  # "default" shards. Everything here is deliberately identical to trunk -- same
+  # job name, build-environment, docker image, cuda-arch-list, shard count and
+  # runners -- so the only variable is the retry policy. The "_retry_experiment"
+  # config suffix is the carrier: .ci/pytorch/test.sh strips it back to "default"
+  # and exports the retry knobs, which keeps test selection, sharding and the
+  # test-times lookup key identical to the trunk arm. The two arms are told apart
+  # by workflow name (unstable vs trunk) and by the config token in the job name.
+  linux-jammy-cuda13_0-py3_10-gcc11-retry-experiment-build:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-cuda13.0-py3.10-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-cuda13.0-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '7.5 8.9'
+      test-matrix: |
+        { include: [
+          { config: "default_retry_experiment", shard: 1, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 2, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 3, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 4, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 5, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 6, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 7, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 8, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 9, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 10, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 11, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 12, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 13, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+          { config: "default_retry_experiment", shard: 14, num_shards: 14, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
+        ]}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
+    secrets: inherit
+
+  linux-jammy-cuda13_0-py3_10-gcc11-retry-experiment-test:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-cuda13.0-py3.10-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_0-py3_10-gcc11-retry-experiment-build
+      - target-determination
+    with:
+      timeout-minutes: 360
+      build-environment: linux-jammy-cuda13.0-py3.10-gcc11
+      docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-retry-experiment-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-retry-experiment-build.outputs.test-matrix }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
+    secrets: inherit
+
+  # Second arm of the same experiment, against pull's linux-jammy-py3.10-gcc11
+  # "default" shards. Same reasoning as above: name, build-environment, docker
+  # image, shard count, runners and tests-to-exclude all match pull exactly, so
+  # the retry policy stays the only difference.
+  linux-jammy-py3_10-gcc11-retry-experiment-build:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-py3.10-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang21
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      test-matrix: |
+        { include: [
+          { config: "default_retry_experiment", shard: 1, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 2, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 3, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 4, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 5, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 6, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 7, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 8, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 9, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default_retry_experiment", shard: 10, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+        ]}
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit
+
+  linux-jammy-py3_10-gcc11-retry-experiment-test:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-py3.10-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-py3_10-gcc11-retry-experiment-build
+      - target-determination
+    with:
+      build-environment: linux-jammy-py3.10-gcc11
+      docker-image: ${{ needs.linux-jammy-py3_10-gcc11-retry-experiment-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-gcc11-retry-experiment-build.outputs.test-matrix }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -113,6 +113,9 @@ TEST_CONFIG = os.getenv("TEST_CONFIG", "")
 BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
 RERUN_DISABLED_TESTS = os.getenv("PYTORCH_TEST_RERUN_DISABLED_TESTS", "0") == "1"
 NUM_PYTEST_RERUNS = int(os.getenv("PYTORCH_NUM_PYTEST_RERUNS", "2"))
+# Process-level counterpart to NUM_PYTEST_RERUNS: how many times a failing test
+# is retried in a fresh process before it is called a consistent failure.
+NUM_PROCESS_RETRIES = int(os.getenv("PYTORCH_NUM_PROCESS_RETRIES", "2"))
 DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
 IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
@@ -872,7 +875,7 @@ def run_test_retries(
             print_to_file(
                 "Test succeeded in new process, continuing with the rest of the tests"
             )
-        elif num_failures[current_failure] >= 3:
+        elif num_failures[current_failure] > NUM_PROCESS_RETRIES:
             # This is for log classifier so it can prioritize consistently
             # failing tests instead of reruns. [1:-1] to remove quotes
             print_to_file(f"FAILED CONSISTENTLY: {current_failure[1:-1]}")
@@ -897,8 +900,12 @@ def run_test_retries(
             print_to_file("Retrying single test...")
         print_items = []  # do not continue printing them, massive waste of space
 
-    consistent_failures = [x[1:-1] for x in num_failures if num_failures[x] >= 3]
-    flaky_failures = [x[1:-1] for x in num_failures if 0 < num_failures[x] < 3]
+    consistent_failures = [
+        x[1:-1] for x in num_failures if num_failures[x] > NUM_PROCESS_RETRIES
+    ]
+    flaky_failures = [
+        x[1:-1] for x in num_failures if 0 < num_failures[x] <= NUM_PROCESS_RETRIES
+    ]
     if len(flaky_failures) > 0:
         print_to_file(
             "The following tests failed and then succeeded when run in a new process"


### PR DESCRIPTION
Mirrors the `default` shards of trunk's `linux-jammy-cuda13.0-py3.10-gcc11` (GPU) and pull's `linux-jammy-py3.10-gcc11` (CPU) into unstable.yml, but with no in-process pytest reruns and exactly one retry in a fresh process. Both source workflows also run on pushes to main, so every main commit yields a paired A/B sample.

Why: over 7 days in-process retry rescued 4,193 test instances for ~853k extra test executions (~1 per 200), and 89% of those rescues come from the first rerun. `distributed/*` already runs `--reruns=0` with process retry only, and there a fresh process alone rescues 30% of first-failure instances. What the data can't show is whether the flakes in-process retry currently catches would also clear in a fresh process — this measures that.

Investigation context: pytorch/test-infra#8407

Authored with assistance from Claude (Claude Code).
