### PR TITLE
Adding NVIDIA B200 to device_info mapping

### DIFF
--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -33,6 +33,28 @@ class DeviceInfo:
 # Indexing is based on `torch.cuda.get_device_name()`, normalized to upper-case.
 # TODO investigate profiler support for tf32 and allow device to report correct number when it's turned on.
 _device_mapping: dict[str, DeviceInfo] = {
+    # Source: NVIDIA Blackwell datasheet, "Individual Blackwell GPU Specifications",
+    # HGX B200 column. Tensor Core rows there are SPARSE; dense is 1/2. FP32/FP64 are
+    # already dense. Values below are all DENSE, so no sparsity factor.
+    # @lint-ignore https://www.nvidia.com/en-us/data-center/hgx/
+    "NVIDIA B200": DeviceInfo(
+        tops={
+            torch.float64: 37.0,
+            torch.float32: 75.0,
+            "torch.tf32": 1125.0,
+            torch.bfloat16: 2250.0,
+            torch.float16: 2250.0,
+            torch.float8_e4m3fn: 4500.0,
+            torch.float8_e4m3fnuz: 4500.0,
+            torch.float8_e5m2: 4500.0,
+            torch.float8_e5m2fnuz: 4500.0,
+            torch.float8_e8m0fnu: 4500.0,
+            torch.int8: 4500.0,
+            # torch.float4_e2m1fn_x2: 9000.0,  # PyTorch >= 2.8
+        },
+        dram_bw_gbs=7700.0,
+        dram_gb=180.0,
+    ),
     # Source:
     # @lint-ignore https://www.nvidia.com/en-us/data-center/h100/
     # Tensor Core values are *with sparsity* per the datasheet.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193471

Adds an entry for "NVIDIA B200" to `_device_mapping` in
torch/_inductor/analysis/device_info.py, so inductor's analysis passes
can compute roofline/utilization numbers on Blackwell instead of
falling back to unknown-device behavior.

Values are taken from the NVIDIA Blackwell datasheet ("Individual
Blackwell GPU Specifications", HGX B200 column). The Tensor Core rows
in that table are quoted *with sparsity*; the numbers here are dense
(1/2 the datasheet figure). FP32/FP64 are already dense in the
datasheet and are copied as-is.

dram_bw_gbs=7700, dram_gb=180.

Note: torch.float4_e2m1fn_x2 (9000 dense TOPS) is left commented out as
it requires PyTorch >= 2.8.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo