### PR TITLE
Remove redundant foreach lerp autogen declarations

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11246,7 +11246,6 @@
     CompositeExplicitAutograd: foreach_tensor_ternary_lerp_slow
     CUDA: foreach_tensor_lerp_ternary_cuda
     XPU: foreach_tensor_lerp_ternary_xpu
-  autogen: _foreach_lerp.List_out
 
 - func: _foreach_lerp_.List(Tensor(a!)[] self, Tensor[] tensors1, Tensor[] weights) -> ()
   device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
@@ -11264,7 +11263,6 @@
     CompositeExplicitAutograd: foreach_tensor_lerp_list_kernel_slow
     CUDA: foreach_tensor_lerp_list_cuda
     XPU: foreach_tensor_lerp_list_xpu
-  autogen: _foreach_lerp.Scalar_out
 
 - func: _foreach_lerp_.Scalar(Tensor(a!)[] self, Tensor[] tensors1, Scalar weight) -> ()
   device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
@@ -11282,7 +11280,6 @@
     CompositeExplicitAutograd: foreach_tensor_lerp_scalarlist_kernel_slow
     CUDA: foreach_tensor_lerp_scalarlist_cuda
     XPU: foreach_tensor_lerp_scalarlist_xpu
-  autogen: _foreach_lerp.ScalarList_out
 
 - func: _foreach_lerp_.ScalarList(Tensor(a!)[] self, Tensor[] tensors1, Scalar[] weight) -> ()
   device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices


### PR DESCRIPTION
^

Deets from Codex:

The functional and in-place foreach lerp schemas both claimed the same generated out variants. Torchgen selects the in-place schema as the generation source and collapses the declarations by name, making the functional declarations redundant.

Remove the functional declarations while retaining the in-place declarations. The generated out schemas and kernels remain unchanged.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #193607
* __->__ #193472
* #193466

Authored with assistance from an AI assistant.