### PR TITLE
[Testcase Refactoring]  Refactor test_package.py to be device-generic with capability gating and hardware classification

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -844,7 +844,6 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         x = torch.randn(10, 10, device=device)
         compiled_fn(x)
 
-
     class _tempTensorSamplerForQualName:
         def __init__(self, val, mask, prob):
             self.val = val
@@ -885,8 +884,8 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             with torch.device(x.device):
                 y = self.instance_method_without_args()
             # test classmethod called from class
-            sampler = (
-                TestPackageAccelerator._tempTensorSamplerForQualName.class_method_that_is_used(x)
+            sampler = TestPackageAccelerator._tempTensorSamplerForQualName.class_method_that_is_used(
+                x
             )
             x = torch.where(torch.rand_like(x) < sampler.prob, sampler.val, x) + y.sum()
             # test instance method called from instance

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import contextlib
 import gc
 import importlib
 import os
@@ -19,15 +20,17 @@ from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._dynamo.utils import CleanupManager
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     parametrize,
     TEST_WITH_TORCHDYNAMO,
-)
-from torch.testing._internal.inductor_utils import (
-    HAS_CUDA_AND_TRITON,
-    HAS_XPU_AND_TRITON,
 )
 
 
@@ -43,6 +46,8 @@ def compiled_region_with_backend_id_for_package_test():
 @torch._dynamo.config.patch({"strict_precompile": True})
 @instantiate_parametrized_tests
 class TestPackage(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def path(self):
         path = os.path.join(cache_dir(), f"package_{self.id()}")
         os.makedirs(path, exist_ok=True)
@@ -85,227 +90,6 @@ class TestPackage(torch._inductor.test_case.TestCase):
 
         cache_entry = package.cache_entry()
         self.assertEqual(cache_entry.codes[0].backend_ids, [backend_id])
-
-    @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
-    def test_nn_module(self):
-        class MyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(10, 10, device="cuda")
-
-            def forward(self, x):
-                return self.linear(x)
-
-        fn = MyModule()
-        package = CompilePackage(fn.forward)
-        compiled_fn = torch._dynamo.optimize("inductor", package=package)(fn)
-        x = torch.randn(10, 10, device="cuda")
-        compiled_fn(x)
-
-    @parametrize("backend", ("eager", "inductor"))
-    @parametrize("device", ("cpu", "cuda", "xpu"))
-    def test_basic_fn(self, backend, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
-        ctx = DiskDynamoStore()
-
-        def fn(x):
-            return x + 1
-
-        args = (
-            torch.randn(
-                3,
-                2,
-                device=device,
-            ),
-        )
-
-        # Saving
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend, package=package)(fn)
-        expected = compiled_fn(*args)
-        if backend == "eager":
-            for backend_id, backend in package.cached_backends.items():
-                ctx.record_eager_backend(backend_id, backend)
-
-        ctx.save_package(package, self.path())
-        # Loading
-        torch._dynamo.reset()
-        with torch.compiler.set_stance("fail_on_recompile"):
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-            ):
-                compiled_fn(*args)
-
-            package, backends = ctx.load_package(fn, self.path())
-            compiled_fn = torch._dynamo.optimize(package=package)(fn)
-            package.install(backends)
-            self.assertEqual(expected, compiled_fn(*args))
-
-    @parametrize("backend", ("eager", "inductor"))
-    @parametrize("device", ("cpu", "cuda", "xpu"))
-    def test_lazy_backward(self, backend, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
-        ctx = DiskDynamoStore()
-
-        def fn(x):
-            return x.sin() + x.cos()
-
-        args = (
-            torch.zeros(
-                3,
-                2,
-                device=device,
-                requires_grad=True,
-            ),
-        )
-
-        # Saving
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend, package=package)(fn)
-        expected = compiled_fn(*args)
-        expected.sum().backward()
-
-        if backend == "eager":
-            for backend_id, backend in package.cached_backends.items():
-                ctx.record_eager_backend(backend_id, backend)
-
-        ctx.save_package(package, self.path())
-        # Loading
-        torch._dynamo.reset()
-        with torch.compiler.set_stance("fail_on_recompile"):
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-            ):
-                compiled_fn(*args)
-
-            package, backends = ctx.load_package(fn, self.path())
-            compiled_fn = torch._dynamo.optimize(package=package)(fn)
-            package.install(backends)
-            self.assertEqual(expected, compiled_fn(*args))
-
-    @parametrize("backend", ("eager", "inductor"))
-    @parametrize("device", ("cpu", "cuda", "xpu"))
-    def test_graph_break_bomb(self, backend, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
-        ctx = DiskDynamoStore()
-
-        def fn(x, l, r):
-            if l > r:
-                return x.sum()
-            mid = (l + r) // 2
-            if x.sum() == mid:
-                return x.sum()
-            elif x.sum() < mid:
-                return fn(x, l, mid)
-            else:
-                return fn(x, mid + 1, r)
-
-        def guard_filter_fn(guards):
-            return [
-                guard.guard_type not in ("CLOSURE_MATCH", "FUNCTION_MATCH")
-                for guard in guards
-            ]
-
-        # Saving
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(
-            backend=backend, package=package, guard_filter_fn=guard_filter_fn
-        )(fn)
-        N = 10
-        args_list = [(torch.tensor(x, device=device), 0, N - 1) for x in range(N)]
-        for args in args_list:
-            compiled_fn(*args)
-        if backend == "eager":
-            for backend_id, backend in package.cached_backends.items():
-                ctx.record_eager_backend(backend_id, backend)
-        ctx.save_package(package, self.path())
-
-        # Loading
-        torch._dynamo.reset()
-        with torch.compiler.set_stance("fail_on_recompile"):
-            for args in args_list:
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-                ):
-                    compiled_fn(*args)
-            package, backends = ctx.load_package(fn, self.path())
-            compiled_fn = torch._dynamo.optimize(
-                backend="eager", package=package, guard_filter_fn=guard_filter_fn
-            )(fn)
-            package.install(backends)
-            for args in args_list:
-                self.assertEqual(compiled_fn(*args), args[0].sum())
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-            ):
-                compiled_fn(torch.tensor(N), 0, N - 1)
-
-    @parametrize("backend", ("eager", "inductor"))
-    @parametrize("device", ("cpu", "cuda", "xpu"))
-    def test_dynamic_shape(self, backend, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
-        ctx = DiskDynamoStore()
-
-        def fn(x):
-            return x + x.shape[0]
-
-        args = (torch.randn(3, 2, device=device),)
-        args1 = (torch.randn(5, 2, device=device),)
-        args2 = (torch.randn(7, 2, device=device),)
-        expected1 = fn(*args1)
-
-        torch._dynamo.mark_dynamic(args[0], 0, min=3, max=5)
-
-        # Saving
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend=backend, package=package)(fn)
-        compiled_fn(*args)
-        if backend == "eager":
-            for backend_id, backend in package.cached_backends.items():
-                ctx.record_eager_backend(backend_id, backend)
-        ctx.save_package(package, self.path())
-
-        # Loading
-        torch._dynamo.reset()
-        with torch.compiler.set_stance("fail_on_recompile"):
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-            ):
-                compiled_fn(*args1)
-
-            package, backends = ctx.load_package(fn, self.path())
-            compiled_fn = torch._dynamo.optimize(package=package)(fn)
-            package.install(backends)
-
-            self.assertEqual(expected1, compiled_fn(*args1))
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
-            ):
-                compiled_fn(*args2)
 
     def test_install_survives_stale_cleanup_hooks(self):
         # The first compile installs its generated functions -- and, on every
@@ -456,13 +240,286 @@ def add(x, y):
             )
             ctx.load_package(fn, self.path())
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
-    def test_dynamo_cache_manual_load(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
+    @parametrize("backend", ("eager", "inductor"))
+    def test_reset_clears_installed_package(self, backend):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190664.
+        # package.install() must register target_code in input_codes so that
+        # torch._dynamo.reset() clears precompile entries on the installed code.
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
 
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            return x.sin() + x.cos()
+
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend=backend, package=package)(fn)
+        compiled_fn(torch.randn(3, 2))
+        if backend == "eager":
+            for backend_id, bknd in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, bknd)
+        ctx.save_package(package, self.path())
+
+        torch._dynamo.reset()
+        package, backends = ctx.load_package(fn, self.path())
+        package.install(backends)
+        self.assertGreater(len(_debug_get_precompile_entries(fn.__code__)), 0)
+
+        torch._dynamo.reset()
+        self.assertEqual(len(_debug_get_precompile_entries(fn.__code__)), 0)
+
+    def test_import_source_unpickle_without_trace(self):
+        # Deserializing an ImportSource happens at torch.compile() time with no
+        # active TracingContext (e.g. precompile warm-load). Reconstructing the
+        # source must not install a guard (which would require a tracing
+        # context), so the round-trip must not raise.
+        import pickle
+
+        from torch._dynamo.source import ImportSource
+
+        source = ImportSource("torch")
+        reloaded = pickle.loads(pickle.dumps(source))
+        self.assertEqual(reloaded, source)
+
+
+class TestPackageAccelerator(torch._inductor.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    _package_config_stack = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._package_config_stack = contextlib.ExitStack()
+        cls._package_config_stack.enter_context(
+            functorch_config.patch("bundled_autograd_cache", True)
+        )
+        cls._package_config_stack.enter_context(
+            torch._dynamo.config.patch({"strict_precompile": True})
+        )
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            super().tearDownClass()
+        finally:
+            cls._package_config_stack.close()
+            cls._package_config_stack = None
+
+    def path(self):
+        path = os.path.join(cache_dir(), f"package_{self.id()}")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        torch._dynamo.utils.counters.clear()
+        DynamoCache.clear()
+        PrecompileContext.clear()
+
+    def _save_and_reload(self, expected_backends, expected_dynamo):
+        """
+        Serializes all artifacts, clears all caches, then reloads the serialized artifact
+        Simulates a new process.
+
+        Args:
+            expected_backends: Expected number of precompile_aot_autograd_artifacts
+            expected_dynamo: Expected number of precompile_dynamo_artifacts
+        """
+        debug_info = PrecompileContext.save_to_dynamo_cache()
+        self.assertEqual(len(debug_info["dynamo"]), expected_dynamo)
+        self.assertEqual(len(debug_info["backends"]), expected_backends)
+        torch._dynamo.reset()
+        PrecompileContext.clear()
+
+    @parametrize("backend", ("eager", "inductor"))
+    @requires_capabilities(Capability.lib.triton)
+    def test_basic_fn(self, device, backend):
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            return x + 1
+
+        args = (
+            torch.randn(
+                3,
+                2,
+                device=device,
+            ),
+        )
+
+        # Saving
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend, package=package)(fn)
+        expected = compiled_fn(*args)
+        if backend == "eager":
+            for backend_id, backend in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, backend)
+
+        ctx.save_package(package, self.path())
+        # Loading
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+            ):
+                compiled_fn(*args)
+
+            package, backends = ctx.load_package(fn, self.path())
+            compiled_fn = torch._dynamo.optimize(package=package)(fn)
+            package.install(backends)
+            self.assertEqual(expected, compiled_fn(*args))
+
+    @parametrize("backend", ("eager", "inductor"))
+    @requires_capabilities(Capability.lib.triton)
+    def test_lazy_backward(self, device, backend):
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            return x.sin() + x.cos()
+
+        args = (
+            torch.zeros(
+                3,
+                2,
+                device=device,
+                requires_grad=True,
+            ),
+        )
+
+        # Saving
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend, package=package)(fn)
+        expected = compiled_fn(*args)
+        expected.sum().backward()
+
+        if backend == "eager":
+            for backend_id, backend in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, backend)
+
+        ctx.save_package(package, self.path())
+        # Loading
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+            ):
+                compiled_fn(*args)
+
+            package, backends = ctx.load_package(fn, self.path())
+            compiled_fn = torch._dynamo.optimize(package=package)(fn)
+            package.install(backends)
+            self.assertEqual(expected, compiled_fn(*args))
+
+    @parametrize("backend", ("eager", "inductor"))
+    @requires_capabilities(Capability.lib.triton)
+    def test_graph_break_bomb(self, device, backend):
+        ctx = DiskDynamoStore()
+
+        def fn(x, l, r):
+            if l > r:
+                return x.sum()
+            mid = (l + r) // 2
+            if x.sum() == mid:
+                return x.sum()
+            elif x.sum() < mid:
+                return fn(x, l, mid)
+            else:
+                return fn(x, mid + 1, r)
+
+        def guard_filter_fn(guards):
+            return [
+                guard.guard_type not in ("CLOSURE_MATCH", "FUNCTION_MATCH")
+                for guard in guards
+            ]
+
+        # Saving
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(
+            backend=backend, package=package, guard_filter_fn=guard_filter_fn
+        )(fn)
+        N = 10
+        args_list = [(torch.tensor(x, device=device), 0, N - 1) for x in range(N)]
+        for args in args_list:
+            compiled_fn(*args)
+        if backend == "eager":
+            for backend_id, backend in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, backend)
+        ctx.save_package(package, self.path())
+
+        # Loading
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            for args in args_list:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+                ):
+                    compiled_fn(*args)
+            package, backends = ctx.load_package(fn, self.path())
+            compiled_fn = torch._dynamo.optimize(
+                backend="eager", package=package, guard_filter_fn=guard_filter_fn
+            )(fn)
+            package.install(backends)
+            for args in args_list:
+                self.assertEqual(compiled_fn(*args), args[0].sum())
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+            ):
+                compiled_fn(torch.tensor(N), 0, N - 1)
+
+    @parametrize("backend", ("eager", "inductor"))
+    @requires_capabilities(Capability.lib.triton)
+    def test_dynamic_shape(self, device, backend):
+        ctx = DiskDynamoStore()
+
+        def fn(x):
+            return x + x.shape[0]
+
+        args = (torch.randn(3, 2, device=device),)
+        args1 = (torch.randn(5, 2, device=device),)
+        args2 = (torch.randn(7, 2, device=device),)
+        expected1 = fn(*args1)
+
+        torch._dynamo.mark_dynamic(args[0], 0, min=3, max=5)
+
+        # Saving
+        package = CompilePackage(fn)
+        compiled_fn = torch._dynamo.optimize(backend=backend, package=package)(fn)
+        compiled_fn(*args)
+        if backend == "eager":
+            for backend_id, backend in package.cached_backends.items():
+                ctx.record_eager_backend(backend_id, backend)
+        ctx.save_package(package, self.path())
+
+        # Loading
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+            ):
+                compiled_fn(*args1)
+
+            package, backends = ctx.load_package(fn, self.path())
+            compiled_fn = torch._dynamo.optimize(package=package)(fn)
+            package.install(backends)
+
+            self.assertEqual(expected1, compiled_fn(*args1))
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'",
+            ):
+                compiled_fn(*args2)
+
+    @requires_capabilities(Capability.lib.triton)
+    def test_dynamo_cache_manual_load(self, device):
         def fn(x):
             return x.sin() + x.cos()
 
@@ -492,42 +549,9 @@ def add(x, y):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @parametrize("backend", ("eager", "inductor"))
-    def test_reset_clears_installed_package(self, backend):
-        # Regression test for https://github.com/pytorch/pytorch/issues/190664.
-        # package.install() must register target_code in input_codes so that
-        # torch._dynamo.reset() clears precompile entries on the installed code.
-        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
-
-        ctx = DiskDynamoStore()
-
-        def fn(x):
-            return x.sin() + x.cos()
-
-        package = CompilePackage(fn)
-        compiled_fn = torch._dynamo.optimize(backend=backend, package=package)(fn)
-        compiled_fn(torch.randn(3, 2))
-        if backend == "eager":
-            for backend_id, bknd in package.cached_backends.items():
-                ctx.record_eager_backend(backend_id, bknd)
-        ctx.save_package(package, self.path())
-
-        torch._dynamo.reset()
-        package, backends = ctx.load_package(fn, self.path())
-        package.install(backends)
-        self.assertGreater(len(_debug_get_precompile_entries(fn.__code__)), 0)
-
-        torch._dynamo.reset()
-        self.assertEqual(len(_debug_get_precompile_entries(fn.__code__)), 0)
-
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_serialize(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x):
             return x.sin() + x.cos()
 
@@ -554,31 +578,13 @@ def add(x, y):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    def test_import_source_unpickle_without_trace(self):
-        # Deserializing an ImportSource happens at torch.compile() time with no
-        # active TracingContext (e.g. precompile warm-load). Reconstructing the
-        # source must not install a guard (which would require a tracing
-        # context), so the round-trip must not raise.
-        import pickle
-
-        from torch._dynamo.source import ImportSource
-
-        source = ImportSource("torch")
-        reloaded = pickle.loads(pickle.dumps(source))
-        self.assertEqual(reloaded, source)
-
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_import_source_guard(self, device):
         # Warm-loading a guard state whose serialized sources include an
         # ImportSource must not raise. `pytree.tree_is_leaf` routes through
         # `get_pytree_SUPPORTED_NODES_source`, which builds an
         # `ImportSource("torch")` that ends up in the serialized guard state.
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x):
             if torch.utils._pytree.tree_is_leaf(x):
                 return torch.nn.functional.relu(x) + x.sin()
@@ -598,14 +604,9 @@ def add(x, y):
             self.assertEqual(result, expected)
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_recompiles(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x):
             return x.sin() + x.cos()
 
@@ -635,14 +636,9 @@ def add(x, y):
         TEST_WITH_TORCHDYNAMO or IS_LINUX,
         "https://github.com/pytorch/pytorch/issues/183810",
     )
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_graph_breaks(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x, l, r):
             if l > r:
                 return x.sum()
@@ -682,14 +678,9 @@ def add(x, y):
             self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/184832")
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_lazy_backward(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x):
             return x.sin() + x.cos()
 
@@ -711,14 +702,9 @@ def add(x, y):
 
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_graph_break_partial_backend(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def fn(x):
             y = x.sin()
             torch._dynamo.graph_break()
@@ -758,13 +744,9 @@ def add(x, y):
         # One recompile on a new frame, so total_frames should increase by 1
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames + 1)
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_call_function_from_resume(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
         mod = torch.nn.Linear(2, 3, device=device)
 
         def foo(x, mod):
@@ -786,14 +768,9 @@ def add(x, y):
 
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_code_with_generator(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def foo(set_of_x):
             if not all(isinstance(s, torch.Tensor) for s in set_of_x):
                 raise TypeError(
@@ -807,14 +784,9 @@ def add(x, y):
         compiled_fn(*args)
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_graph_breaks_from_print_model_as_fn(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         def guard_filter_fn(guards):
             return [
                 guard.guard_type not in ("CLOSURE_MATCH", "FUNCTION_MATCH")
@@ -855,6 +827,23 @@ def add(x, y):
             )
             compiled_fn(x)
             self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
+
+    @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
+    def test_nn_module(self, device):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10, device=device)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        fn = MyModule()
+        package = CompilePackage(fn.forward)
+        compiled_fn = torch._dynamo.optimize("inductor", package=package)(fn)
+        x = torch.randn(10, 10, device=device)
+        compiled_fn(x)
+
 
     class _tempTensorSamplerForQualName:
         def __init__(self, val, mask, prob):
@@ -897,7 +886,7 @@ def add(x, y):
                 y = self.instance_method_without_args()
             # test classmethod called from class
             sampler = (
-                TestPackage._tempTensorSamplerForQualName.class_method_that_is_used(x)
+                TestPackageAccelerator._tempTensorSamplerForQualName.class_method_that_is_used(x)
             )
             x = torch.where(torch.rand_like(x) < sampler.prob, sampler.val, x) + y.sum()
             # test instance method called from instance
@@ -911,22 +900,26 @@ def add(x, y):
             x = self.instance_method_with_args(x)
             return x
 
-    @parametrize("device", ("cpu", "cuda", "xpu"))
+    @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_classmethod_qualname(self, device):
-        if device == "cuda" and not HAS_CUDA_AND_TRITON:
-            raise unittest.SkipTest("Requires CUDA/Triton")
-        if device == "xpu" and not HAS_XPU_AND_TRITON:
-            raise unittest.SkipTest("Requires XPU/Triton")
-
         x = torch.rand(10, device=device)
-        model = TestPackage._tempNetForQualName()
+        model = TestPackageAccelerator._tempNetForQualName()
         model.forward(x)
         compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
             model.forward,
             options=dict(guard_filter_fn=torch.compiler.skip_guard_on_globals_unsafe),
         )
         compiled_fn(x)
+
+
+instantiate_device_type_tests(
+    TestPackageAccelerator,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+    allow_mps=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -282,6 +282,61 @@ def add(x, y):
         self.assertEqual(reloaded, source)
 
 
+class _tempTensorSamplerForQualName:
+    def __init__(self, val, mask, prob):
+        self.val = val
+        self.mask = mask
+        self.prob = prob
+
+    @classmethod
+    def class_method_that_is_used(cls, x):
+        prob = torch.sigmoid(x)
+        thresh = torch.rand(1, device=x.device)
+        mask = (prob > thresh).to(torch.bool)
+        return cls(x, mask, prob)
+
+    @classmethod
+    def class_method_that_is_not_used(cls, x):
+        prob = torch.sigmoid(x)
+        thresh = torch.rand(1, device=x.device)
+        mask = (prob > thresh).to(torch.bool)
+        return cls(x, mask, prob)
+
+    def instance_method_that_is_used(self, x):
+        return x / 2
+
+
+class _tempNetForQualName(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def instance_method_without_args(self):
+        shape = [1, 2, 3, 4]
+        x = torch.randn(shape)
+        return x
+
+    def instance_method_with_args(self, x):
+        return x + 1
+
+    def forward(self, x):
+        x *= x
+        with torch.device(x.device):
+            y = self.instance_method_without_args()
+        # test classmethod called from class
+        sampler = _tempTensorSamplerForQualName.class_method_that_is_used(x)
+        x = torch.where(torch.rand_like(x) < sampler.prob, sampler.val, x) + y.sum()
+        # test instance method called from instance
+        x = sampler.instance_method_that_is_used(x)
+        # test classmethod called from instance
+        another_sampler = sampler.class_method_that_is_not_used(x)
+        # test instance method called from instance
+        x = another_sampler.instance_method_that_is_used(x)
+        # test classmethod called from instance
+        x += y.sum()
+        x = self.instance_method_with_args(x)
+        return x
+
+
 class TestPackageAccelerator(torch._inductor.test_case.TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
@@ -844,66 +899,11 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         x = torch.randn(10, 10, device=device)
         compiled_fn(x)
 
-    class _tempTensorSamplerForQualName:
-        def __init__(self, val, mask, prob):
-            self.val = val
-            self.mask = mask
-            self.prob = prob
-
-        @classmethod
-        def class_method_that_is_used(cls, x):
-            prob = torch.sigmoid(x)
-            thresh = torch.rand(1, device=x.device)
-            mask = (prob > thresh).to(torch.bool)
-            return cls(x, mask, prob)
-
-        @classmethod
-        def class_method_that_is_not_used(cls, x):
-            prob = torch.sigmoid(x)
-            thresh = torch.rand(1, device=x.device)
-            mask = (prob > thresh).to(torch.bool)
-            return cls(x, mask, prob)
-
-        def instance_method_that_is_used(self, x):
-            return x / 2
-
-    class _tempNetForQualName(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-
-        def instance_method_without_args(self):
-            shape = [1, 2, 3, 4]
-            x = torch.randn(shape)
-            return x
-
-        def instance_method_with_args(self, x):
-            return x + 1
-
-        def forward(self, x):
-            x *= x
-            with torch.device(x.device):
-                y = self.instance_method_without_args()
-            # test classmethod called from class
-            sampler = TestPackageAccelerator._tempTensorSamplerForQualName.class_method_that_is_used(
-                x
-            )
-            x = torch.where(torch.rand_like(x) < sampler.prob, sampler.val, x) + y.sum()
-            # test instance method called from instance
-            x = sampler.instance_method_that_is_used(x)
-            # test classmethod called from instance
-            another_sampler = sampler.class_method_that_is_not_used(x)
-            # test instance method called from instance
-            x = another_sampler.instance_method_that_is_used(x)
-            # test classmethod called from instance
-            x += y.sum()
-            x = self.instance_method_with_args(x)
-            return x
-
     @requires_capabilities(Capability.lib.triton)
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_classmethod_qualname(self, device):
         x = torch.rand(10, device=device)
-        model = TestPackageAccelerator._tempNetForQualName()
+        model = _tempNetForQualName()
         model.forward(x)
         compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
             model.forward,
@@ -915,7 +915,6 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
 instantiate_device_type_tests(
     TestPackageAccelerator,
     globals(),
-    except_for=["cpu"],
     allow_xpu=True,
     allow_mps=True,
 )

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -20,9 +20,7 @@ from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._dynamo.utils import CleanupManager
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -21,9 +21,7 @@ from torch._dynamo.utils import CleanupManager
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_device_type import (
-    Capability,
     instantiate_device_type_tests,
-    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -32,6 +30,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     TEST_WITH_TORCHDYNAMO,
 )
+from torch.utils._triton import has_triton
 
 
 def compute_loss_helper(x):
@@ -389,7 +388,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         PrecompileContext.clear()
 
     @parametrize("backend", ("eager", "inductor"))
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_basic_fn(self, device, backend):
         ctx = DiskDynamoStore()
 
@@ -428,7 +427,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(expected, compiled_fn(*args))
 
     @parametrize("backend", ("eager", "inductor"))
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_lazy_backward(self, device, backend):
         ctx = DiskDynamoStore()
 
@@ -470,7 +469,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(expected, compiled_fn(*args))
 
     @parametrize("backend", ("eager", "inductor"))
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_graph_break_bomb(self, device, backend):
         ctx = DiskDynamoStore()
 
@@ -529,7 +528,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
                 compiled_fn(torch.tensor(N), 0, N - 1)
 
     @parametrize("backend", ("eager", "inductor"))
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_dynamic_shape(self, device, backend):
         ctx = DiskDynamoStore()
 
@@ -573,7 +572,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             ):
                 compiled_fn(*args2)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_dynamo_cache_manual_load(self, device):
         def fn(x):
             return x.sin() + x.cos()
@@ -604,7 +603,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_serialize(self, device):
         def fn(x):
@@ -633,7 +632,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(expected, [result1, result2])
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_import_source_guard(self, device):
         # Warm-loading a guard state whose serialized sources include an
@@ -659,7 +658,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(result, expected)
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_recompiles(self, device):
         def fn(x):
@@ -691,7 +690,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         TEST_WITH_TORCHDYNAMO or IS_LINUX,
         "https://github.com/pytorch/pytorch/issues/183810",
     )
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_graph_breaks(self, device):
         def fn(x, l, r):
@@ -733,7 +732,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/184832")
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_lazy_backward(self, device):
         def fn(x):
@@ -757,7 +756,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
 
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_graph_break_partial_backend(self, device):
         def fn(x):
@@ -799,7 +798,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         # One recompile on a new frame, so total_frames should increase by 1
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames + 1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_call_function_from_resume(self, device):
         mod = torch.nn.Linear(2, 3, device=device)
@@ -823,7 +822,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
 
         self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_code_with_generator(self, device):
         def foo(set_of_x):
@@ -839,7 +838,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         compiled_fn(*args)
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_automatic_dynamo_graph_breaks_from_print_model_as_fn(self, device):
         def guard_filter_fn(guards):
@@ -884,7 +883,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     def test_nn_module(self, device):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -900,7 +899,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
         x = torch.randn(10, 10, device=device)
         compiled_fn(x)
 
-    @requires_capabilities(Capability.lib.triton)
+    @unittest.skipIf(not has_triton(), "Requires Triton")
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_classmethod_qualname(self, device):
         x = torch.rand(10, device=device)

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -884,6 +884,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
             self.assertEqual(torch._dynamo.convert_frame.FRAME_COUNTER, total_frames)
 
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
+    @requires_capabilities(Capability.lib.triton)
     def test_nn_module(self, device):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -915,6 +916,7 @@ class TestPackageAccelerator(torch._inductor.test_case.TestCase):
 instantiate_device_type_tests(
     TestPackageAccelerator,
     globals(),
+    except_for=["cpu"],
     allow_xpu=True,
     allow_mps=True,
 )


### PR DESCRIPTION
## Summary
Refactors `test/dynamo/test_package.py` so the tests are no longer pinned to a fixed `("cpu", "cuda", "xpu")` device parametrization. The file is split into a device-unrelated class (`TestPackage`, `HardwareClassification.GENERIC`) and an accelerator-generic class (`TestPackageAccelerator`, `HardwareClassification.ACCELERATOR`) that is instantiated through `instantiate_device_type_tests` with `except_for=["cpu"]`. Accelerator methods that need Triton are gated with `@unittest.skipIf(not has_triton(), ...)`, and the two hardcoded `device="cuda"` usages in `test_nn_module` are replaced with the current `device` parameter.
## Changes
- **test/dynamo/test_package.py**
  - Split the single `TestPackage` class into two classes:
    - `TestPackage` (`HardwareClassification.GENERIC`) keeps the device-unrelated tests (`test_guarded_code_records_backend_ids_from_bytecode`, `test_install_survives_stale_cleanup_hooks`, `test_file_change`, `test_reset_clears_installed_package`, `test_import_source_unpickle_without_trace`) under `instantiate_parametrized_tests`.
    - `TestPackageAccelerator` (`HardwareClassification.ACCELERATOR`) holds the device-parameterized tests and is instantiated for every registered device type via `instantiate_device_type_tests(TestPackageAccelerator, globals(), except_for=["cpu"], allow_xpu=True, allow_mps=True)`.
  - Replace the per-method `@parametrize("device", ("cpu", "cuda", "xpu"))` and the manual `HAS_CUDA_AND_TRITON`/`HAS_XPU_AND_TRITON` skip blocks with Triton gating through `@unittest.skipIf(not has_triton(), "Requires Triton")`, matching the convention already used across the Dynamo tests (e.g. `test/dynamo/test_after_aot.py`). Device type coverage is now expressed once through `instantiate_device_type_tests`.
  - Change the method signatures of the moved tests from `def test_*(self, backend, device)` to `def test_*(self, device, backend)` to follow the `instantiate_device_type_tests` convention.
  - Fix the two hardcoded `device="cuda"` usages in `test_nn_module` to use the `device` parameter, so the test runs on whatever accelerator is active instead of only CUDA.
  - Replace the `@functorch_config.patch(...)` / `@torch._dynamo.config.patch(...)` class decorators on the accelerator class with a `setUpClass`/`tearDownClass` `contextlib.ExitStack` to keep the device-type instantiation machinery compatible.
  - Move the nested helper classes (`_tempTensorSamplerForQualName`, `_tempNetForQualName`) to module level and update their references, so the generated device variants do not hit `NameError` on accelerator runners.
## Not changed
- The `TestPackage` GENERIC tests keep their `@parametrize("backend", ...)` parametrization.
- `@unittest.expectedFailure` on `test_nn_module` is preserved; the test still documents an unrelated known limitation.
- This PR does not modify `torch/testing/_internal/common_device_type.py` / `common_utils.py`.
## Test plan
- `python test/dynamo/test_package.py TestPackage` on an Ascend NPU
  (CANN 9.1.0, torch 2.14.0a0, torch_npu 2.14.0, Ascend 910B2): **6/6 pass, OK**.
  Note: an earlier run on a container with CANN 9.1.0-beta.1 hit 1 environment
  failure in `test_reset_clears_installed_package_backend_inductor` due to a
  missing `aclmdlRICondHandle` symbol (introduced in CANN 9.1.0, absent in
  beta.1); re-verified on a CANN 9.1.0 container the case passes (OK), so the
  failure was purely an environment/version issue, unrelated to this refactor.
- `python test/dynamo/test_package.py TestPackageAcceleratorPRIVATEUSE1`: the
  test module imports and the accelerator methods are generated correctly; on
  healthy CUDA/triton machines these tests run, and on CPU-only CI the
  accelerator class generates no variants.
- Lint (PYFMT, RUFF, FLAKE8, TEST_DEVICE_BIAS) passes on the file.
- TODO: Run the file on CUDA/GPU CI configuration once CI approval is available.
## Notes
This is part of the PyTorch test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98