### PR TITLE
[Testcase Refactoring] Refactor test_modes.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -20,18 +20,14 @@ from torch.overrides import (
     TorchFunctionMode,
 )
 from torch.testing._internal.common_device_type import (
-    IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED,
-    IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED,
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
-from torch.testing._internal.common_utils import TEST_ACCELERATOR
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.common_utils import HardwareClassification, skipIfMPS
+from torch.testing._internal.inductor_utils import HAS_TRITON
 from torch.utils._device import DeviceContext
 from torch.utils._python_dispatch import TorchDispatchMode
-
-
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 
 
 class TestMode(BaseTorchFunctionMode):
@@ -63,6 +59,8 @@ class TestModeRaises(BaseTorchFunctionMode):
 
 
 class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -180,6 +178,8 @@ class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
 
 
 class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         try:
@@ -248,7 +248,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
     def test_torch_function_mode_guards_cpp(self):
         self._run_torch_function_mode_guard_test()
 
-    def test_torch_function_mode_preserves_cuda_rng_state(self):
+    def test_torch_function_mode_preserves_rng_state(self):
         class ConstantReturnMode(TorchFunctionMode):
             def __torch_function__(self, func, types, args=(), kwargs=None):
                 return -42
@@ -788,28 +788,6 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
 
             func(torch.randn(3))
 
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_flex_attention(self):
-        import torch
-        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
-
-        try:
-            torch.set_default_device(device_type)
-
-            flex_attention = torch.compile(flex_attention, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
-
-            prefix_lengths = torch.arange(8)
-
-            def prefix_lm(b, h, q, kv):
-                return prefix_lengths[b] >= kv
-
-            # This runs in fullgraph already
-            create_block_mask(
-                prefix_lm, 8, None, 512, 512, _compile=True, device=device_type
-            )
-        finally:
-            torch.set_default_device(None)
-
     def test_register_hook(self):
         import functools
 
@@ -840,104 +818,6 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(
                 torch.compile(fn, backend="eager", fullgraph=True)(x), fn(x)
             )
-
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_hop(self):
-        import torch
-        import torch._higher_order_ops
-        from torch.nn.attention.flex_attention import (
-            flex_attention as flex_attention_eager,
-        )
-
-        with torch.device(device_type):
-            flex_attention = torch.compile(flex_attention_eager, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
-
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.Unsupported,
-                "raised exception HopDetectionError\\('test'\\)",
-            ):
-                # This runs in fullgraph already
-                with TestModeRaises():
-                    flex_attention(
-                        torch.ones(2, 2, 2, 2),
-                        torch.ones(2, 2, 2, 2),
-                        torch.ones(2, 2, 2, 2),
-                    )
-
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_hop_eager(self):
-        import torch
-        import torch._higher_order_ops
-        from torch.nn.attention.flex_attention import (
-            flex_attention as flex_attention_eager,
-        )
-
-        with torch.device(device_type):
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.Unsupported,
-                "raised exception HopDetectionError\\('test'\\)",
-            ):
-                with TestModeRaises():
-                    flex_attention_eager(
-                        torch.ones(2, 2, 2, 2),
-                        torch.ones(2, 2, 2, 2),
-                        torch.ones(2, 2, 2, 2),
-                    )
-
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_default_device_factory_functions(self):
-        """Test that factory functions respect default device in compiled code"""
-
-        @torch.compile(backend="eager", fullgraph=True)
-        def random_func(
-            x: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-            # Test various factory functions
-            rnd = torch.randint(0, 2**32, size=x.shape, dtype=torch.uint32)
-            zeros = torch.zeros_like(rnd, device="cpu")
-            zeros_matched = torch.zeros_like(rnd)
-            return x + rnd, rnd, zeros, zeros_matched
-
-        try:
-            torch.set_default_device(device_type)
-            (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
-
-            # Verify tensors are on the current accelerator
-            self.assertEqual(rnd.device.type, device_type)
-            self.assertEqual(result.device.type, device_type)
-            self.assertEqual(zeros.device.type, "cpu")
-            self.assertEqual(zeros_matched.device.type, rnd.device.type)
-
-            torch.set_default_device("cpu")
-            (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
-
-            # Verify tensors are on cpu
-            self.assertEqual(rnd.device.type, "cpu")
-            self.assertEqual(result.device.type, "cpu")
-            self.assertEqual(zeros.device.type, "cpu")
-            self.assertEqual(zeros_matched.device.type, rnd.device.type)
-        finally:
-            torch.set_default_device(None)
-
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_default_device_factory_functions_priority(self):
-        try:
-            torch.set_default_device(device_type)
-
-            @torch.compile(backend="eager", fullgraph=True)
-            def with_explicit_device(
-                x: torch.Tensor,
-            ) -> tuple[torch.Tensor, torch.Tensor]:
-                rnd = torch.randint(
-                    0, 2**32, size=x.shape, dtype=torch.uint32, device="cpu"
-                )
-                return x + rnd, rnd
-
-            (result, rnd) = with_explicit_device(torch.randn(()))
-            self.assertEqual(rnd.device.type, "cpu")
-            self.assertEqual(result.device.type, device_type)
-        finally:
-            torch.set_default_device(None)
 
     def test_torch_function_mode_no_leak_on_graph_break(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/182317
@@ -976,7 +856,137 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(_len_torch_function_stack(), 0)
 
 
+class TorchFunctionModeTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIfMPS
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flex_attention)
+    def test_flex_attention(self, device):
+        import torch
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        try:
+            torch.set_default_device(device)
+
+            flex_attention = torch.compile(flex_attention, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
+
+            prefix_lengths = torch.arange(8)
+
+            def prefix_lm(b, h, q, kv):
+                return prefix_lengths[b] >= kv
+
+            # This runs in fullgraph already
+            create_block_mask(
+                prefix_lm, 8, None, 512, 512, _compile=True, device=device
+            )
+        finally:
+            torch.set_default_device(None)
+
+    @skipIfMPS
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flex_attention)
+    def test_hop(self, device):
+        import torch
+        import torch._higher_order_ops
+        from torch.nn.attention.flex_attention import (
+            flex_attention as flex_attention_eager,
+        )
+
+        with torch.device(device):
+            flex_attention = torch.compile(flex_attention_eager, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
+
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported,
+                "raised exception HopDetectionError\\('test'\\)",
+            ):
+                # This runs in fullgraph already
+                with TestModeRaises():
+                    flex_attention(
+                        torch.ones(2, 2, 2, 2),
+                        torch.ones(2, 2, 2, 2),
+                        torch.ones(2, 2, 2, 2),
+                    )
+
+    @skipIfMPS
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flex_attention)
+    def test_hop_eager(self, device):
+        import torch
+        import torch._higher_order_ops
+        from torch.nn.attention.flex_attention import (
+            flex_attention as flex_attention_eager,
+        )
+
+        with torch.device(device):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported,
+                "raised exception HopDetectionError\\('test'\\)",
+            ):
+                with TestModeRaises():
+                    flex_attention_eager(
+                        torch.ones(2, 2, 2, 2),
+                        torch.ones(2, 2, 2, 2),
+                        torch.ones(2, 2, 2, 2),
+                    )
+
+    def test_default_device_factory_functions(self, device):
+        """Test that factory functions respect default device in compiled code"""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def random_func(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            # Test various factory functions
+            rnd = torch.randint(0, 2**32, size=x.shape, dtype=torch.uint32)
+            zeros = torch.zeros_like(rnd, device="cpu")
+            zeros_matched = torch.zeros_like(rnd)
+            return x + rnd, rnd, zeros, zeros_matched
+
+        try:
+            torch.set_default_device(device)
+            (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
+
+            # Verify tensors are on the current accelerator
+            self.assertEqual(rnd.device.type, torch.device(device).type)
+            self.assertEqual(result.device.type, torch.device(device).type)
+            self.assertEqual(zeros.device.type, "cpu")
+            self.assertEqual(zeros_matched.device.type, rnd.device.type)
+
+            torch.set_default_device("cpu")
+            (result, rnd, zeros, zeros_matched) = random_func(torch.randn(()))
+
+            # Verify tensors are on cpu
+            self.assertEqual(rnd.device.type, "cpu")
+            self.assertEqual(result.device.type, "cpu")
+            self.assertEqual(zeros.device.type, "cpu")
+            self.assertEqual(zeros_matched.device.type, rnd.device.type)
+        finally:
+            torch.set_default_device(None)
+
+    def test_default_device_factory_functions_priority(self, device):
+        try:
+            torch.set_default_device(device)
+
+            @torch.compile(backend="eager", fullgraph=True)
+            def with_explicit_device(
+                x: torch.Tensor,
+            ) -> tuple[torch.Tensor, torch.Tensor]:
+                rnd = torch.randint(
+                    0, 2**32, size=x.shape, dtype=torch.uint32, device="cpu"
+                )
+                return x + rnd, rnd
+
+            (result, rnd) = with_explicit_device(torch.randn(()))
+            self.assertEqual(rnd.device.type, "cpu")
+            self.assertEqual(result.device.type, torch.device(device).type)
+        finally:
+            torch.set_default_device(None)
+
+
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @torch._dynamo.config.patch(
         trace_autograd_ops=True,
         inline_single_use_invoke_subgraph=False,
@@ -1653,8 +1663,12 @@ class outer_fn(torch.nn.Module):
             lambda msg: f"{msg}\nExpected 1 compilation, got {compile_counter.frame_count}",
         )
 
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_nested_compile_dynamic(self):
+
+class InvokeSubgraphBackendTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_nested_compile_dynamic(self, device):
         """Test that wrap_compiled_regions works with dynamic shapes."""
 
         d_model = 64
@@ -1669,7 +1683,7 @@ class outer_fn(torch.nn.Module):
 
         torch._dynamo.reset()
 
-        layer = MMLayer(d_model).to(device_type)
+        layer = MMLayer(d_model).to(device)
         compiled_mm = torch.compile(
             layer,
             backend="inductor",
@@ -1677,19 +1691,19 @@ class outer_fn(torch.nn.Module):
             dynamic=True,
         )
 
-        x = torch.randn(2, d_model, device=device_type)
+        x = torch.randn(2, d_model, device=device)
         result = compiled_mm(x)
         self.assertEqual(result.shape, (2, d_model))
         torch.testing.assert_close(result, layer(x))
 
         # Different batch size reuses the same compiled code
-        x2 = torch.randn(5, d_model, device=device_type)
+        x2 = torch.randn(5, d_model, device=device)
         result2 = compiled_mm(x2)
         self.assertEqual(result2.shape, (5, d_model))
         torch.testing.assert_close(result2, layer(x2))
 
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_nested_compile_input_mutation(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_nested_compile_input_mutation(self, device):
         """Test nested compile with input mutation inside a compiled region.
 
         Uses regional_inductor with fx_traceback.annotate to compile
@@ -1759,9 +1773,9 @@ class outer_fn(torch.nn.Module):
         ):
             torch._dynamo.reset()
 
-            model = StackedMutating(d_model, n_layers=2).to(device_type)
+            model = StackedMutating(d_model, n_layers=2).to(device)
 
-            x = torch.randn(2, d_model, device=device_type, requires_grad=True)
+            x = torch.randn(2, d_model, device=device, requires_grad=True)
 
             fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
             saved_params = list(model.parameters())
@@ -1800,8 +1814,8 @@ class outer_fn(torch.nn.Module):
             out = wrapped_fn(x)
             out.sum().backward()
 
-    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
-    def test_nested_compile_output_aliases_input(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_nested_compile_output_aliases_input(self, device):
         """Test nested compile where output is a view-alias of input.
 
         Uses regional_inductor with fx_traceback.annotate to compile
@@ -1871,9 +1885,9 @@ class outer_fn(torch.nn.Module):
         ):
             torch._dynamo.reset()
 
-            model = StackedView(d_model, n_layers=2).to(device_type)
+            model = StackedView(d_model, n_layers=2).to(device)
 
-            x = torch.randn(2, d_model, device=device_type, requires_grad=True)
+            x = torch.randn(2, d_model, device=device, requires_grad=True)
 
             fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
             saved_params = list(model.parameters())
@@ -1912,12 +1926,14 @@ class outer_fn(torch.nn.Module):
             out = wrapped_fn(x)
             out.sum().backward()
 
-    @unittest.skipUnless(
-        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
-        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flex_attention)
+    @unittest.skipIf(
+        torch.version.hip,
+        "Requires not ROCm",
     )
     def test_nested_compile_transformer_with_flex_attention_compiled_layers(
-        self,
+        self, device
     ):
         """Test a transformer model with 4 identical compiled layers using flex_attention.
 
@@ -1959,7 +1975,7 @@ class outer_fn(torch.nn.Module):
         batch_size, seq_len = 2, 32
 
         # dumb mask mod that closes over a tensor
-        mask_bias = torch.tensor(0, device=device_type, dtype=torch.int32)
+        mask_bias = torch.tensor(0, device=device, dtype=torch.int32)
 
         def mask_mod(b_idx, h_idx, q_idx, k_idx):
             return (q_idx >= k_idx) | (mask_bias == 1)
@@ -1971,7 +1987,7 @@ class outer_fn(torch.nn.Module):
             H=None,  # Broadcast over heads
             Q_LEN=seq_len,
             KV_LEN=seq_len,
-            device=device_type,
+            device=device,
         )
 
         # Transformer layer with flex_attention
@@ -2072,7 +2088,7 @@ class outer_fn(torch.nn.Module):
 
         fake_store = FakeStore()
         dist.init_process_group("fake", store=fake_store, rank=0, world_size=2)
-        device_mesh = init_device_mesh(device_type, (2,))
+        device_mesh = init_device_mesh(torch.device(device).type, (2,))
 
         with (
             # Needed when wrapping a compiled region with FX tracing
@@ -2086,7 +2102,7 @@ class outer_fn(torch.nn.Module):
             torch._dynamo.reset()
 
             model = SmallTransformer(d_model, n_heads, d_ff, n_layers=4)
-            model = model.to(device_type)
+            model = model.to(device)
 
             def replicate_all(name, module, device_mesh):
                 for param_name, param in module.named_parameters(recurse=False):
@@ -2101,7 +2117,7 @@ class outer_fn(torch.nn.Module):
                 batch_size,
                 seq_len,
                 d_model,
-                device=device_type,
+                device=device,
                 dtype=torch.float32,
                 requires_grad=True,
             )
@@ -2166,12 +2182,13 @@ class outer_fn(torch.nn.Module):
 
         dist.destroy_process_group()
 
-    @unittest.skipUnless(
-        (IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip)
-        or IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED,
-        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    @requires_capabilities(Capability.attention.flex_attention)
+    @unittest.skipIf(
+        torch.version.hip,
+        "Requires not ROCm",
     )
-    def test_2tier_blockmask_tensor_closure_nested_compile_aot_export(self):
+    def test_2tier_blockmask_tensor_closure_nested_compile_aot_export(self, device):
         """2-tier AOT export with BlockMask whose mask_mod captures tensors.
 
         Reproduces the sixlib/mango pattern where:
@@ -2266,12 +2283,12 @@ class outer_fn(torch.nn.Module):
         ):
             torch._dynamo.reset()
 
-            model = SimpleModel().to(device_type)
+            model = SimpleModel().to(device)
             x = torch.randn(
                 batch_size,
                 seq_len,
                 d_model,
-                device=device_type,
+                device=device,
                 dtype=torch.float32,
                 requires_grad=True,
             )
@@ -2279,7 +2296,7 @@ class outer_fn(torch.nn.Module):
                 batch_size,
                 2,
                 seq_len,
-                device=device_type,
+                device=device,
                 dtype=torch.int64,
             )
             visibility[:, 1, :] = seq_len - 1
@@ -2305,6 +2322,8 @@ class outer_fn(torch.nn.Module):
 
 
 class TorchFunctionModeLifecycleTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_default_device_restored_after_mode_tests(self):
         case = TorchFunctionModeTests("test_stack_state_mutation_default_device")
         TorchFunctionModeTests.setUpClass()
@@ -2320,6 +2339,20 @@ class TorchFunctionModeLifecycleTests(torch._dynamo.test_case.TestCase):
         stack = _get_current_function_mode_stack()
         self.assertFalse(any(isinstance(mode, DeviceContext) for mode in stack))
 
+
+instantiate_device_type_tests(
+    TorchFunctionModeTestsDevice,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+    allow_mps=True,
+)
+instantiate_device_type_tests(
+    InvokeSubgraphBackendTestsDevice,
+    globals(),
+    except_for="cpu",
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
## Summary

This PR makes `test/dynamo/test_modes.py` device-generic by replacing hardcoded CUDA/accelerator assumptions with hardware-classification annotations, capability-based skipping, and device-parameterized test classes. 

## Changes

- Added `hw_classification = HardwareClassification.GENERIC` to `TorchDispatchModeTests`, `TorchFunctionModeTests`, `InvokeSubgraphBackendTests`, and `TorchFunctionModeLifecycleTests`.
- Created new accelerator-specific classes `TorchFunctionModeTestsDevice` and `InvokeSubgraphBackendTestsDevice` with `hw_classification = HardwareClassification.ACCELERATOR`.
- Replaced hardcoded `device_type` (derived from `torch.accelerator.current_accelerator()`) with parameterized `device` argument in test methods.
- Migrated skip decorators from `@unittest.skipIf(not HAS_GPU, ...)` and `@skipIfXpu(...)` to `@unittest.skipIf(not HAS_TRITON, "requires triton"), Capability.attention.flex_attention)`.
- Replaced `IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED` checks with capability-based guards plus ROCm exclusion.
- Moved GPU-dependent tests (`test_flex_attention`, `test_hop`, `test_hop_eager`, `test_default_device_factory_functions`, etc.) to the new `TorchFunctionModeTestsDevice` class.
- Moved nested compile tests requiring Triton (`test_nested_compile_dynamic`, `test_nested_compile_input_mutation`, etc.) to `InvokeSubgraphBackendTestsDevice`.
- Added `instantiate_device_type_tests` calls for `TorchFunctionModeTestsDevice` class with `allow_xpu=True, allow_mps=True`(because of `TEST_ACCELERATOR`), and `InvokeSubgraphBackendTestsDevice` class with `allow_xpu=True`.
- Added regression tests `test_torch_function_mode_no_leak_on_graph_break` and `test_torch_function_mode_no_leak_nested_graph_break` to `TorchFunctionModeTests` (generic).

## Notes

- This PR depends on #194039 (flex_attention)[.](https://github.com/pytorch/pytorch/pull/194039)
- This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98