### PR TITLE
[TEST] Refactor package, cuda, and xeon backend tests to use hw_classification

### DIFF
--- a/test/backends/xeon/test_launch.py
+++ b/test/backends/xeon/test_launch.py
@@ -5,11 +5,18 @@ import subprocess
 import tempfile
 import unittest
 
-from torch.testing._internal.common_utils import IS_LINUX, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_LINUX,
+    run_tests,
+    TestCase,
+)
 
 
 @unittest.skipIf(not IS_LINUX, "Only works on linux")
 class TestTorchrun(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -8,7 +8,11 @@ from unittest import skipIf
 import torch.nn
 from torch.package import EmptyMatchError, Importer, PackageExporter, PackageImporter
 from torch.package.package_exporter import PackagingError
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+)
 
 
 try:
@@ -24,6 +28,8 @@ class TestDependencyAPI(PackageTestCase):
     - extern()
     - deny()
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_extern(self):
         buffer = BytesIO()

--- a/test/package/test_dependency_hooks.py
+++ b/test/package/test_dependency_hooks.py
@@ -3,7 +3,7 @@
 from io import BytesIO
 
 from torch.package import PackageExporter
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -18,6 +18,8 @@ class TestDependencyHooks(PackageTestCase):
     - register_mock_hook()
     - register_extern_hook()
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_single_hook(self):
         buffer = BytesIO()

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: package/deploy"]
 
 from torch.package._digraph import DiGraph
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 try:
@@ -13,6 +13,8 @@ except ImportError:
 
 class TestDiGraph(PackageTestCase):
     """Test the DiGraph structure we use to represent dependencies in PackageExporter"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_successors(self):
         g = DiGraph()

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -7,7 +7,13 @@ import traceback
 import torch
 import torch.cuda._sanitizer as csan
 from torch.cuda._sanitizer import DataPtr, EventId, StreamId
-from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    NoTest,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -17,6 +23,8 @@ if not TEST_CUDA:
 
 
 class TestArgumentHandler(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_add(self):
         add_func = torch.ops.aten.add.Tensor
         a = torch.ones(5, 3, device="cuda")
@@ -141,6 +149,8 @@ def event_id(i: int) -> EventId:
 
 
 class TestEventHandler(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         self.handler = csan.EventHandler()
@@ -396,6 +406,8 @@ class TestEventHandler(TestCase):
 
 
 class TestMessages(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         self.handler = csan.EventHandler()

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -6,7 +6,13 @@ import unittest.mock
 
 import torch
 import torch.cuda._gpu_trace as gpu_trace
-from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    NoTest,
+    run_tests,
+    TEST_CUDA,
+    TestCase,
+)
 
 
 # NOTE: Each test needs to be run in a brand new process, to reset the registered hooks
@@ -19,6 +25,8 @@ if not TEST_CUDA:
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaTrace(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         torch._C._activate_gpu_trace()

--- a/test/test_kernel_launch_checks.py
+++ b/test/test_kernel_launch_checks.py
@@ -1,12 +1,14 @@
 # Owner(s): ["module: cuda"]
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import HardwareClassification, TestCase, run_tests
 from torch.testing._internal.check_kernel_launches import (
     check_cuda_kernel_launches, check_code_for_cuda_kernel_launches
 )
 
 
 class AlwaysCheckCudaLaunchTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_check_code(self):
         """Verifies that the regex works for a few different situations"""
 


### PR DESCRIPTION
## Summary

Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines across five test files.

**`test/package/test_digraph.py`**
- **TestDiGraph**: `GENERIC` — pure graph structure tests, no device dependency

**`test/package/test_dependency_hooks.py`**
- **TestDependencyHooks**: `GENERIC` — package dependency hook tests, no device dependency

**`test/package/test_dependency_api.py`**
- **TestDependencyAPI**: `GENERIC` — package dependency API tests, no device dependency

**`test/backends/xeon/test_launch.py`**
- **TestTorchrun**: `GENERIC` — subprocess/torchrun launch tests, no device dependency

**`test/test_kernel_launch_checks.py`**
- **AlwaysCheckCudaLaunchTest**: `GENERIC` — kernel launch configuration checks, no device dependency

**`test/test_cuda_trace.py`**
- **TestCudaTrace**: `CUDA` — CUDA activity tracing tests, hardcodes CUDA APIs

**`test/test_cuda_sanitizer.py`**
- **TestArgumentHandler**: `CUDA` — CUDA sanitizer argument parsing tests
- **TestEventHandler**: `CUDA` — CUDA event handling tests
- **TestMessages**: `CUDA` — CUDA sanitizer message formatting tests

No structural changes — annotation only.

cc @mansiag05 @RiyaP2508

## Test Plan
```
lintrunner -a test/package/test_digraph.py test/package/test_dependency_hooks.py \
  test/backends/xeon/test_launch.py test/test_cuda_trace.py test/test_cuda_sanitizer.py
# ok No lint issues.

python test/package/test_digraph.py -v
python test/package/test_digraph.py --hw-classification GENERIC -v

python test/package/test_dependency_hooks.py -v
python test/package/test_dependency_hooks.py --hw-classification GENERIC -v

python test/package/test_dependency_api.py -v 
python test/package/test_dependency_api.py --hw-classification GENERIC -v

python test/backends/xeon/test_launch.py -v
python test/backends/xeon/test_launch.py --hw-classification GENERIC -v

python test/test_kernel_launch_checks.py -v 
python test/test_kernel_launch_checks.py --hw-classification GENERIC -v

python test/test_cuda_trace.py -v
python test/test_cuda_trace.py --hw-classification CUDA -v

python test/test_cuda_sanitizer.py -v
python test/test_cuda_sanitizer.py --hw-classification CUDA -v
```

Authored with an AI assistant.