### PR TITLE
[Testcase Refactoring] Device classification for test_iterators.py (GENERIC)

### DIFF
--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -8,6 +8,7 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     make_dynamo_test,
     xfailIfPy313AndEarlier,
 )
@@ -122,6 +123,8 @@ class NotReversibleNone:
 
 class TestIterators(torch._dynamo.test_case.TestCase):
     """Test iterator support in Dynamo"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -931,6 +934,8 @@ class GeneratorIterIterable:
 class TestCustomIteratorMethods(torch._dynamo.test_case.TestCase):
     """Test custom __iter__ implementations on user-defined subclasses"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -994,6 +999,8 @@ class TestIteratorMutationSemantics(torch._dynamo.test_case.TestCase):
     These tests explore whether Dynamo preserves CPython's iterator semantics
     when the underlying container is modified.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -1120,6 +1127,8 @@ class Priority(enum.IntEnum):
 class TestEnumIteration(torch._dynamo.test_case.TestCase):
     """Test iteration over enum classes"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -1171,6 +1180,8 @@ class TestEnumIteration(torch._dynamo.test_case.TestCase):
 
 class TestIterWithBuiltins(torch._dynamo.test_case.TestCase):
     """Test iter() with builtin iterators like zip, map, filter, reversed"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -1405,6 +1416,8 @@ class BlockedLen:
 class TestIterErrors(torch._dynamo.test_case.TestCase):
     """Test that iter() raises the correct exceptions"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -1630,6 +1643,8 @@ class TestSpecialMethodIterLookup(torch._dynamo.test_case.TestCase):
     resolved via MRO-only special lookup with descriptor binding
     (lookup_maybe_method in Objects/typeobject.c)."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._u_prev = torch._dynamo.config.enable_trace_unittest
@@ -1723,6 +1738,8 @@ class ColorInt(enum.IntEnum):
 class TestSpecialMethodLookupRegressions(torch._dynamo.test_case.TestCase):
     """Regressions for the special-method lookup engine: C-slot dunders must
     never recurse, and error messages must match eager."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC`) class attributes to Dynamo test file `test/dynamo/test_iterators.py` so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_iterators.py**
  - Import `HardwareClassification`; tag `TestIterators`, `TestCustomIteratorMethods`, `TestIteratorMutationSemantics`, `TestEnumIteration`, `TestIterWithBuiltins`, `TestIterErrors`, `TestSpecialMethodIterLookup`, and `TestSpecialMethodLookupRegressions` as `GENERIC`.

## Test plan

`python test/dynamo/test_iterators.py --hw-classification GENERIC` - 139 tests, `OK (expected failures=3)`, `HW classification mode active (["GENERIC"]): total=139, passed=139, unclassified=0, mismatched=0`

No runtime behavior is changed; the annotation only enables hardware-generic test admission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98