### PR TITLE
[Testcase Refactoring] Device classification for test_lazy_constant.py (GENERIC)

### DIFF
--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -7,9 +7,12 @@ import torch
 import torch._dynamo
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter, same
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class LazyConstantVariableTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _assert_compile_count(self, fn, arg_sets, expected_frames):
         counter = CompileCounter()
         opt_fn = torch.compile(fn, backend=counter)
@@ -542,6 +545,8 @@ class LazyConstantVariableTests(TestCase):
 
 
 class ComputedLazyConstantTests(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _check(self, fn, arg_sets, expected_frames):
         counter = CompileCounter()
         opt_fn = torch.compile(fn, backend=counter)


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC`) class attributes to Dynamo test file `test/dynamo/test_lazy_constant.py` so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_lazy_constant.py**
  - Import `HardwareClassification`; tag `LazyConstantVariableTests` and `ComputedLazyConstantTests` as `GENERIC`.

## Test plan

`python test/dynamo/test_lazy_constant.py --hw-classification GENERIC` - 22 tests, `OK`, `HW classification mode active (["GENERIC"]): total=22, passed=22, unclassified=0, mismatched=0`

No runtime behavior is changed; the annotation only enables hardware-generic test admission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98