### PR TITLE
[Testcase Refactoring] Device classification for test_len_protocol.py (GENERIC)

### DIFF
--- a/test/dynamo/test_len_protocol.py
+++ b/test/dynamo/test_len_protocol.py
@@ -18,7 +18,7 @@ import types
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 class _BaseSequenceLen:
@@ -84,11 +84,15 @@ class _BaseSequenceLen:
 class TestListLen(_BaseSequenceLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on list objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     thetype = list
 
 
 class TestTupleLen(_BaseSequenceLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on tuple objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     thetype = tuple
 
@@ -157,9 +161,13 @@ class _BaseMappingLen:
 class TestDictLen(_BaseMappingLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on dict objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
 
 class TestOrderedDictLen(_BaseMappingLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on OrderedDict objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def get_mapping(self, items):
         return collections.OrderedDict(items)
@@ -167,6 +175,8 @@ class TestOrderedDictLen(_BaseMappingLen, torch._dynamo.test_case.TestCase):
 
 class TestDefaultDictLen(_BaseMappingLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on defaultdict objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def get_mapping(self, items):
         d = collections.defaultdict(int)
@@ -234,6 +244,8 @@ class _BaseSetLen:
 class TestSetLen(_BaseSetLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on set objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def get_set(self, items):
         return set(items)
 
@@ -241,12 +253,16 @@ class TestSetLen(_BaseSetLen, torch._dynamo.test_case.TestCase):
 class TestFrozenSetLen(_BaseSetLen, torch._dynamo.test_case.TestCase):
     """Tests for len() on frozenset objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def get_set(self, items):
         return frozenset(items)
 
 
 class TestRangeLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on range objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -296,6 +312,8 @@ class TestRangeLen(torch._dynamo.test_case.TestCase):
 class TestStringLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on string objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -336,6 +354,8 @@ class TestStringLen(torch._dynamo.test_case.TestCase):
 
 class TestTensorLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on torch.Tensor objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -391,6 +411,8 @@ class TestTensorLen(torch._dynamo.test_case.TestCase):
 
 class TestNNModuleLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on torch.nn module containers"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -463,6 +485,8 @@ class TestNNModuleLen(torch._dynamo.test_case.TestCase):
 
 class TestDictViewLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on dict view objects (keys, values, items)"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -688,6 +712,8 @@ class SetSubclassCustomLen(set):
 class TestUserDefinedLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on user-defined classes with __len__"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -735,6 +761,8 @@ class TestUserDefinedLen(torch._dynamo.test_case.TestCase):
 
 class TestSubclassOverloadedLen(torch._dynamo.test_case.TestCase):
     """Tests for custom classes that inherit from builtins and overload __len__"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -828,6 +856,8 @@ class CustomDescriptorLenClass:
 class TestUserDefinedMappingLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on user-defined mapping (dict-like) classes"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -907,6 +937,8 @@ class TestUserDefinedMappingLen(torch._dynamo.test_case.TestCase):
 class TestDescriptorLenImpl(torch._dynamo.test_case.TestCase):
     """Test that len_impl handles descriptor-based __len__ correctly"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -976,6 +1008,8 @@ class TestDescriptorLenImpl(torch._dynamo.test_case.TestCase):
 class TestRaisesTypeError(torch._dynamo.test_case.TestCase):
     """Tests for types that don't support len() - should raise TypeError like Python"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -1039,6 +1073,8 @@ class TestRaisesTypeError(torch._dynamo.test_case.TestCase):
 class TestDequeLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on collections.deque objects"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -1087,6 +1123,8 @@ class TestDequeLen(torch._dynamo.test_case.TestCase):
 
 class TestMappingProxyLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on types.MappingProxyType objects"""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -1164,6 +1202,8 @@ class SimpleMetaclassClass(metaclass=MetaclassWithLen):
 class TestMetaclassLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on metaclasses, classmethods, staticmethods, and properties"""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -1231,6 +1271,8 @@ class FrozenData:
 class TestMutableMappingLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on mutable mapping types."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
         torch._dynamo.config.enable_trace_unittest = True
@@ -1256,6 +1298,8 @@ class TestMutableMappingLen(torch._dynamo.test_case.TestCase):
 
 class TestFrozenDataclassLen(torch._dynamo.test_case.TestCase):
     """Tests for len() on frozen dataclasses."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest

--- a/test/dynamo/test_len_protocol.py
+++ b/test/dynamo/test_len_protocol.py
@@ -18,7 +18,10 @@ import types
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 class _BaseSequenceLen:


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC`) class attributes to Dynamo test file `test/dynamo/test_len_protocol.py` so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_len_protocol.py**
  - Import `HardwareClassification`; tag `TestListLen`, `TestTupleLen`, `TestDictLen`, `TestOrderedDictLen`, `TestDefaultDictLen`, `TestSetLen`, `TestFrozenSetLen`, `TestRangeLen`, `TestStringLen`, `TestTensorLen`, `TestNNModuleLen`, `TestDictViewLen`, `TestUserDefinedLen`, `TestSubclassOverloadedLen`, `TestUserDefinedMappingLen`, `TestDescriptorLenImpl`, `TestRaisesTypeError`, `TestDequeLen`, `TestMappingProxyLen`, `TestMetaclassLen`, `TestMutableMappingLen`, and `TestFrozenDataclassLen` as `GENERIC`.

## Test plan

`python test/dynamo/test_len_protocol.py --hw-classification GENERIC` - 264 tests, `OK`, `HW classification mode active (["GENERIC"]): total=264, passed=264, unclassified=0, mismatched=0`

No runtime behavior is changed; the annotation only enables hardware-generic test admission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98