### PR TITLE
[Testcase Refactoring] Device classification for test_list.py (GENERIC)

### DIFF
--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -8,7 +8,7 @@ import sys
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
 
 
 lst = []
@@ -33,6 +33,8 @@ class CmpKeyForListSort:
 
 
 class TupleTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Tuple methods
     # + count
     # + index
@@ -205,6 +207,8 @@ class TupleTests(torch._dynamo.test_case.TestCase):
 
 
 class ListTests(TupleTests):
+    hw_classification = HardwareClassification.GENERIC
+
     # List methods
     # + append
     # + copy

--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -8,7 +8,10 @@ import sys
 
 import torch
 import torch._dynamo.test_case
-from torch.testing._internal.common_utils import HardwareClassification, make_dynamo_test
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    make_dynamo_test,
+)
 
 
 lst = []
@@ -207,8 +210,6 @@ class TupleTests(torch._dynamo.test_case.TestCase):
 
 
 class ListTests(TupleTests):
-    hw_classification = HardwareClassification.GENERIC
-
     # List methods
     # + append
     # + copy
@@ -541,6 +542,8 @@ class ListTests(TupleTests):
 
 
 class IndexNotFoundTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # list/tuple/deque share BaseListVariable.list_index, but CPython's
     # ValueError text does not: on <=3.13 list and deque repr the missing
     # value while tuple ignores it; 3.14 dropped the repr everywhere


### PR DESCRIPTION
## Summary

This PR adds `HardwareClassification` (`GENERIC`) class attributes to Dynamo test file `test/dynamo/test_list.py` so that CI runners can route tests by hardware capability.

## Changes

- **test/dynamo/test_list.py**
  - Import `HardwareClassification`; tag `TupleTests` and `ListTests` as `GENERIC`.

## Test plan

`python test/dynamo/test_list.py --hw-classification GENERIC` - 115 tests, `OK`, `HW classification mode active (["GENERIC"]): total=115, passed=115, unclassified=0, mismatched=0`

No runtime behavior is changed; the annotation only enables hardware-generic test admission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98