### PR TITLE
[AOTInductor] Avoid synthetic launches for indirect-access kernels

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2143,6 +2143,22 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Repro(), example_inputs)
 
+    @requires_autotune_at_compile_time
+    def test_empty_indirect_embedding(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = nn.Embedding(2, 1)
+
+            def forward(self, x):
+                return self.embedding((x[x >= 1] - 1).long())
+
+        inputs = [
+            (torch.zeros(1, dtype=torch.int32, device=self.device),),
+            (torch.ones(1, dtype=torch.int32, device=self.device),),
+        ]
+        self.check_model_with_multiple_inputs(Model(), inputs)
+
     @config.patch({"unbacked_symint_fallback": 12})
     @parametrize("shift_k", [0, 1, 2, 3])
     @parametrize("use_static_size", [True, False])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3331,6 +3331,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._op_trace_cse_names: dict[str, str] = {}
         self._op_trace_symbol_names: dict[sympy.Symbol, sympy.Symbol] = {}
         self._op_trace_symbol_counts: collections.Counter[str] = collections.Counter()
+        self.has_indirect_access: bool = False
 
         # A set of autotuning hints to pass as part of triton_meta
         self.autotune_hints = OrderedSet[AutotuneHint]()
@@ -3803,6 +3804,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         Compute the index and mask to pass to tl.load() or tl.store()
         """
         index = self.prepare_indexing(index)
+        if self.is_indirect_indexing(index):
+            self.has_indirect_access = True
         index_vars = index.free_symbols
         has_rindex = False
 
@@ -7355,6 +7358,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.codegen_prologue(self.body)
         self._prescan_host_tma_materializability()
         self.codegen_body()
+
+        if self.has_indirect_access:
+            self.inductor_meta["has_indirect_access"] = True
 
         tma_fields = (
             "tma_min_block_sizes",

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -961,6 +961,9 @@ class ComboKernel(Kernel):
         inductor_meta = {
             "grid_type": dispatch.grid_expr.__name__,
             "combo_grid_meta": self.combo_grid_meta(size_hints_list),
+            "has_indirect_access": any(
+                sub_kernel.has_indirect_access for sub_kernel in self.sub_kernels
+            ),
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
             "mutated_arg_names": mutated_args,
             # Matches triton.py:codegen_kernel(): inference/backward graphs skip

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4287,11 +4287,9 @@ class PythonWrapperCodegen(CodeGen):
             )
             self.kernel_autotune_calls.do_indent()
             self.kernel_autotune_calls.writeline(
-                (
-                    f"{kernel_name}.precompile_and_save(stream={stream_name})"
-                    if inductor_meta and inductor_meta.get("has_indirect_access")
-                    else f"{kernel_name}.run({', '.join(all_args)}, stream={stream_name})"
-                )
+                f"{kernel_name}.precompile_and_save(stream={stream_name})"
+                if inductor_meta and inductor_meta.get("has_indirect_access")
+                else f"{kernel_name}.run({', '.join(all_args)}, stream={stream_name})"
             )
             self.kernel_autotune_calls.do_unindent()
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4287,7 +4287,11 @@ class PythonWrapperCodegen(CodeGen):
             )
             self.kernel_autotune_calls.do_indent()
             self.kernel_autotune_calls.writeline(
-                f"{kernel_name}.run({', '.join(all_args)}, stream={stream_name})"
+                (
+                    f"{kernel_name}.precompile_and_save(stream={stream_name})"
+                    if inductor_meta and inductor_meta.get("has_indirect_access")
+                    else f"{kernel_name}.run({', '.join(all_args)}, stream={stream_name})"
+                )
             )
             self.kernel_autotune_calls.do_unindent()
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -807,6 +807,21 @@ class CachingAutotuner(KernelInterface):
             self._make_launchers()
             self._dynamic_scale_rblock()
 
+    def precompile_and_save(self, stream) -> None:
+        """Package the first valid config without running synthetic inputs."""
+        if not self.launchers:
+            self.precompile()
+        launcher = self.launchers[0]
+        self._release_static_launchers_except(launcher)
+        self.launchers = [launcher]
+        self._prune_compile_results_to_launcher(launcher)
+        TritonBundler.put_winner(launcher.cache_hash)
+        if launcher.store_cubin:
+            if self.device_props.type == "cpu":
+                self.save_cpu_kernel(launcher)
+            else:
+                self.save_gpu_kernel(stream, launcher)
+
     def _precompile_worker(self):
         if self.compile_results:
             for result in self.compile_results:


### PR DESCRIPTION
已 review，可以 push + PR。

Fixes #192143

> **Root cause.** AOTInductor compile-time autotuning constructs standalone
> example tensors for a generated Triton kernel's intermediate buffers. These
> synthetic tensors reproduce shape and layout but cannot reproduce constraints
> established by upstream ops. For a data-dependent indirect index such as an
> empty boolean-indexing result, a synthetic index tensor can hold `-1`.
> Launching the embedding kernel on that value trips the (correct) embedding
> bounds check and raises a device-side assertion during packaging. The bounds
> check is not the bug; executing a kernel with data-dependent indirect memory
> access on unconstrained synthetic values is.

> **Fix.** Track indirect memory access while Triton indexing code is emitted
> and propagate it into per-kernel `inductor_meta` (and across combo
> subkernels). During compile-time autotuning, kernels marked with indirect
> access no longer run on synthetic tensors; instead they precompile their
> configs, deterministically select the first valid config, and package it via
> a new no-launch `precompile_and_save` path. Ordinary kernels keep normal
> compile-time benchmarking, so the change stays targeted and does not disable
> AOTInductor autotuning globally.

> **Alternative considered.** Disabling compile-time autotuning whenever a
> graph contains data-dependent indexing was rejected as too broad; it would
> penalize kernels whose synthetic values are safe. Marking only the kernels
> that perform indirect access keeps the blast radius minimal.

> ## Test Plan

> Added regression `test_empty_indirect_embedding`, which compiles from an
> empty boolean-indexing result and checks both empty and valid non-empty
> inputs against eager. It requires a CUDA-enabled build:

```bash
python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleGpu.test_empty_indirect_embedding_cuda
```

> Static checks that were run in this workspace:

```bash
git diff --check
python3 -m py_compile \
  torch/_inductor/codegen/triton.py \
  torch/_inductor/codegen/triton_combo_kernel.py \
  torch/_inductor/codegen/wrapper.py \
  torch/_inductor/runtime/triton_heuristics.py \
  test/inductor/test_aot_inductor.py
```

> This workspace is an editable build with `USE_CUDA=0`
> (`torch.cuda.is_available() == False`), so the focused CUDA test could not be
> run here. CUDA validation on a GPU build is required before merge.

> This PR was authored with the assistance of an AI coding agent; the author
> has reviewed the code and takes responsibility for it.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo