### PR TITLE
[inductor] Include custom op schemas in FX graph cache keys

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3357,13 +3357,9 @@ class TestFxGraphCacheHashing(TestCase):
         return torch.fx.GraphModule({}, graph)
 
     def _custom_op_schema_cache_key(self, mutates_out, target_kind):
-        with torch.library._scoped_library(
-            "test_fx_cache_schema", "FRAGMENT"
-        ) as lib:
+        with torch.library._scoped_library("test_fx_cache_schema", "FRAGMENT") as lib:
 
-            def mul_out(
-                x: torch.Tensor, y: torch.Tensor, *, out: torch.Tensor
-            ) -> None:
+            def mul_out(x: torch.Tensor, y: torch.Tensor, *, out: torch.Tensor) -> None:
                 pass
 
             schema = torch.library.infer_schema(

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3341,6 +3341,7 @@ class _TestCustomPartitionerFn(CustomPartitionerFn):
         return self._uuid
 
 
+@instantiate_parametrized_tests
 class TestFxGraphCacheHashing(TestCase):
     def _fx_graph_cache_key(self, gm, example_inputs):
         details = FxGraphHashDetails(gm, example_inputs, cast(Any, {}), [])
@@ -3354,6 +3355,66 @@ class TestFxGraphCacheHashing(TestCase):
         result = graph.call_function(torch.empty, ((4,),), kwargs)
         graph.output(result)
         return torch.fx.GraphModule({}, graph)
+
+    def _custom_op_schema_cache_key(self, mutates_out, target_kind):
+        with torch.library._scoped_library(
+            "test_fx_cache_schema", "FRAGMENT"
+        ) as lib:
+
+            def mul_out(
+                x: torch.Tensor, y: torch.Tensor, *, out: torch.Tensor
+            ) -> None:
+                pass
+
+            schema = torch.library.infer_schema(
+                mul_out, mutates_args=["out"] if mutates_out else []
+            )
+            lib.define("mul" + schema)
+            packet = torch.ops.test_fx_cache_schema.mul
+            op = packet.default
+
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            y = graph.placeholder("y")
+            out = graph.placeholder("out")
+            if target_kind == "auto_functionalized":
+                from torch._higher_order_ops.auto_functionalize import (
+                    auto_functionalized,
+                )
+
+                graph.call_function(
+                    auto_functionalized,
+                    (op,),
+                    {"x": x, "y": y, "out": out},
+                )
+            else:
+                target = packet if target_kind == "packet" else op
+                graph.call_function(target, (x, y), {"out": out})
+            graph.output(out)
+            gm = torch.fx.GraphModule({}, graph)
+
+            with FakeTensorMode():
+                inputs = [torch.empty(4), torch.empty(4), torch.empty(4)]
+            return self._fx_graph_cache_key(gm, inputs), str(op._schema)
+
+    @parametrize("target_kind", ("overload", "packet", "auto_functionalized"))
+    def test_custom_op_schema_affects_cache_key(self, target_kind):
+        non_mutating_key, non_mutating_schema = self._custom_op_schema_cache_key(
+            False, target_kind
+        )
+        mutating_key, mutating_schema = self._custom_op_schema_cache_key(
+            True, target_kind
+        )
+
+        self.assertEqual(
+            non_mutating_schema,
+            "test_fx_cache_schema::mul(Tensor x, Tensor y, *, Tensor out) -> ()",
+        )
+        self.assertEqual(
+            mutating_schema,
+            "test_fx_cache_schema::mul(Tensor x, Tensor y, *, Tensor(a2!) out) -> ()",
+        )
+        self.assertNotEqual(non_mutating_key, mutating_key)
 
     def test_cpu_thread_count_affects_cache_key(self):
         def fn(x):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1372,6 +1372,29 @@ class FxGraphHashDetails:
     )
 
     @classmethod
+    def _record_custom_op_schema_details(
+        cls, value: Any, result: OrderedSet[tuple[str, tuple[str, ...]]]
+    ) -> None:
+        if isinstance(value, torch._ops.OpOverload):
+            is_builtin = value.namespace in ("aten", "prim", "prims")
+            if not is_builtin or value._defined_in_python:
+                result.add(
+                    (
+                        str(value._schema),
+                        tuple(sorted(str(tag) for tag in value.tags)),
+                    )
+                )
+        elif isinstance(value, torch._ops.OpOverloadPacket):
+            for overload in value.op_overloads():
+                cls._record_custom_op_schema_details(overload, result)
+        elif isinstance(value, (list, tuple, AbstractSet)):
+            for item in value:
+                cls._record_custom_op_schema_details(item, result)
+        elif isinstance(value, dict):
+            for item in itertools.chain(value.keys(), value.values()):
+                cls._record_custom_op_schema_details(item, result)
+
+    @classmethod
     def _contains_tensor(cls, value: Any) -> bool:
         if isinstance(value, torch.Tensor):
             return True
@@ -1532,17 +1555,24 @@ class FxGraphHashDetails:
         # the kernel source code separately
         self.user_defined_triton_source: list[Any] = []
         if gm is not None:
+            custom_op_schema_details: OrderedSet[
+                tuple[str, tuple[str, ...]]
+            ] = OrderedSet()
             for module in gm.modules():
                 if not isinstance(module, torch.fx.GraphModule):
                     continue
-                for node in itertools.chain(
-                    module.graph.find_nodes(
-                        op="call_function", target=triton_kernel_wrapper_functional
-                    ),
-                    module.graph.find_nodes(
-                        op="call_function", target=triton_kernel_wrapper_mutation
-                    ),
-                ):
+                for node in module.graph.nodes:
+                    if node.op != "call_function":
+                        continue
+                    self._record_custom_op_schema_details(
+                        (node.target, node.args, node.kwargs), custom_op_schema_details
+                    )
+                    if node.target not in (
+                        triton_kernel_wrapper_functional,
+                        triton_kernel_wrapper_mutation,
+                    ):
+                        continue
+
                     from triton.runtime.autotuner import Autotuner
 
                     kernel = kernel_side_table.get_kernel(node.kwargs["kernel_idx"])
@@ -1568,6 +1598,13 @@ class FxGraphHashDetails:
                     self.user_defined_triton_source.append(
                         (kernel_source, constant_args, configs)
                     )
+
+            if custom_op_schema_details:
+                # GraphModule serialization records operator names, but not the
+                # schemas and tags that determine compiler-visible semantics.
+                self.custom_op_schema_details = tuple(
+                    sorted(custom_op_schema_details)
+                )
 
         no_tensor_inputs = not any(isinstance(x, torch.Tensor) for x in example_inputs)
         # This device index is usually already encoded by the device of the inputs

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1555,9 +1555,9 @@ class FxGraphHashDetails:
         # the kernel source code separately
         self.user_defined_triton_source: list[Any] = []
         if gm is not None:
-            custom_op_schema_details: OrderedSet[
-                tuple[str, tuple[str, ...]]
-            ] = OrderedSet()
+            custom_op_schema_details: OrderedSet[tuple[str, tuple[str, ...]]] = (
+                OrderedSet()
+            )
             for module in gm.modules():
                 if not isinstance(module, torch.fx.GraphModule):
                     continue
@@ -1602,9 +1602,7 @@ class FxGraphHashDetails:
             if custom_op_schema_details:
                 # GraphModule serialization records operator names, but not the
                 # schemas and tags that determine compiler-visible semantics.
-                self.custom_op_schema_details = tuple(
-                    sorted(custom_op_schema_details)
-                )
+                self.custom_op_schema_details = tuple(sorted(custom_op_schema_details))
 
         no_tensor_inputs = not any(isinstance(x, torch.Tensor) for x in example_inputs)
         # This device index is usually already encoded by the device of the inputs


### PR DESCRIPTION
已 review，可以 push + PR。

Fixes #187319

> ## Summary
>
> Custom operators can keep the same qualified name while changing dispatcher schema metadata such as `mutates_args`. `GraphModule` cache serialization records the qualified operator name but not the schema, so AOTAutograd and Inductor can reuse a compiled artifact produced under an old mutation contract. For a `None`-returning out operator, that can silently reuse a graph in which the call was dead-code eliminated, leaving the output untouched (e.g. left at zero) even after the schema is corrected to mutate `out`.
>
> ## Root cause
>
> The FX graph hash derives operator identity from the serialized `GraphModule` source, which names the dispatcher op but omits its `FunctionSchema` and tags. Changing only `mutates_args` therefore produces an identical cache key and a stale cache hit.
>
> ## Fix
>
> Record stable schema and tag details for custom `OpOverload` and `OpOverloadPacket` references in `FxGraphHashDetails`. The traversal folds into the existing per-node pass and inspects each `call_function` node's target, args, and kwargs, which is required for operators nested in arguments after functionalization (`auto_functionalized(_mutable_op, ...)`). Built-in `aten`/`prim`/`prims` operators stay covered by the PyTorch source hash unless defined in Python, and graphs without relevant custom operators do not gain additional key material.
>
> ## Scope
>
> This is a targeted schema/tag identity fix. It does not define the broader cache identity contract for same-schema changes to fake implementations, decompositions, or autograd registrations; that larger API design is intentionally left out of scope.
>
> ## Test Plan
>
> ```
> python test/inductor/test_codecache.py TestFxGraphCacheHashing -k test_custom_op_schema_affects_cache_key
> ```
>
> The parametrized test covers the `overload`, `packet`, and `auto_functionalized` target kinds, asserting that a non-mutating vs. mutating `out` schema produces distinct cache keys.
>
> ## AI assistance disclosure
>
> This PR was authored with assistance from an AI coding assistant (Claude Code). The author reviewed the code and this description and takes responsibility for the change.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo