### PR TITLE
[BE] Make test_nep50 compatible with numpy-2.x

### DIFF
--- a/test/torch_np/test_nep50_examples.py
+++ b/test/torch_np/test_nep50_examples.py
@@ -3,6 +3,7 @@
 """Test examples for NEP 50."""
 
 import itertools
+from contextlib import contextmanager
 from unittest import skipIf as skipif, SkipTest
 
 
@@ -10,7 +11,7 @@ try:
     import numpy as _np
 
     v = _np.__version__.split(".")
-    HAVE_NUMPY = int(v[0]) >= 1 and int(v[1]) >= 24
+    HAVE_NUMPY = (int(v[0]), int(v[1])) >= (1, 24)
 except ImportError:
     HAVE_NUMPY = False
 
@@ -50,6 +51,20 @@ from pytest import raises as assert_raises
 
 
 unchanged = None
+
+
+@contextmanager
+def _promotional_state_cm(state):
+    if hasattr(_np, "_get_promotion_state"):
+        previous_state = _np._get_promotion_state()
+        _np._set_promotion_state(state)
+        try:
+            yield
+        finally:
+            _np._set_promotion_state(previous_state)
+    else:
+        yield
+
 
 # expression    old result   new_result
 examples = {
@@ -162,10 +177,7 @@ class TestCompareToNumpy(TestCase):
     @parametrize("scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes))
     def test_direct_compare(self, scalar, array, dtype):
         # compare to NumPy w/ NEP 50.
-        try:
-            state = _np._get_promotion_state()
-            _np._set_promotion_state("weak")
-
+        with _promotional_state_cm("weak"):
             if dtype is not None:
                 kwargs = {"dtype": dtype}
             try:
@@ -175,7 +187,11 @@ class TestCompareToNumpy(TestCase):
 
             kwargs = {}
             if dtype is not None:
-                kwargs = {"dtype": getattr(tnp, dtype.__name__)}
+                kwargs = {
+                    "dtype": getattr(tnp, dtype.__name__)
+                    if dtype is not _np.bool_
+                    else tnp.bool_
+                }
             result = tnp.add(scalar, array, **kwargs).tensor.numpy()
             if result.dtype != result_numpy.dtype:
                 raise AssertionError(
@@ -183,9 +199,6 @@ class TestCompareToNumpy(TestCase):
                 )
             if result != result_numpy:
                 raise AssertionError(f"Expected result == {result_numpy}, got {result}")
-
-        finally:
-            _np._set_promotion_state(state)
 
     @parametrize("name", tnp._ufuncs._binary)
     @parametrize("scalar, array", itertools.product(weaks, non_weaks))
@@ -196,10 +209,7 @@ class TestCompareToNumpy(TestCase):
         ):
             raise SkipTest(f"{name}(..., dtype=array.dtype)")
 
-        try:
-            state = _np._get_promotion_state()
-            _np._set_promotion_state("weak")
-
+        with _promotional_state_cm("weak"):
             if name in ["matmul", "modf", "divmod", "ldexp"]:
                 return
             ufunc = getattr(tnp, name)
@@ -247,9 +257,6 @@ class TestCompareToNumpy(TestCase):
                 raise AssertionError(
                     f"Expected result numpy dtype == {expected_numpy_dtype}, torch dtype == {expected_torch_dtype}"
                 )
-
-        finally:
-            _np._set_promotion_state(state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #193500

----

- Adjust `HAS_NUMPY` to work with numpy-2.x
- Introduce `_promotional_state_cm` that uses numpy-1.x-2.1 private APIs, but turns into null context in numpy-2.2 or newer
- Fix bool handling