### PR TITLE
[Testcase Refactoring] Decouple autograd CPU logging tests from hardware assumptions

### DIFF
--- a/test/functorch/test_ac_logging.py
+++ b/test/functorch/test_ac_logging.py
@@ -8,10 +8,16 @@ from torch._functorch._activation_checkpointing.ac_logging_utils import (
     create_structured_trace_for_min_cut_info,
 )
 from torch.fx import Graph, Node
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestAcLogging(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         self.graph: MagicMock = MagicMock(spec=Graph)


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple `test_ac_logging.py` from implicit hardware assumptions by adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Add corresponding `HardwareClassification` labels to test classes.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile test/functorch/test_ac_logging.py
> lintrunner -a test/functorch/test_ac_logging.py
> git diff --check
> ```
>
> CI:
>
> - Run the modified test file through its existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian