### PR TITLE
[Testcase Refactoring] Decouple codegen backward prologue tests from hardware assumptions

### DIFF
--- a/test/functorch/test_codegen_backward_prologue.py
+++ b/test/functorch/test_codegen_backward_prologue.py
@@ -18,11 +18,17 @@ from common_utils import capture_codegen_source
 
 import torch
 import torch._functorch.config
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
 class TestCodegenBackwardPrologue(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_saved_subclass_tensors_unwrapped(self):
         """
         When subclass tensors are saved for backward, the prologue should


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple `test_codegen_backward_prologue.py` from implicit hardware assumptions by adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Add corresponding `HardwareClassification` labels to test classes.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile test/functorch/test_codegen_backward_prologue.py
> lintrunner -a test/functorch/test_codegen_backward_prologue.py
> git diff --check
> ```
>
> CI:
>
> - Run the modified test file through its existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian