### PR TITLE
[Testcase Refactoring] Decouple codegen output alias tests from hardware assumptions

### DIFF
--- a/test/functorch/test_codegen_output_alias.py
+++ b/test/functorch/test_codegen_output_alias.py
@@ -22,13 +22,20 @@ import torch
 import torch._functorch.config
 from functorch.compile import nop
 from torch._functorch.aot_autograd import aot_function
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 trace_log = logging.getLogger("torch.__trace")
 
 
 class TestCodegenOutputAlias(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         torch._dynamo.reset()


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple `test_codegen_output_alias.py` from implicit hardware assumptions by adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Add corresponding `HardwareClassification` labels to test classes.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile test/functorch/test_codegen_output_alias.py
> lintrunner -a test/functorch/test_codegen_output_alias.py
> git diff --check
> ```
>
> CI:
>
> - Run the modified test file through its existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian