### PR TITLE
[Testcase Refactoring] Decouple leaf function tests from hardware assumptions

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -18,6 +18,7 @@ from torch._dynamo.testing import normalize_gm
 from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -36,6 +37,8 @@ def extract_graph(fx_g, _, graph_cell):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFx(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _has_invoke_leaf_function_node(self, gm):
         for node in gm.graph.nodes:
             if node.op == "call_function" and node.target is invoke_leaf_function:
@@ -292,6 +295,8 @@ class f(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionAotFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_simple(self):
         @leaf_function
         def my_fn(x, y):
@@ -499,6 +504,8 @@ class GraphModule(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionEscapedGradients(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_escaped_gradient_multiple_closures(self):
         weight1 = torch.randn(3, 3, requires_grad=True)
         weight2 = torch.randn(3, 3, requires_grad=True)
@@ -635,6 +642,8 @@ class TestLeafFunctionEscapedGradients(TestCase):
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFxAndCompile(TestCase):
     """Tests for @leaf_function when mixing torch.compile and make_fx."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_not_called_during_compilation(self):
         """The real leaf_fn body runs only at runtime, not during compilation."""
@@ -840,6 +849,8 @@ class outer(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionDynamo(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -2500,6 +2511,8 @@ instantiate_parametrized_tests(TestLeafFunctionDynamo)
 class TestLeafFunctionRegisterHook(TestCase):
     """Tests for @leaf_function's register_multi_grad_hook API."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_hook_fires_on_backward(self):
         hook_grads = []
 
@@ -2757,6 +2770,8 @@ class TestLeafFunctionRegisterHook(TestCase):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionGradDtype(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_pair(self, size, dtype, grad_dtype):
         torch.manual_seed(42)
         x_ref = torch.randn(size, dtype=dtype, requires_grad=True)


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple `test_leaf_function.py` from implicit hardware assumptions by adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Add corresponding `HardwareClassification` labels to test classes.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile test/functorch/test_leaf_function.py
> lintrunner -a test/functorch/test_leaf_function.py
> git diff --check
> ```
>
> CI:
>
> - Run the modified test file through its existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian