### PR TITLE
[Testcase Refactoring] Decouple subclass codegen tests from hardware assumptions

### DIFF
--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -12,7 +12,11 @@ from torch._functorch._aot_autograd.schemas import PlainTensorMeta
 from torch._functorch._aot_autograd.subclass_codegen import (
     _codegen_subclass_wrapper_source,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.two_tensor import TwoTensor
 
 
@@ -35,6 +39,8 @@ class _TestSubclassMeta:
 
 
 class TestSubclassCodegen(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _two_tensor_meta(self) -> _TestSubclassMeta:
         return _TestSubclassMeta(
             flat_tensor_start_idx=0,


### PR DESCRIPTION
I reviewed the implementation and test results and confirm that the quoted description matches this change. Codex helped draft the quoted text.

> ## Summary
>
> Decouple `test_subclass_codegen.py` from implicit hardware assumptions by adding explicit hardware classification labels.
>
> Part of #185590.
>
> ## Changes
>
> - Add corresponding `HardwareClassification` labels to test classes.
> - Preserve existing parameterization, backend admission, expected failures, and test behavior.
>
> ## Test Plan
>
> Ran:
>
> ```bash
> python -m py_compile test/functorch/test_subclass_codegen.py
> lintrunner -a test/functorch/test_subclass_codegen.py
> git diff --check
> ```
>
> CI:
>
> - Run the modified test file through its existing PyTorch test jobs.
> - Run the Inductor workflows selected by `ciflow/inductor`.

cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian