### PR TITLE
[Testcase Refactoring] Tag test_checkpoint_process.py classes with hw_classification

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_process.py
@@ -20,7 +20,11 @@ from torch.distributed.checkpoint._experimental.checkpoint_writer import (
     CheckpointWriterConfig,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def subprocess_init_fn(name: str, parent_pid: int) -> None:
@@ -117,6 +121,8 @@ def shared_tensor_verifier_init_fn(**kwargs: Any) -> CheckpointWriter:
 class TestRequestTypes(TestCase):
     """Test the request/response data structures."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_request_type_enum(self) -> None:
         """Test RequestType enum values."""
         self.assertEqual(RequestType.PING.value, "ping")
@@ -146,6 +152,8 @@ class TestRequestTypes(TestCase):
 class TestCheckpointProcessConfig(TestCase):
     """Test CheckpointProcessConfig configuration."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_default_options(self) -> None:
         """Test default CheckpointProcessConfig."""
         options = CheckpointProcessConfig()
@@ -163,6 +171,8 @@ class TestCheckpointProcessConfig(TestCase):
 
 
 class TestCheckpointProcess(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         """Set up common test fixtures."""


### PR DESCRIPTION
## Summary

Tags `TestRequestTypes`, `TestCheckpointProcessConfig`, `TestCheckpointProcess` in `test/distributed/checkpoint/_experimental/test_checkpoint_process.py` with `hw_classification = HardwareClassification.GENERIC`.

## Motivation

These three classes test request/response data structures, config defaults, and process bookkeeping directly -- none of them touch a device or an accelerator. `hw_classification` lets the test-infrastructure linter (#190173) tell that apart from classes that actually need a device, instead of leaving it unclassified.

## Changes

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to each of the three classes. None uses `instantiate_device_type_tests`, takes a `device` parameter, or references a device -- `GENERIC` is the correct classification per the decision tree.

No other behavior changes -- this is purely additive metadata.

## Test Plan

`ruff check` / `ruff format --check` clean.

This content is unchanged from #191909, which already ran green in CI; splitting to one file per PR does not change what runs.

## Related

Split out of #191909 (three files bundled into one PR; splitting to one file per PR per team review guidance). Part of #185590.