### PR TITLE
[Testcase Refactoring] Tag test_traverse.py TestTraverse with hw_classification

### DIFF
--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed.checkpoint._traverse as _traverse
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 if TYPE_CHECKING:
@@ -16,6 +20,8 @@ class TestTraverse(TestCase):
     """
     Test class for util methods of _traverse
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_traverse_shallow(self) -> None:
         state_dict = {


### PR DESCRIPTION
## Summary

Tags `TestTraverse` in `test/distributed/checkpoint/test_traverse.py` with `hw_classification = HardwareClassification.GENERIC`.

## Motivation

`TestTraverse` covers `_traverse`'s pure logic over dicts and lists -- no tensors, no device, no accelerator involved. `hw_classification` lets the test-infrastructure linter (#190173) tell that apart from classes that actually need a device, instead of leaving it unclassified.

## Changes

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC`. The class uses no `instantiate_device_type_tests`, no `device` parameter, no device reference -- `GENERIC` is the correct classification per the decision tree.

No other behavior changes -- this is purely additive metadata.

## Test Plan

`ruff check` / `ruff format --check` clean.

This content is unchanged from #191909, which already ran green in CI; splitting to one file per PR does not change what runs.

## Related

Split out of #191909 (three files bundled into one PR; splitting to one file per PR per team review guidance). Part of #185590.