### PR TITLE
[Testcase Refactoring] Tag test_planner.py DCP test classes with hw_classification

### DIFF
--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -48,7 +48,9 @@ from torch.distributed.checkpoint.planner_helpers import (
     _merge_delta_local_plans,
     create_read_items_for_chunk_list,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
@@ -103,17 +105,29 @@ def create_sharded_tensor(rank, world_size, shards_per_rank, shard_size=8):
 
 
 class TestCheckpointableTensorDistributed(DTensorTestBase):
+    # Deliberately CPU, not GENERIC or ACCELERATOR: the test always wants
+    # "cpu" regardless of what accelerator is present, not whatever
+    # `DTensorTestMixin.device_type` would dynamically pick.
+    #
+    # Do NOT add a `device_type` property/classmethod here to pin it: this
+    # class's own dict is scanned by `instantiate_device_type_tests` and any
+    # `device_type` found there is copied verbatim onto the generated
+    # `...CPU` class, shadowing `CPUTestBase.device_type = "cpu"` with the
+    # raw (non-string) descriptor and crashing "_" + cls.device_type with
+    # "can only concatenate str (not 'property') to str". `only_for="cpu"`
+    # below already pins device_type to "cpu" the correct way, through
+    # CPUTestBase, which precedes DTensorTestMixin in the generated class's
+    # MRO -- so `self.device_type` still resolves to "cpu" without an
+    # explicit override.
+    hw_classification = HardwareClassification.CPU
+
     @property
     def world_size(self) -> int:
         return 4
 
-    @property
-    def device_type(self) -> str:
-        return "cpu"
-
     @with_comms
     @with_temp_dir
-    def test_checkpointable_tensor_shard_save_load(self):
+    def test_checkpointable_tensor_shard_save_load(self, device):
         shard_size = 4
         rank = dist.get_rank()
         start = rank * shard_size
@@ -166,6 +180,8 @@ class TestCheckpointableTensorDistributed(DTensorTestBase):
 
 
 class TestSavePlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_fake_comms(rank=1, world_size=4)
     def test_local_plan(self):
         tensor = torch.rand(10)
@@ -620,6 +636,8 @@ class TestSavePlan(TestCase):
 
 
 class TestPlannerHelpers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_create_read_item_from_chunks(self):
         tensor_md = TensorStorageMetadata(
             properties=TensorProperties.create_from_tensor(torch.empty([16])),
@@ -713,6 +731,8 @@ class TestPlannerHelpers(TestCase):
 
 
 class TestValidateGlobalPlan(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_metadata(self, chunks, size):
         storage = TensorStorageMetadata(
             properties=TensorProperties(dtype=torch.float32),
@@ -739,6 +759,8 @@ class TestValidateGlobalPlan(TestCase):
 
 
 class TestLoadPlanner(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_temp_dir
     def test_strict(self):
         original_module = nn.Linear(2, 2)
@@ -789,5 +811,8 @@ class TestLoadPlanner(TestCase):
         self.assertEqual(planner.metadata.version, CURRENT_DCP_VERSION)
 
 
+instantiate_device_type_tests(
+    TestCheckpointableTensorDistributed, globals(), only_for="cpu"
+)
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Tags the test classes in `test/distributed/checkpoint/test_planner.py` with `hw_classification`: `TestCheckpointableTensorDistributed` as `HardwareClassification.CPU`, and `TestSavePlan`, `TestPlannerHelpers`, `TestValidateGlobalPlan`, `TestLoadPlanner` as `HardwareClassification.GENERIC`.

## Motivation

`TestCheckpointableTensorDistributed` always builds its DTensor on `"cpu"` regardless of what accelerator is present -- it's tied to CPU by construction, not device-agnostic, so it needs `CPU` rather than `GENERIC` or `ACCELERATOR`. The other four classes are pure logic over dicts, sharded-tensor metadata, and planner helpers with no device dependency, so `GENERIC` applies.

## Changes

- Import `HardwareClassification` from `torch.testing._internal.common_utils`, `instantiate_device_type_tests` from `torch.testing._internal.common_device_type`.
- `TestCheckpointableTensorDistributed`:
  - Removes the `device_type` property that hard-pinned `"cpu"`, and instead wires the class through `instantiate_device_type_tests(TestCheckpointableTensorDistributed, globals(), only_for="cpu")`. The test method gains the `device` parameter `instantiate_device_type_tests` injects.
  - **Does not** replace the removed property with a `device_type` classmethod/property defined directly on the class. `instantiate_device_type_tests` scans the generic class's own `__dict__` and copies any non-`test_*` member it finds verbatim onto the generated device-specific subclass -- a same-named `device_type` here would shadow `CPUTestBase.device_type = "cpu"` on the generated class with the raw descriptor object instead of the string, crashing string concatenation (`"..." + cls.device_type`) during collection. `only_for="cpu"` already pins `device_type` to `"cpu"` correctly through `CPUTestBase`, which precedes `DTensorTestMixin` in the generated class's MRO, so `self.device_type` still resolves to `"cpu"` without an explicit override.
- `TestSavePlan`, `TestPlannerHelpers`, `TestValidateGlobalPlan`, `TestLoadPlanner` gain `hw_classification = HardwareClassification.GENERIC`. None uses `instantiate_device_type_tests` or a `device` parameter.

## Test Plan

`ruff check` / `ruff format --check` clean.

Verified on an accelerator backend (4 devices): `Ran 8 tests ... OK`. Test count unchanged.

## Related

Split out of #191909 (three files bundled into one PR; splitting to one file per PR per team review guidance). Carries the fix @fffrog asked for in #191909's review -- `TestCheckpointableTensorDistributed` was missing `hw_classification`, and adding it surfaced the `device_type` shadowing pitfall above. Part of #185590.