### PR TITLE
[Inductor] Add FlyDSL MXFP8/MXFP4 BlockWise1x32 scaled_mm for gfx950

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -18,6 +18,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
     'scripts/**',
     'test/generated_type_hints_smoketest.py',
@@ -134,6 +135,7 @@ include_patterns = [
 exclude_patterns = [
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
 ]
 command = [
@@ -1270,6 +1272,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/utils/model_dump/preact.mjs',
     # Generated: mirrors the label names on GitHub verbatim
     'tools/linter/adapters/pytorch_labels.json',
@@ -1653,6 +1656,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
     'test/cpython/**',
     'test/test_torchfuzz_repros.py',
@@ -1867,6 +1871,7 @@ include_patterns = [
 exclude_patterns = [
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
 ]
 is_formatter = false
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -43,6 +43,7 @@ project-excludes = [
   "*/.*",
   "torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**",
   "torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py",
+  "torch/_inductor/kernel/vendored_templates/flydsl/kernels/**",
   "torch/_vendor/quack/**",
 ]
 ignore-missing-imports = [

--- a/test/inductor/test_flydsl_mxfp4.py
+++ b/test/inductor/test_flydsl_mxfp4.py
@@ -1,0 +1,242 @@
+# Owner(s): ["module: inductor"]
+
+from types import SimpleNamespace
+
+import torch
+from torch._inductor import config
+from torch._inductor.kernel import mm
+from torch._inductor.utils import run_and_get_code
+from torch.nn.functional import ScalingType, SwizzleType  # type: ignore[attr-defined]
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+# E2M1 has eight magnitudes and no inf/nan; code = sign << 3 | magnitude index.
+E2M1_MAGNITUDES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+class _FakeNode:
+    def __init__(self, shape, stride, dtype, *, offset=0, device=None):
+        self._shape = list(shape)
+        self._stride = list(stride)
+        self._dtype = dtype
+        self._layout = SimpleNamespace(offset=offset)
+        self._device = device or torch.device("cuda", 0)
+
+    def get_device(self):
+        return self._device
+
+    def get_size(self):
+        return self._shape
+
+    def get_stride(self):
+        return self._stride
+
+    def get_dtype(self):
+        return self._dtype
+
+    def get_layout(self):
+        return self._layout
+
+
+def make_mxfp4_operand(rows, k, device, generator=None):
+    """Return (packed fp4x2 [rows, k // 2], e8m0 scale [rows, k // 32], fp32).
+
+    Values are drawn on the E2M1 grid and the scales are exact powers of two, so
+    the fp32 tensor is the operand's exact value rather than an approximation of
+    it. That keeps a numerics check measuring the kernel instead of the
+    quantizer.
+    """
+    codes = torch.randint(
+        0, 16, (rows, k), device=device, dtype=torch.uint8, generator=generator
+    )
+    lut = torch.tensor(E2M1_MAGNITUDES, device=device, dtype=torch.float32)
+    magnitude = lut[(codes & 7).long()]
+    values = torch.where(codes >= 8, -magnitude, magnitude)
+
+    exponents = torch.randint(
+        124, 131, (rows, k // 32), device=device, dtype=torch.uint8, generator=generator
+    )
+    scales = torch.pow(2.0, exponents.float() - 127.0)
+
+    packed = (
+        codes[:, 0::2].to(torch.int16) | (codes[:, 1::2].to(torch.int16) << 4)
+    ).to(torch.uint8)
+    return (
+        packed.contiguous().view(torch.float4_e2m1fn_x2),
+        exponents.contiguous().view(torch.float8_e8m0fnu),
+        values * scales.repeat_interleave(32, dim=1),
+    )
+
+
+def scaled_mm_mxfp4(a, b_t, scale_a, scale_b, out_dtype):
+    """A [M, K // 2] x B [K // 2, N] under the ROCm MXFP4 contract."""
+    return torch._scaled_mm_v2(
+        a,
+        b_t,
+        [scale_a],
+        [ScalingType.BlockWise1x32.value],
+        [SwizzleType.NO_SWIZZLE.value],
+        [scale_b],
+        [ScalingType.BlockWise1x32.value],
+        [SwizzleType.NO_SWIZZLE.value],
+        None,
+        out_dtype,
+    )
+
+
+class TestFlyDSLMXFP4Metadata(TestCase):
+    def _candidate_args(self, **overrides):
+        m, n, k = 64, 96, 256
+        a = _FakeNode((m, k // 2), (k // 2, 1), torch.float4_e2m1fn_x2)
+        b = _FakeNode((k // 2, n), (1, k // 2), torch.float4_e2m1fn_x2)
+        scale_a = _FakeNode((m, k // 32), (k // 32, 1), torch.float8_e8m0fnu)
+        scale_b = _FakeNode((n, k // 32), (k // 32, 1), torch.float8_e8m0fnu)
+        args = {
+            "mat_a": a,
+            "mat_b": b,
+            "scale_a": [scale_a],
+            "recipe_a": [ScalingType.BlockWise1x32.value],
+            "swizzle_a": [SwizzleType.NO_SWIZZLE.value],
+            "scale_b": [scale_b],
+            "recipe_b": [ScalingType.BlockWise1x32.value],
+            "swizzle_b": [SwizzleType.NO_SWIZZLE.value],
+            "bias": None,
+            "out_dtype": torch.bfloat16,
+            "contraction_dim": None,
+            "use_fast_accum": False,
+        }
+        args.update(overrides)
+        return args
+
+    def test_exact_v2_signature(self):
+        if torch.version.hip is None:
+            self.skipTest("ROCm-only gate")
+        self.assertTrue(mm._is_rocm_mxfp4_v2_candidate(**self._candidate_args()))
+
+    @parametrize(
+        "override",
+        [
+            {"swizzle_a": [SwizzleType.SWIZZLE_32_4_4.value]},
+            {"recipe_b": [ScalingType.BlockWise1x16.value]},
+            {"out_dtype": torch.float32},
+            {"use_fast_accum": True},
+            {"contraction_dim": [1]},
+        ],
+    )
+    def test_rejects_out_of_contract_signature(self, override):
+        if torch.version.hip is None:
+            self.skipTest("ROCm-only gate")
+        self.assertFalse(
+            mm._is_rocm_mxfp4_v2_candidate(**self._candidate_args(**override))
+        )
+
+    def test_rejects_fp8_operands(self):
+        if torch.version.hip is None:
+            self.skipTest("ROCm-only gate")
+        args = self._candidate_args()
+        args["mat_a"] = _FakeNode((64, 256), (256, 1), torch.float8_e4m3fn)
+        args["mat_b"] = _FakeNode((256, 96), (1, 256), torch.float8_e4m3fn)
+        self.assertFalse(mm._is_rocm_mxfp4_v2_candidate(**args))
+
+    def test_tile_config_units_are_elements(self):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp4_gemm_derived,
+        )
+
+        derived = mxfp4_gemm_derived(
+            block_m=256, block_n=256, block_k=256, stages=2, m_waves=2, n_waves=4
+        )
+        # TILE_K counts E2M1 codes, so the staged LDS buffer is half that wide.
+        self.assertEqual(derived.block_k_bytes, 128)
+        self.assertEqual(derived.a_stage_bytes, 256 * 128)
+        self.assertEqual(derived.k_halves, 2)
+
+    def test_odd_tile_k_is_rejected(self):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp4_gemm_derived,
+        )
+
+        with self.assertRaises(ValueError):
+            mxfp4_gemm_derived(
+                block_m=128, block_n=128, block_k=64, stages=2, m_waves=1, n_waves=1
+            )
+
+
+class TestFlyDSLMXFP4Device(TestCase):
+    def _skip_unless_supported(self, device):
+        if torch.version.hip is None:
+            self.skipTest("FlyDSL MXFP4 template is ROCm-only")
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest(f"MXFP4 scaled MFMA requires gfx950, got {arch}")
+
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16])
+    def test_scaled_mm_v2_flydsl_matches_reference(self, device, out_dtype):
+        self._skip_unless_supported(device)
+        m, n, k = 256, 256, 512
+        a, scale_a, a_ref = make_mxfp4_operand(m, k, device)
+        b, scale_b, b_ref = make_mxfp4_operand(n, k, device)
+        b_t = b.view(torch.uint8).t().view(torch.float4_e2m1fn_x2)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "FLYDSL",
+            }
+        ):
+            compiled = torch.compile(scaled_mm_mxfp4, dynamic=False)
+            out, code = run_and_get_code(compiled, a, b_t, scale_a, scale_b, out_dtype)
+
+        self.assertIn("gemm_mxfp4_gfx950", "\n".join(code))
+        # The reference is exact, so the only error left is the output rounding:
+        # about 1.7e-3 for bf16 and 2e-4 for fp16.
+        reference = a_ref @ b_ref.t()
+        rel_l2 = ((out.float() - reference).norm() / reference.norm()).item()
+        self.assertLess(rel_l2, 5e-3)
+
+    def test_unsupported_signature_falls_back(self, device):
+        self._skip_unless_supported(device)
+        m, n, k = 64, 64, 128
+        a = torch.randn(m, k, device=device).to(torch.float8_e4m3fn)
+        b = torch.randn(n, k, device=device).to(torch.float8_e4m3fn).t()
+        scale_a = torch.ones((), device=device)
+        scale_b = torch.ones((), device=device)
+
+        def tensorwise(a, b, scale_a, scale_b):
+            return torch._scaled_mm_v2(
+                a,
+                b,
+                [scale_a],
+                [ScalingType.TensorWise.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                [scale_b],
+                [ScalingType.TensorWise.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                None,
+                torch.bfloat16,
+            )
+
+        # ATen has to stay in the backend list: this signature has no FlyDSL
+        # choice by construction, and with FLYDSL alone there would be nothing
+        # left to select rather than a fallback to exercise.
+        with config.patch(
+            {"max_autotune": True, "max_autotune_gemm_backends": "ATEN,FLYDSL"}
+        ):
+            _, code = run_and_get_code(
+                torch.compile(tensorwise, dynamic=False), a, b, scale_a, scale_b
+            )
+        self.assertNotIn("gemm_mxfp4_gfx950", "\n".join(code))
+
+
+instantiate_parametrized_tests(TestFlyDSLMXFP4Metadata)
+instantiate_device_type_tests(TestFlyDSLMXFP4Device, globals(), only_for="cuda")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -318,10 +318,7 @@ class TestFlyDSLMXFP8Device(TestCase):
             ),  # rectangular 8x8
         ],
     )
-    @parametrize("frag_first", [0, 1])
-    def test_mxfp8_tile_configs_match_reference(
-        self, device, shape, tile, out_dtype, frag_first
-    ):
+    def test_mxfp8_tile_configs_match_reference(self, device, shape, tile, out_dtype):
         if torch.version.hip is None:
             self.skipTest("requires ROCm")
         arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
@@ -355,7 +352,6 @@ class TestFlyDSLMXFP8Device(TestCase):
             m_waves=m_waves,
             n_waves=n_waves,
             group_m=group_m,
-            frag_first=frag_first,
         )
         runtime_args = (a, b, scale_a_u8, scale_b_u8, out, 0)
         compiled = flyc.compile(

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -1,0 +1,242 @@
+# Owner(s): ["module: inductor"]
+
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+from torch._inductor import config
+from torch._inductor.codegen.flydsl import flydsl_utils
+from torch._inductor.kernel import mm
+from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
+from torch._inductor.utils import run_and_get_code
+from torch.nn.functional import ScalingType, SwizzleType  # type: ignore[attr-defined]
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+class _FakeNode:
+    def __init__(self, shape, stride, dtype, *, offset=0, device=None):
+        self._shape = list(shape)
+        self._stride = list(stride)
+        self._dtype = dtype
+        self._layout = SimpleNamespace(offset=offset)
+        self._device = device or torch.device("cuda", 0)
+
+    def get_device(self):
+        return self._device
+
+    def get_size(self):
+        return self._shape
+
+    def get_stride(self):
+        return self._stride
+
+    def get_dtype(self):
+        return self._dtype
+
+    def get_layout(self):
+        return self._layout
+
+
+class _CacheParam:
+    def __cache_signature__(self):
+        return ("mxfp8_gfx950_v1", 64, 96, 256, "bfloat16")
+
+
+class TestFlyDSLMXFP8Metadata(TestCase):
+    def _candidate_args(self):
+        a = _FakeNode((64, 256), (256, 1), torch.float8_e4m3fn)
+        b = _FakeNode((256, 96), (1, 256), torch.float8_e4m3fn)
+        scale_a = _FakeNode((64, 8), (8, 1), torch.float8_e8m0fnu)
+        scale_b = _FakeNode((96, 8), (8, 1), torch.float8_e8m0fnu)
+        return (
+            a,
+            b,
+            [scale_a],
+            [ScalingType.BlockWise1x32.value],
+            [SwizzleType.NO_SWIZZLE.value],
+            [scale_b],
+            [ScalingType.BlockWise1x32.value],
+            [SwizzleType.NO_SWIZZLE.value],
+            None,
+            torch.bfloat16,
+            [],
+            False,
+        )
+
+    def test_exact_v2_signature(self):
+        args = self._candidate_args()
+        with mock.patch.object(torch.version, "hip", "test"):
+            self.assertTrue(mm._is_rocm_mxfp8_v2_candidate(*args))
+
+            bad_fast_accum = (*args[:-1], True)
+            self.assertFalse(mm._is_rocm_mxfp8_v2_candidate(*bad_fast_accum))
+
+            bad_swizzle = list(args)
+            bad_swizzle[4] = [SwizzleType.SWIZZLE_32_4_4.value]
+            self.assertFalse(mm._is_rocm_mxfp8_v2_candidate(*bad_swizzle))
+
+    def test_strict_baseline_layout(self):
+        args = self._candidate_args()
+        a, b, scale_a, _, _, scale_b, *_ = args
+        layout = SimpleNamespace(
+            size=[64, 96],
+            stride=[96, 1],
+            dtype=torch.bfloat16,
+            device=torch.device("cuda", 0),
+            offset=0,
+        )
+
+        with mock.patch.object(mm, "use_flydsl_mxfp8_template", return_value=True):
+            self.assertEqual(
+                mm.get_flydsl_mxfp8_template_kwargs(
+                    layout, a, b, scale_a[0], scale_b[0]
+                ),
+                {
+                    "GEMM_M": 64,
+                    "GEMM_N": 96,
+                    "GEMM_K": 256,
+                    "OUT_DTYPE": "bfloat16",
+                },
+            )
+
+            bad_b = _FakeNode((256, 96), (96, 1), torch.float8_e4m3fn)
+            self.assertIsNone(
+                mm.get_flydsl_mxfp8_template_kwargs(
+                    layout, a, bad_b, scale_a[0], scale_b[0]
+                )
+            )
+
+            bad_scale = _FakeNode((64, 8), (8, 1), torch.float8_e8m0fnu, offset=1)
+            self.assertIsNone(
+                mm.get_flydsl_mxfp8_template_kwargs(layout, a, b, bad_scale, scale_b[0])
+            )
+
+            bad_device_scale = _FakeNode(
+                (64, 8),
+                (8, 1),
+                torch.float8_e8m0fnu,
+                device=torch.device("cpu"),
+            )
+            self.assertIsNone(
+                mm.get_flydsl_mxfp8_template_kwargs(
+                    layout, a, b, bad_device_scale, scale_b[0]
+                )
+            )
+
+            with mock.patch.object(
+                mm,
+                "is_unaligned",
+                side_effect=lambda node: node is a,
+            ):
+                self.assertIsNone(
+                    mm.get_flydsl_mxfp8_template_kwargs(
+                        layout, a, b, scale_a[0], scale_b[0]
+                    )
+                )
+
+    def test_runtime_cache_reuses_specialization(self):
+        jit_func = SimpleNamespace()
+        compiled = mock.Mock()
+        compiler = mock.Mock(return_value=compiled)
+
+        first = run_cached_flydsl(
+            jit_func,
+            "compile-args",
+            constexpr_param=_CacheParam(),
+            compiler=compiler,
+            dispatch_args=("first-dispatch",),
+        )
+        second = run_cached_flydsl(
+            jit_func,
+            "different-compile-args",
+            constexpr_param=_CacheParam(),
+            compiler=compiler,
+            dispatch_args=("second-dispatch",),
+        )
+
+        self.assertIs(first, compiled)
+        self.assertIs(second, compiled)
+        compiler.assert_called_once_with(jit_func, "compile-args")
+        compiled.assert_called_once_with("second-dispatch")
+
+    def test_precompile_uses_flydsl_compile_only_contract(self):
+        source = mm.flydsl_mxfp8_scaled_mm_template.source
+
+        self.assertIn('{"COMPILE_ONLY": "1"}', source)
+        self.assertNotIn("FLYDSL_COMPILE_ONLY", source)
+
+
+class TestFlyDSLMXFP8Device(TestCase):
+    def _make_inputs(self, m, n, k, device):
+        a_values = ((torch.arange(m * k, device=device) % 9) - 4) / 2
+        b_values = ((torch.arange(n * k, device=device) % 11) - 5) / 2
+        a = a_values.reshape(m, k).to(torch.float8_e4m3fn)
+        b = b_values.reshape(n, k).to(torch.float8_e4m3fn)
+
+        k32 = k // 32
+        a_exp = (
+            torch.arange(m, device=device)[:, None]
+            + torch.arange(k32, device=device)[None, :]
+        ) % 5 - 2
+        b_exp = (
+            2 * torch.arange(n, device=device)[:, None]
+            + torch.arange(k32, device=device)[None, :]
+        ) % 5 - 2
+        scale_a = torch.pow(2.0, a_exp.float()).to(torch.float8_e8m0fnu)
+        scale_b = torch.pow(2.0, b_exp.float()).to(torch.float8_e8m0fnu)
+        return a, b, scale_a, scale_b
+
+    @parametrize("out_dtype", [torch.bfloat16, torch.float16])
+    def test_scaled_mm_v2_flydsl_baseline(self, device, out_dtype):
+        if torch.version.hip is None:
+            self.skipTest("requires ROCm")
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest("requires gfx950")
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        m, n, k = 64, 96, 256
+        a, b, scale_a, scale_b = self._make_inputs(m, n, k, device)
+
+        def fn(a, b, scale_a, scale_b):
+            return F.scaled_mm(
+                a,
+                b.t(),
+                scale_a,
+                ScalingType.BlockWise1x32,
+                scale_b,
+                ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.NO_SWIZZLE,
+                swizzle_b=SwizzleType.NO_SWIZZLE,
+                output_dtype=out_dtype,
+            )
+
+        expected = fn(a, b, scale_a, scale_b)
+        a_dequant = a.float() * scale_a.float().repeat_interleave(32, 1)
+        b_dequant = b.float() * scale_b.float().repeat_interleave(32, 1)
+        reference = (a_dequant @ b_dequant.t()).to(out_dtype)
+        self.assertEqual(expected, reference, rtol=2e-2, atol=5e-1)
+
+        torch._dynamo.reset()
+        with config.patch(
+            max_autotune_gemm=True,
+            max_autotune_gemm_backends="FLYDSL",
+        ):
+            compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+            actual, (code,) = run_and_get_code(compiled, a, b, scale_a, scale_b)
+
+        self.assertEqual(actual, expected, rtol=2e-2, atol=5e-1)
+        self.assertIn("async_compile.flydsl", code)
+        self.assertIn("make_mxfp8_scaled_mm_gfx950", code)
+        self.assertIn("mat2.transpose(0, 1)", code)
+        self.assertNotIn("extern_kernels._scaled_mm_v2(", code)
+
+
+instantiate_device_type_tests(TestFlyDSLMXFP8Device, globals(), only_for="cuda")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -89,28 +89,36 @@ class TestFlyDSLMXFP8Metadata(TestCase):
         )
 
         with mock.patch.object(mm, "use_flydsl_mxfp8_template", return_value=True):
-            self.assertEqual(
-                mm.get_flydsl_mxfp8_template_kwargs(
-                    layout, a, b, scale_a[0], scale_b[0]
-                ),
-                {
-                    "GEMM_M": 64,
-                    "GEMM_N": 96,
-                    "GEMM_K": 256,
-                    "OUT_DTYPE": "bfloat16",
-                },
+            configs = mm.get_flydsl_mxfp8_template_kwargs(
+                layout, a, b, scale_a[0], scale_b[0]
             )
+            # Autotuning is off by default, so the selector returns exactly one
+            # config -- the tile it picks must divide 64x96x256 exactly, since
+            # the kernel has no boundary predication.
+            self.assertEqual(len(configs), 1)
+            for gemm_config in configs:
+                self.assertEqual(gemm_config["GEMM_M"], 64)
+                self.assertEqual(gemm_config["GEMM_N"], 96)
+                self.assertEqual(gemm_config["GEMM_K"], 256)
+                self.assertEqual(gemm_config["OUT_DTYPE"], "bfloat16")
+                self.assertEqual(64 % gemm_config["TILE_M"], 0)
+                self.assertEqual(96 % gemm_config["TILE_N"], 0)
+                self.assertEqual(256 % gemm_config["TILE_K"], 0)
 
             bad_b = _FakeNode((256, 96), (96, 1), torch.float8_e4m3fn)
-            self.assertIsNone(
+            self.assertEqual(
                 mm.get_flydsl_mxfp8_template_kwargs(
                     layout, a, bad_b, scale_a[0], scale_b[0]
-                )
+                ),
+                [],
             )
 
             bad_scale = _FakeNode((64, 8), (8, 1), torch.float8_e8m0fnu, offset=1)
-            self.assertIsNone(
-                mm.get_flydsl_mxfp8_template_kwargs(layout, a, b, bad_scale, scale_b[0])
+            self.assertEqual(
+                mm.get_flydsl_mxfp8_template_kwargs(
+                    layout, a, b, bad_scale, scale_b[0]
+                ),
+                [],
             )
 
             bad_device_scale = _FakeNode(
@@ -119,10 +127,11 @@ class TestFlyDSLMXFP8Metadata(TestCase):
                 torch.float8_e8m0fnu,
                 device=torch.device("cpu"),
             )
-            self.assertIsNone(
+            self.assertEqual(
                 mm.get_flydsl_mxfp8_template_kwargs(
                     layout, a, b, bad_device_scale, scale_b[0]
-                )
+                ),
+                [],
             )
 
             with mock.patch.object(
@@ -130,10 +139,11 @@ class TestFlyDSLMXFP8Metadata(TestCase):
                 "is_unaligned",
                 side_effect=lambda node: node is a,
             ):
-                self.assertIsNone(
+                self.assertEqual(
                     mm.get_flydsl_mxfp8_template_kwargs(
                         layout, a, b, scale_a[0], scale_b[0]
-                    )
+                    ),
+                    [],
                 )
 
     def test_runtime_cache_reuses_specialization(self):
@@ -233,6 +243,122 @@ class TestFlyDSLMXFP8Device(TestCase):
         self.assertIn("make_mxfp8_scaled_mm_gfx950", code)
         self.assertIn("mat2.transpose(0, 1)", code)
         self.assertNotIn("extern_kernels._scaled_mm_v2(", code)
+
+    # One entry per tiling feature the parameterized kernel exposes, so a
+    # regression in LDS staging, register blocking or the staged pipeline shows
+    # up as a numerical failure on the specific config that broke.
+    @parametrize(
+        "shape,tile",
+        [
+            # (m, n, k), (TILE_M, TILE_N, TILE_K, STAGES, M_WARPS, N_WARPS, GROUP_M)
+            ((64, 96, 256), (16, 16, 128, 2, 1, 1, 0)),  # minimal, 1 wave
+            ((64, 64, 512), (64, 64, 128, 2, 1, 1, 0)),  # 4x4 register blocking
+            ((128, 128, 512), (64, 64, 128, 2, 2, 2, 0)),  # 2x2 waves over LDS
+            ((128, 128, 512), (64, 64, 256, 2, 2, 2, 0)),  # two MFMA steps / tile
+            ((128, 128, 1024), (64, 64, 128, 4, 2, 2, 0)),  # 4-stage pipeline
+            ((256, 256, 512), (128, 128, 128, 2, 2, 4, 0)),  # asymmetric waves
+            ((256, 256, 512), (128, 128, 128, 2, 2, 2, 4)),  # GROUP_M swizzle
+        ],
+    )
+    def test_mxfp8_tile_configs_match_reference(self, device, shape, tile):
+        if torch.version.hip is None:
+            self.skipTest("requires ROCm")
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest("requires gfx950")
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        import flydsl.compiler as flyc
+
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            make_mxfp8_scaled_mm_gfx950,
+        )
+
+        m, n, k = shape
+        block_m, block_n, block_k, stages, m_waves, n_waves, group_m = tile
+        a, b, scale_a, scale_b = self._make_inputs(m, n, k, device)
+        out = torch.zeros(m, n, device=device, dtype=torch.bfloat16)
+        scale_a_u8 = scale_a.view(torch.uint8)
+        scale_b_u8 = scale_b.view(torch.uint8)
+
+        launcher = make_mxfp8_scaled_mm_gfx950(
+            m=m,
+            n=n,
+            k=k,
+            out_dtype="bfloat16",
+            block_m=block_m,
+            block_n=block_n,
+            block_k=block_k,
+            stages=stages,
+            m_waves=m_waves,
+            n_waves=n_waves,
+            group_m=group_m,
+        )
+        runtime_args = (a, b, scale_a_u8, scale_b_u8, out, 0)
+        compiled = flyc.compile(
+            launcher,
+            *[
+                flyc.from_torch_tensor(t).mark_layout_dynamic()
+                for t in (a, b, scale_a_u8, scale_b_u8, out)
+            ],
+            0,
+        )
+        compiled(*runtime_args)
+        torch.cuda.synchronize()
+
+        a_dequant = a.float() * scale_a.float().repeat_interleave(32, 1)
+        b_dequant = b.float() * scale_b.float().repeat_interleave(32, 1)
+        reference = (a_dequant @ b_dequant.t()).to(torch.bfloat16)
+        self.assertEqual(out, reference, rtol=2e-2, atol=5e-1)
+
+    def test_scaled_mm_v2_flydsl_autotunes_multiple_configs(self, device):
+        if torch.version.hip is None:
+            self.skipTest("requires ROCm")
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest("requires gfx950")
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        m, n, k = 128, 128, 512
+        a, b, scale_a, scale_b = self._make_inputs(m, n, k, device)
+
+        def fn(a, b, scale_a, scale_b):
+            return F.scaled_mm(
+                a,
+                b.t(),
+                scale_a,
+                ScalingType.BlockWise1x32,
+                scale_b,
+                ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.NO_SWIZZLE,
+                swizzle_b=SwizzleType.NO_SWIZZLE,
+                output_dtype=torch.bfloat16,
+            )
+
+        expected = fn(a, b, scale_a, scale_b)
+
+        with config.patch(
+            max_autotune_gemm=True,
+            max_autotune_gemm_backends="FLYDSL",
+            flydsl_enable_autotuning=True,
+        ):
+            # More than one tile divides this shape, so autotuning has a real
+            # choice to make here.
+            candidates = flydsl_heuristics.get_mxfp8_gemm_configs_for_shape(
+                m, n, k, "bfloat16"
+            )
+            self.assertGreater(len(candidates), 1)
+
+            torch._dynamo.reset()
+            compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+            actual, (code,) = run_and_get_code(compiled, a, b, scale_a, scale_b)
+
+        self.assertEqual(actual, expected, rtol=2e-2, atol=5e-1)
+        self.assertIn("async_compile.flydsl", code)
 
 
 instantiate_device_type_tests(TestFlyDSLMXFP8Device, globals(), only_for="cuda")

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -318,7 +318,10 @@ class TestFlyDSLMXFP8Device(TestCase):
             ),  # rectangular 8x8
         ],
     )
-    def test_mxfp8_tile_configs_match_reference(self, device, shape, tile, out_dtype):
+    @parametrize("frag_first", [0, 1])
+    def test_mxfp8_tile_configs_match_reference(
+        self, device, shape, tile, out_dtype, frag_first
+    ):
         if torch.version.hip is None:
             self.skipTest("requires ROCm")
         arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
@@ -352,6 +355,7 @@ class TestFlyDSLMXFP8Device(TestCase):
             m_waves=m_waves,
             n_waves=n_waves,
             group_m=group_m,
+            frag_first=frag_first,
         )
         runtime_args = (a, b, scale_a_u8, scale_b_u8, out, 0)
         compiled = flyc.compile(

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -248,19 +248,77 @@ class TestFlyDSLMXFP8Device(TestCase):
     # regression in LDS staging, register blocking or the staged pipeline shows
     # up as a numerical failure on the specific config that broke.
     @parametrize(
-        "shape,tile",
+        "shape,tile,out_dtype",
         [
             # (m, n, k), (TILE_M, TILE_N, TILE_K, STAGES, M_WARPS, N_WARPS, GROUP_M)
-            ((64, 96, 256), (16, 16, 128, 2, 1, 1, 0)),  # minimal, 1 wave
-            ((64, 64, 512), (64, 64, 128, 2, 1, 1, 0)),  # 4x4 register blocking
-            ((128, 128, 512), (64, 64, 128, 2, 2, 2, 0)),  # 2x2 waves over LDS
-            ((128, 128, 512), (64, 64, 256, 2, 2, 2, 0)),  # two MFMA steps / tile
-            ((128, 128, 1024), (64, 64, 128, 4, 2, 2, 0)),  # 4-stage pipeline
-            ((256, 256, 512), (128, 128, 128, 2, 2, 4, 0)),  # asymmetric waves
-            ((256, 256, 512), (128, 128, 128, 2, 2, 2, 4)),  # GROUP_M swizzle
+            (
+                (64, 96, 256),
+                (16, 16, 128, 2, 1, 1, 0),
+                torch.bfloat16,
+            ),  # minimal, 1 wave
+            (
+                (64, 64, 512),
+                (64, 64, 128, 2, 1, 1, 0),
+                torch.bfloat16,
+            ),  # 4x4 register blocking
+            (
+                (128, 128, 512),
+                (64, 64, 128, 2, 2, 2, 0),
+                torch.bfloat16,
+            ),  # 2x2 waves over LDS
+            (
+                (128, 128, 512),
+                (64, 64, 256, 2, 2, 2, 0),
+                torch.bfloat16,
+            ),  # two MFMA steps / tile
+            (
+                (64, 64, 1024),
+                (64, 64, 512, 2, 1, 1, 0),
+                torch.bfloat16,
+            ),  # four MFMA steps / tile
+            (
+                (128, 128, 512),
+                (64, 64, 128, 3, 2, 2, 0),
+                torch.bfloat16,
+            ),  # odd stage count
+            (
+                (128, 128, 1024),
+                (64, 64, 128, 4, 2, 2, 0),
+                torch.bfloat16,
+            ),  # 4-stage pipeline
+            (
+                (128, 128, 512),
+                (128, 128, 128, 2, 4, 4, 0),
+                torch.bfloat16,
+            ),  # 1024 threads
+            (
+                (256, 256, 512),
+                (128, 128, 128, 2, 2, 4, 0),
+                torch.bfloat16,
+            ),  # asymmetric waves
+            (
+                (1024, 256, 512),
+                (128, 128, 128, 2, 2, 2, 4),
+                torch.bfloat16,
+            ),  # GROUP_M swizzle
+            (
+                (256, 256, 512),
+                (256, 256, 128, 2, 2, 2, 0),
+                torch.bfloat16,
+            ),  # 8x8 deep blocking
+            (
+                (256, 256, 512),
+                (256, 256, 128, 2, 2, 2, 0),
+                torch.float16,
+            ),  # fp16 direct store
+            (
+                (256, 128, 512),
+                (256, 128, 128, 2, 2, 1, 0),
+                torch.bfloat16,
+            ),  # rectangular 8x8
         ],
     )
-    def test_mxfp8_tile_configs_match_reference(self, device, shape, tile):
+    def test_mxfp8_tile_configs_match_reference(self, device, shape, tile, out_dtype):
         if torch.version.hip is None:
             self.skipTest("requires ROCm")
         arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
@@ -278,7 +336,7 @@ class TestFlyDSLMXFP8Device(TestCase):
         m, n, k = shape
         block_m, block_n, block_k, stages, m_waves, n_waves, group_m = tile
         a, b, scale_a, scale_b = self._make_inputs(m, n, k, device)
-        out = torch.zeros(m, n, device=device, dtype=torch.bfloat16)
+        out = torch.zeros(m, n, device=device, dtype=out_dtype)
         scale_a_u8 = scale_a.view(torch.uint8)
         scale_b_u8 = scale_b.view(torch.uint8)
 
@@ -286,7 +344,7 @@ class TestFlyDSLMXFP8Device(TestCase):
             m=m,
             n=n,
             k=k,
-            out_dtype="bfloat16",
+            out_dtype="bfloat16" if out_dtype == torch.bfloat16 else "float16",
             block_m=block_m,
             block_n=block_n,
             block_k=block_k,
@@ -309,7 +367,7 @@ class TestFlyDSLMXFP8Device(TestCase):
 
         a_dequant = a.float() * scale_a.float().repeat_interleave(32, 1)
         b_dequant = b.float() * scale_b.float().repeat_interleave(32, 1)
-        reference = (a_dequant @ b_dequant.t()).to(torch.bfloat16)
+        reference = (a_dequant @ b_dequant.t()).to(out_dtype)
         self.assertEqual(out, reference, rtol=2e-2, atol=5e-1)
 
     def test_scaled_mm_v2_flydsl_autotunes_multiple_configs(self, device):

--- a/test/inductor/test_flydsl_mxfp8.py
+++ b/test/inductor/test_flydsl_mxfp8.py
@@ -88,7 +88,7 @@ class TestFlyDSLMXFP8Metadata(TestCase):
             offset=0,
         )
 
-        with mock.patch.object(mm, "use_flydsl_mxfp8_template", return_value=True):
+        with mock.patch.object(mm, "use_flydsl_scaled_mm_template", return_value=True):
             configs = mm.get_flydsl_mxfp8_template_kwargs(
                 layout, a, b, scale_a[0], scale_b[0]
             )

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -295,6 +295,84 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(metadata["precompile_strides"], {"output": [1]})
         self.assertEqual(metadata["precompile_dtypes"], {"output": "float32"})
 
+    def test_precompile_metadata_preserves_four_input_layouts(self):
+        def fake_node(size, stride, dtype):
+            return SimpleNamespace(
+                get_size=lambda: list(size),
+                get_stride=lambda: list(stride),
+                get_dtype=lambda: dtype,
+            )
+
+        kernel = SimpleNamespace(
+            _template_input_args=[
+                (
+                    "arg_mat1",
+                    fake_node((64, 256), (256, 1), torch.float8_e4m3fn),
+                ),
+                (
+                    "arg_mat2",
+                    fake_node((256, 96), (1, 256), torch.float8_e4m3fn),
+                ),
+                (
+                    "arg_scale_a",
+                    fake_node((64, 8), (8, 1), torch.float8_e8m0fnu),
+                ),
+                (
+                    "arg_scale_b",
+                    fake_node((96, 8), (8, 1), torch.float8_e8m0fnu),
+                ),
+            ]
+        )
+        buffer = SimpleNamespace(
+            layout=SimpleNamespace(
+                size=[64, 96],
+                stride=[96, 1],
+                dtype=torch.bfloat16,
+                device=torch.device("cuda", 0),
+            )
+        )
+        scheduling = FlyDSLScheduling.__new__(FlyDSLScheduling)
+
+        with (
+            mock.patch("torch.cuda.is_available", return_value=False),
+            mock.patch.object(
+                FlyDSLScheduling,
+                "_build_flydsl_gpu_arch",
+                return_value="gfx950",
+            ),
+        ):
+            metadata = scheduling._build_precompile_metadata(kernel, buffer)
+
+        self.assertEqual(
+            metadata,
+            {
+                "precompile_shapes": {
+                    "mat1": [64, 256],
+                    "mat2": [256, 96],
+                    "scale_a": [64, 8],
+                    "scale_b": [96, 8],
+                    "output": [64, 96],
+                },
+                "precompile_strides": {
+                    "mat1": [256, 1],
+                    "mat2": [1, 256],
+                    "scale_a": [8, 1],
+                    "scale_b": [8, 1],
+                    "output": [96, 1],
+                },
+                "precompile_dtypes": {
+                    "mat1": "float8_e4m3fn",
+                    "mat2": "float8_e4m3fn",
+                    "scale_a": "float8_e8m0fnu",
+                    "scale_b": "float8_e8m0fnu",
+                    "output": "bfloat16",
+                },
+                "device_index": 0,
+                "device_capability": None,
+                "flydsl_gpu_arch": "gfx950",
+            },
+        )
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -304,6 +304,7 @@ class TestFlyDSLTemplate(TestCase):
             )
 
         kernel = SimpleNamespace(
+            _template_signature_defined=True,
             _template_input_args=[
                 (
                     "arg_mat1",
@@ -321,7 +322,7 @@ class TestFlyDSLTemplate(TestCase):
                     "arg_scale_b",
                     fake_node((96, 8), (8, 1), torch.float8_e8m0fnu),
                 ),
-            ]
+            ],
         )
         buffer = SimpleNamespace(
             layout=SimpleNamespace(

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -368,6 +368,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.kernel.vendored_templates.cutedsl.dense_blockscaled_gemm_persistent",  # depends on cutlass
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass_api
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_mxfp4_gfx950",  # depends on flydsl
             "torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_mxfp8_gfx950",  # depends on flydsl
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -368,6 +368,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.kernel.vendored_templates.cutedsl.dense_blockscaled_gemm_persistent",  # depends on cutlass
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass_api
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_mxfp8_gfx950",  # depends on flydsl
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",
             "torch.backends._coreml.preprocess",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2667,6 +2667,7 @@ class TestImports(TestCase):
                            "torch.csrc",  # files here are devtools, not part of torch
                            "torch.include",  # torch include files after install
                            "torch._inductor.kernel.vendored_templates.cutedsl",  # depends on cutlass
+                           "torch._inductor.kernel.vendored_templates.flydsl",  # depends on flydsl
                            "torch._vendor.quack",  # depends on cutlass / cuda-python
                            "torch.profiler._cupti",  # depends on cupti-python
                            ]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -761,6 +761,8 @@ cutedsl_enable_autotuning: bool = (
     os.environ.get("CUTEDSL_ENABLE_AUTOTUNING", "0") == "1"
 )
 
+flydsl_enable_autotuning: bool = os.environ.get("FLYDSL_ENABLE_AUTOTUNING", "0") == "1"
+
 # DEPRECATED. This setting is ignored.
 autotune_fallback_to_aten = False
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -640,11 +640,13 @@ multi_kernel_hints: list[int] = []
 
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, NVGEMM, CK, CKTILE, CPP.
+# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, FLYDSL,
+# NVGEMM, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
 # CUTEDSL: CuteDSL templates for Blackwell GPUs (NVidia SM100-SM109 only).
+# FLYDSL: FlyDSL templates for ROCm GPUs (experimental).
 # NVGEMM: NVIDIA Universal GEMM via cutlass.operators (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
 # CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -18,11 +18,6 @@ class FlyDSLMXFP8Config:
     BLOCK_M_WARPS: int = 2
     BLOCK_N_WARPS: int = 2
     GROUP_M: int = 0
-    # 1 reads the tile's LDS fragments before issuing the next tile's
-    # direct-to-LDS DMA, which stops the compiler from draining vmcnt between
-    # them. Worth 11-27% on 2x2 wave grids and -21% on 1- and 2-wave ones, so
-    # it is a search dimension rather than a fixed choice.
-    FRAG_FIRST: int = 1
 
 
 class FlyDSLMXFP8ConfigDict(TypedDict):
@@ -33,10 +28,9 @@ class FlyDSLMXFP8ConfigDict(TypedDict):
     BLOCK_M_WARPS: int
     BLOCK_N_WARPS: int
     GROUP_M: int
-    FRAG_FIRST: int
 
 
-FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int, int]
+FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int]
 
 
 def _check_gemm_config(gemm_config: dict[str, int]) -> None:
@@ -84,7 +78,6 @@ def get_exhaustive_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
         "BLOCK_M_WARPS": [1, 2, 4],
         "BLOCK_N_WARPS": [1, 2, 4],
         "GROUP_M": [0, 4],
-        "FRAG_FIRST": [0, 1],
     }
     keys = selections.keys()
     values = selections.values()
@@ -148,13 +141,7 @@ def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
         (16, 16, 128, 2, 1, 1, 0),
     ]
     # Tuple order must match the FlyDSLMXFP8Config field declaration order.
-    # Which FRAG_FIRST wins depends on how many waves a workgroup has, and the
-    # measured spread is 20-30% either way, so both are searched for every tile.
-    configs = [
-        FlyDSLMXFP8Config(*args, frag_first)
-        for args in tile_tuples
-        for frag_first in (1, 0)
-    ]
+    configs = [FlyDSLMXFP8Config(*args) for args in tile_tuples]
     valid_configs: list[FlyDSLMXFP8Config] = []
     for gemm_config in configs:
         try:

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -18,6 +18,11 @@ class FlyDSLMXFP8Config:
     BLOCK_M_WARPS: int = 2
     BLOCK_N_WARPS: int = 2
     GROUP_M: int = 0
+    # 1 reads the tile's LDS fragments before issuing the next tile's
+    # direct-to-LDS DMA, which stops the compiler from draining vmcnt between
+    # them. Worth 11-27% on 2x2 wave grids and -21% on 1- and 2-wave ones, so
+    # it is a search dimension rather than a fixed choice.
+    FRAG_FIRST: int = 1
 
 
 class FlyDSLMXFP8ConfigDict(TypedDict):
@@ -28,9 +33,10 @@ class FlyDSLMXFP8ConfigDict(TypedDict):
     BLOCK_M_WARPS: int
     BLOCK_N_WARPS: int
     GROUP_M: int
+    FRAG_FIRST: int
 
 
-FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int]
+FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int, int]
 
 
 def _check_gemm_config(gemm_config: dict[str, int]) -> None:
@@ -78,6 +84,7 @@ def get_exhaustive_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
         "BLOCK_M_WARPS": [1, 2, 4],
         "BLOCK_N_WARPS": [1, 2, 4],
         "GROUP_M": [0, 4],
+        "FRAG_FIRST": [0, 1],
     }
     keys = selections.keys()
     values = selections.values()
@@ -99,7 +106,7 @@ def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
     """
     Returns the default configuration set for the gfx950 FlyDSL MXFP8 kernel.
     """
-    config_tuples: list[FlyDSLMXFP8ConfigArgs] = [
+    tile_tuples: list[tuple[int, int, int, int, int, int, int]] = [
         # Deep register blocking (8x8 / 8x4 repeats): fewer, fatter waves so
         # each LDS read feeds four MFMAs instead of two. These win every shape
         # from M=2048 up -- 256x256 with a 2x2 wave grid is the large-GEMM
@@ -141,7 +148,13 @@ def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
         (16, 16, 128, 2, 1, 1, 0),
     ]
     # Tuple order must match the FlyDSLMXFP8Config field declaration order.
-    configs = [FlyDSLMXFP8Config(*args) for args in config_tuples]
+    # Which FRAG_FIRST wins depends on how many waves a workgroup has, and the
+    # measured spread is 20-30% either way, so both are searched for every tile.
+    configs = [
+        FlyDSLMXFP8Config(*args, frag_first)
+        for args in tile_tuples
+        for frag_first in (1, 0)
+    ]
     valid_configs: list[FlyDSLMXFP8Config] = []
     for gemm_config in configs:
         try:

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -100,6 +100,17 @@ def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
     Returns the default configuration set for the gfx950 FlyDSL MXFP8 kernel.
     """
     config_tuples: list[FlyDSLMXFP8ConfigArgs] = [
+        # Deep register blocking (8x8 / 8x4 repeats): fewer, fatter waves so
+        # each LDS read feeds four MFMAs instead of two. These win every shape
+        # from M=2048 up -- 256x256 with a 2x2 wave grid is the large-GEMM
+        # sweet spot -- and are the reason MXFP8_MAX_MMA_REPEAT is 8.
+        (256, 256, 128, 2, 2, 2, 4),
+        (256, 256, 128, 2, 2, 2, 0),
+        (128, 128, 128, 2, 1, 2, 4),
+        (128, 128, 128, 2, 2, 1, 4),
+        (128, 128, 128, 2, 1, 1, 4),
+        (128, 256, 128, 2, 1, 4, 4),
+        (256, 128, 128, 2, 4, 1, 4),
         # Square-ish tiles: the throughput sweet spot for large GEMMs.
         (128, 128, 128, 2, 2, 2, 0),
         (128, 128, 128, 2, 2, 2, 4),

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -1,0 +1,184 @@
+import logging
+from dataclasses import asdict, dataclass
+from itertools import product
+from typing import cast, TypedDict
+
+import torch._inductor.config as config
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FlyDSLMXFP8Config:
+    TILE_M: int = 128
+    TILE_N: int = 128
+    TILE_K: int = 128
+    STAGES: int = 2
+    BLOCK_M_WARPS: int = 2
+    BLOCK_N_WARPS: int = 2
+    GROUP_M: int = 0
+
+
+class FlyDSLMXFP8ConfigDict(TypedDict):
+    TILE_M: int
+    TILE_N: int
+    TILE_K: int
+    STAGES: int
+    BLOCK_M_WARPS: int
+    BLOCK_N_WARPS: int
+    GROUP_M: int
+
+
+FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int]
+
+
+def _check_gemm_config(gemm_config: dict[str, int]) -> None:
+    """Raise if the kernel cannot build this tile config."""
+    # Keep FlyDSL optional when this heuristics module is imported.
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        mxfp8_gemm_derived,
+    )
+
+    mxfp8_gemm_derived(
+        block_m=int(gemm_config["TILE_M"]),
+        block_n=int(gemm_config["TILE_N"]),
+        block_k=int(gemm_config["TILE_K"]),
+        stages=int(gemm_config["STAGES"]),
+        m_waves=int(gemm_config["BLOCK_M_WARPS"]),
+        n_waves=int(gemm_config["BLOCK_N_WARPS"]),
+        group_m=int(gemm_config["GROUP_M"]),
+    )
+
+
+def is_mxfp8_config_valid_for_shape(
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: str,
+    gemm_config: dict[str, int],
+) -> bool:
+    """Return whether a FlyDSL MXFP8 config supports this concrete shape."""
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp8_param_and_validate,
+    )
+
+    return make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config) is not None
+
+
+def get_exhaustive_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
+    """
+    Returns the exhaustive configuration set for the gfx950 FlyDSL MXFP8 kernel.
+    """
+    selections = {
+        "TILE_M": [16, 32, 64, 96, 128, 256],
+        "TILE_N": [16, 32, 64, 96, 128, 256],
+        "TILE_K": [128, 256, 512],
+        "STAGES": [2, 3, 4, 5, 6],
+        "BLOCK_M_WARPS": [1, 2, 4],
+        "BLOCK_N_WARPS": [1, 2, 4],
+        "GROUP_M": [0, 4],
+    }
+    keys = selections.keys()
+    values = selections.values()
+    configs = [dict(zip(keys, combo)) for combo in product(*values)]
+    valid_configs: list[FlyDSLMXFP8Config] = []
+    for gemm_config in configs:
+        try:
+            gemm = FlyDSLMXFP8Config(**cast(FlyDSLMXFP8ConfigDict, gemm_config))
+            _check_gemm_config(asdict(gemm))
+            valid_configs.append(gemm)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid exhaustive FlyDSL MXFP8 config %s: %s", gemm_config, e
+            )
+    return valid_configs
+
+
+def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
+    """
+    Returns the default configuration set for the gfx950 FlyDSL MXFP8 kernel.
+    """
+    config_tuples: list[FlyDSLMXFP8ConfigArgs] = [
+        # Square-ish tiles: the throughput sweet spot for large GEMMs.
+        (128, 128, 128, 2, 2, 2, 0),
+        (128, 128, 128, 2, 2, 2, 4),
+        (128, 128, 128, 3, 2, 2, 0),
+        (256, 128, 128, 2, 4, 2, 0),
+        (128, 256, 128, 2, 2, 4, 0),
+        (256, 256, 128, 2, 4, 4, 0),
+        (128, 128, 256, 2, 2, 2, 0),
+        (64, 64, 128, 2, 2, 2, 0),
+        (64, 128, 128, 2, 1, 2, 0),
+        (128, 64, 128, 2, 2, 1, 0),
+        (64, 64, 256, 2, 1, 1, 0),
+        (64, 64, 512, 2, 1, 1, 0),
+        # Small-M decode shapes: thin tiles keep the N sweep parallel.
+        (16, 128, 128, 4, 1, 2, 0),
+        (16, 256, 128, 4, 1, 4, 0),
+        (32, 128, 128, 4, 1, 2, 0),
+        (32, 256, 128, 3, 1, 4, 0),
+        (32, 128, 256, 3, 1, 2, 0),
+        (64, 256, 128, 2, 1, 4, 0),
+        # Small-N (e.g. 4096x256x4096) wants the opposite aspect ratio.
+        (256, 64, 128, 2, 4, 1, 0),
+        (128, 32, 128, 3, 2, 1, 0),
+        # Tiny catch-all tiles. The kernel has no boundary predication, so a
+        # shape only gets a FlyDSL choice when some tile divides it exactly;
+        # these keep any 16-aligned shape covered.
+        (32, 32, 128, 2, 1, 1, 0),
+        (16, 16, 128, 2, 1, 1, 0),
+    ]
+    # Tuple order must match the FlyDSLMXFP8Config field declaration order.
+    configs = [FlyDSLMXFP8Config(*args) for args in config_tuples]
+    valid_configs: list[FlyDSLMXFP8Config] = []
+    for gemm_config in configs:
+        try:
+            _check_gemm_config(asdict(gemm_config))
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid default FlyDSL MXFP8 config %s: %s", gemm_config, e
+            )
+    return valid_configs
+
+
+def get_mxfp8_gemm_configs() -> list[dict[str, int]]:
+    """
+    Returns the shape-independent configuration set for the gfx950 FlyDSL
+    MXFP8 kernel.
+    """
+    if (
+        config.flydsl_enable_autotuning
+        and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+    ):
+        configs = get_exhaustive_mxfp8_gemm_configs()
+    else:
+        configs = get_default_mxfp8_gemm_configs()
+    if not configs:
+        log.warning("No valid FlyDSL MXFP8 GEMM configuration is available")
+        return []
+    return [asdict(gemm_config) for gemm_config in configs]
+
+
+def get_mxfp8_gemm_configs_for_shape(
+    m: int, n: int, k: int, out_dtype: str
+) -> list[dict[str, int]]:
+    """
+    Returns the configurations to autotune over for one concrete shape.
+
+    Unlike the FP16 GEMM template, this kernel has no boundary predication, so
+    a config is only usable when its tile divides the shape exactly. That makes
+    "the baseline config" shape-dependent: with autotuning disabled we return
+    the single default config that fits, preferring FlyDSLMXFP8Config() when it
+    is valid, rather than a fixed tuple that many shapes would reject outright.
+    """
+    configs = [
+        gemm_config
+        for gemm_config in get_mxfp8_gemm_configs()
+        if is_mxfp8_config_valid_for_shape(m, n, k, out_dtype, gemm_config)
+    ]
+    if config.flydsl_enable_autotuning or not configs:
+        return configs
+    baseline = asdict(FlyDSLMXFP8Config())
+    return [baseline] if baseline in configs else configs[:1]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -33,7 +33,7 @@ class FlyDSLMXFP8ConfigDict(TypedDict):
 FlyDSLMXFP8ConfigArgs = tuple[int, int, int, int, int, int, int]
 
 
-def _check_gemm_config(gemm_config: dict[str, int]) -> None:
+def _check_mxfp8_gemm_config(gemm_config: dict[str, int]) -> None:
     """Raise if the kernel cannot build this tile config."""
     # Keep FlyDSL optional when this heuristics module is imported.
     from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
@@ -86,7 +86,7 @@ def get_exhaustive_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
     for gemm_config in configs:
         try:
             gemm = FlyDSLMXFP8Config(**cast(FlyDSLMXFP8ConfigDict, gemm_config))
-            _check_gemm_config(asdict(gemm))
+            _check_mxfp8_gemm_config(asdict(gemm))
             valid_configs.append(gemm)
         except Exception as e:
             log.debug(
@@ -145,7 +145,7 @@ def get_default_mxfp8_gemm_configs() -> list[FlyDSLMXFP8Config]:
     valid_configs: list[FlyDSLMXFP8Config] = []
     for gemm_config in configs:
         try:
-            _check_gemm_config(asdict(gemm_config))
+            _check_mxfp8_gemm_config(asdict(gemm_config))
             valid_configs.append(gemm_config)
         except Exception as e:
             log.debug(
@@ -192,4 +192,197 @@ def get_mxfp8_gemm_configs_for_shape(
     if config.flydsl_enable_autotuning or not configs:
         return configs
     baseline = asdict(FlyDSLMXFP8Config())
+    return [baseline] if baseline in configs else configs[:1]
+
+
+@dataclass(frozen=True)
+class FlyDSLMXFP4Config:
+    # TILE_K counts E2M1 *elements*; the LDS row it produces is TILE_K // 2
+    # bytes wide, which is what every DMA and swizzle constant is derived from.
+    TILE_M: int = 128
+    TILE_N: int = 128
+    TILE_K: int = 256
+    STAGES: int = 2
+    BLOCK_M_WARPS: int = 2
+    BLOCK_N_WARPS: int = 2
+    GROUP_M: int = 0
+
+
+class FlyDSLMXFP4ConfigDict(TypedDict):
+    TILE_M: int
+    TILE_N: int
+    TILE_K: int
+    STAGES: int
+    BLOCK_M_WARPS: int
+    BLOCK_N_WARPS: int
+    GROUP_M: int
+
+
+FlyDSLMXFP4ConfigArgs = tuple[int, int, int, int, int, int, int]
+
+
+def _check_mxfp4_gemm_config(gemm_config: dict[str, int]) -> None:
+    """Raise if the kernel cannot build this tile config."""
+    # Keep FlyDSL optional when this heuristics module is imported.
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        mxfp4_gemm_derived,
+    )
+
+    mxfp4_gemm_derived(
+        block_m=int(gemm_config["TILE_M"]),
+        block_n=int(gemm_config["TILE_N"]),
+        block_k=int(gemm_config["TILE_K"]),
+        stages=int(gemm_config["STAGES"]),
+        m_waves=int(gemm_config["BLOCK_M_WARPS"]),
+        n_waves=int(gemm_config["BLOCK_N_WARPS"]),
+        group_m=int(gemm_config["GROUP_M"]),
+    )
+
+
+def is_mxfp4_config_valid_for_shape(
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: str,
+    gemm_config: dict[str, int],
+) -> bool:
+    """Return whether a FlyDSL MXFP4 config supports this concrete shape."""
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp4_param_and_validate,
+    )
+
+    return make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config) is not None
+
+
+def get_exhaustive_mxfp4_gemm_configs() -> list[FlyDSLMXFP4Config]:
+    """
+    Returns the exhaustive configuration set for the gfx950 FlyDSL MXFP4 kernel.
+    """
+    selections = {
+        "TILE_M": [16, 32, 64, 96, 128, 256],
+        "TILE_N": [16, 32, 64, 96, 128, 256],
+        # Elements. 128 gives a 64-byte LDS row, 1024 a 512-byte one; the range
+        # is wider than the MXFP8 kernel's because an E2M1 tile costs half the
+        # LDS of the E4M3 tile with the same K.
+        "TILE_K": [128, 256, 512, 1024],
+        "STAGES": [2, 3, 4, 5, 6],
+        "BLOCK_M_WARPS": [1, 2, 4],
+        "BLOCK_N_WARPS": [1, 2, 4],
+        "GROUP_M": [0, 4],
+    }
+    keys = selections.keys()
+    values = selections.values()
+    configs = [dict(zip(keys, combo)) for combo in product(*values)]
+    valid_configs: list[FlyDSLMXFP4Config] = []
+    for gemm_config in configs:
+        try:
+            gemm = FlyDSLMXFP4Config(**cast(FlyDSLMXFP4ConfigDict, gemm_config))
+            _check_mxfp4_gemm_config(asdict(gemm))
+            valid_configs.append(gemm)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid exhaustive FlyDSL MXFP4 config %s: %s", gemm_config, e
+            )
+    return valid_configs
+
+
+def get_default_mxfp4_gemm_configs() -> list[FlyDSLMXFP4Config]:
+    """
+    Returns the default configuration set for the gfx950 FlyDSL MXFP4 kernel.
+    """
+    tile_tuples: list[FlyDSLMXFP4ConfigArgs] = [
+        # TILE_K=256 elements reproduces the byte geometry the MXFP8 kernel
+        # settled on (128-byte LDS rows, 8 DMA and 24 ds_read per K-tile) while
+        # covering twice the K, and its two MFMA K steps let the compiler merge
+        # the pair of E8M0 scale dwords into one dwordx2.
+        (256, 256, 256, 2, 2, 4, 4),
+        (256, 256, 256, 2, 2, 4, 0),
+        (256, 256, 256, 2, 2, 2, 0),
+        (128, 256, 256, 2, 1, 4, 4),
+        (256, 128, 256, 2, 4, 1, 4),
+        (128, 128, 256, 2, 2, 2, 0),
+        (128, 128, 256, 2, 2, 2, 4),
+        # Half the LDS per K-tile instead: deep pipelines that the MXFP8 kernel
+        # could never fit, which is what turns the K-tile boundary from a full
+        # vmcnt(0) drain into a counted wait.
+        (256, 256, 128, 4, 2, 4, 0),
+        (256, 256, 128, 5, 2, 4, 0),
+        (256, 256, 128, 4, 2, 4, 4),
+        (128, 128, 128, 4, 2, 2, 0),
+        # 4 waves/SIMD. Only reachable with 4-bit operands: the same tile in
+        # E4M3 needs more than the 128 VGPRs a wave gets at this occupancy.
+        (256, 256, 128, 2, 4, 4, 0),
+        (256, 256, 128, 4, 4, 4, 0),
+        (256, 256, 256, 2, 4, 4, 0),
+        # TILE_K=512 elements: four MFMA K steps per tile, so the scale dwords
+        # merge into a dwordx4.
+        (128, 128, 512, 2, 2, 2, 0),
+        (64, 128, 512, 2, 1, 2, 0),
+        # Small-M decode shapes: thin tiles keep the N sweep parallel.
+        (16, 128, 256, 4, 1, 2, 0),
+        (16, 256, 256, 4, 1, 4, 0),
+        (32, 128, 256, 4, 1, 2, 0),
+        (32, 256, 256, 3, 1, 4, 0),
+        (64, 256, 256, 2, 1, 4, 0),
+        # Small-N (e.g. 4096x256x4096) wants the opposite aspect ratio.
+        (256, 64, 256, 2, 4, 1, 0),
+        (128, 32, 256, 3, 2, 1, 0),
+        # Tiny catch-all tiles. The kernel has no boundary predication, so a
+        # shape only gets a FlyDSL choice when some tile divides it exactly.
+        (64, 64, 256, 2, 1, 1, 0),
+        (32, 32, 128, 2, 1, 1, 0),
+        (16, 16, 128, 2, 1, 1, 0),
+    ]
+    # Tuple order must match the FlyDSLMXFP4Config field declaration order.
+    configs = [FlyDSLMXFP4Config(*args) for args in tile_tuples]
+    valid_configs: list[FlyDSLMXFP4Config] = []
+    for gemm_config in configs:
+        try:
+            _check_mxfp4_gemm_config(asdict(gemm_config))
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid default FlyDSL MXFP4 config %s: %s", gemm_config, e
+            )
+    return valid_configs
+
+
+def get_mxfp4_gemm_configs() -> list[dict[str, int]]:
+    """
+    Returns the shape-independent configuration set for the gfx950 FlyDSL
+    MXFP4 kernel.
+    """
+    if (
+        config.flydsl_enable_autotuning
+        and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+    ):
+        configs = get_exhaustive_mxfp4_gemm_configs()
+    else:
+        configs = get_default_mxfp4_gemm_configs()
+    if not configs:
+        log.warning("No valid FlyDSL MXFP4 GEMM configuration is available")
+        return []
+    return [asdict(gemm_config) for gemm_config in configs]
+
+
+def get_mxfp4_gemm_configs_for_shape(
+    m: int, n: int, k: int, out_dtype: str
+) -> list[dict[str, int]]:
+    """
+    Returns the configurations to autotune over for one concrete shape.
+
+    This kernel has no boundary predication, so a config is only usable when its
+    tile divides the shape exactly. That makes "the baseline config" shape
+    dependent: with autotuning disabled we return the single default config that
+    fits, preferring FlyDSLMXFP4Config() when it is valid, rather than a fixed
+    tuple that many shapes would reject outright.
+    """
+    configs = [
+        gemm_config
+        for gemm_config in get_mxfp4_gemm_configs()
+        if is_mxfp4_config_valid_for_shape(m, n, k, out_dtype, gemm_config)
+    ]
+    if config.flydsl_enable_autotuning or not configs:
+        return configs
+    baseline = asdict(FlyDSLMXFP4Config())
     return [baseline] if baseline in configs else configs[:1]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -332,6 +332,23 @@ def get_default_mxfp4_gemm_configs() -> list[FlyDSLMXFP4Config]:
         (64, 64, 256, 2, 1, 1, 0),
         (32, 32, 128, 2, 1, 1, 0),
         (16, 16, 128, 2, 1, 1, 0),
+        # Measured winners. Every entry below beat this list's previous best on
+        # at least one of the 13 benchmark shapes once the packed-unit scale
+        # path removed the per-byte scale fallback that used to make shallow
+        # register blocking unusable. Without them the default search cannot
+        # reach the numbers the EXHAUSTIVE space does -- 11 of the 13 per-shape
+        # winners were absent here.
+        (32, 32, 512, 6, 2, 1, 4),    # 32x4096x4096
+        (16, 32, 256, 4, 1, 1, 0),    # 64x4096x4096
+        (32, 64, 1024, 3, 1, 4, 0),   # 32x14336x4096
+        (32, 32, 512, 2, 1, 2, 0),    # 128x4096x4096
+        (32, 64, 256, 2, 1, 2, 0),    # 32x28672x4096
+        (64, 32, 512, 2, 1, 1, 4),    # 4096x256x4096
+        (64, 64, 512, 2, 2, 2, 4),    # 256x4096x4096
+        (64, 128, 512, 2, 2, 2, 4),   # 512x4096x4096
+        (128, 128, 512, 2, 2, 2, 4),  # 1024x4096x4096
+        (256, 256, 256, 2, 4, 4, 4),  # 4096x4096x4096
+        (256, 256, 256, 2, 4, 2, 0),  # 8192x8192x8192
     ]
     # Tuple order must match the FlyDSLMXFP4Config field declaration order.
     configs = [FlyDSLMXFP4Config(*args) for args in tile_tuples]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -206,6 +206,11 @@ class FlyDSLMXFP4Config:
     BLOCK_M_WARPS: int = 2
     BLOCK_N_WARPS: int = 2
     GROUP_M: int = 0
+    # 1 stages the E8M0 block scales through LDS and reads each one back with a
+    # single ds_read_u8; 0 keeps the in-register lane-group transpose. Searched
+    # rather than derived -- see the comment in mxfp4_gemm_derived. Declared
+    # last and defaulted so the 7-tuples in the default list stay valid.
+    LDS_SCALE: int = 0
 
 
 class FlyDSLMXFP4ConfigDict(TypedDict):
@@ -216,6 +221,7 @@ class FlyDSLMXFP4ConfigDict(TypedDict):
     BLOCK_M_WARPS: int
     BLOCK_N_WARPS: int
     GROUP_M: int
+    LDS_SCALE: int
 
 
 FlyDSLMXFP4ConfigArgs = tuple[int, int, int, int, int, int, int]
@@ -236,6 +242,7 @@ def _check_mxfp4_gemm_config(gemm_config: dict[str, int]) -> None:
         m_waves=int(gemm_config["BLOCK_M_WARPS"]),
         n_waves=int(gemm_config["BLOCK_N_WARPS"]),
         group_m=int(gemm_config["GROUP_M"]),
+        lds_scale_req=int(gemm_config.get("LDS_SCALE", 0)),
     )
 
 
@@ -269,6 +276,10 @@ def get_exhaustive_mxfp4_gemm_configs() -> list[FlyDSLMXFP4Config]:
         "BLOCK_M_WARPS": [1, 2, 4],
         "BLOCK_N_WARPS": [1, 2, 4],
         "GROUP_M": [0, 4],
+        # Both variants are generated; a config that cannot express the LDS path
+        # raises in _check_mxfp4_gemm_config and is dropped, so this adds
+        # candidates only where the two are genuinely different kernels.
+        "LDS_SCALE": [0, 1],
     }
     keys = selections.keys()
     values = selections.values()
@@ -349,6 +360,25 @@ def get_default_mxfp4_gemm_configs() -> list[FlyDSLMXFP4Config]:
         (128, 128, 512, 2, 2, 2, 4),  # 1024x4096x4096
         (256, 256, 256, 2, 4, 4, 4),  # 4096x4096x4096
         (256, 256, 256, 2, 4, 2, 0),  # 8192x8192x8192
+        # LDS-staged block scales (8th field = LDS_SCALE). Each of these was
+        # measured against its own LDS_SCALE=0 twin in a paired A/B and won by
+        # more than the 3.4% noise floor of this box:
+        #   32,32,512,2,1,2,0   +18.5%  (128 x 4096 x 4096)
+        #   32,32,512,2,1,1,0   +18.9%  (4096^3)
+        #   32,64,512,2,1,2,0   +17.9%  (4096^3)
+        #   64,64,512,2,2,2,4   +13.0%  (256 x 4096 x 4096)
+        #   64,128,512,2,2,2,4  +11.5%  (512 x 4096 x 4096)
+        #   128,64,512,2,1,2,0  +11.1%  (4096^3)
+        #   64,128,512,2,2,2,0   +8.7%  (4096^3)
+        #   32,64,1024,3,1,4,0   +5.8%  (32 x 14336 x 4096)
+        (32, 32, 512, 2, 1, 2, 0, 1),
+        (32, 32, 512, 2, 1, 1, 0, 1),
+        (32, 64, 512, 2, 1, 2, 0, 1),
+        (64, 64, 512, 2, 2, 2, 4, 1),
+        (64, 128, 512, 2, 2, 2, 4, 1),
+        (128, 64, 512, 2, 1, 2, 0, 1),
+        (64, 128, 512, 2, 2, 2, 0, 1),
+        (32, 64, 1024, 3, 1, 4, 0, 1),
     ]
     # Tuple order must match the FlyDSLMXFP4Config field declaration order.
     configs = [FlyDSLMXFP4Config(*args) for args in tile_tuples]

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -988,20 +988,22 @@ def get_flydsl_mxfp8_template_kwargs(
     mat_b: Any,
     scale_a: Any,
     scale_b: Any,
-) -> dict[str, Any] | None:
-    """Return one correctness-first gfx950 MXFP8 template configuration."""
+) -> list[dict[str, Any]]:
+    """Return shape-compatible gfx950 MXFP8 template configurations."""
+    from ..heuristics.template.flydsl import get_mxfp8_gemm_configs_for_shape
+
     if not use_flydsl_mxfp8_template(layout):
-        return None
+        return []
 
     nodes = (mat_a, mat_b, scale_a, scale_b)
     if any(node.get_device() != layout.device for node in nodes):
-        return None
+        return []
 
     if is_unaligned(mat_a) or is_unaligned(mat_b):
-        return None
+        return []
 
     if any(len(node.get_size()) != 2 for node in nodes):
-        return None
+        return []
 
     static_ints = PythonWrapperCodegen.statically_known_list_of_ints_or_none
     a_shape = static_ints(mat_a.get_size())
@@ -1013,7 +1015,7 @@ def get_flydsl_mxfp8_template_kwargs(
         shape is None
         for shape in (a_shape, b_shape, scale_a_shape, scale_b_shape, out_shape)
     ):
-        return None
+        return []
 
     m, k = a_shape
     b_k, n = b_shape
@@ -1029,7 +1031,7 @@ def get_flydsl_mxfp8_template_kwargs(
         or scale_b_shape != [n, k // 32]
         or out_shape != [m, n]
     ):
-        return None
+        return []
 
     a_stride = static_ints(mat_a.get_stride())
     b_stride = static_ints(mat_b.get_stride())
@@ -1043,7 +1045,7 @@ def get_flydsl_mxfp8_template_kwargs(
         or scale_b_stride != [k // 32, 1]
         or out_stride != [n, 1]
     ):
-        return None
+        return []
 
     static_int = PythonWrapperCodegen.statically_known_int_or_none
     offsets = [
@@ -1054,7 +1056,7 @@ def get_flydsl_mxfp8_template_kwargs(
         layout.offset,
     ]
     if any(static_int(offset) != 0 for offset in offsets):
-        return None
+        return []
 
     if (
         mat_a.get_dtype() != torch.float8_e4m3fn
@@ -1063,14 +1065,21 @@ def get_flydsl_mxfp8_template_kwargs(
         or scale_b.get_dtype() != torch.float8_e8m0fnu
         or layout.dtype not in (torch.bfloat16, torch.float16)
     ):
-        return None
+        return []
 
-    return {
-        "GEMM_M": m,
-        "GEMM_N": n,
-        "GEMM_K": k,
-        "OUT_DTYPE": "bfloat16" if layout.dtype == torch.bfloat16 else "float16",
-    }
+    out_dtype_name = "bfloat16" if layout.dtype == torch.bfloat16 else "float16"
+    # Config generation validates tile construction without a concrete shape;
+    # the selector drops the ones this shape cannot use before autotuning.
+    return [
+        {
+            **gemm_config,
+            "GEMM_M": m,
+            "GEMM_N": n,
+            "GEMM_K": k,
+            "OUT_DTYPE": out_dtype_name,
+        }
+        for gemm_config in get_mxfp8_gemm_configs_for_shape(m, n, k, out_dtype_name)
+    ]
 
 
 # Inductor has no template or extern choice that understands swizzled scale
@@ -1137,7 +1146,7 @@ def tuned_scaled_mm_v2(
             mat2_idx=1,
             out_dtype=out_dtype,
         )
-        mxfp8_kwargs = get_flydsl_mxfp8_template_kwargs(
+        mxfp8_configs = get_flydsl_mxfp8_template_kwargs(
             mxfp8_layout,
             mxfp8_a,
             mxfp8_b,
@@ -1145,7 +1154,7 @@ def tuned_scaled_mm_v2(
             mxfp8_scale_b,
         )
         mxfp8_choices: list[ChoiceCaller] = []
-        if mxfp8_kwargs is not None:
+        for mxfp8_kwargs in mxfp8_configs:
             flydsl_mxfp8_scaled_mm_template.maybe_append_choice(
                 mxfp8_choices,
                 input_nodes=list(mxfp8_kernel_inputs.nodes()),

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -53,7 +53,7 @@ from ..utils import (
     use_cpp_gemm_template,
     use_cutlass_template,
     use_decompose_k_choice,
-    use_flydsl_mxfp8_template,
+    use_flydsl_scaled_mm_template,
     use_nv_universal_gemm_template,
     use_triton_blackwell_tma_template,
     use_triton_scaling_template,
@@ -131,6 +131,10 @@ scaled_mm_device_tma_main_loop_scaling_template = TritonTemplate(
 flydsl_mxfp8_scaled_mm_template = FlyDSLTemplate(
     name="scaled_mm_mxfp8_flydsl",
     source=load_kernel_template("flydsl_mxfp8_scaled_mm"),
+)
+flydsl_mxfp4_scaled_mm_template = FlyDSLTemplate(
+    name="scaled_mm_mxfp4_flydsl",
+    source=load_kernel_template("flydsl_mxfp4_scaled_mm"),
 )
 
 blackwell_ws_persistent_device_tma_mm_template = TritonTemplate(
@@ -992,7 +996,7 @@ def get_flydsl_mxfp8_template_kwargs(
     """Return shape-compatible gfx950 MXFP8 template configurations."""
     from ..heuristics.template.flydsl import get_mxfp8_gemm_configs_for_shape
 
-    if not use_flydsl_mxfp8_template(layout):
+    if not use_flydsl_scaled_mm_template(layout):
         return []
 
     nodes = (mat_a, mat_b, scale_a, scale_b)
@@ -1082,6 +1086,142 @@ def get_flydsl_mxfp8_template_kwargs(
     ]
 
 
+def _is_rocm_mxfp4_v2_candidate(
+    mat_a: Any,
+    mat_b: Any,
+    scale_a: list[Any],
+    recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[Any],
+    recipe_b: list[int],
+    swizzle_b: list[int],
+    bias: Any,
+    out_dtype: torch.dtype | None,
+    contraction_dim: list[int] | None,
+    use_fast_accum: bool,
+) -> bool:
+    return (
+        torch.version.hip is not None
+        and len(scale_a) == 1
+        and len(scale_b) == 1
+        and recipe_a == [ScalingType.BlockWise1x32.value]
+        and recipe_b == [ScalingType.BlockWise1x32.value]
+        and swizzle_a == [SwizzleType.NO_SWIZZLE.value]
+        and swizzle_b == [SwizzleType.NO_SWIZZLE.value]
+        and mat_a.get_dtype() == torch.float4_e2m1fn_x2
+        and mat_b.get_dtype() == torch.float4_e2m1fn_x2
+        and scale_a[0].get_dtype() == torch.float8_e8m0fnu
+        and scale_b[0].get_dtype() == torch.float8_e8m0fnu
+        and bias is None
+        and out_dtype in (torch.bfloat16, torch.float16)
+        and not contraction_dim
+        and use_fast_accum is False
+    )
+
+
+def get_flydsl_mxfp4_template_kwargs(
+    layout: Layout,
+    mat_a: Any,
+    mat_b: Any,
+    scale_a: Any,
+    scale_b: Any,
+) -> list[dict[str, Any]]:
+    """Return shape-compatible gfx950 MXFP4 template configurations."""
+    from ..heuristics.template.flydsl import get_mxfp4_gemm_configs_for_shape
+
+    if not use_flydsl_scaled_mm_template(layout):
+        return []
+
+    nodes = (mat_a, mat_b, scale_a, scale_b)
+    if any(node.get_device() != layout.device for node in nodes):
+        return []
+
+    if is_unaligned(mat_a) or is_unaligned(mat_b):
+        return []
+
+    if any(len(node.get_size()) != 2 for node in nodes):
+        return []
+
+    static_ints = PythonWrapperCodegen.statically_known_list_of_ints_or_none
+    a_shape = static_ints(mat_a.get_size())
+    b_shape = static_ints(mat_b.get_size())
+    scale_a_shape = static_ints(scale_a.get_size())
+    scale_b_shape = static_ints(scale_b.get_size())
+    out_shape = static_ints(layout.size)
+    if any(
+        shape is None
+        for shape in (a_shape, b_shape, scale_a_shape, scale_b_shape, out_shape)
+    ):
+        return []
+
+    # Two E2M1 codes share a byte, so the operands report half the contraction
+    # length. Everything below, and the kernel itself, works in elements.
+    m, k_packed = a_shape
+    b_k_packed, n = b_shape
+    k = 2 * k_packed
+    if (
+        m <= 0
+        or n <= 0
+        or k_packed <= 0
+        or b_k_packed != k_packed
+        or m % 32 != 0
+        or n % 32 != 0
+        or k % 128 != 0
+        or scale_a_shape != [m, k // 32]
+        or scale_b_shape != [n, k // 32]
+        or out_shape != [m, n]
+    ):
+        return []
+
+    a_stride = static_ints(mat_a.get_stride())
+    b_stride = static_ints(mat_b.get_stride())
+    scale_a_stride = static_ints(scale_a.get_stride())
+    scale_b_stride = static_ints(scale_b.get_stride())
+    out_stride = static_ints(layout.stride)
+    if (
+        a_stride != [k_packed, 1]
+        or b_stride != [1, k_packed]
+        or scale_a_stride != [k // 32, 1]
+        or scale_b_stride != [k // 32, 1]
+        or out_stride != [n, 1]
+    ):
+        return []
+
+    static_int = PythonWrapperCodegen.statically_known_int_or_none
+    offsets = [
+        mat_a.get_layout().offset,
+        mat_b.get_layout().offset,
+        scale_a.get_layout().offset,
+        scale_b.get_layout().offset,
+        layout.offset,
+    ]
+    if any(static_int(offset) != 0 for offset in offsets):
+        return []
+
+    if (
+        mat_a.get_dtype() != torch.float4_e2m1fn_x2
+        or mat_b.get_dtype() != torch.float4_e2m1fn_x2
+        or scale_a.get_dtype() != torch.float8_e8m0fnu
+        or scale_b.get_dtype() != torch.float8_e8m0fnu
+        or layout.dtype not in (torch.bfloat16, torch.float16)
+    ):
+        return []
+
+    out_dtype_name = "bfloat16" if layout.dtype == torch.bfloat16 else "float16"
+    # Config generation validates tile construction without a concrete shape;
+    # the selector drops the ones this shape cannot use before autotuning.
+    return [
+        {
+            **gemm_config,
+            "GEMM_M": m,
+            "GEMM_N": n,
+            "GEMM_K": k,
+            "OUT_DTYPE": out_dtype_name,
+        }
+        for gemm_config in get_mxfp4_gemm_configs_for_shape(m, n, k, out_dtype_name)
+    ]
+
+
 # Inductor has no template or extern choice that understands swizzled scale
 # layouts for _scaled_mm_v2 yet; defer those to the eager op. add_to_fallback_set
 # is False because this handler is invoked manually from the lowering below, not
@@ -1115,6 +1255,77 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+
+    if _is_rocm_mxfp4_v2_candidate(
+        mat_a,
+        mat_b,
+        scale_a,
+        recipe_a,
+        swizzle_a,
+        scale_b,
+        recipe_b,
+        swizzle_b,
+        bias,
+        out_dtype,
+        contraction_dim,
+        use_fast_accum,
+    ):
+        m, n, k, mxfp4_layout, mxfp4_a, mxfp4_b = mm_args(
+            mat_a, mat_b, layout=layout, out_dtype=out_dtype
+        )
+        mxfp4_scale_a, mxfp4_scale_b = realize_inputs(scale_a[0], scale_b[0])
+        mxfp4_input_nodes = [
+            mxfp4_a,
+            mxfp4_b,
+            mxfp4_scale_a,
+            mxfp4_scale_b,
+        ]
+        mxfp4_kernel_inputs = MMKernelInputs(
+            mxfp4_input_nodes,
+            mat1_idx=0,
+            mat2_idx=1,
+            out_dtype=out_dtype,
+        )
+        mxfp4_configs = get_flydsl_mxfp4_template_kwargs(
+            mxfp4_layout,
+            mxfp4_a,
+            mxfp4_b,
+            mxfp4_scale_a,
+            mxfp4_scale_b,
+        )
+        mxfp4_choices: list[ChoiceCaller] = []
+        for mxfp4_kwargs in mxfp4_configs:
+            flydsl_mxfp4_scaled_mm_template.maybe_append_choice(
+                mxfp4_choices,
+                input_nodes=list(mxfp4_kernel_inputs.nodes()),
+                layout=mxfp4_layout,
+                **mxfp4_kwargs,
+            )
+        if mxfp4_choices:
+            counters["aten_mm_info"][f"aten._scaled_mm_v2.default_{m}_{n}_{k}"] += 1
+            node, _ = autotune_select_algorithm(
+                "scaled_mm",
+                mxfp4_choices,
+                mxfp4_kernel_inputs.nodes(),
+                mxfp4_layout,
+            )
+            return node
+
+        fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
+        return scaled_mm_v2_fallback(
+            mat_a,
+            mat_b,
+            scale_a,
+            recipe_a,
+            swizzle_a,
+            scale_b,
+            recipe_b,
+            swizzle_b,
+            bias,
+            out_dtype,
+            fallback_contraction_dim,
+            use_fast_accum,
+        )
 
     if _is_rocm_mxfp8_v2_candidate(
         mat_a,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -16,16 +16,18 @@ from torch._inductor.codegen.cpp_gemm_template import CppGemmTemplate
 from torch._inductor.remote_gemm_autotune_cache import gen_best_config
 from torch._inductor.virtualized import ops, V
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.nn.functional import ScalingType  # type: ignore[attr-defined]
+from torch.nn.functional import ScalingType, SwizzleType  # type: ignore[attr-defined]
 from torch.torch_version import TorchVersion
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config as inductor_config, distributed_autotune, lowering as L
 from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemmTemplate
+from ..codegen.flydsl.flydsl_template import FlyDSLTemplate
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
-from ..ir import Buffer, ChoiceCaller, is_triton, Layout
+from ..codegen.wrapper import PythonWrapperCodegen
+from ..ir import Buffer, ChoiceCaller, is_triton, is_unaligned, Layout
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import (
     fallback_handler,
@@ -51,6 +53,7 @@ from ..utils import (
     use_cpp_gemm_template,
     use_cutlass_template,
     use_decompose_k_choice,
+    use_flydsl_mxfp8_template,
     use_nv_universal_gemm_template,
     use_triton_blackwell_tma_template,
     use_triton_scaling_template,
@@ -123,6 +126,11 @@ scaled_mm_device_tma_main_loop_scaling_template = TritonTemplate(
     name="scaled_mm_device_tma_main_loop_scaling",
     grid=persistent_mm_grid,
     source=load_kernel_template("triton_main_loop_scaled_mm"),
+)
+
+flydsl_mxfp8_scaled_mm_template = FlyDSLTemplate(
+    name="scaled_mm_mxfp8_flydsl",
+    source=load_kernel_template("flydsl_mxfp8_scaled_mm"),
 )
 
 blackwell_ws_persistent_device_tma_mm_template = TritonTemplate(
@@ -941,6 +949,130 @@ def get_scaling_options(
     )  # verify that shapes are supported by at least one existing pairing
 
 
+def _is_rocm_mxfp8_v2_candidate(
+    mat_a: Any,
+    mat_b: Any,
+    scale_a: list[Any],
+    recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[Any],
+    recipe_b: list[int],
+    swizzle_b: list[int],
+    bias: Any,
+    out_dtype: torch.dtype | None,
+    contraction_dim: list[int] | None,
+    use_fast_accum: bool,
+) -> bool:
+    return (
+        torch.version.hip is not None
+        and len(scale_a) == 1
+        and len(scale_b) == 1
+        and recipe_a == [ScalingType.BlockWise1x32.value]
+        and recipe_b == [ScalingType.BlockWise1x32.value]
+        and swizzle_a == [SwizzleType.NO_SWIZZLE.value]
+        and swizzle_b == [SwizzleType.NO_SWIZZLE.value]
+        and mat_a.get_dtype() == torch.float8_e4m3fn
+        and mat_b.get_dtype() == torch.float8_e4m3fn
+        and scale_a[0].get_dtype() == torch.float8_e8m0fnu
+        and scale_b[0].get_dtype() == torch.float8_e8m0fnu
+        and bias is None
+        and out_dtype in (torch.bfloat16, torch.float16)
+        and not contraction_dim
+        and use_fast_accum is False
+    )
+
+
+def get_flydsl_mxfp8_template_kwargs(
+    layout: Layout,
+    mat_a: Any,
+    mat_b: Any,
+    scale_a: Any,
+    scale_b: Any,
+) -> dict[str, Any] | None:
+    """Return one correctness-first gfx950 MXFP8 template configuration."""
+    if not use_flydsl_mxfp8_template(layout):
+        return None
+
+    nodes = (mat_a, mat_b, scale_a, scale_b)
+    if any(node.get_device() != layout.device for node in nodes):
+        return None
+
+    if is_unaligned(mat_a) or is_unaligned(mat_b):
+        return None
+
+    if any(len(node.get_size()) != 2 for node in nodes):
+        return None
+
+    static_ints = PythonWrapperCodegen.statically_known_list_of_ints_or_none
+    a_shape = static_ints(mat_a.get_size())
+    b_shape = static_ints(mat_b.get_size())
+    scale_a_shape = static_ints(scale_a.get_size())
+    scale_b_shape = static_ints(scale_b.get_size())
+    out_shape = static_ints(layout.size)
+    if any(
+        shape is None
+        for shape in (a_shape, b_shape, scale_a_shape, scale_b_shape, out_shape)
+    ):
+        return None
+
+    m, k = a_shape
+    b_k, n = b_shape
+    if (
+        m <= 0
+        or n <= 0
+        or k <= 0
+        or b_k != k
+        or m % 32 != 0
+        or n % 32 != 0
+        or k % 128 != 0
+        or scale_a_shape != [m, k // 32]
+        or scale_b_shape != [n, k // 32]
+        or out_shape != [m, n]
+    ):
+        return None
+
+    a_stride = static_ints(mat_a.get_stride())
+    b_stride = static_ints(mat_b.get_stride())
+    scale_a_stride = static_ints(scale_a.get_stride())
+    scale_b_stride = static_ints(scale_b.get_stride())
+    out_stride = static_ints(layout.stride)
+    if (
+        a_stride != [k, 1]
+        or b_stride != [1, k]
+        or scale_a_stride != [k // 32, 1]
+        or scale_b_stride != [k // 32, 1]
+        or out_stride != [n, 1]
+    ):
+        return None
+
+    static_int = PythonWrapperCodegen.statically_known_int_or_none
+    offsets = [
+        mat_a.get_layout().offset,
+        mat_b.get_layout().offset,
+        scale_a.get_layout().offset,
+        scale_b.get_layout().offset,
+        layout.offset,
+    ]
+    if any(static_int(offset) != 0 for offset in offsets):
+        return None
+
+    if (
+        mat_a.get_dtype() != torch.float8_e4m3fn
+        or mat_b.get_dtype() != torch.float8_e4m3fn
+        or scale_a.get_dtype() != torch.float8_e8m0fnu
+        or scale_b.get_dtype() != torch.float8_e8m0fnu
+        or layout.dtype not in (torch.bfloat16, torch.float16)
+    ):
+        return None
+
+    return {
+        "GEMM_M": m,
+        "GEMM_N": n,
+        "GEMM_K": k,
+        "OUT_DTYPE": "bfloat16" if layout.dtype == torch.bfloat16 else "float16",
+    }
+
+
 # Inductor has no template or extern choice that understands swizzled scale
 # layouts for _scaled_mm_v2 yet; defer those to the eager op. add_to_fallback_set
 # is False because this handler is invoked manually from the lowering below, not
@@ -974,6 +1106,77 @@ def tuned_scaled_mm_v2(
     swizzle patterns alongside the scale tensors, and supports multi-level
     scaling via lists.
     """
+
+    if _is_rocm_mxfp8_v2_candidate(
+        mat_a,
+        mat_b,
+        scale_a,
+        recipe_a,
+        swizzle_a,
+        scale_b,
+        recipe_b,
+        swizzle_b,
+        bias,
+        out_dtype,
+        contraction_dim,
+        use_fast_accum,
+    ):
+        m, n, k, mxfp8_layout, mxfp8_a, mxfp8_b = mm_args(
+            mat_a, mat_b, layout=layout, out_dtype=out_dtype
+        )
+        mxfp8_scale_a, mxfp8_scale_b = realize_inputs(scale_a[0], scale_b[0])
+        mxfp8_input_nodes = [
+            mxfp8_a,
+            mxfp8_b,
+            mxfp8_scale_a,
+            mxfp8_scale_b,
+        ]
+        mxfp8_kernel_inputs = MMKernelInputs(
+            mxfp8_input_nodes,
+            mat1_idx=0,
+            mat2_idx=1,
+            out_dtype=out_dtype,
+        )
+        mxfp8_kwargs = get_flydsl_mxfp8_template_kwargs(
+            mxfp8_layout,
+            mxfp8_a,
+            mxfp8_b,
+            mxfp8_scale_a,
+            mxfp8_scale_b,
+        )
+        mxfp8_choices: list[ChoiceCaller] = []
+        if mxfp8_kwargs is not None:
+            flydsl_mxfp8_scaled_mm_template.maybe_append_choice(
+                mxfp8_choices,
+                input_nodes=list(mxfp8_kernel_inputs.nodes()),
+                layout=mxfp8_layout,
+                **mxfp8_kwargs,
+            )
+        if mxfp8_choices:
+            counters["aten_mm_info"][f"aten._scaled_mm_v2.default_{m}_{n}_{k}"] += 1
+            node, _ = autotune_select_algorithm(
+                "scaled_mm",
+                mxfp8_choices,
+                mxfp8_kernel_inputs.nodes(),
+                mxfp8_layout,
+            )
+            return node
+
+        fallback_contraction_dim = [] if contraction_dim is None else contraction_dim
+        return scaled_mm_v2_fallback(
+            mat_a,
+            mat_b,
+            scale_a,
+            recipe_a,
+            swizzle_a,
+            scale_b,
+            recipe_b,
+            swizzle_b,
+            bias,
+            out_dtype,
+            fallback_contraction_dim,
+            use_fast_accum,
+        )
 
     # Inductor only has Triton/extern lowerings for single-level, fp32-scaled,
     # non-swizzled _scaled_mm_v2 with the "supported" recipes (TensorWise,

--- a/torch/_inductor/kernel/templates/flydsl_mxfp4_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp4_scaled_mm.py.jinja
@@ -1,0 +1,169 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_mxfp4_gfx950 import (
+    make_mxfp4_scaled_mm_gfx950,
+    MXFP4GemmParams,
+)
+from torch._inductor.runtime.flydsl_cache import (
+    ensure_flydsl_cache_dir,
+    run_cached_flydsl,
+)
+
+{{gen_defines()}}
+
+
+# GEMM_K is the logical contraction length in E2M1 elements; the operand
+# tensors report half that along K because two codes share a byte.
+_mxfp4_param = MXFP4GemmParams(
+    m=GEMM_M,
+    n=GEMM_N,
+    k=GEMM_K,
+    out_dtype=OUT_DTYPE,
+    block_m=TILE_M,
+    block_n=TILE_N,
+    block_k=TILE_K,
+    stages=STAGES,
+    m_waves=BLOCK_M_WARPS,
+    n_waves=BLOCK_N_WARPS,
+    group_m=GROUP_M,
+)
+_mxfp4_launcher = make_mxfp4_scaled_mm_gfx950(
+    m=GEMM_M,
+    n=GEMM_N,
+    k=GEMM_K,
+    out_dtype=OUT_DTYPE,
+    block_m=TILE_M,
+    block_n=TILE_N,
+    block_k=TILE_K,
+    stages=STAGES,
+    m_waves=BLOCK_M_WARPS,
+    n_waves=BLOCK_N_WARPS,
+    group_m=GROUP_M,
+)
+_mxfp4_executor = None
+_mxfp4_init_lock = threading.Lock()
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+{{def_kernel("mat1", "mat2", "scale_a", "scale_b")}}
+    output = {{get_output()}}
+    # The API RHS is [K // 2, N] column-major. Its transpose is a zero-copy
+    # [N, K // 2] row-major view, which is the storage order consumed by the
+    # kernel. FlyDSL sees the packed operands as plain bytes; only the MFMA atom
+    # knows they hold two E2M1 codes each.
+    mat2_nk = mat2.transpose(0, 1)
+    mat1_u8 = mat1.view(torch.uint8)
+    mat2_nk_u8 = mat2_nk.view(torch.uint8)
+    scale_a_u8 = scale_a.view(torch.uint8)
+    scale_b_u8 = scale_b.view(torch.uint8)
+
+    global _mxfp4_executor
+    executor = _mxfp4_executor
+    if executor is not None:
+        executor(mat1_u8, mat2_nk_u8, scale_a_u8, scale_b_u8, output, stream)
+        return output
+
+    with _mxfp4_init_lock:
+        executor = _mxfp4_executor
+        if executor is None:
+            ensure_flydsl_cache_dir()
+            compile_args = (
+                _inductor_tensor_arg(mat1_u8),
+                _inductor_tensor_arg(mat2_nk_u8),
+                _inductor_tensor_arg(scale_a_u8),
+                _inductor_tensor_arg(scale_b_u8),
+                _inductor_tensor_arg(output),
+                stream,
+            )
+            if os.environ.get("COMPILE_ONLY"):
+                flyc.compile(_mxfp4_launcher, *compile_args)
+            else:
+                executor = run_cached_flydsl(
+                    _mxfp4_launcher,
+                    *compile_args,
+                    constexpr_param=_mxfp4_param,
+                    compiler=flyc.compile,
+                    dispatch_args=(
+                        mat1_u8,
+                        mat2_nk_u8,
+                        scale_a_u8,
+                        scale_b_u8,
+                        output,
+                        stream,
+                    ),
+                )
+                _mxfp4_executor = executor
+            return output
+
+    executor(mat1_u8, mat2_nk_u8, scale_a_u8, scale_b_u8, output, stream)
+    return output
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm the FlyDSL disk cache using metadata-only fake tensors."""
+    del device_index, device_capability
+
+    env_updates = {"COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+
+            def _fake_proxy(name):
+                return torch.empty_strided(
+                    tuple(precompile_shapes[name]),
+                    tuple(precompile_strides[name]),
+                    dtype=getattr(torch, precompile_dtypes[name]),
+                    device="cpu",
+                )
+
+            mat1 = _fake_proxy("mat1")
+            mat2 = _fake_proxy("mat2")
+            scale_a = _fake_proxy("scale_a")
+            scale_b = _fake_proxy("scale_b")
+            output = _fake_proxy("output")
+
+            try:
+                {{kernel_name}}_main(
+                    mat1,
+                    mat2,
+                    scale_a,
+                    scale_b,
+                    output,
+                    stream=0,
+                )
+            finally:
+                global _mxfp4_executor
+                with _mxfp4_init_lock:
+                    _mxfp4_executor = None

--- a/torch/_inductor/kernel/templates/flydsl_mxfp4_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp4_scaled_mm.py.jinja
@@ -28,6 +28,7 @@ _mxfp4_param = MXFP4GemmParams(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
+    lds_scale=LDS_SCALE,
 )
 _mxfp4_launcher = make_mxfp4_scaled_mm_gfx950(
     m=GEMM_M,
@@ -41,6 +42,7 @@ _mxfp4_launcher = make_mxfp4_scaled_mm_gfx950(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
+    lds_scale=LDS_SCALE,
 )
 _mxfp4_executor = None
 _mxfp4_init_lock = threading.Lock()

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
@@ -26,7 +26,6 @@ _mxfp8_param = MXFP8GemmParams(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
-    frag_first=FRAG_FIRST,
 )
 _mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
     m=GEMM_M,
@@ -40,7 +39,6 @@ _mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
-    frag_first=FRAG_FIRST,
 )
 _mxfp8_executor = None
 _mxfp8_init_lock = threading.Lock()

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
@@ -14,12 +14,31 @@ from torch._inductor.runtime.flydsl_cache import (
 {{gen_defines()}}
 
 
-_mxfp8_param = MXFP8GemmParams(GEMM_M, GEMM_N, GEMM_K, OUT_DTYPE)
+_mxfp8_param = MXFP8GemmParams(
+    m=GEMM_M,
+    n=GEMM_N,
+    k=GEMM_K,
+    out_dtype=OUT_DTYPE,
+    block_m=TILE_M,
+    block_n=TILE_N,
+    block_k=TILE_K,
+    stages=STAGES,
+    m_waves=BLOCK_M_WARPS,
+    n_waves=BLOCK_N_WARPS,
+    group_m=GROUP_M,
+)
 _mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
     m=GEMM_M,
     n=GEMM_N,
     k=GEMM_K,
     out_dtype=OUT_DTYPE,
+    block_m=TILE_M,
+    block_n=TILE_N,
+    block_k=TILE_K,
+    stages=STAGES,
+    m_waves=BLOCK_M_WARPS,
+    n_waves=BLOCK_N_WARPS,
+    group_m=GROUP_M,
 )
 _mxfp8_executor = None
 _mxfp8_init_lock = threading.Lock()

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
@@ -1,0 +1,144 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_mxfp8_gfx950 import (
+    MXFP8GemmParams,
+    make_mxfp8_scaled_mm_gfx950,
+)
+from torch._inductor.runtime.flydsl_cache import (
+    ensure_flydsl_cache_dir,
+    run_cached_flydsl,
+)
+
+{{gen_defines()}}
+
+
+_mxfp8_param = MXFP8GemmParams(GEMM_M, GEMM_N, GEMM_K, OUT_DTYPE)
+_mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
+    m=GEMM_M,
+    n=GEMM_N,
+    k=GEMM_K,
+    out_dtype=OUT_DTYPE,
+)
+_mxfp8_executor = None
+_mxfp8_init_lock = threading.Lock()
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+{{def_kernel("mat1", "mat2", "scale_a", "scale_b")}}
+    output = {{get_output()}}
+    # The API RHS is [K, N] column-major. Its transpose is a zero-copy [N, K]
+    # row-major view, which is the storage order consumed by the kernel.
+    mat2_nk = mat2.transpose(0, 1)
+    scale_a_u8 = scale_a.view(torch.uint8)
+    scale_b_u8 = scale_b.view(torch.uint8)
+
+    global _mxfp8_executor
+    executor = _mxfp8_executor
+    if executor is not None:
+        executor(mat1, mat2_nk, scale_a_u8, scale_b_u8, output, stream)
+        return output
+
+    with _mxfp8_init_lock:
+        executor = _mxfp8_executor
+        if executor is None:
+            ensure_flydsl_cache_dir()
+            compile_args = (
+                _inductor_tensor_arg(mat1),
+                _inductor_tensor_arg(mat2_nk),
+                _inductor_tensor_arg(scale_a_u8),
+                _inductor_tensor_arg(scale_b_u8),
+                _inductor_tensor_arg(output),
+                stream,
+            )
+            if os.environ.get("COMPILE_ONLY"):
+                flyc.compile(_mxfp8_launcher, *compile_args)
+            else:
+                executor = run_cached_flydsl(
+                    _mxfp8_launcher,
+                    *compile_args,
+                    constexpr_param=_mxfp8_param,
+                    compiler=flyc.compile,
+                    dispatch_args=(
+                        mat1,
+                        mat2_nk,
+                        scale_a_u8,
+                        scale_b_u8,
+                        output,
+                        stream,
+                    ),
+                )
+                _mxfp8_executor = executor
+            return output
+
+    executor(mat1, mat2_nk, scale_a_u8, scale_b_u8, output, stream)
+    return output
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm the FlyDSL disk cache using metadata-only fake tensors."""
+    del device_index, device_capability
+
+    env_updates = {"COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+
+            def _fake_proxy(name):
+                return torch.empty_strided(
+                    tuple(precompile_shapes[name]),
+                    tuple(precompile_strides[name]),
+                    dtype=getattr(torch, precompile_dtypes[name]),
+                    device="cpu",
+                )
+
+            mat1 = _fake_proxy("mat1")
+            mat2 = _fake_proxy("mat2")
+            scale_a = _fake_proxy("scale_a")
+            scale_b = _fake_proxy("scale_b")
+            output = _fake_proxy("output")
+
+            try:
+                {{kernel_name}}_main(
+                    mat1,
+                    mat2,
+                    scale_a,
+                    scale_b,
+                    output,
+                    stream=0,
+                )
+            finally:
+                global _mxfp8_executor
+                with _mxfp8_init_lock:
+                    _mxfp8_executor = None

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_scaled_mm.py.jinja
@@ -26,6 +26,7 @@ _mxfp8_param = MXFP8GemmParams(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
+    frag_first=FRAG_FIRST,
 )
 _mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
     m=GEMM_M,
@@ -39,6 +40,7 @@ _mxfp8_launcher = make_mxfp8_scaled_mm_gfx950(
     m_waves=BLOCK_M_WARPS,
     n_waves=BLOCK_N_WARPS,
     group_m=GROUP_M,
+    frag_first=FRAG_FIRST,
 )
 _mxfp8_executor = None
 _mxfp8_init_lock = threading.Lock()

--- a/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored FlyDSL kernels used by TorchInductor templates."""

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -4,7 +4,12 @@ import importlib
 from typing import Any
 
 
-__all__ = ["make_mxfp8_scaled_mm_gfx950"]
+__all__ = [
+    "MXFP8GemmParams",
+    "make_mxfp8_param_and_validate",
+    "make_mxfp8_scaled_mm_gfx950",
+    "mxfp8_gemm_derived",
+]
 
 
 def __getattr__(name: str) -> Any:

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,0 +1,17 @@
+"""Lazy exports for optional FlyDSL vendored kernels."""
+
+import importlib
+from typing import Any
+
+
+__all__ = ["make_mxfp8_scaled_mm_gfx950"]
+
+
+def __getattr__(name: str) -> Any:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = importlib.import_module(f"{__name__}.gemm_mxfp8_gfx950")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -4,19 +4,25 @@ import importlib
 from typing import Any
 
 
-__all__ = [
-    "MXFP8GemmParams",
-    "make_mxfp8_param_and_validate",
-    "make_mxfp8_scaled_mm_gfx950",
-    "mxfp8_gemm_derived",
-]
+_MODULE_BY_NAME = {
+    "MXFP4GemmParams": "gemm_mxfp4_gfx950",
+    "make_mxfp4_param_and_validate": "gemm_mxfp4_gfx950",
+    "make_mxfp4_scaled_mm_gfx950": "gemm_mxfp4_gfx950",
+    "mxfp4_gemm_derived": "gemm_mxfp4_gfx950",
+    "MXFP8GemmParams": "gemm_mxfp8_gfx950",
+    "make_mxfp8_param_and_validate": "gemm_mxfp8_gfx950",
+    "make_mxfp8_scaled_mm_gfx950": "gemm_mxfp8_gfx950",
+    "mxfp8_gemm_derived": "gemm_mxfp8_gfx950",
+}
+
+__all__ = list(_MODULE_BY_NAME)
 
 
 def __getattr__(name: str) -> Any:
-    if name not in __all__:
+    if name not in _MODULE_BY_NAME:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    module = importlib.import_module(f"{__name__}.gemm_mxfp8_gfx950")
+    module = importlib.import_module(f"{__name__}.{_MODULE_BY_NAME[name]}")
     value = getattr(module, name)
     globals()[name] = value
     return value

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
@@ -1,0 +1,1108 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tile/Layout gfx950 MXFP4 scaled GEMM.
+
+E2M1 operands use per-32-element E8M0 block scales in CDNA4 scaled 16x16x128
+MFMA instructions. A is [M, K], B is [N, K], and both are row-major over K.
+Two E2M1 codes share a byte, so every LDS and global address is in bytes while
+every MFMA and scale index is in elements; the two units are kept in separate
+names throughout (block_k vs block_k_bytes) rather than being allowed to alias
+as they do in the MXFP8 kernel, where the element is a byte.
+
+TiledMma and TiledCopy describe wave, fragment, and output ownership;
+target-specific direct-to-LDS DMA and the staged waitcnt pipeline remain
+explicit.
+"""
+
+import functools
+from dataclasses import dataclass
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, rocdl as _rocdl_ops
+from flydsl.expr import const_expr, range_constexpr, rocdl
+
+from torch.utils._ordered_set import OrderedSet
+
+
+def _permlane_swap(width, old, src):
+    """v_permlane{16,32}_swap_b32 -> (new_old, new_src) as i32 IR values.
+
+    Both operands are read-modify-write: the instruction exchanges row groups
+    between them and returns both halves. width=32 swaps rows 2,3 of `old` with
+    rows 0,1 of `src`; width=16 swaps the odd rows of `old` with the even rows
+    of `src`.
+    """
+    i32 = ir.IntegerType.get_signless(32)
+    sty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+    fn = _rocdl_ops.permlane16_swap if width == 16 else _rocdl_ops.permlane32_swap
+    res = fn(sty, fx.as_ir_value(old), fx.as_ir_value(src), False, False)
+    return llvm.extractvalue(i32, res, [0]), llvm.extractvalue(i32, res, [1])
+
+
+MXFP4_SCALE_BLOCK_K = 32
+MXFP4_MFMA_M = 16
+MXFP4_MFMA_N = 16
+MXFP4_MFMA_K = 128
+# Two E2M1 codes per storage byte. This is the only source of the byte/element
+# split; everywhere a quantity is derived from block_k it has to say which one
+# it means.
+MXFP4_ELEMS_PER_BYTE = 2
+GFX950_WAVE_SIZE = 64
+GFX950_DMA_BYTES = 16
+GFX950_LDS_CAPACITY = 163840
+GFX950_NUM_XCD = 8
+GFX950_MAX_BLOCK_THREADS = 1024
+# The accumulator, not the fragment, bounds register blocking: a wave holds
+# 4 * m_repeat * n_repeat accumulator VGPRs regardless of the operand format,
+# and 8x8 alone would be 256. Halving the operand width therefore does not
+# raise this cap above the value the MXFP8 kernel settled on.
+MXFP4_MAX_MMA_REPEAT = 8
+
+
+@dataclass(frozen=True)
+class MXFP4GemmParams:
+    """Compile-time identity of one specialized MXFP4 kernel.
+
+    block_k is in *elements*; the LDS row is block_k // 2 bytes wide.
+    """
+
+    m: int
+    n: int
+    k: int
+    out_dtype: str
+    block_m: int = 128
+    block_n: int = 128
+    block_k: int = 256
+    stages: int = 2
+    m_waves: int = 2
+    n_waves: int = 2
+    group_m: int = 0
+    # Asymmetric LDS: A and B may hold a different number of staged buffers.
+    # None means "same as stages", which reproduces the symmetric kernel.
+    stages_a: int = None
+    stages_b: int = None
+
+    def __cache_signature__(self):
+        return (
+            "mxfp4_gfx950_v1",
+            self.m,
+            self.n,
+            self.k,
+            self.out_dtype,
+            self.block_m,
+            self.block_n,
+            self.block_k,
+            self.stages,
+            self.m_waves,
+            self.n_waves,
+            self.group_m,
+            self.stages_a,
+            self.stages_b,
+        )
+
+
+@dataclass(frozen=True)
+class MXFP4GemmDerived:
+    """Quantities derived from a tile config, shared by the kernel and the
+    heuristics filter so the two can never disagree."""
+
+    block_threads: int
+    block_k_bytes: int
+    mma_m_repeat: int
+    mma_n_repeat: int
+    k_halves: int
+    granules_per_row: int
+    ldg_a_iters: int
+    ldg_b_iters: int
+    ldg_wait_count: int
+    a_stage_bytes: int
+    b_stage_bytes: int
+    smem_bytes: int
+    stages_a: int
+    stages_b: int
+
+
+def mxfp4_pipeline_schedule(k_tiles, stages_a, stages_b, ldg_a_iters, ldg_b_iters):
+    """Program-order DMA schedule for an (stages_a, stages_b) LDS pipeline.
+
+    Returns (main_loop_end, steady_wait, tail_waits, wrap_a, wrap_b).
+
+    A is prefetched da = stages_a - 1 tiles ahead, B is prefetched
+    db = stages_b - 1 tiles ahead. Iteration i issues A(i + da) then B(i + db);
+    the prologue is iterations i in [-max(da, db), 0).
+
+    The main loop always issues both operands so its body is one straight-line
+    block with one wait constant. That means iterations near the end would run
+    off the end of K, so the *tile index* of those loads is wrapped modulo
+    k_tiles: they stay in bounds, land in an LDS buffer no later iteration
+    reads, and are never consumed. Only their vmcnt slot matters, and it is
+    accounted for below. The consequence is that exactly ONE tile is peeled as
+    a drain, instead of max(da, db) of them.
+
+    vmcnt is an in-order counter, so the barrier at the top of iteration kt may
+    leave outstanding exactly the loads issued *after* the producer of the
+    later of A_kt / B_kt. That count is enumerated here rather than given in
+    closed form, because with da != db the "later of the two" is not always
+    the same operand.
+
+    This function is byte- and element-agnostic: it only counts load
+    instructions, so it is identical to the MXFP8 kernel's.
+    """
+    da = stages_a - 1
+    db = stages_b - 1
+    deepest = max(da, db)
+    main_loop_end = k_tiles - 1
+    if k_tiles <= deepest:
+        raise ValueError("K must supply more tiles than the deepest prefetch")
+    # A wrapped load must not land on a buffer a later iteration still reads.
+    # Issuing iteration i still has tiles i .. k_tiles-1 to consume, i.e. buffer
+    # offsets 0 .. k_tiles-1-i <= d-1 ahead of it, while the wrapped write sits
+    # d ahead; with d = stages - 1 < stages the two never alias.
+    for d, s in ((da, stages_a), (db, stages_b)):
+        if d >= s:
+            raise ValueError("prefetch distance must be shorter than the buffer count")
+
+    # (kind, live_tile_or_None, issuing_iteration) in program order. A wrapped
+    # load carries None: it occupies a vmcnt slot but produces nothing.
+    events = []
+    for i in range(-deepest, 0):  # prologue
+        for kind, t in (("A", i + da), ("B", i + db)):
+            if t >= 0:
+                events.append((kind, t, i))
+    for i in range(0, main_loop_end):  # steady state: both always issued
+        for kind, t in (("A", i + da), ("B", i + db)):
+            events.append((kind, t if t < k_tiles else None, i))
+    # The drain iteration (kt = k_tiles - 1) issues nothing.
+
+    cost = {"A": ldg_a_iters, "B": ldg_b_iters}
+    pos = {}
+    for idx, (kind, t, _i) in enumerate(events):
+        if t is not None:
+            pos[(kind, t)] = idx
+
+    def wait_at(kt):
+        p = max(pos[("A", kt)], pos[("B", kt)])
+        return sum(cost[kind] for kind, _t, i in events[p + 1 :] if i < kt)
+
+    waits = [wait_at(kt) for kt in range(k_tiles)]
+    steady = OrderedSet(waits[:main_loop_end])
+    if len(steady) != 1:
+        raise ValueError(f"steady-state wait is not uniform: {sorted(steady)}")
+    steady_wait = steady.pop()
+    tail_waits = waits[main_loop_end:]
+    if max(waits) >= 63:
+        raise ValueError("staged pipeline wait count exceeds supported range")
+    # Only emit the runtime wrap on the operand that can actually overrun.
+    wrap_a = (main_loop_end - 1) + da >= k_tiles
+    wrap_b = (main_loop_end - 1) + db >= k_tiles
+    return main_loop_end, steady_wait, tail_waits, wrap_a, wrap_b
+
+
+def mxfp4_gemm_derived(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    stages: int,
+    m_waves: int,
+    n_waves: int,
+    group_m: int = 0,
+    stages_a: int = None,
+    stages_b: int = None,
+    k: int = None,
+) -> MXFP4GemmDerived:
+    """Validate a tile config and return its derived quantities.
+
+    block_m, block_n, block_k and k are all in elements. Raises ValueError for
+    any config the kernel cannot express.
+
+    `k` is optional and only selects the B pipeline depth; leaving it out keeps
+    the result shape-independent, which is what the heuristics validity check
+    wants.
+    """
+    if block_m <= 0 or block_n <= 0 or block_k <= 0:
+        raise ValueError("block_m, block_n, and block_k must be positive")
+    if stages < 2:
+        raise ValueError("stages must be at least 2 for the staged LDS pipeline")
+    if stages_a is None:
+        stages_a = stages
+    if stages_a < 2 or (stages_b is not None and stages_b < 2):
+        raise ValueError("stages_a and stages_b must each be at least 2")
+    if m_waves <= 0 or n_waves <= 0:
+        raise ValueError("m_waves and n_waves must be positive")
+    if group_m < 0:
+        raise ValueError("group_m must be non-negative")
+    if block_k % MXFP4_MFMA_K != 0:
+        raise ValueError(
+            f"block_k must be a multiple of the MFMA K depth: block_k={block_k}"
+        )
+    if block_k % MXFP4_ELEMS_PER_BYTE != 0:
+        raise ValueError(f"block_k must be a whole number of bytes: block_k={block_k}")
+    block_k_bytes = block_k // MXFP4_ELEMS_PER_BYTE
+
+    block_threads = m_waves * n_waves * GFX950_WAVE_SIZE
+    if block_threads > GFX950_MAX_BLOCK_THREADS:
+        raise ValueError(f"block exceeds {GFX950_MAX_BLOCK_THREADS} threads")
+
+    wave_tile_m, rem_m = divmod(block_m, m_waves)
+    wave_tile_n, rem_n = divmod(block_n, n_waves)
+    if rem_m or rem_n:
+        raise ValueError("block_m/block_n must be divisible by m_waves/n_waves")
+
+    mma_m_repeat, rem_m = divmod(wave_tile_m, MXFP4_MFMA_M)
+    mma_n_repeat, rem_n = divmod(wave_tile_n, MXFP4_MFMA_N)
+    if rem_m or rem_n or mma_m_repeat == 0 or mma_n_repeat == 0:
+        raise ValueError(
+            "each wave tile must be a positive multiple of the 16x16 MFMA tile"
+        )
+    if mma_m_repeat > MXFP4_MAX_MMA_REPEAT or mma_n_repeat > MXFP4_MAX_MMA_REPEAT:
+        raise ValueError(
+            "accumulator repeats exceed the register budget: "
+            f"mma_m_repeat={mma_m_repeat}, mma_n_repeat={mma_n_repeat}"
+        )
+
+    granules_per_row = block_k_bytes // GFX950_DMA_BYTES
+    # The LDS layout XORs the granule index with the row, so the granule count
+    # has to be a power of two or the swizzle would leave the row.
+    if granules_per_row == 0 or granules_per_row & (granules_per_row - 1):
+        raise ValueError(
+            f"block_k / {2 * GFX950_DMA_BYTES} must be a power of two for the "
+            f"XOR swizzle: block_k={block_k}"
+        )
+
+    dma_bytes_per_pass = block_threads * GFX950_DMA_BYTES
+    if (block_m * block_k_bytes) % dma_bytes_per_pass != 0:
+        raise ValueError(
+            "A tile load schedule must exactly cover the LDS tile: "
+            f"block_m={block_m}, block_k={block_k}, block_threads={block_threads}"
+        )
+    if (block_n * block_k_bytes) % dma_bytes_per_pass != 0:
+        raise ValueError(
+            "B tile load schedule must exactly cover the LDS tile: "
+            f"block_n={block_n}, block_k={block_k}, block_threads={block_threads}"
+        )
+    ldg_a_iters = (block_m * block_k_bytes) // dma_bytes_per_pass
+    ldg_b_iters = (block_n * block_k_bytes) // dma_bytes_per_pass
+    ldg_wait_count = ldg_a_iters + ldg_b_iters
+
+    a_stage_bytes = block_m * block_k_bytes
+    b_stage_bytes = block_n * block_k_bytes
+
+    if stages_b is None:
+        # Give B one staged buffer more than A when every precondition holds.
+        # B's DMA lands last in program order, so deepening only B is what turns
+        # the K-tile boundary from a full vmcnt(0) drain into a counted wait.
+        #
+        # Every failure mode falls back to the symmetric depth rather than
+        # raising, because raising would drop a tile config that used to be
+        # valid and a shape whose autotune winner it was would silently fall
+        # back to ATen.
+        stages_b = stages
+        deeper = stages_a * a_stage_bytes + (stages + 1) * b_stage_bytes
+        deeper_ok = (
+            k is not None
+            and deeper <= GFX950_LDS_CAPACITY
+            and (max(stages_a, stages + 1) - 2) * ldg_wait_count < 63
+        )
+        if deeper_ok:
+            try:
+                mxfp4_pipeline_schedule(
+                    k // block_k, stages_a, stages + 1, ldg_a_iters, ldg_b_iters
+                )
+            except ValueError:
+                pass
+            else:
+                stages_b = stages + 1
+
+    smem_bytes = stages_a * a_stage_bytes + stages_b * b_stage_bytes
+    if smem_bytes > GFX950_LDS_CAPACITY:
+        raise ValueError(
+            "staged LDS buffers exceed the device shared-memory capacity: "
+            f"stages_a={stages_a}, stages_b={stages_b}, block_m={block_m}, "
+            f"block_n={block_n}, block_k={block_k}, smem_bytes={smem_bytes}, "
+            f"capacity={GFX950_LDS_CAPACITY}"
+        )
+    # The exact wait counts need k_tiles, so the >= 63 check lives in
+    # mxfp4_pipeline_schedule; this is the shape-independent upper bound.
+    if (max(stages_a, stages_b) - 2) * ldg_wait_count >= 63:
+        raise ValueError("staged pipeline wait count exceeds supported range")
+
+    return MXFP4GemmDerived(
+        block_threads=block_threads,
+        block_k_bytes=block_k_bytes,
+        mma_m_repeat=mma_m_repeat,
+        mma_n_repeat=mma_n_repeat,
+        k_halves=block_k // MXFP4_MFMA_K,
+        granules_per_row=granules_per_row,
+        ldg_a_iters=ldg_a_iters,
+        ldg_b_iters=ldg_b_iters,
+        ldg_wait_count=ldg_wait_count,
+        a_stage_bytes=a_stage_bytes,
+        b_stage_bytes=b_stage_bytes,
+        smem_bytes=smem_bytes,
+        stages_a=stages_a,
+        stages_b=stages_b,
+    )
+
+
+def make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config):
+    """Return MXFP4GemmParams for a concrete shape, or None if unsupported.
+
+    m, n, k are in elements: k is the logical contraction length, i.e. twice
+    the packed extent the tensors report.
+    """
+    if out_dtype not in ("bfloat16", "float16"):
+        return None
+    block_m = int(gemm_config["TILE_M"])
+    block_n = int(gemm_config["TILE_N"])
+    block_k = int(gemm_config["TILE_K"])
+    stages = int(gemm_config["STAGES"])
+    m_waves = int(gemm_config["BLOCK_M_WARPS"])
+    n_waves = int(gemm_config["BLOCK_N_WARPS"])
+    group_m = int(gemm_config["GROUP_M"])
+    stages_a = gemm_config.get("STAGES_A")
+    stages_b = gemm_config.get("STAGES_B")
+    stages_a = None if stages_a is None else int(stages_a)
+    stages_b = None if stages_b is None else int(stages_b)
+    try:
+        derived = mxfp4_gemm_derived(
+            block_m,
+            block_n,
+            block_k,
+            stages,
+            m_waves,
+            n_waves,
+            group_m,
+            stages_a,
+            stages_b,
+            k=k,
+        )
+    except Exception:
+        return None
+    # No boundary predication: the tile must divide the problem exactly.
+    if m % block_m or n % block_n or k % block_k:
+        return None
+    # The prologue fills max(stages_a, stages_b) - 1 buffers before the
+    # steady-state loop runs.
+    if (k // block_k) <= max(derived.stages_a, derived.stages_b) - 1:
+        return None
+    try:
+        mxfp4_pipeline_schedule(
+            k // block_k,
+            derived.stages_a,
+            derived.stages_b,
+            derived.ldg_a_iters,
+            derived.ldg_b_iters,
+        )
+    except Exception:
+        return None
+    del derived
+    return MXFP4GemmParams(
+        m=m,
+        n=n,
+        k=k,
+        out_dtype=out_dtype,
+        block_m=block_m,
+        block_n=block_n,
+        block_k=block_k,
+        stages=stages,
+        m_waves=m_waves,
+        n_waves=n_waves,
+        group_m=group_m,
+        stages_a=stages_a,
+        stages_b=stages_b,
+    )
+
+
+def make_mxfp4_gemm_kernel_name(param: MXFP4GemmParams) -> str:
+    sa = param.stages if param.stages_a is None else param.stages_a
+    sb = param.stages if param.stages_b is None else param.stages_b
+    return (
+        "mxfp4_scaled_mm_gfx950"
+        f"_{param.out_dtype}"
+        f"_bm{param.block_m}_bn{param.block_n}_bk{param.block_k}"
+        f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
+        f"_g{param.group_m}"
+        f"_sa{sa}_sb{sb}"
+    )
+
+
+# TODO: Move this common ROCm synchronization helper to FlyDSL.
+def __barrier(vmcnt=0):
+    llvm.InlineAsmOp(
+        None,
+        [],
+        f"s_waitcnt vmcnt({vmcnt})\n\ts_barrier",
+        "",
+        has_side_effects=True,
+    )
+
+
+@functools.lru_cache(maxsize=256)
+def make_mxfp4_scaled_mm_gfx950(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: str,
+    block_m: int = 128,
+    block_n: int = 128,
+    block_k: int = 256,
+    stages: int = 2,
+    m_waves: int = 2,
+    n_waves: int = 2,
+    group_m: int = 0,
+    stages_a: int = None,
+    stages_b: int = None,
+):
+    """Build a tiled gfx950 MXFP4 scaled GEMM launcher for one tile config.
+
+    m, n, k and block_k are in elements. The A and B tensors handed to the
+    launcher are the packed uint8 views: [m, k // 2] and [n, k // 2].
+    """
+    if m <= 0 or n <= 0 or k <= 0:
+        raise ValueError("m, n, and k must be positive")
+    d = mxfp4_gemm_derived(
+        block_m,
+        block_n,
+        block_k,
+        stages,
+        m_waves,
+        n_waves,
+        group_m,
+        stages_a,
+        stages_b,
+        k=k,
+    )
+    stages_a = d.stages_a
+    stages_b = d.stages_b
+    block_k_bytes = d.block_k_bytes
+    prefetch_a = stages_a - 1
+    prefetch_b = stages_b - 1
+    prologue_tiles = max(prefetch_a, prefetch_b)
+    if m % block_m or n % block_n or k % block_k:
+        raise ValueError(
+            f"shape must be divisible by the tile: {m}x{n}x{k} vs "
+            f"{block_m}x{block_n}x{block_k}"
+        )
+    k_tiles = k // block_k
+    if k_tiles <= prologue_tiles:
+        raise ValueError("K must supply more tiles than the deepest prefetch")
+    (
+        main_loop_end,
+        steady_wait,
+        tail_waits,
+        wrap_a,
+        wrap_b,
+    ) = mxfp4_pipeline_schedule(
+        k_tiles, stages_a, stages_b, d.ldg_a_iters, d.ldg_b_iters
+    )
+
+    if out_dtype == "bfloat16":
+        out_elem = fx.BFloat16
+    elif out_dtype == "float16":
+        out_elem = fx.Float16
+    else:
+        raise ValueError(f"unsupported MXFP4 output dtype: {out_dtype}")
+
+    block_threads = d.block_threads
+    granules_per_row = d.granules_per_row
+    swizzle_bits = granules_per_row.bit_length() - 1
+    granule_byte_bits = GFX950_DMA_BYTES.bit_length() - 1
+    k_bytes = k // MXFP4_ELEMS_PER_BYTE
+    scale_k = k // MXFP4_SCALE_BLOCK_K
+    tiles_m = m // block_m
+    tiles_n = n // block_n
+    grid_size = tiles_m * tiles_n
+    # Group consecutive workgroups into GROUP_M rows of the N sweep so their B
+    # tiles stay hot in L2. Only exact groupings are used, which keeps the
+    # index math free of a runtime min.
+    use_group_m = group_m > 0 and tiles_m % group_m == 0 and tiles_m > group_m
+    # The remap only helps when the swizzle is there to compact the result.
+    use_xcd_remap = use_group_m
+    # One dword feeds exactly four repeats through the 4x4 lane-group transpose,
+    # so shallower register blocking keeps the per-byte scale loads.
+    packed_scale = d.mma_m_repeat % 4 == 0 and d.mma_n_repeat % 4 == 0
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def kernel(
+        a: fx.Tensor,
+        b_nk: fx.Tensor,
+        scale_a_u8: fx.Tensor,
+        scale_b_u8: fx.Tensor,
+        out: fx.Tensor,
+    ):
+        tid = fx.thread_idx.x
+
+        pid = fx.Int32(fx.block_idx.x)
+        if const_expr(use_xcd_remap):
+            # Workgroups are handed to the 8 XCDs round-robin by id, so an id
+            # written straight into the GROUP_M swizzle spreads each XCD's
+            # tiles over the whole output and defeats its private L2 slice.
+            # Inverting the round-robin gives every XCD a contiguous id range;
+            # the swizzle below then folds that range into a compact 2-D block.
+            xcd_q, xcd_r = divmod(tiles_m * tiles_n, GFX950_NUM_XCD)
+            xcd = pid % fx.Int32(GFX950_NUM_XCD)
+            in_xcd = pid // fx.Int32(GFX950_NUM_XCD)
+            if const_expr(xcd_r == 0):
+                pid = xcd * fx.Int32(xcd_q) + in_xcd
+            else:
+                # branchless min(xcd, xcd_r) from the sign mask of xcd - xcd_r
+                diff = xcd - fx.Int32(xcd_r)
+                pid = (
+                    xcd * fx.Int32(xcd_q)
+                    + fx.Int32(xcd_r)
+                    + (diff & (diff >> fx.Int32(31)))
+                    + in_xcd
+                )
+        if const_expr(use_group_m):
+            group_tiles = group_m * tiles_n
+            group_id = pid // fx.Int32(group_tiles)
+            within = pid % fx.Int32(group_tiles)
+            bid_m = group_id * fx.Int32(group_m) + within % fx.Int32(group_m)
+            bid_n = within // fx.Int32(group_m)
+        else:
+            bid_m = pid // fx.Int32(tiles_n)
+            bid_n = pid % fx.Int32(tiles_n)
+        m_base = bid_m * fx.Int32(block_m)
+        n_base = bid_n * fx.Int32(block_n)
+
+        # Sized in elements; fx.Array converts with the 4-bit element width, so
+        # the allocation is block_m * block_k_bytes bytes per staged buffer.
+        @fx.struct
+        class SharedStorage:
+            a: fx.Array[fx.Float4E2M1FN, stages_a * block_m * block_k, 16]
+            b: fx.Array[fx.Float4E2M1FN, stages_b * block_n * block_k, 16]
+
+        storage = fx.SharedAllocator().allocate(SharedStorage).peek()
+        smem_a = storage.a.ptr
+        smem_b = storage.b.ptr
+        # Direct-to-LDS stores address bytes, and every DMA constant below
+        # (granule size, wave stride, stage stride) is a byte count, so the
+        # write side gets its own byte-typed iterator over the same allocation.
+        smem_a_bytes = fx.recast_iter(fx.Uint8, storage.a.ptr)
+        smem_b_bytes = fx.recast_iter(fx.Uint8, storage.b.ptr)
+
+        def make_flat_buffer(tensor, elems):
+            flat = fx.Tensor(
+                fx.make_view(fx.get_iter(tensor), fx.make_layout(elems, 1))
+            )
+            return fx.rocdl.make_buffer_tensor(flat, max_size=True)
+
+        # A and B arrive as the packed uint8 views, so their flat extents are
+        # byte counts.
+        a_flat = fx.logical_divide(
+            make_flat_buffer(a, m * k_bytes), fx.make_layout(1, 1)
+        )
+        b_flat = fx.logical_divide(
+            make_flat_buffer(b_nk, n * k_bytes), fx.make_layout(1, 1)
+        )
+        sa_flat = fx.logical_divide(
+            make_flat_buffer(scale_a_u8, m * scale_k), fx.make_layout(1, 1)
+        )
+        sb_flat = fx.logical_divide(
+            make_flat_buffer(scale_b_u8, n * scale_k), fx.make_layout(1, 1)
+        )
+        out_view = fx.Tensor(
+            fx.make_view(
+                fx.get_iter(out),
+                fx.make_layout((m, n), (n, 1)),
+            )
+        )
+        out_buf = fx.rocdl.make_buffer_tensor(out_view, max_size=True)
+        gC = fx.flat_divide(out_buf, (block_m, block_n))[None, None, bid_m, bid_n]
+
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.cdna4.MFMA_Scale(
+                MXFP4_MFMA_M,
+                MXFP4_MFMA_N,
+                MXFP4_MFMA_K,
+                fx.Float4E2M1FN,
+                fx.Float4E2M1FN,
+                fx.Float32,
+                opsel_a=0,
+                opsel_b=0,
+            )
+        )
+        # No K permutation. The scaled MFMA covers K=128 in four lane groups of
+        # 32 elements; for E2M1 those 32 elements are one contiguous 16-byte
+        # block, so the fragment's K order already matches the LDS row order.
+        # E4M3 splits the same 32 elements into two 16-byte blocks 64 elements
+        # apart, which is the only reason the MXFP8 kernel needs one.
+        tiled_mma = fx.make_tiled_mma(
+            mma_atom,
+            fx.make_layout(
+                (m_waves, n_waves, 1),
+                (n_waves, 1, 0),
+            ),
+        )
+        thr_mma = tiled_mma.thr_slice(tid)
+
+        # The MFMA fragment is read with explicit byte arithmetic rather than
+        # through make_fragment_A / partition_S. A layout over a 4-bit element
+        # type addresses one BYTE per element (FlyDSL scales an offset by
+        # max(1, width // 8), the same rule fx.Array uses for its allocation
+        # size), so an element-indexed LDS view has twice the intended row
+        # stride and every wave reads two source rows blended together. That is
+        # invisible at compile time and shows up only as a numerical error, so
+        # the LDS side is modeled in dwords the way the FlyDSL mxfp4 reference
+        # kernel models it, and only the MMA atom is told the element format.
+        lds_copy = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Int32)
+        dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        scale_atom = fx.make_copy_atom(fx.rocdl.BufferCopy8b(), fx.Uint8)
+
+        swizzle_bytes = fx.static(
+            fx.SwizzleType.get(swizzle_bits, granule_byte_bits, swizzle_bits)
+        )
+
+        def make_lds_layout_bytes(rows):
+            return fx.make_composed_layout(
+                swizzle_bytes,
+                fx.make_ordered_layout((rows, block_k_bytes), (1, 0)),
+            )
+
+        a_lds_layout_bytes = make_lds_layout_bytes(block_m)
+        b_lds_layout_bytes = make_lds_layout_bytes(block_n)
+
+        frag_C = thr_mma.make_fragment_C(gC)
+        frag_C.fill(0.0)
+
+        # Wave and lane decomposition, matching the TiledMma's wave layout
+        # (m_waves, n_waves) with n_waves as the fastest mode.
+        lane = fx.Int32(tid) % fx.Int32(GFX950_WAVE_SIZE)
+        wave = rocdl.readfirstlane(
+            fx.Int32.ir_type, fx.Int32(tid) // fx.Int32(GFX950_WAVE_SIZE)
+        )
+        wave_m = fx.Int32(wave) // fx.Int32(n_waves)
+        wave_n = fx.Int32(wave) % fx.Int32(n_waves)
+        lane_row = lane % fx.Int32(MXFP4_MFMA_M)
+        lane_grp = lane // fx.Int32(MXFP4_MFMA_M)
+        # A TiledMma repeats the 16x16 atom across waves, so consecutive waves
+        # own 16-row stripes that interleave rather than contiguous blocks: the
+        # rows a wave owns for repeat r are r * (waves * 16) + wave * 16 + ...
+        # The C fragment still comes from thr_mma, so the A/B row arithmetic
+        # here has to reproduce that same ownership or only the single-wave
+        # case agrees.
+        m_repeat_stride = m_waves * MXFP4_MFMA_M
+        n_repeat_stride = n_waves * MXFP4_MFMA_N
+        a_row_base = wave_m * fx.Int32(MXFP4_MFMA_M) + lane_row
+        b_row_base = wave_n * fx.Int32(MXFP4_MFMA_N) + lane_row
+        # 16-byte granules spanned by one 128-element MFMA K step.
+        granules_per_kh = MXFP4_MFMA_K // (2 * GFX950_DMA_BYTES)
+        row_dwords = block_k_bytes // 4
+        r2g_atom = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), out_elem)
+        thr_copy_C = fx.make_tiled_copy_C(r2g_atom, tiled_mma).get_slice(tid)
+        thr_gC = thr_copy_C.partition_S(gC)
+
+        # The scaled-MFMA state selects one E8M0 byte for each 32-element lane
+        # group. The 16x16x128 A scale is 16 rows x 4 K blocks = 64 values = one
+        # per lane, which depends on the MFMA shape and the 32-element block
+        # granularity only -- not on the operand format.
+        scale_group = (fx.Int32(tid) % fx.Int32(GFX950_WAVE_SIZE)) // fx.Int32(
+            MXFP4_MFMA_N
+        )
+
+        wave_offset = rocdl.readfirstlane(
+            fx.Int64.ir_type,
+            fx.Int64(
+                fx.Int32(tid)
+                // fx.Int32(GFX950_WAVE_SIZE)
+                * fx.Int32(GFX950_WAVE_SIZE * GFX950_DMA_BYTES)
+            ),
+        )
+
+        def make_wave_lds_ptr(ptr):
+            return ptr + fx.Int32(wave_offset)
+
+        def swizzled_col(row, col, layout):
+            return fx.get_scalar(fx.crd2idx((row, col), layout)) % fx.Int32(
+                block_k_bytes
+            )
+
+        def async_load_tile(
+            gmem,
+            smem,
+            stage_bytes,
+            ldg_iters,
+            rows_base,
+            k_tile,
+            stage,
+            layout,
+        ):
+            # Direct-to-LDS stores are linear, so the source coordinate carries
+            # the composed LDS swizzle. Every quantity here is a byte count.
+            lds_ptr = make_wave_lds_ptr(smem + stage * fx.Int32(stage_bytes))
+            for i in range_constexpr(ldg_iters):
+                lin = (fx.Int32(i * block_threads) + fx.Int32(tid)) * fx.Int32(
+                    GFX950_DMA_BYTES
+                )
+                row = lin // fx.Int32(block_k_bytes)
+                dst_col = lin % fx.Int32(block_k_bytes)
+                src_col = swizzled_col(row, dst_col, layout)
+                src_offset = (
+                    (rows_base + row) * fx.Int32(k_bytes)
+                    + k_tile * fx.Int32(block_k_bytes)
+                    + src_col
+                )
+                src = fx.slice(gmem, (None, src_offset))
+                dst = fx.make_view(lds_ptr, fx.make_layout(1, 1))
+                fx.copy(dma_atom, src, dst)
+                if i < ldg_iters - 1:
+                    lds_ptr = lds_ptr + fx.Int32(block_threads * GFX950_DMA_BYTES)
+
+        def async_load_a(k_tile, stage):
+            async_load_tile(
+                a_flat,
+                smem_a_bytes,
+                d.a_stage_bytes,
+                d.ldg_a_iters,
+                m_base,
+                k_tile,
+                stage,
+                a_lds_layout_bytes,
+            )
+
+        def async_load_b(k_tile, stage):
+            async_load_tile(
+                b_flat,
+                smem_b_bytes,
+                d.b_stage_bytes,
+                d.ldg_b_iters,
+                n_base,
+                k_tile,
+                stage,
+                b_lds_layout_bytes,
+            )
+
+        def load_scale_word(scale, row_global, scale_col):
+            scale_offset = fx.Int32(row_global) * fx.Int32(scale_k) + fx.Int32(
+                scale_col
+            )
+            scale_reg = fx.make_rmem_tensor(1, fx.Uint8)
+            fx.copy(
+                scale_atom,
+                fx.slice(scale, (None, scale_offset)),
+                scale_reg,
+            )
+            scale_byte = fx.get_scalar(scale_reg[0])
+            return scale_byte.to(fx.Int32) * fx.Int32(0x01010101)
+
+        def scaled_mma(d_frag, a_frag, b_frag, scale_a, scale_b):
+            # Output ownership still comes from the workgroup TiledMma; the A/B
+            # operands are the raw i32[4] register fragments read above, and the
+            # dynamic E8M0 state is bound on each underlying 16x16 atom call.
+            fx.gemm(
+                mma_atom,
+                d_frag,
+                a_frag,
+                b_frag,
+                d_frag,
+                scale_a=scale_a,
+                scale_b=scale_b,
+            )
+
+        # Packed scale path. One 4-byte load holds a whole 128-element K span of
+        # E8M0 scales for one row, and 64 lanes cover four MMA repeats at once.
+        # VALU permlane swaps perform the 4x4 lane-group transpose that hands
+        # each row's dword to the lane group that needs it; each lane then
+        # shifts out its own K-quarter byte.
+        scale32_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Uint32)
+        scale_k32 = scale_k // 4
+
+        def make_flat_buffer32(tensor, elems32):
+            # The scale tensors arrive as u8 views, so their pointer carries
+            # alignment 1 and a 4-byte load needs that restated.
+            src = fx.get_iter(tensor)
+            flat = fx.Tensor(
+                fx.make_view(
+                    fx.recast_iter(
+                        fx.PointerType.get(fx.Uint32.ir_type, src.memspace, 4), src
+                    ),
+                    fx.make_layout(elems32, 1),
+                )
+            )
+            return fx.rocdl.make_buffer_tensor(flat, max_size=True)
+
+        if const_expr(packed_scale):
+            sa32 = fx.logical_divide(
+                make_flat_buffer32(scale_a_u8, m * scale_k32), fx.make_layout(1, 1)
+            )
+            sb32 = fx.logical_divide(
+                make_flat_buffer32(scale_b_u8, n * scale_k32), fx.make_layout(1, 1)
+            )
+
+        def packed_scale_issue(buf, base, row_base, repeat_stride, n_repeat, col32):
+            """Issue only the dword scale loads and return the landing registers.
+
+            Split out from the transpose so the loads can be hoisted above the
+            tile's direct-to-LDS DMA. vmcnt is an in-order counter, so a scale
+            load issued before the DMA block is satisfied by a counted wait
+            rather than the full drain a trailing load would need.
+            """
+            # A wave's 64 lanes cover 4 repeats at once: lane group g takes the
+            # row of repeat q + g, so one dword load serves four repeats and the
+            # permlane transpose below hands each group the row it needs.
+            regs = []
+            for q in range_constexpr(0, n_repeat, 4):
+                row = row_base + fx.Int32(repeat_stride) * (fx.Int32(q) + scale_group)
+                offset = (base + row) * fx.Int32(scale_k32) + col32
+                reg = fx.make_rmem_tensor(1, fx.Uint32)
+                fx.copy(scale32_atom, fx.slice(buf, (None, offset)), reg)
+                regs.append(reg)
+            return regs
+
+        def packed_scale_finish(regs):
+            """Broadcast each loaded dword's four rows across the four lane
+            groups, then extract this lane's K-quarter byte.
+
+            Feeding the same register to both operands of a swap turns the
+            general 4x4 lane-group transpose into that broadcast and collapses
+            four swaps into three. The VALU swaps replace ds_bpermute, which
+            shares the in-order lgkmcnt with the fragment ds_reads.
+            """
+            words = []
+            for reg in regs:
+                packed = fx.get_scalar(reg[0]).to(fx.Int32)
+                t0, t1 = _permlane_swap(32, packed, packed)
+                u0, u1 = _permlane_swap(16, t0, t0)
+                w0, w1 = _permlane_swap(16, t1, t1)
+                for lane_word in (u0, u1, w0, w1):
+                    lane_word = fx.Int32(lane_word)
+                    # The scaled MFMA reads exactly one byte of its 32-bit scale
+                    # operand, selected by opsel, and ignores the other three.
+                    # The atom sets opsel 0 for both operands, so the byte read
+                    # is byte 0 -- where this shift already lands the E8M0
+                    # exponent. Masking off the upper bytes and replicating the
+                    # byte across the word are therefore both dead.
+                    words.append(lane_word >> (scale_group * fx.Int32(8)))
+            return words
+
+        def stage_dwords(base_bytes, stage, stage_bytes):
+            # Offsetting a pointer advances it by elem_size bytes per unit, so
+            # the stage stride is done in bytes and then recast to dwords, which
+            # is the unit every fragment offset below is expressed in.
+            ptr = base_bytes + stage * fx.Int32(stage_bytes)
+            # Stage strides are whole 16-byte granules, so restate the alignment
+            # the byte pointer lost when it was offset; a ds_read_b128 needs it.
+            return fx.recast_iter(
+                fx.PointerType.get(fx.Int32.ir_type, ptr.memspace, 16), ptr
+            )
+
+        def read_frag(base_i32, row, kh):
+            """One ds_read_b128 -> i32[4]: this lane's 32 E2M1 codes for K step
+            kh. Lane group g owns elements [32g, 32g+32), i.e. the single
+            16-byte granule at index kh * granules_per_kh + g, XOR-swizzled
+            against the row exactly as the direct-to-LDS write was."""
+            granule = (fx.Int32(kh * granules_per_kh) + lane_grp) ^ (
+                row & fx.Int32(granules_per_row - 1)
+            )
+            off = row * fx.Int32(row_dwords) + granule * fx.Int32(GFX950_DMA_BYTES // 4)
+            frag = fx.make_rmem_tensor(4, fx.Int32)
+            fx.copy(
+                lds_copy,
+                fx.make_view(fx.add_offset(base_i32, off), fx.make_layout(4, 1)),
+                frag,
+            )
+            return frag
+
+        def load_fragments(stage_a, stage_b):
+            base_a = stage_dwords(smem_a_bytes, stage_a, d.a_stage_bytes)
+            base_b = stage_dwords(smem_b_bytes, stage_b, d.b_stage_bytes)
+            av = []
+            bv = []
+            for kh in range_constexpr(d.k_halves):
+                for ni in range_constexpr(d.mma_n_repeat):
+                    bv.append(
+                        read_frag(
+                            base_b,
+                            b_row_base + fx.Int32(ni * n_repeat_stride),
+                            kh,
+                        )
+                    )
+                for mi in range_constexpr(d.mma_m_repeat):
+                    av.append(
+                        read_frag(
+                            base_a,
+                            a_row_base + fx.Int32(mi * m_repeat_stride),
+                            kh,
+                        )
+                    )
+            return av, bv
+
+        def mma_stage(k_tile, mid):
+            """Run one K-tile's MFMAs. `mid` performs the tile's fragment reads
+            and direct-to-LDS DMA and returns the fragments; it runs between
+            issuing the scale loads and consuming them so those loads get the
+            whole DMA block as latency shadow.
+            """
+            if const_expr(packed_scale):
+                issued = []
+                for kh in range_constexpr(d.k_halves):
+                    col32 = k_tile * fx.Int32(block_k // MXFP4_MFMA_K) + fx.Int32(kh)
+                    issued.append(
+                        (
+                            packed_scale_issue(
+                                sa32,
+                                m_base,
+                                a_row_base,
+                                m_repeat_stride,
+                                d.mma_m_repeat,
+                                col32,
+                            ),
+                            packed_scale_issue(
+                                sb32,
+                                n_base,
+                                b_row_base,
+                                n_repeat_stride,
+                                d.mma_n_repeat,
+                                col32,
+                            ),
+                        )
+                    )
+                av, bv = mid()
+                for kh in range_constexpr(d.k_halves):
+                    sa_words = packed_scale_finish(issued[kh][0])
+                    sb_words = packed_scale_finish(issued[kh][1])
+                    for ni in range_constexpr(d.mma_n_repeat):
+                        for mi in range_constexpr(d.mma_m_repeat):
+                            scaled_mma(
+                                frag_C[(None, 0), mi, ni],
+                                av[kh * d.mma_m_repeat + mi],
+                                bv[kh * d.mma_n_repeat + ni],
+                                sa_words[mi],
+                                sb_words[ni],
+                            )
+                return
+
+            av, bv = mid()
+            for kh in range_constexpr(d.k_halves):
+                scale_col = (
+                    k_tile * fx.Int32(block_k // MXFP4_SCALE_BLOCK_K)
+                    + fx.Int32(kh * (MXFP4_MFMA_K // MXFP4_SCALE_BLOCK_K))
+                    + scale_group
+                )
+                sa_words = [
+                    load_scale_word(
+                        sa_flat,
+                        m_base + a_row_base + fx.Int32(mi * m_repeat_stride),
+                        scale_col,
+                    )
+                    for mi in range_constexpr(d.mma_m_repeat)
+                ]
+                sb_words = [
+                    load_scale_word(
+                        sb_flat,
+                        n_base + b_row_base + fx.Int32(ni * n_repeat_stride),
+                        scale_col,
+                    )
+                    for ni in range_constexpr(d.mma_n_repeat)
+                ]
+                for ni in range_constexpr(d.mma_n_repeat):
+                    for mi in range_constexpr(d.mma_m_repeat):
+                        scaled_mma(
+                            frag_C[(None, 0), mi, ni],
+                            av[kh * d.mma_m_repeat + mi],
+                            bv[kh * d.mma_n_repeat + ni],
+                            sa_words[mi],
+                            sb_words[ni],
+                        )
+
+        # Prologue: iterations i in [-prologue_tiles, 0) of the same schedule
+        # the steady state runs, so the vmcnt ordering is uniform from tile 0
+        # on. Issue order is A-before-B: with prefetch_a < prefetch_b the A load
+        # is the later of the two a tile waits on, so putting it first leaves
+        # B's loads outstanding across the barrier instead of forcing a full
+        # drain. Reversing this order collapses steady_wait back to 0.
+        for i in range_constexpr(-prologue_tiles, 0):
+            if const_expr(0 <= i + prefetch_a):
+                ta = i + prefetch_a
+                async_load_a(ta, fx.Int32(ta % stages_a))
+            if const_expr(0 <= i + prefetch_b):
+                tb = i + prefetch_b
+                async_load_b(tb, fx.Int32(tb % stages_b))
+        rocdl.sched_barrier(0)
+
+        for kt in range(0, main_loop_end, 1):
+            k_tile = fx.Int32(kt)
+            cur_a = k_tile % fx.Int32(stages_a)
+            cur_b = k_tile % fx.Int32(stages_b)
+            write_a = (k_tile + fx.Int32(prefetch_a)) % fx.Int32(stages_a)
+            write_b = (k_tile + fx.Int32(prefetch_b)) % fx.Int32(stages_b)
+            __barrier(steady_wait)
+
+            # A direct-to-LDS load is a VMEM op that writes LDS, so the compiler
+            # cannot prove it does not alias a later ds_read and drains vmcnt to
+            # zero in between. Reading the tile's fragments before issuing the
+            # DMA removes the reason for that drain: the compiler then emits a
+            # counted wait and sinks the DMA into the MFMA block. This ordering
+            # was measured against the reverse on 12 MXFP8 tile configs and won
+            # 11 of 12 by 2% to 53%, so it is fixed rather than searched.
+            def _mid(
+                cur_a=cur_a,
+                cur_b=cur_b,
+                k_tile=k_tile,
+                write_a=write_a,
+                write_b=write_b,
+            ):
+                frags = load_fragments(cur_a, cur_b)
+                ta = k_tile + fx.Int32(prefetch_a)
+                if const_expr(wrap_a):
+                    ta = ta % fx.Int32(k_tiles)
+                async_load_a(ta, write_a)
+                tb = k_tile + fx.Int32(prefetch_b)
+                if const_expr(wrap_b):
+                    tb = tb % fx.Int32(k_tiles)
+                async_load_b(tb, write_b)
+                return frags
+
+            mma_stage(k_tile, _mid)
+
+        # Drain: exactly one peeled tile. Everything it consumes is already in
+        # flight, so it issues no loads and only has to walk vmcnt down.
+        kt = main_loop_end
+        k_tile = fx.Int32(kt)
+        cur_a = fx.Int32(kt % stages_a)
+        cur_b = fx.Int32(kt % stages_b)
+        __barrier(tail_waits[0])
+        mma_stage(k_tile, lambda: load_fragments(cur_a, cur_b))
+
+        frag_C_out = fx.make_fragment_like(frag_C, out_elem)
+        frag_C_out.store(frag_C.load().to(out_elem))
+        frag_C_retile = thr_copy_C.retile(frag_C_out)
+        fx.copy(r2g_atom, frag_C_retile, thr_gC)
+
+    kernel._func.__name__ = make_mxfp4_gemm_kernel_name(
+        MXFP4GemmParams(
+            m=m,
+            n=n,
+            k=k,
+            out_dtype=out_dtype,
+            block_m=block_m,
+            block_n=block_n,
+            block_k=block_k,
+            stages=stages,
+            m_waves=m_waves,
+            n_waves=n_waves,
+            group_m=group_m,
+            stages_a=stages_a,
+            stages_b=stages_b,
+        )
+    )
+
+    @flyc.jit
+    def launch(
+        a: fx.Tensor,
+        b_nk: fx.Tensor,
+        scale_a_u8: fx.Tensor,
+        scale_b_u8: fx.Tensor,
+        out: fx.Tensor,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        kernel(a, b_nk, scale_a_u8, scale_b_u8, out).launch(
+            grid=(grid_size, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
@@ -51,6 +51,13 @@ MXFP4_MFMA_K = 128
 MXFP4_ELEMS_PER_BYTE = 2
 GFX950_WAVE_SIZE = 64
 GFX950_DMA_BYTES = 16
+# BufferCopyLDS32b moves one dword per lane. It is the widest direct-to-LDS
+# copy usable for the scale tile: the 128b atom needs its 16-byte granule
+# contiguous in global memory, i.e. 512 | block_k, which 6 of the 13 champion
+# configs fail. (BufferCopyLDS64b must not be used -- FlyDSL 0.3.0 has no
+# verifier for it, so it constructs silently and then fails instruction
+# selection, i.e. the copy never happens.)
+GFX950_SCALE_DMA_BYTES = 4
 GFX950_LDS_CAPACITY = 163840
 GFX950_NUM_XCD = 8
 GFX950_MAX_BLOCK_THREADS = 1024
@@ -83,6 +90,10 @@ class MXFP4GemmParams:
     # None means "same as stages", which reproduces the symmetric kernel.
     stages_a: int = None
     stages_b: int = None
+    # Autotune dimension: 1 stages the E8M0 scales through LDS, 0 keeps the
+    # in-register lane-group transpose. Part of the kernel identity, so the two
+    # variants get separate cache entries.
+    lds_scale: int = 0
 
     def __cache_signature__(self):
         return (
@@ -116,7 +127,18 @@ class MXFP4GemmDerived:
     granules_per_row: int
     ldg_a_iters: int
     ldg_b_iters: int
+    # Tile DMA plus scale DMA, in program order. The pipeline schedule counts
+    # load instructions, and the scale copies are issued immediately after the
+    # tile copies for the same K tile, so they simply add to that operand's cost.
+    dma_a_iters: int
+    dma_b_iters: int
     ldg_wait_count: int
+    lds_scale: bool
+    sc_a_iters: int
+    sc_b_iters: int
+    sc_a_bytes: int
+    sc_b_bytes: int
+    scale_row_bytes: int
     a_stage_bytes: int
     b_stage_bytes: int
     smem_bytes: int
@@ -211,6 +233,7 @@ def mxfp4_gemm_derived(
     stages_a: int = None,
     stages_b: int = None,
     k: int = None,
+    lds_scale_req: int = 0,
 ) -> MXFP4GemmDerived:
     """Validate a tile config and return its derived quantities.
 
@@ -284,26 +307,57 @@ def mxfp4_gemm_derived(
         )
     ldg_a_iters = (block_m * block_k_bytes) // dma_bytes_per_pass
     ldg_b_iters = (block_n * block_k_bytes) // dma_bytes_per_pass
-    ldg_wait_count = ldg_a_iters + ldg_b_iters
 
     a_stage_bytes = block_m * block_k_bytes
     b_stage_bytes = block_n * block_k_bytes
 
+    # ---- LDS-staged E8M0 scales -------------------------------------------
+    # The global scale path costs the loop body at both ends. Each dword load
+    # serves four MMA repeats, but row_base carries lane_row, so a wave's 64
+    # lanes read 64 DIFFERENT scale rows -- 64 distinct cache lines per
+    # instruction, which at 64,128,512 is 67% of the loop's L1 traffic. Then a
+    # three-swap permlane transpose plus a per-lane shift turns those dwords
+    # into one word per (repeat, K step): 64 instructions at 128,128,512, the
+    # same count as the MFMAs themselves, and they drag 24 v_mov and 15 hazard
+    # s_nop along with them.
+    #
+    # Staging the tile's scales in LDS collapses both. The tile is fetched once
+    # cooperatively by a linear direct-to-LDS DMA, and each lane then does one
+    # ds_read_u8 per (repeat, K step) -- which lands the E8M0 exponent in bits
+    # 7:0, exactly the byte the scaled MFMA reads at opsel 0, so there is no
+    # shift, no mask and no transpose. The address is a loop-invariant per-lane
+    # base plus a compile-time constant, so it folds into the instruction's
+    # offset field and costs no address arithmetic either.
+    #
+    # It is not free: the ds_read_u8 results are live where the transpose's
+    # were rematerialisable, which costs registers. Configs where that does not
+    # fit fall back below rather than spilling.
+    scale_row_bytes = block_k // MXFP4_SCALE_BLOCK_K
+    sc_bytes_per_pass = block_threads * GFX950_SCALE_DMA_BYTES
+    sc_a_bytes = block_m * scale_row_bytes
+    sc_b_bytes = block_n * scale_row_bytes
+    # The scale DMA has to cover its tile exactly, for the same reason the tile
+    # DMA does: a partial pass would need predication the barrier accounting
+    # cannot express.
+    scale_dma_exact = (
+        sc_a_bytes % sc_bytes_per_pass == 0 and sc_b_bytes % sc_bytes_per_pass == 0
+    )
+
+    # The pipeline depth is chosen exactly as it would be WITHOUT the scale
+    # region, and the scale region is then only taken if it fits in whatever
+    # headroom is left. Letting it buy space by dropping a B stage was measured
+    # and is a clear loss: on the three champion configs whose tiles already sit
+    # at the 163840 cap, stages_b 3 -> 2 turned a +2..+5% scale win into
+    # -4.6% / -6.9% / -12.0%. The kernel's own reason is in the stages_b comment
+    # above -- B's extra buffer is what makes the K-tile boundary a counted wait
+    # instead of a full vmcnt(0) drain, and that is worth more than the scales.
     if stages_b is None:
-        # Give B one staged buffer more than A when every precondition holds.
-        # B's DMA lands last in program order, so deepening only B is what turns
-        # the K-tile boundary from a full vmcnt(0) drain into a counted wait.
-        #
-        # Every failure mode falls back to the symmetric depth rather than
-        # raising, because raising would drop a tile config that used to be
-        # valid and a shape whose autotune winner it was would silently fall
-        # back to ATen.
         stages_b = stages
-        deeper = stages_a * a_stage_bytes + (stages + 1) * b_stage_bytes
         deeper_ok = (
             k is not None
-            and deeper <= GFX950_LDS_CAPACITY
-            and (max(stages_a, stages + 1) - 2) * ldg_wait_count < 63
+            and stages_a * a_stage_bytes + (stages + 1) * b_stage_bytes
+            <= GFX950_LDS_CAPACITY
+            and (max(stages_a, stages + 1) - 2) * (ldg_a_iters + ldg_b_iters) < 63
         )
         if deeper_ok:
             try:
@@ -315,14 +369,59 @@ def mxfp4_gemm_derived(
             else:
                 stages_b = stages + 1
 
-    smem_bytes = stages_a * a_stage_bytes + stages_b * b_stage_bytes
-    if smem_bytes > GFX950_LDS_CAPACITY:
+    tile_bytes = stages_a * a_stage_bytes + stages_b * b_stage_bytes
+    if tile_bytes > GFX950_LDS_CAPACITY:
         raise ValueError(
             "staged LDS buffers exceed the device shared-memory capacity: "
             f"stages_a={stages_a}, stages_b={stages_b}, block_m={block_m}, "
-            f"block_n={block_n}, block_k={block_k}, smem_bytes={smem_bytes}, "
+            f"block_n={block_n}, block_k={block_k}, smem_bytes={tile_bytes}, "
             f"capacity={GFX950_LDS_CAPACITY}"
         )
+
+    # lds_scale_req is an autotune dimension, not a heuristic: 0 keeps the
+    # in-register transpose, 1 demands the LDS path. Requesting a path the
+    # config cannot express raises, so the two variants never collapse onto the
+    # same kernel and the search space carries no duplicates.
+    #
+    # It has to be searched rather than derived. The dominant term is LDS
+    # occupancy -- a scale region that pushes workgroups-per-CU from 2 to 1 cost
+    # -12% to -38% -- but that is not sufficient: the SAME tile 64,64,512 gained
+    # +13.0% at 256x4096x4096 and lost 11.9% at 4096^3, because at the first
+    # shape the grid already limited occupancy to 1 WG/CU so the LDS ceiling
+    # never bound. Two further configs regress with no occupancy change at all,
+    # and mma_m_repeat does not separate the sample either (m_repeat 8 gained
+    # 11.1%, m_repeat 2 lost 11.9%). Gating on a rule that does not fit the
+    # measurements would be worse than letting autotune decide.
+    lds_scale = scale_dma_exact and bool(lds_scale_req)
+    if lds_scale_req and not scale_dma_exact:
+        raise ValueError(
+            "LDS-staged scales need each scale tile to cover a whole DMA pass: "
+            f"block_m={block_m}, block_n={block_n}, block_k={block_k}, "
+            f"block_threads={block_threads}"
+        )
+    sc_a_iters = sc_a_bytes // sc_bytes_per_pass if lds_scale else 0
+    sc_b_iters = sc_b_bytes // sc_bytes_per_pass if lds_scale else 0
+    scale_bytes = stages_a * sc_a_bytes + stages_b * sc_b_bytes if lds_scale else 0
+    if lds_scale and tile_bytes + scale_bytes > GFX950_LDS_CAPACITY:
+        raise ValueError(
+            "LDS-staged scales do not fit beside the staged tiles: "
+            f"tile_bytes={tile_bytes}, scale_bytes={scale_bytes}, "
+            f"capacity={GFX950_LDS_CAPACITY}"
+        )
+
+    dma_a_iters = ldg_a_iters + sc_a_iters
+    dma_b_iters = ldg_b_iters + sc_b_iters
+    ldg_wait_count = dma_a_iters + dma_b_iters
+    # The scale DMA lengthens the in-order vmcnt chain, so the wait budget has
+    # to be rechecked against it -- and given up rather than raised, since the
+    # config is perfectly valid without the scale region.
+    if lds_scale and (max(stages_a, stages_b) - 2) * ldg_wait_count >= 63:
+        raise ValueError(
+            "the scale DMA lengthens the in-order vmcnt chain past the wait "
+            "budget for this pipeline depth"
+        )
+
+    smem_bytes = tile_bytes + scale_bytes
     # The exact wait counts need k_tiles, so the >= 63 check lives in
     # mxfp4_pipeline_schedule; this is the shape-independent upper bound.
     if (max(stages_a, stages_b) - 2) * ldg_wait_count >= 63:
@@ -337,7 +436,15 @@ def mxfp4_gemm_derived(
         granules_per_row=granules_per_row,
         ldg_a_iters=ldg_a_iters,
         ldg_b_iters=ldg_b_iters,
+        dma_a_iters=dma_a_iters,
+        dma_b_iters=dma_b_iters,
         ldg_wait_count=ldg_wait_count,
+        lds_scale=lds_scale,
+        sc_a_iters=sc_a_iters,
+        sc_b_iters=sc_b_iters,
+        sc_a_bytes=sc_a_bytes,
+        sc_b_bytes=sc_b_bytes,
+        scale_row_bytes=scale_row_bytes,
         a_stage_bytes=a_stage_bytes,
         b_stage_bytes=b_stage_bytes,
         smem_bytes=smem_bytes,
@@ -365,6 +472,7 @@ def make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config):
     stages_b = gemm_config.get("STAGES_B")
     stages_a = None if stages_a is None else int(stages_a)
     stages_b = None if stages_b is None else int(stages_b)
+    lds_scale = int(gemm_config.get("LDS_SCALE", 0))
     try:
         derived = mxfp4_gemm_derived(
             block_m,
@@ -377,6 +485,7 @@ def make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config):
             stages_a,
             stages_b,
             k=k,
+            lds_scale_req=lds_scale,
         )
     except Exception:
         return None
@@ -392,8 +501,8 @@ def make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config):
             k // block_k,
             derived.stages_a,
             derived.stages_b,
-            derived.ldg_a_iters,
-            derived.ldg_b_iters,
+            derived.dma_a_iters,
+            derived.dma_b_iters,
         )
     except Exception:
         return None
@@ -412,6 +521,7 @@ def make_mxfp4_param_and_validate(m, n, k, out_dtype, gemm_config):
         group_m=group_m,
         stages_a=stages_a,
         stages_b=stages_b,
+        lds_scale=lds_scale,
     )
 
 
@@ -425,6 +535,7 @@ def make_mxfp4_gemm_kernel_name(param: MXFP4GemmParams) -> str:
         f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
         f"_g{param.group_m}"
         f"_sa{sa}_sb{sb}"
+        f"_ls{param.lds_scale}"
     )
 
 
@@ -455,6 +566,7 @@ def make_mxfp4_scaled_mm_gfx950(
     group_m: int = 0,
     stages_a: int = None,
     stages_b: int = None,
+    lds_scale: int = 0,
 ):
     """Build a tiled gfx950 MXFP4 scaled GEMM launcher for one tile config.
 
@@ -474,6 +586,7 @@ def make_mxfp4_scaled_mm_gfx950(
         stages_a,
         stages_b,
         k=k,
+        lds_scale_req=lds_scale,
     )
     stages_a = d.stages_a
     stages_b = d.stages_b
@@ -496,7 +609,7 @@ def make_mxfp4_scaled_mm_gfx950(
         wrap_a,
         wrap_b,
     ) = mxfp4_pipeline_schedule(
-        k_tiles, stages_a, stages_b, d.ldg_a_iters, d.ldg_b_iters
+        k_tiles, stages_a, stages_b, d.dma_a_iters, d.dma_b_iters
     )
 
     if out_dtype == "bfloat16":
@@ -591,10 +704,22 @@ def make_mxfp4_scaled_mm_gfx950(
 
         # Sized in elements; fx.Array converts with the 4-bit element width, so
         # the allocation is block_m * block_k_bytes bytes per staged buffer.
-        @fx.struct
-        class SharedStorage:
-            a: fx.Array[fx.Float4E2M1FN, stages_a * block_m * block_k, 16]
-            b: fx.Array[fx.Float4E2M1FN, stages_b * block_n * block_k, 16]
+        if const_expr(d.lds_scale):
+
+            @fx.struct
+            class SharedStorage:
+                a: fx.Array[fx.Float4E2M1FN, stages_a * block_m * block_k, 16]
+                b: fx.Array[fx.Float4E2M1FN, stages_b * block_n * block_k, 16]
+                # E8M0 bytes, one per 32 elements, staged on the same schedule.
+                sca: fx.Array[fx.Uint8, stages_a * d.sc_a_bytes, 16]
+                scb: fx.Array[fx.Uint8, stages_b * d.sc_b_bytes, 16]
+
+        else:
+
+            @fx.struct
+            class SharedStorage:
+                a: fx.Array[fx.Float4E2M1FN, stages_a * block_m * block_k, 16]
+                b: fx.Array[fx.Float4E2M1FN, stages_b * block_n * block_k, 16]
 
         storage = fx.SharedAllocator().allocate(SharedStorage).peek()
         smem_a = storage.a.ptr
@@ -604,6 +729,9 @@ def make_mxfp4_scaled_mm_gfx950(
         # write side gets its own byte-typed iterator over the same allocation.
         smem_a_bytes = fx.recast_iter(fx.Uint8, storage.a.ptr)
         smem_b_bytes = fx.recast_iter(fx.Uint8, storage.b.ptr)
+        if const_expr(d.lds_scale):
+            smem_sca = fx.recast_iter(fx.Uint8, storage.sca.ptr)
+            smem_scb = fx.recast_iter(fx.Uint8, storage.scb.ptr)
 
         def make_flat_buffer(tensor, elems):
             flat = fx.Tensor(
@@ -798,6 +926,52 @@ def make_mxfp4_scaled_mm_gfx950(
                 if i < ldg_iters - 1:
                     lds_ptr = lds_ptr + fx.Int32(block_threads * GFX950_DMA_BYTES)
 
+        if const_expr(d.lds_scale):
+            sc_dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS32b(), 32)
+            sc_lds_atom = fx.make_copy_atom(fx.UniversalCopy8b(), fx.Uint8)
+            # Each wave writes its own 64-lane * 4-byte chunk; the hardware
+            # supplies the per-lane 4-byte stride within it.
+            sc_wave_offset = rocdl.readfirstlane(
+                fx.Int64.ir_type,
+                fx.Int64(
+                    fx.Int32(tid)
+                    // fx.Int32(GFX950_WAVE_SIZE)
+                    * fx.Int32(GFX950_WAVE_SIZE * GFX950_SCALE_DMA_BYTES)
+                ),
+            )
+
+        def async_load_scale(gmem, smem, stage_bytes, sc_iters, rows_base, k_tile,
+                             stage):
+            """Linear direct-to-LDS copy of one K tile's E8M0 scales.
+
+            No swizzle: the read side gathers single bytes, so the only thing a
+            swizzle would buy is bank spreading, and the write side is linear by
+            construction (the DMA lays lane i at lds_ptr + i * 4).
+            """
+            lds_ptr = (
+                smem + stage * fx.Int32(stage_bytes) + fx.Int32(sc_wave_offset)
+            )
+            for i in range_constexpr(sc_iters):
+                lin = (
+                    fx.Int32(i * block_threads) + fx.Int32(tid)
+                ) * fx.Int32(GFX950_SCALE_DMA_BYTES)
+                row = lin // fx.Int32(d.scale_row_bytes)
+                col = lin % fx.Int32(d.scale_row_bytes)
+                src_offset = (
+                    (rows_base + row) * fx.Int32(scale_k)
+                    + k_tile * fx.Int32(d.scale_row_bytes)
+                    + col
+                )
+                fx.copy(
+                    sc_dma_atom,
+                    fx.slice(gmem, (None, src_offset)),
+                    fx.make_view(lds_ptr, fx.make_layout(1, 1)),
+                )
+                if i < sc_iters - 1:
+                    lds_ptr = lds_ptr + fx.Int32(
+                        block_threads * GFX950_SCALE_DMA_BYTES
+                    )
+
         def async_load_a(k_tile, stage):
             async_load_tile(
                 a_flat,
@@ -809,6 +983,14 @@ def make_mxfp4_scaled_mm_gfx950(
                 stage,
                 a_lds_layout_bytes,
             )
+            # Issued immediately after the tile copy for the same K tile, which
+            # is what lets the pipeline schedule just add sc_a_iters to this
+            # operand's cost: vmcnt is in-order.
+            if const_expr(d.lds_scale):
+                async_load_scale(
+                    sa_flat, smem_sca, d.sc_a_bytes, d.sc_a_iters,
+                    m_base, k_tile, stage,
+                )
 
         def async_load_b(k_tile, stage):
             async_load_tile(
@@ -821,6 +1003,11 @@ def make_mxfp4_scaled_mm_gfx950(
                 stage,
                 b_lds_layout_bytes,
             )
+            if const_expr(d.lds_scale):
+                async_load_scale(
+                    sb_flat, smem_scb, d.sc_b_bytes, d.sc_b_iters,
+                    n_base, k_tile, stage,
+                )
 
         def load_scale_word(scale, row_global, scale_col):
             scale_offset = fx.Int32(row_global) * fx.Int32(scale_k) + fx.Int32(
@@ -1006,12 +1193,76 @@ def make_mxfp4_scaled_mm_gfx950(
                     )
             return av, bv
 
-        def mma_stage(k_tile, mid):
+        if const_expr(d.lds_scale):
+            # row_base already carries lane_row; scale_group is this lane's
+            # K-block. Both are loop-invariant, so this whole expression is
+            # hoisted and every read below differs from it only by a
+            # compile-time constant that folds into ds_read_u8's offset field.
+            sc_lane_base_a = (
+                a_row_base * fx.Int32(d.scale_row_bytes) + scale_group
+            )
+            sc_lane_base_b = (
+                b_row_base * fx.Int32(d.scale_row_bytes) + scale_group
+            )
+
+        def lds_scale_read(base_bytes, dyn_base, repeat_stride, n_repeat):
+            """Scale words indexed [repeat * k_halves + kh], one ds_read_u8 each.
+
+            ds_read_u8 zero-extends the E8M0 byte into bits 7:0, which is the
+            byte the scaled MFMA reads at opsel 0 -- so there is no shift, no
+            mask, and no lane-group transpose. LLVM does not fuse adjacent byte
+            reads, so the count is exactly (m_repeat + n_repeat) * k_halves.
+            """
+            words = []
+            for r in range_constexpr(n_repeat):
+                for kh in range_constexpr(d.k_halves):
+                    off = dyn_base + fx.Int32(
+                        r * repeat_stride * d.scale_row_bytes
+                        + kh * (MXFP4_MFMA_K // MXFP4_SCALE_BLOCK_K)
+                    )
+                    reg = fx.make_rmem_tensor(1, fx.Uint8)
+                    fx.copy(
+                        sc_lds_atom,
+                        fx.make_view(
+                            fx.add_offset(base_bytes, off), fx.make_layout(1, 1)
+                        ),
+                        reg,
+                    )
+                    words.append(fx.get_scalar(reg[0]).to(fx.Int32))
+            return words
+
+        def mma_stage(k_tile, mid, cur_a, cur_b):
             """Run one K-tile's MFMAs. `mid` performs the tile's fragment reads
             and direct-to-LDS DMA and returns the fragments; it runs between
             issuing the scale loads and consuming them so those loads get the
             whole DMA block as latency shadow.
             """
+            if const_expr(d.lds_scale):
+                av, bv = mid()
+                sa_words = lds_scale_read(
+                    smem_sca,
+                    sc_lane_base_a + cur_a * fx.Int32(d.sc_a_bytes),
+                    m_repeat_stride,
+                    d.mma_m_repeat,
+                )
+                sb_words = lds_scale_read(
+                    smem_scb,
+                    sc_lane_base_b + cur_b * fx.Int32(d.sc_b_bytes),
+                    n_repeat_stride,
+                    d.mma_n_repeat,
+                )
+                for kh in range_constexpr(d.k_halves):
+                    for ni in range_constexpr(d.mma_n_repeat):
+                        for mi in range_constexpr(d.mma_m_repeat):
+                            scaled_mma(
+                                frag_C[(None, 0), mi, ni],
+                                av[kh * d.mma_m_repeat + mi],
+                                bv[kh * d.mma_n_repeat + ni],
+                                sa_words[mi * d.k_halves + kh],
+                                sb_words[ni * d.k_halves + kh],
+                            )
+                return
+
             if const_expr(packed_unit_scale):
                 col_base = k_tile * fx.Int32(block_k // MXFP4_MFMA_K)
                 a_regs = packed_unit_issue(
@@ -1157,7 +1408,7 @@ def make_mxfp4_scaled_mm_gfx950(
                 async_load_b(tb, write_b)
                 return frags
 
-            mma_stage(k_tile, _mid)
+            mma_stage(k_tile, _mid, cur_a, cur_b)
 
         # Drain: exactly one peeled tile. Everything it consumes is already in
         # flight, so it issues no loads and only has to walk vmcnt down.
@@ -1166,7 +1417,7 @@ def make_mxfp4_scaled_mm_gfx950(
         cur_a = fx.Int32(kt % stages_a)
         cur_b = fx.Int32(kt % stages_b)
         __barrier(tail_waits[0])
-        mma_stage(k_tile, lambda: load_fragments(cur_a, cur_b))
+        mma_stage(k_tile, lambda: load_fragments(cur_a, cur_b), cur_a, cur_b)
 
         frag_C_out = fx.make_fragment_like(frag_C, out_elem)
         frag_C_out.store(frag_C.load().to(out_elem))
@@ -1188,6 +1439,7 @@ def make_mxfp4_scaled_mm_gfx950(
             group_m=group_m,
             stages_a=stages_a,
             stages_b=stages_b,
+            lds_scale=lds_scale,
         )
     )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp4_gfx950.py
@@ -521,9 +521,30 @@ def make_mxfp4_scaled_mm_gfx950(
     use_group_m = group_m > 0 and tiles_m % group_m == 0 and tiles_m > group_m
     # The remap only helps when the swizzle is there to compact the result.
     use_xcd_remap = use_group_m
-    # One dword feeds exactly four repeats through the 4x4 lane-group transpose,
-    # so shallower register blocking keeps the per-byte scale loads.
-    packed_scale = d.mma_m_repeat % 4 == 0 and d.mma_n_repeat % 4 == 0
+    # One dword load feeds four repeats through the 4x4 lane-group transpose.
+    # When the register blocking supplies four of them, the per-K-step loads sit
+    # at adjacent dwords and LLVM merges them into dwordx2/x4 -- the dividend
+    # recorded in MXFP4-v1-DERIVATION.md 5.1. Nothing below changes that path.
+    packed_repeat_scale = d.mma_m_repeat % 4 == 0 and d.mma_n_repeat % 4 == 0
+    # Shallower blocking used to fall straight back to per-BYTE scale gathers,
+    # and that is where the kernel loses: every EXHAUSTIVE champion on a cell
+    # that loses to Triton has a per-wave tile under 64 in some dimension, which
+    # is exactly the condition above (repeat = per-wave extent / 16). Measured
+    # cost was 6-10x the L1 accesses per MFMA (P0-STRUCTURAL-FINDINGS.md).
+    #
+    # The four lanes groups do not have to carry four *repeats*. A unit is "one
+    # row's dword at one MFMA K step", and k_halves supplies units just as well,
+    # so flattening (repeat, k_half) refills the groups when repeats alone
+    # cannot. Those loads do not land on adjacent dwords, so they do not merge
+    # -- but ceil(units/4) beats the byte path's one instruction per repeat per
+    # K step, which is the comparison the gate makes.
+    a_scale_units = d.mma_m_repeat * d.k_halves
+    b_scale_units = d.mma_n_repeat * d.k_halves
+    packed_unit_scale = not packed_repeat_scale and (
+        -(-a_scale_units // 4) + -(-b_scale_units // 4)
+        < d.k_halves * (d.mma_m_repeat + d.mma_n_repeat)
+    )
+    packed_scale = packed_repeat_scale or packed_unit_scale
 
     @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def kernel(
@@ -649,7 +670,33 @@ def make_mxfp4_scaled_mm_gfx950(
         # the LDS side is modeled in dwords the way the FlyDSL mxfp4 reference
         # kernel models it, and only the MMA atom is told the element format.
         lds_copy = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Int32)
-        dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        # Async direct-to-LDS DMA (FlyDSL #1023) when the runtime has it.
+        #
+        # On gfx950 this lowers to the same buffer_load ... lds instruction as the
+        # synchronous CDNA3 atom; what changes is that the backend no longer
+        # inserts its own vmcnt wait before the staged LDS data is read, which is
+        # the unexpected vmcnt(0) raised in review on this line.
+        #
+        # The explicit s_waitcnt vmcnt(N) in __barrier stays. gfx950 still counts
+        # this load in vmcnt -- hasAsyncMark() is true here only via
+        # hasVMemToLDSLoad(); the real s_wait_asynccnt is gfx1250+ -- so the manual
+        # wait remains both valid and necessary.
+        #
+        # Bracketing the copies with rocdl.asyncmark(), which the atom's docstring
+        # suggests, was measured and rejected: asyncmark is a side-effecting meta
+        # op, so it acts as a scheduling barrier and blocks sinking the DMA into
+        # the MFMA block -- the ordering v7 ablation adopted. On
+        # 256,256,256,2,4,2,0 it cost 24 spills and 2 extra vmcnt(0) per iteration;
+        # adding wait_asyncmark on top cost 31 and 8.
+        #
+        # Guarded because the released FlyDSL 0.3.1 predates #1023: without this
+        # the template would raise AttributeError instead of falling back.
+        if const_expr(hasattr(fx.rocdl.cdna4, "BufferLoadAsyncLDS128b")):
+            dma_atom = fx.make_copy_atom(
+                fx.rocdl.cdna4.BufferLoadAsyncLDS128b(), 128
+            )
+        else:
+            dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
         scale_atom = fx.make_copy_atom(fx.rocdl.BufferCopy8b(), fx.Uint8)
 
         swizzle_bytes = fx.static(
@@ -852,6 +899,35 @@ def make_mxfp4_scaled_mm_gfx950(
                 regs.append(reg)
             return regs
 
+        def packed_unit_issue(buf, base, row_base, repeat_stride, n_repeat, col_base):
+            """packed_scale_issue for blocking too shallow to give four repeats.
+
+            Unit u = mi * k_halves + kh addresses one row's dword at one MFMA K
+            step; lane group g takes unit q + g. k_halves is the fast axis so a
+            full load's four groups read consecutive dwords of at most two rows.
+            """
+            n_units = n_repeat * d.k_halves
+            regs = []
+            for q in range_constexpr(0, n_units, 4):
+                unit = fx.Int32(q) + scale_group
+                if const_expr(q + 4 > n_units):
+                    # Short tail: wrap onto a valid unit rather than address off
+                    # the end of the scale tensor. The surplus groups' words are
+                    # simply never consumed.
+                    unit = unit % fx.Int32(n_units)
+                row = row_base + fx.Int32(repeat_stride) * (
+                    unit // fx.Int32(d.k_halves)
+                )
+                offset = (
+                    (base + row) * fx.Int32(scale_k32)
+                    + col_base
+                    + unit % fx.Int32(d.k_halves)
+                )
+                reg = fx.make_rmem_tensor(1, fx.Uint32)
+                fx.copy(scale32_atom, fx.slice(buf, (None, offset)), reg)
+                regs.append(reg)
+            return regs
+
         def packed_scale_finish(regs):
             """Broadcast each loaded dword's four rows across the four lane
             groups, then extract this lane's K-quarter byte.
@@ -936,7 +1012,32 @@ def make_mxfp4_scaled_mm_gfx950(
             issuing the scale loads and consuming them so those loads get the
             whole DMA block as latency shadow.
             """
-            if const_expr(packed_scale):
+            if const_expr(packed_unit_scale):
+                col_base = k_tile * fx.Int32(block_k // MXFP4_MFMA_K)
+                a_regs = packed_unit_issue(
+                    sa32, m_base, a_row_base, m_repeat_stride, d.mma_m_repeat,
+                    col_base,
+                )
+                b_regs = packed_unit_issue(
+                    sb32, n_base, b_row_base, n_repeat_stride, d.mma_n_repeat,
+                    col_base,
+                )
+                av, bv = mid()
+                sa_words = packed_scale_finish(a_regs)
+                sb_words = packed_scale_finish(b_regs)
+                for kh in range_constexpr(d.k_halves):
+                    for ni in range_constexpr(d.mma_n_repeat):
+                        for mi in range_constexpr(d.mma_m_repeat):
+                            scaled_mma(
+                                frag_C[(None, 0), mi, ni],
+                                av[kh * d.mma_m_repeat + mi],
+                                bv[kh * d.mma_n_repeat + ni],
+                                sa_words[mi * d.k_halves + kh],
+                                sb_words[ni * d.k_halves + kh],
+                            )
+                return
+
+            if const_expr(packed_repeat_scale):
                 issued = []
                 for kh in range_constexpr(d.k_halves):
                     col32 = k_tile * fx.Int32(block_k // MXFP4_MFMA_K) + fx.Int32(kh)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+import functools
+from dataclasses import dataclass
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import range_constexpr
+
+
+@dataclass(frozen=True)
+class MXFP8GemmParams:
+    """Compile-time identity for one specialized MXFP8 baseline kernel."""
+
+    m: int
+    n: int
+    k: int
+    out_dtype: str
+
+    def __cache_signature__(self):
+        return ("mxfp8_gfx950_v1", self.m, self.n, self.k, self.out_dtype)
+
+
+MXFP8_BLOCK_K = 32
+MXFP8_MFMA_K = 128
+MXFP8_MFMA_M = 16
+MXFP8_MFMA_N = 16
+GFX950_WAVE_SIZE = 64
+
+
+@functools.lru_cache(maxsize=64)
+def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
+    """Build a correctness-first gfx950 MXFP8 scaled GEMM launcher.
+
+    One Wave64 computes one 16x16 output tile. Inputs are contiguous E4M3
+    matrices in [M, K] and [N, K] storage order. Scales are contiguous raw
+    E8M0 bytes in [M, K / 32] and [N, K / 32] order.
+    """
+    if m <= 0 or n <= 0 or k <= 0:
+        raise ValueError("m, n, and k must be positive")
+    if m % 32 != 0 or n % 32 != 0 or k % MXFP8_MFMA_K != 0:
+        raise ValueError("MXFP8 baseline requires M%32 == N%32 == 0 and K%128 == 0")
+
+    if out_dtype == "bfloat16":
+        out_elem = fx.BFloat16
+    elif out_dtype == "float16":
+        out_elem = fx.Float16
+    else:
+        raise ValueError(f"unsupported MXFP8 output dtype: {out_dtype}")
+
+    scale_k = k // MXFP8_BLOCK_K
+    k_iters = k // MXFP8_MFMA_K
+    grid_size = (m // MXFP8_MFMA_M) * (n // MXFP8_MFMA_N)
+
+    @flyc.kernel(known_block_size=[GFX950_WAVE_SIZE, 1, 1])
+    def kernel(
+        a: fx.Tensor,
+        b_nk: fx.Tensor,
+        scale_a_u8: fx.Tensor,
+        scale_b_u8: fx.Tensor,
+        out: fx.Tensor,
+    ):
+        a_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(a))
+        b_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(b_nk))
+        sa_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_a_u8))
+        sb_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_b_u8))
+        out_ptr = fx.recast_iter(out_elem, fx.get_iter(out))
+
+        lane = fx.Int32(fx.thread_idx.x)
+        lane_16 = lane % fx.Int32(MXFP8_MFMA_N)
+        k_group = lane // fx.Int32(MXFP8_MFMA_N)
+
+        tiles_n = n // MXFP8_MFMA_N
+        linear_tile = fx.Int32(fx.block_idx.x)
+        tile_m = linear_tile // fx.Int32(tiles_n)
+        tile_n = linear_tile % fx.Int32(tiles_n)
+        m0 = tile_m * fx.Int32(MXFP8_MFMA_M)
+        n0 = tile_n * fx.Int32(MXFP8_MFMA_N)
+        a_row = m0 + lane_16
+        b_row = n0 + lane_16
+
+        mma_atom = fx.make_mma_atom(
+            fx.rocdl.cdna4.MFMA_Scale(
+                MXFP8_MFMA_M,
+                MXFP8_MFMA_N,
+                MXFP8_MFMA_K,
+                fx.Float8E4M3FN,
+                fx.Float8E4M3FN,
+                fx.Float32,
+                opsel_a=0,
+                opsel_b=0,
+            )
+        )
+        c_frag = fx.make_rmem_tensor(4, fx.Float32)
+        c_frag.store(fx.Vector.filled(4, 0.0, fx.Float32))
+        vec16_u8_ty = fx.Vector.make_type(16, fx.Uint8)
+
+        def load_operand_i32x8(base_u8, row, k_tile):
+            row_base = fx.Int64(row) * fx.Int64(k)
+            k_base = fx.Int64(k_tile * MXFP8_MFMA_K) + fx.Int64(k_group) * fx.Int64(16)
+            lo = fx.ptr_load(
+                base_u8 + row_base + k_base, result_type=vec16_u8_ty
+            ).bitcast(fx.Int32)
+            hi = fx.ptr_load(
+                base_u8 + row_base + k_base + fx.Int64(64),
+                result_type=vec16_u8_ty,
+            ).bitcast(fx.Int32)
+            packed = lo.shuffle(hi, list(range(8)))
+            frag = fx.make_rmem_tensor(8, fx.Int32)
+            frag.store(fx.Vector(packed))
+            return frag
+
+        def load_scale_word(scale_u8, row, k_tile):
+            scale_offset = (
+                fx.Int64(row) * fx.Int64(scale_k)
+                + fx.Int64(k_tile * 4)
+                + fx.Int64(k_group)
+            )
+            scale_byte = fx.ptr_load(scale_u8 + scale_offset)
+            return scale_byte.to(fx.Int32) * fx.Int32(0x01010101)
+
+        for k_tile in range_constexpr(k_iters):
+            a_frag = load_operand_i32x8(a_u8, a_row, k_tile)
+            b_frag = load_operand_i32x8(b_u8, b_row, k_tile)
+            scale_a_word = load_scale_word(sa_u8, a_row, k_tile)
+            scale_b_word = load_scale_word(sb_u8, b_row, k_tile)
+            fx.gemm(
+                mma_atom,
+                c_frag,
+                a_frag,
+                b_frag,
+                c_frag,
+                scale_a=scale_a_word,
+                scale_b=scale_b_word,
+            )
+
+        out4 = fx.Vector(c_frag.load().ir_value()).to(out_elem)
+        col = n0 + lane_16
+        row0 = m0 + k_group * fx.Int32(4)
+        for i in range_constexpr(4):
+            out_offset = fx.Int64(row0 + fx.Int32(i)) * fx.Int64(n) + fx.Int64(col)
+            fx.ptr_store(out4[i], out_ptr + out_offset)
+
+    @flyc.jit
+    def launch(
+        a: fx.Tensor,
+        b_nk: fx.Tensor,
+        scale_a_u8: fx.Tensor,
+        scale_b_u8: fx.Tensor,
+        out: fx.Tensor,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        kernel(a, b_nk, scale_a_u8, scale_b_u8, out).launch(
+            grid=(grid_size, 1, 1),
+            block=(GFX950_WAVE_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -14,8 +14,24 @@ from dataclasses import dataclass
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir.dialects import llvm
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, rocdl as _rocdl_ops
 from flydsl.expr import const_expr, range_constexpr, rocdl
+
+
+def _permlane_swap(width, old, src):
+    """v_permlane{16,32}_swap_b32 -> (new_old, new_src) as i32 IR values.
+
+    Both operands are read-modify-write: the instruction exchanges row groups
+    between them and returns both halves. width=32 swaps rows 2,3 of `old` with
+    rows 0,1 of `src`; width=16 swaps the odd rows of `old` with the even rows
+    of `src`.
+    """
+    i32 = ir.IntegerType.get_signless(32)
+    sty = ir.Type.parse("!llvm.struct<(i32, i32)>")
+    fn = _rocdl_ops.permlane16_swap if width == 16 else _rocdl_ops.permlane32_swap
+    res = fn(sty, fx.as_ir_value(old), fx.as_ir_value(src), False, False)
+    return llvm.extractvalue(i32, res, [0]), llvm.extractvalue(i32, res, [1])
 
 
 MXFP8_SCALE_BLOCK_K = 32
@@ -46,11 +62,10 @@ class MXFP8GemmParams:
     m_waves: int = 2
     n_waves: int = 2
     group_m: int = 0
-    frag_first: int = 1
 
     def __cache_signature__(self):
         return (
-            "mxfp8_gfx950_v3",
+            "mxfp8_gfx950_v4",
             self.m,
             self.n,
             self.k,
@@ -62,7 +77,6 @@ class MXFP8GemmParams:
             self.m_waves,
             self.n_waves,
             self.group_m,
-            self.frag_first,
         )
 
 
@@ -199,9 +213,6 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
     m_waves = int(gemm_config["BLOCK_M_WARPS"])
     n_waves = int(gemm_config["BLOCK_N_WARPS"])
     group_m = int(gemm_config["GROUP_M"])
-    frag_first = int(gemm_config["FRAG_FIRST"])
-    if frag_first not in (0, 1):
-        return None
     try:
         derived = mxfp8_gemm_derived(
             block_m, block_n, block_k, stages, m_waves, n_waves, group_m
@@ -227,7 +238,6 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
         m_waves=m_waves,
         n_waves=n_waves,
         group_m=group_m,
-        frag_first=frag_first,
     )
 
 
@@ -237,7 +247,7 @@ def make_mxfp8_gemm_kernel_name(param: MXFP8GemmParams) -> str:
         f"_{param.out_dtype}"
         f"_bm{param.block_m}_bn{param.block_n}_bk{param.block_k}"
         f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
-        f"_g{param.group_m}_f{param.frag_first}"
+        f"_g{param.group_m}"
     )
 
 
@@ -266,7 +276,6 @@ def make_mxfp8_scaled_mm_gfx950(
     m_waves: int = 2,
     n_waves: int = 2,
     group_m: int = 0,
-    frag_first: int = 1,
 ):
     """Build a tiled gfx950 MXFP8 scaled GEMM launcher for one tile config."""
     if m <= 0 or n <= 0 or k <= 0:
@@ -539,7 +548,6 @@ def make_mxfp8_scaled_mm_gfx950(
         # their bytes, that the MFMA stream waits on.
         scale32_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Uint32)
         scale_k32 = scale_k // 4
-        lane_row = (fx.Int32(tid) % fx.Int32(GFX950_WAVE_SIZE)) % fx.Int32(MXFP8_MFMA_N)
 
         def make_flat_buffer32(tensor, elems32):
             # The scale tensors arrive as u8 views, so their pointer carries
@@ -563,21 +571,45 @@ def make_mxfp8_scaled_mm_gfx950(
                 make_flat_buffer32(scale_b_u8, n * scale_k32), fx.make_layout(1, 1)
             )
 
-        def packed_scale_words(buf, base, thr_row, n_repeat, kh, col32):
+        def packed_scale_issue(buf, base, thr_row, n_repeat, kh, col32):
+            """Issue only the dword scale loads and return the landing registers.
+
+            Split out from the transpose so the loads can be hoisted above the
+            tile's direct-to-LDS DMA. vmcnt is an in-order counter, so a scale
+            load issued before the DMA block is satisfied by a counted wait
+            rather than the full drain a trailing load would need.
+            """
             rows = [fx.get_scalar(thr_row[0, mi, kh]) for mi in range(n_repeat)]
             repeat_stride = rows[1] - rows[0]
-            words = []
+            regs = []
             for q in range_constexpr(0, n_repeat, 4):
                 row = rows[q] + repeat_stride * scale_group
                 offset = (base + row) * fx.Int32(scale_k32) + col32
                 reg = fx.make_rmem_tensor(1, fx.Uint32)
                 fx.copy(scale32_atom, fx.slice(buf, (None, offset)), reg)
+                regs.append(reg)
+            return regs
+
+        def packed_scale_finish(regs):
+            """Broadcast each loaded dword's four rows across the four lane
+            groups, then extract this lane's K-quarter byte.
+
+            One dword holds a whole K-tile of scales for one row, and a wave's
+            64 lanes cover four MMA repeats, so lane group g needs row g of the
+            dword. Feeding the same register to both operands of a swap turns
+            the general 4x4 lane-group transpose into exactly that broadcast and
+            collapses four swaps into three. The VALU swaps replace ds_bpermute,
+            which shares the in-order lgkmcnt with the fragment ds_reads and so
+            drained them on every transpose.
+            """
+            words = []
+            for reg in regs:
                 packed = fx.get_scalar(reg[0]).to(fx.Int32)
-                for j in range_constexpr(4):
-                    idx = (fx.Int32(j * MXFP8_MFMA_N) + lane_row) * fx.Int32(4)
-                    lane_word = fx.Int32(
-                        rocdl.ds_bpermute(fx.Int32.ir_type, idx, packed)
-                    )
+                t0, t1 = _permlane_swap(32, packed, packed)
+                u0, u1 = _permlane_swap(16, t0, t0)
+                w0, w1 = _permlane_swap(16, t1, t1)
+                for lane_word in (u0, u1, w0, w1):
+                    lane_word = fx.Int32(lane_word)
                     byte = (lane_word >> (scale_group * fx.Int32(8))) & fx.Int32(0xFF)
                     words.append(byte * fx.Int32(0x01010101))
             return words
@@ -605,43 +637,70 @@ def make_mxfp8_scaled_mm_gfx950(
                     frag_A_retile[None, None, kh],
                 )
 
-        def mma_stage(k_tile):
-            for kh in range_constexpr(d.k_halves):
-                if const_expr(packed_scale):
+        def mma_stage(k_tile, mid=None):
+            """Run one K-tile's MFMAs. `mid` is the tile's fragment reads and
+            direct-to-LDS DMA, run between issuing the scale loads and consuming
+            them so those loads get the whole DMA block as latency shadow.
+            """
+            if const_expr(packed_scale):
+                issued = []
+                for kh in range_constexpr(d.k_halves):
                     col32 = k_tile * fx.Int32(block_k // MXFP8_MFMA_K) + fx.Int32(kh)
-                    sa_words = packed_scale_words(
-                        sa32, m_base, thr_mma_aRow, d.mma_m_repeat, kh, col32
-                    )
-                    sb_words = packed_scale_words(
-                        sb32, n_base, thr_mma_bRow, d.mma_n_repeat, kh, col32
-                    )
-                else:
-                    scale_col = (
-                        k_tile * fx.Int32(block_k // MXFP8_SCALE_BLOCK_K)
-                        + fx.Int32(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
-                        + scale_group
-                    )
-                    sa_words = []
-                    for mi in range_constexpr(d.mma_m_repeat):
-                        local_row = fx.get_scalar(thr_mma_aRow[0, mi, kh])
-                        sa_words.append(
-                            load_scale_word(
-                                sa_flat,
-                                m_base + local_row,
-                                scale_col,
-                            )
+                    issued.append(
+                        (
+                            packed_scale_issue(
+                                sa32, m_base, thr_mma_aRow, d.mma_m_repeat, kh, col32
+                            ),
+                            packed_scale_issue(
+                                sb32, n_base, thr_mma_bRow, d.mma_n_repeat, kh, col32
+                            ),
                         )
-
-                    sb_words = []
+                    )
+                if mid is not None:
+                    mid()
+                for kh in range_constexpr(d.k_halves):
+                    sa_words = packed_scale_finish(issued[kh][0])
+                    sb_words = packed_scale_finish(issued[kh][1])
                     for ni in range_constexpr(d.mma_n_repeat):
-                        local_row = fx.get_scalar(thr_mma_bRow[0, ni, kh])
-                        sb_words.append(
-                            load_scale_word(
-                                sb_flat,
-                                n_base + local_row,
-                                scale_col,
+                        for mi in range_constexpr(d.mma_m_repeat):
+                            scaled_mma(
+                                frag_C[(None, 0), mi, ni],
+                                frag_A[None, mi, kh],
+                                frag_B[None, ni, kh],
+                                sa_words[mi],
+                                sb_words[ni],
                             )
+                return
+
+            if mid is not None:
+                mid()
+            for kh in range_constexpr(d.k_halves):
+                scale_col = (
+                    k_tile * fx.Int32(block_k // MXFP8_SCALE_BLOCK_K)
+                    + fx.Int32(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
+                    + scale_group
+                )
+                sa_words = []
+                for mi in range_constexpr(d.mma_m_repeat):
+                    local_row = fx.get_scalar(thr_mma_aRow[0, mi, kh])
+                    sa_words.append(
+                        load_scale_word(
+                            sa_flat,
+                            m_base + local_row,
+                            scale_col,
                         )
+                    )
+
+                sb_words = []
+                for ni in range_constexpr(d.mma_n_repeat):
+                    local_row = fx.get_scalar(thr_mma_bRow[0, ni, kh])
+                    sb_words.append(
+                        load_scale_word(
+                            sb_flat,
+                            n_base + local_row,
+                            scale_col,
+                        )
+                    )
 
                 for ni in range_constexpr(d.mma_n_repeat):
                     for mi in range_constexpr(d.mma_m_repeat):
@@ -666,29 +725,28 @@ def make_mxfp8_scaled_mm_gfx950(
             cur = k_tile % fx.Int32(stages)
             write = (cur + fx.Int32(stages - 1)) % fx.Int32(stages)
             __barrier(steady_wait)
+
             # A direct-to-LDS load is a VMEM op that writes LDS, so the compiler
             # cannot prove it does not alias a later ds_read and drains vmcnt to
-            # zero in between. With frag_first the tile's fragments are read
-            # first, which leaves the DMA free to overlap the whole MFMA block;
-            # workgroups small enough to keep several resident per CU hide that
-            # latency across waves instead and prefer issuing the DMA earliest.
-            if const_expr(frag_first):
+            # zero in between. Reading the tile's fragments before issuing the
+            # DMA removes the reason for that drain: the compiler then emits a
+            # counted wait and sinks the DMA into the MFMA block. This ordering
+            # was measured against the reverse on 12 tile configs spanning
+            # 1 to 16 waves per CU and won 11 of 12 (the twelfth was a tie),
+            # by 2% to 53%, so it is fixed rather than searched.
+            def _mid(cur=cur, k_tile=k_tile, write=write):
                 load_fragments(cur)
                 async_load_b(k_tile + fx.Int32(stages - 1), write)
                 async_load_a(k_tile + fx.Int32(stages - 1), write)
-            else:
-                async_load_b(k_tile + fx.Int32(stages - 1), write)
-                async_load_a(k_tile + fx.Int32(stages - 1), write)
-                load_fragments(cur)
-            mma_stage(k_tile)
+
+            mma_stage(k_tile, _mid)
 
         # Drain: consume the buffers still in flight, walking vmcnt down to 0.
         for s in range_constexpr(stages - 1):
             k_tile = fx.Int32(main_loop_end + s)
             cur = k_tile % fx.Int32(stages)
             __barrier((stages - 2 - s) * d.ldg_wait_count)
-            load_fragments(cur)
-            mma_stage(k_tile)
+            mma_stage(k_tile, lambda cur=cur: load_fragments(cur))
 
         frag_C_out = fx.make_fragment_like(frag_C, out_elem)
         frag_C_out.store(frag_C.load().to(out_elem))
@@ -708,7 +766,6 @@ def make_mxfp8_scaled_mm_gfx950(
             m_waves=m_waves,
             n_waves=n_waves,
             group_m=group_m,
-            frag_first=frag_first,
         )
     )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -252,7 +252,7 @@ def make_mxfp8_gemm_kernel_name(param: MXFP8GemmParams) -> str:
     )
 
 
-# TODO: Move common ROCm synchronization and buffer-load helpers to FlyDSL.
+# TODO: Move this common ROCm synchronization helper to FlyDSL.
 def __barrier(vmcnt=0):
     llvm.InlineAsmOp(
         None,
@@ -568,11 +568,11 @@ def make_mxfp8_scaled_mm_gfx950(
             )
 
         # Packed scale path. One 4-byte load holds a whole K-tile of E8M0 scales
-        # for one row, and 64 lanes cover four MMA repeats at once, so
-        # ds_bpermute can do the 4x4 lane-group transpose that hands each row's
-        # dword to the lane group that needs it; each lane then shifts out its
-        # own K-quarter byte. This turns 16 single-byte loads per K-tile into 4
-        # dword loads, and it is the number of outstanding scale loads, not
+        # for one row, and 64 lanes cover four MMA repeats at once. VALU
+        # permlane swaps perform the 4x4 lane-group transpose that hands each
+        # row's dword to the lane group that needs it; each lane then shifts out
+        # its own K-quarter byte. This turns 16 single-byte loads per K-tile into
+        # 4 dword loads, and it is the number of outstanding scale loads, not
         # their bytes, that the MFMA stream waits on.
         scale32_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Uint32)
         scale_k32 = scale_k // 4

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -41,6 +41,7 @@ MXFP8_MFMA_K = 128
 GFX950_WAVE_SIZE = 64
 GFX950_DMA_BYTES = 16
 GFX950_LDS_CAPACITY = 163840
+GFX950_NUM_XCD = 8
 GFX950_MAX_BLOCK_THREADS = 1024
 # The pre-Layout v2 kernel benefited from 8x8 register blocking. Keep that
 # search bound while v3 resource use is re-measured.
@@ -65,7 +66,7 @@ class MXFP8GemmParams:
 
     def __cache_signature__(self):
         return (
-            "mxfp8_gfx950_v4",
+            "mxfp8_gfx950_v6",
             self.m,
             self.n,
             self.k,
@@ -309,6 +310,8 @@ def make_mxfp8_scaled_mm_gfx950(
     # tiles stay hot in L2. Only exact groupings are used, which keeps the
     # index math free of a runtime min.
     use_group_m = group_m > 0 and tiles_m % group_m == 0 and tiles_m > group_m
+    # The remap only helps when the swizzle is there to compact the result.
+    use_xcd_remap = use_group_m
     # One dword feeds exactly four repeats through the 4x4 lane-group transpose,
     # so shallower register blocking keeps the per-byte scale loads.
     packed_scale = d.mma_m_repeat % 4 == 0 and d.mma_n_repeat % 4 == 0
@@ -324,6 +327,31 @@ def make_mxfp8_scaled_mm_gfx950(
         tid = fx.thread_idx.x
 
         pid = fx.Int32(fx.block_idx.x)
+        if const_expr(use_xcd_remap):
+            # Workgroups are handed to the 8 XCDs round-robin by id, so an id
+            # written straight into the GROUP_M swizzle spreads each XCD's
+            # tiles over the whole output and defeats its private L2 slice.
+            # Inverting the round-robin gives every XCD a contiguous id range;
+            # the swizzle below then folds that range into a compact 2-D block.
+            # Both halves are needed -- without the swizzle the contiguous
+            # range is a full row band, which is worse than not remapping at
+            # all, so this is tied to group_m rather than enabled on its own.
+            # tiles_m and tiles_n are trace-time constants, so the division and
+            # remainder fold away.
+            xcd_q, xcd_r = divmod(tiles_m * tiles_n, GFX950_NUM_XCD)
+            xcd = pid % fx.Int32(GFX950_NUM_XCD)
+            in_xcd = pid // fx.Int32(GFX950_NUM_XCD)
+            if const_expr(xcd_r == 0):
+                pid = xcd * fx.Int32(xcd_q) + in_xcd
+            else:
+                # branchless min(xcd, xcd_r) from the sign mask of xcd - xcd_r
+                diff = xcd - fx.Int32(xcd_r)
+                pid = (
+                    xcd * fx.Int32(xcd_q)
+                    + fx.Int32(xcd_r)
+                    + (diff & (diff >> fx.Int32(31)))
+                    + in_xcd
+                )
         if const_expr(use_group_m):
             group_tiles = group_m * tiles_n
             group_id = pid // fx.Int32(group_tiles)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -50,9 +50,20 @@ GFX950_WAVE_SIZE = 64
 GFX950_DMA_BYTES = 16
 GFX950_LDS_CAPACITY = 163840
 GFX950_MAX_BLOCK_THREADS = 1024
-# Repeats beyond this spill the f32[4] accumulators; same cutoff the FP16
-# exhaustive generator uses.
-MXFP8_MAX_MMA_REPEAT = 4
+# Per-wave register blocking depth. Each k step issues Rm + Rn LDS reads and
+# Rm * Rn MFMAs, so the cap directly sets the MFMA-per-LDS-read ratio that this
+# kernel is limited by -- 4x4 gives 2, 8x8 gives 4. It is not an LDS-bandwidth
+# limit (removing the XOR swizzle, i.e. going from 2-way to 16-way bank
+# conflicts, costs only 1.5%) nor an occupancy limit (20 waves/CU at 2x2
+# repeats is slower than 8 waves/CU at 4x4); the MFMA unit idles waiting on
+# ds_read issue slots and latency, which deeper blocking amortizes.
+#
+# Measured on gfx950 with bf16 output: 8x8 uses 224 of 512 VGPRs with no
+# scratch and is 1.17-1.29x faster than 4x4 for M >= 2048, while 16x8 spills
+# and collapses to roughly a fifth of the throughput. The FP16 template caps at
+# 4 because its 2-byte elements make each fragment twice as wide; e4m3 halves
+# that, so the cutoff has to be re-derived rather than inherited.
+MXFP8_MAX_MMA_REPEAT = 8
 # 16-byte granules spanned by one 128-K MFMA step.
 MXFP8_GRANULES_PER_MFMA_K = MXFP8_MFMA_K // GFX950_DMA_BYTES
 # The f8f6f4 ABI splits a lane's 32 operand bytes into two 16-byte halves that

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -1,45 +1,337 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+"""Parameterized gfx950 MXFP8 scaled GEMM.
+
+E4M3 operands with per-32-element E8M0 block scales, folded into the CDNA4
+scaled 16x16x128 MFMA. A is [M, K] and B is [N, K], both row-major over K;
+the output is [M, N] bf16/fp16.
+
+The tiling mirrors the FP16/BF16 gfx950 GEMM in ``gemm_gfx950.py``:
+
+  * LDS blocking      -- a workgroup stages [block_m, block_k] of A and
+                         [block_n, block_k] of B into LDS so every wave in the
+                         group reuses them.
+  * multi-stage       -- ``stages`` LDS buffers are filled by global->LDS DMA;
+    pipelining           the loop waits on a counted ``vmcnt`` so the DMAs for
+                         later stages stay in flight across the MFMAs.
+  * register blocking -- each wave keeps mma_m_repeat x mma_n_repeat f32[4]
+                         accumulators and reuses one LDS read across the repeat
+                         loops.
+
+Together these lift arithmetic intensity from the previous baseline's fixed
+8 flops/byte (one wave, one 16x16 tile, operands straight from global) to
+2*block_m*block_n/(block_m+block_n), which is what lets throughput scale with
+problem size instead of saturating.
+
+The MFMA operand plumbing follows FlyDSL's own tiled MX kernel
+(``kernels/gemm/mxfp4_preshuffle.py``) rather than the CuTe-style
+``make_fragment_A``/``make_tiled_mma`` path used by the FP16 kernel: the scaled
+MFMA takes two extra i32 scale operands, which that path does not carry, so A/B
+fragments are built by hand as rank-1 i32[8] registers.
+"""
+
 import functools
 from dataclasses import dataclass
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import range_constexpr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm
+from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+
+
+MXFP8_SCALE_BLOCK_K = 32
+MXFP8_MFMA_M = 16
+MXFP8_MFMA_N = 16
+MXFP8_MFMA_K = 128
+GFX950_WAVE_SIZE = 64
+GFX950_DMA_BYTES = 16
+GFX950_LDS_CAPACITY = 163840
+GFX950_MAX_BLOCK_THREADS = 1024
+# Repeats beyond this spill the f32[4] accumulators; same cutoff the FP16
+# exhaustive generator uses.
+MXFP8_MAX_MMA_REPEAT = 4
+# 16-byte granules spanned by one 128-K MFMA step.
+MXFP8_GRANULES_PER_MFMA_K = MXFP8_MFMA_K // GFX950_DMA_BYTES
+# The f8f6f4 ABI splits a lane's 32 operand bytes into two 16-byte halves that
+# sit 64 bytes apart inside the 128-K block.
+MXFP8_HI_GRANULE_OFFSET = 4
 
 
 @dataclass(frozen=True)
 class MXFP8GemmParams:
-    """Compile-time identity for one specialized MXFP8 baseline kernel."""
+    """Compile-time identity of one specialized MXFP8 kernel."""
 
     m: int
     n: int
     k: int
     out_dtype: str
+    block_m: int = 128
+    block_n: int = 128
+    block_k: int = 256
+    stages: int = 2
+    m_waves: int = 2
+    n_waves: int = 2
+    group_m: int = 0
 
     def __cache_signature__(self):
-        return ("mxfp8_gfx950_v1", self.m, self.n, self.k, self.out_dtype)
+        return (
+            "mxfp8_gfx950_v2",
+            self.m,
+            self.n,
+            self.k,
+            self.out_dtype,
+            self.block_m,
+            self.block_n,
+            self.block_k,
+            self.stages,
+            self.m_waves,
+            self.n_waves,
+            self.group_m,
+        )
 
 
-MXFP8_BLOCK_K = 32
-MXFP8_MFMA_K = 128
-MXFP8_MFMA_M = 16
-MXFP8_MFMA_N = 16
-GFX950_WAVE_SIZE = 64
+@dataclass(frozen=True)
+class MXFP8GemmDerived:
+    """Quantities derived from a tile config, shared by the kernel and the
+    heuristics filter so the two can never disagree."""
+
+    block_threads: int
+    wave_tile_m: int
+    wave_tile_n: int
+    mma_m_repeat: int
+    mma_n_repeat: int
+    k_halves: int
+    scale_cols: int
+    granules_per_row: int
+    ldg_a_iters: int
+    ldg_b_iters: int
+    ldg_wait_count: int
+    a_stage_bytes: int
+    b_stage_bytes: int
+    smem_bytes: int
 
 
-@functools.lru_cache(maxsize=64)
-def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
-    """Build a correctness-first gfx950 MXFP8 scaled GEMM launcher.
+def mxfp8_gemm_derived(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    stages: int,
+    m_waves: int,
+    n_waves: int,
+    group_m: int = 0,
+) -> MXFP8GemmDerived:
+    """Validate a tile config and return its derived quantities.
 
-    One Wave64 computes one 16x16 output tile. Inputs are contiguous E4M3
-    matrices in [M, K] and [N, K] storage order. Scales are contiguous raw
-    E8M0 bytes in [M, K / 32] and [N, K / 32] order.
+    Raises ValueError for any config the kernel cannot express. Mirrors
+    make_gemm_gfx950_param in the FP16 kernel.
     """
+    if block_m <= 0 or block_n <= 0 or block_k <= 0:
+        raise ValueError("block_m, block_n, and block_k must be positive")
+    if stages < 2:
+        raise ValueError("stages must be at least 2 for the staged LDS pipeline")
+    if m_waves <= 0 or n_waves <= 0:
+        raise ValueError("m_waves and n_waves must be positive")
+    if group_m < 0:
+        raise ValueError("group_m must be non-negative")
+    if block_k % MXFP8_MFMA_K != 0:
+        raise ValueError(
+            f"block_k must be a multiple of the MFMA K depth: block_k={block_k}"
+        )
+
+    block_threads = m_waves * n_waves * GFX950_WAVE_SIZE
+    if block_threads > GFX950_MAX_BLOCK_THREADS:
+        raise ValueError(f"block exceeds {GFX950_MAX_BLOCK_THREADS} threads")
+
+    wave_tile_m, rem_m = divmod(block_m, m_waves)
+    wave_tile_n, rem_n = divmod(block_n, n_waves)
+    if rem_m or rem_n:
+        raise ValueError("block_m/block_n must be divisible by m_waves/n_waves")
+
+    mma_m_repeat, rem_m = divmod(wave_tile_m, MXFP8_MFMA_M)
+    mma_n_repeat, rem_n = divmod(wave_tile_n, MXFP8_MFMA_N)
+    if rem_m or rem_n or mma_m_repeat == 0 or mma_n_repeat == 0:
+        raise ValueError(
+            "each wave tile must be a positive multiple of the 16x16 MFMA tile"
+        )
+    if mma_m_repeat > MXFP8_MAX_MMA_REPEAT or mma_n_repeat > MXFP8_MAX_MMA_REPEAT:
+        raise ValueError(
+            "accumulator repeats exceed the register budget: "
+            f"mma_m_repeat={mma_m_repeat}, mma_n_repeat={mma_n_repeat}"
+        )
+
+    granules_per_row = block_k // GFX950_DMA_BYTES
+    # The LDS layout XORs the granule index with the row, so the granule count
+    # has to be a power of two or the swizzle would leave the row.
+    if granules_per_row & (granules_per_row - 1):
+        raise ValueError(
+            f"block_k / {GFX950_DMA_BYTES} must be a power of two for the XOR "
+            f"swizzle: block_k={block_k}"
+        )
+
+    dma_bytes_per_pass = block_threads * GFX950_DMA_BYTES
+    if (block_m * block_k) % dma_bytes_per_pass != 0:
+        raise ValueError(
+            "A tile load schedule must exactly cover the LDS tile: "
+            f"block_m={block_m}, block_k={block_k}, block_threads={block_threads}"
+        )
+    if (block_n * block_k) % dma_bytes_per_pass != 0:
+        raise ValueError(
+            "B tile load schedule must exactly cover the LDS tile: "
+            f"block_n={block_n}, block_k={block_k}, block_threads={block_threads}"
+        )
+    ldg_a_iters = (block_m * block_k) // dma_bytes_per_pass
+    ldg_b_iters = (block_n * block_k) // dma_bytes_per_pass
+    ldg_wait_count = ldg_a_iters + ldg_b_iters
+
+    a_stage_bytes = block_m * block_k
+    b_stage_bytes = block_n * block_k
+    smem_bytes = stages * (a_stage_bytes + b_stage_bytes)
+    if smem_bytes > GFX950_LDS_CAPACITY:
+        raise ValueError(
+            "staged LDS buffers exceed the device shared-memory capacity: "
+            f"stages={stages}, block_m={block_m}, block_n={block_n}, "
+            f"block_k={block_k}, smem_bytes={smem_bytes}, "
+            f"capacity={GFX950_LDS_CAPACITY}"
+        )
+    if (stages - 2) * ldg_wait_count >= 63:
+        raise ValueError("staged pipeline wait count exceeds supported range")
+
+    return MXFP8GemmDerived(
+        block_threads=block_threads,
+        wave_tile_m=wave_tile_m,
+        wave_tile_n=wave_tile_n,
+        mma_m_repeat=mma_m_repeat,
+        mma_n_repeat=mma_n_repeat,
+        k_halves=block_k // MXFP8_MFMA_K,
+        scale_cols=block_k // MXFP8_SCALE_BLOCK_K,
+        granules_per_row=granules_per_row,
+        ldg_a_iters=ldg_a_iters,
+        ldg_b_iters=ldg_b_iters,
+        ldg_wait_count=ldg_wait_count,
+        a_stage_bytes=a_stage_bytes,
+        b_stage_bytes=b_stage_bytes,
+        smem_bytes=smem_bytes,
+    )
+
+
+def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
+    """Return MXFP8GemmParams for a concrete shape, or None if unsupported.
+
+    Mirrors make_gemm_param_and_validate in the FP16 kernel: the autotuning
+    filter uses None to mean "drop this choice".
+    """
+    if out_dtype not in ("bfloat16", "float16"):
+        return None
+    block_m = int(gemm_config["TILE_M"])
+    block_n = int(gemm_config["TILE_N"])
+    block_k = int(gemm_config["TILE_K"])
+    stages = int(gemm_config["STAGES"])
+    m_waves = int(gemm_config["BLOCK_M_WARPS"])
+    n_waves = int(gemm_config["BLOCK_N_WARPS"])
+    group_m = int(gemm_config["GROUP_M"])
+    try:
+        derived = mxfp8_gemm_derived(
+            block_m, block_n, block_k, stages, m_waves, n_waves, group_m
+        )
+    except Exception:
+        return None
+    # No boundary predication: the tile must divide the problem exactly.
+    if m % block_m or n % block_n or k % block_k:
+        return None
+    # The prologue fills stages-1 buffers before the steady-state loop runs.
+    if (k // block_k) < stages:
+        return None
+    del derived
+    return MXFP8GemmParams(
+        m=m,
+        n=n,
+        k=k,
+        out_dtype=out_dtype,
+        block_m=block_m,
+        block_n=block_n,
+        block_k=block_k,
+        stages=stages,
+        m_waves=m_waves,
+        n_waves=n_waves,
+        group_m=group_m,
+    )
+
+
+def make_mxfp8_gemm_kernel_name(param: MXFP8GemmParams) -> str:
+    return (
+        "mxfp8_scaled_mm_gfx950"
+        f"_{param.out_dtype}"
+        f"_bm{param.block_m}_bn{param.block_n}_bk{param.block_k}"
+        f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
+        f"_g{param.group_m}"
+    )
+
+
+# TODO: Move common ROCm synchronization and buffer-load helpers to FlyDSL.
+def __barrier(vmcnt=0):
+    llvm.InlineAsmOp(
+        None,
+        [],
+        f"s_waitcnt vmcnt({vmcnt})\n\ts_barrier",
+        "",
+        has_side_effects=True,
+    )
+
+
+def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
+    buffer_load_asm_dict = {
+        16: "buffer_load_dwordx4",
+        8: "buffer_load_dwordx2",
+        4: "buffer_load_dword",
+    }
+    llvm.InlineAsmOp(
+        None,
+        [
+            llvm.IntToPtrOp(
+                ir.Type.parse("!llvm.ptr<3>"),
+                fx.as_ir_value(fx.ptrtoint(lds_ptr)),
+            ).result,
+            fx.as_ir_value(global_offset),
+            fx.as_ir_value(rsrc),
+        ],
+        f"s_mov_b32 m0, $0\n\t{buffer_load_asm_dict[dma_bytes]} $1, $2, 0 offen sc0 lds",
+        "s,v,s",
+        has_side_effects=True,
+    )
+
+
+@functools.lru_cache(maxsize=256)
+def make_mxfp8_scaled_mm_gfx950(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: str,
+    block_m: int = 128,
+    block_n: int = 128,
+    block_k: int = 256,
+    stages: int = 2,
+    m_waves: int = 2,
+    n_waves: int = 2,
+    group_m: int = 0,
+):
+    """Build a tiled gfx950 MXFP8 scaled GEMM launcher for one tile config."""
     if m <= 0 or n <= 0 or k <= 0:
         raise ValueError("m, n, and k must be positive")
-    if m % 32 != 0 or n % 32 != 0 or k % MXFP8_MFMA_K != 0:
-        raise ValueError("MXFP8 baseline requires M%32 == N%32 == 0 and K%128 == 0")
+    d = mxfp8_gemm_derived(
+        block_m, block_n, block_k, stages, m_waves, n_waves, group_m
+    )
+    if m % block_m or n % block_n or k % block_k:
+        raise ValueError(
+            f"shape must be divisible by the tile: {m}x{n}x{k} vs "
+            f"{block_m}x{block_n}x{block_k}"
+        )
+    k_tiles = k // block_k
+    if k_tiles < stages:
+        raise ValueError("K must supply at least `stages` tiles for the pipeline")
 
     if out_dtype == "bfloat16":
         out_elem = fx.BFloat16
@@ -48,11 +340,20 @@ def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
     else:
         raise ValueError(f"unsupported MXFP8 output dtype: {out_dtype}")
 
-    scale_k = k // MXFP8_BLOCK_K
-    k_iters = k // MXFP8_MFMA_K
-    grid_size = (m // MXFP8_MFMA_M) * (n // MXFP8_MFMA_N)
+    block_threads = d.block_threads
+    granules_per_row = d.granules_per_row
+    granule_mask = granules_per_row - 1
+    scale_k = k // MXFP8_SCALE_BLOCK_K
+    tiles_m = m // block_m
+    tiles_n = n // block_n
+    grid_size = tiles_m * tiles_n
+    main_loop_end = k_tiles - (stages - 1)
+    # Group consecutive workgroups into GROUP_M rows of the N sweep so their B
+    # tiles stay hot in L2. Only exact groupings are used, which keeps the
+    # index math free of a runtime min.
+    use_group_m = group_m > 0 and tiles_m % group_m == 0 and tiles_m > group_m
 
-    @flyc.kernel(known_block_size=[GFX950_WAVE_SIZE, 1, 1])
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def kernel(
         a: fx.Tensor,
         b_nk: fx.Tensor,
@@ -60,24 +361,49 @@ def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
         scale_b_u8: fx.Tensor,
         out: fx.Tensor,
     ):
-        a_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(a))
-        b_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(b_nk))
         sa_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_a_u8))
         sb_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_b_u8))
         out_ptr = fx.recast_iter(out_elem, fx.get_iter(out))
 
-        lane = fx.Int32(fx.thread_idx.x)
+        a_rsrc = fx.rocdl.get_buffer_rsrc(
+            fx.get_iter(fx.rocdl.make_buffer_tensor(a, max_size=True))
+        )
+        b_rsrc = fx.rocdl.get_buffer_rsrc(
+            fx.get_iter(fx.rocdl.make_buffer_tensor(b_nk, max_size=True))
+        )
+
+        tid = fx.Int32(fx.thread_idx.x)
+        wave = rocdl.readfirstlane(T.i32, tid // fx.Int32(GFX950_WAVE_SIZE))
+        lane = tid % fx.Int32(GFX950_WAVE_SIZE)
         lane_16 = lane % fx.Int32(MXFP8_MFMA_N)
         k_group = lane // fx.Int32(MXFP8_MFMA_N)
+        wave_m = wave // fx.Int32(n_waves)
+        wave_n = wave % fx.Int32(n_waves)
 
-        tiles_n = n // MXFP8_MFMA_N
-        linear_tile = fx.Int32(fx.block_idx.x)
-        tile_m = linear_tile // fx.Int32(tiles_n)
-        tile_n = linear_tile % fx.Int32(tiles_n)
-        m0 = tile_m * fx.Int32(MXFP8_MFMA_M)
-        n0 = tile_n * fx.Int32(MXFP8_MFMA_N)
-        a_row = m0 + lane_16
-        b_row = n0 + lane_16
+        pid = fx.Int32(fx.block_idx.x)
+        if const_expr(use_group_m):
+            group_tiles = group_m * tiles_n
+            group_id = pid // fx.Int32(group_tiles)
+            within = pid % fx.Int32(group_tiles)
+            bid_m = group_id * fx.Int32(group_m) + within % fx.Int32(group_m)
+            bid_n = within // fx.Int32(group_m)
+        else:
+            bid_m = pid // fx.Int32(tiles_n)
+            bid_n = pid % fx.Int32(tiles_n)
+        m_base = bid_m * fx.Int32(block_m)
+        n_base = bid_n * fx.Int32(block_n)
+
+        @fx.struct
+        class SharedAB:
+            a: fx.Array[fx.Int8, stages * d.a_stage_bytes, 16]
+            b: fx.Array[fx.Int8, stages * d.b_stage_bytes, 16]
+
+        lds = fx.SharedAllocator().allocate(SharedAB).peek()
+        sA_i8 = fx.recast_iter(fx.Int8, lds.a.ptr)
+        sB_i8 = fx.recast_iter(fx.Int8, lds.b.ptr)
+        sA_i32 = fx.recast_iter(fx.Int32, lds.a.ptr)
+        sB_i32 = fx.recast_iter(fx.Int32, lds.b.ptr)
+        lds_copy = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Int32)
 
         mma_atom = fx.make_mma_atom(
             fx.rocdl.cdna4.MFMA_Scale(
@@ -91,55 +417,184 @@ def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
                 opsel_b=0,
             )
         )
-        c_frag = fx.make_rmem_tensor(4, fx.Float32)
-        c_frag.store(fx.Vector.filled(4, 0.0, fx.Float32))
-        vec16_u8_ty = fx.Vector.make_type(16, fx.Uint8)
 
-        def load_operand_i32x8(base_u8, row, k_tile):
-            row_base = fx.Int64(row) * fx.Int64(k)
-            k_base = fx.Int64(k_tile * MXFP8_MFMA_K) + fx.Int64(k_group) * fx.Int64(16)
-            lo = fx.ptr_load(
-                base_u8 + row_base + k_base, result_type=vec16_u8_ty
-            ).bitcast(fx.Int32)
-            hi = fx.ptr_load(
-                base_u8 + row_base + k_base + fx.Int64(64),
-                result_type=vec16_u8_ty,
-            ).bitcast(fx.Int32)
-            packed = lo.shuffle(hi, list(range(8)))
+        def async_load_tile(rsrc, lds_i8, stage_bytes, ldg_iters, rows_base, k_tile, stage):
+            """Stage one [rows, block_k] byte tile from global into LDS.
+
+            The DMA writes lanes contiguously from a wave-uniform LDS base, so
+            the destination is fixed and the *source* column is permuted to
+            realize the XOR swizzle (same trick as the FP16 kernel).
+            """
+            stage_off = stage * fx.Int32(stage_bytes)
+            for i in range_constexpr(ldg_iters):
+                lin = (fx.Int32(i * block_threads) + tid) * fx.Int32(GFX950_DMA_BYTES)
+                row = lin // fx.Int32(block_k)
+                granule = (lin % fx.Int32(block_k)) // fx.Int32(GFX950_DMA_BYTES)
+                src_granule = granule ^ (row & fx.Int32(granule_mask))
+                gmem = (rows_base + row) * fx.Int32(k) + fx.Int32(
+                    k_tile
+                ) * fx.Int32(block_k) + src_granule * fx.Int32(GFX950_DMA_BYTES)
+                wave_base = stage_off + fx.Int32(
+                    (i * block_threads) * GFX950_DMA_BYTES
+                ) + wave * fx.Int32(GFX950_WAVE_SIZE * GFX950_DMA_BYTES)
+                lds_ptr = fx.add_offset(
+                    lds_i8, rocdl.readfirstlane(T.i32, wave_base)
+                )
+                buffer_load_lds_inline(rsrc, lds_ptr, gmem, GFX950_DMA_BYTES)
+
+        def async_load_a(k_tile, stage):
+            async_load_tile(
+                a_rsrc, sA_i8, d.a_stage_bytes, d.ldg_a_iters, m_base, k_tile, stage
+            )
+
+        def async_load_b(k_tile, stage):
+            async_load_tile(
+                b_rsrc, sB_i8, d.b_stage_bytes, d.ldg_b_iters, n_base, k_tile, stage
+            )
+
+        def read_frag(lds_i32, stage_bytes, stage, row_in_block, kh):
+            """ds_read_b128 x2 -> one i32[8] MFMA operand fragment."""
+            row_swz = row_in_block & fx.Int32(granule_mask)
+            lo_logical = fx.Int32(kh * MXFP8_GRANULES_PER_MFMA_K) + k_group
+            hi_logical = lo_logical + fx.Int32(MXFP8_HI_GRANULE_OFFSET)
+            base_i32 = (
+                stage * fx.Int32(stage_bytes // 4)
+                + row_in_block * fx.Int32(block_k // 4)
+            )
+
+            def read16(logical):
+                phys = logical ^ row_swz
+                off = base_i32 + phys * fx.Int32(GFX950_DMA_BYTES // 4)
+                frag = fx.make_rmem_tensor(4, fx.Int32)
+                fx.copy(
+                    lds_copy,
+                    fx.make_view(fx.add_offset(lds_i32, off), fx.make_layout(4, 1)),
+                    frag,
+                )
+                return frag
+
+            lo = Vec(fx.memref_load_vec(read16(lo_logical)))
+            hi = Vec(fx.memref_load_vec(read16(hi_logical)))
             frag = fx.make_rmem_tensor(8, fx.Int32)
-            frag.store(fx.Vector(packed))
+            frag.store(lo.shuffle(hi, list(range(8))))
             return frag
 
-        def load_scale_word(scale_u8, row, k_tile):
-            scale_offset = (
-                fx.Int64(row) * fx.Int64(scale_k)
-                + fx.Int64(k_tile * 4)
+        def load_scale_word(scale_u8, row_global, k_tile, kh):
+            off = (
+                fx.Int64(row_global) * fx.Int64(scale_k)
+                + fx.Int64(k_tile) * fx.Int64(d.scale_cols)
+                + fx.Int64(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
                 + fx.Int64(k_group)
             )
-            scale_byte = fx.ptr_load(scale_u8 + scale_offset)
+            scale_byte = fx.ptr_load(scale_u8 + off)
+            # The atom reads one e8m0 byte per 32-K block; broadcasting keeps
+            # it independent of the opsel byte lane.
             return scale_byte.to(fx.Int32) * fx.Int32(0x01010101)
 
-        for k_tile in range_constexpr(k_iters):
-            a_frag = load_operand_i32x8(a_u8, a_row, k_tile)
-            b_frag = load_operand_i32x8(b_u8, b_row, k_tile)
-            scale_a_word = load_scale_word(sa_u8, a_row, k_tile)
-            scale_b_word = load_scale_word(sb_u8, b_row, k_tile)
-            fx.gemm(
-                mma_atom,
-                c_frag,
-                a_frag,
-                b_frag,
-                c_frag,
-                scale_a=scale_a_word,
-                scale_b=scale_b_word,
-            )
+        # Row/col of this wave's first 16x16 tile inside the block tile.
+        wave_row0 = wave_m * fx.Int32(d.wave_tile_m)
+        wave_col0 = wave_n * fx.Int32(d.wave_tile_n)
 
-        out4 = fx.Vector(c_frag.load().ir_value()).to(out_elem)
-        col = n0 + lane_16
-        row0 = m0 + k_group * fx.Int32(4)
-        for i in range_constexpr(4):
-            out_offset = fx.Int64(row0 + fx.Int32(i)) * fx.Int64(n) + fx.Int64(col)
-            fx.ptr_store(out4[i], out_ptr + out_offset)
+        accs = [
+            fx.make_rmem_tensor(4, fx.Float32)
+            for _ in range_constexpr(d.mma_m_repeat * d.mma_n_repeat)
+        ]
+        for idx in range_constexpr(d.mma_m_repeat * d.mma_n_repeat):
+            accs[idx].store(Vec.filled(4, 0.0, fx.Float32))
+
+        def compute_stage(stage, k_tile):
+            for kh in range_constexpr(d.k_halves):
+                a_frags = []
+                sa_words = []
+                for mi in range_constexpr(d.mma_m_repeat):
+                    row_in_block = wave_row0 + fx.Int32(mi * MXFP8_MFMA_M) + lane_16
+                    a_frags.append(
+                        read_frag(sA_i32, d.a_stage_bytes, stage, row_in_block, kh)
+                    )
+                    sa_words.append(
+                        load_scale_word(sa_u8, m_base + row_in_block, k_tile, kh)
+                    )
+                b_frags = []
+                sb_words = []
+                for ni in range_constexpr(d.mma_n_repeat):
+                    col_in_block = wave_col0 + fx.Int32(ni * MXFP8_MFMA_N) + lane_16
+                    b_frags.append(
+                        read_frag(sB_i32, d.b_stage_bytes, stage, col_in_block, kh)
+                    )
+                    sb_words.append(
+                        load_scale_word(sb_u8, n_base + col_in_block, k_tile, kh)
+                    )
+                # Register blocking: each LDS read feeds every repeat on the
+                # other axis.
+                for ni in range_constexpr(d.mma_n_repeat):
+                    for mi in range_constexpr(d.mma_m_repeat):
+                        acc = accs[mi * d.mma_n_repeat + ni]
+                        fx.gemm(
+                            mma_atom,
+                            acc,
+                            a_frags[mi],
+                            b_frags[ni],
+                            acc,
+                            scale_a=sa_words[mi],
+                            scale_b=sb_words[ni],
+                        )
+
+        # Prologue: fill stages-1 buffers so the steady-state loop always has a
+        # landed tile to consume.
+        for stage in range_constexpr(stages - 1):
+            async_load_b(stage, fx.Int32(stage))
+            async_load_a(stage, fx.Int32(stage))
+        rocdl.sched_barrier(0)
+
+        steady_wait = (stages - 2) * d.ldg_wait_count
+        for kt in range(0, main_loop_end, 1):
+            k_tile = fx.Int32(kt)
+            cur = k_tile % fx.Int32(stages)
+            write = (cur + fx.Int32(stages - 1)) % fx.Int32(stages)
+            __barrier(steady_wait)
+            async_load_b(k_tile + fx.Int32(stages - 1), write)
+            async_load_a(k_tile + fx.Int32(stages - 1), write)
+            compute_stage(cur, k_tile)
+
+        # Drain: consume the buffers still in flight, walking vmcnt down to 0.
+        for s in range_constexpr(stages - 1):
+            k_tile = fx.Int32(main_loop_end + s)
+            cur = k_tile % fx.Int32(stages)
+            __barrier((stages - 2 - s) * d.ldg_wait_count)
+            compute_stage(cur, k_tile)
+
+        # Epilogue: each lane owns 4 rows of every 16x16 accumulator.
+        for mi in range_constexpr(d.mma_m_repeat):
+            row0 = (
+                m_base
+                + wave_row0
+                + fx.Int32(mi * MXFP8_MFMA_M)
+                + k_group * fx.Int32(4)
+            )
+            for ni in range_constexpr(d.mma_n_repeat):
+                col = n_base + wave_col0 + fx.Int32(ni * MXFP8_MFMA_N) + lane_16
+                out4 = Vec(accs[mi * d.mma_n_repeat + ni].load().ir_value()).to(
+                    out_elem
+                )
+                for i in range_constexpr(4):
+                    off = fx.Int64(row0 + fx.Int32(i)) * fx.Int64(n) + fx.Int64(col)
+                    fx.ptr_store(out4[i], out_ptr + off)
+
+    kernel._func.__name__ = make_mxfp8_gemm_kernel_name(
+        MXFP8GemmParams(
+            m=m,
+            n=n,
+            k=k,
+            out_dtype=out_dtype,
+            block_m=block_m,
+            block_n=block_n,
+            block_k=block_k,
+            stages=stages,
+            m_waves=m_waves,
+            n_waves=n_waves,
+            group_m=group_m,
+        )
+    )
 
     @flyc.jit
     def launch(
@@ -152,7 +607,7 @@ def make_mxfp8_scaled_mm_gfx950(*, m: int, n: int, k: int, out_dtype: str):
     ):
         kernel(a, b_nk, scale_a_u8, scale_b_u8, out).launch(
             grid=(grid_size, 1, 1),
-            block=(GFX950_WAVE_SIZE, 1, 1),
+            block=(block_threads, 1, 1),
             stream=stream,
         )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -46,6 +46,7 @@ class MXFP8GemmParams:
     m_waves: int = 2
     n_waves: int = 2
     group_m: int = 0
+    frag_first: int = 1
 
     def __cache_signature__(self):
         return (
@@ -61,6 +62,7 @@ class MXFP8GemmParams:
             self.m_waves,
             self.n_waves,
             self.group_m,
+            self.frag_first,
         )
 
 
@@ -197,6 +199,9 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
     m_waves = int(gemm_config["BLOCK_M_WARPS"])
     n_waves = int(gemm_config["BLOCK_N_WARPS"])
     group_m = int(gemm_config["GROUP_M"])
+    frag_first = int(gemm_config["FRAG_FIRST"])
+    if frag_first not in (0, 1):
+        return None
     try:
         derived = mxfp8_gemm_derived(
             block_m, block_n, block_k, stages, m_waves, n_waves, group_m
@@ -222,6 +227,7 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
         m_waves=m_waves,
         n_waves=n_waves,
         group_m=group_m,
+        frag_first=frag_first,
     )
 
 
@@ -231,7 +237,7 @@ def make_mxfp8_gemm_kernel_name(param: MXFP8GemmParams) -> str:
         f"_{param.out_dtype}"
         f"_bm{param.block_m}_bn{param.block_n}_bk{param.block_k}"
         f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
-        f"_g{param.group_m}"
+        f"_g{param.group_m}_f{param.frag_first}"
     )
 
 
@@ -260,6 +266,7 @@ def make_mxfp8_scaled_mm_gfx950(
     m_waves: int = 2,
     n_waves: int = 2,
     group_m: int = 0,
+    frag_first: int = 1,
 ):
     """Build a tiled gfx950 MXFP8 scaled GEMM launcher for one tile config."""
     if m <= 0 or n <= 0 or k <= 0:
@@ -293,6 +300,9 @@ def make_mxfp8_scaled_mm_gfx950(
     # tiles stay hot in L2. Only exact groupings are used, which keeps the
     # index math free of a runtime min.
     use_group_m = group_m > 0 and tiles_m % group_m == 0 and tiles_m > group_m
+    # One dword feeds exactly four repeats through the 4x4 lane-group transpose,
+    # so shallower register blocking keeps the per-byte scale loads.
+    packed_scale = d.mma_m_repeat % 4 == 0 and d.mma_n_repeat % 4 == 0
 
     @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def kernel(
@@ -520,7 +530,59 @@ def make_mxfp8_scaled_mm_gfx950(
                 scale_b=scale_b,
             )
 
-        def compute_stage(stage, k_tile):
+        # Packed scale path. One 4-byte load holds a whole K-tile of E8M0 scales
+        # for one row, and 64 lanes cover four MMA repeats at once, so
+        # ds_bpermute can do the 4x4 lane-group transpose that hands each row's
+        # dword to the lane group that needs it; each lane then shifts out its
+        # own K-quarter byte. This turns 16 single-byte loads per K-tile into 4
+        # dword loads, and it is the number of outstanding scale loads, not
+        # their bytes, that the MFMA stream waits on.
+        scale32_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Uint32)
+        scale_k32 = scale_k // 4
+        lane_row = (fx.Int32(tid) % fx.Int32(GFX950_WAVE_SIZE)) % fx.Int32(MXFP8_MFMA_N)
+
+        def make_flat_buffer32(tensor, elems32):
+            # The scale tensors arrive as u8 views, so their pointer carries
+            # alignment 1 and a 4-byte load needs that restated.
+            src = fx.get_iter(tensor)
+            flat = fx.Tensor(
+                fx.make_view(
+                    fx.recast_iter(
+                        fx.PointerType.get(fx.Uint32.ir_type, src.memspace, 4), src
+                    ),
+                    fx.make_layout(elems32, 1),
+                )
+            )
+            return fx.rocdl.make_buffer_tensor(flat, max_size=True)
+
+        if const_expr(packed_scale):
+            sa32 = fx.logical_divide(
+                make_flat_buffer32(scale_a_u8, m * scale_k32), fx.make_layout(1, 1)
+            )
+            sb32 = fx.logical_divide(
+                make_flat_buffer32(scale_b_u8, n * scale_k32), fx.make_layout(1, 1)
+            )
+
+        def packed_scale_words(buf, base, thr_row, n_repeat, kh, col32):
+            rows = [fx.get_scalar(thr_row[0, mi, kh]) for mi in range(n_repeat)]
+            repeat_stride = rows[1] - rows[0]
+            words = []
+            for q in range_constexpr(0, n_repeat, 4):
+                row = rows[q] + repeat_stride * scale_group
+                offset = (base + row) * fx.Int32(scale_k32) + col32
+                reg = fx.make_rmem_tensor(1, fx.Uint32)
+                fx.copy(scale32_atom, fx.slice(buf, (None, offset)), reg)
+                packed = fx.get_scalar(reg[0]).to(fx.Int32)
+                for j in range_constexpr(4):
+                    idx = (fx.Int32(j * MXFP8_MFMA_N) + lane_row) * fx.Int32(4)
+                    lane_word = fx.Int32(
+                        rocdl.ds_bpermute(fx.Int32.ir_type, idx, packed)
+                    )
+                    byte = (lane_word >> (scale_group * fx.Int32(8))) & fx.Int32(0xFF)
+                    words.append(byte * fx.Int32(0x01010101))
+            return words
+
+        def load_fragments(stage):
             sA_stage = fx.make_view(
                 smem_a + stage * fx.Int32(block_m * block_k),
                 a_lds_layout,
@@ -542,33 +604,44 @@ def make_mxfp8_scaled_mm_gfx950(
                     thr_sA[None, None, kh],
                     frag_A_retile[None, None, kh],
                 )
-                scale_col = (
-                    k_tile * fx.Int32(block_k // MXFP8_SCALE_BLOCK_K)
-                    + fx.Int32(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
-                    + scale_group
-                )
 
-                sa_words = []
-                for mi in range_constexpr(d.mma_m_repeat):
-                    local_row = fx.get_scalar(thr_mma_aRow[0, mi, kh])
-                    sa_words.append(
-                        load_scale_word(
-                            sa_flat,
-                            m_base + local_row,
-                            scale_col,
-                        )
+        def mma_stage(k_tile):
+            for kh in range_constexpr(d.k_halves):
+                if const_expr(packed_scale):
+                    col32 = k_tile * fx.Int32(block_k // MXFP8_MFMA_K) + fx.Int32(kh)
+                    sa_words = packed_scale_words(
+                        sa32, m_base, thr_mma_aRow, d.mma_m_repeat, kh, col32
                     )
+                    sb_words = packed_scale_words(
+                        sb32, n_base, thr_mma_bRow, d.mma_n_repeat, kh, col32
+                    )
+                else:
+                    scale_col = (
+                        k_tile * fx.Int32(block_k // MXFP8_SCALE_BLOCK_K)
+                        + fx.Int32(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
+                        + scale_group
+                    )
+                    sa_words = []
+                    for mi in range_constexpr(d.mma_m_repeat):
+                        local_row = fx.get_scalar(thr_mma_aRow[0, mi, kh])
+                        sa_words.append(
+                            load_scale_word(
+                                sa_flat,
+                                m_base + local_row,
+                                scale_col,
+                            )
+                        )
 
-                sb_words = []
-                for ni in range_constexpr(d.mma_n_repeat):
-                    local_row = fx.get_scalar(thr_mma_bRow[0, ni, kh])
-                    sb_words.append(
-                        load_scale_word(
-                            sb_flat,
-                            n_base + local_row,
-                            scale_col,
+                    sb_words = []
+                    for ni in range_constexpr(d.mma_n_repeat):
+                        local_row = fx.get_scalar(thr_mma_bRow[0, ni, kh])
+                        sb_words.append(
+                            load_scale_word(
+                                sb_flat,
+                                n_base + local_row,
+                                scale_col,
+                            )
                         )
-                    )
 
                 for ni in range_constexpr(d.mma_n_repeat):
                     for mi in range_constexpr(d.mma_m_repeat):
@@ -593,16 +666,29 @@ def make_mxfp8_scaled_mm_gfx950(
             cur = k_tile % fx.Int32(stages)
             write = (cur + fx.Int32(stages - 1)) % fx.Int32(stages)
             __barrier(steady_wait)
-            async_load_b(k_tile + fx.Int32(stages - 1), write)
-            async_load_a(k_tile + fx.Int32(stages - 1), write)
-            compute_stage(cur, k_tile)
+            # A direct-to-LDS load is a VMEM op that writes LDS, so the compiler
+            # cannot prove it does not alias a later ds_read and drains vmcnt to
+            # zero in between. With frag_first the tile's fragments are read
+            # first, which leaves the DMA free to overlap the whole MFMA block;
+            # workgroups small enough to keep several resident per CU hide that
+            # latency across waves instead and prefer issuing the DMA earliest.
+            if const_expr(frag_first):
+                load_fragments(cur)
+                async_load_b(k_tile + fx.Int32(stages - 1), write)
+                async_load_a(k_tile + fx.Int32(stages - 1), write)
+            else:
+                async_load_b(k_tile + fx.Int32(stages - 1), write)
+                async_load_a(k_tile + fx.Int32(stages - 1), write)
+                load_fragments(cur)
+            mma_stage(k_tile)
 
         # Drain: consume the buffers still in flight, walking vmcnt down to 0.
         for s in range_constexpr(stages - 1):
             k_tile = fx.Int32(main_loop_end + s)
             cur = k_tile % fx.Int32(stages)
             __barrier((stages - 2 - s) * d.ldg_wait_count)
-            compute_stage(cur, k_tile)
+            load_fragments(cur)
+            mma_stage(k_tile)
 
         frag_C_out = fx.make_fragment_like(frag_C, out_elem)
         frag_C_out.store(frag_C.load().to(out_elem))
@@ -622,6 +708,7 @@ def make_mxfp8_scaled_mm_gfx950(
             m_waves=m_waves,
             n_waves=n_waves,
             group_m=group_m,
+            frag_first=frag_first,
         )
     )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -18,6 +18,8 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, rocdl as _rocdl_ops
 from flydsl.expr import const_expr, range_constexpr, rocdl
 
+from torch.utils._ordered_set import OrderedSet
+
 
 def _permlane_swap(width, old, src):
     """v_permlane{16,32}_swap_b32 -> (new_old, new_src) as i32 IR values.
@@ -63,10 +65,14 @@ class MXFP8GemmParams:
     m_waves: int = 2
     n_waves: int = 2
     group_m: int = 0
+    # Asymmetric LDS: A and B may hold a different number of staged buffers.
+    # None means "same as stages", which reproduces the symmetric kernel.
+    stages_a: int = None
+    stages_b: int = None
 
     def __cache_signature__(self):
         return (
-            "mxfp8_gfx950_v6",
+            "mxfp8_gfx950_v6_asym",
             self.m,
             self.n,
             self.k,
@@ -78,6 +84,8 @@ class MXFP8GemmParams:
             self.m_waves,
             self.n_waves,
             self.group_m,
+            self.stages_a,
+            self.stages_b,
         )
 
 
@@ -97,6 +105,82 @@ class MXFP8GemmDerived:
     a_stage_bytes: int
     b_stage_bytes: int
     smem_bytes: int
+    stages_a: int
+    stages_b: int
+
+
+def mxfp8_pipeline_schedule(k_tiles, stages_a, stages_b, ldg_a_iters, ldg_b_iters):
+    """Program-order DMA schedule for an (stages_a, stages_b) LDS pipeline.
+
+    Returns (main_loop_end, steady_wait, tail_waits, wrap_a, wrap_b).
+
+    A is prefetched da = stages_a - 1 tiles ahead, B is prefetched
+    db = stages_b - 1 tiles ahead. Iteration i issues A(i + da) then B(i + db);
+    the prologue is iterations i in [-max(da, db), 0).
+
+    The main loop always issues both operands so its body is one straight-line
+    block with one wait constant. That means iterations near the end would run
+    off the end of K, so the *tile index* of those loads is wrapped modulo
+    k_tiles: they stay in bounds, land in an LDS buffer no later iteration
+    reads, and are never consumed. Only their vmcnt slot matters, and it is
+    accounted for below. The consequence is that exactly ONE tile is peeled as
+    a drain, instead of max(da, db) of them -- one fully unrolled 32-MFMA
+    epilogue stage instead of a ragged pile of them.
+
+    vmcnt is an in-order counter, so the barrier at the top of iteration kt may
+    leave outstanding exactly the loads issued *after* the producer of the
+    later of A_kt / B_kt. That count is enumerated here rather than given in
+    closed form, because with da != db the "later of the two" is not always
+    the same operand.
+    """
+    da = stages_a - 1
+    db = stages_b - 1
+    deepest = max(da, db)
+    main_loop_end = k_tiles - 1
+    if k_tiles <= deepest:
+        raise ValueError("K must supply more tiles than the deepest prefetch")
+    # A wrapped load must not land on a buffer a later iteration still reads.
+    # Issuing iteration i still has tiles i .. k_tiles-1 to consume, i.e. buffer
+    # offsets 0 .. k_tiles-1-i <= d-1 ahead of it, while the wrapped write sits
+    # d ahead; with d = stages - 1 < stages the two never alias.
+    for d, s in ((da, stages_a), (db, stages_b)):
+        if d >= s:
+            raise ValueError("prefetch distance must be shorter than the buffer count")
+
+    # (kind, live_tile_or_None, issuing_iteration) in program order. A wrapped
+    # load carries None: it occupies a vmcnt slot but produces nothing.
+    events = []
+    for i in range(-deepest, 0):  # prologue
+        for kind, t in (("A", i + da), ("B", i + db)):
+            if t >= 0:
+                events.append((kind, t, i))
+    for i in range(0, main_loop_end):  # steady state: both always issued
+        for kind, t in (("A", i + da), ("B", i + db)):
+            events.append((kind, t if t < k_tiles else None, i))
+    # The drain iteration (kt = k_tiles - 1) issues nothing.
+
+    cost = {"A": ldg_a_iters, "B": ldg_b_iters}
+    pos = {}
+    for idx, (kind, t, _i) in enumerate(events):
+        if t is not None:
+            pos[(kind, t)] = idx
+
+    def wait_at(kt):
+        p = max(pos[("A", kt)], pos[("B", kt)])
+        return sum(cost[kind] for kind, _t, i in events[p + 1 :] if i < kt)
+
+    waits = [wait_at(kt) for kt in range(k_tiles)]
+    steady = OrderedSet(waits[:main_loop_end])
+    if len(steady) != 1:
+        raise ValueError(f"steady-state wait is not uniform: {sorted(steady)}")
+    steady_wait = steady.pop()
+    tail_waits = waits[main_loop_end:]
+    if max(waits) >= 63:
+        raise ValueError("staged pipeline wait count exceeds supported range")
+    # Only emit the runtime wrap on the operand that can actually overrun.
+    wrap_a = (main_loop_end - 1) + da >= k_tiles
+    wrap_b = (main_loop_end - 1) + db >= k_tiles
+    return main_loop_end, steady_wait, tail_waits, wrap_a, wrap_b
 
 
 def mxfp8_gemm_derived(
@@ -107,16 +191,27 @@ def mxfp8_gemm_derived(
     m_waves: int,
     n_waves: int,
     group_m: int = 0,
+    stages_a: int = None,
+    stages_b: int = None,
+    k: int = None,
 ) -> MXFP8GemmDerived:
     """Validate a tile config and return its derived quantities.
 
     Raises ValueError for any config the kernel cannot express. Mirrors
     make_gemm_gfx950_param in the FP16 kernel.
+
+    `k` is optional and only selects the B pipeline depth; leaving it out keeps
+    the result shape-independent, which is what the heuristics validity check
+    wants.
     """
     if block_m <= 0 or block_n <= 0 or block_k <= 0:
         raise ValueError("block_m, block_n, and block_k must be positive")
     if stages < 2:
         raise ValueError("stages must be at least 2 for the staged LDS pipeline")
+    if stages_a is None:
+        stages_a = stages
+    if stages_a < 2 or (stages_b is not None and stages_b < 2):
+        raise ValueError("stages_a and stages_b must each be at least 2")
     if m_waves <= 0 or n_waves <= 0:
         raise ValueError("m_waves and n_waves must be positive")
     if group_m < 0:
@@ -173,15 +268,56 @@ def mxfp8_gemm_derived(
 
     a_stage_bytes = block_m * block_k
     b_stage_bytes = block_n * block_k
-    smem_bytes = stages * (a_stage_bytes + b_stage_bytes)
+
+    if stages_b is None:
+        # Give B one staged buffer more than A when every precondition holds.
+        # B's DMA lands last in program order, so deepening only B is what turns
+        # the K-tile boundary from a full vmcnt(0) drain into a counted wait; A
+        # gains nothing from a third buffer and could not afford one anyway.
+        # Worth +1.235% at 8192x8192x8192 on the champion tile (paired n=16,
+        # t=4.372, p=0.00055).
+        #
+        # Every failure mode falls back to the symmetric depth rather than
+        # raising, because raising would drop a tile config that used to be
+        # valid and a shape whose autotune winner it was would silently fall
+        # back to ATen. The preconditions are the extra buffer fitting in LDS,
+        # K supplying more tiles than the deeper prefetch distance, and the
+        # resulting waitcnt still being expressible; the last two need k, so a
+        # caller that does not know the shape (the heuristics validity check)
+        # gets the symmetric depth and therefore the unchanged validity set.
+        stages_b = stages
+        deeper = stages_a * a_stage_bytes + (stages + 1) * b_stage_bytes
+        # Every check further down that could reject the deeper pipeline has to
+        # be repeated here, or the fallback does not happen and a tile config
+        # that was valid before is lost. The shape-independent waitcnt bound in
+        # particular is looser than the one inside mxfp8_pipeline_schedule and
+        # rejects configs the enumerator accepts.
+        deeper_ok = (
+            k is not None
+            and deeper <= GFX950_LDS_CAPACITY
+            and (max(stages_a, stages + 1) - 2) * ldg_wait_count < 63
+        )
+        if deeper_ok:
+            try:
+                mxfp8_pipeline_schedule(
+                    k // block_k, stages_a, stages + 1, ldg_a_iters, ldg_b_iters
+                )
+            except ValueError:
+                pass
+            else:
+                stages_b = stages + 1
+
+    smem_bytes = stages_a * a_stage_bytes + stages_b * b_stage_bytes
     if smem_bytes > GFX950_LDS_CAPACITY:
         raise ValueError(
             "staged LDS buffers exceed the device shared-memory capacity: "
-            f"stages={stages}, block_m={block_m}, block_n={block_n}, "
-            f"block_k={block_k}, smem_bytes={smem_bytes}, "
+            f"stages_a={stages_a}, stages_b={stages_b}, block_m={block_m}, "
+            f"block_n={block_n}, block_k={block_k}, smem_bytes={smem_bytes}, "
             f"capacity={GFX950_LDS_CAPACITY}"
         )
-    if (stages - 2) * ldg_wait_count >= 63:
+    # The exact wait counts need k_tiles, so the >= 63 check lives in
+    # mxfp8_pipeline_schedule; this is the shape-independent upper bound.
+    if (max(stages_a, stages_b) - 2) * ldg_wait_count >= 63:
         raise ValueError("staged pipeline wait count exceeds supported range")
 
     return MXFP8GemmDerived(
@@ -196,6 +332,8 @@ def mxfp8_gemm_derived(
         a_stage_bytes=a_stage_bytes,
         b_stage_bytes=b_stage_bytes,
         smem_bytes=smem_bytes,
+        stages_a=stages_a,
+        stages_b=stages_b,
     )
 
 
@@ -214,17 +352,41 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
     m_waves = int(gemm_config["BLOCK_M_WARPS"])
     n_waves = int(gemm_config["BLOCK_N_WARPS"])
     group_m = int(gemm_config["GROUP_M"])
+    stages_a = gemm_config.get("STAGES_A")
+    stages_b = gemm_config.get("STAGES_B")
+    stages_a = None if stages_a is None else int(stages_a)
+    stages_b = None if stages_b is None else int(stages_b)
     try:
         derived = mxfp8_gemm_derived(
-            block_m, block_n, block_k, stages, m_waves, n_waves, group_m
+            block_m,
+            block_n,
+            block_k,
+            stages,
+            m_waves,
+            n_waves,
+            group_m,
+            stages_a,
+            stages_b,
+            k=k,
         )
     except Exception:
         return None
     # No boundary predication: the tile must divide the problem exactly.
     if m % block_m or n % block_n or k % block_k:
         return None
-    # The prologue fills stages-1 buffers before the steady-state loop runs.
-    if (k // block_k) < stages:
+    # The prologue fills max(stages_a, stages_b) - 1 buffers before the
+    # steady-state loop runs.
+    if (k // block_k) <= max(derived.stages_a, derived.stages_b) - 1:
+        return None
+    try:
+        mxfp8_pipeline_schedule(
+            k // block_k,
+            derived.stages_a,
+            derived.stages_b,
+            derived.ldg_a_iters,
+            derived.ldg_b_iters,
+        )
+    except Exception:
         return None
     del derived
     return MXFP8GemmParams(
@@ -239,16 +401,21 @@ def make_mxfp8_param_and_validate(m, n, k, out_dtype, gemm_config):
         m_waves=m_waves,
         n_waves=n_waves,
         group_m=group_m,
+        stages_a=stages_a,
+        stages_b=stages_b,
     )
 
 
 def make_mxfp8_gemm_kernel_name(param: MXFP8GemmParams) -> str:
+    sa = param.stages if param.stages_a is None else param.stages_a
+    sb = param.stages if param.stages_b is None else param.stages_b
     return (
         "mxfp8_scaled_mm_gfx950"
         f"_{param.out_dtype}"
         f"_bm{param.block_m}_bn{param.block_n}_bk{param.block_k}"
         f"_s{param.stages}_mw{param.m_waves}_nw{param.n_waves}"
         f"_g{param.group_m}"
+        f"_sa{sa}_sb{sb}"
     )
 
 
@@ -277,19 +444,46 @@ def make_mxfp8_scaled_mm_gfx950(
     m_waves: int = 2,
     n_waves: int = 2,
     group_m: int = 0,
+    stages_a: int = None,
+    stages_b: int = None,
 ):
     """Build a tiled gfx950 MXFP8 scaled GEMM launcher for one tile config."""
     if m <= 0 or n <= 0 or k <= 0:
         raise ValueError("m, n, and k must be positive")
-    d = mxfp8_gemm_derived(block_m, block_n, block_k, stages, m_waves, n_waves, group_m)
+    d = mxfp8_gemm_derived(
+        block_m,
+        block_n,
+        block_k,
+        stages,
+        m_waves,
+        n_waves,
+        group_m,
+        stages_a,
+        stages_b,
+        k=k,
+    )
+    stages_a = d.stages_a
+    stages_b = d.stages_b
+    prefetch_a = stages_a - 1
+    prefetch_b = stages_b - 1
+    prologue_tiles = max(prefetch_a, prefetch_b)
     if m % block_m or n % block_n or k % block_k:
         raise ValueError(
             f"shape must be divisible by the tile: {m}x{n}x{k} vs "
             f"{block_m}x{block_n}x{block_k}"
         )
     k_tiles = k // block_k
-    if k_tiles < stages:
-        raise ValueError("K must supply at least `stages` tiles for the pipeline")
+    if k_tiles <= prologue_tiles:
+        raise ValueError("K must supply more tiles than the deepest prefetch")
+    (
+        main_loop_end,
+        steady_wait,
+        tail_waits,
+        wrap_a,
+        wrap_b,
+    ) = mxfp8_pipeline_schedule(
+        k_tiles, stages_a, stages_b, d.ldg_a_iters, d.ldg_b_iters
+    )
 
     if out_dtype == "bfloat16":
         out_elem = fx.BFloat16
@@ -305,7 +499,6 @@ def make_mxfp8_scaled_mm_gfx950(
     tiles_m = m // block_m
     tiles_n = n // block_n
     grid_size = tiles_m * tiles_n
-    main_loop_end = k_tiles - (stages - 1)
     # Group consecutive workgroups into GROUP_M rows of the N sweep so their B
     # tiles stay hot in L2. Only exact groupings are used, which keeps the
     # index math free of a runtime min.
@@ -366,8 +559,8 @@ def make_mxfp8_scaled_mm_gfx950(
 
         @fx.struct
         class SharedStorage:
-            a: fx.Array[fx.Float8E4M3FN, stages * block_m * block_k, 16]
-            b: fx.Array[fx.Float8E4M3FN, stages * block_n * block_k, 16]
+            a: fx.Array[fx.Float8E4M3FN, stages_a * block_m * block_k, 16]
+            b: fx.Array[fx.Float8E4M3FN, stages_b * block_n * block_k, 16]
 
         storage = fx.SharedAllocator().allocate(SharedStorage).peek()
         smem_a = storage.a.ptr
@@ -638,17 +831,26 @@ def make_mxfp8_scaled_mm_gfx950(
                 w0, w1 = _permlane_swap(16, t1, t1)
                 for lane_word in (u0, u1, w0, w1):
                     lane_word = fx.Int32(lane_word)
-                    byte = (lane_word >> (scale_group * fx.Int32(8))) & fx.Int32(0xFF)
-                    words.append(byte * fx.Int32(0x01010101))
+                    # The scaled MFMA reads exactly one byte of its 32-bit scale
+                    # operand, selected by opsel, and ignores the other three.
+                    # The atom above sets opsel 0 for both operands, so the byte
+                    # read is byte 0 -- which is where this shift already lands
+                    # the E8M0 exponent. Masking off the upper bytes and then
+                    # replicating the byte across the word are therefore both
+                    # dead, and dropping them shortens the dependency chain from
+                    # the scale load to the MFMA. Verified by placing the byte at
+                    # slot 1 with the other three zeroed: opsel 1 reproduces the
+                    # reference bit for bit, opsel 0 returns garbage.
+                    words.append(lane_word >> (scale_group * fx.Int32(8)))
             return words
 
-        def load_fragments(stage):
+        def load_fragments(stage_a, stage_b):
             sA_stage = fx.make_view(
-                smem_a + stage * fx.Int32(block_m * block_k),
+                smem_a + stage_a * fx.Int32(block_m * block_k),
                 a_lds_layout,
             )
             sB_stage = fx.make_view(
-                smem_b + stage * fx.Int32(block_n * block_k),
+                smem_b + stage_b * fx.Int32(block_n * block_k),
                 b_lds_layout,
             )
             thr_sA = thr_copy_A.partition_S(sA_stage)
@@ -740,18 +942,28 @@ def make_mxfp8_scaled_mm_gfx950(
                             sb_words[ni],
                         )
 
-        # Prologue: fill stages-1 buffers so the steady-state loop always has a
-        # landed tile to consume.
-        for stage in range_constexpr(stages - 1):
-            async_load_b(stage, fx.Int32(stage))
-            async_load_a(stage, fx.Int32(stage))
+        # Prologue: iterations i in [-prologue_tiles, 0) of the same schedule
+        # the steady state runs, so the vmcnt ordering is uniform from tile 0
+        # on. A is filled prefetch_a deep, B prefetch_b deep, and issue order
+        # is A-before-B: with prefetch_a < prefetch_b the A load is the later
+        # of the two a tile waits on, so putting it first leaves B's loads
+        # outstanding across the barrier instead of forcing a full drain.
+        # Reversing this order collapses steady_wait back to 0.
+        for i in range_constexpr(-prologue_tiles, 0):
+            if const_expr(0 <= i + prefetch_a):
+                ta = i + prefetch_a
+                async_load_a(ta, fx.Int32(ta % stages_a))
+            if const_expr(0 <= i + prefetch_b):
+                tb = i + prefetch_b
+                async_load_b(tb, fx.Int32(tb % stages_b))
         rocdl.sched_barrier(0)
 
-        steady_wait = (stages - 2) * d.ldg_wait_count
         for kt in range(0, main_loop_end, 1):
             k_tile = fx.Int32(kt)
-            cur = k_tile % fx.Int32(stages)
-            write = (cur + fx.Int32(stages - 1)) % fx.Int32(stages)
+            cur_a = k_tile % fx.Int32(stages_a)
+            cur_b = k_tile % fx.Int32(stages_b)
+            write_a = (k_tile + fx.Int32(prefetch_a)) % fx.Int32(stages_a)
+            write_b = (k_tile + fx.Int32(prefetch_b)) % fx.Int32(stages_b)
             __barrier(steady_wait)
 
             # A direct-to-LDS load is a VMEM op that writes LDS, so the compiler
@@ -762,19 +974,43 @@ def make_mxfp8_scaled_mm_gfx950(
             # was measured against the reverse on 12 tile configs spanning
             # 1 to 16 waves per CU and won 11 of 12 (the twelfth was a tie),
             # by 2% to 53%, so it is fixed rather than searched.
-            def _mid(cur=cur, k_tile=k_tile, write=write):
-                load_fragments(cur)
-                async_load_b(k_tile + fx.Int32(stages - 1), write)
-                async_load_a(k_tile + fx.Int32(stages - 1), write)
+            # Both operands are issued on every trip, unconditionally, so the
+            # body stays one straight-line block with one wait constant. The
+            # last prefetch_b - 1 trips would address tile k_tiles or beyond;
+            # the tile index is wrapped instead. The buffer tensors are built
+            # with max_size=True and have no hardware bounds clamp, so the
+            # wrap is what keeps the address in range. The wrapped tile lands
+            # in LDS buffer (kt + prefetch_b) % stages_b, which no remaining
+            # iteration reads (see mxfp8_pipeline_schedule), and its vmcnt
+            # slot is accounted for by the enumerator.
+            def _mid(
+                cur_a=cur_a,
+                cur_b=cur_b,
+                k_tile=k_tile,
+                write_a=write_a,
+                write_b=write_b,
+            ):
+                load_fragments(cur_a, cur_b)
+                ta = k_tile + fx.Int32(prefetch_a)
+                if const_expr(wrap_a):
+                    ta = ta % fx.Int32(k_tiles)
+                async_load_a(ta, write_a)
+                tb = k_tile + fx.Int32(prefetch_b)
+                if const_expr(wrap_b):
+                    tb = tb % fx.Int32(k_tiles)
+                async_load_b(tb, write_b)
 
             mma_stage(k_tile, _mid)
 
-        # Drain: consume the buffers still in flight, walking vmcnt down to 0.
-        for s in range_constexpr(stages - 1):
-            k_tile = fx.Int32(main_loop_end + s)
-            cur = k_tile % fx.Int32(stages)
-            __barrier((stages - 2 - s) * d.ldg_wait_count)
-            mma_stage(k_tile, lambda cur=cur: load_fragments(cur))
+        # Drain: exactly one peeled tile, the same shape the symmetric kernel
+        # peels. Everything it consumes is already in flight, so it issues no
+        # loads and only has to walk vmcnt down.
+        kt = main_loop_end
+        k_tile = fx.Int32(kt)
+        cur_a = fx.Int32(kt % stages_a)
+        cur_b = fx.Int32(kt % stages_b)
+        __barrier(tail_waits[0])
+        mma_stage(k_tile, lambda: load_fragments(cur_a, cur_b))
 
         frag_C_out = fx.make_fragment_like(frag_C, out_elem)
         frag_C_out.store(frag_C.load().to(out_elem))
@@ -794,6 +1030,8 @@ def make_mxfp8_scaled_mm_gfx950(
             m_waves=m_waves,
             n_waves=n_waves,
             group_m=group_m,
+            stages_a=stages_a,
+            stages_b=stages_b,
         )
     )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -1,33 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Parameterized gfx950 MXFP8 scaled GEMM.
+"""Tile/Layout gfx950 MXFP8 scaled GEMM.
 
-E4M3 operands with per-32-element E8M0 block scales, folded into the CDNA4
-scaled 16x16x128 MFMA. A is [M, K] and B is [N, K], both row-major over K;
-the output is [M, N] bf16/fp16.
-
-The tiling mirrors the FP16/BF16 gfx950 GEMM in ``gemm_gfx950.py``:
-
-  * LDS blocking      -- a workgroup stages [block_m, block_k] of A and
-                         [block_n, block_k] of B into LDS so every wave in the
-                         group reuses them.
-  * multi-stage       -- ``stages`` LDS buffers are filled by global->LDS DMA;
-    pipelining           the loop waits on a counted ``vmcnt`` so the DMAs for
-                         later stages stay in flight across the MFMAs.
-  * register blocking -- each wave keeps mma_m_repeat x mma_n_repeat f32[4]
-                         accumulators and reuses one LDS read across the repeat
-                         loops.
-
-Together these lift arithmetic intensity from the previous baseline's fixed
-8 flops/byte (one wave, one 16x16 tile, operands straight from global) to
-2*block_m*block_n/(block_m+block_n), which is what lets throughput scale with
-problem size instead of saturating.
-
-The MFMA operand plumbing follows FlyDSL's own tiled MX kernel
-(``kernels/gemm/mxfp4_preshuffle.py``) rather than the CuTe-style
-``make_fragment_A``/``make_tiled_mma`` path used by the FP16 kernel: the scaled
-MFMA takes two extra i32 scale operands, which that path does not carry, so A/B
-fragments are built by hand as rank-1 i32[8] registers.
+E4M3 operands use per-32-element E8M0 block scales in CDNA4 scaled
+16x16x128 MFMA instructions. A is [M, K], B is [N, K], and both are row-major
+over K. TiledMma and TiledCopy describe wave, fragment, and output ownership;
+target-specific direct-to-LDS DMA and the staged waitcnt pipeline remain
+explicit.
 """
 
 import functools
@@ -35,11 +14,8 @@ from dataclasses import dataclass
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
-from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
-from flydsl.expr.typing import T
-from flydsl.expr.typing import Vector as Vec
+from flydsl.expr import const_expr, range_constexpr, rocdl
 
 
 MXFP8_SCALE_BLOCK_K = 32
@@ -50,25 +26,9 @@ GFX950_WAVE_SIZE = 64
 GFX950_DMA_BYTES = 16
 GFX950_LDS_CAPACITY = 163840
 GFX950_MAX_BLOCK_THREADS = 1024
-# Per-wave register blocking depth. Each k step issues Rm + Rn LDS reads and
-# Rm * Rn MFMAs, so the cap directly sets the MFMA-per-LDS-read ratio that this
-# kernel is limited by -- 4x4 gives 2, 8x8 gives 4. It is not an LDS-bandwidth
-# limit (removing the XOR swizzle, i.e. going from 2-way to 16-way bank
-# conflicts, costs only 1.5%) nor an occupancy limit (20 waves/CU at 2x2
-# repeats is slower than 8 waves/CU at 4x4); the MFMA unit idles waiting on
-# ds_read issue slots and latency, which deeper blocking amortizes.
-#
-# Measured on gfx950 with bf16 output: 8x8 uses 224 of 512 VGPRs with no
-# scratch and is 1.17-1.29x faster than 4x4 for M >= 2048, while 16x8 spills
-# and collapses to roughly a fifth of the throughput. The FP16 template caps at
-# 4 because its 2-byte elements make each fragment twice as wide; e4m3 halves
-# that, so the cutoff has to be re-derived rather than inherited.
+# The pre-Layout v2 kernel benefited from 8x8 register blocking. Keep that
+# search bound while v3 resource use is re-measured.
 MXFP8_MAX_MMA_REPEAT = 8
-# 16-byte granules spanned by one 128-K MFMA step.
-MXFP8_GRANULES_PER_MFMA_K = MXFP8_MFMA_K // GFX950_DMA_BYTES
-# The f8f6f4 ABI splits a lane's 32 operand bytes into two 16-byte halves that
-# sit 64 bytes apart inside the 128-K block.
-MXFP8_HI_GRANULE_OFFSET = 4
 
 
 @dataclass(frozen=True)
@@ -89,7 +49,7 @@ class MXFP8GemmParams:
 
     def __cache_signature__(self):
         return (
-            "mxfp8_gfx950_v2",
+            "mxfp8_gfx950_v3",
             self.m,
             self.n,
             self.k,
@@ -110,12 +70,9 @@ class MXFP8GemmDerived:
     heuristics filter so the two can never disagree."""
 
     block_threads: int
-    wave_tile_m: int
-    wave_tile_n: int
     mma_m_repeat: int
     mma_n_repeat: int
     k_halves: int
-    scale_cols: int
     granules_per_row: int
     ldg_a_iters: int
     ldg_b_iters: int
@@ -212,12 +169,9 @@ def mxfp8_gemm_derived(
 
     return MXFP8GemmDerived(
         block_threads=block_threads,
-        wave_tile_m=wave_tile_m,
-        wave_tile_n=wave_tile_n,
         mma_m_repeat=mma_m_repeat,
         mma_n_repeat=mma_n_repeat,
         k_halves=block_k // MXFP8_MFMA_K,
-        scale_cols=block_k // MXFP8_SCALE_BLOCK_K,
         granules_per_row=granules_per_row,
         ldg_a_iters=ldg_a_iters,
         ldg_b_iters=ldg_b_iters,
@@ -292,28 +246,6 @@ def __barrier(vmcnt=0):
     )
 
 
-def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
-    buffer_load_asm_dict = {
-        16: "buffer_load_dwordx4",
-        8: "buffer_load_dwordx2",
-        4: "buffer_load_dword",
-    }
-    llvm.InlineAsmOp(
-        None,
-        [
-            llvm.IntToPtrOp(
-                ir.Type.parse("!llvm.ptr<3>"),
-                fx.as_ir_value(fx.ptrtoint(lds_ptr)),
-            ).result,
-            fx.as_ir_value(global_offset),
-            fx.as_ir_value(rsrc),
-        ],
-        f"s_mov_b32 m0, $0\n\t{buffer_load_asm_dict[dma_bytes]} $1, $2, 0 offen sc0 lds",
-        "s,v,s",
-        has_side_effects=True,
-    )
-
-
 @functools.lru_cache(maxsize=256)
 def make_mxfp8_scaled_mm_gfx950(
     *,
@@ -332,9 +264,7 @@ def make_mxfp8_scaled_mm_gfx950(
     """Build a tiled gfx950 MXFP8 scaled GEMM launcher for one tile config."""
     if m <= 0 or n <= 0 or k <= 0:
         raise ValueError("m, n, and k must be positive")
-    d = mxfp8_gemm_derived(
-        block_m, block_n, block_k, stages, m_waves, n_waves, group_m
-    )
+    d = mxfp8_gemm_derived(block_m, block_n, block_k, stages, m_waves, n_waves, group_m)
     if m % block_m or n % block_n or k % block_k:
         raise ValueError(
             f"shape must be divisible by the tile: {m}x{n}x{k} vs "
@@ -353,7 +283,7 @@ def make_mxfp8_scaled_mm_gfx950(
 
     block_threads = d.block_threads
     granules_per_row = d.granules_per_row
-    granule_mask = granules_per_row - 1
+    swizzle_bits = granules_per_row.bit_length() - 1
     scale_k = k // MXFP8_SCALE_BLOCK_K
     tiles_m = m // block_m
     tiles_n = n // block_n
@@ -372,24 +302,7 @@ def make_mxfp8_scaled_mm_gfx950(
         scale_b_u8: fx.Tensor,
         out: fx.Tensor,
     ):
-        sa_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_a_u8))
-        sb_u8 = fx.recast_iter(fx.Uint8, fx.get_iter(scale_b_u8))
-        out_ptr = fx.recast_iter(out_elem, fx.get_iter(out))
-
-        a_rsrc = fx.rocdl.get_buffer_rsrc(
-            fx.get_iter(fx.rocdl.make_buffer_tensor(a, max_size=True))
-        )
-        b_rsrc = fx.rocdl.get_buffer_rsrc(
-            fx.get_iter(fx.rocdl.make_buffer_tensor(b_nk, max_size=True))
-        )
-
-        tid = fx.Int32(fx.thread_idx.x)
-        wave = rocdl.readfirstlane(T.i32, tid // fx.Int32(GFX950_WAVE_SIZE))
-        lane = tid % fx.Int32(GFX950_WAVE_SIZE)
-        lane_16 = lane % fx.Int32(MXFP8_MFMA_N)
-        k_group = lane // fx.Int32(MXFP8_MFMA_N)
-        wave_m = wave // fx.Int32(n_waves)
-        wave_n = wave % fx.Int32(n_waves)
+        tid = fx.thread_idx.x
 
         pid = fx.Int32(fx.block_idx.x)
         if const_expr(use_group_m):
@@ -405,16 +318,36 @@ def make_mxfp8_scaled_mm_gfx950(
         n_base = bid_n * fx.Int32(block_n)
 
         @fx.struct
-        class SharedAB:
-            a: fx.Array[fx.Int8, stages * d.a_stage_bytes, 16]
-            b: fx.Array[fx.Int8, stages * d.b_stage_bytes, 16]
+        class SharedStorage:
+            a: fx.Array[fx.Float8E4M3FN, stages * block_m * block_k, 16]
+            b: fx.Array[fx.Float8E4M3FN, stages * block_n * block_k, 16]
 
-        lds = fx.SharedAllocator().allocate(SharedAB).peek()
-        sA_i8 = fx.recast_iter(fx.Int8, lds.a.ptr)
-        sB_i8 = fx.recast_iter(fx.Int8, lds.b.ptr)
-        sA_i32 = fx.recast_iter(fx.Int32, lds.a.ptr)
-        sB_i32 = fx.recast_iter(fx.Int32, lds.b.ptr)
-        lds_copy = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Int32)
+        storage = fx.SharedAllocator().allocate(SharedStorage).peek()
+        smem_a = storage.a.ptr
+        smem_b = storage.b.ptr
+
+        def make_flat_buffer(tensor, elems):
+            flat = fx.Tensor(
+                fx.make_view(fx.get_iter(tensor), fx.make_layout(elems, 1))
+            )
+            return fx.rocdl.make_buffer_tensor(flat, max_size=True)
+
+        a_flat = fx.logical_divide(make_flat_buffer(a, m * k), fx.make_layout(1, 1))
+        b_flat = fx.logical_divide(make_flat_buffer(b_nk, n * k), fx.make_layout(1, 1))
+        sa_flat = fx.logical_divide(
+            make_flat_buffer(scale_a_u8, m * scale_k), fx.make_layout(1, 1)
+        )
+        sb_flat = fx.logical_divide(
+            make_flat_buffer(scale_b_u8, n * scale_k), fx.make_layout(1, 1)
+        )
+        out_view = fx.Tensor(
+            fx.make_view(
+                fx.get_iter(out),
+                fx.make_layout((m, n), (n, 1)),
+            )
+        )
+        out_buf = fx.rocdl.make_buffer_tensor(out_view, max_size=True)
+        gC = fx.flat_divide(out_buf, (block_m, block_n))[None, None, bid_m, bid_n]
 
         mma_atom = fx.make_mma_atom(
             fx.rocdl.cdna4.MFMA_Scale(
@@ -428,126 +361,223 @@ def make_mxfp8_scaled_mm_gfx950(
                 opsel_b=0,
             )
         )
+        mma_permutation = fx.make_tile(
+            None,
+            None,
+            fx.make_layout(
+                (GFX950_DMA_BYTES, 2, MXFP8_MFMA_K // (2 * GFX950_DMA_BYTES)),
+                (1, MXFP8_MFMA_K // 2, GFX950_DMA_BYTES),
+            ),
+        )
+        tiled_mma = fx.make_tiled_mma(
+            mma_atom,
+            fx.make_layout(
+                (m_waves, n_waves, 1),
+                (n_waves, 1, 0),
+            ),
+            mma_permutation,
+        )
+        thr_mma = tiled_mma.thr_slice(tid)
 
-        def async_load_tile(rsrc, lds_i8, stage_bytes, ldg_iters, rows_base, k_tile, stage):
-            """Stage one [rows, block_k] byte tile from global into LDS.
+        s2r_layout_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float8E4M3FN)
+        s2r_atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float8E4M3FN)
+        thr_copy_A = fx.make_tiled_copy_A(s2r_layout_atom, tiled_mma).get_slice(tid)
+        thr_copy_B = fx.make_tiled_copy_B(s2r_layout_atom, tiled_mma).get_slice(tid)
+        dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        scale_atom = fx.make_copy_atom(fx.rocdl.BufferCopy8b(), fx.Uint8)
 
-            The DMA writes lanes contiguously from a wave-uniform LDS base, so
-            the destination is fixed and the *source* column is permuted to
-            realize the XOR swizzle (same trick as the FP16 kernel).
-            """
-            stage_off = stage * fx.Int32(stage_bytes)
+        swizzle = fx.static(fx.SwizzleType.get(swizzle_bits, 4, swizzle_bits))
+
+        def make_lds_layout(rows):
+            return fx.make_composed_layout(
+                swizzle,
+                fx.make_ordered_layout((rows, block_k), (1, 0)),
+            )
+
+        a_lds_layout = make_lds_layout(block_m)
+        b_lds_layout = make_lds_layout(block_n)
+        sA = fx.make_view(smem_a, a_lds_layout)
+        sB = fx.make_view(smem_b, b_lds_layout)
+
+        frag_A = thr_mma.make_fragment_A(sA)
+        frag_B = thr_mma.make_fragment_B(sB)
+        frag_C = thr_mma.make_fragment_C(gC)
+        frag_A_retile = thr_copy_A.retile(frag_A)
+        frag_B_retile = thr_copy_B.retile(frag_B)
+        frag_C.fill(0.0)
+        r2g_atom = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), out_elem)
+        thr_copy_C = fx.make_tiled_copy_C(r2g_atom, tiled_mma).get_slice(tid)
+        thr_gC = thr_copy_C.partition_S(gC)
+
+        a_row_coords = fx.make_view(0, fx.make_layout((block_m, block_k), (1, 0)))
+        b_row_coords = fx.make_view(0, fx.make_layout((block_n, block_k), (1, 0)))
+        thr_mma_aRow = thr_mma.partition_A(a_row_coords)
+        thr_mma_bRow = thr_mma.partition_B(b_row_coords)
+        # The scaled-MFMA state selects one E8M0 byte for each 32-K lane group.
+        scale_group = (fx.Int32(tid) % fx.Int32(GFX950_WAVE_SIZE)) // fx.Int32(
+            MXFP8_MFMA_N
+        )
+
+        wave_offset = rocdl.readfirstlane(
+            fx.Int64.ir_type,
+            fx.Int64(
+                fx.Int32(tid)
+                // fx.Int32(GFX950_WAVE_SIZE)
+                * fx.Int32(GFX950_WAVE_SIZE * GFX950_DMA_BYTES)
+            ),
+        )
+
+        def make_wave_lds_ptr(ptr):
+            return ptr + fx.Int32(wave_offset)
+
+        def swizzled_col(row, col, layout):
+            return fx.get_scalar(fx.crd2idx((row, col), layout)) % fx.Int32(block_k)
+
+        def async_load_tile(
+            gmem,
+            smem,
+            stage_bytes,
+            ldg_iters,
+            rows_base,
+            k_tile,
+            stage,
+            layout,
+        ):
+            # Direct-to-LDS stores are linear, so the source coordinate carries
+            # the composed LDS swizzle.
+            lds_ptr = make_wave_lds_ptr(smem + stage * fx.Int32(stage_bytes))
             for i in range_constexpr(ldg_iters):
-                lin = (fx.Int32(i * block_threads) + tid) * fx.Int32(GFX950_DMA_BYTES)
-                row = lin // fx.Int32(block_k)
-                granule = (lin % fx.Int32(block_k)) // fx.Int32(GFX950_DMA_BYTES)
-                src_granule = granule ^ (row & fx.Int32(granule_mask))
-                gmem = (rows_base + row) * fx.Int32(k) + fx.Int32(
-                    k_tile
-                ) * fx.Int32(block_k) + src_granule * fx.Int32(GFX950_DMA_BYTES)
-                wave_base = stage_off + fx.Int32(
-                    (i * block_threads) * GFX950_DMA_BYTES
-                ) + wave * fx.Int32(GFX950_WAVE_SIZE * GFX950_DMA_BYTES)
-                lds_ptr = fx.add_offset(
-                    lds_i8, rocdl.readfirstlane(T.i32, wave_base)
+                lin = (fx.Int32(i * block_threads) + fx.Int32(tid)) * fx.Int32(
+                    GFX950_DMA_BYTES
                 )
-                buffer_load_lds_inline(rsrc, lds_ptr, gmem, GFX950_DMA_BYTES)
+                row = lin // fx.Int32(block_k)
+                dst_col = lin % fx.Int32(block_k)
+                src_col = swizzled_col(row, dst_col, layout)
+                src_offset = (
+                    (rows_base + row) * fx.Int32(k)
+                    + k_tile * fx.Int32(block_k)
+                    + src_col
+                )
+                src = fx.slice(gmem, (None, src_offset))
+                dst = fx.make_view(lds_ptr, fx.make_layout(1, 1))
+                fx.copy(dma_atom, src, dst)
+                if i < ldg_iters - 1:
+                    lds_ptr = lds_ptr + fx.Int32(block_threads * GFX950_DMA_BYTES)
 
         def async_load_a(k_tile, stage):
             async_load_tile(
-                a_rsrc, sA_i8, d.a_stage_bytes, d.ldg_a_iters, m_base, k_tile, stage
+                a_flat,
+                smem_a,
+                d.a_stage_bytes,
+                d.ldg_a_iters,
+                m_base,
+                k_tile,
+                stage,
+                a_lds_layout,
             )
 
         def async_load_b(k_tile, stage):
             async_load_tile(
-                b_rsrc, sB_i8, d.b_stage_bytes, d.ldg_b_iters, n_base, k_tile, stage
+                b_flat,
+                smem_b,
+                d.b_stage_bytes,
+                d.ldg_b_iters,
+                n_base,
+                k_tile,
+                stage,
+                b_lds_layout,
             )
 
-        def read_frag(lds_i32, stage_bytes, stage, row_in_block, kh):
-            """ds_read_b128 x2 -> one i32[8] MFMA operand fragment."""
-            row_swz = row_in_block & fx.Int32(granule_mask)
-            lo_logical = fx.Int32(kh * MXFP8_GRANULES_PER_MFMA_K) + k_group
-            hi_logical = lo_logical + fx.Int32(MXFP8_HI_GRANULE_OFFSET)
-            base_i32 = (
-                stage * fx.Int32(stage_bytes // 4)
-                + row_in_block * fx.Int32(block_k // 4)
+        def load_scale_word(scale, row_global, scale_col):
+            scale_offset = fx.Int32(row_global) * fx.Int32(scale_k) + fx.Int32(
+                scale_col
             )
-
-            def read16(logical):
-                phys = logical ^ row_swz
-                off = base_i32 + phys * fx.Int32(GFX950_DMA_BYTES // 4)
-                frag = fx.make_rmem_tensor(4, fx.Int32)
-                fx.copy(
-                    lds_copy,
-                    fx.make_view(fx.add_offset(lds_i32, off), fx.make_layout(4, 1)),
-                    frag,
-                )
-                return frag
-
-            lo = Vec(fx.memref_load_vec(read16(lo_logical)))
-            hi = Vec(fx.memref_load_vec(read16(hi_logical)))
-            frag = fx.make_rmem_tensor(8, fx.Int32)
-            frag.store(lo.shuffle(hi, list(range(8))))
-            return frag
-
-        def load_scale_word(scale_u8, row_global, k_tile, kh):
-            off = (
-                fx.Int64(row_global) * fx.Int64(scale_k)
-                + fx.Int64(k_tile) * fx.Int64(d.scale_cols)
-                + fx.Int64(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
-                + fx.Int64(k_group)
+            scale_reg = fx.make_rmem_tensor(1, fx.Uint8)
+            fx.copy(
+                scale_atom,
+                fx.slice(scale, (None, scale_offset)),
+                scale_reg,
             )
-            scale_byte = fx.ptr_load(scale_u8 + off)
-            # The atom reads one e8m0 byte per 32-K block; broadcasting keeps
-            # it independent of the opsel byte lane.
+            scale_byte = fx.get_scalar(scale_reg[0])
             return scale_byte.to(fx.Int32) * fx.Int32(0x01010101)
 
-        # Row/col of this wave's first 16x16 tile inside the block tile.
-        wave_row0 = wave_m * fx.Int32(d.wave_tile_m)
-        wave_col0 = wave_n * fx.Int32(d.wave_tile_n)
-
-        accs = [
-            fx.make_rmem_tensor(4, fx.Float32)
-            for _ in range_constexpr(d.mma_m_repeat * d.mma_n_repeat)
-        ]
-        for idx in range_constexpr(d.mma_m_repeat * d.mma_n_repeat):
-            accs[idx].store(Vec.filled(4, 0.0, fx.Float32))
+        def scaled_mma(d_frag, a_frag, b_frag, scale_a, scale_b):
+            # Ownership and fragments come from the workgroup TiledMma, while
+            # dynamic E8M0 state is bound on each underlying 16x16 atom call.
+            a_atom = fx.Tensor(
+                fx.make_view(fx.get_iter(a_frag), fx.coalesce(a_frag.layout))
+            )
+            b_atom = fx.Tensor(
+                fx.make_view(fx.get_iter(b_frag), fx.coalesce(b_frag.layout))
+            )
+            fx.gemm(
+                mma_atom,
+                d_frag,
+                a_atom,
+                b_atom,
+                d_frag,
+                scale_a=scale_a,
+                scale_b=scale_b,
+            )
 
         def compute_stage(stage, k_tile):
+            sA_stage = fx.make_view(
+                smem_a + stage * fx.Int32(block_m * block_k),
+                a_lds_layout,
+            )
+            sB_stage = fx.make_view(
+                smem_b + stage * fx.Int32(block_n * block_k),
+                b_lds_layout,
+            )
+            thr_sA = thr_copy_A.partition_S(sA_stage)
+            thr_sB = thr_copy_B.partition_S(sB_stage)
             for kh in range_constexpr(d.k_halves):
-                a_frags = []
+                fx.copy(
+                    s2r_atom,
+                    thr_sB[None, None, kh],
+                    frag_B_retile[None, None, kh],
+                )
+                fx.copy(
+                    s2r_atom,
+                    thr_sA[None, None, kh],
+                    frag_A_retile[None, None, kh],
+                )
+                scale_col = (
+                    k_tile * fx.Int32(block_k // MXFP8_SCALE_BLOCK_K)
+                    + fx.Int32(kh * (MXFP8_MFMA_K // MXFP8_SCALE_BLOCK_K))
+                    + scale_group
+                )
+
                 sa_words = []
                 for mi in range_constexpr(d.mma_m_repeat):
-                    row_in_block = wave_row0 + fx.Int32(mi * MXFP8_MFMA_M) + lane_16
-                    a_frags.append(
-                        read_frag(sA_i32, d.a_stage_bytes, stage, row_in_block, kh)
-                    )
+                    local_row = fx.get_scalar(thr_mma_aRow[0, mi, kh])
                     sa_words.append(
-                        load_scale_word(sa_u8, m_base + row_in_block, k_tile, kh)
+                        load_scale_word(
+                            sa_flat,
+                            m_base + local_row,
+                            scale_col,
+                        )
                     )
-                b_frags = []
+
                 sb_words = []
                 for ni in range_constexpr(d.mma_n_repeat):
-                    col_in_block = wave_col0 + fx.Int32(ni * MXFP8_MFMA_N) + lane_16
-                    b_frags.append(
-                        read_frag(sB_i32, d.b_stage_bytes, stage, col_in_block, kh)
-                    )
+                    local_row = fx.get_scalar(thr_mma_bRow[0, ni, kh])
                     sb_words.append(
-                        load_scale_word(sb_u8, n_base + col_in_block, k_tile, kh)
+                        load_scale_word(
+                            sb_flat,
+                            n_base + local_row,
+                            scale_col,
+                        )
                     )
-                # Register blocking: each LDS read feeds every repeat on the
-                # other axis.
+
                 for ni in range_constexpr(d.mma_n_repeat):
                     for mi in range_constexpr(d.mma_m_repeat):
-                        acc = accs[mi * d.mma_n_repeat + ni]
-                        fx.gemm(
-                            mma_atom,
-                            acc,
-                            a_frags[mi],
-                            b_frags[ni],
-                            acc,
-                            scale_a=sa_words[mi],
-                            scale_b=sb_words[ni],
+                        scaled_mma(
+                            frag_C[(None, 0), mi, ni],
+                            frag_A[None, mi, kh],
+                            frag_B[None, ni, kh],
+                            sa_words[mi],
+                            sb_words[ni],
                         )
 
         # Prologue: fill stages-1 buffers so the steady-state loop always has a
@@ -574,22 +604,10 @@ def make_mxfp8_scaled_mm_gfx950(
             __barrier((stages - 2 - s) * d.ldg_wait_count)
             compute_stage(cur, k_tile)
 
-        # Epilogue: each lane owns 4 rows of every 16x16 accumulator.
-        for mi in range_constexpr(d.mma_m_repeat):
-            row0 = (
-                m_base
-                + wave_row0
-                + fx.Int32(mi * MXFP8_MFMA_M)
-                + k_group * fx.Int32(4)
-            )
-            for ni in range_constexpr(d.mma_n_repeat):
-                col = n_base + wave_col0 + fx.Int32(ni * MXFP8_MFMA_N) + lane_16
-                out4 = Vec(accs[mi * d.mma_n_repeat + ni].load().ir_value()).to(
-                    out_elem
-                )
-                for i in range_constexpr(4):
-                    off = fx.Int64(row0 + fx.Int32(i)) * fx.Int64(n) + fx.Int64(col)
-                    fx.ptr_store(out4[i], out_ptr + off)
+        frag_C_out = fx.make_fragment_like(frag_C, out_elem)
+        frag_C_out.store(frag_C.load().to(out_elem))
+        frag_C_retile = thr_copy_C.retile(frag_C_out)
+        fx.copy(r2g_atom, frag_C_retile, thr_gC)
 
     kernel._func.__name__ = make_mxfp8_gemm_kernel_name(
         MXFP8GemmParams(

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_mxfp8_gfx950.py
@@ -623,7 +623,33 @@ def make_mxfp8_scaled_mm_gfx950(
         s2r_atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Float8E4M3FN)
         thr_copy_A = fx.make_tiled_copy_A(s2r_layout_atom, tiled_mma).get_slice(tid)
         thr_copy_B = fx.make_tiled_copy_B(s2r_layout_atom, tiled_mma).get_slice(tid)
-        dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        # Async direct-to-LDS DMA (FlyDSL #1023) when the runtime has it.
+        #
+        # On gfx950 this lowers to the same buffer_load ... lds instruction as the
+        # synchronous CDNA3 atom; what changes is that the backend no longer
+        # inserts its own vmcnt wait before the staged LDS data is read, which is
+        # the unexpected vmcnt(0) raised in review on this line.
+        #
+        # The explicit s_waitcnt vmcnt(N) in __barrier stays. gfx950 still counts
+        # this load in vmcnt -- hasAsyncMark() is true here only via
+        # hasVMemToLDSLoad(); the real s_wait_asynccnt is gfx1250+ -- so the manual
+        # wait remains both valid and necessary.
+        #
+        # Bracketing the copies with rocdl.asyncmark(), which the atom's docstring
+        # suggests, was measured and rejected: asyncmark is a side-effecting meta
+        # op, so it acts as a scheduling barrier and blocks sinking the DMA into
+        # the MFMA block -- the ordering v7 ablation adopted. On
+        # 256,256,256,2,4,2,0 it cost 24 spills and 2 extra vmcnt(0) per iteration;
+        # adding wait_asyncmark on top cost 31 and 8.
+        #
+        # Guarded because the released FlyDSL 0.3.1 predates #1023: without this
+        # the template would raise AttributeError instead of falling back.
+        if const_expr(hasattr(fx.rocdl.cdna4, "BufferLoadAsyncLDS128b")):
+            dma_atom = fx.make_copy_atom(
+                fx.rocdl.cdna4.BufferLoadAsyncLDS128b(), 128
+            )
+        else:
+            dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
         scale_atom = fx.make_copy_atom(fx.rocdl.BufferCopy8b(), fx.Uint8)
 
         swizzle = fx.static(fx.SwizzleType.get(swizzle_bits, 4, swizzle_bits))

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -1,0 +1,64 @@
+"""Helpers for routing FlyDSL JIT artifacts through TorchInductor's cache."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor.runtime.cache_dir_utils import cache_dir
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+_compiled_cache_lock = threading.Lock()
+
+
+def run_cached_flydsl(
+    jit_func: Any,
+    *compile_args: Any,
+    constexpr_param: Any,
+    compiler: Callable[..., Any],
+    dispatch_args: tuple[Any, ...],
+) -> Any:
+    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param."""
+    cache_key = constexpr_param.__cache_signature__()
+    with _compiled_cache_lock:
+        compiled_cache = getattr(jit_func, "_compiled_cache", None)
+        if compiled_cache is None:
+            compiled_cache = {}
+            jit_func._compiled_cache = compiled_cache
+        compile_locks = getattr(jit_func, "_compiled_cache_locks", None)
+        if compile_locks is None:
+            compile_locks = {}
+            jit_func._compiled_cache_locks = compile_locks
+        compile_lock = compile_locks.setdefault(cache_key, threading.Lock())
+
+    with compile_lock:
+        compiled = compiled_cache.get(cache_key)
+        if compiled is None:
+            # FlyDSL compilation executes the first invocation using compile_args.
+            compiled = compiler(jit_func, *compile_args)
+            compiled_cache[cache_key] = compiled
+            return compiled
+
+    # Keep steady-state kernel launches outside all compilation locks.
+    compiled(*dispatch_args)
+    return compiled
+
+
+def _cache_dir() -> Path:
+    return Path(cache_dir()) / "flydsl_compile_cache"
+
+
+def ensure_flydsl_cache_dir() -> str:
+    """Put FlyDSL artifacts under the Inductor cache unless explicitly set."""
+    existing = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR")
+    if existing:
+        return existing
+    resolved = str(_cache_dir())
+    os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = resolved
+    return resolved

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2217,8 +2217,12 @@ def ensure_nvmatmul_heuristics_available() -> bool:
         return False
 
 
-def use_flydsl_mxfp8_template(layout: Layout) -> bool:
-    """Return whether the gfx950 MXFP8 FlyDSL template may be selected."""
+def use_flydsl_scaled_mm_template(layout: Layout) -> bool:
+    """Return whether a gfx950 FlyDSL scaled_mm template may be selected.
+
+    Shared by the MXFP8 and MXFP4 lowerings: nothing here depends on the input
+    dtype, only on the backend list, the runtime being importable, and the arch.
+    """
     if not _use_autotune_backend("FLYDSL"):
         return False
     if torch.version.hip is None:
@@ -2240,7 +2244,7 @@ def use_flydsl_mxfp8_template(layout: Layout) -> bool:
         props = torch.cuda.get_device_properties(device_index)
         gcn_arch = getattr(props, "gcnArchName", "") or ""
     except Exception:
-        log.debug("Could not determine ROCm arch for MXFP8 FlyDSL gate", exc_info=True)
+        log.debug("Could not determine ROCm arch for FlyDSL gate", exc_info=True)
         return False
     return gcn_arch.split(":", 1)[0] == "gfx950"
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2217,6 +2217,34 @@ def ensure_nvmatmul_heuristics_available() -> bool:
         return False
 
 
+def use_flydsl_mxfp8_template(layout: Layout) -> bool:
+    """Return whether the gfx950 MXFP8 FlyDSL template may be selected."""
+    if not _use_autotune_backend("FLYDSL"):
+        return False
+    if torch.version.hip is None:
+        return False
+    if not (config.max_autotune or config.max_autotune_gemm):
+        return False
+    if not _use_template_for_gpu(layout, [torch.float16, torch.bfloat16]):
+        return False
+
+    from .codegen.flydsl import flydsl_utils
+
+    if not flydsl_utils.runtime_available():
+        return False
+
+    try:
+        device_index = layout.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device_index)
+        gcn_arch = getattr(props, "gcnArchName", "") or ""
+    except Exception:
+        log.debug("Could not determine ROCm arch for MXFP8 FlyDSL gate", exc_info=True)
+        return False
+    return gcn_arch.split(":", 1)[0] == "gfx950"
+
+
 def use_blackwell_cutedsl_grouped_mm(
     mat_a: Any,
     mat_b: Any,


### PR DESCRIPTION
## What this is

**Operator contract.** 

| | |
|---|---|
| A | `float8_e4m3fn`, `[M, K]`, row-major |
| B | `float8_e4m3fn`, `[K, N]`, column-major (NT) |
| A/B scales | `float8_e8m0fnu`, `BlockWise1x32` along K, `NO_SWIZZLE` |
| Output | `bfloat16` or `float16`, FP32 accumulation |
| Constraint | M, N, K multiples of 32 |

**Instruction.** `v_mfma_scale_f32_16x16x128_f8f6f4`, Wave64. The MFMA shape is fixed at 16x16x128
for the whole series.

**Machine.** MI355X, gfx950 (CDNA4): 256 CU, 8 XCDs, 160 KiB LDS per CU. The measured scaled-MFMA
instruction roof on this part is 4970 TFLOP/s, so the final 8192^3 number is 47% of the instruction
roof.

**Harness.** `--warmup 25 --iters 100 --repeats 4 --modes percall,graph --search-space EXHAUSTIVE`. Tables report `graph_tflops` (CUDA-graph replay, median of per-repeat medians).

## Final numbers

| M x N x K | ATen TFLOP/s | CK TFLOP/s | FlyDSL TFLOP/s | FlyDSL / ATen | FlyDSL / CK |
|---|---:|---:|---:|---:|---:|
| 32 x 4096 x 4096 | 31.3 | 45.6 | 65.5 | 2.09x | 1.44x |
| 32 x 14336 x 4096 | 100.3 | 137.6 | 169.6 | 1.69x | 1.23x |
| 32 x 28672 x 4096 | 181.6 | 221.9 | 254.1 | 1.40x | 1.15x |
| 64 x 4096 x 4096 | 71.2 | 93.2 | 115.7 | 1.62x | 1.24x |
| 128 x 4096 x 4096 | 138.6 | 174.7 | 202.8 | 1.46x | 1.16x |
| 256 x 4096 x 4096 | 296.5 | 319.7 | 334.0 | 1.13x | 1.04x |
| 512 x 4096 x 4096 | 455.5 | 559.2 | 560.9 | 1.23x | 1.00x |
| 1024 x 4096 x 4096 | 716.3 | 955.0 | 957.6 | 1.34x | 1.00x |
| 2048 x 4096 x 4096 | 1128.9 | 1227.6 | 1276.3 | 1.13x | 1.04x |
| 4096 x 256 x 4096 | 294.4 | 333.6 | 336.6 | 1.14x | 1.01x |
| 4096 x 4096 x 4096 | 1306.6 | 1419.4 | 1831.0 | 1.40x | 1.29x |
| 4096 x 4096 x 8192 | 1502.7 | 1767.4 | 2124.6 | 1.41x | 1.20x |
| 8192 x 8192 x 8192 | 1376.9 | 1925.1 | 2331.6 | 1.69x | 1.21x |
| **geomean** | | | | **1.42x** | **1.15x** |

## How the three columns were measured

**ATen and FlyDSL are strictly apples-to-apples.** Same process, same harness, same
`aten._scaled_mm_v2` call, same inputs, same `graph` metric, measured back to back inside one run.

**CK is a useful reference, not a like-for-like one.** It is
`DeviceGemmMX_Xdl_CShuffleV3` (the gfx950 MX instances), driven from a standalone C++ program,
correctness-checked against an FP32 CPU reference.

## Test plan

```
lintrunner -a

python test/inductor/test_flydsl_mxfp8.py
python test/inductor/test_flydsl_template.py
python test/inductor/test_async_compile.py
python test/test_public_bindings.py
python test/test_testing.py
```