### PR TITLE
[Testcase Refactoring] Capability-based test admission and dynamic Au…

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2,6 +2,7 @@
 
 import copy
 import gc
+import importlib.util
 import inspect
 import logging
 import os
@@ -12,7 +13,7 @@ import unittest
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
-from functools import partial, wraps
+from functools import cache, partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
@@ -318,6 +319,99 @@ def _update_param_kwargs(param_kwargs, name, value):
     # Leave param_kwargs as-is when value is None.
 
 
+class Capability:
+    """Structured namespace of device capability identifiers.
+
+    Each constant is a ``"<category>.<name>"`` string. The inner classes group
+    them by category so tests can reference capabilities as
+    ``Capability.dtype.fp8`` instead of bare strings.
+
+    Tests declare requirements with :func:`requires_capabilities`::
+
+        @requires_capabilities(Capability.lib.triton, Capability.dtype.fp8)
+        def test_foo(self, device): ...
+
+    Device test bases declare what they support by overriding
+    :meth:`DeviceTypeTestBase._capabilities` with the same constants as keys.
+    """
+
+    class dtype:
+        """Data type capabilities (fp8, bf16, etc.)."""
+
+        fp8 = "dtype.fp8"
+        bf16 = "dtype.bf16"
+
+    class lib:
+        """Third-party library capabilities (triton, etc.)."""
+
+        safetensors = "lib.safetensors"
+        triton = "lib.triton"
+
+    class attention:
+        """Attention backend capabilities."""
+
+        flash_attention = "attention.flash_attention"
+        mem_efficient_attention = "attention.mem_efficient_attention"
+        cuda_attention = "attention.cuda_attention"
+        fused_attention = "attention.fused_attention"
+
+    class distributed:
+        """Distributed runtime capabilities."""
+
+        backend = "distributed.backend"
+        dtensor = "distributed.dtensor"
+        fsdp = "distributed.fsdp"
+
+    class memory:
+        """Device memory capabilities."""
+
+        non_blocking_copy = "memory.non_blocking_copy"
+
+    class stream:
+        """Device stream capabilities."""
+
+        generic = "stream.generic"
+
+
+def _check_capabilities(test_case, required_capabilities) -> None:
+    capabilities = type(test_case).get_capabilities()
+    missing = set(required_capabilities) - capabilities.keys()
+    unsupported = {
+        cap
+        for cap in required_capabilities
+        if cap in capabilities and not capabilities[cap]
+    }
+
+    if missing:
+        raise unittest.SkipTest(
+            f"Missing capabilities on device '{type(test_case).device_type}': "
+            f"{', '.join(sorted(missing))}"
+        )
+    if unsupported:
+        raise unittest.SkipTest(
+            f"Unsupported capabilities: {', '.join(sorted(unsupported))}"
+        )
+
+
+def _distributed_backend_available(device_type: str) -> bool:
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        return False
+    try:
+        backend = dist.get_default_backend_for_device(device_type)
+    except (AttributeError, ValueError):
+        return False
+    return dist.is_backend_available(backend)
+
+
+def _device_module_available(device_type: str) -> bool:
+    try:
+        return torch.get_device_module(device_type).is_available()
+    except (AttributeError, RuntimeError):
+        return False
+
+
 class DeviceTypeTestBase(TestCase):
     device_type: str = "generic_device_type"
 
@@ -385,6 +479,40 @@ class DeviceTypeTestBase(TestCase):
     #   @ops-generated dtype variants and other parametrized arguments are
     #   ignored for now.
     test_exclusions: ClassVar[dict[str, Any] | None] = None
+
+    # Returns the capability map used by @requires_capabilities.
+    # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
+    # declare supported capabilities grouped by namespace. This method flattens
+    # the nested map, evaluates the support checks, and caches the result.
+    @classmethod
+    @cache
+    def get_capabilities(cls) -> dict[str, bool]:
+        return {
+            k: fn() for sub in cls._capabilities().values() for k, fn in sub.items()
+        }
+
+    # Returns a nested capability map grouped by namespace.
+    # Each namespace (e.g. Capability.dtype) groups related capabilities
+    # (e.g. Capability.dtype.fp8) mapped to callables that determine whether
+    # the current device supports them.
+    @classmethod
+    def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
+        return {
+            Capability.lib: {
+                Capability.lib.safetensors: lambda: importlib.util.find_spec(
+                    "safetensors"
+                )
+                is not None,
+            }
+        }
+
+    def setUp(self) -> None:
+        test_method = getattr(self, self._testMethodName)
+        required_capabilities = getattr(test_method, "_required_capabilities", ())
+        if required_capabilities:
+            _check_capabilities(self, required_capabilities)
+
+        super().setUp()
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -740,6 +868,45 @@ class CPUTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
+    @classmethod
+    def _capabilities(cls):
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: False,
+                    Capability.attention.mem_efficient_attention: lambda: False,
+                    Capability.attention.cuda_attention: lambda: False,
+                    Capability.attention.fused_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: False,
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: False,
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: False,
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
+
 
 class CUDATestBase(DeviceTypeTestBase):
     device_type = "cuda"
@@ -752,6 +919,59 @@ class CUDATestBase(DeviceTypeTestBase):
 
     def has_cudnn(self):
         return not self.no_cudnn
+
+    @classmethod
+    def _capabilities(cls):
+        from torch.testing._internal.common_cuda import (
+            PLATFORM_SUPPORTS_FLASH_ATTENTION,
+            PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+            PLATFORM_SUPPORTS_FUSED_ATTENTION,
+            PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            PLATFORM_SUPPORTS_FP8,
+            SM80OrLater,
+        )
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                    Capability.dtype.bf16: lambda: SM80OrLater,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                    Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                    Capability.attention.cuda_attention: lambda: PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+                    Capability.attention.fused_attention: lambda: PLATFORM_SUPPORTS_FUSED_ATTENTION,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -835,6 +1055,51 @@ class XPUTestBase(DeviceTypeTestBase):
     primary_device: ClassVar[str]
 
     @classmethod
+    def _capabilities(cls):
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: True,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                    Capability.attention.cuda_attention: lambda: False,
+                    Capability.attention.fused_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
+
+    @classmethod
     def get_primary_device(cls):
         return cls.primary_device
 
@@ -879,6 +1144,33 @@ class PrivateUse1TestBase(DeviceTypeTestBase):
     device_mod = None
     device_type = "privateuse1"
     bypass_device_restrictions = False
+
+    @classmethod
+    def _capabilities(cls):
+        capabilities = super()._capabilities()
+        device_type = torch._C._get_privateuse1_backend_name()
+        capabilities.update(
+            {
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: True,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                    Capability.attention.cuda_attention: lambda: False,
+                    Capability.attention.fused_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        device_type
+                    ),
+                },
+            }
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -1084,6 +1376,28 @@ def get_desired_device_type_test_bases(
     return filter_desired_device_types(
         desired_device_type_test_bases, env_except_for, env_only_for
     )
+
+
+def requires_capabilities(*caps: str):
+    """Declare that a test method requires device capabilities.
+
+    Wraps the test to call ``type(self).get_capabilities()`` at runtime
+    and skip if any required capability is missing.
+    """
+    caps_set = frozenset(caps)
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            _check_capabilities(self, caps_set)
+            return fn(self, *args, **kwargs)
+
+        wrapper._required_capabilities = (
+            frozenset(getattr(fn, "_required_capabilities", ())) | caps_set
+        )
+        return wrapper
+
+    return decorator
 
 
 # Adds 'instantiated' device-specific test cases to the given scope.

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -1222,7 +1222,7 @@ class LocalDTensorTestBase(DTensorTestBase):
 
 def make_wrapped(fn, ctxs):
     @functools.wraps(fn)
-    def wrapped(self):
+    def wrapped(self, *args, **kwargs):
         torch._dynamo.reset()
         stack = contextlib.ExitStack()
         for ctx in ctxs:
@@ -1231,7 +1231,7 @@ def make_wrapped(fn, ctxs):
             else:
                 stack.enter_context(ctx)
         try:
-            out = fn(self)
+            out = fn(self, *args, **kwargs)
         finally:
             stack.close()
         return out

--- a/torch/testing/_internal/optests/autograd_registration.py
+++ b/torch/testing/_internal/optests/autograd_registration.py
@@ -84,17 +84,40 @@ def autograd_registration_check(op, args, kwargs):
 
     # Determine which AutogradBACKEND key to check
     all_device_types = {arg.device.type for arg in all_tensors}
-    if not all_device_types.issubset(["cpu", "cuda", "xpu"]):
-        # Don't want to support other keys yet
+
+    # Map each device type to its Autograd dispatch key dynamically
+    # (e.g. "cuda" -> "AutogradCUDA", "npu" -> "AutogradPrivateUse1").
+    # This avoids hardcoding a device-type whitelist so that newly integrated
+    # accelerators are supported without modifying this function.
+    autograd_keys = {
+        "Autograd" + torch._C._dispatch_key_for_device(device_type)
+        for device_type in all_device_types
+    }
+
+    _known_priority = ["AutogradCUDA", "AutogradCPU", "AutogradXPU"]
+    known_key = next((k for k in _known_priority if k in autograd_keys), None)
+
+
+    new_accelerator_keys = autograd_keys - set(_known_priority)
+    if known_key is not None and known_key != "AutogradCPU" and new_accelerator_keys:
         raise NotImplementedError(
-            f"autograd_registration_check: NYI devices other than CPU/CUDA/XPU, got {all_device_types}"
+            f"autograd_registration_check: mixed accelerator device types with "
+            f"different Autograd dispatch keys are not supported, got {all_device_types}"
         )
-    if "cuda" in all_device_types:
-        key = "AutogradCUDA"
-    elif "cpu" in all_device_types:
+    if len(new_accelerator_keys) > 1:
+        raise NotImplementedError(
+            f"autograd_registration_check: mixed accelerator device types with "
+            f"different Autograd dispatch keys are not supported, got {all_device_types}"
+        )
+
+    # Select the key: new accelerator takes precedence over known priority,
+    # and known priority over fallback AutogradCPU.
+    if new_accelerator_keys:
+        key = next(iter(new_accelerator_keys))
+    elif known_key is not None:
+        key = known_key
+    else:
         key = "AutogradCPU"
-    elif "xpu" in all_device_types:
-        key = "AutogradXPU"
 
     if torch._C._dispatch_has_kernel_for_dispatch_key(op.name(), key):
         return


### PR DESCRIPTION
Capability-based test admission and dynamic Autograd dispatch-key resolution

1.Introduce a capability registration mechanism in the device-type test base classes (`DeviceTypeTestBase` and its subclasses) so that test admission is driven by per-device capability queries rather than hardcoded device flags 
2.Resolve Autograd dispatch keys dynamically in `autograd_registration_check`: map each input tensor's `device.type` to its Autograd dispatch key via `torch._C._dispatch_key_for_device(device_type)`
 instead of a hardcoded `{"cuda", "cpu", "xpu"}` whitelist, so accelerators registered under `PrivateUse1` (e.g. NPU → `AutogradPrivateUse1`) are covered without modifying the check.