### PR TITLE
[Testcase Refactoring] Add hardware classification for test_schedule_multiproc.py

### DIFF
--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -331,7 +331,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self._device_type, self.rank)
+        return torch.device(self.device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -346,7 +346,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_forward_only(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [_ScheduleForwardOnly]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 mod, mod_ref, x, _, _ = setup_models_and_data(self.config)
@@ -383,7 +383,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_eval_inference_mode(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [
             ScheduleGPipe,
             Schedule1F1B,
@@ -460,7 +460,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_return_output(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [
             ScheduleGPipe,
             Schedule1F1B,
@@ -524,7 +524,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_multi_iter(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 mod, _, x, target, loss_fn = setup_models_and_data(self.config)
@@ -550,7 +550,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_kwargs_with_tracer(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
             for pre_split in [False, True]:
                 with self.subTest(ScheduleClass=ScheduleClass, pre_split=pre_split):
@@ -622,7 +622,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_tracer(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
             for pre_split in [False, True]:
                 with self.subTest(ScheduleClass=ScheduleClass, pre_split=pre_split):
@@ -682,7 +682,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_manual(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
             for shape_inference in [True, False]:
                 with self.subTest(ScheduleClass=ScheduleClass, shape_inference=shape_inference):
@@ -746,7 +746,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_manual_interleaved(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [
             ScheduleInterleaved1F1B,
             ScheduleLoopedBFS,
@@ -833,7 +833,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_schedule_with_weight_update_mlp_e2e(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleInterleavedZeroBubble]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 stages_per_rank = 2
@@ -919,7 +919,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_v_shape_schedules(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for schedule_class in [ScheduleZBVZeroBubble, ScheduleDualPipeV]:
             with self.subTest(schedule_class=schedule_class):
                 n_stages = 8
@@ -967,8 +967,8 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_custom_function_callback(self, device):
-        self._device_type = torch.device(device).type
         """Test the custom function callback functionality with _PipelineScheduleRuntime."""
+        self.device_type = torch.device(device).type
         n_stages = 8
         rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
         mod, ref_mod, x, target, loss_fn = setup_models_and_data(
@@ -1170,7 +1170,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_zero_bubble_with_model_kwargs(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleInterleavedZeroBubble, ScheduleInterleaved1F1B]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 stages_per_rank = 2
@@ -1285,7 +1285,7 @@ class ScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_NoneGrad_conditional_input_grad(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, ScheduleInterleaved1F1B, ScheduleZBVZeroBubble]:
             for pattern in ["first_false_then_true", "first_true_then_false"]:
                 with self.subTest(ScheduleClass=ScheduleClass, pattern=pattern):
@@ -1302,7 +1302,7 @@ class ScheduleTestCUDA(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self._device_type, self.rank)
+        return torch.device(self.device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -1316,7 +1316,7 @@ class ScheduleTestCUDA(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_interleaved_1f1b_pre_split_flex_attention(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         stages_per_rank = 2
         n_stages = stages_per_rank * self.world_size
         num_microbatches = 8
@@ -1459,7 +1459,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self._device_type, self.rank)
+        return torch.device(self.device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -1474,7 +1474,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_non_symmetric_stage_ids(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for schedule_class in [ScheduleVShaped, ScheduleUnbalanced]:
             with self.subTest(schedule_class=schedule_class):
                 n_stages = schedule_class.n_stages
@@ -1526,7 +1526,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_pipeline_schedule_runtime_custom_sched(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleWithReorderedB]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 n_stages = 2
@@ -1592,7 +1592,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_schedule_with_native_zero_bubble(self, device):
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleWithW]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 n_stages = ScheduleClass.n_stages
@@ -1692,7 +1692,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self._device_type, self.rank)
+        return torch.device(self.device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -1708,7 +1708,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
     def test_creates_distinct_direction_groups(self, device):
         """PipelineStage builds two distinct, non-WORLD direction groups when the
         config flag is set (no constructor arg)."""
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         with dist_config.patch(pipeline_per_direction_p2p=True):
             mod, _, x, _, _ = setup_models_and_data(self.config)
             chunks = 2 * self.world_size
@@ -1728,7 +1728,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
     def test_grad_with_manual_per_direction(self, device):
         """Per-direction P2P only changes which communicator carries the bytes,
         not the math: gradients/outputs must still match the reference model."""
-        self._device_type = torch.device(device).type
+        self.device_type = torch.device(device).type
         for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
             with self.subTest(ScheduleClass=ScheduleClass):
                 with dist_config.patch(pipeline_per_direction_p2p=True):

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -49,14 +49,17 @@ from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 from torch.nn.modules.loss import MSELoss
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
-    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
     check_leaked_tensors,
     DeterministicGuard,
-    instantiate_parametrized_tests,
-    parametrize,
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_MULTIACCELERATOR,
@@ -70,8 +73,6 @@ batch_size = 64
 none_grad_d_hid = 32
 none_grad_microbatches = 8
 torch.manual_seed(0)
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = dist.get_default_backend_for_device(device_type)
 
 
 @dataclass
@@ -321,16 +322,16 @@ def create_packed_document_block_mask(
 
 
 class ScheduleTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 4
 
     @classmethod
     def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return backend
+        return dist.get_default_backend_for_device(cls.device_type)
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -339,758 +340,634 @@ class ScheduleTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize("ScheduleClass", [_ScheduleForwardOnly])
     @skip_if_lt_x_gpu(4)
-    def test_forward_only(self, ScheduleClass):
-        mod, mod_ref, x, _, _ = setup_models_and_data(self.config)
-        x_clone = x.clone()
+    def test_forward_only(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [_ScheduleForwardOnly]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                mod, mod_ref, x, _, _ = setup_models_and_data(self.config)
+                x_clone = x.clone()
 
-        num_microbatches = 2 * self.world_size
-        stage, _, _ = create_single_stage_pipeline(
-            self.config, mod, x, num_microbatches
-        )
-        schedule = ScheduleClass(stage, num_microbatches, scale_grads=False)
+                num_microbatches = 2 * self.world_size
+                stage, _, _ = create_single_stage_pipeline(
+                    self.config, mod, x, num_microbatches
+                )
+                schedule = ScheduleClass(stage, num_microbatches, scale_grads=False)
 
-        # Run forward-only schedule
-        out = None
-        num_iters = 20
-        for _ in range(num_iters):
-            if self.rank == 0:
-                schedule.step(x)
-                dist.recv(x, src=self.world_size - 1)
-            elif self.rank == self.world_size - 1:
-                out = schedule.step()
-                dist.send(out, dst=0)
-            else:
-                schedule.step()
+                # Run forward-only schedule
+                out = None
+                num_iters = 20
+                for _ in range(num_iters):
+                    if self.rank == 0:
+                        schedule.step(x)
+                        dist.recv(x, src=self.world_size - 1)
+                    elif self.rank == self.world_size - 1:
+                        out = schedule.step()
+                        dist.send(out, dst=0)
+                    else:
+                        schedule.step()
 
-        # Validate pipelined output matches reference model
-        if self.rank == self.world_size - 1:
-            for _ in range(num_iters):
-                x_clone = mod_ref(x_clone)
-            torch.testing.assert_close(x_clone, out)
+                # Validate pipelined output matches reference model
+                if self.rank == self.world_size - 1:
+                    for _ in range(num_iters):
+                        x_clone = mod_ref(x_clone)
+                    torch.testing.assert_close(x_clone, out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize(
-        "ScheduleClass",
-        [
+    @skip_if_lt_x_gpu(4)
+    def test_eval_inference_mode(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [
             ScheduleGPipe,
             Schedule1F1B,
             ScheduleInterleaved1F1B,
             ScheduleLoopedBFS,
             ScheduleInterleavedZeroBubble,
-        ],
-    )
-    @skip_if_lt_x_gpu(4)
-    def test_eval_inference_mode(self, ScheduleClass):
-        num_microbatches = 4
-        if ScheduleClass in [
-            ScheduleInterleaved1F1B,
-            ScheduleLoopedBFS,
-            ScheduleInterleavedZeroBubble,
         ]:
-            # Multi-stage schedules
-            stages_per_rank = 2
-            n_stages = stages_per_rank * self.world_size
-            mod, _, x, target, loss_fn = setup_models_and_data(
-                self.config, n_layers=n_stages
-            )
-
-            # Create multi-stage pipeline
-            stages, stage_modules, _ = create_multi_stage_pipeline(
-                self.config, mod, stages_per_rank, n_stages
-            )
-            schedule = ScheduleClass(
-                stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-            )
-        else:
-            # Single-stage schedules
-            mod, _, x, target, loss_fn = setup_models_and_data(self.config)
-
-            # Create single-stage pipeline
-            stage, stage_module, _ = create_single_stage_pipeline(
-                self.config, mod, x, num_microbatches
-            )
-            stage_modules = [stage_module]
-            schedule = ScheduleClass(
-                stage, num_microbatches, loss_fn=loss_fn, scale_grads=False
-            )
-
-        # Clear gradients and run eval
-        zero_gradients(stage_modules)
-        losses = []
-
-        if self.rank == 0:
-            # Support with and without no_grad()
-            with torch.no_grad():
-                schedule.eval(x)
-        elif self.rank == self.world_size - 1:
-            schedule.eval(target=target, losses=losses)
-        else:
-            schedule.eval()
-
-        # Check that gradients were NOT computed during eval
-        grad_computed_eval = any(
-            param.grad is not None
-            for stage_module in stage_modules
-            for param in stage_module.parameters()
-        )
-
-        # Verify that gradients were not computed during eval
-        self.assertFalse(
-            grad_computed_eval, "Gradients should not be computed during eval()"
-        )
-
-        # Verify that losses are still computed during eval
-        if self.rank == self.world_size - 1:
-            self.assertTrue(len(losses) > 0, "Losses should be computed during eval()")
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize(
-        "ScheduleClass",
-        [
-            ScheduleGPipe,
-            Schedule1F1B,
-            ScheduleInterleaved1F1B,
-            ScheduleLoopedBFS,
-            ScheduleInterleavedZeroBubble,
-        ],
-    )
-    @skip_if_lt_x_gpu(4)
-    def test_return_output(self, ScheduleClass):
-        num_microbatches = 4
-        if ScheduleClass in [
-            ScheduleInterleaved1F1B,
-            ScheduleLoopedBFS,
-            ScheduleInterleavedZeroBubble,
-        ]:
-            # Multi-stage schedules
-            stages_per_rank = 2
-            n_stages = stages_per_rank * self.world_size
-            mod, _, x, target, loss_fn = setup_models_and_data(
-                self.config, n_layers=n_stages
-            )
-
-            # Create multi-stage pipeline
-            stages, stage_modules, _ = create_multi_stage_pipeline(
-                self.config, mod, stages_per_rank, n_stages
-            )
-            schedule = ScheduleClass(
-                stages,
-                num_microbatches,
-                loss_fn=loss_fn,
-                scale_grads=False,
-            )
-        else:
-            # Single-stage schedules
-            mod, _, x, target, loss_fn = setup_models_and_data(self.config)
-
-            # Create single-stage pipeline
-            stage, stage_module, _ = create_single_stage_pipeline(
-                self.config, mod, x, num_microbatches
-            )
-            schedule = ScheduleClass(
-                stage,
-                num_microbatches,
-                loss_fn=loss_fn,
-                scale_grads=False,
-            )
-
-        losses = []
-
-        if self.rank == self.world_size - 1:
-            output = schedule.step(target=target, losses=losses, return_outputs=False)
-        else:
-            schedule.step(x)
-
-        # Verify that output is None
-        if self.rank == self.world_size - 1:
-            self.assertTrue(output is None, "Output should be None")
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
-    @skip_if_lt_x_gpu(4)
-    def test_multi_iter(self, ScheduleClass):
-        mod, _, x, target, loss_fn = setup_models_and_data(self.config)
-        chunks = 4
-        stage, _, _ = create_single_stage_pipeline(self.config, mod, x, chunks)
-        schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
-
-        # Run
-        for _ in range(20):
-            if self.rank == 0:
-                schedule.step(x)
-            elif self.rank == self.world_size - 1:
-                losses = []
-                schedule.step(target=target, losses=losses)
-            else:
-                schedule.step()
-
-        dist.barrier(device_ids=[self.rank])
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
-    @parametrize("pre_split", [False, True])
-    @skip_if_lt_x_gpu(4)
-    def test_kwargs_with_tracer(self, ScheduleClass, pre_split):
-        mod = ModelWithKwargs(d_hid, splits=self.world_size)
-        mod.to(self.device)
-
-        x = torch.randn(batch_size, d_hid, device=self.device)
-        y = torch.randn(batch_size, d_hid, device=self.device)
-        target = torch.randn(batch_size, d_hid, device=self.device)
-        loss_fn = torch.nn.MSELoss(reduction="sum")
-
-        chunks = 4
-        x_mb = x.chunk(chunks)[0]
-        y_mb = y.chunk(chunks)[0]
-
-        pipe = pipeline(
-            mod,
-            mb_args=(x_mb,),
-            mb_kwargs={"y": y_mb},
-        )
-
-        stage = pipe.build_stage(
-            self.rank,
-            self.device,
-        )
-
-        # Attach to a schedule
-        schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
-
-        # Run
-        out = None
-        losses = []
-        if self.rank == 0:
-            step_with_optional_pre_split(
-                schedule,
-                chunks,
-                args=(x,),
-                kwargs={"y": y},
-                pre_split=pre_split,
-            )
-        elif self.rank == self.world_size - 1:
-            out = step_with_optional_pre_split(
-                schedule,
-                chunks,
-                target=target,
-                losses=losses,
-                pre_split=pre_split,
-            )
-        else:
-            step_with_optional_pre_split(
-                schedule,
-                chunks,
-                pre_split=pre_split,
-            )
-
-        dist.barrier(device_ids=[self.rank])
-
-        # Last rank checks result
-        if self.rank == self.world_size - 1:
-            ref_out = mod(x, y=y)
-            ref_loss = loss_fn(ref_out, target)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=5e-3)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
-    @parametrize("pre_split", [False, True])
-    @skip_if_lt_x_gpu(4)
-    def test_grad_with_tracer(self, ScheduleClass, pre_split):
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
-
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create pipeline and schedule
-        chunks = 2 * self.world_size
-        stage, stage_module, stage_modules = create_single_stage_pipeline(
-            self.config, mod, x, chunks
-        )
-        schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
-
-        # Run pipeline
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_module)
-            if self.rank == 0:
-                step_with_optional_pre_split(
-                    schedule,
-                    chunks,
-                    args=(x,),
-                    pre_split=pre_split,
-                )
-            elif self.rank == self.world_size - 1:
-                out = step_with_optional_pre_split(
-                    schedule,
-                    chunks,
-                    target=target,
-                    losses=losses,
-                    pre_split=pre_split,
-                )
-            else:
-                step_with_optional_pre_split(
-                    schedule,
-                    chunks,
-                    pre_split=pre_split,
-                )
-
-        dist.barrier(device_ids=[self.rank])
-
-        # Last rank checks result
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        check_gradients(self.config, stage_module, ref_mod)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
-    @parametrize("shape_inference", [True, False])
-    @skip_if_lt_x_gpu(4)
-    def test_grad_with_manual(self, ScheduleClass, shape_inference):
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
-
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create manual pipeline stage
-        chunks = 2 * self.world_size
-        stage, stage_module, _ = create_single_stage_pipeline(
-            self.config, mod, x, chunks, use_tracer=False
-        )
-
-        # Handle shape inference
-        if not shape_inference:
-            input_args = (x.chunk(chunks)[0],)
-            if self.rank > 0:
-                # Non-first stages receive activations from previous stages,
-                # which have requires_grad=True in training mode.
-                input_args = tuple(a.detach().requires_grad_(True) for a in input_args)
-            output_args = stage_module(*input_args)
-            output_args = output_args.detach().requires_grad_(output_args.requires_grad)
-            stage = PipelineStage(
-                stage_module,
-                self.rank,
-                self.world_size,
-                self.device,
-                input_args=input_args,
-                output_args=output_args,
-            )
-
-        schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
-
-        # Run pipeline
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_module)
-            if self.rank == 0:
-                schedule.step(x)
-            elif self.rank == self.world_size - 1:
-                out = schedule.step(target=target, losses=losses)
-            else:
-                schedule.step()
-
-        dist.barrier(device_ids=[self.rank])
-
-        # Last rank checks result
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        check_gradients(self.config, stage_module, ref_mod)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize(
-        "ScheduleClass",
-        [
-            ScheduleInterleaved1F1B,
-            ScheduleLoopedBFS,
-            ScheduleInterleavedZeroBubble,
-        ],
-    )
-    @parametrize("pre_split", [False, True])
-    @skip_if_lt_x_gpu(4)
-    def test_grad_with_manual_interleaved(self, ScheduleClass, pre_split):
-        stages_per_rank = 2
-        n_stages = stages_per_rank * self.world_size
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages
-        )
-
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create multi-stage pipeline
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, stages_per_rank, n_stages
-        )
-        print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
-
-        num_microbatches = (
-            ScheduleClass.num_microbatches
-            if hasattr(ScheduleClass, "num_microbatches")
-            else 2 * self.world_size
-        )
-
-        # Create schedule
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-
-        # Run pipeline with tensor leak checking
-        out = None
-        losses = []
-        with check_leaked_tensors() as garbage_tensors:
-            for _ in range(2):
-                zero_gradients(stage_modules)
-                if self.rank == 0:
-                    step_with_optional_pre_split(
-                        schedule,
-                        num_microbatches,
-                        args=(x,),
-                        pre_split=pre_split,
+            with self.subTest(ScheduleClass=ScheduleClass):
+                num_microbatches = 4
+                if ScheduleClass in [
+                    ScheduleInterleaved1F1B,
+                    ScheduleLoopedBFS,
+                    ScheduleInterleavedZeroBubble,
+                ]:
+                    # Multi-stage schedules
+                    stages_per_rank = 2
+                    n_stages = stages_per_rank * self.world_size
+                    mod, _, x, target, loss_fn = setup_models_and_data(
+                        self.config, n_layers=n_stages
                     )
-                elif self.rank == self.world_size - 1:
-                    out = step_with_optional_pre_split(
-                        schedule,
-                        num_microbatches,
-                        target=target,
-                        losses=losses,
-                        pre_split=pre_split,
+
+                    # Create multi-stage pipeline
+                    stages, stage_modules, _ = create_multi_stage_pipeline(
+                        self.config, mod, stages_per_rank, n_stages
+                    )
+                    schedule = ScheduleClass(
+                        stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
                     )
                 else:
-                    step_with_optional_pre_split(
-                        schedule,
+                    # Single-stage schedules
+                    mod, _, x, target, loss_fn = setup_models_and_data(self.config)
+
+                    # Create single-stage pipeline
+                    stage, stage_module, _ = create_single_stage_pipeline(
+                        self.config, mod, x, num_microbatches
+                    )
+                    stage_modules = [stage_module]
+                    schedule = ScheduleClass(
+                        stage, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                    )
+
+                # Clear gradients and run eval
+                zero_gradients(stage_modules)
+                losses = []
+
+                if self.rank == 0:
+                    # Support with and without no_grad()
+                    with torch.no_grad():
+                        schedule.eval(x)
+                elif self.rank == self.world_size - 1:
+                    schedule.eval(target=target, losses=losses)
+                else:
+                    schedule.eval()
+
+                # Check that gradients were NOT computed during eval
+                grad_computed_eval = any(
+                    param.grad is not None
+                    for stage_module in stage_modules
+                    for param in stage_module.parameters()
+                )
+
+                # Verify that gradients were not computed during eval
+                self.assertFalse(
+                    grad_computed_eval, "Gradients should not be computed during eval()"
+                )
+
+                # Verify that losses are still computed during eval
+                if self.rank == self.world_size - 1:
+                    self.assertTrue(len(losses) > 0, "Losses should be computed during eval()")
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_return_output(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [
+            ScheduleGPipe,
+            Schedule1F1B,
+            ScheduleInterleaved1F1B,
+            ScheduleLoopedBFS,
+            ScheduleInterleavedZeroBubble,
+        ]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                num_microbatches = 4
+                if ScheduleClass in [
+                    ScheduleInterleaved1F1B,
+                    ScheduleLoopedBFS,
+                    ScheduleInterleavedZeroBubble,
+                ]:
+                    # Multi-stage schedules
+                    stages_per_rank = 2
+                    n_stages = stages_per_rank * self.world_size
+                    mod, _, x, target, loss_fn = setup_models_and_data(
+                        self.config, n_layers=n_stages
+                    )
+
+                    # Create multi-stage pipeline
+                    stages, stage_modules, _ = create_multi_stage_pipeline(
+                        self.config, mod, stages_per_rank, n_stages
+                    )
+                    schedule = ScheduleClass(
+                        stages,
                         num_microbatches,
-                        pre_split=pre_split,
+                        loss_fn=loss_fn,
+                        scale_grads=False,
+                    )
+                else:
+                    # Single-stage schedules
+                    mod, _, x, target, loss_fn = setup_models_and_data(self.config)
+
+                    # Create single-stage pipeline
+                    stage, stage_module, _ = create_single_stage_pipeline(
+                        self.config, mod, x, num_microbatches
+                    )
+                    schedule = ScheduleClass(
+                        stage,
+                        num_microbatches,
+                        loss_fn=loss_fn,
+                        scale_grads=False,
                     )
 
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
-        dist.barrier()
+                losses = []
 
-        # Verify results
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
+                if self.rank == self.world_size - 1:
+                    output = schedule.step(target=target, losses=losses, return_outputs=False)
+                else:
+                    schedule.step(x)
 
-        # Check gradients - use relaxed tolerances for interleaved schedules
-        # since gradients are small
-        check_gradients(
-            self.config, stage_modules, ref_mod, submod_names, rtol=5e-3, atol=5e-3
-        )
+                # Verify that output is None
+                if self.rank == self.world_size - 1:
+                    self.assertTrue(output is None, "Output should be None")
 
-    @requires_accelerator_dist_backend(["nccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        device_type != "cuda" or not TEST_MULTIACCELERATOR,
-        "CUDA/NCCL flex attention test requires 4+ GPUs",
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
     @skip_if_lt_x_gpu(4)
-    def test_interleaved_1f1b_pre_split_flex_attention(self):
-        stages_per_rank = 2
-        n_stages = stages_per_rank * self.world_size
-        num_microbatches = 8
-        batch = 8
-        seq_len = 64
-        model_dim = 32
-        num_heads = 2
-        ffn_dim = 64
+    def test_multi_iter(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                mod, _, x, target, loss_fn = setup_models_and_data(self.config)
+                chunks = 4
+                stage, _, _ = create_single_stage_pipeline(self.config, mod, x, chunks)
+                schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
-        auto_mod = FlexAttentionTransformer(model_dim, num_heads, ffn_dim, n_stages).to(
-            self.device
-        )
-        pre_split_mod = copy.deepcopy(auto_mod)
-        ref_mod = copy.deepcopy(auto_mod)
-        x = torch.randn(batch, seq_len, model_dim, device=self.device)
-        target = torch.randn_like(x)
-        positions = torch.stack(
-            [
-                torch.arange(seq_len, device=self.device) % (8 * (i % 4 + 1))
-                for i in range(batch)
-            ]
-        )
-        block_mask = create_packed_document_block_mask(positions, num_heads)
-        loss_fn = torch.nn.MSELoss(reduction="sum")
+                # Run
+                for _ in range(20):
+                    if self.rank == 0:
+                        schedule.step(x)
+                    elif self.rank == self.world_size - 1:
+                        losses = []
+                        schedule.step(target=target, losses=losses)
+                    else:
+                        schedule.step()
 
-        auto_stages, auto_stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, auto_mod, stages_per_rank, n_stages
-        )
-        pre_split_stages, pre_split_stage_modules, pre_split_submod_names = (
-            create_multi_stage_pipeline(
-                self.config, pre_split_mod, stages_per_rank, n_stages
-            )
-        )
-        self.assertEqual(pre_split_submod_names, submod_names)
+                dist.barrier(device_ids=[self.rank])
 
-        has_first_stage = any(stage.is_first for stage in auto_stages)
-        has_last_stage = any(stage.is_last for stage in auto_stages)
-        self.assertEqual(
-            has_first_stage,
-            any(stage.is_first for stage in pre_split_stages),
-        )
-        self.assertEqual(
-            has_last_stage,
-            any(stage.is_last for stage in pre_split_stages),
-        )
-
-        arg_mbs = [(x_mb,) for x_mb in torch.tensor_split(x, num_microbatches)]
-        target_mbs = list(torch.tensor_split(target, num_microbatches))
-        position_mbs = torch.tensor_split(positions, num_microbatches)
-        kwarg_mbs = [
-            {"block_mask": create_packed_document_block_mask(positions_mb, num_heads)}
-            for positions_mb in position_mbs
-        ]
-
-        auto_schedule = ScheduleInterleaved1F1B(
-            auto_stages,
-            num_microbatches,
-            loss_fn=loss_fn,
-            scale_grads=False,
-        )
-        pre_split_schedule = ScheduleInterleaved1F1B(
-            pre_split_stages,
-            num_microbatches,
-            loss_fn=loss_fn,
-            scale_grads=False,
-        )
-
-        auto_out = None
-        auto_losses = []
-        pre_split_out = None
-        pre_split_losses = []
-        with DeterministicGuard(True):
-            ref_out, ref_loss = run_reference_model(
-                ref_mod,
-                x,
-                target,
-                loss_fn,
-                num_iterations=1,
-                block_mask=block_mask,
-            )
-
-            zero_gradients(auto_stage_modules)
-            auto_out = auto_schedule.step(
-                *((x,) if has_first_stage else ()),
-                block_mask=block_mask,
-                target=target if has_last_stage else None,
-                losses=auto_losses if has_last_stage else None,
-            )
-
-            dist.barrier()
-
-            zero_gradients(pre_split_stage_modules)
-            pre_split_out = pre_split_schedule.step(
-                arg_mbs=arg_mbs if has_first_stage else None,
-                kwarg_mbs=kwarg_mbs,
-                target_mbs=target_mbs if has_last_stage else None,
-                losses=pre_split_losses if has_last_stage else None,
-            )
-
-            dist.barrier()
-
-        if has_last_stage:
-            self.assertEqual(pre_split_out, auto_out)
-            self.assertEqual(
-                torch.stack(pre_split_losses),
-                torch.stack(auto_losses),
-            )
-            self.assertEqual(auto_out, ref_out)
-            self.assertEqual(sum(auto_losses), ref_loss)
-
-        for auto_stage_module, pre_split_stage_module in zip(
-            auto_stage_modules,
-            pre_split_stage_modules,
-            strict=True,
-        ):
-            for (auto_name, auto_param), (pre_split_name, pre_split_param) in zip(
-                auto_stage_module.named_parameters(),
-                pre_split_stage_module.named_parameters(),
-                strict=True,
-            ):
-                self.assertEqual(auto_name, pre_split_name)
-                self.assertEqual(pre_split_param.grad, auto_param.grad)
-
-        check_gradients(self.config, auto_stage_modules, ref_mod, submod_names)
-        check_gradients(self.config, pre_split_stage_modules, ref_mod, submod_names)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize("ScheduleClass", [ScheduleInterleavedZeroBubble])
     @skip_if_lt_x_gpu(4)
-    def test_schedule_with_weight_update_mlp_e2e(self, ScheduleClass):
-        stages_per_rank = 2
-        n_stages = stages_per_rank * self.world_size
-        full_mod, ref_mod, x, target, _ = setup_models_and_data(
-            self.config, n_layers=n_stages, model_class=MultiMLPWithDw
-        )
-        full_mod.toggle()
-        loss_fn = MSELoss()
+    def test_kwargs_with_tracer(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
+            for pre_split in [False, True]:
+                with self.subTest(ScheduleClass=ScheduleClass, pre_split=pre_split):
+                    mod = ModelWithKwargs(d_hid, splits=self.world_size)
+                    mod.to(self.device)
 
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+                    x = torch.randn(batch_size, d_hid, device=self.device)
+                    y = torch.randn(batch_size, d_hid, device=self.device)
+                    target = torch.randn(batch_size, d_hid, device=self.device)
+                    loss_fn = torch.nn.MSELoss(reduction="sum")
 
-        # Create multi-stage pipeline with custom dw_builder
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, full_mod, stages_per_rank, n_stages
-        )
+                    chunks = 4
+                    x_mb = x.chunk(chunks)[0]
+                    y_mb = y.chunk(chunks)[0]
 
-        class CustomState:
-            def __init__(self, stage_module, stage_idx, rank):
-                self.i = 0
-                self.stage_module = stage_module
-                self.stage_idx = stage_idx
-                self.rank = rank
-
-            def dw_builder(self):
-                def dw_runner():
-                    self.i += 1
-                    print(
-                        f"[Rank {self.rank}] dw_count={self.i} stage={self.stage_idx}"
+                    pipe = pipeline(
+                        mod,
+                        mb_args=(x_mb,),
+                        mb_kwargs={"y": y_mb},
                     )
-                    self.stage_module.compute_dW()
 
-                return dw_runner
+                    stage = pipe.build_stage(
+                        self.rank,
+                        self.device,
+                    )
 
-        # Create custom states and rebuild stages with dw_builder
-        cs = {}
-        stage_indices = [
-            self.rank + i * self.world_size for i in range(stages_per_rank)
-        ]
-        for stage_module, stage_idx in zip(stage_modules, stage_indices):
-            cs[stage_idx] = CustomState(stage_module, stage_idx, self.rank)
+                    # Attach to a schedule
+                    schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
-        stages = [
-            PipelineStage(
-                stage_module,
-                stage_idx,
-                n_stages,
-                self.device,
-                dw_builder=cs[stage_idx].dw_builder,
-            )
-            for stage_module, stage_idx in zip(stage_modules, stage_indices)
-        ]
+                    # Run
+                    out = None
+                    losses = []
+                    if self.rank == 0:
+                        step_with_optional_pre_split(
+                            schedule,
+                            chunks,
+                            args=(x,),
+                            kwargs={"y": y},
+                            pre_split=pre_split,
+                        )
+                    elif self.rank == self.world_size - 1:
+                        out = step_with_optional_pre_split(
+                            schedule,
+                            chunks,
+                            target=target,
+                            losses=losses,
+                            pre_split=pre_split,
+                        )
+                    else:
+                        step_with_optional_pre_split(
+                            schedule,
+                            chunks,
+                            pre_split=pre_split,
+                        )
 
-        schedule = ScheduleClass(stages, 2, loss_fn=loss_fn)
+                    dist.barrier(device_ids=[self.rank])
 
-        # Run pipeline
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_modules)
-            if self.rank == 0:
-                schedule.step(x)
-            elif self.rank == self.world_size - 1:
-                out = schedule.step(target=target, losses=losses)
-            else:
-                schedule.step()
+                    # Last rank checks result
+                    if self.rank == self.world_size - 1:
+                        ref_out = mod(x, y=y)
+                        ref_loss = loss_fn(ref_out, target)
+                        pipe_loss = sum(losses)
+                        torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=5e-3)
+                        torch.testing.assert_close(pipe_loss, ref_loss)
 
-        dist.barrier(device_ids=[self.rank])
-
-        # Verify results
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses) / len(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        check_gradients(self.config, stage_modules, ref_mod, submod_names)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize(
-        "schedule_class",
-        [ScheduleZBVZeroBubble, ScheduleDualPipeV],
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
     @skip_if_lt_x_gpu(4)
-    def test_v_shape_schedules(self, schedule_class):
-        n_stages = 8
-        rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages
-        )
+    def test_grad_with_tracer(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
+            for pre_split in [False, True]:
+                with self.subTest(ScheduleClass=ScheduleClass, pre_split=pre_split):
+                    mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
 
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+                    # Run reference
+                    ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
-        # Create multi-stage pipeline with custom stage indices
-        num_microbatches = 8
-        stage_indices = rank_stages[self.rank]
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, len(stage_indices), n_stages, stage_indices
-        )
+                    # Create pipeline and schedule
+                    chunks = 2 * self.world_size
+                    stage, stage_module, stage_modules = create_single_stage_pipeline(
+                        self.config, mod, x, chunks
+                    )
+                    schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
-        schedule = schedule_class(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
+                    # Run pipeline
+                    out = None
+                    losses = []
+                    for _ in range(2):
+                        zero_gradients(stage_module)
+                        if self.rank == 0:
+                            step_with_optional_pre_split(
+                                schedule,
+                                chunks,
+                                args=(x,),
+                                pre_split=pre_split,
+                            )
+                        elif self.rank == self.world_size - 1:
+                            out = step_with_optional_pre_split(
+                                schedule,
+                                chunks,
+                                target=target,
+                                losses=losses,
+                                pre_split=pre_split,
+                            )
+                        else:
+                            step_with_optional_pre_split(
+                                schedule,
+                                chunks,
+                                pre_split=pre_split,
+                            )
 
-        # Run pipeline - special case where first and last stage are on rank 0
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_modules)
-            if self.rank == 0:
-                out = schedule.step(x, target=target, losses=losses)
-            else:
-                schedule.step()
+                    dist.barrier(device_ids=[self.rank])
 
-        # Verify results (rank 0 has both first and last stages)
-        if self.rank == 0:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
+                    # Last rank checks result
+                    if self.rank == self.world_size - 1:
+                        torch.testing.assert_close(out, ref_out)
+                        pipe_loss = sum(losses)
+                        torch.testing.assert_close(pipe_loss, ref_loss)
 
-        # Check gradients using helper method
-        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+                    # Check gradients using helper method
+                    check_gradients(self.config, stage_module, ref_mod)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
     @skip_if_lt_x_gpu(4)
-    def test_custom_function_callback(self):
+    def test_grad_with_manual(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
+            for shape_inference in [True, False]:
+                with self.subTest(ScheduleClass=ScheduleClass, shape_inference=shape_inference):
+                    mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
+
+                    # Run reference
+                    ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+                    # Create manual pipeline stage
+                    chunks = 2 * self.world_size
+                    stage, stage_module, _ = create_single_stage_pipeline(
+                        self.config, mod, x, chunks, use_tracer=False
+                    )
+
+                    # Handle shape inference
+                    if not shape_inference:
+                        input_args = (x.chunk(chunks)[0],)
+                        if self.rank > 0:
+                            # Non-first stages receive activations from previous stages,
+                            # which have requires_grad=True in training mode.
+                            input_args = tuple(a.detach().requires_grad_(True) for a in input_args)
+                        output_args = stage_module(*input_args)
+                        output_args = output_args.detach().requires_grad_(output_args.requires_grad)
+                        stage = PipelineStage(
+                            stage_module,
+                            self.rank,
+                            self.world_size,
+                            self.device,
+                            input_args=input_args,
+                            output_args=output_args,
+                        )
+
+                    schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
+
+                    # Run pipeline
+                    out = None
+                    losses = []
+                    for _ in range(2):
+                        zero_gradients(stage_module)
+                        if self.rank == 0:
+                            schedule.step(x)
+                        elif self.rank == self.world_size - 1:
+                            out = schedule.step(target=target, losses=losses)
+                        else:
+                            schedule.step()
+
+                    dist.barrier(device_ids=[self.rank])
+
+                    # Last rank checks result
+                    if self.rank == self.world_size - 1:
+                        torch.testing.assert_close(out, ref_out)
+                        pipe_loss = sum(losses)
+                        torch.testing.assert_close(pipe_loss, ref_loss)
+
+                    # Check gradients using helper method
+                    check_gradients(self.config, stage_module, ref_mod)
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_grad_with_manual_interleaved(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [
+            ScheduleInterleaved1F1B,
+            ScheduleLoopedBFS,
+            ScheduleInterleavedZeroBubble,
+        ]:
+            for pre_split in [False, True]:
+                with self.subTest(ScheduleClass=ScheduleClass, pre_split=pre_split):
+                    stages_per_rank = 2
+                    n_stages = stages_per_rank * self.world_size
+                    mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                        self.config, n_layers=n_stages
+                    )
+
+                    # Run reference
+                    ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+                    # Create multi-stage pipeline
+                    stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                        self.config, mod, stages_per_rank, n_stages
+                    )
+                    print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
+
+                    num_microbatches = (
+                        ScheduleClass.num_microbatches
+                        if hasattr(ScheduleClass, "num_microbatches")
+                        else 2 * self.world_size
+                    )
+
+                    # Create schedule
+                    schedule = ScheduleClass(
+                        stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                    )
+
+                    # Run pipeline with tensor leak checking
+                    out = None
+                    losses = []
+                    with check_leaked_tensors() as garbage_tensors:
+                        for _ in range(2):
+                            zero_gradients(stage_modules)
+                            if self.rank == 0:
+                                step_with_optional_pre_split(
+                                    schedule,
+                                    num_microbatches,
+                                    args=(x,),
+                                    pre_split=pre_split,
+                                )
+                            elif self.rank == self.world_size - 1:
+                                out = step_with_optional_pre_split(
+                                    schedule,
+                                    num_microbatches,
+                                    target=target,
+                                    losses=losses,
+                                    pre_split=pre_split,
+                                )
+                            else:
+                                step_with_optional_pre_split(
+                                    schedule,
+                                    num_microbatches,
+                                    pre_split=pre_split,
+                                )
+
+                    self.assertEqual(
+                        len(garbage_tensors),
+                        0,
+                        "Found leaked tensors, check logs above for debug info",
+                    )
+                    dist.barrier()
+
+                    # Verify results
+                    if self.rank == self.world_size - 1:
+                        torch.testing.assert_close(out, ref_out)
+                        pipe_loss = sum(losses)
+                        torch.testing.assert_close(pipe_loss, ref_loss)
+
+                    # Check gradients - use relaxed tolerances for interleaved schedules
+                    # since gradients are small
+                    check_gradients(
+                        self.config, stage_modules, ref_mod, submod_names, rtol=5e-3, atol=5e-3
+                    )
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_schedule_with_weight_update_mlp_e2e(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleInterleavedZeroBubble]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                stages_per_rank = 2
+                n_stages = stages_per_rank * self.world_size
+                full_mod, ref_mod, x, target, _ = setup_models_and_data(
+                    self.config, n_layers=n_stages, model_class=MultiMLPWithDw
+                )
+                full_mod.toggle()
+                loss_fn = MSELoss()
+
+                # Run reference
+                ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+                # Create multi-stage pipeline with custom dw_builder
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, full_mod, stages_per_rank, n_stages
+                )
+
+                class CustomState:
+                    def __init__(self, stage_module, stage_idx, rank):
+                        self.i = 0
+                        self.stage_module = stage_module
+                        self.stage_idx = stage_idx
+                        self.rank = rank
+
+                    def dw_builder(self):
+                        def dw_runner():
+                            self.i += 1
+                            print(
+                                f"[Rank {self.rank}] dw_count={self.i} stage={self.stage_idx}"
+                            )
+                            self.stage_module.compute_dW()
+
+                        return dw_runner
+
+                # Create custom states and rebuild stages with dw_builder
+                cs = {}
+                stage_indices = [
+                    self.rank + i * self.world_size for i in range(stages_per_rank)
+                ]
+                for stage_module, stage_idx in zip(stage_modules, stage_indices):
+                    cs[stage_idx] = CustomState(stage_module, stage_idx, self.rank)
+
+                stages = [
+                    PipelineStage(
+                        stage_module,
+                        stage_idx,
+                        n_stages,
+                        self.device,
+                        dw_builder=cs[stage_idx].dw_builder,
+                    )
+                    for stage_module, stage_idx in zip(stage_modules, stage_indices)
+                ]
+
+                schedule = ScheduleClass(stages, 2, loss_fn=loss_fn)
+
+                # Run pipeline
+                out = None
+                losses = []
+                for _ in range(2):
+                    zero_gradients(stage_modules)
+                    if self.rank == 0:
+                        schedule.step(x)
+                    elif self.rank == self.world_size - 1:
+                        out = schedule.step(target=target, losses=losses)
+                    else:
+                        schedule.step()
+
+                dist.barrier(device_ids=[self.rank])
+
+                # Verify results
+                if self.rank == self.world_size - 1:
+                    torch.testing.assert_close(out, ref_out)
+                    pipe_loss = sum(losses) / len(losses)
+                    torch.testing.assert_close(pipe_loss, ref_loss)
+
+                # Check gradients using helper method
+                check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_v_shape_schedules(self, device):
+        self._device_type = torch.device(device).type
+        for schedule_class in [ScheduleZBVZeroBubble, ScheduleDualPipeV]:
+            with self.subTest(schedule_class=schedule_class):
+                n_stages = 8
+                rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
+                mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                    self.config, n_layers=n_stages
+                )
+
+                # Run reference
+                ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+
+                # Create multi-stage pipeline with custom stage indices
+                num_microbatches = 8
+                stage_indices = rank_stages[self.rank]
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, mod, len(stage_indices), n_stages, stage_indices
+                )
+
+                schedule = schedule_class(
+                    stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                )
+
+                # Run pipeline - special case where first and last stage are on rank 0
+                out = None
+                losses = []
+                for _ in range(2):
+                    zero_gradients(stage_modules)
+                    if self.rank == 0:
+                        out = schedule.step(x, target=target, losses=losses)
+                    else:
+                        schedule.step()
+
+                # Verify results (rank 0 has both first and last stages)
+                if self.rank == 0:
+                    torch.testing.assert_close(out, ref_out)
+                    pipe_loss = sum(losses)
+                    torch.testing.assert_close(pipe_loss, ref_loss)
+
+                # Check gradients using helper method
+                check_gradients(self.config, stage_modules, ref_mod, submod_names)
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_custom_function_callback(self, device):
+        self._device_type = torch.device(device).type
         """Test the custom function callback functionality with _PipelineScheduleRuntime."""
         n_stages = 8
         rank_stages = {0: [0, 7], 1: [1, 6], 2: [2, 5], 3: [3, 4]}
@@ -1287,70 +1164,70 @@ class ScheduleTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, "NCCL test requires 2+ GPUs"
     )
-    @parametrize(
-        "ScheduleClass",
-        [ScheduleInterleavedZeroBubble, ScheduleInterleaved1F1B],
-    )
     @skip_if_lt_x_gpu(4)
-    def test_zero_bubble_with_model_kwargs(self, ScheduleClass):
-        stages_per_rank = 2
-        n_stages = stages_per_rank * self.world_size
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages, model_class=MultiMLPKwargs
-        )
-        unused_kwarg = torch.tensor([1.0], device=self.device)
-
-        # Run reference with kwargs
-        ref_out, ref_loss = run_reference_model(
-            ref_mod, x, target, loss_fn, unused_kwarg=unused_kwarg
-        )
-
-        # Create multi-stage pipeline
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, stages_per_rank, n_stages
-        )
-
-        num_microbatches = (
-            ScheduleClass.num_microbatches
-            if hasattr(ScheduleClass, "num_microbatches")
-            else 2 * self.world_size
-        )
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-
-        # Run pipeline with kwargs
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_modules)
-            if self.rank == 0:
-                schedule.step(
-                    x,
-                    unused_kwarg=unused_kwarg.clone()
-                    .unsqueeze(0)
-                    .expand(num_microbatches, -1),
+    def test_zero_bubble_with_model_kwargs(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleInterleavedZeroBubble, ScheduleInterleaved1F1B]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                stages_per_rank = 2
+                n_stages = stages_per_rank * self.world_size
+                mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                    self.config, n_layers=n_stages, model_class=MultiMLPKwargs
                 )
-            elif self.rank == self.world_size - 1:
-                out = schedule.step(target=target, losses=losses)
-            else:
-                schedule.step()
+                unused_kwarg = torch.tensor([1.0], device=self.device)
 
-        dist.barrier()
+                # Run reference with kwargs
+                ref_out, ref_loss = run_reference_model(
+                    ref_mod, x, target, loss_fn, unused_kwarg=unused_kwarg
+                )
 
-        # Verify results
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
+                # Create multi-stage pipeline
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, mod, stages_per_rank, n_stages
+                )
 
-        # Check gradients using helper method
-        check_gradients(
-            self.config, stage_modules, ref_mod, submod_names, rtol=3e-5, atol=5e-3
-        )
+                num_microbatches = (
+                    ScheduleClass.num_microbatches
+                    if hasattr(ScheduleClass, "num_microbatches")
+                    else 2 * self.world_size
+                )
+                schedule = ScheduleClass(
+                    stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                )
+
+                # Run pipeline with kwargs
+                out = None
+                losses = []
+                for _ in range(2):
+                    zero_gradients(stage_modules)
+                    if self.rank == 0:
+                        schedule.step(
+                            x,
+                            unused_kwarg=unused_kwarg.clone()
+                            .unsqueeze(0)
+                            .expand(num_microbatches, -1),
+                        )
+                    elif self.rank == self.world_size - 1:
+                        out = schedule.step(target=target, losses=losses)
+                    else:
+                        schedule.step()
+
+                dist.barrier()
+
+                # Verify results
+                if self.rank == self.world_size - 1:
+                    torch.testing.assert_close(out, ref_out)
+                    pipe_loss = sum(losses)
+                    torch.testing.assert_close(pipe_loss, ref_loss)
+
+                # Check gradients using helper method
+                check_gradients(
+                    self.config, stage_modules, ref_mod, submod_names, rtol=3e-5, atol=5e-3
+                )
 
     def _none_grad_stage_indices(self, ScheduleClass):
         if ScheduleClass is ScheduleGPipe:
@@ -1402,21 +1279,169 @@ class ScheduleTest(MultiProcContinuousTest):
             self.config, stage_modules, ref_mod, submod_names, rtol=1e-5, atol=1e-5
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize(
-        "ScheduleClass",
-        [ScheduleGPipe, ScheduleInterleaved1F1B, ScheduleZBVZeroBubble],
-    )
-    @parametrize("pattern", ["first_false_then_true", "first_true_then_false"])
     @skip_if_lt_x_gpu(4)
-    def test_NoneGrad_conditional_input_grad(self, ScheduleClass, pattern):
-        self._run_none_grad_schedule(ScheduleClass, pattern)
+    def test_NoneGrad_conditional_input_grad(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, ScheduleInterleaved1F1B, ScheduleZBVZeroBubble]:
+            for pattern in ["first_false_then_true", "first_true_then_false"]:
+                with self.subTest(ScheduleClass=ScheduleClass, pattern=pattern):
+                    self._run_none_grad_schedule(ScheduleClass, pattern)
 
 
-instantiate_parametrized_tests(ScheduleTest)
+class ScheduleTestCUDA(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+    world_size = 4
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return dist.get_default_backend_for_device(cls.device_type)
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(self._device_type, self.rank)
+
+    @property
+    def config(self) -> PipelineTestConfig:
+        return PipelineTestConfig(
+            world_size=self.world_size, device=self.device, rank=self.rank
+        )
+
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "CUDA/NCCL flex attention test requires 4+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_interleaved_1f1b_pre_split_flex_attention(self, device):
+        self._device_type = torch.device(device).type
+        stages_per_rank = 2
+        n_stages = stages_per_rank * self.world_size
+        num_microbatches = 8
+        batch = 8
+        seq_len = 64
+        model_dim = 32
+        num_heads = 2
+        ffn_dim = 64
+
+        auto_mod = FlexAttentionTransformer(model_dim, num_heads, ffn_dim, n_stages).to(
+            self.device
+        )
+        pre_split_mod = copy.deepcopy(auto_mod)
+        ref_mod = copy.deepcopy(auto_mod)
+        x = torch.randn(batch, seq_len, model_dim, device=self.device)
+        target = torch.randn_like(x)
+        positions = torch.stack(
+            [
+                torch.arange(seq_len, device=self.device) % (8 * (i % 4 + 1))
+                for i in range(batch)
+            ]
+        )
+        block_mask = create_packed_document_block_mask(positions, num_heads)
+        loss_fn = torch.nn.MSELoss(reduction="sum")
+
+        auto_stages, auto_stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, auto_mod, stages_per_rank, n_stages
+        )
+        pre_split_stages, pre_split_stage_modules, pre_split_submod_names = (
+            create_multi_stage_pipeline(
+                self.config, pre_split_mod, stages_per_rank, n_stages
+            )
+        )
+        self.assertEqual(pre_split_submod_names, submod_names)
+
+        has_first_stage = any(stage.is_first for stage in auto_stages)
+        has_last_stage = any(stage.is_last for stage in auto_stages)
+        self.assertEqual(
+            has_first_stage,
+            any(stage.is_first for stage in pre_split_stages),
+        )
+        self.assertEqual(
+            has_last_stage,
+            any(stage.is_last for stage in pre_split_stages),
+        )
+
+        arg_mbs = [(x_mb,) for x_mb in torch.tensor_split(x, num_microbatches)]
+        target_mbs = list(torch.tensor_split(target, num_microbatches))
+        position_mbs = torch.tensor_split(positions, num_microbatches)
+        kwarg_mbs = [
+            {"block_mask": create_packed_document_block_mask(positions_mb, num_heads)}
+            for positions_mb in position_mbs
+        ]
+
+        auto_schedule = ScheduleInterleaved1F1B(
+            auto_stages,
+            num_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+        )
+        pre_split_schedule = ScheduleInterleaved1F1B(
+            pre_split_stages,
+            num_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+        )
+
+        auto_out = None
+        auto_losses = []
+        pre_split_out = None
+        pre_split_losses = []
+        with DeterministicGuard(True):
+            ref_out, ref_loss = run_reference_model(
+                ref_mod,
+                x,
+                target,
+                loss_fn,
+                num_iterations=1,
+                block_mask=block_mask,
+            )
+
+            zero_gradients(auto_stage_modules)
+            auto_out = auto_schedule.step(
+                *((x,) if has_first_stage else ()),
+                block_mask=block_mask,
+                target=target if has_last_stage else None,
+                losses=auto_losses if has_last_stage else None,
+            )
+
+            dist.barrier()
+
+            zero_gradients(pre_split_stage_modules)
+            pre_split_out = pre_split_schedule.step(
+                arg_mbs=arg_mbs if has_first_stage else None,
+                kwarg_mbs=kwarg_mbs,
+                target_mbs=target_mbs if has_last_stage else None,
+                losses=pre_split_losses if has_last_stage else None,
+            )
+
+            dist.barrier()
+
+        if has_last_stage:
+            self.assertEqual(pre_split_out, auto_out)
+            self.assertEqual(
+                torch.stack(pre_split_losses),
+                torch.stack(auto_losses),
+            )
+            self.assertEqual(auto_out, ref_out)
+            self.assertEqual(sum(auto_losses), ref_loss)
+
+        for auto_stage_module, pre_split_stage_module in zip(
+            auto_stage_modules,
+            pre_split_stage_modules,
+            strict=True,
+        ):
+            for (auto_name, auto_param), (pre_split_name, pre_split_param) in zip(
+                auto_stage_module.named_parameters(),
+                pre_split_stage_module.named_parameters(),
+                strict=True,
+            ):
+                self.assertEqual(auto_name, pre_split_name)
+                self.assertEqual(pre_split_param.grad, auto_param.grad)
+
+        check_gradients(self.config, auto_stage_modules, ref_mod, submod_names)
+        check_gradients(self.config, pre_split_stage_modules, ref_mod, submod_names)
 
 
 class CustomSchedulesTest(MultiProcContinuousTest):
@@ -1425,16 +1450,16 @@ class CustomSchedulesTest(MultiProcContinuousTest):
     The schedules test weird and unconventional schedules for edge cases
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 2
 
     @classmethod
     def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return backend
+        return dist.get_default_backend_for_device(cls.device_type)
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -1443,180 +1468,180 @@ class CustomSchedulesTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize(
-        "schedule_class",
-        [ScheduleVShaped, ScheduleUnbalanced],
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
     @skip_if_lt_x_gpu(4)
-    def test_non_symmetric_stage_ids(self, schedule_class):
-        n_stages = schedule_class.n_stages
-        rank_stages = schedule_class.rank_stages
+    def test_non_symmetric_stage_ids(self, device):
+        self._device_type = torch.device(device).type
+        for schedule_class in [ScheduleVShaped, ScheduleUnbalanced]:
+            with self.subTest(schedule_class=schedule_class):
+                n_stages = schedule_class.n_stages
+                rank_stages = schedule_class.rank_stages
 
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages
-        )
+                mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                    self.config, n_layers=n_stages
+                )
 
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+                # Run reference
+                ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
-        # Create multi-stage pipeline with custom stage indices
-        num_microbatches = 1
-        stage_indices = rank_stages[self.rank]
-        print(f"Rank {self.rank} stages: {stage_indices}")
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, len(stage_indices), n_stages, stage_indices
-        )
+                # Create multi-stage pipeline with custom stage indices
+                num_microbatches = 1
+                stage_indices = rank_stages[self.rank]
+                print(f"Rank {self.rank} stages: {stage_indices}")
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, mod, len(stage_indices), n_stages, stage_indices
+                )
 
-        schedule = schedule_class(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
+                schedule = schedule_class(
+                    stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                )
 
-        # Run pipeline - special case where first and last stage are on rank 0
-        out = None
-        losses = []
-        for _ in range(2):
-            zero_gradients(stage_modules)
-            if self.rank == 0:
-                out = schedule.step(x, target=target, losses=losses)
-            else:
-                schedule.step()
+                # Run pipeline - special case where first and last stage are on rank 0
+                out = None
+                losses = []
+                for _ in range(2):
+                    zero_gradients(stage_modules)
+                    if self.rank == 0:
+                        out = schedule.step(x, target=target, losses=losses)
+                    else:
+                        schedule.step()
 
-        dist.barrier()
+                dist.barrier()
 
-        # Verify results (rank 0 has both first and last stages)
-        if self.rank == 0:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        check_gradients(self.config, stage_modules, ref_mod, submod_names)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
-    @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
-    )
-    @parametrize("ScheduleClass", [ScheduleWithReorderedB])
-    @skip_if_lt_x_gpu(4)
-    def test_pipeline_schedule_runtime_custom_sched(self, ScheduleClass):
-        n_stages = 2
-        stages_per_rank = 1
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages
-        )
-
-        # Run reference
-        ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
-
-        # Create pipeline stages
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, stages_per_rank, n_stages
-        )
-        print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
-
-        num_microbatches = (
-            ScheduleClass.num_microbatches
-            if hasattr(ScheduleClass, "num_microbatches")
-            else 8
-        )
-
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
-        if not isinstance(schedule, _PipelineScheduleRuntime):
-            raise AssertionError(
-                f"Expected _PipelineScheduleRuntime, got {type(schedule)}"
-            )
-
-        # Run pipeline with tensor leak checking
-        with check_leaked_tensors() as garbage_tensors:
-            for _ in range(2):
-                zero_gradients(stage_modules)
+                # Verify results (rank 0 has both first and last stages)
                 if self.rank == 0:
-                    schedule.step(x)
-                elif self.rank == self.world_size - 1:
-                    losses = []
-                    out = schedule.step(target=target, losses=losses)
-                else:
-                    schedule.step()
+                    torch.testing.assert_close(out, ref_out)
+                    pipe_loss = sum(losses)
+                    torch.testing.assert_close(pipe_loss, ref_loss)
 
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
-        dist.barrier()
+                # Check gradients using helper method
+                check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-        # Verify results
-        if self.rank == self.world_size - 1:
-            torch.testing.assert_close(out, ref_out)
-            pipe_loss = sum(losses)
-            torch.testing.assert_close(pipe_loss, ref_loss)
-
-        # Check gradients using helper method
-        check_gradients(self.config, stage_modules, ref_mod, submod_names)
-
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize("ScheduleClass", [ScheduleWithW])
     @skip_if_lt_x_gpu(4)
-    def test_schedule_with_native_zero_bubble(self, ScheduleClass):
-        n_stages = ScheduleClass.n_stages
-        num_microbatches = ScheduleClass.num_microbatches
-        rank_stages = ScheduleClass.rank_stages
+    def test_pipeline_schedule_runtime_custom_sched(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleWithReorderedB]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                n_stages = 2
+                stages_per_rank = 1
+                mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                    self.config, n_layers=n_stages
+                )
 
-        num_steps = 4
-        mod, ref_mod, x, target, loss_fn = setup_models_and_data(
-            self.config, n_layers=n_stages
-        )
+                # Run reference
+                ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
-        # Create multi-stage pipeline with custom stage indices
-        stage_indices = rank_stages[self.rank]
-        print(f"Rank {self.rank} stages: {stage_indices}")
-        stages, stage_modules, submod_names = create_multi_stage_pipeline(
-            self.config, mod, len(stage_indices), n_stages, stage_indices
-        )
+                # Create pipeline stages
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, mod, stages_per_rank, n_stages
+                )
+                print(f"Rank {self.rank} stages: {[stage.stage_index for stage in stages]}")
 
-        schedule = ScheduleClass(
-            stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
-        )
+                num_microbatches = (
+                    ScheduleClass.num_microbatches
+                    if hasattr(ScheduleClass, "num_microbatches")
+                    else 8
+                )
 
-        # Run reference model
-        ref_x = x.detach().clone().requires_grad_(x.requires_grad)
-        torch.testing.assert_close(x, ref_x)
-        for _ in range(num_steps):
-            ref_out = ref_mod(ref_x)
-            ref_loss = loss_fn(ref_out, target)
-            ref_loss.backward()
+                schedule = ScheduleClass(
+                    stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                )
+                if not isinstance(schedule, _PipelineScheduleRuntime):
+                    raise AssertionError(
+                        f"Expected _PipelineScheduleRuntime, got {type(schedule)}"
+                    )
 
-        # Run pipeline with tensor leak checking
-        losses = []
-        with check_leaked_tensors() as garbage_tensors:
-            for _ in range(num_steps):
-                if self.rank == 0:
-                    schedule.step(x)
-                elif self.rank == self.world_size - 1:
-                    schedule.step(target=target, losses=losses)
-                else:
-                    schedule.step()
+                # Run pipeline with tensor leak checking
+                with check_leaked_tensors() as garbage_tensors:
+                    for _ in range(2):
+                        zero_gradients(stage_modules)
+                        if self.rank == 0:
+                            schedule.step(x)
+                        elif self.rank == self.world_size - 1:
+                            losses = []
+                            out = schedule.step(target=target, losses=losses)
+                        else:
+                            schedule.step()
 
-        self.assertEqual(
-            len(garbage_tensors),
-            0,
-            "Found leaked tensors, check logs above for debug info",
-        )
+                self.assertEqual(
+                    len(garbage_tensors),
+                    0,
+                    "Found leaked tensors, check logs above for debug info",
+                )
+                dist.barrier()
 
-        # Check gradients using helper method
-        check_gradients(self.config, stage_modules, ref_mod, submod_names)
+                # Verify results
+                if self.rank == self.world_size - 1:
+                    torch.testing.assert_close(out, ref_out)
+                    pipe_loss = sum(losses)
+                    torch.testing.assert_close(pipe_loss, ref_loss)
 
+                # Check gradients using helper method
+                check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-instantiate_parametrized_tests(CustomSchedulesTest)
+    @requires_capabilities(Capability.distributed.backend)
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_schedule_with_native_zero_bubble(self, device):
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleWithW]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                n_stages = ScheduleClass.n_stages
+                num_microbatches = ScheduleClass.num_microbatches
+                rank_stages = ScheduleClass.rank_stages
+
+                num_steps = 4
+                mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                    self.config, n_layers=n_stages
+                )
+
+                # Create multi-stage pipeline with custom stage indices
+                stage_indices = rank_stages[self.rank]
+                print(f"Rank {self.rank} stages: {stage_indices}")
+                stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                    self.config, mod, len(stage_indices), n_stages, stage_indices
+                )
+
+                schedule = ScheduleClass(
+                    stages, num_microbatches, loss_fn=loss_fn, scale_grads=False
+                )
+
+                # Run reference model
+                ref_x = x.detach().clone().requires_grad_(x.requires_grad)
+                torch.testing.assert_close(x, ref_x)
+                for _ in range(num_steps):
+                    ref_out = ref_mod(ref_x)
+                    ref_loss = loss_fn(ref_out, target)
+                    ref_loss.backward()
+
+                # Run pipeline with tensor leak checking
+                losses = []
+                with check_leaked_tensors() as garbage_tensors:
+                    for _ in range(num_steps):
+                        if self.rank == 0:
+                            schedule.step(x)
+                        elif self.rank == self.world_size - 1:
+                            schedule.step(target=target, losses=losses)
+                        else:
+                            schedule.step()
+
+                self.assertEqual(
+                    len(garbage_tensors),
+                    0,
+                    "Found leaked tensors, check logs above for debug info",
+                )
+
+                # Check gradients using helper method
+                check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
 
 class PerDirectionScheduleTest(MultiProcContinuousTest):
@@ -1630,11 +1655,12 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
     than relying on the shared MultiProcContinuousTest path.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
     world_size = 4
 
     @classmethod
     def backend_str(cls) -> str:
-        return backend
+        return dist.get_default_backend_for_device(cls.device_type)
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -1652,7 +1678,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
         # would make init_process_group raise instead of skip.
         device_id = None
         if torch.accelerator.device_count() >= world_size:
-            device_id = torch.device(cls.device_type(), rank)
+            device_id = torch.device(cls.device_type, rank)
         dist.init_process_group(
             backend=cls.backend_str(),
             world_size=world_size,
@@ -1666,7 +1692,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+        return torch.device(self._device_type, self.rank)
 
     @property
     def config(self) -> PipelineTestConfig:
@@ -1674,14 +1700,15 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
     @skip_if_lt_x_gpu(4)
-    def test_creates_distinct_direction_groups(self):
+    def test_creates_distinct_direction_groups(self, device):
         """PipelineStage builds two distinct, non-WORLD direction groups when the
         config flag is set (no constructor arg)."""
+        self._device_type = torch.device(device).type
         with dist_config.patch(pipeline_per_direction_p2p=True):
             mod, _, x, _, _ = setup_models_and_data(self.config)
             chunks = 2 * self.world_size
@@ -1693,57 +1720,62 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             self.assertIsNot(stage._upstream_group, dist.group.WORLD)
             self.assertIsNot(stage._downstream_group, stage._upstream_group)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
     )
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @skip_if_lt_x_gpu(4)
-    def test_grad_with_manual_per_direction(self, ScheduleClass):
+    def test_grad_with_manual_per_direction(self, device):
         """Per-direction P2P only changes which communicator carries the bytes,
         not the math: gradients/outputs must still match the reference model."""
-        with dist_config.patch(pipeline_per_direction_p2p=True):
-            mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
+        self._device_type = torch.device(device).type
+        for ScheduleClass in [ScheduleGPipe, Schedule1F1B]:
+            with self.subTest(ScheduleClass=ScheduleClass):
+                with dist_config.patch(pipeline_per_direction_p2p=True):
+                    mod, ref_mod, x, target, loss_fn = setup_models_and_data(self.config)
 
-            # Run reference
-            ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+                    # Run reference
+                    ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
-            # Create manual pipeline stage; the per-direction groups are built
-            # inside PipelineStage from the config flag set above.
-            chunks = 2 * self.world_size
-            stage, stage_module, _ = create_single_stage_pipeline(
-                self.config, mod, x, chunks, use_tracer=False
-            )
-            self.assertTrue(stage.p2p_per_direction)
-            self.assertIsNot(stage._downstream_group, stage._upstream_group)
+                    # Create manual pipeline stage; the per-direction groups are built
+                    # inside PipelineStage from the config flag set above.
+                    chunks = 2 * self.world_size
+                    stage, stage_module, _ = create_single_stage_pipeline(
+                        self.config, mod, x, chunks, use_tracer=False
+                    )
+                    self.assertTrue(stage.p2p_per_direction)
+                    self.assertIsNot(stage._downstream_group, stage._upstream_group)
 
-            schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
+                    schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
-            # Run pipeline
-            out = None
-            losses = []
-            for _ in range(2):
-                zero_gradients(stage_module)
-                if self.rank == 0:
-                    schedule.step(x)
-                elif self.rank == self.world_size - 1:
-                    out = schedule.step(target=target, losses=losses)
-                else:
-                    schedule.step()
+                    # Run pipeline
+                    out = None
+                    losses = []
+                    for _ in range(2):
+                        zero_gradients(stage_module)
+                        if self.rank == 0:
+                            schedule.step(x)
+                        elif self.rank == self.world_size - 1:
+                            out = schedule.step(target=target, losses=losses)
+                        else:
+                            schedule.step()
 
-            dist.barrier(device_ids=[self.rank])
+                    dist.barrier(device_ids=[self.rank])
 
-            # Last rank checks result
-            if self.rank == self.world_size - 1:
-                torch.testing.assert_close(out, ref_out)
-                pipe_loss = sum(losses)
-                torch.testing.assert_close(pipe_loss, ref_loss)
+                    # Last rank checks result
+                    if self.rank == self.world_size - 1:
+                        torch.testing.assert_close(out, ref_out)
+                        pipe_loss = sum(losses)
+                        torch.testing.assert_close(pipe_loss, ref_loss)
 
-            # Check gradients using helper method
-            check_gradients(self.config, stage_module, ref_mod)
+                    # Check gradients using helper method
+                    check_gradients(self.config, stage_module, ref_mod)
 
 
-instantiate_parametrized_tests(PerDirectionScheduleTest)
+instantiate_device_type_tests(ScheduleTest, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(ScheduleTestCUDA, globals(), only_for="cuda")
+instantiate_device_type_tests(CustomSchedulesTest, globals(), except_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(PerDirectionScheduleTest, globals(), except_for="cpu", allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -342,7 +342,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_forward_only(self, device):
@@ -379,7 +379,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_eval_inference_mode(self, device):
@@ -456,7 +456,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_return_output(self, device):
@@ -520,7 +520,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_multi_iter(self, device):
@@ -546,7 +546,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_kwargs_with_tracer(self, device):
@@ -618,7 +618,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_tracer(self, device):
@@ -678,7 +678,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_manual(self, device):
@@ -742,7 +742,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_manual_interleaved(self, device):
@@ -829,7 +829,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_schedule_with_weight_update_mlp_e2e(self, device):
@@ -915,7 +915,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_v_shape_schedules(self, device):
@@ -963,7 +963,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_custom_function_callback(self, device):
@@ -1166,7 +1166,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_zero_bubble_with_model_kwargs(self, device):
@@ -1281,7 +1281,7 @@ class ScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_NoneGrad_conditional_input_grad(self, device):
@@ -1470,7 +1470,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_non_symmetric_stage_ids(self, device):
@@ -1522,7 +1522,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_pipeline_schedule_runtime_custom_sched(self, device):
@@ -1588,7 +1588,7 @@ class CustomSchedulesTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_schedule_with_native_zero_bubble(self, device):
@@ -1702,7 +1702,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_creates_distinct_direction_groups(self, device):
@@ -1722,7 +1722,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
     @requires_capabilities(Capability.distributed.backend)
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL/XCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, "Distributed backend test requires 2+ accelerators"
     )
     @skip_if_lt_x_gpu(4)
     def test_grad_with_manual_per_direction(self, device):


### PR DESCRIPTION
## Summary:
  I. Split one CUDA-only test class.
  II. Add hardware classification for `test_schedule_multiproc.py`.
  III. Add CUDA-only and ACCELERATOR classes instantiating.

## Changes:
  I. Add new CUDA-only test class -- `ScheduleTestCUDA`.
  II. Set `hw_classification = HardwareClassification.ACCELERATOR` on accelerator-agnostic classes.
  III. Set `hw_classification = HardwareClassification.CUDA` on CUDA-only classes.
  IV. Add `device` param to all test cases, replace `@parametrize` with for loop and `self.subTest`.
  V. Modify the way of getting the property of `backend_str`, `config` and `device`.
  VI. Replace `requires_accelerator_dist_backend` with capability gate control mechanism.

## Test Plan:
  `python test/distributed/pipelining/test_schedule_multiproc.py`

This PR depends on the capability gate control mechanism in PR #190846 , #191919 , #193080 .