### PR TITLE
[TEST] Refactor test_cuda_graph_debug.py with hw_classification

### DIFF
--- a/test/test_cuda_graph_debug.py
+++ b/test/test_cuda_graph_debug.py
@@ -7,6 +7,7 @@ import warnings
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     NoTest,
     run_tests,
     skipIfRocm,
@@ -38,6 +39,8 @@ def _capture_graph(op, **graph_kwargs):
 
 @skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugInputs(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_nothing_dead_ok(self):
         x = torch.randn(100, device="cuda")
         g, y = _capture_graph(lambda: x * 2)
@@ -253,6 +256,8 @@ class TestCUDAGraphDebugInputs(TestCase):
 
 @skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugBacktraces(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_error_message_contains_all_tracebacks(self):
         a = torch.randn(100, device="cuda")
         b = torch.randn(100, device="cuda")
@@ -278,6 +283,8 @@ class TestCUDAGraphDebugBacktraces(TestCase):
 
 @skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugExternalOps(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_custom_autograd_function(self):
         from torch.autograd import Function
 


### PR DESCRIPTION
## Summary
Apply hardware classification structure following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines.

Changes:
- Add `hw_classification = HardwareClassification.CUDA` to all three test classes

## Test Plan

```
python test/test_cuda_graph_debug.py -v
Ran 19 tests in 2.442s -- OK

python test/test_cuda_graph_debug.py -v --hw-classification CUDA
Ran 19 tests in 2.624s -- OK
```