### PR TITLE
[meta][easy] fix multiple ops `out=` dtype promotion

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -137,20 +137,15 @@ aten = torch.ops.aten
 
 meta_consistency_out_dtype_mismatch_xfails = {
     xfail("bucketize"),
-    xfail("conj_physical"),
     xfail("cross"),
     xfail("cummax"),
     xfail("cummin"),
     xfail("diag"),
     xfail("fft.ihfft2"),
     xfail("fft.ihfftn"),
-    xfail("frexp"),
     xfail("geqrf"),
     xfail("heaviside"),
     xfail("histc"),
-    xfail("index_add"),
-    xfail("index_copy"),
-    xfail("index_select"),
     xfail("isin"),
     xfail("kthvalue"),
     xfail("lerp"),
@@ -176,7 +171,6 @@ meta_consistency_out_dtype_mismatch_xfails = {
     xfail("mode"),
     xfail("msort"),
     xfail("multinomial"),
-    xfail("nan_to_num"),
     xfail("native_batch_norm"),
     xfail("neg"),
     xfail("nn.functional.avg_pool3d"),
@@ -200,8 +194,6 @@ meta_consistency_out_dtype_mismatch_xfails = {
     xfail("sort"),
     xfail("sparse.sampled_addmm"),
     xfail("take"),
-    xfail("tril"),
-    xfail("triu"),
     xfail("unfold_copy"),
     # Output has dynamic shape.
     # Does not have a meta kernel implementation.

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -141,8 +141,6 @@ meta_consistency_out_dtype_mismatch_xfails = {
     xfail("cummax"),
     xfail("cummin"),
     xfail("diag"),
-    xfail("fft.ihfft2"),
-    xfail("fft.ihfftn"),
     xfail("geqrf"),
     xfail("heaviside"),
     xfail("histc"),

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3363,7 +3363,7 @@ def index_add_(
 
 
 @register_decomposition(aten.index_add)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def index_add(
     x: TensorLike,
     dim: int,
@@ -3468,7 +3468,7 @@ def index_copy_(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
 
 
 @register_decomposition(aten.index_copy)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def index_copy(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
     return _index_copy(x, dim, index, tensor, inplace=False)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8206,7 +8206,7 @@ def _amp_foreach_non_finite_check_and_unscale_(self, found_inf, inv_scale):
 
 # From aten/src/ATen/native/UnaryOps.cpp
 @register_meta([aten.nan_to_num.default, aten.nan_to_num.out])
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def nan_to_num(self, nan=None, posinf=None, neginf=None):
     return torch.empty_like(self)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -694,7 +694,7 @@ def is_complex(input: TensorLikeType):
 
 
 @register_decomposition(aten.conj_physical)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def conj_physical(input: TensorLikeType):
     if not utils.is_complex_dtype(input.dtype):
         return input
@@ -943,7 +943,7 @@ def logsumexp(
 
 
 @register_decomposition(aten.nan_to_num)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def nan_to_num(
     a: TensorLikeType,
     nan: NumberType | None = 0.0,
@@ -1539,7 +1539,7 @@ def fmod(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
 
 
 @register_decomposition(aten.frexp)
-@out_wrapper("mantissa", "exponent")
+@out_wrapper("mantissa", "exponent", exact_dtype=True)
 def frexp(self: TensorLikeType) -> tuple[TensorLikeType, TensorLikeType]:
     return torch.return_types.frexp(prims.frexp(self))
 
@@ -4467,7 +4467,7 @@ def unbind(t: TensorLikeType, dim: int = 0) -> TensorSequenceType:
         )
 
 
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def index_copy(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
     return x.clone(memory_format=torch.contiguous_format).index_copy_(
         dim, index, tensor
@@ -4552,7 +4552,7 @@ def _index_fill(
         return out
 
 
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def index_add(
     x: TensorLike,
     dim: int,
@@ -4571,7 +4571,7 @@ def index_add(
 
 
 @register_decomposition(aten.index_select)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def index_select(x: TensorLike, dim: int, index: TensorLike):
     dim = utils.canonicalize_dims(x.ndim, dim)
     torch._check(
@@ -6379,7 +6379,7 @@ rpow = _make_r_binary_op(pow)
 
 
 @register_decomposition(aten.triu)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def triu(a: TensorLikeType, diagonal: int = 0) -> TensorLikeType:
     torch._check(
         a.ndim >= 2, lambda: "triu: input tensor must have at least 2 dimensions"
@@ -6396,7 +6396,7 @@ def triu(a: TensorLikeType, diagonal: int = 0) -> TensorLikeType:
 
 
 @register_decomposition(aten.tril)
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def tril(a: TensorLikeType, diagonal: int = 0) -> TensorLikeType:
     torch._check(
         a.ndim >= 2, lambda: "tril: input tensor must have at least 2 dimensions"


### PR DESCRIPTION
Follows: #138399

Fixes the following operators:
- conj_physical
- frexp
- index_add
- index_copy
- index_select
- nan_to_num
- tril
- triu