### PR TITLE
[Testcase Refactoring] Decouple test_coordinate_descent_tuner.py from CUDA-specific

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -13,8 +13,9 @@ from torch._inductor.runtime.hints import (
     TRITON_MAX_TENSOR_NUMEL,
 )
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 try:
@@ -54,6 +55,8 @@ def mock_compare_config_prefer_larger_XBLOCK(
 
 
 class TestCoordinateDescentTuner(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_abs_function(self):
         """
         The benchmark result is simply abs(XBLOCK - 15)
@@ -89,23 +92,6 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertEqual(set(neighbours), {1, 3, 4})
         neighbours = tuner.get_neighbour_values("num_warps", 2, radius=2)
         self.assertEqual(set(neighbours), {1, 4, 8})
-
-    def test_persistent_reduction(self):
-        def f(x):
-            return x / x.sum(dim=-1, keepdim=True)
-
-        with mock.patch.object(
-            CoordescTuner, "compare_config", mock_compare_config_prefer_larger_XBLOCK
-        ):
-            x = torch.ones(2, 256).to(GPU_TYPE)
-            expected = f(x)
-            # the first call get correct result when cache miss. Don't know why yet
-            _ = torch.compile(f)(x)
-            actual = torch.compile(f)(x)
-            self.assertTrue(
-                torch.allclose(expected, actual, atol=1e-4, rtol=1e-4),
-                lambda msg: f"{msg}\nExpected:\n{expected}\nActual:\n{actual}",
-            )
 
     def test_value_too_large(self):
         # Simulate a reduction
@@ -393,6 +379,31 @@ class TestCoordinateDescentTuner(TestCase):
         )
 
 
+class TestCoordinateDescentTunerAccel(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_persistent_reduction(self, device):
+        def f(x):
+            return x / x.sum(dim=-1, keepdim=True)
+
+        with mock.patch.object(
+            CoordescTuner, "compare_config", mock_compare_config_prefer_larger_XBLOCK
+        ):
+            x = torch.ones(2, 256).to(device)
+            expected = f(x)
+            # the first call get correct result when cache miss. Don't know why yet
+            _ = torch.compile(f)(x)
+            actual = torch.compile(f)(x)
+            self.assertTrue(
+                torch.allclose(expected, actual, atol=1e-4, rtol=1e-4),
+                lambda msg: f"{msg}\nExpected:\n{expected}\nActual:\n{actual}",
+            )
+
+
+instantiate_device_type_tests(
+    TestCoordinateDescentTunerAccel, globals(), allow_xpu=True, except_for="cpu"
+)
+
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU:
+    if IS_LINUX and HAS_TRITON:
         run_tests()


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Split tests class into generic class and corresponding devices class.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR` to tests class.

## Motivation
`torch.cuda` only recognizes CUDA. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_coordinate_descent_tuner.py --hw-classification GENERIC ACCELERATOR`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo