### PR TITLE
[dynamo] Preserve is_inference in after-AOT repros

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -5,6 +5,7 @@ import io
 import os
 import pickle
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -29,7 +30,12 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import HardwareClassification, IS_FBCODE
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    IS_FBCODE,
+    parametrize,
+)
 from torch.utils._traceback import report_compile_source_on_error
 from torch.utils._triton import has_triton
 
@@ -47,6 +53,7 @@ def _make_test_graph():
     return make_fx(f)(*args), args
 
 
+@instantiate_parametrized_tests
 class TestAfterAot(torch._dynamo.test_case.TestCase):
     @patch("torch.cuda.is_available", lambda: False)
     def test_save_args_dynamic_shapes(self):
@@ -175,186 +182,225 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
 
         self.assertIsNone(seen_repro_after)
 
-    def test_save_graph_repro_preserves_is_inference(self):
+    @parametrize("is_inference", (False, True))
+    def test_save_graph_repro_preserves_is_inference(self, is_inference):
         gm, args = _make_test_graph()
-        for is_inference in (False, True):
-            with self.subTest(is_inference=is_inference):
-                buf = io.StringIO()
-                save_graph_repro(
-                    buf,
-                    gm,
-                    args,
-                    "inductor",
-                    save_dir=None,
-                    is_inference=is_inference,
+        buf = io.StringIO()
+        save_graph_repro(
+            buf,
+            gm,
+            args,
+            "inductor",
+            save_dir=None,
+            is_inference=is_inference,
+        )
+        self.assertIn(
+            f"is_inference={is_inference!r}",
+            buf.getvalue(),
+        )
+
+    @parametrize("is_inference", (False, True))
+    @parametrize("deferred", (False, True))
+    def test_wrap_compiler_debug_preserves_is_inference_for_failures(
+        self, is_inference, deferred
+    ):
+        gm, args = _make_test_graph()
+
+        def fake_compiler(gm, example_inputs, **kwargs):
+            if not deferred:
+                raise RuntimeError("compiler failure")
+
+            def compiled(real_args):
+                raise RuntimeError("deferred failure")
+
+            return compiled
+
+        with (
+            torch._dynamo.config.patch(repro_after="aot", repro_level=1),
+            patch.object(after_aot, "dump_compiler_graph_state") as dump,
+            self.assertRaisesRegex(RuntimeError, "failure"),
+        ):
+            compiled = after_aot.wrap_compiler_debug(fake_compiler, "inductor")(
+                gm, args, is_inference=is_inference
+            )
+            compiled(args)
+
+        dump.assert_called_once()
+        self.assertIs(
+            dump.call_args.kwargs["is_inference"],
+            is_inference,
+        )
+
+    @unittest.skipIf(IS_FBCODE, "Subprocess spawning doesn't work in fbcode")
+    def test_after_aot_inference_repro_e2e(self):
+        gm, args = _make_test_graph()
+
+        def failing_compiler(gm, example_inputs, **kwargs):
+            raise RuntimeError("intentional compiler failure")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoints = os.path.join(tmpdir, "checkpoints")
+            with (
+                torch._dynamo.config.patch(repro_after="aot", repro_level=1),
+                patch.object(after_aot, "minifier_dir", return_value=tmpdir),
+                patch.object(after_aot.os, "getcwd", return_value=tmpdir),
+                self.assertRaisesRegex(RuntimeError, "intentional compiler failure"),
+            ):
+                after_aot.wrap_compiler_debug(failing_compiler, "inductor")(
+                    gm, args, is_inference=True
                 )
-                self.assertIn(
-                    f"is_inference={is_inference!r}",
-                    buf.getvalue(),
-                )
 
-    def test_wrap_compiler_debug_preserves_is_inference_for_failures(self):
+            repro_path = os.path.join(checkpoints, f"{len(gm.graph.nodes)}.py")
+            with open(repro_path) as fd:
+                self.assertIn("is_inference=True", fd.read())
+
+            res = subprocess.run(
+                [sys.executable, repro_path],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            self.assertEqual(
+                res.returncode,
+                0,
+                lambda msg: f"{msg}\nRepro failed:\nSTDERR:\n{res.stderr[-1000:]}",
+            )
+
+    @parametrize(
+        "passed_is_inference,cli_flag,expected",
+        (
+            (None, None, False),
+            (False, None, False),
+            (True, None, True),
+            (False, "--is-inference", True),
+            (True, "--no-is-inference", False),
+        ),
+    )
+    def test_run_repro_preserves_is_inference_in_options(
+        self, passed_is_inference, cli_flag, expected
+    ):
+        seen = []
+
+        def fake_repro_run(options, mod, load_args):
+            seen.append(options.is_inference)
+
+        kwargs = {}
+        if passed_is_inference is not None:
+            kwargs["is_inference"] = passed_is_inference
+        argv = ["repro.py"]
+        if cli_flag is not None:
+            argv.extend(["run", cli_flag])
+
+        with (
+            patch.object(after_aot, "repro_run", fake_repro_run),
+            patch.object(sys, "argv", argv),
+        ):
+            after_aot.run_repro(
+                torch.nn.Identity(),
+                lambda reader: None,
+                **kwargs,
+            )
+
+        self.assertEqual(seen, [expected])
+
+    @parametrize("is_inference", (False, True))
+    def test_repro_run_preserves_is_inference(self, is_inference):
         gm, args = _make_test_graph()
 
-        for is_inference in (False, True):
-            for deferred in (False, True):
-                with self.subTest(is_inference=is_inference, deferred=deferred):
+        seen = []
 
-                    def fake_compiler(gm, example_inputs, **kwargs):
-                        if not deferred:
-                            raise RuntimeError("compiler failure")
+        def fake_compile_fx_inner(gm, compile_args, **kwargs):
+            seen.append(kwargs["is_inference"])
 
-                        def compiled(real_args):
-                            raise RuntimeError("deferred failure")
+            def compiled(real_args):
+                return gm(*real_args)
 
-                        return compiled
+            return compiled
 
-                    with (
-                        torch._dynamo.config.patch(repro_after="aot", repro_level=1),
-                        patch.object(after_aot, "dump_compiler_graph_state") as dump,
-                        self.assertRaisesRegex(RuntimeError, "failure"),
-                    ):
-                        compiled = after_aot.wrap_compiler_debug(
-                            fake_compiler, "inductor"
-                        )(gm, args, is_inference=is_inference)
-                        compiled(args)
+        options = SimpleNamespace(
+            accuracy="",
+            is_inference=is_inference,
+            save_dir=None,
+            tracing_mode="real",
+        )
+        with (
+            patch.object(after_aot, "repro_common", return_value=(gm, args)),
+            patch(
+                "torch._inductor.compile_fx.compile_fx_inner",
+                fake_compile_fx_inner,
+            ),
+        ):
+            repro_run(options, torch.nn.Identity(), lambda reader: None)
 
-                    dump.assert_called_once()
-                    self.assertIs(
-                        dump.call_args.kwargs["is_inference"],
-                        is_inference,
-                    )
+        self.assertEqual(seen, [is_inference])
 
-    def test_run_repro_preserves_is_inference_in_options(self):
-        cases = ((None, False), (False, False), (True, True))
-        for passed_is_inference, expected in cases:
-            with self.subTest(is_inference=passed_is_inference):
-                seen = []
-
-                def fake_repro_run(options, mod, load_args):
-                    seen.append(options.is_inference)
-
-                kwargs = {}
-                if passed_is_inference is not None:
-                    kwargs["is_inference"] = passed_is_inference
-
-                with (
-                    patch.object(after_aot, "repro_run", fake_repro_run),
-                    patch.object(sys, "argv", ["repro.py"]),
-                ):
-                    after_aot.run_repro(
-                        torch.nn.Identity(),
-                        lambda reader: None,
-                        **kwargs,
-                    )
-
-                self.assertEqual(seen, [expected])
-
-    def test_repro_run_preserves_is_inference(self):
+    @parametrize("is_inference", (False, True))
+    @parametrize("isolate", (False, True))
+    def test_repro_minify_preserves_is_inference(self, is_inference, isolate):
         gm, args = _make_test_graph()
 
-        for is_inference in (False, True):
-            with self.subTest(is_inference=is_inference):
-                seen = []
+        seen = []
 
-                def fake_compile_fx_inner(gm, compile_args, **kwargs):
-                    seen.append(kwargs["is_inference"])
+        def fake_fails(gm, args, **kwargs):
+            seen.append(kwargs["is_inference"])
+            return False
 
-                    def compiled(real_args):
-                        return gm(*real_args)
+        def fake_minifier(mod, args, *, module_fails, dump_state, **kwargs):
+            module_fails(mod, args)
+            self.assertIs(
+                dump_state.keywords["is_inference"],
+                is_inference,
+            )
 
-                    return compiled
+        options = SimpleNamespace(
+            accuracy="",
+            check_str=None,
+            is_inference=is_inference,
+            isolate=isolate,
+            save_dir=None,
+            tracing_mode="real",
+            offload_to_disk=False,
+            skip_saving_eager_intermediates=False,
+            skip_sanity=False,
+            max_granularity=None,
+        )
 
-                options = SimpleNamespace(
-                    accuracy="",
-                    is_inference=is_inference,
-                    save_dir=None,
-                    tracing_mode="real",
-                )
-                with (
-                    patch.object(after_aot, "repro_common", return_value=(gm, args)),
-                    patch(
-                        "torch._inductor.compile_fx.compile_fx_inner",
-                        fake_compile_fx_inner,
-                    ),
-                ):
-                    repro_run(options, torch.nn.Identity(), lambda reader: None)
+        with (
+            patch.object(after_aot, "repro_common", return_value=(gm, args)),
+            patch.object(after_aot, "isolate_fails", fake_fails),
+            patch.dict(after_aot.ACCURACY_FAILS, {"": fake_fails}),
+            patch("functorch.compile.minifier", fake_minifier),
+        ):
+            repro_minify(options, torch.nn.Identity(), lambda reader: None)
 
-                self.assertEqual(seen, [is_inference])
+        self.assertEqual(seen, [is_inference])
 
-    def test_repro_minify_preserves_is_inference(self):
+    @parametrize("is_inference", (False, True))
+    def test_repro_analyze_preserves_is_inference(self, is_inference):
         gm, args = _make_test_graph()
 
-        for is_inference in (False, True):
-            for isolate in (False, True):
-                with self.subTest(is_inference=is_inference, isolate=isolate):
-                    seen = []
+        seen = []
 
-                    def fake_fails(gm, args, **kwargs):
-                        seen.append(kwargs["is_inference"])
-                        return False
+        def fake_compile_fx_inner(gm, compile_args, **kwargs):
+            seen.append(kwargs["is_inference"])
+            raise RuntimeError("stop after compile")
 
-                    def fake_minifier(mod, args, *, module_fails, dump_state, **kwargs):
-                        module_fails(mod, args)
-                        self.assertIs(
-                            dump_state.keywords["is_inference"],
-                            is_inference,
-                        )
+        options = SimpleNamespace(
+            is_inference=is_inference,
+            save_dir=None,
+            tracing_mode="real",
+        )
+        with (
+            patch.object(after_aot, "repro_common", return_value=(gm, args)),
+            patch(
+                "torch._inductor.compile_fx.compile_fx_inner",
+                fake_compile_fx_inner,
+            ),
+            self.assertRaisesRegex(RuntimeError, "stop after compile"),
+        ):
+            after_aot.repro_analyze(options, torch.nn.Identity(), lambda reader: None)
 
-                    options = SimpleNamespace(
-                        accuracy="",
-                        check_str=None,
-                        is_inference=is_inference,
-                        isolate=isolate,
-                        save_dir=None,
-                        tracing_mode="real",
-                        offload_to_disk=False,
-                        skip_saving_eager_intermediates=False,
-                        skip_sanity=False,
-                        max_granularity=None,
-                    )
-
-                    with (
-                        patch.object(
-                            after_aot, "repro_common", return_value=(gm, args)
-                        ),
-                        patch.object(after_aot, "isolate_fails", fake_fails),
-                        patch.dict(after_aot.ACCURACY_FAILS, {"": fake_fails}),
-                        patch("functorch.compile.minifier", fake_minifier),
-                    ):
-                        repro_minify(options, torch.nn.Identity(), lambda reader: None)
-
-                    self.assertEqual(seen, [is_inference])
-
-    def test_repro_analyze_preserves_is_inference(self):
-        gm, args = _make_test_graph()
-
-        for is_inference in (False, True):
-            with self.subTest(is_inference=is_inference):
-                seen = []
-
-                def fake_compile_fx_inner(gm, compile_args, **kwargs):
-                    seen.append(kwargs["is_inference"])
-                    raise RuntimeError("stop after compile")
-
-                options = SimpleNamespace(
-                    is_inference=is_inference,
-                    save_dir=None,
-                    tracing_mode="real",
-                )
-                with (
-                    patch.object(after_aot, "repro_common", return_value=(gm, args)),
-                    patch(
-                        "torch._inductor.compile_fx.compile_fx_inner",
-                        fake_compile_fx_inner,
-                    ),
-                    self.assertRaisesRegex(RuntimeError, "stop after compile"),
-                ):
-                    after_aot.repro_analyze(
-                        options, torch.nn.Identity(), lambda reader: None
-                    )
-
-                self.assertEqual(seen, [is_inference])
+        self.assertEqual(seen, [is_inference])
 
     @unittest.skipIf(IS_FBCODE, "NotImplementedError")
     def test_save_graph_repro(self):
@@ -736,9 +782,6 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
     def test_symint_expr_e2e_repro(self):
         """End-to-end: generate a repro from a symbolically-traced graph
         with SymInt args, verify expr= appears, and run the repro."""
-        import subprocess
-        import tempfile
-
         from torch._dynamo.source import ConstantSource
         from torch.fx.experimental.sym_node import SymNode
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
@@ -763,11 +806,13 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
             "inductor",
             save_dir=None,
             tracing_mode="symbolic",
+            is_inference=True,
         )
         repro_src = buf.getvalue()
 
         # Verify expr= is serialized for the SymInt arg
         self.assertIn("expr=", repro_src)
+        self.assertIn("is_inference=True", repro_src)
 
         # Run the generated repro in a subprocess
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch._dynamo.test_case
+from torch._dynamo.repro import after_aot
 from torch._dynamo.repro.after_aot import (
     _extract_distributed_info,
     _get_compile_args,
@@ -35,6 +36,15 @@ from torch.utils._triton import has_triton
 
 def strip_trailing_whitespace(r):
     return "\n".join([l.rstrip() for l in r.split("\n")])
+
+
+def _make_test_graph():
+    args = [torch.randn(4)]
+
+    def f(x):
+        return (x.sin(),)
+
+    return make_fx(f)(*args), args
 
 
 class TestAfterAot(torch._dynamo.test_case.TestCase):
@@ -143,6 +153,7 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
         options = SimpleNamespace(
             accuracy="accuracy",
             check_str=None,
+            is_inference=False,
             isolate=False,
             save_dir=None,
             tracing_mode="real",
@@ -163,6 +174,187 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
             repro_minify(options, torch.nn.Identity(), lambda reader: None)
 
         self.assertIsNone(seen_repro_after)
+
+    def test_save_graph_repro_preserves_is_inference(self):
+        gm, args = _make_test_graph()
+        for is_inference in (False, True):
+            with self.subTest(is_inference=is_inference):
+                buf = io.StringIO()
+                save_graph_repro(
+                    buf,
+                    gm,
+                    args,
+                    "inductor",
+                    save_dir=None,
+                    is_inference=is_inference,
+                )
+                self.assertIn(
+                    f"is_inference={is_inference!r}",
+                    buf.getvalue(),
+                )
+
+    def test_wrap_compiler_debug_preserves_is_inference_for_failures(self):
+        gm, args = _make_test_graph()
+
+        for is_inference in (False, True):
+            for deferred in (False, True):
+                with self.subTest(is_inference=is_inference, deferred=deferred):
+
+                    def fake_compiler(gm, example_inputs, **kwargs):
+                        if not deferred:
+                            raise RuntimeError("compiler failure")
+
+                        def compiled(real_args):
+                            raise RuntimeError("deferred failure")
+
+                        return compiled
+
+                    with (
+                        torch._dynamo.config.patch(repro_after="aot", repro_level=1),
+                        patch.object(after_aot, "dump_compiler_graph_state") as dump,
+                        self.assertRaisesRegex(RuntimeError, "failure"),
+                    ):
+                        compiled = after_aot.wrap_compiler_debug(
+                            fake_compiler, "inductor"
+                        )(gm, args, is_inference=is_inference)
+                        compiled(args)
+
+                    dump.assert_called_once()
+                    self.assertIs(
+                        dump.call_args.kwargs["is_inference"],
+                        is_inference,
+                    )
+
+    def test_run_repro_preserves_is_inference_in_options(self):
+        cases = ((None, False), (False, False), (True, True))
+        for passed_is_inference, expected in cases:
+            with self.subTest(is_inference=passed_is_inference):
+                seen = []
+
+                def fake_repro_run(options, mod, load_args):
+                    seen.append(options.is_inference)
+
+                kwargs = {}
+                if passed_is_inference is not None:
+                    kwargs["is_inference"] = passed_is_inference
+
+                with (
+                    patch.object(after_aot, "repro_run", fake_repro_run),
+                    patch.object(sys, "argv", ["repro.py"]),
+                ):
+                    after_aot.run_repro(
+                        torch.nn.Identity(),
+                        lambda reader: None,
+                        **kwargs,
+                    )
+
+                self.assertEqual(seen, [expected])
+
+    def test_repro_run_preserves_is_inference(self):
+        gm, args = _make_test_graph()
+
+        for is_inference in (False, True):
+            with self.subTest(is_inference=is_inference):
+                seen = []
+
+                def fake_compile_fx_inner(gm, compile_args, **kwargs):
+                    seen.append(kwargs["is_inference"])
+
+                    def compiled(real_args):
+                        return gm(*real_args)
+
+                    return compiled
+
+                options = SimpleNamespace(
+                    accuracy="",
+                    is_inference=is_inference,
+                    save_dir=None,
+                    tracing_mode="real",
+                )
+                with (
+                    patch.object(after_aot, "repro_common", return_value=(gm, args)),
+                    patch(
+                        "torch._inductor.compile_fx.compile_fx_inner",
+                        fake_compile_fx_inner,
+                    ),
+                ):
+                    repro_run(options, torch.nn.Identity(), lambda reader: None)
+
+                self.assertEqual(seen, [is_inference])
+
+    def test_repro_minify_preserves_is_inference(self):
+        gm, args = _make_test_graph()
+
+        for is_inference in (False, True):
+            for isolate in (False, True):
+                with self.subTest(is_inference=is_inference, isolate=isolate):
+                    seen = []
+
+                    def fake_fails(gm, args, **kwargs):
+                        seen.append(kwargs["is_inference"])
+                        return False
+
+                    def fake_minifier(mod, args, *, module_fails, dump_state, **kwargs):
+                        module_fails(mod, args)
+                        self.assertIs(
+                            dump_state.keywords["is_inference"],
+                            is_inference,
+                        )
+
+                    options = SimpleNamespace(
+                        accuracy="",
+                        check_str=None,
+                        is_inference=is_inference,
+                        isolate=isolate,
+                        save_dir=None,
+                        tracing_mode="real",
+                        offload_to_disk=False,
+                        skip_saving_eager_intermediates=False,
+                        skip_sanity=False,
+                        max_granularity=None,
+                    )
+
+                    with (
+                        patch.object(
+                            after_aot, "repro_common", return_value=(gm, args)
+                        ),
+                        patch.object(after_aot, "isolate_fails", fake_fails),
+                        patch.dict(after_aot.ACCURACY_FAILS, {"": fake_fails}),
+                        patch("functorch.compile.minifier", fake_minifier),
+                    ):
+                        repro_minify(options, torch.nn.Identity(), lambda reader: None)
+
+                    self.assertEqual(seen, [is_inference])
+
+    def test_repro_analyze_preserves_is_inference(self):
+        gm, args = _make_test_graph()
+
+        for is_inference in (False, True):
+            with self.subTest(is_inference=is_inference):
+                seen = []
+
+                def fake_compile_fx_inner(gm, compile_args, **kwargs):
+                    seen.append(kwargs["is_inference"])
+                    raise RuntimeError("stop after compile")
+
+                options = SimpleNamespace(
+                    is_inference=is_inference,
+                    save_dir=None,
+                    tracing_mode="real",
+                )
+                with (
+                    patch.object(after_aot, "repro_common", return_value=(gm, args)),
+                    patch(
+                        "torch._inductor.compile_fx.compile_fx_inner",
+                        fake_compile_fx_inner,
+                    ),
+                    self.assertRaisesRegex(RuntimeError, "stop after compile"),
+                ):
+                    after_aot.repro_analyze(
+                        options, torch.nn.Identity(), lambda reader: None
+                    )
+
+                self.assertEqual(seen, [is_inference])
 
     @unittest.skipIf(IS_FBCODE, "NotImplementedError")
     def test_save_graph_repro(self):
@@ -351,7 +543,10 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
 
         load_args._version = 0
         options = SimpleNamespace(
-            accuracy="accuracy", save_dir=None, tracing_mode="real"
+            accuracy="accuracy",
+            is_inference=False,
+            save_dir=None,
+            tracing_mode="real",
         )
         repro_run(options, Repro(), load_args)
 
@@ -759,7 +954,9 @@ class TestWrapCompilerDebugSync(torch._dynamo.test_case.TestCase):
                     "torch.accelerator.synchronize",
                     side_effect=lambda: called.append(1),
                 ):
-                    repro_run(argparse.Namespace(accuracy=""), None, None)
+                    repro_run(
+                        argparse.Namespace(accuracy="", is_inference=False), None, None
+                    )
 
         self.assertGreater(len(called), 0)
 

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -11,7 +11,9 @@ import torch
 import torch._logging.structured
 import torch.distributed as dist
 from torch._inductor.codecache import WritableTempFile
+from torch._inductor.compile_fx import compile_fx_inner
 from torch._inductor.test_case import TestCase
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE
 from torch.utils._triton import has_triton
 
@@ -175,11 +177,15 @@ class FxGraphRunnableTest(TestCase):
         trace_log.removeHandler(self.handler)
         trace_log.setLevel(self.old_level)
 
-    def _exec_and_verify_payload(self):
-        # Write captured payload & run it in a fresh Python process
+    def _get_payload(self):
         payload = self.buffer.getvalue().strip()
         self.assertTrue(payload, "Expected fx_graph_runnable payload but got nothing")
         self.assertIn("def forward", payload)  # sanity-check for actual FX code
+        return payload
+
+    def _exec_and_verify_payload(self):
+        # Write captured payload & run it in a fresh Python process
+        payload = self._get_payload()
 
         with WritableTempFile("w", suffix=".py") as tmp:
             tmp.write(payload)
@@ -200,6 +206,19 @@ class FxGraphRunnableTest(TestCase):
             return x + 1
 
         torch.compile(f)(torch.randn(4))  # noqa: UNSPECIFIED_BACKEND
+        self._exec_and_verify_payload()
+
+    def test_inference_graph_preserves_is_inference(self):
+        args = [torch.randn(4)]
+
+        def f(x):
+            return (x + 1,)
+
+        gm = make_fx(f)(*args)
+        compiled = compile_fx_inner(gm, args, is_inference=True)
+        compiled(args)
+
+        self.assertIn("is_inference=True", self._get_payload())
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")

--- a/test/inductor/test_debug_graph_dump.py
+++ b/test/inductor/test_debug_graph_dump.py
@@ -27,14 +27,24 @@ class _FakeDebugHandler:
     def filename(self, name: str) -> str:
         return os.path.join(self.root, name)
 
-    def fopen(self, name: str) -> None:
-        raise AssertionError(f"unexpected fopen({name})")
+    def fopen(self, name: str):
+        return open(self.filename(name), "w")
 
     def fopen_context(self) -> None:
         raise AssertionError("unexpected fopen_context()")
 
 
 class TestDebugGraphDump(TestCase):
+    def test_fx_graph_preserves_is_inference(self) -> None:
+        gm = _make_graph_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            formatter = DebugFormatter(_FakeDebugHandler(tmpdir))
+            formatter.fx_graph(gm, [torch.randn(4)], is_inference=True)
+
+            with open(os.path.join(tmpdir, "fx_graph_runnable.py")) as fd:
+                self.assertIn("is_inference=True", fd.read())
+
     def test_legacy_svg_flags_default_to_svg_with_global_dot_format(self) -> None:
         with mock.patch.dict(
             os.environ,

--- a/torch/_dynamo/repro/__init__.py
+++ b/torch/_dynamo/repro/__init__.py
@@ -63,6 +63,7 @@ class ReproOptions(Protocol):
     # after_aot-only attributes.
     tracing_mode: str | None
     check_str: str | None
+    is_inference: bool
     isolate: bool
     offload_to_disk: bool
     skip_saving_eager_intermediates: bool

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1637,10 +1637,10 @@ default settings on this script:
   {tracing_mode=}
   {save_dir=}
   {check_str=}
+  {is_inference=}
 """,
         formatter_class=argparse.RawTextHelpFormatter,
     )
-    parser.set_defaults(is_inference=is_inference)
 
     def common_flags(parser: argparse.ArgumentParser) -> None:
         accuracy_group = parser.add_mutually_exclusive_group()
@@ -1713,6 +1713,20 @@ divergences--you just might not end up with a useful repro in the end.""",
             default=tracing_mode,
             help="how to trace the repro module into a GraphModule with metadata",
         )
+        inference_group = parser.add_mutually_exclusive_group()
+        inference_group.add_argument(
+            "--is-inference",
+            dest="is_inference",
+            action="store_true",
+            help="compile the repro as an inference graph",
+        )
+        inference_group.add_argument(
+            "--no-is-inference",
+            dest="is_inference",
+            action="store_false",
+            help="compile the repro as a training graph",
+        )
+        parser.set_defaults(is_inference=is_inference)
 
     subparsers = parser.add_subparsers(
         dest="command", metavar="{run,minify,analyze}", required=True

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -135,7 +135,7 @@ def _find_repeat_interleave_constraints(
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
     from torch._inductor.compile_fx import _CompileFxCallable, _CompileFxKwargs
     from torch._inductor.output_code import OutputCode
@@ -305,6 +305,7 @@ def wrap_compiler_debug(
     ) -> OutputCode:
         from torch._subclasses import FakeTensorMode
 
+        is_inference = kwargs.get("is_inference", False)
         compiler_fn = functools.partial(
             unconfigured_compiler_fn,
             compile_region_name=compile_region_name,
@@ -335,12 +336,14 @@ def wrap_compiler_debug(
                         fx.GraphModule(gm, orig_graph),
                         example_inputs,
                         compiler_name,
+                        is_inference=is_inference,
                     )
                 elif config.repro_level == 2:
                     dump_to_minify(
                         fx.GraphModule(gm, orig_graph),
                         example_inputs,
                         compiler_name,
+                        is_inference=is_inference,
                     )
                 log.error("CompilerError")
             raise
@@ -381,7 +384,10 @@ def wrap_compiler_debug(
             if config.repro_level == 3:
                 # Always dump the original module in case we have segfaults
                 dump_to_minify(
-                    fx.GraphModule(gm, orig_graph), real_inputs, compiler_name
+                    fx.GraphModule(gm, orig_graph),
+                    real_inputs,
+                    compiler_name,
+                    is_inference=is_inference,
                 )
 
             if config.repro_level == 4:
@@ -405,11 +411,13 @@ def wrap_compiler_debug(
                         fx.GraphModule(gm, orig_graph),
                         real_inputs,
                         f"{compiler_name}_accuracy",
+                        is_inference=is_inference,
                     )
                     dump_to_minify(
                         fx.GraphModule(gm, orig_graph),
                         real_inputs,
                         f"{compiler_name}_accuracy",
+                        is_inference=is_inference,
                     )
                     raise AccuracyError("Bad accuracy detected")
                 else:
@@ -435,12 +443,14 @@ def wrap_compiler_debug(
                             fx.GraphModule(gm, orig_graph),
                             copy_tensor_attrs,
                             compiler_name,
+                            is_inference=is_inference,
                         )
                     elif config.repro_level == 2:
                         dump_to_minify(
                             fx.GraphModule(gm, orig_graph),
                             copy_tensor_attrs,
                             compiler_name,
+                            is_inference=is_inference,
                         )
                     raise
 
@@ -858,6 +868,7 @@ def save_graph_repro(
     tracing_mode: str | None = None,
     check_str: str | None = None,
     stable_hash: bool = False,
+    is_inference: bool = False,
 ) -> None:
     if any(
         isinstance(arg, torch.fx.experimental._backward_state.BackwardState)
@@ -906,10 +917,12 @@ def save_graph_repro(
     fd.write(
         f"    with torch.no_grad():\n"
         f"        run_repro(mod, load_args, accuracy={accuracy!r}, command={command!r}, "
-        f"save_dir={save_dir!r}, tracing_mode={tracing_mode!r}, check_str={check_str!r})\n"
+        f"save_dir={save_dir!r}, tracing_mode={tracing_mode!r}, check_str={check_str!r}, "
+        f"is_inference={is_inference!r})\n"
         f"        # To run it separately, do \n"
         f"        # mod, args = run_repro(mod, load_args, accuracy={accuracy!r}, command='get_args', "
-        f"save_dir={save_dir!r}, tracing_mode={tracing_mode!r}, check_str={check_str!r})\n"
+        f"save_dir={save_dir!r}, tracing_mode={tracing_mode!r}, check_str={check_str!r}, "
+        f"is_inference={is_inference!r})\n"
         f"        # mod(*args)"
     )
 
@@ -924,6 +937,7 @@ def dump_compiler_graph_state(
     compiler_name: str,
     *,
     accuracy: str | bool | None = None,
+    is_inference: bool = False,
 ) -> None:
     subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
@@ -934,7 +948,13 @@ def dump_compiler_graph_state(
     )
     with open(file_name, "w") as fd:
         save_graph_repro(
-            fd, gm, args, compiler_name, save_dir=subdir, accuracy=accuracy
+            fd,
+            gm,
+            args,
+            compiler_name,
+            save_dir=subdir,
+            accuracy=accuracy,
+            is_inference=is_inference,
         )
     curdir = os.getcwd()
     repro_path = os.path.join(curdir, "repro.py")
@@ -953,14 +973,26 @@ def dump_compiler_graph_state(
 
 
 def dump_to_minify(
-    gm: torch.fx.GraphModule, args: Sequence[Any], compiler_name: str
+    gm: torch.fx.GraphModule,
+    args: Sequence[Any],
+    compiler_name: str,
+    *,
+    is_inference: bool = False,
 ) -> None:
     out = io.StringIO()
     # TODO: factor this out
     subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
-    save_graph_repro(out, gm, args, compiler_name, save_dir=subdir, command="minify")
+    save_graph_repro(
+        out,
+        gm,
+        args,
+        compiler_name,
+        save_dir=subdir,
+        command="minify",
+        is_inference=is_inference,
+    )
     return helper_for_dump_minify(out.getvalue())
 
 
@@ -973,6 +1005,7 @@ def isolate_fails(
     accuracy: bool | str | None = None,
     tracing_mode: str | None = None,
     check_str: str | None = None,
+    is_inference: bool = False,
 ) -> bool:
     if env is None:
         env = {}
@@ -991,6 +1024,7 @@ def isolate_fails(
             accuracy=accuracy,
             tracing_mode=tracing_mode,
             check_str=check_str,
+            is_inference=is_inference,
         )
     # with open(file_name, "r") as fd:
     #     print(fd.read())
@@ -1033,7 +1067,11 @@ def isolate_fails(
 
 
 def inductor_fails(
-    fx_g: torch.fx.GraphModule, args: Sequence[Any], check_str: str | None = None
+    fx_g: torch.fx.GraphModule,
+    args: Sequence[Any],
+    check_str: str | None = None,
+    *,
+    is_inference: bool = False,
 ) -> bool:
     has_gpu = any(
         isinstance(arg, torch.Tensor) and arg.device.type != "cpu" for arg in args
@@ -1061,7 +1099,7 @@ def inductor_fails(
 
     try:
         compile_args = _get_compile_args(fx_g, args)
-        compile_mod = compile_fx_inner(fx_g, compile_args)
+        compile_mod = compile_fx_inner(fx_g, compile_args, is_inference=is_inference)
         if isinstance(compile_mod, str):
             raise AssertionError("compile_fx_inner should not return a string")
         compile_mod(args)
@@ -1081,13 +1119,16 @@ def inductor_accuracy_fails(
     *,
     require_fp64: bool = False,
     ignore_non_fp: bool = False,
+    is_inference: bool = False,
 ) -> bool:
     from torch._inductor.compile_fx import compile_fx_inner
 
     def _compile_with_symbolic_args(
         gm: torch.fx.GraphModule, inputs: list[Any]
     ) -> torch.fx.GraphModule:
-        return compile_fx_inner(gm, _get_compile_args(gm, inputs))  # type: ignore[return-value]
+        return compile_fx_inner(  # type: ignore[return-value]
+            gm, _get_compile_args(gm, inputs), is_inference=is_inference
+        )
 
     return backend_aot_accuracy_fails(
         fx_g,
@@ -1274,7 +1315,18 @@ def _get_compile_args(mod: torch.fx.GraphModule, args: Sequence[Any]) -> Sequenc
     return [n.meta.get("val", a) for n, a in zip(placeholders, args)]
 
 
-ACCURACY_FAILS: dict[str, Callable[[torch.fx.GraphModule, Any], bool]] = {
+class _AccuracyFailsFn(typing.Protocol):
+    def __call__(
+        self,
+        fx_g: torch.fx.GraphModule,
+        args: Sequence[Any],
+        check_str: str | None = None,
+        *,
+        is_inference: bool = False,
+    ) -> bool: ...
+
+
+ACCURACY_FAILS: dict[str, _AccuracyFailsFn] = {
     "": inductor_fails,
     # This might look inverted but it's not.  strict_accuracy means "we will
     # minify any time we see anything that diverges", whereas accuracy is more
@@ -1291,7 +1343,8 @@ def repro_minifier_query(options: ReproOptions, mod: nn.Module, load_args: Any) 
     mod, args = repro_common(options, mod, load_args)
     fail_fn = functools.partial(
         ACCURACY_FAILS[options.accuracy],
-        check_str=options.check_str,  # type: ignore[call-arg]
+        check_str=options.check_str,
+        is_inference=options.is_inference,
     )
     if fail_fn(mod, args):
         sys.exit(1)
@@ -1317,9 +1370,13 @@ def repro_minify(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
             save_dir=options.save_dir,
             accuracy=options.accuracy,
             tracing_mode=options.tracing_mode,
+            is_inference=options.is_inference,
         )
     else:
-        module_fails = ACCURACY_FAILS[options.accuracy]
+        module_fails = functools.partial(
+            ACCURACY_FAILS[options.accuracy],
+            is_inference=options.is_inference,
+        )
 
     with config.patch(repro_after=None), _minifier_sanity_guard() as sanity:
         minifier(
@@ -1327,7 +1384,9 @@ def repro_minify(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
             args,
             module_fails=functools.partial(module_fails, check_str=options.check_str),
             dump_state=functools.partial(
-                dump_compiler_graph_state, compiler_name=compiler_name
+                dump_compiler_graph_state,
+                compiler_name=compiler_name,
+                is_inference=options.is_inference,
             ),
             save_dir=options.save_dir,
             offload_to_disk=options.offload_to_disk,
@@ -1353,7 +1412,9 @@ def repro_analyze(options: ReproOptions, mod: nn.Module, load_args: Any) -> None
     compile_mod = copy.deepcopy(mod)
     compile_args = _get_compile_args(compile_mod, args)
     with tqdm(desc="Compiling"):
-        compiled = compile_fx_inner(compile_mod, compile_args)
+        compiled = compile_fx_inner(
+            compile_mod, compile_args, is_inference=options.is_inference
+        )
     total = counters["inductor"]["intermediate_hooks"]
 
     known_names = set()
@@ -1505,7 +1566,9 @@ def repro_run(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
 
     compile_mod = copy.deepcopy(mod)
     compile_args = _get_compile_args(compile_mod, args)
-    compiled = compile_fx_inner(compile_mod, compile_args)
+    compiled = compile_fx_inner(
+        compile_mod, compile_args, is_inference=options.is_inference
+    )
     if isinstance(compiled, str):
         raise AssertionError("compile_fx_inner should not return a string")
 
@@ -1543,6 +1606,7 @@ def run_repro(
     tracing_mode: str | None = None,
     patch_code: str | None = None,
     check_str: str | None = None,
+    is_inference: bool = False,
     **kwargs: Any,
 ) -> Any:
     for k in kwargs:
@@ -1576,6 +1640,7 @@ default settings on this script:
 """,
         formatter_class=argparse.RawTextHelpFormatter,
     )
+    parser.set_defaults(is_inference=is_inference)
 
     def common_flags(parser: argparse.ArgumentParser) -> None:
         accuracy_group = parser.add_mutually_exclusive_group()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1606,7 +1606,12 @@ class _InProcessFxCompile(FxCompile):
             def _fx_graph_runnable_payload() -> str:
                 fd = io.StringIO()
                 torch._dynamo.repro.after_aot.save_graph_repro(
-                    fd, gm, example_inputs, "inductor", save_dir=None
+                    fd,
+                    gm,
+                    example_inputs,
+                    "inductor",
+                    save_dir=None,
+                    is_inference=is_inference,
                 )
                 produced.append(fd.getvalue())
                 return produced[0]
@@ -1621,7 +1626,7 @@ class _InProcessFxCompile(FxCompile):
             )
             runnable_graph_str = produced[0] if produced else ""
 
-            V.debug.fx_graph(gm, example_inputs)
+            V.debug.fx_graph(gm, example_inputs, is_inference=is_inference)
             # TODO: Should we actually dump this?  It should be redundant with the aot
             # structured logs...
             # trace_structured("inductor_input_graph", payload_fn=lambda: gm.print_readable(print_output=False))

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -625,6 +625,8 @@ class DebugFormatter:
         self,
         gm: torch.fx.GraphModule,
         inputs: list[torch.Tensor],
+        *,
+        is_inference: bool = False,
     ) -> None:
         with self.fopen("fx_graph_runnable.py") as fd:
             save_dir = None
@@ -646,6 +648,7 @@ class DebugFormatter:
                     "inductor",
                     save_dir=save_dir,
                     stable_hash=stable_hash,
+                    is_inference=is_inference,
                 )
 
         with self.fopen("fx_graph_readable.py") as fd:


### PR DESCRIPTION
After-AOT repro generation receives is_inference through the compiler
kwargs but drops it while dumping and replaying the graph. When an
inference compilation fails with repro_after="aot", the generated repro
therefore recompiles the graph with compile_fx_inner's default
is_inference=False, potentially changing its behavior and preventing the
original failure from reproducing.

Propagate is_inference through graph dumping, serialization, replay,
minification, isolation, and analysis paths. Keep False as the default
for compatibility with previously generated repros.

Add coverage for inference and training graphs, compile-time and deferred
failures, and the run, minify, and analyze commands.

Fixes #193557

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98