### PR TITLE
Preserve storage sharing when loading checkpoints on meta/fake devices

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -682,6 +682,33 @@ class SerializationMixin:
             self.assertEqual(sd_meta['weight'].untyped_storage().nbytes(), sd['weight'].untyped_storage().nbytes())
             self.assertEqual(sd_meta['bias'].untyped_storage().nbytes(), sd['bias'].untyped_storage().nbytes())
 
+    def _test_load_preserves_storage_sharing(self, load_mode):
+        buf = torch.randn(16)
+        empty = torch.empty(0)
+        sd = {'a': buf[:8], 'b': buf[8:], 'empty': empty, 'empty_int': empty.view(torch.int32)}
+
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(sd, f)
+            f.seek(0)
+            if load_mode == "fake_tensor_mode":
+                with FakeTensorMode():
+                    sd_loaded = torch.load(f)
+            elif load_mode == "map_location_meta":
+                sd_loaded = torch.load(f, map_location='meta')
+            else:
+                sd_loaded = torch.load(f)
+
+        # the checkpoint holds two records: the shared buffer and the empty storage
+        storages = {t.untyped_storage()._cdata for t in sd_loaded.values()}
+        self.assertEqual(len(storages), 2)
+
+        self.assertEqual(sd_loaded['a'].untyped_storage().nbytes(), buf.untyped_storage().nbytes())
+        self.assertEqual(sd_loaded['b'].storage_offset(), 8)
+
+        # A record with no data can be saved under more than one dtype
+        self.assertEqual(sd_loaded['empty'].dtype, torch.float32)
+        self.assertEqual(sd_loaded['empty_int'].dtype, torch.int32)
+
     @unittest.skipIf(torch.cuda.is_available(), "Testing torch.load on CPU-only machine")
     def test_load_nonexistent_device(self):
         # Setup: create a serialized file object with a 'cuda:0' restore location
@@ -927,6 +954,10 @@ class TestBothSerialization(TestCase):
 
 
 class TestOldSerialization(TestCase, SerializationMixin):
+    @parametrize("load_mode", ["default", "fake_tensor_mode", "map_location_meta"])
+    def test_load_preserves_storage_sharing(self, load_mode):
+        self._test_load_preserves_storage_sharing(load_mode)
+
     # unique_key is necessary because on Python 2.7, if a warning passed to
     # the warning module is the same, it is not raised again.
     def _test_serialization_container(self, unique_key, filecontext_lambda):
@@ -1027,6 +1058,10 @@ class TestOldSerialization(TestCase, SerializationMixin):
 
 
 class TestSerialization(TestCase, SerializationMixin):
+    @parametrize("load_mode", ["default", "fake_tensor_mode", "map_location_meta"])
+    def test_load_preserves_storage_sharing(self, load_mode):
+        self._test_load_preserves_storage_sharing(load_mode)
+
     @parametrize('weights_only', (True, False))
     def test_serialization_zipfile(self, weights_only):
         data = self._test_serialization_data()
@@ -4630,33 +4665,21 @@ class TestSerialization(TestCase, SerializationMixin):
             finally:
                 serialization_config.save.storage_alignment = storage_alignment_before
 
-    @parametrize("load_mode", ["default", "fake_tensor_mode", "map_location_meta"])
-    def test_load_preserves_storage_sharing(self, load_mode):
-        buf = torch.randn(16)
-        empty = torch.empty(0)
-        sd = {'a': buf[:8], 'b': buf[8:], 'empty': empty, 'empty_int': empty.view(torch.int32)}
+    def test_load_record_referenced_with_conflicting_sizes(self):
+        # skip_data lets a record be saved under two dtypes that disagree on how long
+        # it is, which save cannot reject because there is no data to compare. The two
+        # references cannot share a storage, so each keeps its own size.
+        untyped = torch.empty(6, dtype=torch.uint8, device='meta').untyped_storage()
+        as_float = torch.storage.TypedStorage(wrap_storage=untyped, dtype=torch.float32, _internal=True)
 
         with tempfile.NamedTemporaryFile() as f:
-            torch.save(sd, f)
+            with skip_data():
+                torch.save([as_float, untyped], f)
             f.seek(0)
-            if load_mode == "fake_tensor_mode":
-                with FakeTensorMode():
-                    sd_loaded = torch.load(f)
-            elif load_mode == "map_location_meta":
-                sd_loaded = torch.load(f, map_location='meta')
-            else:
-                sd_loaded = torch.load(f)
+            float_loaded, untyped_loaded = torch.load(f, map_location='meta', weights_only=False)
 
-        a, b = sd_loaded['a'].untyped_storage(), sd_loaded['b'].untyped_storage()
-        self.assertEqual(a._cdata, b._cdata)
-        self.assertEqual(a.nbytes(), buf.untyped_storage().nbytes())
-        self.assertEqual(sd_loaded['b'].storage_offset(), 8)
-
-        # A record with no data can be saved under more than one dtype
-        e, e_int = sd_loaded['empty'].untyped_storage(), sd_loaded['empty_int'].untyped_storage()
-        self.assertEqual(e._cdata, e_int._cdata)
-        self.assertEqual(sd_loaded['empty'].dtype, torch.float32)
-        self.assertEqual(sd_loaded['empty_int'].dtype, torch.int32)
+        self.assertEqual(float_loaded._untyped_storage.nbytes(), 4)
+        self.assertEqual(untyped_loaded.nbytes(), 6)
 
     @parametrize('path_type', (str, Path))
     @unittest.skipIf(IS_WINDOWS, "TemporaryFileName on windows")

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4630,6 +4630,33 @@ class TestSerialization(TestCase, SerializationMixin):
             finally:
                 serialization_config.save.storage_alignment = storage_alignment_before
 
+    @parametrize("load_mode", ["default", "fake_tensor_mode", "map_location_meta"])
+    def test_load_preserves_storage_sharing(self, load_mode):
+        buf = torch.randn(16)
+        empty = torch.empty(0)
+        sd = {'a': buf[:8], 'b': buf[8:], 'empty': empty, 'empty_int': empty.view(torch.int32)}
+
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(sd, f)
+            f.seek(0)
+            if load_mode == "fake_tensor_mode":
+                with FakeTensorMode():
+                    sd_loaded = torch.load(f)
+            elif load_mode == "map_location_meta":
+                sd_loaded = torch.load(f, map_location='meta')
+            else:
+                sd_loaded = torch.load(f)
+
+        a, b = sd_loaded['a'].untyped_storage(), sd_loaded['b'].untyped_storage()
+        self.assertEqual(a._cdata, b._cdata)
+        self.assertEqual(a.nbytes(), buf.untyped_storage().nbytes())
+        self.assertEqual(sd_loaded['b'].storage_offset(), 8)
+
+        # A record with no data can be saved under more than one dtype
+        e, e_int = sd_loaded['empty'].untyped_storage(), sd_loaded['empty_int'].untyped_storage()
+        self.assertEqual(e._cdata, e_int._cdata)
+        self.assertEqual(sd_loaded['empty'].dtype, torch.float32)
+        self.assertEqual(sd_loaded['empty_int'].dtype, torch.int32)
 
     @parametrize('path_type', (str, Path))
     @unittest.skipIf(IS_WINDOWS, "TemporaryFileName on windows")

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1855,12 +1855,16 @@ def _legacy_load(
                 deserialized_objects[root_key] = typed_storage
             else:
                 typed_storage = deserialized_objects[root_key]
-                if typed_storage._data_ptr() == 0:
-                    typed_storage = torch.storage.TypedStorage(
-                        device=typed_storage._untyped_storage.device,
-                        dtype=dtype,
-                        _internal=True,
-                    )
+                if typed_storage.dtype != dtype:
+                    untyped_storage = typed_storage._untyped_storage
+                    if untyped_storage.nbytes() == nbytes:
+                        typed_storage = torch.storage.TypedStorage(
+                            wrap_storage=untyped_storage, dtype=dtype, _internal=True
+                        )
+                    else:
+                        typed_storage = torch.storage.TypedStorage(
+                            device=untyped_storage.device, dtype=dtype, _internal=True
+                        )
 
             if view_metadata is not None:
                 view_key, offset, view_size = view_metadata
@@ -2094,9 +2098,10 @@ def _load(
             )
             local_header_offset = current_offset
 
-        # This is only actually needed for storages that have typed_storage._data_ptr() == 0
-        # after being read. Otherwise persistent_load would never "re-call" load_tensor
-        # for a given key.
+        # load_tensor is normally called at most once per key, but a record with no
+        # data can be referenced under dtypes that disagree on its byte length, and
+        # those references each get their own storage. Memoize so the repeat call
+        # does not recompute the offset from a current_offset that has moved on.
         offsets[name] = storage_offset
 
         # Increment current_offset to offset where next zipfile header starts
@@ -2175,8 +2180,6 @@ def _load(
             _internal=True,
         )
 
-        loaded_storages[key] = typed_storage
-
         return typed_storage
 
     def persistent_load(saved_id):
@@ -2197,23 +2200,29 @@ def _load(
         else:
             dtype = storage_type.dtype
 
-        if key in loaded_storages:
-            typed_storage = loaded_storages[key]
-            if typed_storage.dtype != dtype:
-                # torch.save rejects saving allocated data as two different types,
-                # but it cannot detect that for records with no data (empty
-                # storages), so those can come back under several dtypes. Rewrap
-                # rather than rebuild so the record keeps a single storage.
-                typed_storage = torch.storage.TypedStorage(
-                    wrap_storage=typed_storage._untyped_storage,
-                    dtype=dtype,
-                    _internal=True,
-                )
-        else:
-            nbytes = numel * torch._utils._element_size(dtype)
+        nbytes = numel * torch._utils._element_size(dtype)
+        typed_storage = loaded_storages.get(key)
+
+        if typed_storage is None:
             typed_storage = load_tensor(
                 dtype, nbytes, key, _maybe_decode_ascii(location)
             )
+            loaded_storages[key] = typed_storage
+        elif typed_storage.dtype != dtype:
+            # _save only allows one dtype per record for storages that have data, so
+            # this is a record with none: an empty storage, or one saved from meta.
+            untyped_storage = typed_storage._untyped_storage
+            if untyped_storage.nbytes() == nbytes:
+                typed_storage = torch.storage.TypedStorage(
+                    wrap_storage=untyped_storage, dtype=dtype, _internal=True
+                )
+            else:
+                # The references disagree on how long the record is, so no single
+                # storage can serve both. Give this one its own and keep the cached
+                # storage for whoever asked first.
+                typed_storage = load_tensor(
+                    dtype, nbytes, key, _maybe_decode_ascii(location)
+                )
 
         return typed_storage
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -2175,8 +2175,7 @@ def _load(
             _internal=True,
         )
 
-        if typed_storage._data_ptr() != 0:
-            loaded_storages[key] = typed_storage
+        loaded_storages[key] = typed_storage
 
         return typed_storage
 
@@ -2200,6 +2199,16 @@ def _load(
 
         if key in loaded_storages:
             typed_storage = loaded_storages[key]
+            if typed_storage.dtype != dtype:
+                # torch.save rejects saving allocated data as two different types,
+                # but it cannot detect that for records with no data (empty
+                # storages), so those can come back under several dtypes. Rewrap
+                # rather than rebuild so the record keeps a single storage.
+                typed_storage = torch.storage.TypedStorage(
+                    wrap_storage=typed_storage._untyped_storage,
+                    dtype=dtype,
+                    _internal=True,
+                )
         else:
             nbytes = numel * torch._utils._element_size(dtype)
             typed_storage = load_tensor(


### PR DESCRIPTION
Fixes #158080

### Root cause

`_load` recorded a deserialized storage in `loaded_storages` only when `typed_storage._data_ptr() != 0`. Meta and fake storages always have a null data pointer, so they were never cached and `persistent_load` re-entered `load_tensor` for every reference to the same record. Each reference got a storage of its own, so any sharing present in the checkpoint was silently dropped.

For a 100 MB checkpoint whose 64 tensors are views of one buffer:

| load | before | after |
| --- | --- | --- |
| `map_location="cpu"` | 1 storage, 100.0 MB | 1 storage, 100.0 MB |
| `map_location="meta"` | 64 storages, 6400.0 MB | 1 storage, 100.0 MB |
| under `FakeTensorMode` | 64 storages, 6400.0 MB | 1 storage, 100.0 MB |

That defeats the main reason to load on meta or under `FakeTensorMode` in the first place, which is sizing a checkpoint without materializing it. Plain CPU loads were affected too whenever the shared storage was empty, since an empty storage also has a null data pointer.

Note that the timing regression in the issue no longer reproduces on main: `_get_offset` memoizes record offsets, so the repeated `load_tensor` calls are cheap and `meta` measures ~1.2x `cpu`, not "forever". The caching bug it diagnosed is still there; the live symptom is the lost sharing above.

### Fix

The `_data_ptr() != 0` guard is not arbitrary: it came from #91285, fixing #90497. `torch.save` rejects saving allocated data as two different types, but it cannot detect that for records with no data, so an empty record can legitimately come back under several dtypes and returning the cached `TypedStorage` would hand back the wrong one.

Rather than skip the cache for those records, this caches unconditionally and, on a dtype mismatch, rewraps the cached *untyped* storage with the requested dtype. That keeps the #90497 fix while leaving one storage per record, which is what preserves the sharing.

`_legacy_load` had the same bug behind a different condition, and worse: its replacement storage is constructed with no size argument, so it comes back sized to whatever the referencing tensor needs rather than to the record. A legacy checkpoint whose 16-element buffer is also referenced by a 2-element view reports that record as 8 bytes under meta and fake, against 64 on CPU. Same fix applies.

One case cannot be shared. `_save` skips its dtype-consistency check for meta storages as well as unallocated ones, so a checkpoint written under `skip_data` can reference one record under two dtypes that disagree on its byte length — a 6-byte record read as `float32` (4 bytes) and as `UntypedStorage` (6 bytes). Rewrapping there would silently truncate the second reference, so those references each keep their own storage, as they did before this PR. That is also why `load_tensor` is still reachable twice for a key and the `_get_offset` memo it relies on stays, with its comment corrected.

### Behavior change

Two empty tensors that shared a storage at save time now share one on load, so `resize_` on one is visible through the other. That is what was saved, but it is user-visible beyond "fewer storages allocated".

### Test plan

`test_load_preserves_storage_sharing` lives in `SerializationMixin`, so it runs against both the zipfile and the legacy format, parametrized over `default` / `fake_tensor_mode` / `map_location_meta`. All six fail on main and pass with the fix:

```
python test/test_serialization.py TestSerialization.test_load_preserves_storage_sharing_load_mode_default
python test/test_serialization.py TestSerialization.test_load_preserves_storage_sharing_load_mode_fake_tensor_mode
python test/test_serialization.py TestSerialization.test_load_preserves_storage_sharing_load_mode_map_location_meta
python test/test_serialization.py TestOldSerialization.test_load_preserves_storage_sharing_load_mode_default
python test/test_serialization.py TestOldSerialization.test_load_preserves_storage_sharing_load_mode_fake_tensor_mode
python test/test_serialization.py TestOldSerialization.test_load_preserves_storage_sharing_load_mode_map_location_meta
```

`test_load_record_referenced_with_conflicting_sizes` covers the size guard, and passes both before and after since it pins behavior this PR must not change:

```
python test/test_serialization.py TestSerialization.test_load_record_referenced_with_conflicting_sizes
```

The #90497 regression guards still pass, as do the rest of the file and the neighbouring suites:

```
python test/test_serialization.py -k different_dtype
python test/test_serialization.py
python test/test_fake_tensor.py -k "load or serial or storage"
python test/test_torch.py -k "serial or storage"
```

Run locally on macOS/arm64 against a nightly build (`2.14.0.dev20260811`), since the change is pure Python: 198 passed / 25 skipped for `test_serialization.py`, 25 passed for the `test_fake_tensor.py` selection, 146 passed for the `test_torch.py` selection.

This change was authored with AI assistance; I reviewed and verified the analysis, the code, and the test results myself.

cc @ezyang @eellison @bdhirsh @bobrenjc93 @aorenste @liangel-02 @mruberry @mikaylagawarecki @msaroufim @Skylion007
