### PR TITLE
[Testcase Refactoring] Add HardwareClassification to cycling_iterator_test.py

### DIFF
--- a/test/distributed/elastic/utils/data/cycling_iterator_test.py
+++ b/test/distributed/elastic/utils/data/cycling_iterator_test.py
@@ -9,9 +9,12 @@
 import unittest
 
 from torch.distributed.elastic.utils.data import CyclingIterator
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class CyclingIteratorTest(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def generator(self, epoch, stride, max_epochs):
         # generate an continuously incrementing list each epoch
         # e.g. [0,1,2] [3,4,5] [6,7,8] ...


### PR DESCRIPTION
## Summary

Tags `CyclingIteratorTest` in `test/distributed/elastic/utils/data/cycling_iterator_test.py`
with `hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/elastic/utils/data/cycling_iterator_test.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `CyclingIteratorTest`.

## Context

`CyclingIteratorTest` is a plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so this class is classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `test/distributed/elastic/utils/data/cycling_iterator_test.py`

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.