### PR TITLE
[MPS] Surface swallowed command-buffer faults in commitAndWait

### DIFF
--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -108,21 +108,45 @@ void MPSStream::commit() {
   }
 }
 
+// Surface GPU command-buffer faults that commitAndWait would otherwise swallow.
+// waitUntilCompleted returns even when the buffer aborted (e.g. a GPU interactivity/timeout
+// abort or a faulting encoder), and checkLastError() only inspects the in-kernel shared error
+// buffer (c10::metal::ErrorMessages), never MTLCommandBuffer.status/.error. Without this, a
+// faulted command buffer passes silently and downstream reads its uninitialized / incomplete
+// output as a garbage integer. Returns the fault message (empty if none); the message is read
+// while the buffer is still alive, and the CALLER must release/nil the buffer before throwing
+// so the stream isn't left holding an already-committed buffer (a re-commit aborts the process).
+static std::string commandBufferErrorMessage(id<MTLCommandBuffer> commandBuffer) {
+  if ([commandBuffer status] != MTLCommandBufferStatusError) {
+    return {};
+  }
+  NSError* error = [commandBuffer error];
+  std::string msg = "MPS command buffer execution failed (MTLCommandBufferStatusError, code ";
+  msg += std::to_string(error ? static_cast<long>([error code]) : -1L);
+  msg += "): ";
+  msg += error ? [[error localizedDescription] UTF8String] : "unknown error";
+  return msg;
+}
+
 void MPSStream::commitAndWait() {
   if (_prevCommandBuffer) {
     // the previous command buffer (if exists) has already been committed,
     // so we just wait until it's completed and then dispose it.
     [_prevCommandBuffer waitUntilCompleted];
+    std::string cbError = commandBufferErrorMessage(_prevCommandBuffer);
     [_prevCommandBuffer release];
     _prevCommandBuffer = nil;
+    TORCH_CHECK(cbError.empty(), cbError);
     checkLastError();
   }
 
   if (_commandBuffer) {
     [_commandBuffer commit];
     [_commandBuffer waitUntilCompleted];
+    std::string cbError = commandBufferErrorMessage(_commandBuffer);
     [_commandBuffer release];
     _commandBuffer = nil;
+    TORCH_CHECK(cbError.empty(), cbError);
     checkLastError();
   }
 }


### PR DESCRIPTION
`waitUntilCompleted` returns even when a command buffer aborts (e.g. a GPU interactivity/timeout abort or a faulting encoder), and `checkLastError()` only reads the in-kernel shared error buffer, never `MTLCommandBuffer.status`/`.error`. A faulted buffer therefore passed silently, and downstream code read its uninitialized/incomplete output as a garbage integer, observed as garbage nonzero counts, OOB indices, and bogus shapes in Mask R-CNN backward on M2 Max.

Checks status after `waitUntilCompleted` and raises with the underlying `MTLCommandBufferStatusError` message, capturing the message while the buffer is still alive and clearing the buffer before throwing so the stream isn't left holding an already-committed buffer (a re-commit would abort the process).

Test plan:

```
python test/test_mps.py -k "profiler or Event or synchronize or elapsed_time" -q
```

Also ran the full `TestConsistencyMPS` suite (5548 passed, only the pre-existing unrelated `combinations` fp16 flake from issue #188985 failed).