### PR TITLE
[MPS] Diagnostics for command-buffer fault attribution (env-gated)

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -6,6 +6,7 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Logging.h>
+#include <c10/util/ScopeExit.h>
 #include <c10/util/env.h>
 
 #include <algorithm>
@@ -549,12 +550,16 @@ bool MPSHeapAllocatorImpl::release_cached_buffers() {
   }
   // before releasing the buffers make sure the command buffer has finished.
   // we need to release the lock temporarily as synchronizing may cause deadlock with completion handlers.
-  m_mutex.unlock();
-  auto stream = getDefaultMPSStream();
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    stream->synchronize(SyncType::COMMIT_AND_WAIT);
-  });
-  m_mutex.lock();
+  // commitAndWait throws on a faulted command buffer, so re-lock via scope guard: our caller holds
+  // m_mutex through a lock_guard and would otherwise unlock a mutex we no longer own while unwinding.
+  {
+    m_mutex.unlock();
+    auto relock = c10::make_scope_exit([this]() { m_mutex.lock(); });
+    auto stream = getDefaultMPSStream();
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    });
+  }
   // Give back every heap no allocation is left in
   for (const auto& poolIt : m_pools) {
     release_free_heaps(*poolIt.second, std::numeric_limits<size_t>::max());

--- a/aten/src/ATen/mps/MPSEvent.mm
+++ b/aten/src/ATen/mps/MPSEvent.mm
@@ -220,7 +220,9 @@ bool MPSEventPool::queryEvent(id_t event_id) {
 
 double MPSEventPool::elapsedTime(id_t start_event_id, id_t end_event_id) {
   // first make sure notifyListeners are called to capture events' completion times
-  dispatch_sync(m_default_stream->queue(), ^() {
+  // commitAndWait throws on a faulted command buffer, so route it through the rethrow helper
+  // rather than letting the exception unwind through the dispatch_sync block.
+  dispatch_sync_with_rethrow(m_default_stream->queue(), ^() {
     m_default_stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
   std::lock_guard<std::recursive_mutex> lock(m_mutex);

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -126,7 +126,13 @@ MPSProfiler::MPSProfiler() : m_os_log_events(nullptr), m_os_log_intervals(nullpt
 MPSProfiler::~MPSProfiler() {
   // first make sure completion handlers are completed
   if (hasPendingCompletionHandlers) {
-    at::mps::synchronizeAllMPSStreams(SyncType::COMMIT_AND_WAIT);
+    // commitAndWait throws on a faulted command buffer; a throw out of this destructor would
+    // terminate instead of reporting, losing both the fault and the Python-level traceback.
+    try {
+      at::mps::synchronizeAllMPSStreams(SyncType::COMMIT_AND_WAIT);
+    } catch (const std::exception& e) {
+      TORCH_WARN("MPSProfiler: error while draining the stream at shutdown: ", e.what());
+    }
   }
   logProfilingStats();
 

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
+#include <string>
 #include <utility>
 
 #include <ATen/mps/MPSDevice.h>
@@ -21,6 +23,7 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-property-no-attribute")
 C10_DIAGNOSTIC_POP()
 C10_DIAGNOSTIC_POP()
 typedef MPSCommandBuffer* MPSCommandBuffer_t;
+typedef id<MTLCommandBuffer> MTLCommandBuffer_t;
 typedef id<MTLCommandQueue> MTLCommandQueue_t;
 typedef id<MTLComputeCommandEncoder> MTLComputeCommandEncoder_t;
 typedef id<MTLSharedEvent> MTLSharedEvent_t;
@@ -29,6 +32,7 @@ typedef id<MTLBuffer> MTLBuffer_t;
 #else
 #include <dispatch/dispatch.h>
 typedef void* MPSCommandBuffer_t;
+typedef void* MTLCommandBuffer_t;
 typedef void* MPSGraph;
 typedef void* MPSGraphExecutionDescriptor;
 typedef void* MPSGraphCompilationDescriptor;
@@ -130,6 +134,23 @@ class TORCH_API MPSStream {
   bool _enableCommitAndContinue = true;
   // Buffer that contains last raised error
   MTLBuffer_t _errorBuffer = nil;
+
+  // Fault state for root MTLCommandBuffers. commitAndContinue retires the root out from under the
+  // MPSCommandBuffer wrapper (MPSGraph does this internally too), so a faulted root's status can no
+  // longer be queried by the time we wait on it. Each root gets a completion handler that records the
+  // fault in _pendingFault instead, tagged with the root it came from so commitAndWait can prefer its
+  // own better-attributed message for the root it waited on. Both roots are retained: the tags are
+  // compared by pointer, and a released root could otherwise be replaced at the same address.
+  // _pendingFault is written from Metal's completion queue and drained on the calling thread, hence
+  // the lock.
+  MTLCommandBuffer_t _trackedRoot = nil;
+  std::mutex _faultMutex;
+  std::string _pendingFault;
+  MTLCommandBuffer_t _pendingFaultRoot = nil;
+
+  void trackRootCommandBuffer(MPSCommandBuffer_t buffer);
+  std::string rootFaultMessage(MPSCommandBuffer_t buffer);
+  std::string takePendingFault(MTLCommandBuffer_t currentRoot);
 
   // use synchronize() to access any of these commit functions outside MPSStream
   void commit();

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -108,21 +108,45 @@ void MPSStream::commit() {
   }
 }
 
+// Surface GPU command-buffer faults that commitAndWait would otherwise swallow.
+// waitUntilCompleted returns even when the buffer aborted (e.g. a GPU interactivity/timeout
+// abort or a faulting encoder), and checkLastError() only inspects the in-kernel shared error
+// buffer (c10::metal::ErrorMessages), never MTLCommandBuffer.status/.error. Without this, a
+// faulted command buffer passes silently and downstream reads its uninitialized / incomplete
+// output as a garbage integer. Returns the fault message (empty if none); the message is read
+// while the buffer is still alive, and the CALLER must release/nil the buffer before throwing
+// so the stream isn't left holding an already-committed buffer (a re-commit aborts the process).
+static std::string commandBufferErrorMessage(id<MTLCommandBuffer> commandBuffer) {
+  if ([commandBuffer status] != MTLCommandBufferStatusError) {
+    return {};
+  }
+  NSError* error = [commandBuffer error];
+  std::string msg = "MPS command buffer execution failed (MTLCommandBufferStatusError, code ";
+  msg += std::to_string(error ? static_cast<long>([error code]) : -1L);
+  msg += "): ";
+  msg += error ? [[error localizedDescription] UTF8String] : "unknown error";
+  return msg;
+}
+
 void MPSStream::commitAndWait() {
   if (_prevCommandBuffer) {
     // the previous command buffer (if exists) has already been committed,
     // so we just wait until it's completed and then dispose it.
     [_prevCommandBuffer waitUntilCompleted];
+    std::string cbError = commandBufferErrorMessage(_prevCommandBuffer);
     [_prevCommandBuffer release];
     _prevCommandBuffer = nil;
+    TORCH_CHECK(cbError.empty(), cbError);
     checkLastError();
   }
 
   if (_commandBuffer) {
     [_commandBuffer commit];
     [_commandBuffer waitUntilCompleted];
+    std::string cbError = commandBufferErrorMessage(_commandBuffer);
     [_commandBuffer release];
     _commandBuffer = nil;
+    TORCH_CHECK(cbError.empty(), cbError);
     checkLastError();
   }
 }

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -10,6 +10,9 @@
 #include <array>
 #include <atomic>
 
+#include <cstdio>
+#include <cstdlib>
+
 @interface MPSGraphExecutionDescriptor ()
 @property(readwrite, atomic) BOOL enableCommitAndContinue;
 @end
@@ -18,6 +21,16 @@ namespace at::mps {
 //-----------------------------------------------------------------
 //  MPSStream
 //-----------------------------------------------------------------
+
+// DIAGNOSTIC (env MPS_FAULT_NAME_DIAG) fault-naming hooks; also forward-declared in Indexing.mm.
+void mpsSetCurrentOp(const char* name);
+bool mpsFaultNameDiag();
+
+// env FULL_SYNC: per-op COMMIT_AND_WAIT (hazard test). Local to this TU; declared here because
+// commandEncoder()/trackRootCommandBuffer() below are defined ahead of them.
+static bool mpsFullSync();
+static void mpsSetEncoderLive(bool live);
+static void mpsClearCurrentOp();
 
 MPSStream::MPSStream(Stream stream) : _stream(stream) {
   _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
@@ -50,6 +63,10 @@ MPSStream::~MPSStream() {
   [_errorBuffer release];
   _errorBuffer = nil;
   _compilationDescriptor = nil;
+  [_trackedRoot release];
+  _trackedRoot = nil;
+  [_pendingFaultRoot release];
+  _pendingFaultRoot = nil;
 
   assert(_commandBuffer == nil);
 }
@@ -58,6 +75,9 @@ MPSCommandBuffer* MPSStream::commandBuffer() {
   if (!_commandBuffer) {
     _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
   }
+  // The wrapper outlives its root: commitAndContinue (ours or MPSGraph's) swaps a fresh root in
+  // behind it, so re-check on every access rather than only on creation.
+  trackRootCommandBuffer(_commandBuffer);
 
   return _commandBuffer;
 }
@@ -68,7 +88,19 @@ id<MTLDevice> MPSStream::device() const {
 
 id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
   if (!_commandEncoder) {
+    // DIAGNOSTIC (env FULL_SYNC): per-op hazard test. Draining here fully completes all previously
+    // encoded work before this op encodes, serializing every op; if a command-buffer abort vanishes
+    // under FULL_SYNC, the fault is an execution-order hazard. This is the only safe point for the
+    // drain: COMMIT_AND_WAIT ends the open encoder via endKernelCoalescing, and most call sites hold
+    // their encoder in a local across kernel setup, so draining once they have one would leave them
+    // encoding into an ended encoder. Here no encoder is outstanding yet, by construction.
+    if (mpsFullSync()) {
+      commitAndWait();
+    }
     _commandEncoder = [commandBuffer() computeCommandEncoder].retain;
+    if (mpsFaultNameDiag()) {
+      mpsSetEncoderLive(true);
+    }
   }
 
   return _commandEncoder;
@@ -108,46 +140,204 @@ void MPSStream::commit() {
   }
 }
 
+// DIAGNOSTIC (env MPS_FAULT_NAME_DIAG): name the op whose command buffer faults. When the env var is
+// set, commitAndWait LOGS the faulting op instead of throwing, so a forced per-op commit+wait can
+// attribute the FIRST fault without the throw-through-ObjC SIGABRT. Off by default -> deliverable
+// behavior unchanged.
+//
+// Guarded because the two ends run on different threads: ops encode on whatever thread called into
+// ATen, while a drain can come from another thread entirely (torch.mps.synchronize, the allocator
+// reclaiming buffers, the profiler at shutdown). An unguarded std::string here would be a data race,
+// not merely a stale read -- assigning one while another thread copies it can free the buffer mid-read.
+//
+// Two slots, because an op names itself when it resolves its pipeline state, which is not yet the point
+// where its work joins the command buffer. Only once it holds an encoder is its work really in the root
+// being built, so a fault can fairly be blamed on it. Ops that name themselves before taking an encoder
+// (getLibraryPipelineState runs first at many call sites) park the name in `pending`; it becomes
+// `current` when the encoder is handed out. This also keeps the FULL_SYNC drain in commandEncoder()
+// honest: that drain reports work encoded BEFORE this op, so it must not see this op's name.
+static std::mutex g_op_name_mutex;
+static std::string g_pending_op; // named itself, not encoding yet
+static std::string g_current_op; // holds an encoder, so its work is in the root being built
+static bool g_encoder_live = false;
+
+void mpsSetCurrentOp(const char* name) {
+  std::lock_guard<std::mutex> lock(g_op_name_mutex);
+  // Kernel coalescing keeps one encoder open across consecutive ops, so an op that names itself while
+  // an encoder is already live is encoding into the current root right now: name it directly.
+  (g_encoder_live ? g_current_op : g_pending_op) = name ? name : "";
+}
+
+bool mpsFaultNameDiag() {
+  static const bool on = (std::getenv("MPS_FAULT_NAME_DIAG") != nullptr);
+  return on;
+}
+
+static std::string mpsCurrentOp() {
+  std::lock_guard<std::mutex> lock(g_op_name_mutex);
+  return g_current_op;
+}
+
+// Called with the encoder live/dead state that just changed. Handing out an encoder promotes whatever
+// op was parked in `pending`; ending one leaves the name in place, since work already encoded stays in
+// the root and remains a fair thing to blame.
+static void mpsSetEncoderLive(bool live) {
+  std::lock_guard<std::mutex> lock(g_op_name_mutex);
+  g_encoder_live = live;
+  if (live) {
+    g_current_op = g_pending_op;
+  }
+}
+
+// Drop the name when the root is replaced, so the new root does not inherit blame for the old root's
+// work. A live encoder is left alone: its work is going into the root being built, so the name still
+// applies (in practice callers end coalescing before swapping roots, so this is belt-and-braces).
+static void mpsClearCurrentOp() {
+  std::lock_guard<std::mutex> lock(g_op_name_mutex);
+  if (!g_encoder_live) {
+    g_current_op.clear();
+  }
+}
+
+static bool mpsFullSync() {
+  static const bool on = (std::getenv("FULL_SYNC") != nullptr);
+  return on;
+}
+
 // Surface GPU command-buffer faults that commitAndWait would otherwise swallow.
 // waitUntilCompleted returns even when the buffer aborted (e.g. a GPU interactivity/timeout
 // abort or a faulting encoder), and checkLastError() only inspects the in-kernel shared error
 // buffer (c10::metal::ErrorMessages), never MTLCommandBuffer.status/.error. Without this, a
 // faulted command buffer passes silently and downstream reads its uninitialized / incomplete
-// output as a garbage integer. Returns the fault message (empty if none); the message is read
-// while the buffer is still alive, and the CALLER must release/nil the buffer before throwing
-// so the stream isn't left holding an already-committed buffer (a re-commit aborts the process).
-static std::string commandBufferErrorMessage(id<MTLCommandBuffer> commandBuffer) {
-  if ([commandBuffer status] != MTLCommandBufferStatusError) {
-    return {};
-  }
-  NSError* error = [commandBuffer error];
+// output as a garbage integer.
+static std::string describeCommandBufferFault(id<MTLCommandBuffer> root, const std::string& attribution) {
+  NSError* error = [root error];
   std::string msg = "MPS command buffer execution failed (MTLCommandBufferStatusError, code ";
   msg += std::to_string(error ? static_cast<long>([error code]) : -1L);
   msg += "): ";
   msg += error ? [[error localizedDescription] UTF8String] : "unknown error";
+  msg += attribution;
   return msg;
 }
 
+// Status must be read from -rootCommandBuffer, never the MPSCommandBuffer wrapper: per
+// MPSCommandBuffer.h, commitAndContinue commits the root and swaps in a fresh one, so the wrapper's
+// status reflects only the newest root. Returns the fault message (empty if none); the message is
+// read while the buffer is still alive, and the CALLER must release/nil the buffer before throwing so
+// the stream isn't left holding an already-committed buffer (a re-commit aborts the process).
+std::string MPSStream::rootFaultMessage(MPSCommandBuffer_t buffer) {
+  id<MTLCommandBuffer> root = [buffer rootCommandBuffer];
+  if ([root status] != MTLCommandBufferStatusError) {
+    return {};
+  }
+  std::string attribution;
+  if (mpsFaultNameDiag()) {
+    const std::string op = mpsCurrentOp();
+    if (!op.empty()) {
+      attribution = " [current op: " + op + "]";
+    }
+  }
+  return describeCommandBufferFault(root, attribution);
+}
+
+// Install a completion handler on the root MTLCommandBuffer so a fault is still recorded when the
+// root is retired before anyone can query it. commitAndContinue commits the current root and swaps in
+// a new one, and MPSGraph does this internally whenever _executionDescriptor.enableCommitAndContinue
+// is set, so most roots never pass through our own commit path. Per MPSCommandBuffer.h, handlers stay
+// attached to the root they were added to and fire as that root completes. Called from commandBuffer(),
+// which every op goes through before encoding, so each new root is tracked before work lands on it.
+void MPSStream::trackRootCommandBuffer(MPSCommandBuffer_t buffer) {
+  id<MTLCommandBuffer> root = [buffer rootCommandBuffer];
+  if (root == _trackedRoot) {
+    return;
+  }
+  // Retained so the identity check above stays sound: a deallocated root could otherwise be
+  // replaced by a new one at the same address and silently skip tracking.
+  [_trackedRoot release];
+  _trackedRoot = [root retain];
+  // A fresh root holds none of the previous root's work, so the name must not carry over: otherwise a
+  // root containing only MPSGraph work would be blamed on the last custom Metal kernel to run. The
+  // caller in commandEncoder() re-promotes the pending name right after this, so an op that is about
+  // to encode still gets named.
+  if (mpsFaultNameDiag()) {
+    mpsClearCurrentOp();
+  }
+
+  // Capturing `this` is safe: the stream is a leaked singleton (MPSStreamImpl::getInstance).
+  [root addCompletedHandler:^(id<MTLCommandBuffer> cb) {
+    if ([cb status] != MTLCommandBufferStatusError) {
+      return;
+    }
+    // The faulting op cannot be named here: this fires asynchronously, long after the op that encoded
+    // into this root has moved on, so the current-op name no longer refers to it.
+    std::string msg = describeCommandBufferFault(cb, " [retired command buffer; rerun with FULL_SYNC=1 to attribute]");
+    std::lock_guard<std::mutex> lock(_faultMutex);
+    // Keep the FIRST fault: later ones are usually cascade damage from the same root cause.
+    if (_pendingFault.empty()) {
+      _pendingFault = std::move(msg);
+      _pendingFaultRoot = [cb retain];
+    }
+  }];
+}
+
+// Hand back a fault recorded by a completion handler. A fault belonging to `currentRoot` is dropped
+// rather than returned: the caller can still read that root's status directly and build a better
+// attributed message, so returning it here would only shadow the more informative one.
+std::string MPSStream::takePendingFault(MTLCommandBuffer_t currentRoot) {
+  std::lock_guard<std::mutex> lock(_faultMutex);
+  std::string msg;
+  if (_pendingFaultRoot != currentRoot) {
+    msg = std::move(_pendingFault);
+  }
+  _pendingFault.clear();
+  [_pendingFaultRoot release];
+  _pendingFaultRoot = nil;
+  return msg;
+}
+
+// Surface both fault channels of a completed command buffer. The in-kernel error buffer is drained
+// FIRST and unconditionally: a throw that skips checkLastError() leaves the reported error queued,
+// where it resurfaces on a later unrelated sync attributed to the wrong op. checkLastError() also
+// raises the more specific c10::AcceleratorError, so a kernel-reported error outranks the buffer
+// status. Under MPS_FAULT_NAME_DIAG the fault is logged rather than thrown (so a forced per-op
+// commit+wait can attribute the FIRST fault), and is logged before the drain can throw.
+static void handleCbFault(MPSStream* stream, const std::string& cbError) {
+  if (!cbError.empty() && mpsFaultNameDiag()) {
+    fprintf(stderr, "MPS_FAULT_OP: %s\n", cbError.c_str());
+    fflush(stderr);
+    stream->checkLastError();
+    return;
+  }
+  stream->checkLastError();
+  TORCH_CHECK(cbError.empty(), cbError);
+}
+
+// commitAndWait reports the FIRST fault it can find: a fault recorded by a completion handler
+// belongs to an earlier root than the buffer we just waited on, so it wins over that buffer's own
+// status. Buffers are detached from the stream before reporting, since reporting may throw and a
+// stream left holding an already-committed buffer aborts the process on the next commit.
 void MPSStream::commitAndWait() {
   if (_prevCommandBuffer) {
     // the previous command buffer (if exists) has already been committed,
     // so we just wait until it's completed and then dispose it.
     [_prevCommandBuffer waitUntilCompleted];
-    std::string cbError = commandBufferErrorMessage(_prevCommandBuffer);
-    [_prevCommandBuffer release];
+    MPSCommandBuffer_t buffer = _prevCommandBuffer;
     _prevCommandBuffer = nil;
-    TORCH_CHECK(cbError.empty(), cbError);
-    checkLastError();
+    std::string cbError = rootFaultMessage(buffer);
+    std::string pending = takePendingFault([buffer rootCommandBuffer]);
+    [buffer release];
+    handleCbFault(this, pending.empty() ? cbError : pending);
   }
 
   if (_commandBuffer) {
     [_commandBuffer commit];
     [_commandBuffer waitUntilCompleted];
-    std::string cbError = commandBufferErrorMessage(_commandBuffer);
-    [_commandBuffer release];
+    MPSCommandBuffer_t buffer = _commandBuffer;
     _commandBuffer = nil;
-    TORCH_CHECK(cbError.empty(), cbError);
-    checkLastError();
+    std::string cbError = rootFaultMessage(buffer);
+    std::string pending = takePendingFault([buffer rootCommandBuffer]);
+    [buffer release];
+    handleCbFault(this, pending.empty() ? cbError : pending);
   }
 }
 
@@ -161,6 +351,9 @@ void MPSStream::endKernelCoalescing() {
     [_commandEncoder endEncoding];
     [_commandEncoder release];
     _commandEncoder = nil;
+    if (mpsFaultNameDiag()) {
+      mpsSetEncoderLive(false);
+    }
   }
 }
 

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -726,7 +726,7 @@ void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
     auto cplState = getPipelineStateForFunc(kernel_name);
 
     MPSStream* mpsStream = getCurrentMPSStream();
-    dispatch_sync(mpsStream->queue(), ^() {
+    dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
       auto computeEncoder = mpsStream->commandEncoder();
 
       getMPSProfiler().beginProfileKernel(cplState, name, {inputTensor}, mpsStream);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -26,6 +26,12 @@
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 
+namespace at::mps {
+// DIAGNOSTIC (env MPS_FAULT_NAME_DIAG) fault-naming hooks, defined in MPSStream.mm.
+void mpsSetCurrentOp(const char* name);
+bool mpsFaultNameDiag();
+} // namespace at::mps
+
 namespace at::native::mps {
 /**
  * Computes distance from lowest to highest element offset in given tensor.
@@ -846,6 +852,10 @@ id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
 std::pair<id<MTLComputePipelineState>, id<MTLFunction>> MetalShaderLibrary::getLibraryPipelineState(
     id<MTLLibrary> lib,
     const std::string& fname) {
+  // DIAGNOSTIC: central place to record the currently-executing kernel name for fault attribution.
+  if (at::mps::mpsFaultNameDiag()) {
+    at::mps::mpsSetCurrentOp(fname.c_str());
+  }
   auto key = fmt::format("{}:{}", reinterpret_cast<void*>(lib), fname);
   auto found_cpl = cplMap.find(key);
   if (found_cpl != cplMap.end()) {
@@ -1092,7 +1102,7 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     auto cplState = getPipelineStateForFunc(kernel_name);
 
     MPSStream* mpsStream = getCurrentMPSStream();
-    dispatch_sync(mpsStream->queue(), ^() {
+    dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
       auto computeEncoder = mpsStream->commandEncoder();
 
       getMPSProfiler().beginProfileKernel(cplState, name, {inputTensor}, mpsStream);
@@ -1194,7 +1204,7 @@ void MetalShaderLibrary::exec_unary_kernel_raw(std::string_view name,
   @autoreleasepool {
     auto cplState = getPipelineStateForFunc(kernel_name);
     MPSStream* mpsStream = getCurrentMPSStream();
-    dispatch_sync(mpsStream->queue(), ^() {
+    dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
       auto computeEncoder = mpsStream->commandEncoder();
       getMPSProfiler().beginProfileKernel(cplState, kernel_name, /*isGraph=*/false, mpsStream);
       [computeEncoder setComputePipelineState:cplState];

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -1,4 +1,6 @@
 //  Copyright © 2022 Apple Inc.
+#include <cstdio>
+#include <cstdlib>
 #include <limits>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch_v2.h>
@@ -43,6 +45,12 @@
 #include <ATen/ops/nonzero_static_native.h>
 #include <ATen/ops/ones_like.h>
 #endif
+
+namespace at::mps {
+// DIAGNOSTIC hooks (defined in MPSStream.mm): name the faulting op under env MPS_FAULT_NAME_DIAG.
+void mpsSetCurrentOp(const char* name);
+bool mpsFaultNameDiag();
+} // namespace at::mps
 
 namespace at::native {
 namespace mps {
@@ -110,6 +118,76 @@ static void dispatch_index_kernel(TensorIteratorBase& iter,
     return;
   }
   const auto mpsStream = getCurrentMPSStream();
+  // DIAGNOSTIC (env IDX_SYNC): force all prior GPU work (incl. the index buffer's producer) to fully
+  // complete before this index kernel runs. If this makes the fault vanish, the bug is a read-before-write
+  // RACE on the bindless index buffer (missing hazard barrier), not a wrong/uninitialized buffer identity.
+  if (std::getenv("IDX_SYNC")) {
+    mpsStream->synchronize(SyncType::COMMIT_AND_WAIT);
+  }
+  if (at::mps::mpsFaultNameDiag()) {
+    // Dump ALL CPU-side metadata that feeds the kernel's offset math (no GPU sync): a garbage stride
+    // or size here produces a garbage input_offs even with valid index VALUES -> OOB read/write.
+    auto fmt = [](IntArrayRef a) {
+      std::string s = "[";
+      for (auto d : a) {
+        s += std::to_string(d) + ",";
+      }
+      return s + "]";
+    };
+    std::string meta = kernel_name + " ndim=" + std::to_string(iter.ndim()) + " numel=" + std::to_string(iter.numel()) +
+        " out.shape=" + fmt(iter.shape()) + " out.str=" + fmt(iter.strides(0)) + " in.str=" + fmt(iter.strides(1)) +
+        " idxtns.str=" + fmt(iter.strides(2)) + " index_size=" + fmt(index_size) +
+        " index_stride=" + fmt(index_stride) + " in.numel=" + std::to_string(iter.tensor_base(1).numel());
+    // Storage bytes of the indexed tensors + max byte offset the kernel can reach: if the max reach
+    // exceeds storage, the "valid" (idx < index_size) index still reads/writes OUT OF BOUNDS.
+    const int64_t out_bytes = static_cast<int64_t>(iter.tensor_base(0).storage().nbytes());
+    const int64_t in_bytes = static_cast<int64_t>(iter.tensor_base(1).storage().nbytes());
+    int64_t max_indexed = 0;
+    for (size_t k = 0; k < index_size.size(); k++) {
+      max_indexed += (index_size[k] - 1) * index_stride[k];
+    }
+    meta += " out.store_bytes=" + std::to_string(out_bytes) + " in.store_bytes=" + std::to_string(in_bytes) +
+        " max_indexed_byte=" + std::to_string(max_indexed);
+    // Account for storage_offset: the kernel indexes from data_ptr = storage_base + offset*elemsize,
+    // so the bytes actually available past data_ptr = store_bytes - offset*elemsize. A tight-fit access
+    // + a non-zero offset overruns the buffer.
+    const int64_t out_off_b = iter.tensor_base(0).storage_offset() * iter.tensor_base(0).element_size();
+    const int64_t in_off_b = iter.tensor_base(1).storage_offset() * iter.tensor_base(1).element_size();
+    meta += " out.off_bytes=" + std::to_string(out_off_b) + " in.off_bytes=" + std::to_string(in_off_b) +
+        " in.avail=" + std::to_string(in_bytes - in_off_b) + " out.avail=" + std::to_string(out_bytes - out_off_b);
+    fprintf(stderr, "IDXMETA: %s\n", meta.c_str());
+    fflush(stderr);
+    // Value check (copies index tensors to CPU; may sync): confirm index VALUES are in-bounds.
+    for (uint32_t k = 0; k < index_size.size(); k++) {
+      const auto& it = iter.tensor_base(k + 2);
+      try {
+        auto host = it.to(at::kCPU).contiguous();
+        const int64_t n = host.numel();
+        const int64_t* p = host.data_ptr<int64_t>();
+        int64_t mn = n ? p[0] : 0, mx = n ? p[0] : 0;
+        for (int64_t i = 1; i < n; i++) {
+          mn = p[i] < mn ? p[i] : mn;
+          mx = p[i] > mx ? p[i] : mx;
+        }
+        const int64_t dim = index_size[k];
+        const bool bad = (mx >= dim || mn < 0 || mn < -1000000 || mx > 1000000000);
+        fprintf(stderr,
+                "IDXVAL%s: %s idx#%u numel=%lld min=%lld max=%lld indexed_dim=%lld\n",
+                bad ? "_BAD" : "",
+                kernel_name.c_str(),
+                k,
+                static_cast<long long>(n),
+                static_cast<long long>(mn),
+                static_cast<long long>(mx),
+                static_cast<long long>(dim));
+        fflush(stderr);
+      } catch (const std::exception& e) {
+        fprintf(stderr, "IDXVAL_COPYFAIL: %s idx#%u : %s\n", kernel_name.c_str(), k, e.what());
+        fflush(stderr);
+      }
+    }
+    at::mps::mpsSetCurrentOp(kernel_name.c_str());
+  }
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     const int64_t num_indices = index_size.size();
     auto indexSelectPSO = lib.getPipelineStateForFunc(kernel_name);
@@ -390,6 +468,18 @@ static void nonzero_impl_mps(const Tensor& self, Tensor& out_, std::optional<int
     // Dynamic path: sync to learn output size. total_nonzero is int64, so the
     // count reads back directly even when it exceeds INT_MAX.
     const int64_t total_nonzero = total_nonzero_buf.item<int64_t>();
+    // DIAGNOSTIC (env NZ_DIAG): a real nonzero count can never exceed the input numel, so a count
+    // outside [0, numel] proves total_nonzero_buf was read garbage/uninitialized (the phase-3 hypothesis).
+    if (std::getenv("NZ_DIAG")) {
+      const int64_t nel = self.numel();
+      fprintf(stderr,
+              "NZ_COUNT: total_nonzero=%lld self.numel=%lld nDim=%lld%s\n",
+              static_cast<long long>(total_nonzero),
+              static_cast<long long>(nel),
+              static_cast<long long>(nDim),
+              (total_nonzero < 0 || total_nonzero > nel) ? "  <-- GARBAGE COUNT (> numel)" : "");
+      fflush(stderr);
+    }
     at::native::resize_output(out_, {total_nonzero, nDim});
     max_elements = total_nonzero;
   }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -13,6 +13,8 @@
 #include <c10/util/irange.h>
 #include <algorithm>
 #include <bit>
+#include <cstdio>
+#include <cstdlib>
 #include <numeric>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -584,6 +586,30 @@ static void min_max_out_mps(const Tensor& input_t,
   int64_t dims[1] = {dim_};
   auto iter = at::meta::make_reduction(input_t, output_t, IntArrayRef(dims, 1), keepdim, input_t.scalar_type());
   value_reduction_kernel_mps(iter, reduction_type == MPSReductionType::MIN ? "min_" : "max_");
+
+  // DIAGNOSTIC (env ARGMAX_DIAG): argmax indices MUST be in [0, input.size(dim)); anything outside proves
+  // the arg-reduction wrote garbage/uninitialized indices (a candidate producer of a bad index buffer).
+  if (std::getenv("ARGMAX_DIAG")) {
+    const int64_t dimsz = input_t.size(dim_);
+    auto h = indices_t.to(at::kCPU).contiguous();
+    const int64_t n = h.numel();
+    const int64_t* p = h.data_ptr<int64_t>();
+    int64_t mn = n ? p[0] : 0, mx = n ? p[0] : 0;
+    for (int64_t i = 1; i < n; i++) {
+      mn = p[i] < mn ? p[i] : mn;
+      mx = p[i] > mx ? p[i] : mx;
+    }
+    const bool bad = (mx >= dimsz || mn < 0);
+    fprintf(stderr,
+            "ARGMAX_%s: %s numel=%lld min=%lld max=%lld reduced_dim=%lld\n",
+            bad ? "BAD" : "OK",
+            func_name.c_str(),
+            static_cast<long long>(n),
+            static_cast<long long>(mn),
+            static_cast<long long>(mx),
+            static_cast<long long>(dimsz));
+    fflush(stderr);
+  }
 }
 
 // Min/Max with dim
@@ -639,6 +665,30 @@ static std::tuple<Tensor, Tensor> min_max_mps_impl(const Tensor& input_t,
   }
 
   min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, reduction_type, func_name);
+
+  // DIAGNOSTIC (env ARGMAX_DIAG): the argmax indices MUST be in [0, input.size(dim)); anything outside
+  // proves MPSGraph's arg-reduction wrote garbage/uninitialized indices (the producer of a bad index buffer).
+  if (std::getenv("ARGMAX_DIAG")) {
+    const int64_t dimsz = input_t.size(maybe_wrap_dim(dim, input_t.dim()));
+    auto h = indices_t.to(at::kCPU).contiguous();
+    const int64_t n = h.numel();
+    const int64_t* p = h.data_ptr<int64_t>();
+    int64_t mn = n ? p[0] : 0, mx = n ? p[0] : 0;
+    for (int64_t i = 1; i < n; i++) {
+      mn = p[i] < mn ? p[i] : mn;
+      mx = p[i] > mx ? p[i] : mx;
+    }
+    const bool bad = (mx >= dimsz || mn < 0);
+    fprintf(stderr,
+            "ARGMAX_%s: %s numel=%lld min=%lld max=%lld reduced_dim=%lld\n",
+            bad ? "BAD" : "OK",
+            func_name.c_str(),
+            static_cast<long long>(n),
+            static_cast<long long>(mn),
+            static_cast<long long>(mx),
+            static_cast<long long>(dimsz));
+    fflush(stderr);
+  }
 
   return std::tuple<Tensor, Tensor>{output_t, indices_t};
 }

--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -43,7 +43,7 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
   id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
   id<MTLComputePipelineState> renormPSO = lib.getPipelineStateForFunc(key);
 
-  dispatch_sync(mpsStream->queue(), ^() {
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       // this function call is a no-op if MPSProfiler is not enabled
       getMPSProfiler().beginProfileKernel(renormPSO, key, {norm}, mpsStream);

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -130,7 +130,7 @@ Tensor repeat_interleave_mps(const Tensor& repeat, std::optional<int64_t> output
   auto result = at::empty({total}, repeat.options());
 
   MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
+  at::mps::dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();
       auto pipelineState = lib.getPipelineStateForFunc(fmt::format("repeat_interleave_{}", scalar_type));


### PR DESCRIPTION
Adds env-gated diagnostics used to attribute an uninitialized-buffer / command-buffer-abort bug in Mask R-CNN backward on M2 Max: `MPS_FAULT_NAME_DIAG` names the op whose command buffer faulted, `FULL_SYNC` forces a per-op `COMMIT_AND_WAIT` to bisect execution-order hazards, `IDX_SYNC`/`IDXMETA`/`IDXVAL` dump indexing-kernel metadata and validate index bounds, and `ARGMAX_DIAG` validates argmax/argmin output is in-bounds. All probes are off by default, so deliverable behavior is unchanged.

One piece is always-on, not diagnostic: each root `MTLCommandBuffer` now gets a completion handler that records a fault even when `commitAndContinue` retires the root before `commitAndWait` can query it directly (this happens both in our own commit path and internally inside MPSGraph whenever `enableCommitAndContinue` is set), so a fault on a retired root is no longer silently lost.

Also completes the fault-surfacing PR's audit of `dispatch_sync` call sites that can now throw: fixed `RenormKernel.mm`, which reaches the throwing path via `torch.mps.profiler.profile(wait_until_completed=True)` regardless of the op's own sync type.

Test plan:

```
python test/test_mps.py -k "renorm or (eye and mps) or nonzero or argmax or argmin or index_select" -q
```

Also ran the full `TestConsistencyMPS` suite (5547 passed; 2 failures, both pre-existing and unrelated: the known `combinations` fp16 flake from issue #188985, and a bf16 `index_reduce`/`prod` tolerance flake that fails a different sample index on each run and passes reliably in isolation — GPU float nondeterminism at a tight 1% tolerance, not touched by this diff).