### PR TITLE
[MPS][docs] Document torch.compile graph-break/recompile fixes

### DIFF
--- a/docs/source/notes/mps.md
+++ b/docs/source/notes/mps.md
@@ -41,3 +41,61 @@ else:
     # Now every call runs on the GPU
     pred = model(x)
 ```
+
+## torch.compile on MPS
+
+Two Dynamo config flags come up often enough with MPS models that they are
+worth calling out here, even though neither is MPS-specific:
+
+* `capture_scalar_outputs`: without it, any `.item()` call on a GPU tensor
+  graph-breaks (`Reason: Unsupported: Tensor.item`), since not all backends
+  support tracing a scalar readout into the FX graph. Note this only fixes
+  that specific break -- if the scalar is then used in a data-dependent
+  `if`/`while`, tracing still breaks separately (`Reason: Data-dependent
+  jump`); see {ref}`the graph-break troubleshooting guide<torch.compiler_troubleshooting>`
+  for that case.
+* `allow_unspec_int_on_nn_module`: without it, an integer `nn.Module`
+  attribute that changes every call (a step counter incremented in
+  `forward`, for example) causes Dynamo to specialize on its exact value,
+  recompiling on every change. See
+  {ref}`dynamic_shapes_advanced_control_options` for the full set of related
+  static/dynamic control flags.
+
+```python
+import torch
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.step = 0
+
+    def forward(self, x):
+        self.step += 1
+        return x.sum().item() + self.step
+
+model = Model()
+x = torch.randn(4, device="mps")
+
+with torch._dynamo.config.patch(
+    capture_scalar_outputs=True,
+    allow_unspec_int_on_nn_module=True,
+):
+    compiled_model = torch.compile(model, backend="eager")
+    out = compiled_model(x)
+```
+
+To apply these for the whole process instead of a single call, set the
+attributes directly instead of using the context manager:
+
+```python
+import torch._dynamo as dynamo
+
+dynamo.config.capture_scalar_outputs = True
+dynamo.config.allow_unspec_int_on_nn_module = True
+```
+
+Both flags are also available, under the same names, through the newer
+backend-agnostic `torch.compiler.config` module
+(`torch.compiler.config.patch(...)`), which aliases the same underlying
+Dynamo settings. Prefer it for new code; `torch._dynamo.config.patch` remains
+supported and behaves identically for these two flags.


### PR DESCRIPTION
Two Dynamo config flags come up often enough with MPS models that they are worth documenting, even though neither is MPS-specific: `capture_scalar_outputs` (fixes the graph break from `.item()` calls, e.g. models like OPT) and `allow_unspec_int_on_nn_module` (fixes recompilation from an integer step counter on an nn.Module, e.g. Phi-4).

Docs-only, no wrapper API: matches this project's own documented convention of using `torch._dynamo.config.patch(...)` directly rather than a backend-specific wrapper. Shows both the classic `torch._dynamo.config.patch(...)` context manager and the newer `torch.compiler.config` equivalent, which aliases the same underlying Dynamo settings.

The example is a minimal runnable `nn.Module`, verified to actually compile and run under `torch.compile(backend="eager")` with both flags patched, on an MPS tensor.

Test plan:

Ran the example directly; compiles and runs under `torch.compile(backend="eager")` with both flags patched, on an MPS tensor.