### PR TITLE
[Metal][ops] Fix Event.elapsed_time() deadlock after Event.synchronize() (#162872)

### DIFF
--- a/aten/src/ATen/mps/MPSEvent.h
+++ b/aten/src/ATen/mps/MPSEvent.h
@@ -52,7 +52,7 @@ class MPSEvent {
   std::mutex m_cpu_sync_mutex{};
   std::condition_variable m_cpu_sync_cv{};
   // CondVar predicate to sync the events created on this Stream with CPU
-  bool m_cpu_sync_completed = false;
+  uint32_t m_cpu_sync_pending = 0;
   // used to compute elapsed time
   uint64_t m_completion_time = 0;
 

--- a/aten/src/ATen/mps/MPSEvent.mm
+++ b/aten/src/ATen/mps/MPSEvent.mm
@@ -102,14 +102,14 @@ bool MPSEvent::notify(bool needsLock, MTLSharedEventNotificationBlock block) {
 
 void MPSEvent::notifyCpuSync() {
   std::lock_guard<std::mutex> lock(m_cpu_sync_mutex);
-  m_cpu_sync_completed = true;
+  ++m_cpu_sync_pending;
   m_cpu_sync_cv.notify_one();
 }
 
 void MPSEvent::waitForCpuSync() {
   std::unique_lock<std::mutex> lock(m_cpu_sync_mutex);
-  m_cpu_sync_cv.wait(lock, [&] { return m_cpu_sync_completed; });
-  m_cpu_sync_completed = false;
+  m_cpu_sync_cv.wait(lock, [&] { return m_cpu_sync_pending > 0; });
+  --m_cpu_sync_pending;
 }
 
 bool MPSEvent::synchronize() {
@@ -139,7 +139,7 @@ void MPSEvent::reset(MPSStream* stream, bool enable_timing) {
   // reset record time
   m_completion_time = 0;
   m_enable_timing = enable_timing;
-  m_cpu_sync_completed = false;
+  m_cpu_sync_pending = 0;
 };
 
 //-----------------------------------------------------------------

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10555,6 +10555,45 @@ class TestMPS(TestCaseMPS):
             ref = torch.ops.aten._fused_rms_norm(x.float(), [N], w.float(), 1e-5)[0].to(dtype)
         self.assertEqual(y, ref, atol=0, rtol=0)
 
+    # https://github.com/pytorch/pytorch/issues/162872
+    def test_synchronize_then_elapsed_time(self):
+        start = torch.mps.Event(enable_timing=True)
+        end = torch.mps.Event(enable_timing=True)
+        start.record()
+        # Run a small op so start/end don't land on the same GPU timestamp
+        _ = torch.zeros(1024, device="mps") + 1
+        end.record()
+        end.synchronize()
+        t = start.elapsed_time(end)
+        self.assertGreaterEqual(t, 0.0)
+
+    def test_elapsed_time_without_synchronize(self):
+        start = torch.mps.Event(enable_timing=True)
+        end = torch.mps.Event(enable_timing=True)
+        start.record()
+        # Run a small op to give the GPU something to time
+        _ = torch.zeros(1024, device="mps") + 1
+        end.record()
+        t = start.elapsed_time(end)
+        self.assertGreaterEqual(t, 0.0)
+
+    def test_multiple_synchronize_then_elapsed_time(self):
+        start = torch.mps.Event(enable_timing=True)
+        end = torch.mps.Event(enable_timing=True)
+        start.record()
+        # Run a small op so start/end don't land on the same GPU timestamp
+        _ = torch.zeros(1024, device="mps") + 1
+        end.record()
+        start.synchronize()
+        end.synchronize()
+        t = start.elapsed_time(end)
+        self.assertGreaterEqual(t, 0.0)
+
+    def test_synchronize_idempotent(self):
+        e = torch.mps.Event(enable_timing=True)
+        e.record()
+        e.synchronize()
+        e.synchronize()
 
 # Conformance suite for the MPS binary TensorIterator dispatcher: two
 # synthetic kernels (simple_add for arithmetic, simple_ge for comparison)


### PR DESCRIPTION
Fixes #162872.

When `enable_timing=True`, `recordLocked()` registers a Metal listener callback that calls `notifyCpuSync()`. If `synchronize()` is called before GPU completion, it adds a second callback that also calls `notifyCpuSync()`. Both callbacks fire on GPU completion, but the boolean predicate `m_cpu_sync_completed` collapsed both signals into a single `true`: `synchronize()`'s `waitForCpuSync()` consumed it and reset it to `false`, leaving `elapsed_time()`'s `waitForCpuSync()` waiting forever.

Replaces the boolean with a `uint32_t` counter, so each `notifyCpuSync()` produces an independent pending token that `waitForCpuSync()` consumes exactly once, regardless of how many callers are waiting.

Prior art: #162874 fixed the same issue by deleting the `waitForCpuSync()` call entirely, putting the sync burden on the user; that PR went stale and was closed. This keeps the wait (so `elapsed_time()` still blocks until GPU completion as the API implies) and fixes the counting semantics instead.

Test plan:

```
python test/test_mps.py -v -k "elapsed_time or synchronize_idempotent"
```