### PR TITLE
[dynamo] Split FrozensetVariable off SetVariable to match CPython

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -970,6 +970,118 @@ class OrderedSetTests(_SetBase, _BaseSetTests):
         self.assertEqual(list(s), [0, 1, 2, 3])
 
 
+class FrozensetHierarchyTests(_BaseSetTests):
+    """frozenset must not be a subclass of set (CPython parity). Part of #192874."""
+
+    def test_frozenset_not_a_set_variable(self):
+        from torch._dynamo.variables.sets import (
+            BaseSetVariable,
+            FrozensetVariable,
+            SetVariable,
+        )
+
+        self.assertFalse(issubclass(FrozensetVariable, SetVariable))
+        self.assertTrue(issubclass(FrozensetVariable, BaseSetVariable))
+        self.assertTrue(issubclass(SetVariable, BaseSetVariable))
+        # Matches real CPython.
+        self.assertFalse(issubclass(frozenset, set))
+
+    def test_frozenset_has_no_mutating_methods(self):
+        # Before the VT split, FrozensetVariable inherited SetVariable's
+        # named methods via the tp_methods MRO-merge, so eight of the nine
+        # below were reachable on a traced frozenset even though real
+        # frozenset doesn't have them. `update` is the exception: it already
+        # returned early on `not self.is_mutable()`, so it degraded correctly.
+        for name, args in [
+            ("add", (1,)),
+            ("pop", ()),
+            ("remove", (1,)),
+            ("discard", (1,)),
+            ("clear", ()),
+            ("update", ({1},)),
+            ("intersection_update", ({1},)),
+            ("difference_update", ({1},)),
+            ("symmetric_difference_update", ({1},)),
+        ]:
+            with self.subTest(name=name):
+                self.assertFalse(hasattr(frozenset(), name))
+
+                @torch.compile(backend="eager", fullgraph=True)
+                def fn(fs, _name=name, _args=args):
+                    return getattr(fs, _name)(*_args)
+
+                with self.assertRaises(Unsupported):
+                    fn(frozenset({1, 2, 3}))
+
+    def test_frozenset_mutating_method_graph_breaks(self):
+        # With fullgraph=False a frozenset mutation must graph break and let
+        # eager raise the real AttributeError. Before the split it surfaced an
+        # internal "mutation_type is None for FrozensetVariable() in
+        # check_allowed_side_effect" AssertionError instead.
+        @torch.compile(backend="eager")
+        def fn(fs):
+            fs.add(1)
+            return fs
+
+        with self.assertRaises(AttributeError):
+            fn(frozenset({1, 2, 3}))
+
+    @make_dynamo_test
+    def test_frozenset_inplace_operators_rebind_not_mutate(self):
+        """Not a regression test: this also passes before the split.
+
+        Real frozenset defines no __ior__/__iand__/__ixor__/__isub__, so
+        `fs |= other` rebinds the name to a new frozenset built by __or__.
+        FrozensetVariable used to inherit SetVariable's nb_inplace_* handlers,
+        but binary_iop1 gates on the real CPython type's nb slot bits (see
+        object_protocol.binary_iop1) and frozenset sets none of them, so the
+        inherited handlers were never reachable. Kept as a guard that the
+        split does not change this.
+        """
+        fs = frozenset({1, 2, 3})
+        other = frozenset({3, 4, 5})
+
+        fs_or = fs
+        fs_or |= other
+        self.assertEqual(fs_or, frozenset({1, 2, 3, 4, 5}))
+
+        fs_and = fs
+        fs_and &= other
+        self.assertEqual(fs_and, frozenset({3}))
+
+        fs_xor = fs
+        fs_xor ^= other
+        self.assertEqual(fs_xor, frozenset({1, 2, 4, 5}))
+
+    @make_dynamo_test
+    def test_frozenset_readonly_ops_still_work(self):
+        fs = frozenset({1, 2, 3})
+        other = frozenset({3, 4, 5})
+        self.assertEqual(fs | other, frozenset({1, 2, 3, 4, 5}))
+        self.assertEqual(fs & other, frozenset({3}))
+        self.assertEqual(fs - other, frozenset({1, 2}))
+        self.assertEqual(fs ^ other, frozenset({1, 2, 4, 5}))
+        self.assertEqual(fs.union(other), frozenset({1, 2, 3, 4, 5}))
+        self.assertEqual(fs.intersection(other), frozenset({3}))
+        self.assertEqual(fs.difference(other), frozenset({1, 2}))
+        self.assertEqual(fs.symmetric_difference(other), frozenset({1, 2, 4, 5}))
+        self.assertTrue(fs.isdisjoint(frozenset({7, 8})))
+        self.assertTrue(frozenset({1, 2}).issubset(fs))
+        self.assertTrue(fs.issuperset(frozenset({1, 2})))
+        self.assertEqual(fs.copy(), fs)
+        self.assertEqual(len(fs), 3)
+        self.assertTrue(3 in fs)
+
+    @make_dynamo_test
+    def test_regular_set_mutations_unaffected(self):
+        # The mutable-set path must be completely unaffected by the split.
+        s = {1, 2, 3}
+        s.add(4)
+        s.discard(1)
+        s |= {10}
+        self.assertEqual(s, {2, 3, 4, 10})
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1309,7 +1309,7 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.ListVariable,
             variables.ListIteratorVariable,
             variables.RangeVariable,
-            variables.SetVariable,
+            variables.BaseSetVariable,
             variables.TensorVariable,
             variables.TupleVariable,
         )

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1309,7 +1309,8 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.ListVariable,
             variables.ListIteratorVariable,
             variables.RangeVariable,
-            variables.BaseSetVariable,
+            variables.SetVariable,
+            variables.FrozensetVariable,
             variables.TensorVariable,
             variables.TupleVariable,
         )

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -165,7 +165,6 @@ from .nn_module import (
 from .optimizer import OptimizerVariable
 from .sdpa import SDPAParamsVariable
 from .sets import (
-    BaseSetVariable,
     DictKeySetVariable,
     FrozensetVariable,
     OrderedSetClassVariable,
@@ -218,7 +217,6 @@ __all__ = [
     "BackwardHookVariable",
     "BaseBuiltinVariable",
     "BaseListVariable",
-    "BaseSetVariable",
     "CallMethodVariable",
     "BuiltinVariable",
     "CatchWarningsCtxManagerVariable",

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -165,6 +165,7 @@ from .nn_module import (
 from .optimizer import OptimizerVariable
 from .sdpa import SDPAParamsVariable
 from .sets import (
+    BaseSetVariable,
     DictKeySetVariable,
     FrozensetVariable,
     OrderedSetClassVariable,
@@ -217,6 +218,7 @@ __all__ = [
     "BackwardHookVariable",
     "BaseBuiltinVariable",
     "BaseListVariable",
+    "BaseSetVariable",
     "CallMethodVariable",
     "BuiltinVariable",
     "CatchWarningsCtxManagerVariable",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -142,7 +142,7 @@ from .object_protocol import (
     type_implements_sq_length,
     vt_identity_compare,
 )
-from .sets import FrozensetVariable, SetVariable
+from .sets import BaseSetVariable, FrozensetVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,
@@ -2434,7 +2434,9 @@ class BuiltinVariable(BaseBuiltinVariable):
         # Reuse existing HashableTracker keys from a set/frozenset/dict operand
         # instead of re-hashing, mirroring CPython's set_update_internal fast
         # path (do-not-rehash-dict-keys).
-        if isinstance(args[0], (variables.SetVariable, variables.ConstDictVariable)):
+        if isinstance(
+            args[0], (variables.BaseSetVariable, variables.ConstDictVariable)
+        ):
             items = list(args[0].items.keys())
         else:
             items = unpack_iterable(tx, args[0])
@@ -3196,7 +3198,7 @@ class BuiltinVariable(BaseBuiltinVariable):
         # Unwrap the underlying ConstDictVariable
         if isinstance(a, DictViewVariable):
             a = a.dv_dict
-        if isinstance(a, (ListVariable, ConstDictVariable, SetVariable)):
+        if isinstance(a, (ListVariable, ConstDictVariable, BaseSetVariable)):
             return VariableTracker.build(tx, len(a.items) == 0)
         if isinstance(a, UserDefinedObjectVariable):
             bool_result = self.call_bool(tx, a)
@@ -3369,7 +3371,7 @@ class DictBuiltinVariable(BaseBuiltinVariable):
         # re-wrapping (and thus re-hashing) the underlying VTs, mirroring
         # CPython's do-not-rehash-dict-keys behavior when building a dict from
         # an existing set/frozenset/dict.
-        if isinstance(arg, (variables.SetVariable, ConstDictVariable)):
+        if isinstance(arg, (variables.BaseSetVariable, ConstDictVariable)):
             # HashableTracker keys are accepted by ConstDictVariable.__init__.
             return _make_result(dict.fromkeys(arg.items.keys(), value))  # type: ignore[arg-type]
         if isinstance(arg, dict):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -142,7 +142,7 @@ from .object_protocol import (
     type_implements_sq_length,
     vt_identity_compare,
 )
-from .sets import BaseSetVariable, FrozensetVariable, SetVariable
+from .sets import FrozensetVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,
@@ -2435,7 +2435,12 @@ class BuiltinVariable(BaseBuiltinVariable):
         # instead of re-hashing, mirroring CPython's set_update_internal fast
         # path (do-not-rehash-dict-keys).
         if isinstance(
-            args[0], (variables.BaseSetVariable, variables.ConstDictVariable)
+            args[0],
+            (
+                variables.SetVariable,
+                variables.FrozensetVariable,
+                variables.ConstDictVariable,
+            ),
         ):
             items = list(args[0].items.keys())
         else:
@@ -3198,7 +3203,9 @@ class BuiltinVariable(BaseBuiltinVariable):
         # Unwrap the underlying ConstDictVariable
         if isinstance(a, DictViewVariable):
             a = a.dv_dict
-        if isinstance(a, (ListVariable, ConstDictVariable, BaseSetVariable)):
+        if isinstance(
+            a, (ListVariable, ConstDictVariable, SetVariable, FrozensetVariable)
+        ):
             return VariableTracker.build(tx, len(a.items) == 0)
         if isinstance(a, UserDefinedObjectVariable):
             bool_result = self.call_bool(tx, a)
@@ -3371,7 +3378,9 @@ class DictBuiltinVariable(BaseBuiltinVariable):
         # re-wrapping (and thus re-hashing) the underlying VTs, mirroring
         # CPython's do-not-rehash-dict-keys behavior when building a dict from
         # an existing set/frozenset/dict.
-        if isinstance(arg, (variables.BaseSetVariable, ConstDictVariable)):
+        if isinstance(
+            arg, (variables.SetVariable, variables.FrozensetVariable, ConstDictVariable)
+        ):
             # HashableTracker keys are accepted by ConstDictVariable.__init__.
             return _make_result(dict.fromkeys(arg.items.keys(), value))  # type: ignore[arg-type]
         if isinstance(arg, dict):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,7 +67,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import SetVariable
+from .sets import BaseSetVariable
 
 
 if TYPE_CHECKING:
@@ -249,7 +249,7 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
-    elif isinstance(var, SetVariable):
+    elif isinstance(var, BaseSetVariable):
         for key in var.items:
             mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
@@ -4352,7 +4352,7 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # TODO (tmanlaibaatar) support pytree here
         for arg in unpacked_sequence:
             if isinstance(
-                arg, (ListVariable, TupleVariable, ConstDictVariable, SetVariable)
+                arg, (ListVariable, TupleVariable, ConstDictVariable, BaseSetVariable)
             ):
                 unimplemented(
                     gb_type="strict_mode: improper args",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,7 +67,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import BaseSetVariable
+from .sets import FrozensetVariable, SetVariable
 
 
 if TYPE_CHECKING:
@@ -249,7 +249,7 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
-    elif isinstance(var, BaseSetVariable):
+    elif isinstance(var, (SetVariable, FrozensetVariable)):
         for key in var.items:
             mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
@@ -4352,7 +4352,14 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # TODO (tmanlaibaatar) support pytree here
         for arg in unpacked_sequence:
             if isinstance(
-                arg, (ListVariable, TupleVariable, ConstDictVariable, BaseSetVariable)
+                arg,
+                (
+                    ListVariable,
+                    TupleVariable,
+                    ConstDictVariable,
+                    SetVariable,
+                    FrozensetVariable,
+                ),
             ):
                 unimplemented(
                     gb_type="strict_mode: improper args",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -530,7 +530,7 @@ class BaseListVariable(VariableTracker):
         # CPython has a series of checks to optimize list.extend for different data types
         # ref: https://github.com/python/cpython/blob/0fd4fd4496c557b68477a99c1c231a5870c91daf/Objects/listobject.c#L1389-L1444
         from .dicts import ConstDictVariable
-        from .sets import BaseSetVariable
+        from .sets import FrozensetVariable, SetVariable
         from .user_defined import UserDefinedObjectVariable
 
         sz = len(self.items)
@@ -538,7 +538,7 @@ class BaseListVariable(VariableTracker):
             self.items.extend(args[0].items)
         elif isinstance(args[0], UserDefinedObjectVariable):
             self.items.extend(unpack_iterable(tx, args[0]))
-        elif isinstance(args[0], (ConstDictVariable, BaseSetVariable)):
+        elif isinstance(args[0], (ConstDictVariable, SetVariable, FrozensetVariable)):
             items = [item.vt for item in args[0].items]
             self.items.extend(items)
         elif isinstance(args[0], ConstantVariable):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -530,7 +530,7 @@ class BaseListVariable(VariableTracker):
         # CPython has a series of checks to optimize list.extend for different data types
         # ref: https://github.com/python/cpython/blob/0fd4fd4496c557b68477a99c1c231a5870c91daf/Objects/listobject.c#L1389-L1444
         from .dicts import ConstDictVariable
-        from .sets import SetVariable
+        from .sets import BaseSetVariable
         from .user_defined import UserDefinedObjectVariable
 
         sz = len(self.items)
@@ -538,7 +538,7 @@ class BaseListVariable(VariableTracker):
             self.items.extend(args[0].items)
         elif isinstance(args[0], UserDefinedObjectVariable):
             self.items.extend(unpack_iterable(tx, args[0]))
-        elif isinstance(args[0], (ConstDictVariable, SetVariable)):
+        elif isinstance(args[0], (ConstDictVariable, BaseSetVariable)):
             items = [item.vt for item in args[0].items]
             self.items.extend(items)
         elif isinstance(args[0], ConstantVariable):

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -85,14 +85,15 @@ def vt_identity_compare(
     from .dicts import ConstDictVariable
     from .lists import ListVariable
     from .misc import ExceptionVariable, TracebackVariable
-    from .sets import BaseSetVariable
+    from .sets import FrozensetVariable, SetVariable
 
     if isinstance(
         left,
         (
             ConstDictVariable,
             ListVariable,
-            BaseSetVariable,
+            SetVariable,
+            FrozensetVariable,
             TracebackVariable,
             ExceptionVariable,
         ),

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -85,14 +85,14 @@ def vt_identity_compare(
     from .dicts import ConstDictVariable
     from .lists import ListVariable
     from .misc import ExceptionVariable, TracebackVariable
-    from .sets import SetVariable
+    from .sets import BaseSetVariable
 
     if isinstance(
         left,
         (
             ConstDictVariable,
             ListVariable,
-            SetVariable,
+            BaseSetVariable,
             TracebackVariable,
             ExceptionVariable,
         ),

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -78,11 +78,17 @@ def set_copy(obj: VariableTracker) -> VariableTracker:
     )
 
 
-class SetVariable(VariableTracker):
-    """Represents a Python set during symbolic execution."""
+class BaseSetVariable(VariableTracker):
+    """Shared logic for the set-family VTs (set, frozenset, dict_keys, OrderedSet).
 
-    # PySet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2436
-    _cpython_type = set
+    In CPython these are siblings, not a subclass chain: frozenset is not a
+    subclass of set, and neither is dict_keys (see #192874). This base holds
+    every operation that is valid on an immutable set-like collection.
+    SetVariable (mutable Python ``set``) adds the mutating operations on top.
+    FrozensetVariable inherits only this base, so a traced frozenset is no
+    longer matched by isinstance checks against SetVariable. DictKeySetVariable
+    still derives from SetVariable; that row of #192874 is not addressed here.
+    """
 
     CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
     NOT_CONTAINS_GUARD = GuardBuilder.SET_NOT_CONTAINS
@@ -114,24 +120,13 @@ class SetVariable(VariableTracker):
                 hashable_items.append(HashableTracker(item.realize()))
         # Internal representation as dict allows for simple integration with
         # OrderedSet, notably polyfills. Using set moves complexity to OrderedSet
-        self.items = dict.fromkeys(hashable_items, SetVariable._default_value())
+        self.items = dict.fromkeys(hashable_items, BaseSetVariable._default_value())
         self.should_reconstruct_all = (
             not is_from_local_source(self.source) if self.source else True
         )
         self.original_items = dict.fromkeys(
-            hashable_items, SetVariable._default_value()
+            hashable_items, BaseSetVariable._default_value()
         )
-
-    def debug_repr(self) -> str:
-        if not self.items:
-            return "set()"
-        else:
-            items: list[str] = []
-            for v in self.items:
-                vt = v.vt if isinstance(v, HashableTracker) else v
-                val_str = _item_debug_repr(vt)
-                items.append(val_str)
-            return "{" + ", ".join(items) + "}"
 
     @property
     def set_items(self) -> set["HashableTracker"]:
@@ -145,28 +140,11 @@ class SetVariable(VariableTracker):
     def as_proxy(self) -> Any:
         return {k.vt.as_proxy() for k in self.set_items}
 
-    def python_type(self) -> type:
-        return set
-
     def is_python_constant(self) -> bool:
         # Avoid the base implementation, which probes as_python_constant() and
         # thus rebuilds a real set, re-hashing the elements (wrong for elements
         # with a side-effecting __hash__).  Check element constness directly.
         return all(k.vt.is_python_constant() for k in self.set_items)
-
-    def as_python_constant(self) -> Any:
-        return {k.vt.as_python_constant() for k in self.set_items}
-
-    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
-        # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
-        if not self.items:
-            return VariableTracker.build(tx, f"{self.python_type_name()}()")
-        items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
-        return VariableTracker.build(tx, "{" + items + "}")
-
-    def reconstruct(self, codegen: "PyCodegen") -> None:
-        codegen.foreach([x.vt for x in self.set_items])
-        codegen.append_output(create_instruction("BUILD_SET", arg=len(self.set_items)))
 
     def __contains__(self, vt: VariableTracker) -> bool:
         if not isinstance(vt, VariableTracker):
@@ -206,14 +184,6 @@ class SetVariable(VariableTracker):
         ):
             kwargs["source"] = None
         return super().clone(**kwargs)
-
-    def is_hashable(self) -> bool:
-        return False
-
-    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
-        from ..exc import raise_type_error
-
-        raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -271,7 +241,7 @@ class SetVariable(VariableTracker):
         # matching CPython's hash-at-insert behavior.
         from .dicts import ConstDictVariable
 
-        if isinstance(other, (SetVariable, ConstDictVariable)):
+        if isinstance(other, (BaseSetVariable, ConstDictVariable)):
             yield from other.items.keys()
             return
 
@@ -285,11 +255,11 @@ class SetVariable(VariableTracker):
         # protocol.
         from .dicts import ConstDictVariable
 
-        if isinstance(other, (SetVariable, ConstDictVariable)):
+        if isinstance(other, (BaseSetVariable, ConstDictVariable)):
             return list(other.items.keys())
         return [HashableTracker(x) for x in unpack_iterable(tx, other)]
 
-    def _new_set(self, items: "Iterable[HashableTracker]") -> "SetVariable":
+    def _new_set(self, items: "Iterable[HashableTracker]") -> "BaseSetVariable":
         # Build a fresh set of the same concrete type (set / frozenset /
         # OrderedSet). list() preserves insertion order, which matters for
         # OrderedSet.
@@ -330,40 +300,13 @@ class SetVariable(VariableTracker):
         # OrderedSet is excluded because as_python_constant() loses insertion
         # order (it routes through the unordered set_items).
         if (
-            not any(isinstance(a, (SetVariable, ConstDictVariable)) for a in args)
+            not any(isinstance(a, (BaseSetVariable, ConstDictVariable)) for a in args)
             and check_constant_args(args, kwargs)
             and self.python_type() in (set, frozenset)
         ):
             py_type = self.python_type()
             return self._fast_set_method(tx, getattr(py_type, name), args, kwargs)
         return None
-
-    def add(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        # Convert add to __setitem__ with None value
-        tx.output.side_effects.mutation(self)
-        self.items[HashableTracker(args[0])] = SetVariable._default_value()
-        return ConstantVariable.create(None)
-
-    def pop(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        # Choose an item at random and pop it
-        try:
-            result: VariableTracker = self.set_items.pop().vt  # type: ignore[assignment]
-        except KeyError as e:
-            raise_observed_exception(KeyError, tx, args=list(e.args))
-        self.should_reconstruct_all = True
-        tx.output.side_effects.mutation(self)
-        self.items.pop(HashableTracker(result))
-        return result
 
     def isdisjoint(
         self,
@@ -394,22 +337,6 @@ class SetVariable(VariableTracker):
             out_items = {k: v for k, v in out_items.items() if k in other_keys}
         return self._new_set(out_items)
 
-    def intersection_update(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        kept = dict(self.items)
-        for other in args:
-            other_keys = set(self._operand_keys(tx, other))
-            kept = {k: v for k, v in kept.items() if k in other_keys}
-        tx.output.side_effects.mutation(self)
-        self.should_reconstruct_all = True
-        self.items.clear()
-        self.items.update(kept)
-        return ConstantVariable.create(None)
-
     def union(
         self,
         tx: "InstructionTranslatorBase",
@@ -422,7 +349,7 @@ class SetVariable(VariableTracker):
         out_items = dict(self.items)
         for other in args:
             for key in self._operand_keys(tx, other):
-                out_items.setdefault(key, SetVariable._default_value())
+                out_items.setdefault(key, BaseSetVariable._default_value())
         return self._new_set(out_items)
 
     def difference(
@@ -440,6 +367,269 @@ class SetVariable(VariableTracker):
                 out_items.pop(key, None)
         return self._new_set(out_items)
 
+    def symmetric_difference(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        fast = self._try_fast_set_method(tx, "symmetric_difference", args, kwargs)
+        if fast is not None:
+            return fast
+        other = dict.fromkeys(
+            self._operand_keys(tx, args[0]), BaseSetVariable._default_value()
+        )
+        out_items = {k: v for k, v in self.items.items() if k not in other}
+        out_items.update({k: v for k, v in other.items() if k not in self.items})
+        return self._new_set(out_items)
+
+    def _ordering_test(self, tx, args, op):
+        from .builder import SourcelessBuilder
+
+        other = args[0].realize()
+        if not istype(other, SetVariable):
+            other = SourcelessBuilder.create(tx, set).call_function(tx, [other], {})
+        return SourcelessBuilder.create(tx, op).call_function(tx, [self, other], {})
+
+    def issubset(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self._ordering_test(tx, args, operator.le)
+
+    def issuperset(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self._ordering_test(tx, args, operator.ge)
+
+    def copy(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return set_copy(self)
+
+    def getitem_const(
+        self, tx: "InstructionTranslatorBase", arg: VariableTracker
+    ) -> VariableTracker:
+        raise RuntimeError("Illegal to getitem on a set")
+
+    def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        from .iter import SetIterator
+
+        if self.source and not is_constant_source(self.source):
+            tx.output.guard_on_key_order.add(self.source)
+        return SetIterator(self.items)
+
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1318-L1338
+        self_, other_ = (other, self) if reverse else (self, other)
+
+        if not pyanyset_check(self_) or not pyanyset_check(other_):
+            return ConstantVariable.create(NotImplemented)
+
+        result = set_copy(self_)
+        if self_ is other_:
+            return result
+        result.items.update(other_.items)  # type: ignore[missing-attribute]
+        return result
+
+    def nb_subtract_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L1801-L1812
+        self_, other_ = (other, self) if reverse else (self, other)
+
+        if not pyanyset_check(self_) or not pyanyset_check(other_):
+            return ConstantVariable.create(NotImplemented)
+
+        result = set_copy(self_)
+        for k in list(other_.items.keys()):  # type: ignore[missing-attribute]
+            result.items.pop(k, None)  # type: ignore[missing-attribute]
+        return result
+
+    def nb_and_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1506-L1518 (set_and)
+        self_, other_ = (other, self) if reverse else (self, other)
+
+        if not pyanyset_check(self_) or not pyanyset_check(other_):
+            return ConstantVariable.create(NotImplemented)
+
+        return self_.call_method(tx, "intersection", [other_], {})
+
+    def nb_xor_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1984-L1990 (set_xor)
+        self_, other_ = (other, self) if reverse else (self, other)
+
+        if not pyanyset_check(self_) or not pyanyset_check(other_):
+            return ConstantVariable.create(NotImplemented)
+
+        return self_.call_method(tx, "symmetric_difference", [other_], {})
+
+    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        return VariableTracker.build(tx, len(self.set_items))
+
+    def tp_richcompare_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        op: str,
+    ) -> VariableTracker:
+        """set_richcompare: subset/superset comparisons for all 6 ops.
+
+        https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L2097
+        CPython uses PyAnySet_Check: only accepts set/frozenset (not dict views).
+        """
+        if not isinstance(other, BaseSetVariable):
+            try:
+                other_type = other.python_type()
+            except NotImplementedError:
+                return ConstantVariable.create(NotImplemented)
+            if not issubclass(other_type, (set, frozenset)):
+                return ConstantVariable.create(NotImplemented)
+
+        # Accessing set_items directly is correct: CPython's set_richcompare
+        # operates on the internal C struct (PySet_GET_SIZE, set_next,
+        # set_contains_entry) -- it never calls __len__ or __contains__.
+        # https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L2093-L2130
+        self_items = self.set_items
+        other_items = other.set_items  # type: ignore[attr-defined]
+        if op == "__eq__":
+            # len check + issubset: same length and subset implies equality.
+            if len(self_items) != len(other_items):
+                return ConstantVariable.create(False)
+            return VariableTracker.build(tx, self_items <= other_items)
+        elif op == "__ne__":
+            if len(self_items) != len(other_items):
+                return ConstantVariable.create(True)
+            return VariableTracker.build(tx, not (self_items <= other_items))
+        else:
+            return VariableTracker.build(
+                tx,
+                cmp_name_to_op_mapping[op](self_items, other_items),
+            )
+
+    tp_methods = {
+        "isdisjoint": Method(isdisjoint),
+        "intersection": Method(intersection),
+        "union": Method(union),
+        "difference": Method(difference),
+        "symmetric_difference": Method(symmetric_difference),
+        "issubset": Method(issubset),
+        "issuperset": Method(issuperset),
+        "copy": Method(copy),
+    }
+
+
+class SetVariable(BaseSetVariable):
+    """Represents a Python set during symbolic execution."""
+
+    # PySet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2436
+    _cpython_type = set
+
+    def debug_repr(self) -> str:
+        if not self.items:
+            return "set()"
+        else:
+            items: list[str] = []
+            for v in self.items:
+                vt = v.vt if isinstance(v, HashableTracker) else v
+                val_str = _item_debug_repr(vt)
+                items.append(val_str)
+            return "{" + ", ".join(items) + "}"
+
+    def python_type(self) -> type:
+        return set
+
+    def as_python_constant(self) -> Any:
+        return {k.vt.as_python_constant() for k in self.set_items}
+
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+        # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
+        if not self.items:
+            return VariableTracker.build(tx, f"{self.python_type_name()}()")
+        items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
+        return VariableTracker.build(tx, "{" + items + "}")
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen.foreach([x.vt for x in self.set_items])
+        codegen.append_output(create_instruction("BUILD_SET", arg=len(self.set_items)))
+
+    def is_hashable(self) -> bool:
+        return False
+
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
+        from ..exc import raise_type_error
+
+        raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
+
+    def add(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # Convert add to __setitem__ with None value
+        tx.output.side_effects.mutation(self)
+        self.items[HashableTracker(args[0])] = BaseSetVariable._default_value()
+        return ConstantVariable.create(None)
+
+    def pop(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # Choose an item at random and pop it
+        try:
+            result: VariableTracker = self.set_items.pop().vt  # type: ignore[assignment]
+        except KeyError as e:
+            raise_observed_exception(KeyError, tx, args=list(e.args))
+        self.should_reconstruct_all = True
+        tx.output.side_effects.mutation(self)
+        self.items.pop(HashableTracker(result))
+        return result
+
+    def intersection_update(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        kept = dict(self.items)
+        for other in args:
+            other_keys = set(self._operand_keys(tx, other))
+            kept = {k: v for k, v in kept.items() if k in other_keys}
+        tx.output.side_effects.mutation(self)
+        self.should_reconstruct_all = True
+        self.items.clear()
+        self.items.update(kept)
+        return ConstantVariable.create(None)
+
     def difference_update(
         self,
         tx: "InstructionTranslatorBase",
@@ -453,22 +643,6 @@ class SetVariable(VariableTracker):
                 self.items.pop(key, None)
         return ConstantVariable.create(None)
 
-    def symmetric_difference(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        fast = self._try_fast_set_method(tx, "symmetric_difference", args, kwargs)
-        if fast is not None:
-            return fast
-        other = dict.fromkeys(
-            self._operand_keys(tx, args[0]), SetVariable._default_value()
-        )
-        out_items = {k: v for k, v in self.items.items() if k not in other}
-        out_items.update({k: v for k, v in other.items() if k not in self.items})
-        return self._new_set(out_items)
-
     def symmetric_difference_update(
         self,
         tx: "InstructionTranslatorBase",
@@ -476,7 +650,7 @@ class SetVariable(VariableTracker):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         other = dict.fromkeys(
-            self._operand_keys(tx, args[0]), SetVariable._default_value()
+            self._operand_keys(tx, args[0]), BaseSetVariable._default_value()
         )
         new_items = {k: v for k, v in self.items.items() if k not in other}
         new_items.update({k: v for k, v in other.items() if k not in self.items})
@@ -497,7 +671,7 @@ class SetVariable(VariableTracker):
         tx.output.side_effects.mutation(self)
         for other in args:
             for key in self._operand_keys(tx, other):
-                self.items.setdefault(key, SetVariable._default_value())
+                self.items.setdefault(key, BaseSetVariable._default_value())
         return ConstantVariable.create(None)
 
     def remove(
@@ -533,38 +707,6 @@ class SetVariable(VariableTracker):
             self.items.pop(HashableTracker(key))
         return ConstantVariable.create(None)
 
-    def _ordering_test(self, tx, args, op):
-        from .builder import SourcelessBuilder
-
-        other = args[0].realize()
-        if not istype(other, SetVariable):
-            other = SourcelessBuilder.create(tx, set).call_function(tx, [other], {})
-        return SourcelessBuilder.create(tx, op).call_function(tx, [self, other], {})
-
-    def issubset(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        return self._ordering_test(tx, args, operator.le)
-
-    def issuperset(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        return self._ordering_test(tx, args, operator.ge)
-
-    def copy(
-        self,
-        tx: "InstructionTranslatorBase",
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        return set_copy(self)
-
     def clear(
         self,
         tx: "InstructionTranslatorBase",
@@ -575,31 +717,6 @@ class SetVariable(VariableTracker):
         tx.output.side_effects.mutation(self)
         self.items.clear()
         return ConstantVariable.create(None)
-
-    tp_methods = {
-        "add": Method(add),
-        "pop": Method(pop),
-        "isdisjoint": Method(isdisjoint),
-        "intersection": Method(intersection),
-        "intersection_update": Method(intersection_update),
-        "union": Method(union),
-        "difference": Method(difference),
-        "difference_update": Method(difference_update),
-        "symmetric_difference": Method(symmetric_difference),
-        "symmetric_difference_update": Method(symmetric_difference_update),
-        "update": Method(update),
-        "remove": Method(remove),
-        "discard": Method(discard),
-        "issubset": Method(issubset),
-        "issuperset": Method(issuperset),
-        "copy": Method(copy),
-        "clear": Method(clear),
-    }
-
-    def getitem_const(
-        self, tx: "InstructionTranslatorBase", arg: VariableTracker
-    ) -> VariableTracker:
-        raise RuntimeError("Illegal to getitem on a set")
 
     def tp_init_impl(
         self,
@@ -615,31 +732,6 @@ class SetVariable(VariableTracker):
         self.items.update(temp_set_vt.items)  # type: ignore[attr-defined]
         return ConstantVariable.create(None)
 
-    def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        from .iter import SetIterator
-
-        if self.source and not is_constant_source(self.source):
-            tx.output.guard_on_key_order.add(self.source)
-        return SetIterator(self.items)
-
-    def nb_or_impl(
-        self,
-        tx: "InstructionTranslatorBase",
-        other: VariableTracker,
-        reverse: bool = False,
-    ) -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1318-L1338
-        self_, other_ = (other, self) if reverse else (self, other)
-
-        if not pyanyset_check(self_) or not pyanyset_check(other_):
-            return ConstantVariable.create(NotImplemented)
-
-        result = set_copy(self_)
-        if self_ is other_:
-            return result
-        result.items.update(other_.items)  # type: ignore[missing-attribute]
-        return result
-
     def nb_inplace_or_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker
     ) -> VariableTracker:
@@ -650,23 +742,6 @@ class SetVariable(VariableTracker):
         tx.output.side_effects.mutation(self)
         self.items.update(other.items)  # type: ignore[missing-attribute]
         return self
-
-    def nb_subtract_impl(
-        self,
-        tx: "InstructionTranslatorBase",
-        other: VariableTracker,
-        reverse: bool = False,
-    ) -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L1801-L1812
-        self_, other_ = (other, self) if reverse else (self, other)
-
-        if not pyanyset_check(self_) or not pyanyset_check(other_):
-            return ConstantVariable.create(NotImplemented)
-
-        result = set_copy(self_)
-        for k in list(other_.items.keys()):  # type: ignore[missing-attribute]
-            result.items.pop(k, None)  # type: ignore[missing-attribute]
-        return result
 
     def nb_inplace_subtract_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker
@@ -680,20 +755,6 @@ class SetVariable(VariableTracker):
             self.items.pop(k, None)
         return self
 
-    def nb_and_impl(
-        self,
-        tx: "InstructionTranslatorBase",
-        other: VariableTracker,
-        reverse: bool = False,
-    ) -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1506-L1518 (set_and)
-        self_, other_ = (other, self) if reverse else (self, other)
-
-        if not pyanyset_check(self_) or not pyanyset_check(other_):
-            return ConstantVariable.create(NotImplemented)
-
-        return self_.call_method(tx, "intersection", [other_], {})
-
     def nb_inplace_and_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker
     ) -> VariableTracker:
@@ -703,20 +764,6 @@ class SetVariable(VariableTracker):
 
         self.call_method(tx, "intersection_update", [other], {})
         return self
-
-    def nb_xor_impl(
-        self,
-        tx: "InstructionTranslatorBase",
-        other: VariableTracker,
-        reverse: bool = False,
-    ) -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L1984-L1990 (set_xor)
-        self_, other_ = (other, self) if reverse else (self, other)
-
-        if not pyanyset_check(self_) or not pyanyset_check(other_):
-            return ConstantVariable.create(NotImplemented)
-
-        return self_.call_method(tx, "symmetric_difference", [other_], {})
 
     def nb_inplace_xor_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker
@@ -728,48 +775,17 @@ class SetVariable(VariableTracker):
         self.call_method(tx, "symmetric_difference_update", [other], {})
         return self
 
-    def sq_length_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        return VariableTracker.build(tx, len(self.set_items))
-
-    def tp_richcompare_impl(
-        self,
-        tx: "InstructionTranslatorBase",
-        other: VariableTracker,
-        op: str,
-    ) -> VariableTracker:
-        """set_richcompare: subset/superset comparisons for all 6 ops.
-
-        https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L2097
-        CPython uses PyAnySet_Check: only accepts set/frozenset (not dict views).
-        """
-        if not isinstance(other, SetVariable):
-            try:
-                other_type = other.python_type()
-            except NotImplementedError:
-                return ConstantVariable.create(NotImplemented)
-            if not issubclass(other_type, (set, frozenset)):
-                return ConstantVariable.create(NotImplemented)
-
-        # Accessing set_items directly is correct: CPython's set_richcompare
-        # operates on the internal C struct (PySet_GET_SIZE, set_next,
-        # set_contains_entry) -- it never calls __len__ or __contains__.
-        # https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L2093-L2130
-        self_items = self.set_items
-        other_items = other.set_items  # type: ignore[attr-defined]
-        if op == "__eq__":
-            # len check + issubset: same length and subset implies equality.
-            if len(self_items) != len(other_items):
-                return ConstantVariable.create(False)
-            return VariableTracker.build(tx, self_items <= other_items)
-        elif op == "__ne__":
-            if len(self_items) != len(other_items):
-                return ConstantVariable.create(True)
-            return VariableTracker.build(tx, not (self_items <= other_items))
-        else:
-            return VariableTracker.build(
-                tx,
-                cmp_name_to_op_mapping[op](self_items, other_items),
-            )
+    tp_methods = {
+        "add": Method(add),
+        "pop": Method(pop),
+        "intersection_update": Method(intersection_update),
+        "difference_update": Method(difference_update),
+        "symmetric_difference_update": Method(symmetric_difference_update),
+        "update": Method(update),
+        "remove": Method(remove),
+        "discard": Method(discard),
+        "clear": Method(clear),
+    }
 
 
 class OrderedSetClassVariable(VariableTracker):
@@ -918,11 +934,9 @@ class OrderedSetVariable(SetVariable):
         return self
 
 
-class FrozensetVariable(SetVariable):
+class FrozensetVariable(BaseSetVariable):
     # PyFrozenSet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2526
     _cpython_type = frozenset
-
-    nb_inplace_subtract_impl = None  # type: ignore[bad-override]
 
     def debug_repr(self) -> str:
         if not self.items:
@@ -933,10 +947,6 @@ class FrozensetVariable(SetVariable):
                 key_str = _item_debug_repr(k.vt)
                 items.append(key_str)
             return "frozenset({" + ", ".join(items) + "})"
-
-    @property
-    def set_items(self) -> set["HashableTracker"]:
-        return set(self.items.keys())
 
     def python_type(self) -> type:
         return frozenset
@@ -975,7 +985,7 @@ class FrozensetVariable(SetVariable):
     ) -> VariableTracker:
         if type(self) is FrozensetVariable:
             return self
-        return SetVariable.copy(self, tx, args, kwargs)
+        return BaseSetVariable.copy(self, tx, args, kwargs)
 
     def difference(
         self,
@@ -983,7 +993,7 @@ class FrozensetVariable(SetVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        r = SetVariable.difference(self, tx, args, kwargs)
+        r = BaseSetVariable.difference(self, tx, args, kwargs)
         return FrozensetVariable(r.items)  # type: ignore[attr-defined]
 
     def intersection(
@@ -992,7 +1002,7 @@ class FrozensetVariable(SetVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        r = SetVariable.intersection(self, tx, args, kwargs)
+        r = BaseSetVariable.intersection(self, tx, args, kwargs)
         return FrozensetVariable(r.items)  # type: ignore[attr-defined]
 
     def symmetric_difference(
@@ -1001,7 +1011,7 @@ class FrozensetVariable(SetVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        r = SetVariable.symmetric_difference(self, tx, args, kwargs)
+        r = BaseSetVariable.symmetric_difference(self, tx, args, kwargs)
         return FrozensetVariable(r.items)  # type: ignore[attr-defined]
 
     tp_methods = {
@@ -1024,7 +1034,7 @@ class FrozensetVariable(SetVariable):
         return True
 
     def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
-        # Overrides SetVariable.hash_impl (which raises TypeError for mutable sets).
+        # frozenset is hashable, unlike set (SetVariable.hash_impl raises TypeError).
         # CPython frozenset_hash: https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L769
         from .hashable import RawHash
         from .object_protocol import generic_hash_impl

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -127,7 +127,7 @@ from .object_protocol import (
     type_disallows_instantiation,
     type_implements_nb_slot,
 )
-from .sets import SetVariable
+from .sets import FrozensetVariable, SetVariable
 
 
 try:
@@ -5010,7 +5010,10 @@ class UserDefinedSetVariable(UserDefinedObjectVariable):
     """
 
     def __init__(
-        self, value: object, set_vt: SetVariable | None = None, **kwargs: Any
+        self,
+        value: object,
+        set_vt: SetVariable | FrozensetVariable | None = None,
+        **kwargs: Any,
     ) -> None:
         from .builder import SourcelessBuilder
 


### PR DESCRIPTION
## Issue

Part of #192874, the `FrozensetVariable(SetVariable)` row. That tracker lists eight rows, so this does not close it.

## Summary

Under `torch.compile`, calling a mutating `set` method on a `frozenset` raised an internal assertion instead of the `AttributeError` CPython raises:

```python
import torch

def f(fs):
    fs.add(4)          # frozenset has no .add
    return fs

torch.compile(f, backend="eager")(frozenset({1, 2, 3}))
```

Before, with `fullgraph=False`, where a graph break was expected:

```
AssertionError: mutation_type is None for FrozensetVariable() in check_allowed_side_effect
```

After, with `fullgraph=False`, matching eager:

```
AttributeError: 'frozenset' object has no attribute 'add'
```

After, with `fullgraph=True`, an ordinary unsupported-call error:

```
Unsupported method call
  Explanation: Dynamo does not know how to trace method `add` of class `frozenset`
```

The same applied to `pop`, `remove`, `discard`, `clear`, `intersection_update`, `difference_update` and `symmetric_difference_update`. `update` is the exception: it already returned early on `not self.is_mutable()`, so it degraded correctly before this change.

Cause: `FrozensetVariable` subclassed `SetVariable`, so it picked up all nine mutating entries of `SetVariable.tp_methods` through the tp_methods MRO merge. In CPython `frozenset` and `set` are siblings, not parent and child.

## Fix

A new `BaseSetVariable(VariableTracker)` holds the shared read-only surface: the eight read-only `tp_methods` (`isdisjoint`, `intersection`, `union`, `difference`, `symmetric_difference`, `issubset`, `issuperset`, `copy`), the `nb_or_impl` / `nb_and_impl` / `nb_xor_impl` / `nb_subtract_impl` slots, and the storage, guard and iteration helpers. `SetVariable(BaseSetVariable)` keeps the nine mutating `tp_methods` and the `nb_inplace_*` slots, so `FrozensetVariable(BaseSetVariable)` can reach neither group.

Eight `SetVariable` references outside `sets.py` that used to match frozensets transitively are widened to `BaseSetVariable`: seven `isinstance` checks (`builtin.py` x3, `higher_order_ops.py` x2, `lists.py`, `object_protocol.py`) and the `_unpack_fast_types()` tuple in `utils.py`. `BaseSetVariable` is exported from `variables/__init__.py`.

Two `isinstance(..., SetVariable)` checks are deliberately left alone, because the split makes them more accurate: `SET_ADD` and `SET_UPDATE` in `symbolic_convert.py` assert their accumulator is a mutable set, and the `const_dict_or_set_mutation` replay handler in `side_effects.py` emits `update` and `clear`, neither of which exists on a frozenset. `OrderedSetClassVariable.call_method` also stops routing unbound `OrderedSet.union(some_frozenset, ...)` calls into the frozenset tracker, which matches eager, where that raises.

### Why a base class

The split follows a line CPython already draws. `frozenset` and `set` are both `collections.abc.Set`, only `set` is a `MutableSet`, and `set(dir(MutableSet)) - set(dir(Set))` is exactly `{add, clear, discard, pop, remove, __ior__, __iand__, __isub__, __ixor__}`. That is the group `SetVariable` keeps, so `BaseSetVariable` is `Set` and `SetVariable` is `MutableSet`. (`update` and the three `*_update` methods have no ABC counterpart, but they are mutators too, so they stay on `SetVariable`.) Happy to rename it `AbstractSetVariable` if that reads better.

It also avoids a large copy. If `FrozensetVariable` inherited `VariableTracker` directly, it would have to duplicate 31 methods and 2 class constants, 355 lines, out of `SetVariable`: everything now in `BaseSetVariable` that `FrozensetVariable` does not already shadow (it shadows only five, `copy`, `intersection`, `difference`, `symmetric_difference` and `tp_methods`).

`BaseListVariable`, `BaseUserFunctionVariable` and `BaseBuiltinVariable` are used the same way in the same package, and #193261 takes the same approach (`BaseListIteratorVariable`) for the deque iterator row.

`DictKeySetVariable` and `OrderedSetVariable` still subclass `SetVariable`. They are separate rows of #192874 and out of scope here.

## Test plan

New `FrozensetHierarchyTests` in `test/dynamo/test_sets.py`, 6 tests. Run against the same test file with only `torch` swapped:

```
patched     Ran 6 tests, OK
unpatched   Ran 6 tests, FAILED (failures=9, errors=1)
```

Being precise about what that demonstrates, since not all six are regression coverage:

- `test_frozenset_has_no_mutating_methods` sub-tests all nine mutators under `fullgraph=True`. Eight fail unpatched: `add`, `pop`, `remove`, `discard`, `clear`, `intersection_update`, `difference_update`, `symmetric_difference_update`. The `update` sub-test passes unpatched, per the early return noted above.
- `test_frozenset_mutating_method_graph_breaks` covers `fullgraph=False` and fails unpatched with the `mutation_type is None` assertion above. This is the user-visible bug.
- `test_frozenset_not_a_set_variable` is a structural assertion, not behaviour. It errors unpatched with `ImportError: cannot import name 'BaseSetVariable'`, so it guards against the classes being merged again rather than proving a fix.
- The remaining three pass both before and after and are non-regression guards: `test_frozenset_inplace_operators_rebind_not_mutate`, `test_frozenset_readonly_ops_still_work`, `test_regular_set_mutations_unaffected`.

Suites run locally, all against the patched tree:

```
test/dynamo/test_sets.py              Ran 196 tests, OK (skipped=1)
test/dynamo/test_functions.py         Ran 531 tests, OK (skipped=9, expected failures=2)
test/dynamo/test_dicts.py             Ran 323 tests, OK (expected failures=1)
test/dynamo/test_higher_order_ops.py  Ran 224 tests, OK (skipped=17, expected failures=1)
test/dynamo/test_repros.py            Ran 388 tests, OK (skipped=19, expected failures=4)
test/dynamo/test_misc.py              Ran 822 tests, FAILED (failures=1, errors=1, skipped=13, expected failures=4)
```

The two `test_misc.py` problems are environmental and pre-existing on this machine: `test_pybind11_enum_conversion` needs `ninja`, which is not installed, and `test_debugmode_respects_custom_op_aliasing_env_override` spawns a subprocess that imports the unbuilt source tree from the working directory (it passes when run from another directory). Neither traceback contains a `set`, `frozenset` or `SetVariable` frame.

These ran on a nightly CPU wheel, `2.15.0.dev20260812+cpu`, with the repository sources overlaid (the `tools/nightly.py` workflow in CONTRIBUTING.md) rather than a from-source build. The change is pure Python with no C++ coupling, so the modified code is the code under test, but I have run no CUDA or distributed suites locally and am relying on CI for those.

Lint, at the versions the repo pins:

```
lintrunner 0.12.7 --take RUFF,PYFMT,NEWLINE,SPACES,CODESPELL,FLAKE8,TYPEIGNORE,NOQA,TABS
  ok No lint issues.
ruff 0.14.4  All checks passed! / 8 files already formatted
```

`pyrefly 0.58.0` reports 131 pre-existing errors on these files, all `missing-attribute` or `missing-module-attribute` against `torch._C` symbols, caused by the build-generated stubs being absent from a non-source checkout. None falls on a line this change adds, checked by intersecting the reported error locations with the added lines; `sets.py` reports zero. I did not run a pre-change `pyrefly` baseline, so that is an attribution check rather than a differential one.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable, no expected perf impact)

## BC-breaking?

No for user-visible behaviour. An internal assertion that used to escape becomes either the `AttributeError` CPython raises or, under `fullgraph=True`, an ordinary unsupported-call error. For out-of-tree code touching Dynamo internals, `isinstance(x, SetVariable)` no longer matches a frozenset tracker and needs `BaseSetVariable`.

Related: #192867 (draft) also edits `torch/_dynamo/variables/sets.py`. Happy to rebase onto whichever lands first.

Authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98