### PR TITLE
[ROCm] Enable CK SDPA on gfx1200/gfx1201 (RDNA4)

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -198,19 +198,19 @@ file(GLOB flash_attention_hip_hip CONFIGURE_DEPENDS "native/transformers/hip/fla
 if(USE_FLASH_ATTENTION)
   # Now building CK by default
   if(USE_ROCM)
-    # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs
-    # are in PYTORCH_ROCM_ARCH; otherwise the ck_sdpa target ends up with an
-    # empty HIP_ARCHITECTURES and CMake errors out.
+    # CK SDPA supports gfx942/gfx950 (CDNA, MFMA) and gfx1200/gfx1201 (RDNA4, WMMA).
+    # Auto-disable when none of those archs are in PYTORCH_ROCM_ARCH; otherwise the
+    # ck_sdpa target ends up with an empty HIP_ARCHITECTURES and CMake errors out.
     if(USE_ROCM_CK_SDPA)
       set(_have_ck_sdpa_arch FALSE)
-      foreach(ARCH gfx942 gfx950)
+      foreach(ARCH gfx942 gfx950 gfx1200 gfx1201)
         if("${ARCH}" IN_LIST PYTORCH_ROCM_ARCH)
           set(_have_ck_sdpa_arch TRUE)
           break()
         endif()
       endforeach()
       if(NOT _have_ck_sdpa_arch)
-        message(STATUS "USE_ROCM_CK_SDPA disabled: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) has no MI3xx arch (gfx942/gfx950)")
+        message(STATUS "USE_ROCM_CK_SDPA disabled: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) has no CK SDPA arch (gfx942/gfx950/gfx1200/gfx1201)")
         caffe2_update_option(USE_ROCM_CK_SDPA OFF)
       endif()
     endif()
@@ -298,10 +298,11 @@ if(USE_FLASH_ATTENTION)
 
     set_source_files_properties(${ck_sdpa_sources_hip} PROPERTIES LANGUAGE HIP)
 
-    # Only build for MI3xx series architectures as building for all targets takes too long
+    # Only build for the architectures we generate CK SDPA instances for, as
+    # building for all targets takes too long.
     # We will selectively add supported architectures when/if needed
     set(_ck_sdpa_hip_arches "")
-    foreach(ARCH gfx942 gfx950)
+    foreach(ARCH gfx942 gfx950 gfx1200 gfx1201)
       if("${ARCH}" IN_LIST PYTORCH_ROCM_ARCH)
         list(APPEND _ck_sdpa_hip_arches ${ARCH})
       endif()

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -578,7 +578,7 @@ bool Context::ckSDPASupported() {
 #ifdef USE_ROCM
   // CK SDPA is only built for a subset of architectures to limit compile time.
   static const std::vector<std::string> supported_archs = {
-      "gfx942", "gfx950",
+      "gfx942", "gfx950", "gfx1200", "gfx1201",
   };
   for (auto index : c10::irange(detail::getCUDAHooks().deviceCount())) {
     if (!detail::getCUDAHooks().isGPUArch(supported_archs, index)) {

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
@@ -5,9 +5,30 @@
 set(CK_FMHA_GENERATE python3 ${CMAKE_CURRENT_LIST_DIR}/generate_compat.py
     ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py)
 
+# Ask the CK codegen for the architecture families matching PYTORCH_ROCM_ARCH.
+# Without --targets the generator falls back to its own default ("gfx9,gfx950"),
+# so no instances are emitted for RDNA4 even when PYTORCH_ROCM_ARCH asks for it.
+set(_ck_fmha_targets "")
+if("gfx942" IN_LIST PYTORCH_ROCM_ARCH)
+  list(APPEND _ck_fmha_targets gfx9)
+endif()
+if("gfx950" IN_LIST PYTORCH_ROCM_ARCH)
+  list(APPEND _ck_fmha_targets gfx950)
+endif()
+if("gfx1200" IN_LIST PYTORCH_ROCM_ARCH OR "gfx1201" IN_LIST PYTORCH_ROCM_ARCH)
+  list(APPEND _ck_fmha_targets gfx12)
+endif()
+if(NOT _ck_fmha_targets)
+  # Should not happen: aten/src/ATen/CMakeLists.txt disables USE_ROCM_CK_SDPA first.
+  message(FATAL_ERROR "CK Tile FMHA: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) maps to no CK codegen target")
+endif()
+list(JOIN _ck_fmha_targets "," _ck_fmha_targets_arg)
+message(STATUS "CK Tile FMHA codegen targets: ${_ck_fmha_targets_arg}")
+set(CK_FMHA_TARGETS --targets ${_ck_fmha_targets_arg})
+
 # generate a list of kernels, but not actually emit files at config stage
 execute_process(
-  COMMAND ${CK_FMHA_GENERATE} --optdim=32,64,128,256
+  COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --optdim=32,64,128,256
   --api fwd --receipt 4 --filter "*_lse*ntrload*nsink*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -17,7 +38,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND ${CK_FMHA_GENERATE} --optdim=32,64,128,256
+  COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --optdim=32,64,128,256
   --api fwd_splitkv --receipt 4 --filter "*psdv*_lse*_nsquant*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -27,7 +48,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND ${CK_FMHA_GENERATE} --optdim=32,64,128,256
+  COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --optdim=32,64,128,256
   --api fwd_appendkv --receipt 4 --filter "*psskddv_*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -37,7 +58,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND ${CK_FMHA_GENERATE}
+  COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS}
   --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -47,28 +68,28 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 # Generate the files for both fwd, fwd_splitkv, fwd_appendkv, and bwd
-execute_process(COMMAND ${CK_FMHA_GENERATE} --api fwd  --optdim=32,64,128,256 --receipt 4 --filter "*_lse*ntrload*nsink*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --api fwd  --optdim=32,64,128,256 --receipt 4 --filter "*_lse*ntrload*nsink*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
   message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD kernels.")
 endif()
 
-execute_process(COMMAND ${CK_FMHA_GENERATE} --api fwd_splitkv --optdim=32,64,128,256 --receipt 4 --filter "*psdv*_lse*_nsquant*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --api fwd_splitkv --optdim=32,64,128,256 --receipt 4 --filter "*psdv*_lse*_nsquant*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_SPLITKV kernels.")
 endif()
 
-execute_process(COMMAND ${CK_FMHA_GENERATE} --api fwd_appendkv --optdim=32,64,128,256 --receipt 4 --filter "*psskddv_*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --api fwd_appendkv --optdim=32,64,128,256 --receipt 4 --filter "*psskddv_*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_APPENDKV kernels.")
 endif()
 
-execute_process(COMMAND ${CK_FMHA_GENERATE} --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND ${CK_FMHA_GENERATE} ${CK_FMHA_TARGETS} --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
   RESULT_VARIABLE ret
 )
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/launch_kernel_pt.hpp
@@ -14,7 +14,8 @@ __launch_bounds__(Kernel::kBlockSize, MinBlockPerCu)
 #endif
     __global__ void kentry_pt(Args... args)
 {
-#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
+#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || \
+     defined(__gfx1200__) || defined(__gfx1201__))
     Kernel{}(args...);
 #else
     CUDA_KERNEL_ASSERT(false && "Fatal! Attempting to call a CK SDPA kernel on unsupported hardware");
@@ -27,7 +28,8 @@ __launch_bounds__(Kernel::kBlockSize, MinBlockPerCu)
 #endif
     __global__ void kentry_pt(Args... args)
 {
-#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
+#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || \
+     defined(__gfx1200__) || defined(__gfx1201__))
     Kernel{}(args...);
 #else
     CUDA_KERNEL_ASSERT(false && "Fatal! Attempting to call a CK SDPA kernel on unsupported hardware");


### PR DESCRIPTION
Related to #188113. Draft: this enables CK SDPA on RDNA4 and is verified on one gfx1201 device,
but it needs CDNA CI and a multi-arch build check before it should be considered for merge (see
"What is missing" below).

## Why

CK SDPA is unavailable on gfx1200/gfx1201 for several independent reasons, at different stages of
the build:

| Stage | Location | What blocks gfx12 |
|---|---|---|
| configure | `aten/src/ATen/CMakeLists.txt` | `USE_ROCM_CK_SDPA` is force-disabled unless `PYTORCH_ROCM_ARCH` contains gfx942/gfx950 |
| codegen | `aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt` | none of the 8 generator invocations passes `--targets`, so `generate.py` uses its default `gfx9,gfx950` and emits no gfx12-tagged instance |
| compile | `aten/src/ATen/CMakeLists.txt` | the `ck_sdpa` target's `HIP_ARCHITECTURES` |
| runtime selection | `aten/src/ATen/Context.cpp` `ckSDPASupported()` | `supported_archs` |
| kernel launch | `.../flash_attn/ck/launch_kernel_pt.hpp` (2 sites) | `kentry_pt`'s arch allowlist, which asserts otherwise |

The codegen gate is the one that is invisible from Python: `_is_ck_sdpa_available()` is
`ckSDPASupported() && hasCKSDPA()` and never looks at the generated instances, so opening only the
allowlists would produce a build that reports CK as available while containing no gfx12 kernels.

## What this does

Derives the CK codegen target families from `PYTORCH_ROCM_ARCH` (gfx942 → `gfx9`, gfx950 →
`gfx950`, gfx1200/gfx1201 → `gfx12`) and passes them to all 8 generator invocations; adds
gfx1200/gfx1201 to the four architecture lists. Existing architectures keep their entries and their
codegen targets, so the intent is additive.

**No change under `third_party/composable_kernel`.** `ck_tile` already carries gfx1200/gfx1201
target ids, a gfx12 WMMA implementation, and a `gfx12` `ArchTrait` in the FMHA codegen; the
instances simply were never requested.

## Verification

Radeon RX 9070 XT (gfx1201, 16 GB), x86_64, `rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.9.1`
(AMD clang 22.0.0git, `roc-7.2.4`). Scripts and raw logs:
https://gist.github.com/doplxyz/e6dfd202ac48b30520405546860a9193

**Codegen** — with PyTorch's own `--receipt 4` and filter strings, `--targets gfx12` yields
fwd 321 / fwd_splitkv 17 / fwd_appendkv 41 / bwd 225 instances. No API comes back empty. Names
carry `w16x16x16` (WMMA) where gfx9 carries `w32x32x16`; disassembling a forward and a backward
instance for gfx1201 gives 80 `v_wmma` and 0 `v_mfma` each.

**Build** — `ninja ck_sdpa` with `PYTORCH_ROCM_ARCH=gfx1201`: 610 TUs, 0 errors, 30 minutes on 12
CPU cores. Full `libtorch_hip.so` afterwards: 0 errors.

**Dispatch** — `F.scaled_dot_product_attention` on raw Q/K/V (fp16, `(2,4,256,64)`, non-causal)
under `AMD_LOG_LEVEL=3`:

```
ShaderName : void ck_tile::kentry_pt<ck_tile::gfx12_t, 3, ck_tile::FmhaFwdKernel<
    ck_tile::BlockFmhaPipelineQRKSVS<ck_tile::BlockFmhaPipelineProblem<_Float16, ...
```

The same call with `preferred_rocm_fa_library("aotriton")` gives `ShaderName : attn_fwd`.

**Correctness** — 42 forward cases (head_dim ∈ {32,64,128} × seqlen ∈ {64,256,1024} ×
causal/non-causal × fp16/bf16, plus a non-square and a non-power-of-two shape per dtype) against a
float64 `SDPBackend.MATH` reference: fp16 max relative error 2.4e-4 – 6.0e-4, bf16 2.0e-3 – 5.8e-3.
Unsupported configurations are rejected with an exception rather than crashing. Backward completes
with finite gradients (smoke test only; not compared against a reference yet).

Two cases, `s_q=127, s_kv=129, is_causal=True`, are rejected under forced CK *and* forced AOTriton
by `check_flash_causal_non_square_seqlens`
(`aten/src/ATen/native/transformers/hip/sdp_utils.cpp:629`), a backend-independent check applied
before dispatch — not gfx12 behaviour.

**Forward timing vs forced AOTriton** — CUDA events, 5 interleaved repeats of 50 iterations,
median (observed range). Below 1.00 means CK is faster.

| shape (b,h,s,d) | fp16 | bf16 |
|---|---|---|
| (2,8,512,64) | 0.95x | 0.99x |
| (2,8,1024,64) | 0.87x | 0.75x |
| (2,8,2048,64) | 0.67x | 0.71x |
| (1,16,4096,64) | 0.71x | 0.75x |
| (2,8,1024,128) | 0.64x | 0.75x |
| (1,8,2048,128) | 0.65x | 0.76x |

The two smallest results overlap in range and should not be read as an improvement; from seqlen
1024 upward the ranges are disjoint. Absolute medians are in the gist.

## What is missing before this is ready

- **CDNA regression.** I have no gfx942/gfx950 hardware. The change is meant to be additive, but
  that needs ROCm CI to confirm — please advise which workflows to request.
- **Multi-arch build** such as `PYTORCH_ROCM_ARCH="gfx942;gfx1201"`. `CK_USE_XDL` / `CK_USE_GFX94`
  are target-wide compile definitions today; for a gfx1201-only build they are harmless (gfx12
  instances compile identically with and without them), but a mixed build may need them per-arch.
- **gfx1200** is untested — it is enabled here by symmetry with gfx1201.
- **Split-KV / append-KV** instances are generated and compiled but not exercised at runtime.
- **Backward correctness** against a reference.
- **Tests.** Happy to add coverage under `test/test_transformers.py`; tell me the shape you want
  (an availability check on gfx12, a CK-vs-math numerical test, or both) and whether it should be
  gated on `is_ck_sdpa_available()`.
- **`PYTORCH_ROCM_ARCH` normalisation.** The mapping does not yet handle `:xnack+`-style suffixes
  or `native`.

One design question, since it decides the shape of the patch: should the CK codegen family list be
derived from `PYTORCH_ROCM_ARCH` as done here, or stay a hand-maintained list of supported CK
families in CMake?

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @drisspg @alugorey
