### PR TITLE
[Testcase Refactoring][ao][sparsity] Add GENERIC hw_classification to test_scheduler.py

### DIFF
--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -4,7 +4,11 @@ import warnings
 
 from torch import nn
 from torch.ao.pruning import BaseScheduler, CubicSL, LambdaSL, WeightNormSparsifier
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ImplementedScheduler(BaseScheduler):
@@ -16,6 +20,8 @@ class ImplementedScheduler(BaseScheduler):
 
 
 class TestScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_constructor(self):
         model = nn.Sequential(nn.Linear(16, 16))
         sparsifier = WeightNormSparsifier()
@@ -98,6 +104,8 @@ class TestScheduler(TestCase):
 
 
 class TestCubicScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.model_sparse_config = [


### PR DESCRIPTION
## Summary

This PR marks `test/ao/sparsity/test_scheduler.py` as device-agnostic by adding
`hw_classification = HardwareClassification.GENERIC` to `TestScheduler` and
`TestCubicScheduler`, aligning with the community device-adaptation spec and
enabling hardware-agnostic test filtering.

### Why no decoupling is needed

`test_scheduler.py` contains only pure-CPU sparsifier-scheduler logic with **no
accelerator-specific code**. Per the decoupling standard, a test case only needs
decoupling if it has any of the following — none apply here:

| Check | Result |
|---|---|
| Hardcoded `"cuda"` string / device instance | ❌ None |
| CUDA-only decorators (`@onlyCUDA`, `@skipCUDAIf`, ...) | ❌ None |
| Ops/tensors pinned to CUDA device | ❌ None (no tensors created) |
| CUDA-only device branches | ❌ None |
| `instantiate_device_type_tests` / device dispatch | ❌ None |

All test methods exercise the sparsifier scheduler's step arithmetic on
`nn.Linear` models, entirely on CPU. No decoupling is therefore required.

### Changes

- Add `HardwareClassification` to the `common_utils` import
- `TestScheduler.hw_classification = HardwareClassification.GENERIC`
- `TestCubicScheduler.hw_classification = HardwareClassification.GENERIC`

No test methods, test count, or execution semantics are changed.

## Test Plan

- CPU: `python test/test_ao_sparsity.py -k ao.sparsity.test_scheduler -v`
  ```
  Ran 6 tests in 0.626s
  OK
  ```
- CUDA: covered by the Pull Request CI (same command, 6 tests)
- `pytest --collect-only`:
Running 6 items in this shard
test/ao/sparsity/test_scheduler.py::TestScheduler::test_constructor
test/ao/sparsity/test_scheduler.py::TestScheduler::test_lambda_scheduler
test/ao/sparsity/test_scheduler.py::TestScheduler::test_order_of_steps
test/ao/sparsity/test_scheduler.py::TestScheduler::test_step
test/ao/sparsity/test_scheduler.py::TestCubicScheduler::test_constructor
test/ao/sparsity/test_scheduler.py::TestCubicScheduler::test_step

6 tests collected in 0.54s