### PR TITLE
[TEST] Refactor stateless and subclass tests with hw_classification

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,10 +9,7 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -47,38 +44,38 @@ class MockTiedModule(torch.nn.Module):
         return self.l1(x) + self.tied_bias + self.buffer + self.tied_buffer
 
 
-def _run_call_with_mock_module(test, module, functional_call, device='cpu', prefix=''):
-    x = torch.rand((1, 1), device=device)
-    weight = torch.tensor([[1.0]], device=device)
-    bias = torch.tensor([0.0], device=device)
-    buffer = torch.tensor([0.0], device=device)
-    if prefix != '':
-        parameters = {f'{prefix}.l1.weight': weight,
-                      f'{prefix}.l1.bias': bias,
-                      f'{prefix}.buffer': buffer}
-    else:
-        parameters = {'l1.weight': weight,
-                      'l1.bias': bias,
-                      'buffer': buffer}
-    to_check = module
-    if prefix != '':
-        to_check = getattr(module, prefix)
-    prev_weight = to_check.l1.weight.clone()
-    prev_buffer = to_check.buffer.clone()
-    # the parameters represent an identity function contrary to the
-    # existing params in module. So here we expect the result to be the
-    # same as the input if the weight swapping went well.
-    res = functional_call(module, parameters, x)
-    test.assertEqual(x, res)
-    # check that the weight remain unmodified
-    cur_weight = to_check.l1.weight
-    cur_buffer = to_check.buffer
-    test.assertEqual(cur_weight, prev_weight)
-    test.assertEqual(cur_buffer, prev_buffer)
-
-
 class TestStatelessFunctionalAPI(TestCase):
     hw_classification = HardwareClassification.GENERIC
+
+    def _run_call_with_mock_module(self, module, functional_call, device='cpu', prefix=''):
+
+        x = torch.rand((1, 1)).to(device)
+        weight = torch.tensor([[1.0]], device=device)
+        bias = torch.tensor([0.0], device=device)
+        buffer = torch.tensor([0.0], device=device)
+        if prefix != '':
+            parameters = {f'{prefix}.l1.weight': weight,
+                          f'{prefix}.l1.bias': bias,
+                          f'{prefix}.buffer': buffer}
+        else:
+            parameters = {'l1.weight': weight,
+                          'l1.bias': bias,
+                          'buffer': buffer}
+        to_check = module
+        if prefix != '':
+            to_check = getattr(module, prefix)
+        prev_weight = to_check.l1.weight.clone()
+        prev_buffer = to_check.buffer.clone()
+        # the parameters represent an identity function contrary to the
+        # existing params in module. So here we expect the result to be the
+        # same as the input if the weight swapping went well.
+        res = functional_call(module, parameters, x)
+        self.assertEqual(x, res)
+        # check that the weight remain unmodified
+        cur_weight = to_check.l1.weight
+        cur_buffer = to_check.buffer
+        self.assertEqual(cur_weight, prev_weight)
+        self.assertEqual(cur_buffer, prev_buffer)
 
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
@@ -109,7 +106,7 @@ class TestStatelessFunctionalAPI(TestCase):
     ])
     def test_functional_call(self, functional_call):
         module = MockModule()
-        _run_call_with_mock_module(self, module, functional_call)
+        self._run_call_with_mock_module(module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -122,14 +119,14 @@ class TestStatelessFunctionalAPI(TestCase):
             RuntimeError,
             r'used with Jitted modules'
         ):
-            _run_call_with_mock_module(self, jit_module, functional_call)
+            self._run_call_with_mock_module(jit_module, functional_call)
         x = torch.rand((1, 1))
         traced_module = torch.jit.trace(module, x)
         with self.assertRaisesRegex(
             RuntimeError,
             r'used with Jitted modules'
         ):
-            _run_call_with_mock_module(self, traced_module, functional_call)
+            self._run_call_with_mock_module(traced_module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -860,8 +857,8 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertTrue(all(t1 is t2 for t1, t2 in zip(buffers, (module.buffer,))))
 
 
-class TestStatelessFunctionalAPIDevice(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
+class TestStatelessFunctionalAPICUDASpecific(TestStatelessFunctionalAPI):
+    hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
     @unittest.skip("This doesn't work right now")
@@ -870,18 +867,19 @@ class TestStatelessFunctionalAPIDevice(TestCase):
         subtest(stateless.functional_call, "stateless")
     ])
     def test_functional_call_with_data_parallel(self, device, functional_call):
-        module = MockModule().to(device)
+        module = MockModule()
+        module.to(device)
         dp_module = torch.nn.DataParallel(module, [0, 1])
-        _run_call_with_mock_module(self, dp_module, functional_call, device=device, prefix='module')
+        self._run_call_with_mock_module(dp_module, functional_call, device=device, prefix='module')
 
-    @onlyAccelerator
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multiple accelerator devices not available')
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
     ])
     def test_functional_call_with_data_parallel_error(self, device, functional_call):
-        module = MockModule().to(device)
+        module = MockModule()
+        module.to(device)
         dp_module = torch.nn.DataParallel(module, [0, 1])
         with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
             functional_call(
@@ -941,7 +939,11 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
-instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestStatelessFunctionalAPICUDASpecific,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -9,7 +9,10 @@ import unittest
 
 import torch
 import torch.nn.utils.stateless as stateless
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -44,38 +47,38 @@ class MockTiedModule(torch.nn.Module):
         return self.l1(x) + self.tied_bias + self.buffer + self.tied_buffer
 
 
+def _run_call_with_mock_module(test, module, functional_call, device='cpu', prefix=''):
+    x = torch.rand((1, 1), device=device)
+    weight = torch.tensor([[1.0]], device=device)
+    bias = torch.tensor([0.0], device=device)
+    buffer = torch.tensor([0.0], device=device)
+    if prefix != '':
+        parameters = {f'{prefix}.l1.weight': weight,
+                      f'{prefix}.l1.bias': bias,
+                      f'{prefix}.buffer': buffer}
+    else:
+        parameters = {'l1.weight': weight,
+                      'l1.bias': bias,
+                      'buffer': buffer}
+    to_check = module
+    if prefix != '':
+        to_check = getattr(module, prefix)
+    prev_weight = to_check.l1.weight.clone()
+    prev_buffer = to_check.buffer.clone()
+    # the parameters represent an identity function contrary to the
+    # existing params in module. So here we expect the result to be the
+    # same as the input if the weight swapping went well.
+    res = functional_call(module, parameters, x)
+    test.assertEqual(x, res)
+    # check that the weight remain unmodified
+    cur_weight = to_check.l1.weight
+    cur_buffer = to_check.buffer
+    test.assertEqual(cur_weight, prev_weight)
+    test.assertEqual(cur_buffer, prev_buffer)
+
+
 class TestStatelessFunctionalAPI(TestCase):
     hw_classification = HardwareClassification.GENERIC
-
-    def _run_call_with_mock_module(self, module, functional_call, device='cpu', prefix=''):
-
-        x = torch.rand((1, 1)).to(device)
-        weight = torch.tensor([[1.0]], device=device)
-        bias = torch.tensor([0.0], device=device)
-        buffer = torch.tensor([0.0], device=device)
-        if prefix != '':
-            parameters = {f'{prefix}.l1.weight': weight,
-                          f'{prefix}.l1.bias': bias,
-                          f'{prefix}.buffer': buffer}
-        else:
-            parameters = {'l1.weight': weight,
-                          'l1.bias': bias,
-                          'buffer': buffer}
-        to_check = module
-        if prefix != '':
-            to_check = getattr(module, prefix)
-        prev_weight = to_check.l1.weight.clone()
-        prev_buffer = to_check.buffer.clone()
-        # the parameters represent an identity function contrary to the
-        # existing params in module. So here we expect the result to be the
-        # same as the input if the weight swapping went well.
-        res = functional_call(module, parameters, x)
-        self.assertEqual(x, res)
-        # check that the weight remain unmodified
-        cur_weight = to_check.l1.weight
-        cur_buffer = to_check.buffer
-        self.assertEqual(cur_weight, prev_weight)
-        self.assertEqual(cur_buffer, prev_buffer)
 
     @contextlib.contextmanager
     def _ensure_module_unchanged(self, module, message):
@@ -106,7 +109,7 @@ class TestStatelessFunctionalAPI(TestCase):
     ])
     def test_functional_call(self, functional_call):
         module = MockModule()
-        self._run_call_with_mock_module(module, functional_call)
+        _run_call_with_mock_module(self, module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -119,14 +122,14 @@ class TestStatelessFunctionalAPI(TestCase):
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(jit_module, functional_call)
+            _run_call_with_mock_module(self, jit_module, functional_call)
         x = torch.rand((1, 1))
         traced_module = torch.jit.trace(module, x)
         with self.assertRaisesRegex(
             RuntimeError,
             r'used with Jitted modules'
         ):
-            self._run_call_with_mock_module(traced_module, functional_call)
+            _run_call_with_mock_module(self, traced_module, functional_call)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -857,8 +860,8 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertTrue(all(t1 is t2 for t1, t2 in zip(buffers, (module.buffer,))))
 
 
-class TestStatelessFunctionalAPICUDASpecific(TestStatelessFunctionalAPI):
-    hw_classification = HardwareClassification.CUDA
+class TestStatelessFunctionalAPIDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
     @unittest.skip("This doesn't work right now")
@@ -867,19 +870,18 @@ class TestStatelessFunctionalAPICUDASpecific(TestStatelessFunctionalAPI):
         subtest(stateless.functional_call, "stateless")
     ])
     def test_functional_call_with_data_parallel(self, device, functional_call):
-        module = MockModule()
-        module.to(device)
+        module = MockModule().to(device)
         dp_module = torch.nn.DataParallel(module, [0, 1])
-        self._run_call_with_mock_module(dp_module, functional_call, device=device, prefix='module')
+        _run_call_with_mock_module(self, dp_module, functional_call, device=device, prefix='module')
 
-    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multi-GPU not supported')
+    @onlyAccelerator
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, 'multiple accelerator devices not available')
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
         subtest(stateless.functional_call, "stateless")
     ])
     def test_functional_call_with_data_parallel_error(self, device, functional_call):
-        module = MockModule()
-        module.to(device)
+        module = MockModule().to(device)
         dp_module = torch.nn.DataParallel(module, [0, 1])
         with self.assertRaisesRegex(RuntimeError, r'used with nn.DataParallel module'):
             functional_call(
@@ -939,11 +941,7 @@ class TestPythonOptimizeMode(TestCase):
 instantiate_parametrized_tests(
     TestStatelessFunctionalAPI,
 )
-instantiate_device_type_tests(
-    TestStatelessFunctionalAPICUDASpecific,
-    globals(),
-    only_for=("cuda",),
-)
+instantiate_device_type_tests(TestStatelessFunctionalAPIDevice, globals(), allow_xpu=True)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_dtype import floating_types_and
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     parametrize,
     run_tests,
     subtest,
@@ -37,6 +38,8 @@ int_bits = {dt: torch.iinfo(dt).bits for dt in all_int_dtypes}
 
 
 class TestStatelessRNGKey(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_basic_shape_and_dtype(self, device):
         key = random.key(42, device=device)
         self.assertEqual(key.shape, (2,))
@@ -61,6 +64,8 @@ class TestStatelessRNGKey(TestCase):
 
 
 class TestStatelessRNGKeySplit(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_basic_shape_and_dtype(self, device):
         key = random.key(42, device=device)
         splits = random.split(key, 4)
@@ -185,6 +190,8 @@ class TestStatelessRNGKeySplit(TestCase):
 
 
 class TestStatelessRNGKeyFoldIn(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_basic_shape_and_dtype(self, device):
         key = random.key(42, device=device)
         result = random.fold_in(key, 7)
@@ -373,6 +380,8 @@ class TestStatelessRNGKeyFoldIn(TestCase):
 
 
 class TestStatelessRNGDistribution(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _gen(self, gen_fn_name, *args, **kwargs):
         return getattr(random, gen_fn_name)(*args, **kwargs)
 
@@ -675,6 +684,8 @@ class TestStatelessRNGDistribution(TestCase):
 
 
 class TestStatelessRNGCompile(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_split_fullgraph(self, device):
         key = random.key(42, device=device)
 

--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -840,6 +840,8 @@ class TestStatelessRNGCompile(TestCase):
 
 
 class TestStatelessRNGInteger(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize("dtype", all_int_dtypes)
     def test_basic_shape_and_dtype(self, device, dtype):
         key = random.key(42, device=device)
@@ -1166,22 +1168,12 @@ class TestStatelessRNGInteger(TestCase):
         )
 
 
-instantiate_device_type_tests(TestStatelessRNGKey, globals(), only_for=("cpu", "cuda"))
-instantiate_device_type_tests(
-    TestStatelessRNGKeySplit, globals(), only_for=("cpu", "cuda")
-)
-instantiate_device_type_tests(
-    TestStatelessRNGKeyFoldIn, globals(), only_for=("cpu", "cuda")
-)
-instantiate_device_type_tests(
-    TestStatelessRNGDistribution, globals(), only_for=("cpu", "cuda")
-)
-instantiate_device_type_tests(
-    TestStatelessRNGCompile, globals(), only_for=("cpu", "cuda")
-)
-instantiate_device_type_tests(
-    TestStatelessRNGInteger, globals(), only_for=("cpu", "cuda")
-)
+instantiate_device_type_tests(TestStatelessRNGKey, globals())
+instantiate_device_type_tests(TestStatelessRNGKeySplit, globals())
+instantiate_device_type_tests(TestStatelessRNGKeyFoldIn, globals())
+instantiate_device_type_tests(TestStatelessRNGDistribution, globals())
+instantiate_device_type_tests(TestStatelessRNGCompile, globals())
+instantiate_device_type_tests(TestStatelessRNGInteger, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_subclass.py
+++ b/test/test_subclass.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_subclass import (
     subclass_db,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     instantiate_parametrized_tests,
     parametrize,
@@ -39,6 +40,8 @@ parametrize_tensor_cls = parametrize("tensor_cls", [
 
 
 class TestSubclass(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_tensor(self, tensor_cls):
         return subclass_db[tensor_cls].create_fn(3)
 


### PR DESCRIPTION
## Summary

Apply hardware classification to stateless and subclass tests following #186918 guidelines.

**`test/test_subclass.py`**
- **TestSubclass**: `GENERIC` (CPU-only subclass framework/API tests)

**`test/test_stateless_rng.py`**
- **TestStatelessRNGKey**, **TestStatelessRNGKeySplit**, **TestStatelessRNGKeyFoldIn**, **TestStatelessRNGDistribution**, **TestStatelessRNGCompile**: `ACCELERATOR` (device-parametrized via `instantiate_device_type_tests` with cpu/cuda)


## Test plan

```

python -c "import ast; ast.parse(open('test/test_subclass.py').read()); print('OK')"
python -c "import ast; ast.parse(open('test/test_stateless_rng.py').read()); print('OK')"

python test/test_subclass.py --hw-classification GENERIC -v
python test/test_stateless_rng.py --hw-classification ACCELERATOR -v
```

Authored with an AI assistant.