### PR TITLE
Enable nested reductions for AOTI C++ wrappers (#193598)

### DIFF
--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -2322,6 +2322,38 @@ class NestedReductionInternalsNonPersistentTest(_InternalsBase, TestCase):
     force_persistent_outer_reduction = False
 
 
+class NestedReductionAOTITest(TestCase):
+    __unittest_skip__ = not HAS_GPU
+
+    def test_rmsnorm_block_amax(self):
+        B, D, G = 8, 1024, 32
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                normalized = _rmsnorm(x)
+                block_amax = normalized.reshape(B, D // G, G).abs().amax(dim=-1)
+                return normalized, block_amax
+
+        model = Model()
+        x = torch.randn(B, D, device=GPU_TYPE)
+        expected = model(x)
+        metrics.reset()
+        with fresh_inductor_cache():
+            exported = torch.export.export(model, (x,))
+            package_path = torch._inductor.aoti_compile_and_package(
+                exported,
+                inductor_configs={
+                    "loop_ordering_after_fusion": True,
+                    "triton.nested_reduction": True,
+                },
+            )
+            compiled = torch._inductor.aoti_load_package(package_path)
+            actual = compiled(x)
+
+        self.assertEqual(actual, expected, atol=1e-2, rtol=1e-2)
+        self.assertEqual(metrics.codegen_nested_reduction, 1)
+
+
 if __name__ == "__main__":
     if HAS_GPU:
         run_tests()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -539,7 +539,6 @@ class NestedReduction:
     ) -> bool:
         return (
             config.triton.nested_reduction
-            and not V.graph.cpp_wrapper
             and _is_gpu_triton_backend(outer_node, grouped_node)
             and not outer_node.has_strict_reduction()
             and not grouped_node.has_strict_reduction()
@@ -1143,8 +1142,6 @@ class NestedReduction:
         node2: BaseSchedulerNode,
     ) -> StagedReductionPlan | None:
         """Plan a dependent cross-axis reduction pair for staged code generation."""
-        # TODO: enable nested reduction with cpp wrapper after validating the
-        # additional autotuning meta (min_xblock / min_rblock).
         if not cls._is_enabled_for(node1, node2):
             return None
 


### PR DESCRIPTION
Summary:

Enable nested-reduction fusion when AOTI uses the C++ wrapper. Add an AOTI package/load regression test covering RMSNorm followed by block `amax`.

Test Plan: `arc lint -a` and Citrine lint passed for the changed files. End-to-end GPU execution is deferred to the H100 environment.

Differential Revision: D115935277




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo