### PR TITLE
Auto-label ciflow/b200 on CuTeDSL and DLPack paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -151,6 +151,22 @@
 - torch/_inductor/kernel/mm.py
 - test/inductor/test_max_autotune.py
 - third_party/fbgemm
+# CuTeDSL: smoke_b200 is the only CI job with CuTeDSL installed, so these are
+# unreachable pre-merge without the label. DLPack is the tensor handover into
+# CuTeDSL (tvm-ffi) kernels.
+- aten/src/ATen/DLConvertor.*
+- aten/src/ATen/dlpack.h
+- torch/utils/dlpack.py
+- test/test_dlpack.py
+- torch/_native/**
+- torch/backends/python_native/**
+- torch/_vendor/quack/**
+- torch/_inductor/codegen/cutedsl/**
+- torch/_inductor/codegen/nv_universal_gemm/**
+- torch/_inductor/heuristics/template/nv_universal_gemm.py
+- torch/_inductor/kernel/flex_gemm/**
+- torch/_inductor/kernel/flex/flex_flash_attention.py
+- torch/_inductor/runtime/cutedsl_cache.py
 
 "ciflow/h100":
 - test/test_matmul_cuda.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193606
* __->__ #193605

CuTeDSL receives its tensors through the DLPack interface, and ciflow/b200 is
the only job that runs CuTeDSL. Its label paths are matmul/blas-only, so DLPack
and DSL changes get no CuTeDSL coverage pre-merge: #182924 exported a nonzero
byte_offset, which tvm-ffi rejects, and merged with 421 green checks.

torch/_tensor.py owns __dlpack__ but is deliberately left out: it changes too
often for unrelated reasons to gate b200 on.

Test Plan: labeler.yml is only consumed by pytorch-probot at PR time, so
verification is a YAML parse plus checking that every added glob matches
tracked files and that #182924's changed files (DLConvertor.cpp,
torch/utils/dlpack.py, test/test_dlpack.py) match.

```
python -c "import yaml; yaml.safe_load(open('.github/labeler.yml'))"
lintrunner -a --paths-cmd 'echo .github/labeler.yml'
```

Authored with assistance from an AI coding agent (Claude Code).