### PR TITLE
[GPU][AOTI] Support host TMA in C++ wrappers (#193608)

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -327,6 +327,32 @@ class TestGpuWrapper(InductorTestCase):
         self.assertIn("aoti_custom_ops::forward_maybe_weighted", code)
         self.assertIn("c10::IValue(at::Tensor())", code)
 
+    @skipIfXpu(msg="tests CUDA TMA helper codegen")
+    def test_tma_descriptor_separates_global_and_kernel_shapes(self):
+        if torch.version.hip is not None:
+            self.skipTest("requires CUDA TMA helpers")
+
+        helpers = CUDADeviceOpOverrides().tma_descriptor_helpers()
+        self.assertNotIn("int32_t* shape", helpers)
+        self.assertIn("uint64_t* shape", helpers)
+        self.assertIn("int32_t kernel_shape[5];", helpers)
+        self.assertIn("uint64_t global_shape[5];", helpers)
+        self.assertIn("uint64_t dim = shape[i];", helpers)
+
+        wrapper = CppWrapperGpu.__new__(CppWrapperGpu)
+        wrapper.arg_var_id = itertools.count()
+        launch_args = wrapper.generate_args_decl(
+            IndentedBuffer(),
+            ["descriptor"],
+            [torch.float32],
+            ["tensordesc<fp32[16, 32]>"],
+        )
+        self.assertEqual(
+            launch_args,
+            "&var_0.m, &var_0.kernel_shape[0], &var_0.kernel_shape[1], "
+            "&var_0.strides[0], &var_0.strides[1]",
+        )
+
     @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")
     def test_cpp_scratch_scales_with_grid_size_for_tma(self):
         scratch_def, scratch_var = CUDADeviceOpOverrides().cpp_scratch(

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -147,6 +147,25 @@ if HAS_GPU:
         output = x + y
         tl.store(out_ptr + offsets, output, mask=mask)
 
+    @triton.jit
+    def _add_kernel_with_interleaved_tma_args(
+        in_desc_ptr0,
+        scale_ptr,
+        in_desc_ptr1,
+        bias_ptr,
+        out_desc_ptr,
+        BLOCK_SIZE_X: "tl.constexpr",
+        BLOCK_SIZE_Y: "tl.constexpr",
+    ):
+        pid_x = tl.program_id(axis=0)
+        pid_y = tl.program_id(axis=1)
+        offsets = [pid_x * BLOCK_SIZE_X, pid_y * BLOCK_SIZE_Y]
+        x = tl.load_tensor_descriptor(in_desc_ptr0, offsets)
+        scale = tl.load(scale_ptr)
+        y = tl.load_tensor_descriptor(in_desc_ptr1, offsets)
+        bias = tl.load(bias_ptr)
+        tl.store_tensor_descriptor(out_desc_ptr, offsets, x * scale + y + bias)
+
     def _get_backend_options_kernel(*, with_enable_fp_fusion):
         # These kernels are intentionally illustrative. `enable_fp_fusion` is a
         # real backend option name, but the branch below only makes the kwarg's
@@ -5073,6 +5092,187 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         code = "\n".join(codes[0])
         self.assertNotIn(libname, code)
         self.assertNotIn(opname, code)
+
+    @requires_gpu
+    @common_utils.parametrize("backend", ["aot_eager", "inductor", "aoti"])
+    def test_host_tma_descriptor_in_triton_op(self, backend):
+        # Host-side TMA descriptors built inside a triton_op body are captured by
+        # the non-Dynamo tracing path, which must turn them into TMA descriptor
+        # metadata instead of leaving them as opaque constant args.
+        if not has_triton_tensor_descriptor_host_tma():
+            self.skipTest("requires triton.tools.tensor_descriptor TMA support")
+
+        from triton.tools.tensor_descriptor import TensorDescriptor
+
+        libname = "my_cool_namespace"
+        opname = "my_tma_operator"
+        BLOCK_SIZE_X, BLOCK_SIZE_Y = 16, 32
+
+        @torch.library.triton_op(f"{libname}::{opname}", mutates_args={})
+        def tma_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            x_size, y_size = out.size()
+
+            def grid(meta):
+                return (
+                    triton.cdiv(x_size, meta["BLOCK_SIZE_X"]),
+                    triton.cdiv(y_size, meta["BLOCK_SIZE_Y"]),
+                )
+
+            descs = [
+                TensorDescriptor.from_tensor(t, [BLOCK_SIZE_X, BLOCK_SIZE_Y])
+                for t in (x, y, out)
+            ]
+            capture_triton(add_kernel_with_tma_2d_new_api)[grid](
+                *descs,
+                BLOCK_SIZE_X=BLOCK_SIZE_X,
+                BLOCK_SIZE_Y=BLOCK_SIZE_Y,
+            )
+            return out
+
+        def f(x, y):
+            return tma_add(x, y)
+
+        x = torch.randn((25, 16), device=GPU_TYPE)
+        y = torch.randn((25, 16), device=GPU_TYPE)
+        expected = x + y
+
+        self.assertEqual(f(x, y), expected)
+
+        if backend == "aoti":
+            try:
+                from .test_aot_inductor_utils import AOTIRunnerUtil
+            except ImportError:
+                from test_aot_inductor_utils import AOTIRunnerUtil
+
+            empty_x = torch.empty((0, 16), device=GPU_TYPE)
+            empty_y = torch.empty((0, 16), device=GPU_TYPE)
+            batch = torch.export.Dim("tma_batch")
+            with inductor_config.patch("triton.autotune_at_compile_time", False):
+                outputs = AOTIRunnerUtil.run_multiple(
+                    f,
+                    [(x, y), (empty_x, empty_y)],
+                    dynamic_shapes=(({0: batch}, {0: batch}),),
+                )
+            self.assertEqual(outputs[0], expected)
+            self.assertEqual(outputs[1], empty_x + empty_y)
+            return
+
+        compiled = torch.compile(f, fullgraph=True, backend=backend)
+        if backend == "inductor":
+            from torch._inductor.utils import run_and_get_code
+
+            compiled_out, codes = run_and_get_code(compiled, x, y)
+            # The descriptors must be codegen'd as TMA descriptor args rather
+            # than passed through as opaque constant args.
+            self.assertIn("TensorDescriptor.from_tensor(", codes[0])
+            self.assertIn(f"tensordesc<fp32[{BLOCK_SIZE_X}, {BLOCK_SIZE_Y}]>", codes[0])
+        else:
+            compiled_out = compiled(x, y)
+        self.assertEqual(compiled_out, expected)
+
+    @requires_gpu
+    @common_utils.parametrize("backend", ["inductor", "aoti"])
+    def test_host_tma_descriptor_wide_block_interleaved_args(self, backend):
+        # A descriptor whose innermost block spans more than 128 bytes
+        # (fp16 x 128 = 256B). The compiler chooses the swizzle and final box
+        # shape; AOTI must use that metadata rather than re-derive either value.
+        if not has_triton_tensor_descriptor_host_tma():
+            self.skipTest("requires triton.tools.tensor_descriptor TMA support")
+
+        from triton.tools.tensor_descriptor import TensorDescriptor
+
+        BLOCK_SIZE_X, BLOCK_SIZE_Y = 64, 128
+        TENSOR_SIZE_X, TENSOR_SIZE_Y = 128, 256
+
+        @torch.library.triton_op("my_cool_namespace::my_wide_tma_op", mutates_args={})
+        def tma_add_wide(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale: torch.Tensor,
+            bias: torch.Tensor,
+        ) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            x_view = x.view(TENSOR_SIZE_X, TENSOR_SIZE_Y)
+            y_view = y.view(TENSOR_SIZE_X, TENSOR_SIZE_Y)
+            out_view = out.view(TENSOR_SIZE_X, TENSOR_SIZE_Y)
+
+            def grid(meta):
+                return (
+                    triton.cdiv(TENSOR_SIZE_X, meta["BLOCK_SIZE_X"]),
+                    triton.cdiv(TENSOR_SIZE_Y, meta["BLOCK_SIZE_Y"]),
+                )
+
+            descs = [
+                TensorDescriptor.from_tensor(t, [BLOCK_SIZE_X, BLOCK_SIZE_Y])
+                for t in (x_view, y_view, out_view)
+            ]
+            capture_triton(_add_kernel_with_interleaved_tma_args)[grid](
+                descs[0],
+                scale,
+                descs[1],
+                bias,
+                descs[2],
+                BLOCK_SIZE_X=BLOCK_SIZE_X,
+                BLOCK_SIZE_Y=BLOCK_SIZE_Y,
+            )
+            return out
+
+        def f(x, y, scale, bias):
+            return tma_add_wide(x, y, scale, bias)
+
+        input_shape = (128, 2, 128)
+        x = torch.randn(input_shape, device=GPU_TYPE, dtype=torch.float16)
+        y = torch.randn(input_shape, device=GPU_TYPE, dtype=torch.float16)
+        scale = torch.tensor([2.0], device=GPU_TYPE, dtype=torch.float16)
+        bias = torch.tensor([3.0], device=GPU_TYPE, dtype=torch.float16)
+        x2 = torch.randn(input_shape, device=GPU_TYPE, dtype=torch.float16)
+        y2 = torch.randn(input_shape, device=GPU_TYPE, dtype=torch.float16)
+        scale2 = torch.tensor([-1.0], device=GPU_TYPE, dtype=torch.float16)
+        bias2 = torch.tensor([0.5], device=GPU_TYPE, dtype=torch.float16)
+        expected = x * scale + y + bias
+        expected2 = x2 * scale2 + y2 + bias2
+
+        self.assertEqual(f(x, y, scale, bias), expected)
+
+        if backend == "aoti":
+            try:
+                from .test_aot_inductor_utils import AOTIRunnerUtil
+            except ImportError:
+                from test_aot_inductor_utils import AOTIRunnerUtil
+
+            for autotune_at_compile_time in (True, False):
+                with (
+                    self.subTest(autotune_at_compile_time=autotune_at_compile_time),
+                    inductor_config.patch(
+                        "triton.autotune_at_compile_time", autotune_at_compile_time
+                    ),
+                ):
+                    outputs = AOTIRunnerUtil.run_multiple(
+                        f,
+                        [
+                            (x, y, scale, bias),
+                            (x2, y2, scale2, bias2),
+                        ],
+                    )
+                    self.assertEqual(outputs[0], expected)
+                    self.assertEqual(outputs[1], expected2)
+        else:
+            configs = (
+                ("default", {}),
+                (
+                    "cpp_wrapper_lazy",
+                    {
+                        "cpp_wrapper": True,
+                        "triton.autotune_at_compile_time": False,
+                    },
+                ),
+            )
+            for name, config in configs:
+                with self.subTest(config=name), inductor_config.patch(config):
+                    compiled = torch.compile(f, fullgraph=True, backend=backend)
+                    self.assertEqual(compiled(x, y, scale, bias), expected)
+                    self.assertEqual(compiled(x2, y2, scale2, bias2), expected2)
 
     @requires_gpu
     def test_subclass(self):

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -124,6 +124,49 @@ def maybe_unpack_tma_stable_metadata(
     return None
 
 
+def maybe_unpack_host_tma_descriptor(arg: Any) -> tuple[Any, TMAStableMetadata] | None:
+    """Split a host-side (stable API) TMA descriptor into its base tensor and the
+    metadata needed to rebuild it downstream. Returns None for non-descriptor args.
+
+    Only descriptors equivalent to ``TensorDescriptor.from_tensor(base, block_shape)``
+    can be represented: the metadata carries just the block shape, so the descriptor's
+    shape/strides must be the base tensor's own.
+    """
+    from torch.utils._triton import has_triton_tensor_descriptor_host_tma
+
+    if not has_triton_tensor_descriptor_host_tma():
+        return None
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    if not isinstance(arg, TensorDescriptor):
+        return None
+
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+    def matches(actual: Sequence[Any], expected: Sequence[Any]) -> bool:
+        # Sizes may be symbolic, so compare without installing guards.
+        return len(actual) == len(expected) and all(
+            a is b or statically_known_true(a == b) for a, b in zip(actual, expected)
+        )
+
+    base = arg.base
+    if (
+        not matches(arg.shape, base.shape)
+        or not matches(arg.strides, base.stride())
+        or arg.padding != "zero"
+        or getattr(arg, "round_f32_to_tf32", False)
+    ):
+        raise RuntimeError(
+            "Only TMA descriptors built by TensorDescriptor.from_tensor() with the "
+            "default padding and rounding can be traced; the descriptor's "
+            "shape/strides must match its base tensor because only the block shape is "
+            "carried through the graph."
+        )
+
+    return base, create_tma_stable_metadata(list(arg.block_shape))
+
+
 # TMADescriptorMetadata maps kernel parameter names to the metadata that allows
 # reconstructing TMA descriptors from the underlying tensors (passed as kernel
 # arguments in the fx graph, instead of the TMA descriptors).
@@ -558,6 +601,7 @@ def ttir_to_functions(
     )
     region_id_to_block_ids: dict[int, list[int]] = defaultdict(list)
     block_id_to_block_arg_ids: dict[int, list[int]] = {}
+    warp_specialize_partition_block_args: dict[int, list[list[int]]] = defaultdict(list)
     replacements: dict[int, Intermediate | Param] = {}
     reindex_map: dict[int, int] = {}
     next_fake_intermediate = 0
@@ -640,7 +684,18 @@ def ttir_to_functions(
             fn_name = op.get_str_attr("sym_name")
             functions[fn_name] = fn_ops
         elif child_block_ids:
-            if name in {"scf.if", "scf.for", "scf.while", "tt.reduce", "tt.scan"}:
+            structured_region_ops = {
+                "scf.if",
+                "scf.for",
+                "scf.while",
+                "tt.reduce",
+                "tt.scan",
+            }
+            supported_region_ops = structured_region_ops | {
+                "ttg.warp_specialize",
+                "ttg.warp_specialize.partitions",
+            }
+            if name in supported_region_ops:
                 # for blocked ops: inline the enclosed ops into
                 # the parent block + rewire the last op in each
                 # child block to return the block result
@@ -676,11 +731,7 @@ def ttir_to_functions(
                         for idx in block_id_to_block_arg_ids[block_id]:
                             next_fake_intermediate -= 1
                             replacements[idx] = Intermediate(next_fake_intermediate)
-                    else:
-                        if name not in ("tt.reduce", "tt.scan"):
-                            raise AssertionError(
-                                f"Expected op name to be 'tt.reduce' or 'tt.scan', got {name}"
-                            )
+                    elif name in ("tt.reduce", "tt.scan"):
                         # wire the block arguments to the op arguments
                         num_operands = len(operand_ids)
                         block_arg_ids = block_id_to_block_arg_ids[block_id]
@@ -697,6 +748,38 @@ def ttir_to_functions(
                             replacements[idx] = Intermediate(
                                 operand_ids[i % num_operands]
                             )
+                    elif name == "ttg.warp_specialize.partitions":
+                        block_arg_ids = block_id_to_block_arg_ids[block_id]
+                        # Beta puts explicit captures on this container; stable
+                        # puts them on the enclosing ttg.warp_specialize.
+                        if operand_ids and len(block_arg_ids) != len(operand_ids):
+                            raise RuntimeError(
+                                "Cannot map explicit captures for "
+                                "ttg.warp_specialize.partitions: "
+                                f"{len(block_arg_ids)} block arguments for "
+                                f"{len(operand_ids)} operands"
+                            )
+                        if operand_ids:
+                            for idx, operand_id in zip(block_arg_ids, operand_ids):
+                                replacements[idx] = Intermediate(operand_id)
+                        elif block_arg_ids:
+                            warp_specialize_partition_block_args[
+                                parent_block_id
+                            ].append(block_arg_ids)
+                    else:
+                        block_arg_groups = [block_id_to_block_arg_ids[block_id]]
+                        block_arg_groups.extend(
+                            warp_specialize_partition_block_args.pop(block_id, [])
+                        )
+                        for block_arg_ids in block_arg_groups:
+                            if len(block_arg_ids) not in (0, len(operand_ids)):
+                                raise RuntimeError(
+                                    "Cannot map block arguments for region op "
+                                    f"{name}: {len(block_arg_ids)} block arguments "
+                                    f"for {len(operand_ids)} operands"
+                                )
+                            for idx, operand_id in zip(block_arg_ids, operand_ids):
+                                replacements[idx] = Intermediate(operand_id)
 
                     if block_id in op_stack:
                         block_ops = op_stack.pop(block_id)
@@ -705,7 +788,13 @@ def ttir_to_functions(
                         last_ret, last_ops = block_ops.popitem()
                         if all(
                             op.name
-                            in ("scf.yield", "tt.reduce.return", "tt.scan.return")
+                            in (
+                                "scf.yield",
+                                "tt.reduce.return",
+                                "tt.scan.return",
+                                "ttg.warp_yield",
+                                "ttg.warp_return",
+                            )
                             for op in last_ops
                         ):
                             # if last_ops are all return ops, treat them separately
@@ -718,8 +807,23 @@ def ttir_to_functions(
 
                 scf_results = [Intermediate(idx) for idx in result_ids]
 
+                if name not in structured_region_ops:
+                    return_ops = [
+                        op for op in return_ops if len(op.args) == len(result_ids)
+                    ]
+                    if result_ids and not return_ops:
+                        raise RuntimeError(
+                            f"Cannot map results for region op {name}: no region "
+                            "terminator returns the expected number of values"
+                        )
+
                 if return_ops and all(
-                    (op.name == "scf.yield" and len(result_ids) == len(op.args))
+                    (
+                        len(result_ids) == len(op.args)
+                        and (
+                            op.name == "scf.yield" or name not in structured_region_ops
+                        )
+                    )
                     for op in return_ops
                 ):
                     # [Note: scf.yield fix-up]
@@ -923,6 +1027,11 @@ def first_arg(op: Op) -> list[int]:
     return [0]
 
 
+def first_two_args(op: Op) -> list[int]:
+    """Cover descriptor positions with and without an optional multicast target."""
+    return list(range(min(2, len(op.args))))
+
+
 @dataclasses.dataclass(frozen=True)
 class _KernelAccessOpInfo:
     read_indexes: ReadWriteIndexes | None = None
@@ -949,6 +1058,20 @@ _KERNEL_ACCESS_OPS: dict[str, _KernelAccessOpInfo] = {
     "tt.load": _KernelAccessOpInfo(read_indexes=first_arg),
     "tt.load_tensor_descriptor": _KernelAccessOpInfo(read_indexes=first_arg),
     "tt.descriptor_load": _KernelAccessOpInfo(read_indexes=first_arg),
+    "tt.descriptor_reduce": _KernelAccessOpInfo(
+        read_indexes=first_arg, write_indexes=first_arg
+    ),
+    "tt.descriptor_scatter": _KernelAccessOpInfo(write_indexes=first_arg),
+    "tt.descriptor_gather": _KernelAccessOpInfo(read_indexes=first_arg),
+    "ttng.async_tma_copy_global_to_local": _KernelAccessOpInfo(
+        read_indexes=first_two_args
+    ),
+    "ttng.async_tma_copy_local_to_global": _KernelAccessOpInfo(write_indexes=first_arg),
+    "ttng.async_tma_reduce": _KernelAccessOpInfo(
+        read_indexes=first_arg, write_indexes=first_arg
+    ),
+    "ttng.async_tma_scatter": _KernelAccessOpInfo(write_indexes=first_arg),
+    "ttng.async_tma_gather": _KernelAccessOpInfo(read_indexes=first_arg),
     "tt.elementwise_inline_asm": _KernelAccessOpInfo(ignore_if=lambda op: op.is_pure),
 }
 
@@ -2583,6 +2706,21 @@ class TracingTritonHOPifier(TritonHOPifier):
                 f"Expected TraceableTritonKernelWrapper, got {type(variable)}"
             )
 
+        # Only tensors can be passed as non-const args in the fx graph, so replace
+        # host-side TMA descriptors with their base tensors and carry the descriptor
+        # metadata alongside, mirroring what Dynamo does. Without this the descriptor
+        # would be stashed as an opaque constant arg and downstream consumers (TTIR
+        # generation, Inductor codegen) would not recognize it as a TMA descriptor.
+        combined_args = dict(combined_args)
+        tma_descriptor_metadata: TMADescriptorMetadata = {}
+        for k in list(combined_args.keys()):
+            if (
+                unpacked := maybe_unpack_host_tma_descriptor(combined_args[k])
+            ) is not None:
+                tensor, metadata = unpacked
+                combined_args[k] = tensor
+                tma_descriptor_metadata[k] = metadata
+
         graphable_args, constant_args_idx = self.store_non_graphable_args(combined_args)
         # launch_kwargs records the names passed as kwargs at the Triton launch
         # site. A non-kernel launch kwarg can only be a compiler option, so it
@@ -2609,9 +2747,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             kernel_idx=variable.kernel_idx,
             constant_args_idx=constant_args_idx,
             grid=grids,  # type: ignore[arg-type]
-            # TMA descriptor capturing not yet
-            # supported in non-dynamo tracing
-            tma_descriptor_metadata={},
+            tma_descriptor_metadata=tma_descriptor_metadata,
             kwargs=graphable_args,
             launch_kwargs=launch_kwargs,
         )

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -94,6 +94,56 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
     def braced(values: list[int]) -> str:
         return "{" + ", ".join(str(v) for v in values) + "}"
 
+    def tma_metadata_initializer(params: dict[str, Any]) -> str:
+        triton_meta = params.get("triton_meta") or {}
+        signature = triton_meta.get("signature", {})
+        tma_arg_names = [
+            name
+            for name, sig_type in signature.items()
+            if isinstance(sig_type, str) and sig_type.startswith("tensordesc<")
+        ]
+        if not tma_arg_names:
+            return "{}"
+
+        tensordesc_meta = params.get("tensordesc_meta")
+        if tensordesc_meta is None or len(tensordesc_meta) != len(tma_arg_names):
+            raise RuntimeError(
+                f"Expected final TMA metadata for {len(tma_arg_names)} descriptors, "
+                f"got {tensordesc_meta}"
+            )
+
+        entries = []
+        for name, metadata in zip(tma_arg_names, tensordesc_meta):
+            if metadata is None:
+                raise RuntimeError(f"Missing final TMA metadata for {name}")
+            if metadata.get("is_im2col", False):
+                raise RuntimeError(
+                    "AOTInductor does not support TMA im2col descriptors"
+                )
+            if metadata.get("fp4_padded", False):
+                raise RuntimeError(
+                    "Inductor C++ wrappers do not support fp4-padded TMA descriptors"
+                )
+            block_size = [int(value) for value in metadata["block_size"]]
+            elem_size = int(metadata["elem_size"])
+            elem_type = _tma_dtype_device_to_host(int(metadata["elem_type"]))
+            swizzle = int(metadata["swizzle"])
+            fp4_padded = str(bool(metadata.get("fp4_padded", False))).lower()
+            entries.append(
+                "{"
+                + ", ".join(
+                    [
+                        braced(block_size),
+                        str(elem_size),
+                        str(elem_type),
+                        str(swizzle),
+                        fp4_padded,
+                    ]
+                )
+                + "}"
+            )
+        return "{" + ", ".join(entries) + "}"
+
     buf = IndentedBuffer()
     buf.splice("""
         #pragma once
@@ -169,6 +219,7 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
         ci = config_index if config_index is not None else -1
         gs = params.get("global_scratch", -1) or -1
         ps = params.get("profile_scratch", -1) or -1
+        tensordesc_meta = tma_metadata_initializer(params)
 
         buf.writeline("")
         buf.splice(f"""
@@ -186,6 +237,7 @@ def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
             #define {macro_prefix}_CONFIG_INDEX {ci}
             #define {macro_prefix}_GLOBAL_SCRATCH {gs}
             #define {macro_prefix}_PROFILE_SCRATCH {ps}
+            #define {macro_prefix}_TENSORDESC_META {tensordesc_meta}
         """)
 
     return buf.getvalue()
@@ -210,23 +262,32 @@ def signature_is_tma_desc(sig: str | None) -> bool:
     return False
 
 
+def _tma_signature_rank(sig_type: str) -> int:
+    match = re.match(r"tensordesc<[^[]*\[([^\]]*)\]", sig_type)
+    if match is None:
+        raise AssertionError(f"Cannot parse tensordesc signature: {sig_type}")
+    return match.group(1).count(",") + 1
+
+
 def _unpack_tma_descriptor_args(var_name: str, sig_type: str) -> list[str]:
     """Unpack a StableTMADescriptor into kernel launch args.
 
     Given a variable name holding a StableTMADescriptor and its tensordesc<...>
-    signature, returns the list of pointer args: &var.m, &var.block_shape[i]...,
+    signature, returns the list of pointer args: &var.m, &var.kernel_shape[i]...,
     &var.strides[i]...
     """
-    match = re.match(r"tensordesc<[^[]*\[([^\]]*)\]", sig_type)
-    if match is None:
-        raise AssertionError(f"Cannot parse tensordesc signature: {sig_type}")
-    ndim = match.group(1).count(",") + 1
+    ndim = _tma_signature_rank(sig_type)
     result = [f"&{var_name}.m"]
     for i in range(ndim):
-        result.append(f"&{var_name}.block_shape[{i}]")
+        result.append(f"&{var_name}.kernel_shape[{i}]")
     for i in range(ndim):
         result.append(f"&{var_name}.strides[{i}]")
     return result
+
+
+def _tma_dtype_device_to_host(elem_type: int) -> int:
+    """Map Triton's device TMA dtype enum to CUtensorMapDataType."""
+    return {8: 10, 9: 8, 10: 9}.get(elem_type, elem_type)
 
 
 class _LazyTritonCompileKickoffLine(DeferredLineBase):
@@ -274,15 +335,125 @@ class DeferredTritonCallWrapper:
             if isinstance(sig_type, str) and sig_type.startswith("tensordesc<")
         }
 
+    def _generate_tma_descriptor_initializers(
+        self,
+        prefix: IndentedBuffer,
+        def_args: list[str],
+        params: dict[str, Any],
+    ) -> None:
+        triton_meta = params.get("triton_meta") or self.triton_meta or {}
+        signature = triton_meta.get("signature", {})
+        tma_arg_names = [
+            name
+            for name, sig_type in signature.items()
+            if isinstance(sig_type, str) and sig_type.startswith("tensordesc<")
+        ]
+        if not tma_arg_names:
+            return
+
+        tensordesc_meta = params.get("tensordesc_meta")
+        if tensordesc_meta is None or len(tensordesc_meta) != len(tma_arg_names):
+            raise RuntimeError(
+                f"Expected final TMA metadata for {len(tma_arg_names)} descriptors "
+                f"in {self.kernel_name}, got {tensordesc_meta}"
+            )
+
+        for name, metadata in zip(tma_arg_names, tensordesc_meta):
+            if name not in def_args:
+                raise RuntimeError(
+                    f"TMA descriptor argument {name} is missing from {self.kernel_name}"
+                )
+            if metadata is None:
+                raise RuntimeError(
+                    f"AOTInductor requires final TMA metadata for {name} "
+                    f"in {self.kernel_name}"
+                )
+            if metadata.get("is_im2col", False):
+                raise RuntimeError(
+                    "AOTInductor does not support TMA im2col descriptors"
+                )
+            if metadata.get("fp4_padded", False):
+                raise RuntimeError(
+                    "Inductor C++ wrappers do not support fp4-padded TMA descriptors"
+                )
+
+            block_size = [int(value) for value in metadata["block_size"]]
+            rank = len(block_size)
+            if not 1 <= rank <= 5:
+                raise RuntimeError(f"Unsupported TMA descriptor rank: {rank}")
+            for i, value in enumerate(block_size):
+                prefix.writeline(f"{name}.block_shape[{i}] = {value};")
+
+            elem_size = int(metadata["elem_size"])
+            elem_type = _tma_dtype_device_to_host(int(metadata["elem_type"]))
+            swizzle = int(metadata["swizzle"])
+            fp4_padded = int(bool(metadata.get("fp4_padded", False)))
+            args = ", ".join(
+                [
+                    f"&{name}.m",
+                    f"{name}.global_address",
+                    str(elem_size),
+                    str(elem_type),
+                    str(rank),
+                    f"{name}.block_shape",
+                    f"{name}.global_shape",
+                    f"{name}.strides",
+                    str(swizzle),
+                    str(fp4_padded),
+                ]
+            )
+            prefix.writeline(f"initTMADescriptorWithMetadata({args});")
+
+    def _generate_lazy_tma_descriptor_initializers(
+        self,
+        prefix: IndentedBuffer,
+    ) -> None:
+        tma_args = self._get_tma_args()
+        if not tma_args:
+            return
+
+        metadata = f"{self.kernel_name}_result.tensordesc_meta"
+        prefix.writeline(
+            f"if ({metadata}.size() != {len(tma_args)}) "
+            'throw std::runtime_error("Unexpected TMA descriptor metadata count");'
+        )
+        for index, (name, sig_type) in enumerate(tma_args.items()):
+            rank = _tma_signature_rank(sig_type)
+            per_desc = f"{metadata}[{index}]"
+            prefix.writeline(
+                f"if ({per_desc}.block_size.size() != {rank}) "
+                'throw std::runtime_error("Unexpected TMA descriptor rank");'
+            )
+            for dim in range(rank):
+                prefix.writeline(
+                    f"{name}.block_shape[{dim}] = {per_desc}.block_size[{dim}];"
+                )
+            args = ", ".join(
+                [
+                    f"&{name}.m",
+                    f"{name}.global_address",
+                    f"{per_desc}.elem_size",
+                    f"{per_desc}.elem_type",
+                    str(rank),
+                    f"{name}.block_shape",
+                    f"{name}.global_shape",
+                    f"{name}.strides",
+                    f"{per_desc}.swizzle",
+                    f"{per_desc}.fp4_padded",
+                ]
+            )
+            prefix.writeline(f"initTMADescriptorWithMetadata({args});")
+
     def _get_cpp_param_type(
         self, name: str, arg_type: Any, signature: dict[str, str] | None = None
     ) -> str:
         """Get the C++ parameter declaration for a given arg type."""
         if isinstance(arg_type, (torch_dtype, UnwrapUnspecArg)):
-            # TMA descriptors need non-const references since their fields
-            # are passed as void* pointers to kernel launch args
+            # Each formal TMA argument needs its own copy: the same descriptor
+            # may be passed to multiple formals whose compiler-selected metadata
+            # differs, and each copy is initialized immediately before launch.
             if signature and signature_is_tma_desc(signature.get(name)):
-                return f"{name}_type_& {name}"
+                return f"{name}_type_ {name}"
             return f"const {name}_type_& {name}"
         elif issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
             return f"int64_t {name}"
@@ -388,7 +559,12 @@ class DeferredTritonCallWrapper:
             kernel_var_name = f"kernels_.{self.kernel_name}"
 
         # Write wrapper function signature
-        self._write_wrapper_signature(prefix, wrapper, def_args, arg_types)
+        signature = (params.get("triton_meta") or self.triton_meta or {}).get(
+            "signature", {}
+        )
+        self._write_wrapper_signature(
+            prefix, wrapper, def_args, arg_types, signature=signature
+        )
 
         with prefix.indent():
             if V.graph.aot_mode:
@@ -398,6 +574,7 @@ class DeferredTritonCallWrapper:
                 prefix.writeline("*/")
             self.generate_grid(prefix, inductor_meta, params)
             self.generate_load_kernel(prefix, kernel_var_name, params)
+            self._generate_tma_descriptor_initializers(prefix, def_args, params)
             self.generate_launch_kernel(prefix, wrapper, kernel_var_name, params)
         prefix.writeline("}")
 
@@ -524,24 +701,6 @@ class DeferredTritonCallWrapper:
                 """
             )
 
-    def _generate_lazy_tma_args(
-        self,
-        prefix: IndentedBuffer,
-        call_args_str: str,
-        kernel_arg_names: list[str],
-        tma_arg_names: OrderedSet[str],
-        signature: dict[str, str],
-    ) -> str:
-        """Unpack TMA descriptor args into kernel launch args."""
-        for arg_name in kernel_arg_names:
-            if arg_name in tma_arg_names:
-                tma_parts = _unpack_tma_descriptor_args(arg_name, signature[arg_name])
-                tma_str = ", ".join(tma_parts)
-                call_args_str = (
-                    f"{call_args_str}, {tma_str}" if call_args_str else tma_str
-                )
-        return call_args_str
-
     def _generate_lazy_scratch(
         self,
         prefix: IndentedBuffer,
@@ -572,7 +731,10 @@ class DeferredTritonCallWrapper:
             """
                 )
             )
-            call_args_str += f", &{var}"
+            scratch_arg = f"&{var}"
+            call_args_str = (
+                f"{call_args_str}, {scratch_arg}" if call_args_str else scratch_arg
+            )
         return call_args_str
 
     def _generate_lazy_launch(
@@ -602,23 +764,27 @@ class DeferredTritonCallWrapper:
         # so we just unpack them directly (no need to reconstruct from tensors).
         tma_arg_names = OrderedSet(self._get_tma_args().keys())
 
-        # Non-TMA args go through generate_args_decl
-        non_tma_arg_names = [n for n in kernel_arg_names if n not in tma_arg_names]
-        non_tma_arg_types = [
-            arg_type_lookup[n] for n in non_tma_arg_names if n in arg_type_lookup
-        ]
-        non_tma_arg_sigs = [signature.get(n) for n in non_tma_arg_names]
+        kernel_args = []
+        for arg_name in kernel_arg_names:
+            if arg_name in tma_arg_names:
+                kernel_args.extend(
+                    _unpack_tma_descriptor_args(arg_name, signature[arg_name])
+                )
+                continue
+            if arg_name not in arg_type_lookup:
+                raise AssertionError(
+                    f"Missing lazy kernel arg type for {arg_name} in {kernel_name}"
+                )
+            kernel_args.append(
+                wrapper.generate_args_decl(
+                    prefix,
+                    [arg_name],
+                    [arg_type_lookup[arg_name]],
+                    [signature.get(arg_name)],
+                )
+            )
 
-        call_args_str = wrapper.generate_args_decl(
-            prefix,
-            non_tma_arg_names,
-            non_tma_arg_types,
-            non_tma_arg_sigs,
-        )
-
-        call_args_str = self._generate_lazy_tma_args(
-            prefix, call_args_str, kernel_arg_names, tma_arg_names, signature
-        )
+        call_args_str = ", ".join(kernel_args)
         call_args_str = self._generate_lazy_scratch(prefix, wrapper, call_args_str)
 
         launch_pdl = (
@@ -732,6 +898,7 @@ class DeferredTritonCallWrapper:
                 {macro_prefix}_CONFIG_INDEX,
                 {macro_prefix}_GLOBAL_SCRATCH,
                 {macro_prefix}_PROFILE_SCRATCH,
+                {macro_prefix}_TENSORDESC_META,
             }};
             """
         )
@@ -822,6 +989,7 @@ class DeferredTritonCallWrapper:
 
             # Shared: grid computation and launch using result struct
             self._generate_lazy_grid(prefix)
+            self._generate_lazy_tma_descriptor_initializers(prefix)
             self._generate_lazy_launch(
                 prefix,
                 wrapper,
@@ -1566,34 +1734,27 @@ static inline void ensure_triton_kernel_compiles_started() {{
         desc_name = desc.name
         # Pack the relevant information into a StableTMADescriptor struct.
         # See [Note: AOTI TMA Stable handling] for more details.
-        self.writeline(f"alignas(64) StableTMADescriptor {desc_name};")
+        self.writeline(f"alignas(64) StableTMADescriptor {desc_name}{{}};")
 
         def fill_array(name, values):
             for i, val in enumerate(values):
                 self.writeline(f"{name}[{i}] = {val};")
 
         ptr = f"reinterpret_cast<void*>(*({source}))"
-        rank = len(desc.tensor.get_size())
 
+        self.writeline(f"{desc_name}.global_address = {ptr};")
         fill_array(f"{desc_name}.block_shape", desc.block_shape)
-        fill_array(f"{desc_name}.global_shape", desc.tensor.get_size())
+        global_shape = desc.tensor.get_size()
+        fill_array(f"{desc_name}.global_shape", global_shape)
+        for i in range(len(global_shape)):
+            self.writeline(
+                f"{desc_name}.kernel_shape[{i}] = "
+                f"static_cast<int32_t>({desc_name}.global_shape[{i}]);"
+            )
         fill_array(f"{desc_name}.strides", desc.tensor.get_stride())
 
-        element_size = self.val_to_arg_str(desc.tensor.get_dtype().itemsize)
-        fn = "initTMADescriptor"
-        args = ", ".join(
-            str(x)
-            for x in [
-                f"&{desc_name}.m",
-                ptr,
-                element_size,
-                rank,
-                f"{desc_name}.block_shape",
-                f"{desc_name}.global_shape",
-                f"{desc_name}.strides",
-            ]
-        )
-        self.writeline(f"{fn}({args});")
+        # The deferred kernel wrapper initializes the CUtensorMap immediately
+        # before launch from Triton's final per-formal descriptor metadata.
 
     def generate_args_decl(
         self,
@@ -1788,7 +1949,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
                 arg_types,
             )
 
-            # For lazy compile mode with TMA, extract underlying tensor names
+            # For lazy compile mode with TMA, preserve tensor view expressions
             tma_tensor_args: dict[str, str] = {}
             is_lazy_compile = config.triton.autotune_at_compile_time is False
             if is_lazy_compile and raw_args and triton_meta:
@@ -1798,9 +1959,10 @@ static inline void ensure_triton_kernel_compiles_started() {{
                     sig_type = signature.get(key, "")
                     if isinstance(sig_type, str) and signature_is_tma_desc(sig_type):
                         if isinstance(raw_arg, TMADescriptorStable):
-                            # Get the underlying tensor name
-                            tensor_name = raw_arg.get_tensor().get_name()
-                            tma_tensor_args[key] = tensor_name
+                            tensor_arg = self.create_tmp_raii_handle_var_if_needed(
+                                self.val_to_arg_str(raw_arg.get_tensor())
+                            )
+                            tma_tensor_args[key] = tensor_arg
                         else:
                             raise AssertionError("Unsupported TMA descriptor type")
 
@@ -1818,8 +1980,8 @@ static inline void ensure_triton_kernel_compiles_started() {{
 
             # For TMA in lazy compile mode, add tensor args to the call
             if is_lazy_compile and tma_tensor_args:
-                for tensor_name in tma_tensor_args.values():
-                    call_args.append(tensor_name)
+                for tensor_arg in tma_tensor_args.values():
+                    call_args.append(tensor_arg)
                     arg_types.append(
                         torch.float32
                     )  # dtype doesn't matter, just need tensor type

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -318,7 +318,7 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                 int rank,
                 uint32_t* blockSize,
                 uint64_t* shape,
-                uint64_t* stride
+                int64_t* stride
             ) {
                 uint32_t elementStrides[5] = {1, 1, 1, 1, 1};
                 uint32_t blockSizeInt[5];
@@ -337,7 +337,8 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
 
                 // Reorder and calculate strides
                 for (int i = 0; i + 1 < rank; ++i) {
-                    stridesLL[rank - i - 2] = elemSize * stride[i];
+                    stridesLL[rank - i - 2] =
+                        elemSize * static_cast<uint64_t>(stride[i]);
                 }
                 stridesLL[rank - 1] =
                     shapeInt[rank - 1] * (rank == 1 ? elemSize : stridesLL[rank - 2]);
@@ -383,11 +384,74 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
             }
 
+            [[maybe_unused]] static void initTMADescriptorWithMetadata(
+                CUtensorMap* m,
+                void* globalAddress,
+                int elemSize,
+                int elemType,
+                int rank,
+                uint32_t* blockSize,
+                uint64_t* shape,
+                int64_t* stride,
+                int swizzle,
+                int fp4Padded
+            ) {
+                if (rank < 1 || rank > 5) {
+                    throw std::runtime_error("TMA descriptor rank must be between 1 and 5");
+                }
+
+                uint32_t elementStrides[5] = {1, 1, 1, 1, 1};
+                uint32_t blockSizeInt[5] = {0, 0, 0, 0, 0};
+                uint64_t shapeInt[5] = {0, 0, 0, 0, 0};
+                uint64_t stridesLL[5] = {0, 0, 0, 0, 0};
+
+                for (int i = 0; i < rank; ++i) {
+                    blockSizeInt[rank - i - 1] = blockSize[i];
+                    uint64_t dim = shape[i];
+                    if (fp4Padded && i == rank - 1) {
+                        dim *= 2;
+                    }
+                    shapeInt[rank - i - 1] = dim;
+                }
+
+                for (int i = 0; i + 1 < rank; ++i) {
+                    stridesLL[rank - i - 2] =
+                        elemSize * static_cast<uint64_t>(stride[i]);
+                }
+                stridesLL[rank - 1] =
+                    shapeInt[rank - 1] * (rank == 1 ? elemSize : stridesLL[rank - 2]);
+
+                CUDA_DRIVER_CHECK(cuTensorMapEncodeTiled(
+                    m, static_cast<CUtensorMapDataType>(elemType), rank, globalAddress,
+                    shapeInt, stridesLL, blockSizeInt, elementStrides,
+                    CU_TENSOR_MAP_INTERLEAVE_NONE,
+                    static_cast<CUtensorMapSwizzle>(swizzle),
+                    CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+                    CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
+
+                int driverVersion = -1;
+                cuDriverGetVersion(&driverVersion);
+                if (driverVersion <= 13010) {
+                    int64_t maxByteIndex = 0;
+                    for (int i = 0; i < rank; ++i) {
+                        int64_t bytesStride =
+                            i == 0 ? elemSize : static_cast<int64_t>(stridesLL[i - 1]);
+                        maxByteIndex +=
+                            (static_cast<int64_t>(shapeInt[i]) - 1) * bytesStride;
+                    }
+                    if (maxByteIndex + 1 < 128 * 1024) {
+                        reinterpret_cast<uint64_t*>(m)[1] &= ~(1ULL << 21);
+                    }
+                }
+            }
+
             struct StableTMADescriptor {
                 CUtensorMap m;
+                void* global_address;
                 uint32_t block_shape[5];
+                int32_t kernel_shape[5];
                 uint64_t global_shape[5];
-                uint64_t strides[5];
+                int64_t strides[5];
             };
             #endif
         """

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2560,6 +2560,18 @@ class PythonWrapperCodegen(CodeGen):
                 wrapper_name = kernel
             self.writeline(f"{wrapper_name}({', '.join(args)})")
 
+    def _tma_descriptor_tensor_ref(self, desc, in_autotune_block):
+        """Reference to the descriptor's source tensor.
+
+        The compile-time autotune block is Python even when the wrapper emits C++,
+        and it already materializes an example tensor in the descriptor tensor's
+        own layout. Referring to that buffer by name keeps the block valid Python;
+        codegen_reference() would emit a C++ reinterpret (e.g. a `0L` literal).
+        """
+        if in_autotune_block:
+            return desc.get_tensor().get_name()
+        return desc.tensor.codegen_reference()
+
     def _generate_tma_descriptor_call_experimental(self, desc, apply_size_hints=False):
         dims = desc.dims
         block_dims = desc.block_dims
@@ -2567,7 +2579,7 @@ class PythonWrapperCodegen(CodeGen):
             dims = V.graph.sizevars.optimization_hint(dims)
             block_dims = V.graph.sizevars.optimization_hints(block_dims)
 
-        ptr = f"{desc.tensor.codegen_reference()}.data_ptr()"
+        ptr = f"{self._tma_descriptor_tensor_ref(desc, apply_size_hints)}.data_ptr()"
         # Explicitly call the Python version of val_to_arg_str
         dims = ", ".join(PythonWrapperCodegen.val_to_arg_str(self, dim) for dim in dims)
         block_dims = ", ".join(
@@ -2587,7 +2599,8 @@ class PythonWrapperCodegen(CodeGen):
 
         prefix = "triton.tools.tensor_descriptor.TensorDescriptor"
         fn = f"{prefix}.from_tensor"
-        args = f"{desc.tensor.codegen_reference()}, {block_shape}"
+        tensor_ref = self._tma_descriptor_tensor_ref(desc, apply_size_hints)
+        args = f"{tensor_ref}, {block_shape}"
         call = f"{fn}({args})"
         return call
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2155,6 +2155,12 @@ class CachingAutotuner(KernelInterface):
         # CTA clusters, add num_ctas/cluster_dims here from the schema.
         # Currently num_ctas is already captured via config_to_dict(launcher.config)
         # for scratch space scaling, but is not used in the actual kernel launch.
+        binary_metadata = binary.metadata
+        legacy_tensordesc_meta = (
+            binary_metadata.get("tensordesc_meta")
+            if isinstance(binary_metadata, dict)
+            else getattr(binary_metadata, "tensordesc_meta", None)
+        )
         schema = getattr(binary, "launch_metadata_schema", None)
         if schema is not None and inductor_config.use_launch_metadata_schema:
             params: dict[str, Any] = {
@@ -2170,6 +2176,9 @@ class CachingAutotuner(KernelInterface):
                 "global_scratch": launcher.global_scratch,
                 "profile_scratch": launcher.profile_scratch,
                 "cuda_arch": cuda_arch,
+                "tensordesc_meta": schema.get(
+                    "tensordesc_meta", legacy_tensordesc_meta
+                ),
             }
         else:
             # Fallback: hasattr probing for older Triton versions
@@ -2198,6 +2207,7 @@ class CachingAutotuner(KernelInterface):
                 "global_scratch": launcher.global_scratch,
                 "profile_scratch": launcher.profile_scratch,
                 "cuda_arch": cuda_arch,
+                "tensordesc_meta": legacy_tensordesc_meta,
             }
 
         from torch._inductor.codecache import CudaKernelParamCache

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -30,6 +30,15 @@ log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
+class TritonTmaDescriptorMetadata:
+    block_size: list[int]
+    elem_size: int
+    elem_type: int
+    swizzle: int
+    fp4_padded: bool
+
+
+@dataclasses.dataclass
 class TritonKernelCompileResult:
     cubin_path: str
     mangled_name: str
@@ -44,6 +53,7 @@ class TritonKernelCompileResult:
     config_index: int | None
     global_scratch: int | None
     profile_scratch: int | None
+    tensordesc_meta: list[TritonTmaDescriptorMetadata]
 
 
 _async_compile: Any = None
@@ -238,6 +248,26 @@ def run_triton_kernel_with_autotune(
 
     global_scratch: int | None = cached_params.get("global_scratch")
     profile_scratch: int | None = cached_params.get("profile_scratch")
+    tensordesc_meta = []
+    for metadata in cached_params.get("tensordesc_meta") or []:
+        if metadata is None:
+            raise RuntimeError(f"Missing final TMA metadata for {kernel_name}")
+        if metadata.get("is_im2col", False):
+            raise RuntimeError("AOTInductor does not support TMA im2col descriptors")
+        if metadata.get("fp4_padded", False):
+            raise RuntimeError(
+                "Inductor C++ wrappers do not support fp4-padded TMA descriptors"
+            )
+        device_elem_type = int(metadata["elem_type"])
+        tensordesc_meta.append(
+            TritonTmaDescriptorMetadata(
+                block_size=[int(value) for value in metadata["block_size"]],
+                elem_size=int(metadata["elem_size"]),
+                elem_type={8: 10, 9: 8, 10: 9}.get(device_elem_type, device_elem_type),
+                swizzle=int(metadata["swizzle"]),
+                fp4_padded=bool(metadata.get("fp4_padded", False)),
+            )
+        )
 
     log.debug(
         "Successfully autotuned Triton kernel: cubin_path=%s, "
@@ -274,5 +304,6 @@ def run_triton_kernel_with_autotune(
         config_index=config_index,
         global_scratch=global_scratch,
         profile_scratch=profile_scratch,
+        tensordesc_meta=tensordesc_meta,
     )
     return result

--- a/torch/csrc/inductor/aoti_include/kernel_compile_result.h
+++ b/torch/csrc/inductor/aoti_include/kernel_compile_result.h
@@ -6,6 +6,14 @@
 // Shared struct for Triton kernel compilation results.
 // Used by both cpp-wrapper JIT (filled at runtime via Python) and AOTInductor
 // (filled at compile time from a generated config header).
+struct LazyTmaDescriptorMetadata {
+  std::vector<int> block_size;
+  int elem_size;
+  int elem_type;
+  int swizzle;
+  bool fp4_padded;
+};
+
 struct LazyKernelCompileResult {
   std::string cubin_path;
   std::string mangled_name;
@@ -20,4 +28,5 @@ struct LazyKernelCompileResult {
   int config_index;
   int global_scratch;
   int profile_scratch;
+  std::vector<LazyTmaDescriptorMetadata> tensordesc_meta;
 };

--- a/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
+++ b/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
@@ -76,6 +76,35 @@ static inline std::vector<int> getIntListAttr(PyObject* obj, const char* attr) {
   return result;
 }
 
+static inline bool getBoolAttr(PyObject* obj, const char* attr) {
+  RAIIPyObject val = PyObject_GetAttrString(obj, attr);
+  AOTI_TORCH_CHECK(val, "Failed to get attribute");
+  int result = PyObject_IsTrue(val.get());
+  AOTI_TORCH_CHECK(result >= 0, "Failed to convert attribute to bool");
+  return result != 0;
+}
+
+static inline std::vector<LazyTmaDescriptorMetadata>
+getTmaDescriptorMetadataListAttr(PyObject* obj, const char* attr) {
+  RAIIPyObject val = PyObject_GetAttrString(obj, attr);
+  AOTI_TORCH_CHECK(val && PyList_Check(val.get()), "Expected list attribute");
+  Py_ssize_t size = PyList_Size(val);
+  std::vector<LazyTmaDescriptorMetadata> result;
+  result.reserve(size);
+  for (Py_ssize_t i = 0; i < size; i++) {
+    PyObject* item = PyList_GetItem(val, i);
+    AOTI_TORCH_CHECK(item, "Failed to get TMA descriptor metadata");
+    result.push_back({
+        getIntListAttr(item, "block_size"),
+        getIntAttr(item, "elem_size"),
+        getIntAttr(item, "elem_type"),
+        getIntAttr(item, "swizzle"),
+        getBoolAttr(item, "fp4_padded"),
+    });
+  }
+  return result;
+}
+
 static inline LazyKernelCompileResult extractCompileResult(PyObject* result) {
   LazyKernelCompileResult compile_result;
   compile_result.cubin_path = getStringAttr(result, "cubin_path");
@@ -92,6 +121,8 @@ static inline LazyKernelCompileResult extractCompileResult(PyObject* result) {
   compile_result.global_scratch = getOptionalIntAttr(result, "global_scratch");
   compile_result.profile_scratch =
       getOptionalIntAttr(result, "profile_scratch");
+  compile_result.tensordesc_meta =
+      getTmaDescriptorMetadataListAttr(result, "tensordesc_meta");
   return compile_result;
 }
 


### PR DESCRIPTION
Summary:

Host-side `TensorDescriptor` values created inside a `torch.library.triton_op` are captured through a non-Dynamo tracing path. That path previously treated descriptors as opaque constants, so AOTInductor could not reliably preserve the source tensor view or reconstruct the lowered TMA launch ABI in C++ wrappers.

This change decomposes supported host descriptors into their base tensors plus stable block-shape metadata. It then carries the final compiler-selected `tensordesc_meta` through eager and lazy compilation and initializes a per-formal `StableTMADescriptor` immediately before launch. Per-formal copies preserve the selected block shape, element type, swizzle, global shape, and strides when descriptors are reused or interleaved with ordinary arguments.

The mutation analysis now also follows captures through `ttg.warp_specialize` and recognizes TLX/Triton asynchronous TMA copy, gather, scatter, and reduce accesses. The implementation and tests remain mirrored between `fbcode` and `xplat`.

Test Plan:
Automated validation:

- `arc f`
- `arc lint`
- `buck2 test fbcode//mode/opt-split-dwarf fbcode//mode/inplace fbcode//caffe2/test/inductor:triton_kernels -- test_host_tma_descriptor_in_triton_op_backend_aoti --timeout=1800` (2 passed). This compiles a dynamic lazy-AOTI package with `(25, 16)` inputs, then invokes the same package with `(0, 16)` inputs.
- `buck2 test fbcode//mode/opt-split-dwarf fbcode//mode/inplace fbcode//caffe2/test/inductor/fb/tlx:test_mutation_analysis` (3 passed)

H100 / CUDA 12.8 validation:

- `CustomOpTests.test_host_tma_descriptor_in_triton_op_backend_aoti`
- `CustomOpTests.test_host_tma_descriptor_wide_block_interleaved_args_backend_aoti`, covering both compile-time and lazy autotuning

Production-model validation:

- Model `1115474317/10` AOTInductor benchmark with `TLX_IKBO_MSPLIT=0` (accuracy: true)

Reviewed By: zoranzhao

Differential Revision: D115459977




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo