### PR TITLE
[ROCm] Temporarily disable rocm-origami install (ABI mismatch with ROCm SDK)

### DIFF
--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -104,10 +104,15 @@ COPY ./common/install_openmpi.sh install_openmpi.sh
 RUN if [ -n "${CUDA_VERSION}" ]; then bash install_openmpi.sh; fi
 RUN rm install_openmpi.sh
 
-# Install rocm-origami
-COPY ./common/common_utils.sh common_utils.sh
-COPY ci_commit_pins/rocm-origami.txt rocm-origami.txt
-RUN bash -c 'source /etc/rocm_env.sh && source common_utils.sh && env_run pip install "rocm-origami==$(cat rocm-origami.txt)"' && rm -f common_utils.sh rocm-origami.txt
+# rocm-origami install temporarily disabled: the pinned wheel can be
+# ABI-incompatible with the liborigami.so shipped by newer ROCm SDK builds,
+# which may crash when both are loaded in the same process. Origami's
+# import in Inductor already falls back gracefully when unavailable.
+# Re-enable once there's a rocm-origami release verified compatible with
+# the ROCm SDK it's paired with.
+# COPY ./common/common_utils.sh common_utils.sh
+# COPY ci_commit_pins/rocm-origami.txt rocm-origami.txt
+# RUN bash -c 'source /etc/rocm_env.sh && source common_utils.sh && env_run pip install "rocm-origami==$(cat rocm-origami.txt)"' && rm -f common_utils.sh rocm-origami.txt
 
 ARG BUILD_ENVIRONMENT
 ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}


### PR DESCRIPTION
The pip-installed rocm-origami wheel can end up ABI-incompatible with the
liborigami.so already shipped by the ROCm SDK, since the two are built and
released independently. When both get loaded into the same process, this
can lead to a crash.

Origami's import in `torch/_inductor/heuristics/template/triton.py` is
already guarded with try/except, so removing the package here means that
import fails cleanly and Inductor falls back to the regular autotune
config generator. No autotune correctness impact, just a compile-time
tradeoff during max-autotune on ROCm. The dedicated origami test file is
gated on `HAS_ORIGAMI` and self-skips.

This only touches the Docker image, not Inductor source, so it's a
one-line revert once there's a rocm-origami release verified compatible
with the ROCm SDK it ships alongside.

Note: this only protects PyTorch's CI. Anyone who separately installs
rocm-origami on a machine with a different ROCm SDK version may still see
this.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang