### PR TITLE
Consolidate device-side assert stderr checks into shared helper

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -17,6 +17,7 @@ import torch.nn.functional as F
 from torch import inf, nan
 from torch.autograd import gradcheck, gradgradcheck
 from torch.testing import make_tensor
+from torch.testing._internal.common_cuda import has_device_side_assert
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -867,14 +868,8 @@ torch.cuda.synchronize()
             error_msg = error_msgs[module_name]
 
             if should_error:
-                # CUDA shows assertion message
-                # ROCm shows launch failure or HSA_STATUS_ERROR_EXCEPTION
-                has_cuda_assert = error_msg in output
-                has_hip_error = (
-                    "launch failure" in output or "HSA_STATUS_ERROR_EXCEPTION" in output
-                )
                 self.assertTrue(
-                    has_cuda_assert or has_hip_error,
+                    error_msg in output or has_device_side_assert(output),
                     lambda msg: f"{msg}\nExpected device assert error, got: {output[-500:]}",
                 )
             else:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_cuda import (
     _create_scaling_case,
     _get_torch_cuda_version,
     blas_library_context,
+    has_device_side_assert,
     PLATFORM_SUPPORTS_GREEN_CONTEXT,
     PLATFORM_SUPPORTS_WORKQUEUE_CONFIG,
     SM70OrLater,
@@ -1968,17 +1969,7 @@ except RuntimeError as e:
         except subprocess.TimeoutExpired:
             p.kill()
             out, err = p.communicate()
-        expected_messages = [
-            "device-side assert triggered",  # CUDA
-            "Assertion",  # CUDA
-            "HSA_STATUS_ERROR_EXCEPTION",  # ROCm with TORCH_USE_HIP_DSA
-            "Device-side assertion",  # ROCm with TORCH_USE_HIP_DSA
-            # ROCm without TORCH_USE_HIP_DSA returns a launch failure instead
-            # of a proper device-side assertion, but still catches the error
-            "hipErrorLaunchFailure",
-            "unspecified launch failure",
-        ]
-        self.assertTrue(any(msg in out or msg in err for msg in expected_messages))
+        self.assertTrue(has_device_side_assert(out) or has_device_side_assert(err))
 
     @unittest.skipIf(
         not TEST_CUDAMALLOCASYNC, "requires the cudaMallocAsync allocator backend"
@@ -2069,16 +2060,8 @@ class TestThatContainsCUDAAssertFailure(TestCase):
 if __name__ == '__main__':
     run_tests()
 """)
-        # CUDA raises cudaErrorAssert (710) with "device-side assert triggered"
-        # ROCm with TORCH_USE_HIP_DSA raises a proper device-side assertion
-        # ROCm without TORCH_USE_HIP_DSA raises hipErrorLaunchFailure (719)
-        # which still catches the error but with less specific messaging
-        is_cuda_assert = "device-side assert triggered" in stderr
-        is_hip_assert = "hipErrorLaunchFailure" in stderr
-        is_hip_assert = is_hip_assert or "unspecified launch failure" in stderr
-        is_hip_assert = is_hip_assert or "HSA_STATUS_ERROR_EXCEPTION" in stderr
         self.assertTrue(
-            is_cuda_assert or is_hip_assert,
+            has_device_side_assert(stderr),
             lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
         )
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12213,11 +12213,13 @@ if __name__ == '__main__':
     run_tests()
         """)
         # CUDA says "device-side assert triggered"
-        # ROCm says "unspecified launch failure", or HSA_STATUS_ERROR_EXCEPTION
+        # ROCm may say "unspecified launch failure", HSA_STATUS_ERROR_EXCEPTION,
+        # or "Memory access fault"
         has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
         has_hip_assert = ('launch failure' in stderr
                           or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
-                          or 'illegal memory access' in stderr)
+                          or 'illegal memory access' in stderr
+                          or 'Memory access fault' in stderr)
         self.assertTrue(has_cuda_assert or has_hip_assert,
                         lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}")
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -41,7 +41,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
     skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN, \
-    SM80OrLater, SM90OrLater, _get_torch_rocm_version
+    SM80OrLater, SM90OrLater, _get_torch_rocm_version, has_device_side_assert
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, _create_basic_net, \
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
@@ -12212,15 +12212,7 @@ class TestThatContainsCUDAAssert(TestCase):
 if __name__ == '__main__':
     run_tests()
         """)
-        # CUDA says "device-side assert triggered"
-        # ROCm may say "unspecified launch failure", HSA_STATUS_ERROR_EXCEPTION,
-        # or "Memory access fault"
-        has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
-        has_hip_assert = ('launch failure' in stderr
-                          or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
-                          or 'illegal memory access' in stderr
-                          or 'Memory access fault' in stderr)
-        self.assertTrue(has_cuda_assert or has_hip_assert,
+        self.assertTrue(has_device_side_assert(stderr),
                         lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}")
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
     TEST_WITH_ROCM, decorateIf, skipIfXpu
 )
+from torch.testing._internal.common_cuda import has_device_side_assert
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
      get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
@@ -380,12 +381,8 @@ class TestThatContainsCUDAAssertFailure(TestCase):
 if __name__ == '__main__':
     run_tests()
 """)
-        # CUDA says "device-side assert triggered"
-        # ROCm says "unspecified launch failure" or HSA_STATUS_ERROR_EXCEPTION
-        has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
-        has_hip_assert = 'launch failure' in stderr or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
         self.assertTrue(
-            has_cuda_assert or has_hip_assert,
+            has_device_side_assert(stderr),
             lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
         )
         if torch.version.cuda:
@@ -427,12 +424,8 @@ instantiate_device_type_tests(
 if __name__ == '__main__':
     run_tests()
 """)
-        # CUDA says "device-side assert triggered"
-        # ROCm says "unspecified launch failure" or HSA_STATUS_ERROR_EXCEPTION
-        has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
-        has_hip_assert = 'launch failure' in stderr or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
         self.assertTrue(
-            has_cuda_assert or has_hip_assert,
+            has_device_side_assert(stderr),
             lambda msg: f"{msg}\nExpected device assert error in stderr, got: {stderr}",
         )
         if torch.version.cuda:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -93,6 +93,24 @@ IS_SM10X = LazyVal(lambda: torch.version.hip is None and torch.cuda.is_available
 IS_SM12X = LazyVal(lambda: torch.version.hip is None and torch.cuda.is_available() and
                    torch.cuda.get_device_capability()[0] == 12)
 
+# Substrings a subprocess prints when it dies from a device-side assert, or
+# from the GPU fault ROCm reports instead when device-side asserts are not
+# enabled. Tests that trigger a device assert in a child process should check
+# its output with has_device_side_assert rather than growing a local copy.
+DEVICE_ASSERT_MARKERS = (
+    "device-side assert triggered",  # CUDA
+    "Assertion `",  # CUDA/ROCm device-side printf: Assertion `cond` failed.
+    "HSA_STATUS_ERROR_EXCEPTION",  # ROCm with TORCH_USE_HIP_DSA
+    "Device-side assertion",  # ROCm with TORCH_USE_HIP_DSA
+    "hipErrorLaunchFailure",
+    "launch failure",  # covers "unspecified launch failure"
+    "illegal memory access",
+    "Memory access fault",  # ROCm 7.14+ VM fault abort
+)
+
+def has_device_side_assert(output):
+    return any(marker in output for marker in DEVICE_ASSERT_MARKERS)
+
 @contextlib.contextmanager
 def blas_library_context(backend):
     prev_backend = torch.backends.cuda.preferred_blas_library()


### PR DESCRIPTION
ROCm 7.14+ can report GPU VM faults as "Memory access fault by GPU node...", not only launch failure or HSA_STATUS_ERROR_EXCEPTION, when cross_entropy hits an out-of-bounds class index. This fixes:

- test_nn.py::TestNNDeviceTypeCUDA::test_cross_entropy_loss_2d_out_of_bounds_class_index_cuda_float16
- test_nn.py::TestNNDeviceTypeCUDA::test_cross_entropy_loss_2d_out_of_bounds_class_index_cuda_float32

Rather than patching the new message into that one test, this PR consolidates all six sites that grep subprocess output for device-side assert markers (test_nn.py, test_testing.py x2, test_cuda.py x2, test/nn/test_pooling.py), whose accepted-string sets had diverged and which hit the same failure mode on ROCm 7.14+, into a shared has_device_side_assert() helper backed by a DEVICE_ASSERT_MARKERS tuple in torch/testing/_internal/common_cuda.py. The next runtime message change is then a one-place fix. One marker is deliberately tightened: bare "Assertion" is now "Assertion `" (the device-side printf format), so a Python AssertionError in a child's stderr cannot satisfy the check.

All migrated call sites were validated on a gfx90a host running ROCm 7.14.60850, which emits the new "Memory access fault" message:

```
python test/test_nn.py -v -k test_cross_entropy_loss_2d_out_of_bounds_class_index
PYTORCH_TEST_WITH_SLOW=1 python test/test_testing.py -v -k test_cuda_assert_should_stop
PYTORCH_TEST_WITH_SLOW=1 python test/test_cuda.py -v -k test_multinomial_invalid_probs_cuda
PYTORCH_TEST_WITH_SLOW=1 python test/test_cuda.py -v -k test_index_out_of_bounds_exception_cuda
PYTORCH_TEST_WITH_SLOW=1 python test/nn/test_pooling.py -v -k test_MaxUnpool_index_errors
```

All pass. The CUDA-only markers cannot be exercised on a ROCm host and ride on upstream CI.

The consolidation was authored with Claude (AI assistant), reviewed and tested by @jeffdaily.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
