### PR TITLE
[TEST] Refactor utils, futures, and dataloader tests with hw_classification

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_CI,
     IS_JETSON,
     IS_LINUX,
@@ -170,6 +171,8 @@ def _sparse_coo_collate(b):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestDatasetRandomSplit(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_lengths_must_equal_dataset_size(self):
         with self.assertRaises(ValueError):
             random_split([1, 2, 3, 4], [1, 2])
@@ -399,6 +402,8 @@ class CountingIterableDataset(IterableDataset):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestTensorDataset(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_len(self):
         source = TensorDataset(torch.randn(15, 10, 2, 3, 4, 5), torch.randperm(15))
         self.assertEqual(len(source), 15)
@@ -453,6 +458,8 @@ class TestTensorDataset(TestCase):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestStackDataset(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_empty(self):
         with self.assertRaisesRegex(
             ValueError, "At least one dataset should be passed"
@@ -593,6 +600,8 @@ class TestStackDataset(TestCase):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestConcatDataset(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_concat_two_singletons(self):
         result = ConcatDataset([[0], [1]])
         self.assertEqual(2, len(result))
@@ -1225,6 +1234,8 @@ def filter_len(row):
     "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223",
 )
 class TestDataLoader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.data = torch.randn(100, 2, 3, 5)
@@ -3071,6 +3082,8 @@ except RuntimeError as e:
 
 
 class TestDataLoaderDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize(
         "context",
         [ctx for ctx in supported_multiprocessing_contexts if ctx is not None],
@@ -3162,6 +3175,8 @@ class TestDataLoaderDeviceType(TestCase):
 
 
 class IntegrationTestDataLoaderDataPipe(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     r"""
     Verify the behavior of a certain ``DataPipes`` with ``DataLoader``
     """
@@ -3237,6 +3252,8 @@ class StringDataset(Dataset):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestStringDataLoader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.dataset = StringDataset()
@@ -3268,6 +3285,8 @@ class DictDataset(Dataset):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestDictDataLoader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.dataset = DictDataset()
@@ -3608,6 +3627,8 @@ class NamedTupleDataset(Dataset):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestNamedTupleDataLoader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.dataset = NamedTupleDataset()
@@ -3677,6 +3698,8 @@ def collate_into_packed_sequence_batch_first(batch):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestCustomPinFn(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         inps = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
@@ -3684,7 +3707,7 @@ class TestCustomPinFn(TestCase):
         self.dataset = TensorDataset(inps, tgts)
 
     @unittest.skipIf(not TEST_PIN_MEMORY, "pin_memory requires accelerator")
-    def test_custom_batch_pin(self):
+    def test_custom_batch_pin(self, device):
         test_cases = [
             (collate_wrapper, self_module.SimpleCustomBatch),
             (collate_into_packed_sequence, torch.nn.utils.rnn.PackedSequence),
@@ -3702,7 +3725,7 @@ class TestCustomPinFn(TestCase):
                 self.assertTrue(sample.is_pinned())
 
     @unittest.skipIf(not TEST_PIN_MEMORY, "pin_memory requires accelerator")
-    def test_custom_batch_pin_worker(self):
+    def test_custom_batch_pin_worker(self, device):
         test_cases = [
             (collate_wrapper, self_module.SimpleCustomBatch),
             (collate_into_packed_sequence, torch.nn.utils.rnn.PackedSequence),
@@ -3745,6 +3768,8 @@ class TestWorkerQueueDataset(Dataset):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestIndividualWorkerQueue(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.dataset = TestWorkerQueueDataset(list(range(128)))
@@ -3804,6 +3829,8 @@ def _worker_set_affinity_init(worker_id):
     not hasattr(os, "sched_setaffinity"), "os.sched_setaffinity is not available"
 )
 class TestSetAffinity(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_affinity_in_worker_init(self):
         # Query the current affinity mask to avoid setting a disallowed one
         old_affinity = os.sched_getaffinity(0)
@@ -3839,6 +3866,8 @@ class ConvDataset(Dataset):
 
 @unittest.skipIf(IS_WINDOWS, "Needs fork")
 class TestConvAfterFork(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Tests crash reported in https://github.com/pytorch/pytorch/issues/53565
     def test_conv_after_fork(self):
         loader = DataLoader(ConvDataset(), num_workers=1)
@@ -3888,6 +3917,8 @@ class TestSlowIterableDataset(IterableDataset):
 
 
 class TestOutOfOrderDataLoader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_in_order_index_ds(self):
         dataset = TestSlowIndexDataset(end=10, slow_index=0)
 
@@ -3967,6 +3998,7 @@ class TestOutOfOrderDataLoader(TestCase):
 
 
 instantiate_device_type_tests(TestDataLoaderDeviceType, globals())
+instantiate_device_type_tests(TestCustomPinFn, globals(), except_for=["cpu"])
 
 
 if __name__ == "__main__":

--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -6,7 +6,13 @@ import time
 import torch
 import unittest
 from torch.futures import Future
-from torch.testing._internal.common_utils import IS_WINDOWS, TestCase, TemporaryFileName, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    TestCase,
+    TemporaryFileName,
+    run_tests,
+)
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -17,6 +23,8 @@ def add_one(fut):
 
 
 class TestFuture(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_exception(self) -> None:
         # This test is to ensure errors can propagate across futures.
         error_msg = "Intentional Value Error"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -960,7 +960,7 @@ class TestDeviceUtilsAccelerator(TestCase):
             torch.set_default_device(None)
 
 
-class TestDeviceUtilsCPU(TestCase):
+class TestDeviceModeOps(TestCase):
     hw_classification = HardwareClassification.CPU
 
     @onlyCPU
@@ -994,7 +994,7 @@ class TestDeviceUtilsCPU(TestCase):
 
 
 instantiate_device_type_tests(TestDeviceUtilsAccelerator, globals())
-instantiate_device_type_tests(TestDeviceUtilsCPU, globals(), only_for=("cpu",))
+instantiate_device_type_tests(TestDeviceModeOps, globals(), only_for=("cpu",))
 
 
 class TestCppExtensionUtils(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -57,7 +57,11 @@ from torch.utils.data import DataLoader
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests  # noqa: PLW0127
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # mypy: disable-error-code="name-defined"
@@ -72,6 +76,8 @@ class RandomDatasetMock(torch.utils.data.Dataset):
 
 
 class TestCheckpoint(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # This runs checkpoint_sequential on each of the nets in
     # module_lists_to_compare, and compares them against the uncheckpointed model.
     # To compare, it checks outputs as well as input gradients and parameter gradients
@@ -397,6 +403,15 @@ class TestCheckpoint(TestCase):
             out = checkpoint(run_fn2, input_var, input_var2, use_reentrant=True)
             out.sum().backward()
 
+    def test_infer_device_state_recursive_meta(self):
+        inp = {"foo": torch.rand(10, device="meta")}
+        device_type = _infer_device_type(inp)
+        self.assertEqual("meta", device_type)
+
+
+class TestCheckpointAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(not torch.accelerator.is_available(), "No accelerator")
     def test_checkpointing_without_reentrant_early_free(self):
         _acc = torch.accelerator.current_accelerator()
@@ -466,13 +481,10 @@ class TestCheckpoint(TestCase):
         self.assertEqual(non_retain_stats, checkpoint_non_retain_stats)
         self.assertEqual(non_retain_stats, checkpoint_retain_stats)
 
-    def test_infer_device_state_recursive_meta(self):
-        inp = {"foo": torch.rand(10, device="meta")}
-        device_type = _infer_device_type(inp)
-        self.assertEqual("meta", device_type)
-
 
 class TestCheckpointDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     def test_checkpoint_rng_accelerator(self, device):
         for _ in range(5):
@@ -592,6 +604,8 @@ instantiate_device_type_tests(
 
 
 class TestDataLoaderUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     MAX_TIMEOUT_IN_SECOND = 300
 
     @unittest.skipIf(TEST_WITH_ASAN, "https://github.com/pytorch/pytorch/issues/84937")
@@ -669,17 +683,23 @@ from torch.utils.collect_env import get_pretty_env_info
 
 @unittest.skipIf(IS_FBCODE, "runs pip which is not available internally")
 class TestCollectEnv(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_smoke(self):
         info_output = get_pretty_env_info()
         self.assertTrue(info_output.count("\n") >= 17)
 
 
 class TestHipify(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_import_hipify(self):
         from torch.utils.hipify import hipify_python  # noqa: F401
 
 
 class TestHipifyTrie(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         from torch.utils.hipify import hipify_python
@@ -752,6 +772,8 @@ class TestHipifyTrie(TestCase):
 
 
 class TestAssert(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_assert_true(self):
         # verify assertions work as expected
         # bool argument
@@ -781,6 +803,8 @@ class TestAssert(TestCase):
 
 @unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()
         try:
@@ -836,6 +860,8 @@ class TestStandaloneCPPJIT(TestCase):
 
 
 class TestRenderUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         self.assertExpectedInline(
             torch._utils.render_call(torch.sum, [torch.randn(100)], {"dim": 0}),
@@ -848,6 +874,8 @@ class TestRenderUtils(TestCase):
 
 
 class TestDeviceUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         with torch.device("meta") as dev:
             x = torch.empty(3, 3)
@@ -890,6 +918,10 @@ class TestDeviceUtils(TestCase):
         self.assertEqual(torch.get_default_device().type, "meta")
         torch.set_default_device(None)
 
+
+class TestDeviceUtilsAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     @deviceCountAtLeast(2)
     def test_get_default_device_more(self, devices):
@@ -927,6 +959,10 @@ class TestDeviceUtils(TestCase):
         finally:
             torch.set_default_device(None)
 
+
+class TestDeviceUtilsCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @onlyCPU
     @ops(op_db)
     def test_device_mode_ops(self, device, dtype, op):
@@ -957,10 +993,13 @@ class TestDeviceUtils(TestCase):
             self.assertTrue(tree_all_only(torch.Tensor, is_meta_device, r))
 
 
-instantiate_device_type_tests(TestDeviceUtils, globals())
+instantiate_device_type_tests(TestDeviceUtilsAccelerator, globals())
+instantiate_device_type_tests(TestDeviceUtilsCPU, globals(), only_for=("cpu",))
 
 
 class TestCppExtensionUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_cpp_compiler_is_ok(self):
         self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform("c++"))
 
@@ -969,6 +1008,8 @@ class TestCppExtensionUtils(TestCase):
 
 
 class TestTraceback(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         source = """\
 def f(x):
@@ -1019,6 +1060,8 @@ def f(x):
 
 
 class TestTryImport(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_import_imported(self):
         self.assertIn("os", sys.modules)
         os_module = try_import("os")
@@ -1037,6 +1080,8 @@ class TestTryImport(TestCase):
 
 
 class TestUtilsInternal(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_max_clock_rate_falls_back_to_pynvml_when_nvidia_smi_missing(self):
         def nvsmi(_query):
             raise FileNotFoundError("nvidia-smi")
@@ -1093,6 +1138,8 @@ def _deprecated_api(x, y=15):
 
 
 class TestDeprecate(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_deprecated(self):
         with self.assertWarnsRegex(Warning, "is DEPRECATED"):
             # pyrefly: ignore [unknown-name]
@@ -1105,6 +1152,8 @@ class TestDeprecate(TestCase):
 
 
 class TestDeviceLazyInit(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(IS_WINDOWS, "pthread_atfork not available on Windows")
     def test_fork_poison_on_lazy_init(self, device):
         torch.empty(1, device=device)
@@ -1136,6 +1185,8 @@ instantiate_device_type_tests(
 
 
 class TestEnv(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_getenv_matches_os(self):
         for name in ("PATH", "PATH_DOES_NOT_EXIST_TORCH_TEST"):
             self.assertEqual(torch._utils.getenv(name), os.environ.get(name))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20318,7 +20318,7 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                # AssertionError in CUDA variant
                DecorateInfo(unittest.skip("Skipped!"), 'TestFakeTensor', device_type=('cuda', 'xpu')),
-               DecorateInfo(unittest.skip("Skipped!"), 'TestDeviceUtils', 'test_device_mode_ops'))),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestDeviceModeOps', 'test_device_mode_ops'))),
     OpInfo('bernoulli',
            op=lambda inp, *args, **kwargs:
                wrapper_set_seed(torch.bernoulli, inp, *args, **kwargs),


### PR DESCRIPTION
## Summary

Apply hardware classification to utils, futures, and dataloader tests following #186918 guidelines.

**`test/test_futures.py`**
- **TestFuture**: `GENERIC` (CPU-only futures API tests)

**`test/test_utils.py`**
- **TestCheckpoint**, **TestDataLoaderUtils**, **TestCollectEnv**, **TestHipify**, **TestHipifyTrie**, **TestAssert**, **TestStandaloneCPPJIT**, **TestRenderUtils**, **TestDeviceUtils**, **TestCppExtensionUtils**, **TestTraceback**, **TestTryImport**, **TestDeprecate**, **TestEnv**, **TestUtilsInternal**, **TestVerifyDynamoRocm**: `GENERIC`
- **TestCheckpointAccelerator**, **TestCheckpointDeviceType**, **TestDeviceUtilsAccelerator**, **TestDeviceLazyInit**: `ACCELERATOR`
- **TestDeviceModeOps**: `CPU`
- **TestCheckpointAccelerator**: device-generic via `instantiate_device_type_tests(..., except_for=["cpu"], allow_xpu=True)` (review follow-up)

**`test/test_dataloader.py`**
- Fourteen classes (`TestDatasetRandomSplit` through `TestConvAfterFork`, `TestOutOfOrderDataLoader`, etc.): `GENERIC`
- **TestDataLoaderDeviceType**, **TestCustomPinFn**: `ACCELERATOR` (`instantiate_device_type_tests`; `TestCustomPinFn` uses `except_for=["cpu"]` and `TEST_PIN_MEMORY` skip guards)

**`torch/testing/_internal/common_methods_invocations.py`**
- Update `DecorateInfo` skip for the renamed `TestDeviceModeOps` (was `TestDeviceUtilsCPU`)

## Test plan

```
lintrunner -a test/test_futures.py test/test_utils.py test/test_dataloader.py
# ok No lint issues.

python -c "import ast; ast.parse(open('test/test_futures.py').read()); print('OK')"
python -c "import ast; ast.parse(open('test/test_utils.py').read()); print('OK')"
python -c "import ast; ast.parse(open('test/test_dataloader.py').read()); print('OK')"

python test/test_futures.py --hw-classification GENERIC -v
python test/test_utils.py --hw-classification GENERIC -v
python test/test_utils.py --hw-classification ACCELERATOR -v
python test/test_utils.py --hw-classification CPU -v
python test/test_dataloader.py --hw-classification GENERIC -v
python test/test_dataloader.py --hw-classification ACCELERATOR -v
```

Authored with an AI assistant.