### PR TITLE
[inductor] Fix missing int_array declarations in AOTI C++ wrapper

### DIFF
--- a/test/inductor/test_wrapper_codegen.py
+++ b/test/inductor/test_wrapper_codegen.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+from itertools import count
 from types import SimpleNamespace
 
 import sympy
@@ -381,6 +382,50 @@ int64_t s1 = arg0_1.sizes()[0];
 int64_t s0 = s1;""",
         )
         self.assertEqual(list(bound_vars), [canonical, raw])
+
+    def _new_int_array_wrapper(self):
+        wrapper = CppWrapperCpu.__new__(CppWrapperCpu)
+        wrapper.int_array_id = count()
+        wrapper.declared_int_array_vars = OrderedSet()
+        wrapper.codegen_int_array_var_cache = {}
+        wrapper._int_array_writeline_targets = []
+        return wrapper
+
+    def test_int_array_declared_in_every_fresh_writeline_target(self):
+        # codegen_int_array_var emits no declaration on a cache hit, so a key that
+        # aliases a dead target hands back a name whose declaration went into a
+        # discarded buffer. Short-lived targets (per-callsite IndentedBuffers, as
+        # used by ReinterpretView.codegen_reference) make that reachable: CPython
+        # reuses the address of a freed object, in practice on the very next
+        # allocation.
+        wrapper = self._new_int_array_wrapper()
+        for _ in range(64):
+            buffer = IndentedBuffer()
+            var = wrapper.codegen_int_array_var("{2, 3}", buffer.writeline)
+            self.assertIn(f"{var}[] = {{2, 3}};", buffer.getvalue())
+            del buffer
+
+    def test_int_array_declared_once_per_live_writeline_target(self):
+        wrapper = self._new_int_array_wrapper()
+        buffer = IndentedBuffer()
+
+        first = wrapper.codegen_int_array_var("{2, 3}", buffer.writeline)
+        second = wrapper.codegen_int_array_var("{2, 3}", buffer.writeline)
+
+        self.assertEqual(first, second)
+        self.assertEqual(buffer.getvalue().count(f"{first}[] = {{2, 3}};"), 1)
+
+    def test_int_array_distinct_per_writeline_target(self):
+        wrapper = self._new_int_array_wrapper()
+        first_buffer = IndentedBuffer()
+        second_buffer = IndentedBuffer()
+
+        first = wrapper.codegen_int_array_var("{2, 3}", first_buffer.writeline)
+        second = wrapper.codegen_int_array_var("{2, 3}", second_buffer.writeline)
+
+        self.assertNotEqual(first, second)
+        self.assertIn(f"{first}[] = {{2, 3}};", first_buffer.getvalue())
+        self.assertIn(f"{second}[] = {{2, 3}};", second_buffer.getvalue())
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -321,6 +321,12 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.device_codegen = get_device_op_overrides(self.device)
         self._included_extra_headers: OrderedSet[str] = OrderedSet()
         self.codegen_int_array_var_cache = {}
+        # codegen_int_array_var_cache keys on id() of the writeline target. CPython
+        # reuses the address of a freed object, so a short-lived target (a per-callsite
+        # IndentedBuffer) can collide with a dead one and produce a spurious cache hit,
+        # which returns a var name whose declaration was written into the dead buffer.
+        # Pin the targets for the lifetime of codegen so their ids stay unique.
+        self._int_array_writeline_targets: list[Any] = []
         self.needs_vec_isa = self.device == "cpu"
 
     @contextlib.contextmanager
@@ -2405,16 +2411,19 @@ class CppWrapperCpu(PythonWrapperCodegen):
     ) -> str:
         # Use id(graph) for caching to avoid circular references
         # Bound methods have transient IDs, so we use the ID of the bound object instead.
-        writeline_id = (
-            id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)
+        writeline_target = (
+            writeline.__self__ if hasattr(writeline, "__self__") else writeline
         )
         cache_key = (
             int_array,
-            writeline_id,
+            id(writeline_target),
             known_statically,
             id(graph) if graph else None,
         )
         if cache_key not in self.codegen_int_array_var_cache:
+            # A cache hit emits no declaration, so the key must not alias a dead
+            # target; see _int_array_writeline_targets.
+            self._int_array_writeline_targets.append(writeline_target)
             self.codegen_int_array_var_cache[cache_key] = (
                 self._codegen_int_array_var_impl(int_array, writeline, known_statically)
             )


### PR DESCRIPTION
Summary:
AOTI C++ wrapper codegen can emit references to `int_array_N` variables that are
never declared, so the generated wrapper fails to compile:

```
wrapper.cpp:25903:232: error: use of undeclared identifier 'int_array_2'
wrapper.cpp:25903:245: error: use of undeclared identifier 'int_array_3'
wrapper.cpp:26743:293: error: use of undeclared identifier 'int_array_12'
```

On the affected model the generated wrapper referenced 294 distinct `int_array_N`
and declared only 277. All but one of the 17 missing declarations were referenced
from `reinterpret_tensor_wrapper(...)` nested inside
`aoti_torch_proxy_executor_call_function(...)` argument lists, i.e. extern /
custom-op fallbacks.

**Mechanism.** `_codegen_int_array_var_impl` mints a fresh name off
`self.int_array_id` on every call, so the `if var not in self.declared_int_array_vars`
guard is always true and the only deduplication is `codegen_int_array_var_cache`.
A cache hit therefore emits no declaration at all -- it assumes one already exists
in the same writeline target.

The cache key embeds `id(writeline.__self__)`. For `V.graph.wrapper_code.writeline`
that object is long-lived, but `ReinterpretView.codegen_reference` passes
`writer.writeline` where `writer` is a per-callsite `IndentedBuffer`:

```python
writer.writeline if writer is not None else V.graph.wrapper_code.writeline
```

CPython reuses the address of a freed object, so a newly created temporary buffer
can land on a dead one's address, collide with its cache entry, and receive a var
name whose declaration was written into the buffer that has since been discarded.

Evidence that this is address aliasing rather than a systematic routing split: of
the 22 int arrays referenced from proxy-executor calls in the failing wrapper, 6
were declared and 16 were not. A routing bug would have dropped all 22.

**Why it surfaced.** Reproduced with `triton.autotune_at_compile_time=False`, whose
dual-wrapper path generates both a JIT and an AOT source and creates many more
short-lived buffers. The failing compile is the JIT variant (the command carries
`-D TORCH_INDUCTOR_CPP_WRAPPER` but no `-DAOT_INDUCTOR`). The hazard is latent in
the default one-pass mode -- nothing about it is specific to dual-wrapper mode
beyond allocation churn making address reuse likely.

**Fix.** Retain a reference to the object whose `id()` participates in the cache
key, so ids stay unique for the lifetime of wrapper codegen. There is no behavior
change on the intended path: a target that is genuinely still alive has the same
`id()` with or without this change, so only the already-broken cases differ.

Two things a reviewer may prefer, happy to switch to either:

- Rather than retaining targets, give each writeline target an explicit monotonic
  scope id (an attribute set on first use) and key on that. Avoids retention
  entirely; the cost is annotating foreign objects.
- More fundamentally, `declared_int_array_vars` is effectively dead code because
  `var` is always freshly generated, so there is no backstop if the cache key is
  ever wrong. Tracking declarations per output buffer would make a missing
  declaration structurally impossible. That is a larger change.

---
> Authored with [Claude Code](https://fb.workplace.com/groups/claude.code.community)

Test Plan:
VALIDATED. Before/after on the same artifact and the same lowering config, with
only this change differing.

Config under test: AOTI lowering of the `user_merge_request_only` submodule of an
HSTU/jagged ads model -- model entity 2110169256, lowering lib `ien.lower.cg1:ed48c07`,
with `'triton.autotune_at_compile_time': False` in `aot_inductor_config`. That is
the dual-wrapper path which generates both a JIT and an AOT source.

## Before -- P2459674964, P2460666553

```
InductorError: CppCompileError: C++ compile error
wrapper.cpp:25903:232: error: use of undeclared identifier 'int_array_2'
wrapper.cpp:25903:245: error: use of undeclared identifier 'int_array_3'
wrapper.cpp:26743:293: error: use of undeclared identifier 'int_array_12'
```

16 undeclared identifiers: `int_array_2`, `int_array_3`, `int_array_12`..`int_array_17`,
`int_array_22`..`int_array_29`.

Static analysis of the generated wrapper from that run
(`ci2br4znz6zm3d75f6r6ruuhgbxpeg7jxynjchzautftn4obqqhh.wrapper.cpp`):

```
declared: 277   used: 294
int_arrays used in proxy_executor calls: 22
  ...of which declared:     6
  ...of which NOT declared: 16
```

6 of 22 declared is what distinguishes address aliasing from a systematic
JIT/AOT routing split, which would have dropped all 22.

## After -- P2460793587

Same entity, same lowering lib, same config. The log's shell prompt shows the run
was made from commit `802b5691f7`, i.e. this change (hash predates a later
metadata sync), so there is no ambiguity about the patch being in the build.

- 0 occurrences of `use of undeclared identifier`
- 0 `CppCompileError`
- every lowering stage completed:

```
torch_package_deserialization             8.9s
lowering_submodule_split                  0.2s
move_to_cuda                              5.3s
weight_changing_transform                 0.0s
preset_application                        0.0s
dper_pass_application                     9.1s
lowering_graph_split                     29.2s
export                                   57.3s
aoti_compilation                        209.8s
lower_pass                              273.5s
aoti_lowerer                            311.9s
lowered_module_inference_check            0.0s
generate_lowered_module                 317.4s
jit_generation                            0.3s
aoti_lowering                           319.6s
packing_lowering_artifacts               25.5s
```

```
Upload lowered model elapsed time: 0:00:22.976000 size: 5530033139 bytes
Lowering duration: 404.37236428260803 seconds
```

`jit_generation` in the stage list confirms the two-pass dual-wrapper path
actually ran; that stage is absent when `autotune_at_compile_time` is left at its
default, i.e. the fixed code path was exercised.

Reproduced independently in an earlier run, P2460772279 -- same config, same
result, byte-identical output size (5530033139).

Caveat: AOTI removes the generated wrapper `.cpp` after a successful compile, so
the declared-vs-used grep could not be re-run post-fix; only the two pre-fix
wrappers remain on disk. A successful clang compile of that source is a stronger
check than the grep anyway, since the compiler validates every identifier rather
than just the `int_array_*` ones.

## Secondary result

With this fix, `autotune_at_compile_time=False` lowers the artifact unmodified.
That matters beyond the compile error: with the default (`True`), the standalone
autotuner seeds extern-op outputs via `generate_example_value`, which is
zero-filled for int64 (`torch/_dynamo/testing.py`). A zero offsets array makes
`searchsorted` return B, out of range for a B-length consumer, and the resulting
`tl.device_assert` poisons the CUDA context and aborts compilation. 13 of 169
kernels in this graph carry indirect-indexing asserts, so that recurs. The
no-fabrication path runs the real graph, so none of them can fire. Fixing this
codegen bug therefore unblocks that whole class, not just the compile error.


## Unit tests

Three tests added to
`caffe2/test/inductor/test_wrapper_codegen.py`, driving `codegen_int_array_var`
directly. The file already builds wrappers with `CppWrapperCpu.__new__`, bypassing
`__init__`, so no `V.graph` is needed; a small `_new_int_array_wrapper` helper sets
the four attributes the method touches.

- `test_int_array_declared_in_every_fresh_writeline_target` -- the regression test.
  Calls `codegen_int_array_var` 64 times, each with a newly allocated
  `IndentedBuffer` that is dropped afterwards, and asserts the declaration lands in
  that buffer every time. This is exactly the reported failure mode: CPython hands
  the freed buffer's address to the next allocation, the stale `id()` key matches,
  and the call returns a name whose declaration went into a discarded buffer.
  Short-lived targets are not contrived -- `ReinterpretView.codegen_reference`
  creates one per callsite.
- `test_int_array_declared_once_per_live_writeline_target` -- caching still works:
  two calls against one live buffer return the same name and emit one declaration.
- `test_int_array_distinct_per_writeline_target` -- two live buffers get distinct
  names, each declared into its own buffer.

```
buck2 test fbcode//caffe2/test/inductor:wrapper_codegen -- --regex "int_array"
```

```
Tests finished: Pass 4. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0.
```

(4 = the 3 tests above plus the `main` pseudo-test TestPilot reports.)
https://www.internalfb.com/intern/testinfra/testrun/281475496913760

Negative control, to show the regression test is pinned to this fix rather than
passing incidentally -- delete only the
`self._int_array_writeline_targets.append(writeline_target)` line and re-run:

```
Tests finished: Pass 3. Fail 1.
```

The failure is `test_int_array_declared_in_every_fresh_writeline_target`; the other
two still pass, as they should, since neither depends on the pin.

Address reuse is timing-dependent in principle but is deterministic in practice
here: a standalone simulation hit the spurious cache hit at iteration 1 without the
pin and never within 2000 iterations with it. 64 iterations leaves ample margin.

Differential Revision: D115934107




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo