### PR TITLE
Add TORCH_COMPILE_STATIC_SOURCES (#193626)

### DIFF
--- a/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_core_concepts.md
+++ b/docs/source/user_guide/torch_compiler/compile/dynamic_shapes_core_concepts.md
@@ -72,6 +72,10 @@ source names stay consistent. You can also use this to mark integers as dynamic.
 You can also use regexes, for example, `"L\['x.*'\], L\['y.*'\]")`.
 This whitelist takes precedence over other flags like `dynamic=False` `force_nn_module_property_static_shapes`, and `force_parameter_static_shapes`.
 
+The mirror image is `TORCH_COMPILE_STATIC_SOURCES` / `torch.compiler.config.static_sources`,
+which pins the listed sources static. It accepts the same source-name, regex and `:N` per-dim
+syntax, and takes precedence over automatic dynamic shapes, PGO and `dynamic=True`.
+
 Sometimes it can be cumbersome to find the right inputs to mark as dynamic. If
 you're willing to take a performance hit for the first batch, one other affordable
 option we have are the `eager_then_compile` stances which derive dynamism for you.

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamic_shapes.md
@@ -273,6 +273,35 @@ f(torch.rand(30))
 f(torch.rand(40))
 ```
 
+(static_sources_allow_list)=
+#### Static Source List (`STATIC_SOURCES`)
+
+The inverse of the dynamic source list: use the environment variable
+`TORCH_COMPILE_STATIC_SOURCES` (or `torch.compiler.config.static_sources`) to pass a
+list of source names that should stay static. This is useful when automatic dynamic
+shapes or PGO makes something dynamic and that dynamism hurts you, for example when
+it produces a worse kernel. It accepts the same exact-name,
+regex and `:N` per-dim syntax as `TORCH_COMPILE_DYNAMIC_SOURCES`, and works for both
+integers and tensor sizes.
+
+Entries override automatic dynamic shapes, PGO and `dynamic=True`. They do not override
+an explicit {func}`torch._dynamo.mark_dynamic`.
+
+Here is an example:
+
+```{code-cell}
+import torch
+
+@torch.compile()
+def g(x):
+     return x * x.size()[0]
+
+with torch.compiler.config.patch(static_sources="L['x']"):
+    g(torch.rand(10))
+    g(torch.rand(20))
+    g(torch.rand(30))
+```
+
 (torch.compiler.set_stance_eager_then_compile)=
 #### `torch.compiler.set_stance ("eager_then_compile")`
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11209,6 +11209,136 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         self.assertEqual(counter.frame_count, 1)
 
+    @torch.compiler.config.patch(static_sources="L['x']")
+    def test_static_sources_tensor(self):
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x * x
+
+        # Without static-sources automatic dynamic would kick in on the second
+        # call and give us 2 frames; here every size specializes.
+        fn(torch.randn(2))
+        fn(torch.randn(3))
+        fn(torch.randn(4))
+
+        self.assertEqual(counter.frame_count, 3)
+
+    @torch.compiler.config.patch(static_sources="L['x']")
+    def test_static_sources_int(self):
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return torch.randn(5) * x
+
+        fn(1)
+        fn(2)
+        fn(3)
+
+        self.assertEqual(counter.frame_count, 3)
+
+    @torch.compiler.config.patch(static_sources="L['x']")
+    def test_static_sources_dynamic_override(self):
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=True, backend=counter)
+        def fn(x):
+            return x * x
+
+        fn(torch.randn(2))
+        fn(torch.randn(3))
+        fn(torch.randn(4))
+
+        self.assertEqual(counter.frame_count, 3)
+
+    @torch.compiler.config.patch(static_sources="L\\['x.*'\\]")
+    def test_static_sources_regex(self):
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=True, backend=counter)
+        def fn(x1):
+            return x1 * x1
+
+        fn(torch.randn(2))
+        fn(torch.randn(3))
+
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(static_sources="L['x']:1")
+    def test_static_sources_per_dim(self):
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=True, backend=counter)
+        def fn(x):
+            return x * x
+
+        # Dim 0 stays dynamic, so varying it does not recompile.
+        fn(torch.randn(2, 4))
+        fn(torch.randn(3, 4))
+        self.assertEqual(counter.frame_count, 1)
+
+        # Dim 1 is static, so varying it does.
+        fn(torch.randn(3, 5))
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(
+        dynamic_values="1111",
+        static_sources="L['x']",
+    )
+    def test_static_sources_beat_dynamic_values_tensor(self):
+        builder._DYNAMIC_VALUES = None
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x * x
+
+        # Same shapes as test_dynamic_values_tensor, which gets 1 frame: the
+        # sentinel dim 1111 marks the dim dynamic. static-sources undoes that,
+        # so every size specializes instead.
+        fn(torch.randn(1111))
+        fn(torch.randn(3))
+        fn(torch.randn(4))
+
+        self.assertEqual(counter.frame_count, 3)
+
+    @torch.compiler.config.patch(
+        dynamic_values="1111",
+        static_sources="L['x']",
+    )
+    def test_static_sources_beat_dynamic_values_int(self):
+        builder._DYNAMIC_VALUES = None
+        builder._STATIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return torch.randn(5) * x
+
+        # Same values as test_dynamic_values_int, which gets 1 frame. Unlike the
+        # tensor path, precedence here comes from is_static_source being checked
+        # before is_dynamic_value in wrap_literal -- this pins that ordering.
+        fn(1111)
+        fn(2)
+        fn(3)
+
+        self.assertEqual(counter.frame_count, 3)
+
     @torch.compiler.config.patch(unbacked_sources="L['x']:0")
     def test_unbacked_sources_per_dim(self):
         builder._UNBACKED_SOURCES = None

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2776,25 +2776,29 @@ class VariableBuilder:
                         f"{int_spec!r} (expected int, IntVar, or None)"
                     )
 
-            if is_dynamic_source(self.source.name):
+            # Precedence, highest first: static-sources, dynamic-sources,
+            # unbacked-sources, dynamic-values.
+            if is_static_source(self.source.name):
+                log.debug("%s marked static via static-sources list", self.source.name)
+                self.install_guards(GuardBuilder.CONSTANT_MATCH)
+                return ConstantVariable.create(value=value, source=self.source)
+            elif is_dynamic_source(self.source.name):
                 log.debug(
                     "%s marked dynamic via dynamic-sources list", self.source.name
                 )
                 return self.wrap_symint(value, dynamism=DimDynamic.DYNAMIC)
-
-            if is_dynamic_value(value):
+            elif is_unbacked_source(self.source.name):
+                log.debug(
+                    "%s marked unbacked via unbacked-sources list", self.source.name
+                )
+                return self.wrap_symint(value, dynamism=DimDynamic.UNBACKED)
+            elif is_dynamic_value(value):
                 log.debug(
                     "%s marked dynamic via dynamic-values list (value=%s)",
                     self.source.name,
                     value,
                 )
                 return self.wrap_symint(value, dynamism=DimDynamic.DYNAMIC)
-
-            if is_unbacked_source(self.source.name):
-                log.debug(
-                    "%s marked unbacked via unbacked-sources list", self.source.name
-                )
-                return self.wrap_symint(value, dynamism=DimDynamic.UNBACKED)
 
             if not config.specialize_int:
                 # unspecializing int by default, but still
@@ -4413,6 +4417,21 @@ def get_dynamic_sources() -> list[tuple[str, int | None]]:
     return _DYNAMIC_SOURCES
 
 
+def _match_source_list(
+    sources: list[tuple[str, int | None]], source_name: str, dim: int | None
+) -> str | None:
+    """Return the matching entry, pretty printed, or None if nothing matches.
+
+    Unlike the ``is_*_source`` wrappers this does not log, so it is safe to call
+    when merely resolving precedence between the source lists.
+    """
+    for pattern, pat_dim in sources:
+        if pattern == source_name or re.match(pattern, source_name):
+            if dim is None or pat_dim is None or pat_dim == dim:
+                return pattern if pat_dim is None else f"{pattern}:{pat_dim}"
+    return None
+
+
 def is_dynamic_source(source_name: str, dim: int | None = None) -> bool:
     """Check whether ``source_name`` is in the dynamic-sources list.
 
@@ -4424,23 +4443,16 @@ def is_dynamic_source(source_name: str, dim: int | None = None) -> bool:
     If ``dim`` is given, returns True only when a matching entry either has no
     dim qualifier ("all dims dynamic") or its dim qualifier equals ``dim``.
     """
-    dynamic_sources = get_dynamic_sources()
-    for pattern, pat_dim in dynamic_sources:
-        if pattern == source_name or re.match(pattern, source_name):
-            if dim is None or pat_dim is None or pat_dim == dim:
-                pretty = pattern if pat_dim is None else f"{pattern}:{pat_dim}"
-                log.debug(
-                    "%s was marked dynamic due to dynamic-sources entry: %s",
-                    source_name,
-                    pretty,
-                )
-                symbolic_shape_log.info(
-                    "%s was marked dynamic due to dynamic-sources entry: %s",
-                    source_name,
-                    pretty,
-                )
-                return True
-    return False
+    entry = _match_source_list(get_dynamic_sources(), source_name, dim)
+    if entry is None:
+        return False
+    log.debug(
+        "%s was marked dynamic due to dynamic-sources entry: %s", source_name, entry
+    )
+    symbolic_shape_log.info(
+        "%s was marked dynamic due to dynamic-sources entry: %s", source_name, entry
+    )
+    return True
 
 
 def record_automatic_dynamic(
@@ -4506,17 +4518,59 @@ def is_unbacked_source(source_name: str, dim: int | None = None) -> bool:
 
     See :func:`is_dynamic_source` for the ``dim`` argument semantics.
     """
-    unbacked_sources = get_unbacked_sources()
-    for pattern, pat_dim in unbacked_sources:
-        if pattern == source_name or re.match(pattern, source_name):
-            if dim is None or pat_dim is None or pat_dim == dim:
-                log.debug(
-                    "%s was marked unbacked due to unbacked-sources entry: %s",
-                    source_name,
-                    pattern if pat_dim is None else f"{pattern}:{pat_dim}",
-                )
-                return True
-    return False
+    entry = _match_source_list(get_unbacked_sources(), source_name, dim)
+    if entry is None:
+        return False
+    log.debug(
+        "%s was marked unbacked due to unbacked-sources entry: %s", source_name, entry
+    )
+    return True
+
+
+# Same per-dim suffix syntax as _DYNAMIC_SOURCES: optional ":N" restricts the
+# match to dim N of the matched tensor.
+_STATIC_SOURCES: list[tuple[str, int | None]] | None = None
+_STATIC_SOURCES_CONFIG_HASH: int | None = None
+
+
+def get_static_sources() -> list[tuple[str, int | None]]:
+    global _STATIC_SOURCES, _STATIC_SOURCES_CONFIG_HASH
+
+    current_hash = hash(torch.compiler.config.static_sources)
+
+    # If we have already calculated the sources and the config hasn't changed, return cached result
+    if _STATIC_SOURCES is not None and _STATIC_SOURCES_CONFIG_HASH == current_hash:
+        return _STATIC_SOURCES
+
+    # Config has changed or first time, (re)calculate the sources
+    _STATIC_SOURCES = [
+        _parse_source_entry(s)
+        for s in torch.compiler.config.static_sources.replace(" ", "").split(",")
+        if s
+    ]
+    _STATIC_SOURCES_CONFIG_HASH = current_hash
+
+    return _STATIC_SOURCES
+
+
+def is_static_source(source_name: str, dim: int | None = None) -> bool:
+    """Check whether ``source_name`` is in the static-sources list.
+
+    Precedence against the dynamic-/unbacked-sources lists is resolved by the
+    callers, which check static-sources first.
+
+    See :func:`is_dynamic_source` for the ``dim`` argument semantics.
+    """
+    entry = _match_source_list(get_static_sources(), source_name, dim)
+    if entry is None:
+        return False
+    log.debug(
+        "%s was marked static due to static-sources entry: %s", source_name, entry
+    )
+    symbolic_shape_log.info(
+        "%s was marked static due to static-sources entry: %s", source_name, entry
+    )
+    return True
 
 
 # Cache for the parsed `torch.compiler.config.dynamic_values` config.
@@ -4771,21 +4825,33 @@ def _automatic_dynamic(
             config.automatic_dynamic_shapes and frame_state_entry.is_stride_dynamic(i)
         )
 
-        if is_dynamic_source(name, i):
+        # Precedence, highest first: static-sources, dynamic-sources,
+        # unbacked-sources, dynamic-values.
+        unbacked_via_source = False
+        if is_static_source(name, i):
+            log.debug("%s dim %d marked static via static-sources list", name, i)
+            marked_static = True
+            automatic_dynamic_size = False
+            automatic_dynamic_stride = False
+            # Weak/propagated dynamism is a hint (maybe_mark_dynamic, or AOTAutograd
+            # propagating dynamism across a graph break), so the explicit static
+            # request wins. A hard mark_dynamic still takes precedence, matching
+            # the precedence mark_static has.
+            marked_weak_dynamic = False
+        elif is_dynamic_source(name, i):
             log.debug("%s dim %d marked dynamic via dynamic-sources list", name, i)
             automatic_dynamic_size = True
-
-        if is_dynamic_value(e.size(i)):
+        elif is_unbacked_source(name, i):
+            log.debug("%s dim %d marked unbacked via unbacked-sources list", name, i)
+            unbacked_via_source = True
+            automatic_dynamic_size = True
+        elif is_dynamic_value(e.size(i)):
             log.debug(
                 "%s dim %d marked dynamic via dynamic-values list (value=%s)",
                 name,
                 i,
                 e.size(i),
             )
-            automatic_dynamic_size = True
-
-        if is_unbacked_source(name, i):
-            log.debug("%s dim %d marked unbacked via unbacked-sources list", name, i)
             automatic_dynamic_size = True
 
         automatic_dynamic = automatic_dynamic_size or automatic_dynamic_stride
@@ -4838,7 +4904,7 @@ def _automatic_dynamic(
         constraint_sizes.append(constraint_size)
         constraint_strides.append(constraint_stride)
 
-        if marked_unbacked or is_unbacked_source(name, i):
+        if marked_unbacked or unbacked_via_source:
             dynamic_size = DimDynamic.UNBACKED
         elif (
             constraint_size is not None

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -147,7 +147,7 @@ Regex examples (``re.match`` anchors at the start, not the end)::
 The ``:N`` suffix is ignored for non-tensor (int/scalar) sources, which have no dim.
 
 Entries in this list are dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
-and force_parameter_static_shapes.
+and force_parameter_static_shapes, but lose to ``static_sources``.
 """
 
 dynamic_values: str = Config(
@@ -189,7 +189,30 @@ Supports the same ``:N`` per-dim suffix syntax as ``dynamic_sources``; see that 
 docstring for details.
 
 Entries in this list are dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
-and force_parameter_static_shapes.
+and force_parameter_static_shapes, but lose to ``static_sources``.
+"""
+
+static_sources: str = Config(
+    env_name_default="TORCH_COMPILE_STATIC_SOURCES", default=""
+)
+r"""
+Comma delimited list of sources that should be marked as static. This is the inverse of
+``dynamic_sources``: it is useful when automatic dynamic shapes (or PGO) makes a source
+dynamic and that dynamism hurts you, e.g. it produces a worse kernel, or it causes an
+unwanted specialization/guard failure downstream. Ints listed here are specialized as
+constants and tensor dims listed here are held static.
+
+Supports the same exact-name / regex / ``:N`` per-dim suffix syntax as ``dynamic_sources``;
+see that config's docstring for details. Examples::
+
+    L['x']                  # all dims of x static
+    L['x']:0                # only dim 0 of x static
+    L\['x.*'\]              # every source whose name starts with L['x
+
+Entries in this list override automatic dynamic shapes, PGO, ``dynamic_values``,
+``dynamic=True``, ``dynamic_sources`` and ``unbacked_sources``: when the same source is
+listed in both, static wins. They do NOT override an explicit
+``torch._dynamo.mark_dynamic`` / ``mark_unbacked`` call.
 """
 
 # force a python GC before recording cudagraphs


### PR DESCRIPTION
Summary:

Mirror `TORCH_COMPILE_DYNAMIC_SOURCES`, we add `TORCH_COMPILE_STATIC_SOURCES` (or `torch.compiler.config.static_sources`) to pass a list of source names that should be marked as static. 

This is useful when automatic dynamic shapes or PGO makes something dynamic and that dynamism is hurting you, for example: producing a worse kernel. It accepts the exact name, regex and :N per-dmi syntax as `TORCH_COMPILE_DYNAMIC_SOURCES`, and it works for both integres and tensor sizes

Test Plan:
buck2 test @//fbcode/mode/opt fbcode//caffe2/test/dynamo:test_dynamo -- \
  --regex "static_sources|unbacked_sources|dynamic_sources|dynamic_values"


https://www.internalfb.com/intern/testinfra/testrun/562950472946260

Differential Revision: D116081301




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98