### PR TITLE
[inductor] fix: don't cache int_array vars keyed on a transient callable id (#193628)

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -1,10 +1,12 @@
 # Owner(s): ["oncall: cpu inductor"]
+import itertools
 import sys
 import unittest
 from typing import NamedTuple
 
 import torch
 from torch._inductor import config
+from torch._inductor.codegen.common import IndentedBuffer
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
@@ -17,6 +19,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import has_cpp_wrapper_for_device, HAS_CPU
+from torch.utils._ordered_set import OrderedSet
 
 
 try:
@@ -47,6 +50,69 @@ RUN_CPU = (
     and not IS_MACOS
     and has_cpp_wrapper_for_device("cpu")
 )
+
+
+class TestIntArrayVarCodegen(InductorTestCase):
+    """`codegen_int_array_var` must never return a variable whose declaration was
+    written into a different buffer than the caller's -- that emits
+    `use of undeclared identifier int_array_N` into the generated wrapper."""
+
+    @staticmethod
+    def _make_wrapper():
+        # Build the instance without __init__, which needs a full graph context.
+        # Only the int-array bookkeeping is exercised here.
+        from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
+
+        wrapper = object.__new__(CppWrapperCpu)
+        wrapper.codegen_int_array_var_cache = {}
+        wrapper.int_array_id = itertools.count()
+        wrapper.declared_int_array_vars = OrderedSet()
+        return wrapper
+
+    def test_unbound_writeline_is_not_cached(self):
+        wrapper = self._make_wrapper()
+        lines = []
+
+        def writeline(line):
+            lines.append(line)
+
+        # A plain callable exposes no stable object to key the cache on, and
+        # CPython recycles the addresses of short-lived ones. Seed the entry that
+        # a since-freed callable sharing this address would have left behind; the
+        # declaration it names lives in a buffer this caller cannot see.
+        wrapper.codegen_int_array_var_cache[
+            ("{1000L, }", id(writeline), False, None)
+        ] = "int_array_stale"
+
+        var = wrapper.codegen_int_array_var("{1000L, }", writeline)
+
+        self.assertNotEqual(var, "int_array_stale")
+        self.assertTrue(
+            any(var in line for line in lines),
+            f"{var} was returned without a declaration in the caller's buffer: {lines}",
+        )
+
+    def test_bound_writeline_is_still_cached(self):
+        wrapper = self._make_wrapper()
+        buf = IndentedBuffer()
+
+        first = wrapper.codegen_int_array_var("{1000L, }", buf.writeline)
+        second = wrapper.codegen_int_array_var("{1000L, }", buf.writeline)
+
+        # A bound method keys on its owner, which is stable, so the declaration is
+        # reused rather than duplicated.
+        self.assertEqual(first, second)
+        self.assertEqual(buf.getvalue().count(f"{first}[]"), 1)
+
+    def test_distinct_buffers_each_get_a_declaration(self):
+        wrapper = self._make_wrapper()
+        buf_a, buf_b = IndentedBuffer(), IndentedBuffer()
+
+        var_a = wrapper.codegen_int_array_var("{1000L, }", buf_a.writeline)
+        var_b = wrapper.codegen_int_array_var("{1000L, }", buf_b.writeline)
+
+        self.assertIn(f"{var_a}[]", buf_a.getvalue())
+        self.assertIn(f"{var_b}[]", buf_b.getvalue())
 
 
 class CppWrapperTemplate:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2405,12 +2405,21 @@ class CppWrapperCpu(PythonWrapperCodegen):
     ) -> str:
         # Use id(graph) for caching to avoid circular references
         # Bound methods have transient IDs, so we use the ID of the bound object instead.
-        writeline_id = (
-            id(writeline.__self__) if hasattr(writeline, "__self__") else id(writeline)
-        )
+        owner = getattr(writeline, "__self__", None)
+        if owner is None:
+            # `writeline` is a plain callable (closure/partial), not a bound method, so
+            # there is no stable object to key on -- id(writeline) belongs to a
+            # short-lived object whose address CPython recycles. Reusing a cached
+            # variable across two such callables emits the reference into one buffer
+            # while its `int64_t int_array_N[] = ...` declaration went into another,
+            # producing "use of undeclared identifier" in the generated code. Skip the
+            # cache instead: re-emitting a declaration is harmless, omitting one is not.
+            return self._codegen_int_array_var_impl(
+                int_array, writeline, known_statically
+            )
         cache_key = (
             int_array,
-            writeline_id,
+            id(owner),
             known_statically,
             id(graph) if graph else None,
         )


### PR DESCRIPTION
Summary:

AOTInductor's cpp_wrapper can emit a `reinterpret_tensor` referencing
`int_array_N` size/stride arrays that are never declared, so the generated C++
fails to compile with `use of undeclared identifier 'int_array_N'`. Seen on an
ads preproc graph where the reference is emitted inside an
`aoti_torch_proxy_executor_call_function` argument list: the wrapper used
`int_array_0..105` and declared every one except the four reached only through
that path.

`codegen_int_array_var` caches the variable name so each buffer emits a
declaration once. The cache key falls back to `id(writeline)` when `writeline`
is not a bound method. That id belongs to a short-lived closure whose address
CPython recycles, so two unrelated callables can collide and the second caller
gets back a variable whose declaration was written into a buffer it cannot see.
Instrumenting a real compile showed 23 of 106 declarations take this path, and
all 23 reported the same recycled address.

Skip the cache when there is no stable object to key on. Re-emitting a
declaration is harmless; omitting one is a compile error.

Test Plan:
```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:cpu_cpp_wrapper_cpu -- --regex "TestIntArrayVarCodegen"
```
Pass 3, Fail 0. `test_unbound_writeline_is_not_cached` is the regression test: it
seeds a stale entry under the pre-fix key and asserts the returned variable is
declared in the caller's buffer. Reverting the fix reproduces the failure
(Pass 2, Fail 1) with the other two staying green.

End to end on the graph that surfaced this (ads preproc model 1093887841, AOTI +
Triton transforms + grouping, A100): previously failed with four undeclared
identifiers; now both submodules compile, the generated wrapper uses and declares
335 of 335 `int_array` vars, and the benchmark completes.

Differential Revision: D116074670


