### PR TITLE
[dynamo] Raise on writes to read-only tp_getset/tp_members attributes

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -1509,6 +1509,81 @@ class ExceptionTests(torch._dynamo.test_case.TestCase):
         # tb_lasti is a known-unsupportable attribute, not a Dynamo bug
         self.assertNotIn("Dynamo bug", msg)
 
+    @parametrize("attr", ("tb_lasti", "tb_lineno", "frame_summary", "foo"))
+    def test_traceback_readonly_attr_write(self, attr):
+        # A write to an attribute a traceback declares read-only, or does not
+        # have at all, must raise rather than silently land in an instance dict.
+        def fn(x, attr):
+            try:
+                raise ValueError("oops")
+            except ValueError as e:
+                tb = e.__traceback__
+                try:
+                    setattr(tb, attr, 0)
+                    return "no error"
+                except AttributeError as a:
+                    return str(a)
+
+        x = torch.randn(4)
+        ref = fn(x, attr)
+        self.assertNotEqual(ref, "no error")
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(ref, opt_fn(x, attr))
+
+    def test_exception_class_assignment_raises(self):
+        # __class__ is a getset whose CPython setter raises TypeError; it must
+        # not be modelled as a plain read-only attribute or an instance-dict key.
+        def fn(x):
+            try:
+                raise ValueError(1)
+            except ValueError as e:
+                try:
+                    e.__class__ = TypeError
+                    return "no error"
+                except TypeError as t:
+                    return str(t)
+
+        x = torch.randn(4)
+        ref = fn(x)
+        self.assertNotEqual(ref, "no error")
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(ref, opt_fn(x))
+
+    def test_exception_writable_members(self):
+        # StopIteration.value and the keyword-only attrs of AttributeError and
+        # NameError are writable in CPython (flags 0, not READONLY). Writing
+        # them must update the attribute itself, not shadow it in the instance
+        # dict, and must leave args alone.
+        def fn(x):
+            si = StopIteration(1)
+            si.value = 5
+            ae = AttributeError("m", name="n", obj=None)
+            ae.name = "z"
+            ae.obj = 3
+            ne = NameError("m", name="n")
+            ne.name = "w"
+            return (si.value, si.args, ae.name, ae.obj, ne.name, x + 1)
+
+        x = torch.randn(4)
+        ref = fn(x)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(ref, opt_fn(x))
+
+    def test_stop_iteration_mutated_value_reconstruct(self):
+        # A mutated `value` must survive reconstruction, which rebuilds the
+        # exception from args -- args[0] no longer reproduces it.
+        def fn(x):
+            e = StopIteration(1)
+            e.value = x.sum() + 3
+            return e
+
+        x = torch.ones(4)
+        ref = fn(x)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(ref.value, res.value)
+        self.assertEqual(ref.args, res.args)
+
     def test_exception_set_tb_next(self):
         # Test setting tb_next on a traceback
         def fn(x):

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -1629,6 +1629,38 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def lookup_tp_method(self, name: str) -> Method | None:
         return self._lookup_tp_table(name, "tp_methods")
 
+    def tp_setattro_impl(
+        self, tx: InstructionTranslatorBase, name: str, val: VariableTracker
+    ) -> bool:
+        """Write `name` through its tp_getset/tp_members setter.
+
+        Returns False if `name` is in neither table, leaving the caller to
+        decide what that means for its type: an instance-dict store for types
+        that have a __dict__, an AttributeError for those that don't.
+
+        A name that is declared but has no setter raises, matching CPython,
+        where a setter-less descriptor rejects the write. Treating it as
+        undeclared instead would shadow the descriptor with an instance-dict
+        entry, so the write would silently succeed and later reads would
+        disagree with whatever internal field the descriptor exposes.
+        """
+        slot = self.lookup_tp_getset_member(name)
+        if slot is None:
+            return False
+        if slot.setter is None:
+            # ref: CPython PyMember_SetOne vs. PyObject_GenericSetAttr, which
+            # word the two cases differently.
+            if isinstance(slot, Member):
+                msg = "readonly attribute"
+            else:
+                msg = (
+                    f"attribute '{name}' of '{self.python_type_name()}' "
+                    "objects is not writable"
+                )
+            raise_observed_exception(AttributeError, tx, args=[msg])
+        slot.setter(self, tx, val)
+        return True
+
     def method_flags_type(self) -> type:
         """Type whose CPython ml_flags define this VT's tp_methods arities
         (see _derive_method_flags). Defaults to python_type(); a VT whose

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -456,8 +456,10 @@ class FrameSummaryVariable(VariableTracker):
     def python_type(self) -> type:
         return traceback.FrameSummary
 
-    # traceback.FrameSummary is pure-Python with __slots__ (Lib/traceback.py);
-    # each slot is exposed as a read-only member_descriptor.
+    # traceback.FrameSummary is pure-Python with __slots__ (Lib/traceback.py).
+    # The slots are writable and `line` is a read-only property, but Dynamo
+    # models all four read-only: no setattr path reaches this VT, so declaring
+    # setters would be untested dead code.
     tp_members = {
         "lineno": Member(getset_build(lambda s: s.frame_summary.lineno)),
         "filename": Member(getset_build(lambda s: s.frame_summary.filename)),
@@ -522,9 +524,17 @@ class TracebackVariable(VariableTracker):
         val: VariableTracker,
     ) -> VariableTracker:
         name = name_var.as_python_constant()
-        getset = self.lookup_tp_getset_member(name)
-        if getset is not None and getset.setter is not None:
-            getset.setter(self, tx, val)
+        # traceback objects have no __dict__, so a name that is not one of the
+        # tp_getset/tp_members entries cannot be stored anywhere.
+        if not self.tp_setattro_impl(tx, name, val):
+            raise_observed_exception(
+                AttributeError,
+                tx,
+                args=[
+                    f"'{self.python_type_name()}' object has no attribute '{name}' "
+                    "and no __dict__ for setting new attributes"
+                ],
+            )
         return variables.ConstantVariable.create(None)
 
     def _get_tb_next(self, tx: "InstructionTranslatorBase") -> VariableTracker:
@@ -559,12 +569,13 @@ class TracebackVariable(VariableTracker):
 
     # ref: CPython Objects/traceback.c tb_getsetters. `tb_next` is a getset with
     # getter+setter (tb_next_get / tb_next_set, which runs a reference-cycle
-    # check); `tb_lineno` is a get-only getset. `frame_summary` is dynamo-internal
-    # (not a real CPython traceback attribute).
+    # check); `tb_lineno` is a get-only getset. `frame_summary` is deliberately
+    # absent: it is a dynamo-internal field read directly off the VT, and listing
+    # it here would both make traced code see an attribute real tracebacks do not
+    # have and break the audit of these tables against CPython.
     tp_getset = {
         "tb_next": GetSet(_get_tb_next, _set_tb_next),
         "tb_lineno": GetSet(_get_tb_lineno, None),
-        "frame_summary": GetSet(getset_read(lambda s: s.frame_summary)),
     }
 
     # ref: CPython Objects/traceback.c tb_memberlist, where tb_lasti is
@@ -676,14 +687,12 @@ class ExceptionVariable(VariableTracker):
     ) -> VariableTracker:
         if name == "__setattr__":
             attr = args[0].as_python_constant()
-            # Writable attributes route through their tp_getset/tp_members
-            # setter. Anything else becomes a custom instance-dict attribute.
-            getset = self.lookup_tp_getset_member(attr)
-            if getset is not None and getset.setter is not None:
-                getset.setter(self, tx, args[1])
-            else:
-                # Arbitrary user attribute -> store in the instance __dict__
-                # via the side effects table.
+            # Declared attributes route through their tp_getset/tp_members
+            # setter, which rejects the write if the entry is read-only.
+            if not self.tp_setattro_impl(tx, attr, args[1]):
+                # BaseException has a __dict__, so an undeclared name is just
+                # an arbitrary user attribute; store it via the side effects
+                # table.
                 se = tx.output.side_effects
                 if not se.is_attribute_mutation(self):
                     se.track_attribute_mutation_new(self)
@@ -826,8 +835,18 @@ class ExceptionVariable(VariableTracker):
         self.args = unpack_iterable(tx, val)
         return variables.ConstantVariable.create(None)
 
+    def _set_class(
+        self, tx: "InstructionTranslatorBase", val: VariableTracker
+    ) -> VariableTracker:
+        # object.__class__ is a getset whose setter raises for a non-heap type,
+        # so this is a TypeError rather than the read-only AttributeError.
+        raise_type_error(
+            tx,
+            "__class__ assignment only supported for mutable types or ModuleType subclasses",
+        )
+
     tp_getset = {
-        "__class__": GetSet(getset_build(lambda s: s.exc_type)),
+        "__class__": GetSet(getset_build(lambda s: s.exc_type), _set_class),
         "__context__": GetSet(getset_read(lambda s: s.__context__), _set_context),
         "__cause__": GetSet(getset_read(lambda s: s.__cause__), _set_cause),
         "__traceback__": GetSet(getset_read(lambda s: s.__traceback__), _set_traceback),
@@ -884,12 +903,32 @@ class StopIterationVariable(ExceptionVariable):
         mutation_type: MutationType | None = None,
     ) -> None:
         self.value = args[0] if args else variables.ConstantVariable.create(None)
+        # Set once `value` is written directly. CPython leaves args alone on such
+        # a write, so args[0] no longer reproduces it and reconstruct has to
+        # store it back explicitly.
+        self.value_mutated = False
         super().__init__(exc_type, args, init_kwargs, source, mutation_type)
 
-    # ref: StopIteration_members in CPython Objects/exceptions.c
+    def _set_value(
+        self, tx: "InstructionTranslatorBase", val: VariableTracker
+    ) -> VariableTracker:
+        self.value = val
+        self.value_mutated = True
+        return variables.ConstantVariable.create(None)
+
+    # ref: StopIteration_members in CPython Objects/exceptions.c, where `value`
+    # is writable (flags 0, not READONLY).
     tp_members = {
-        "value": Member(getset_read(lambda s: s.value)),
+        "value": Member(getset_read(lambda s: s.value), _set_value),
     }
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        super().reconstruct(codegen)
+        if self.value_mutated:
+            codegen.dup_top()
+            codegen(self.value)
+            codegen.extend_output(codegen.rot_n(2))
+            codegen.store_attr("value")
 
 
 class _KwargAttrExceptionVariable(ExceptionVariable):
@@ -922,19 +961,42 @@ class _KwargAttrExceptionVariable(ExceptionVariable):
                 codegen.store_attr(name)
 
 
+def _kwarg_attr_setter(name: str) -> Callable[..., VariableTracker]:
+    """Setter for a `_kwarg_attrs` entry. These are writable in CPython, and
+    `_KwargAttrExceptionVariable.reconstruct` already replays `_attrs`."""
+
+    def setter(
+        self: "_KwargAttrExceptionVariable",
+        tx: "InstructionTranslatorBase",
+        val: VariableTracker,
+    ) -> VariableTracker:
+        self._attrs[name] = val
+        return variables.ConstantVariable.create(None)
+
+    return setter
+
+
 class AttributeErrorVariable(_KwargAttrExceptionVariable):
     # https://docs.python.org/3/library/exceptions.html#AttributeError
     _kwarg_attrs = ("name", "obj")
     tp_members = {
-        "name": Member(getset_read(lambda s: s._attrs["name"])),
-        "obj": Member(getset_read(lambda s: s._attrs["obj"])),
+        "name": Member(
+            getset_read(lambda s: s._attrs["name"]), _kwarg_attr_setter("name")
+        ),
+        "obj": Member(
+            getset_read(lambda s: s._attrs["obj"]), _kwarg_attr_setter("obj")
+        ),
     }
 
 
 class NameErrorVariable(_KwargAttrExceptionVariable):
     # https://docs.python.org/3/library/exceptions.html#NameError
     _kwarg_attrs = ("name",)
-    tp_members = {"name": Member(getset_read(lambda s: s._attrs["name"]))}
+    tp_members = {
+        "name": Member(
+            getset_read(lambda s: s._attrs["name"]), _kwarg_attr_setter("name")
+        )
+    }
 
 
 class UnknownVariable(VariableTracker):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193629
* #193587

Writing an attribute that a VariableTracker declares in tp_getset/tp_members
without a setter silently landed the value in the instance dict instead of
raising. Since `generic_getattr` consults side effects before the getset
tables, that value was also what later reads returned, so under Dynamo

    try:
        raise ValueError(1)
    except ValueError as e:
        e.__class__ = TypeError

appeared to succeed and stuck, where eager raises TypeError.

The dispatchers had two branches where CPython has three: a declared name
with no setter fell into the same branch as a name that is not declared at
all. `tp_setattro_impl` in base.py now separates them - a name with a setter
is written through it, a declared name without one raises, and an undeclared
name is reported back to the caller so it can apply its own rule (instance
dict for exceptions, which have a __dict__; AttributeError for tracebacks,
which do not). `ExceptionVariable.call_method` and
`TracebackVariable.call_setattr` both route through it. The two read-only
messages follow CPython, which words members and getsets differently.

Correcting the dispatcher alone would have turned silent success into a
spurious AttributeError for attributes that are in fact writable, so each
declaration was checked against eager CPython and fixed where it disagreed:

- `StopIteration.value` and the keyword-only attrs of `AttributeError` and
  `NameError` use flags `0`, not `Py_READONLY`, so they get real setters.
  For `value` that also fixes a state divergence: CPython leaves `args`
  alone on such a write, so `reconstruct` has to store the value back
  explicitly or the mutation is lost when the exception escapes the graph.
- `__class__` gets a setter that raises TypeError. In CPython it is a getset
  whose setter rejects non-heap types, so leaving it setter-less would raise
  AttributeError instead.
- `frame_summary` is dropped from `TracebackVariable.tp_getset`. It is a
  dynamo-internal field, read directly off the VT and never through the
  table, and listing it made traced code see an attribute real tracebacks do
  not have. That became observable once read-only writes started raising,
  because the error text disagreed with eager.

`FrameSummaryVariable`'s comment claimed its `__slots__` entries were
read-only member descriptors. They are writable, and `line` is a read-only
property rather than a member at all; the comment now says why Dynamo still
models all four read-only.

An alternative was to raise for every setter-less name and leave the
writable ones alone, which is a smaller diff but would have regressed
working code, so the declarations were corrected instead.

Test Plan:

Each new test compares the compiled exception type and message against
eager rather than a hardcoded string, so the CPython behaviour is the
reference.

```
lintrunner torch/_dynamo/variables/base.py torch/_dynamo/variables/misc.py test/dynamo/test_exceptions.py
python test/dynamo/test_exceptions.py
python test/dynamo/test_misc.py
python test/dynamo/test_functions.py
python test/dynamo/test_dicts.py
python test/dynamo/test_sets.py
python test/dynamo/test_user_defined_object.py
python test/dynamo/test_error_messages.py
python test/dynamo/test_exc.py
python test/dynamo/test_repr_protocol.py
python test/dynamo/test_tp_getattro.py
python test/dynamo/test_tp_richcompare.py
python test/dynamo/test_tp_slots.py
python test/dynamo/test_getitem.py
python test/dynamo/test_contains_protocol.py
```

The sweep is wide because `tp_setattro_impl` lands on `VariableTracker` and
so is inherited by every VT. All pass except test_misc.py's
test_pybind11_enum_conversion, which fails identically on clean main (local
cpp_extension environment issue).

Not addressed, pre-existing and unrelated: `clone()` raises on exception
VTs, because `self.__class__(**self.__dict__)` passes fields like `value`
and `_attrs` that `__init__` does not accept.

This PR was authored with the assistance of an AI agent (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98