### PR TITLE
[cuDNN][SDPA] Bump tolerances for `test_cudnn_attention_compiles_cuda`

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3844,7 +3844,7 @@ class TestSDPACudaOnly(NNTestCase):
         out_cpu = torch.nn.functional.scaled_dot_product_attention(q_cpu, q_cpu, q_cpu)
         out_cpu.backward(grad_cpu)
         self.assertEqual(out, out_cpu.cuda().half(), atol=1e-3, rtol=1e-3)
-        self.assertEqual(q.grad, q_cpu.grad.cuda().half(), atol=7e-3, rtol=5e-3)
+        self.assertEqual(q.grad, q_cpu.grad.cuda().half(), atol=7e-3, rtol=7e-3)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_seqlen1_dropout_heuristic(self):


### PR DESCRIPTION
otherwise shows `1 / 2097152` mismatches just barely above the tolerance

authored manually

cc @csarofeen @ptrblck @nWEIdia @mruberry @drisspg @liangel-02 @howardzhang-cv