### PR TITLE
[TEST] Refactor xpu gemm and transformers tests to use hw_classification

### DIFF
--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_quantization import (
 )
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
+    HardwareClassification,
     iter_indices,
     parametrize,
     run_tests,
@@ -131,6 +132,8 @@ def with_tf32_off(f):
 
 
 class TestBasicGEMM(TestCase):
+    hw_classification = HardwareClassification.XPU
+
     def _test_addmm_addmv(
         self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False, activation=None
     ):

--- a/test/xpu/test_transformers.py
+++ b/test/xpu/test_transformers.py
@@ -7,13 +7,15 @@ import torch.nn.functional as F
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
-from torch.testing._internal.common_utils import parametrize, run_tests
+from torch.testing._internal.common_utils import HardwareClassification, parametrize, run_tests
 
 
 Tolerances = namedtuple("Tolerances", ["atol", "rtol"])
 
 
 class TestSDPAXpuOnly(NNTestCase):
+    hw_classification = HardwareClassification.XPU
+
     @parametrize("dtype", [torch.half, torch.bfloat16, torch.float32])
     @parametrize("train", [False])
     def test_onednn_attention_unaligned_input(self, device, dtype, train):

--- a/test/xpu/test_transformers.py
+++ b/test/xpu/test_transformers.py
@@ -7,7 +7,11 @@ import torch.nn.functional as F
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
-from torch.testing._internal.common_utils import HardwareClassification, parametrize, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+)
 
 
 Tolerances = namedtuple("Tolerances", ["atol", "rtol"])


### PR DESCRIPTION
## Summary

Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines across two test files.

**`test/xpu/test_gemm.py`**
- **TestBasicGEMM**: `XPU` — XPU GEMM operation tests, hardcodes XPU APIs

**`test/xpu/test_transformers.py`**
- **TestSDPAXpuOnly**: `XPU` — XPU-specific SDPA transformer tests, hardcodes XPU APIs

No structural changes — annotation only.

cc @mansiag05 @RiyaP2508

