### PR TITLE
[Distributed Tools] Restore operation count in MemoryTracker.load

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,5 +1,8 @@
 # Owner(s): ["oncall: distributed"]
+import contextlib
+import io
 import os
+import pickle
 import unittest
 
 import torch
@@ -62,6 +65,52 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    def _make_tracker_with_entries(self) -> MemoryTracker:
+        tracker = MemoryTracker()
+        for i, (name, mem) in enumerate([("op_a", 1.0), ("op_b", 3.0)]):
+            tracker.memories_allocated[i] = (name, mem)
+            tracker.memories_active[i] = (name, mem)
+            tracker.memories_reserved[i] = (name, mem)
+            tracker._op_index += 1
+        return tracker
+
+    def _summary_text(self, tracker: MemoryTracker) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            tracker.summary()
+        return out.getvalue()
+
+    def test_save_load_restores_op_index(self):
+        tracker = self._make_tracker_with_entries()
+        path = "memory_op_index.trace"
+        try:
+            tracker.save_stats(path)
+            loaded = MemoryTracker()
+            loaded.load(path)
+            self.assertEqual(loaded._op_index, tracker._op_index)
+            self.assertEqual(self._summary_text(loaded), self._summary_text(tracker))
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_load_legacy_stats_without_op_index(self):
+        tracker = self._make_tracker_with_entries()
+        path = "memory_legacy.trace"
+        try:
+            tracker.save_stats(path)
+            with open(path, "rb") as f:
+                stats = pickle.load(f)
+            del stats["op_index"]
+            with open(path, "wb") as f:
+                pickle.dump(stats, f, pickle.HIGHEST_PROTOCOL)
+            loaded = MemoryTracker()
+            loaded.load(path)
+            self.assertEqual(loaded._op_index, tracker._op_index)
+            self.assertEqual(self._summary_text(loaded), self._summary_text(tracker))
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,9 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # Older stats files predate the "op_index" key, so fall back to the
+        # number of recorded entries, which is what _op_index counted.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397.

save_stats persists the three trace dicts but not `_op_index`, and load never rebuilds it. summary bounds its loop with `_op_index`, so a loaded tracker prints no per operator deltas even though every trace entry is present. This persists `op_index` in the stats dict. For stats files written before this change load falls back to `len(memories_allocated)`, which is exactly what the counter had counted when the file was saved, so old files round trip too.

Two CPU only tests: a save and load round trip restores the count and produces identical summary output, and the same after deleting the new key to simulate a legacy file.

```
python test/distributed/_tools/test_memory_tracker.py -k op_index
python test/distributed/_tools/test_memory_tracker.py -k legacy
```

Written with AI assistance (Claude). I have reviewed the change.