### PR TITLE
[ATen][CPU] Speed up sort by packing (value, index) into a contiguous buffer

### DIFF
--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -1,6 +1,8 @@
 #define TORCH_ASSERT_NO_OPERATORS
 
 #include <limits>
+#include <utility>
+#include <vector>
 
 #include <ATen/native/Sorting.h>
 #include <ATen/core/TensorBase.h>
@@ -75,8 +77,8 @@ template <typename scalar_t>
 struct KeyValueCompAsc {
   template <typename LHS, typename RHS>
   constexpr bool operator()(LHS lhs, RHS rhs) const {
-    return (!_isnan<scalar_t>(get<0>(lhs)) && _isnan<scalar_t>(get<0>(rhs)))
-      || (get<0>(lhs) < get<0>(rhs));
+    return (get<0>(lhs) < get<0>(rhs))
+      || (!_isnan<scalar_t>(get<0>(lhs)) && _isnan<scalar_t>(get<0>(rhs)));
   }
 };
 
@@ -84,8 +86,8 @@ template <typename scalar_t>
 struct KeyValueCompDesc {
   template <typename LHS, typename RHS>
   constexpr bool operator()(LHS lhs, RHS rhs) const {
-    return (_isnan<scalar_t>(get<0>(lhs)) && !_isnan<scalar_t>(get<0>(rhs)))
-      || (get<0>(lhs) > get<0>(rhs));
+    return (get<0>(lhs) > get<0>(rhs))
+      || (_isnan<scalar_t>(get<0>(lhs)) && !_isnan<scalar_t>(get<0>(rhs)));
   }
 };
 
@@ -143,25 +145,47 @@ template <typename scalar_t, typename value_accessor_t, typename indices_accesso
 inline void sort_kernel_impl(const value_accessor_t& value_accessor,
             const indices_accessor_t& indices_accessor,
             int64_t dim_size, bool descending, bool stable) {
-  auto composite_accessor = CompositeRandomAccessorCPU<
-    value_accessor_t, indices_accessor_t
-  >(value_accessor, indices_accessor);
+  using elem_t = std::pair<scalar_t, int64_t>;
+  // Pack (value, index) pairs into one contiguous buffer to sort, then scatter
+  // back. Common-size rows reuse a grow-only thread_local buffer; rows larger
+  // than kMaxCachedElems use a transient buffer so that a one-off huge sort does
+  // not permanently retain memory for the lifetime of the thread. The cached
+  // buffer is per (scalar_t, accessor) template instantiation, so keep the cap
+  // modest: worst-case retained memory is kMaxCachedElems * sizeof(elem_t) per
+  // instantiation, per thread.
+  constexpr int64_t kMaxCachedElems = 1 << 12;
+  static thread_local std::vector<elem_t> cached_buffer;
+  std::vector<elem_t> transient_buffer;
+  elem_t* first = nullptr;
+  if (dim_size <= kMaxCachedElems) {
+    if (static_cast<int64_t>(cached_buffer.size()) < dim_size) {
+      cached_buffer.resize(dim_size);
+    }
+    first = cached_buffer.data();
+  } else {
+    transient_buffer.resize(dim_size);
+    first = transient_buffer.data();
+  }
+  for (const auto i : c10::irange(dim_size)) {
+    first[i] = elem_t(value_accessor[i], indices_accessor[i]);
+  }
+  auto* last = first + dim_size;
   if (descending) {
     if (stable) {
-      std::stable_sort(composite_accessor, composite_accessor + dim_size,
-        KeyValueCompDesc<scalar_t>());
+      std::stable_sort(first, last, KeyValueCompDesc<scalar_t>());
     } else {
-      std::sort(composite_accessor, composite_accessor + dim_size,
-        KeyValueCompDesc<scalar_t>());
+      std::sort(first, last, KeyValueCompDesc<scalar_t>());
     }
   } else {
     if (stable) {
-      std::stable_sort(composite_accessor, composite_accessor + dim_size,
-        KeyValueCompAsc<scalar_t>());
+      std::stable_sort(first, last, KeyValueCompAsc<scalar_t>());
     } else {
-      std::sort(composite_accessor, composite_accessor + dim_size,
-        KeyValueCompAsc<scalar_t>());
+      std::sort(first, last, KeyValueCompAsc<scalar_t>());
     }
+  }
+  for (const auto i : c10::irange(dim_size)) {
+    value_accessor[i] = first[i].first;
+    indices_accessor[i] = first[i].second;
   }
 }
 


### PR DESCRIPTION
The CPU sort path used by at::native::_dim_apply sorted the values and indices arrays through a CompositeRandomAccessorCPU proxy iterator, which presents two separate strided arrays as one logical sequence of (value, index) pairs. Profiling showed the proxy iterator's operators dominating the sort:
operator++ and operator-- alone accounted for roughly 22% of sort_kernel_impl, and each element swap went through a tuple-of-references swap touching two distant memory regions.

This change packs each row's (value, index) pairs into a single contiguous std::pair<scalar_t, int64_t> buffer, sorts that buffer with the existing comparators, then scatters the results back to the strided value and index arrays. Iteration becomes plain pointer arithmetic that inlines into std::sort/std::stable_sort, and each swap becomes a contiguous 16-byte pair swap with much better cache locality. Rows up to 4096 elements reuse a grow-only thread_local buffer so the packing does not add an allocation to the hot path; larger rows use a transient buffer so a one-off large sort does not permanently retain memory.

A second change reorders the || operands in KeyValueCompAsc and KeyValueCompDesc so the cheap value comparison is evaluated before the _isnan checks. || is commutative over these pure operands, so the induced
ordering is unchanged; in the common non-NaN case the NaN checks are now short-circuited away. This is a no-op for integral types, where _isnan is already trivially false.

Behavior is unchanged. NaN placement (last for ascending, first for descending), stable-sort tie ordering, and the 1-D integer FBGEMM radix path are all identical; a parity check over float32, float64 and int64 across stable and non-stable, ascending and descending confirms byte-identical values and indices against the previous implementation.

Benchmarks on the contiguous path (AMD EPYC Turin, 3 repetitions): float32 is 6-9% faster at 256 and 4096 elements, float64 is ~11.5% faster, and int64 is neutral within noise.

Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/193645

Differential Revision: D115216120




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01