### PR TITLE
ci: align FlashAttention and CuTeDSL dependencies

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -351,16 +351,15 @@ function install_spmd_types() {
 
 function install_flash_attn_cute() {
   echo "Installing FlashAttention 4 from PyPI..."
-  # b17 adds aux_scalars; CUDA 13 wheels are behind the cu13 extra.
+  local flash_attn_package=flash-attn-4==4.0.0b17
   if [[ "${DESIRED_CUDA:-}" == 13.* || "${CUDA_VERSION:-}" == 13.* || "${BUILD_ENVIRONMENT:-}" == *cuda13* ]]; then
-    pip_install "flash-attn-4[cu13]==4.0.0b17"
-  else
-    pip_install flash-attn-4==4.0.0b17
+    flash_attn_package="flash-attn-4[cu13]==4.0.0b17"
   fi
-  # flash-attn-4 pulls quack unpinned; newer quack needs cutlass._mlir_helpers,
-  # absent from the gated cutlass-dsl 4.5.2. Pin quack to the SHA torch vendors
-  # (torch/_vendor/quack), which uses cutlass._mlir and works with 4.5.2. See #188477.
-  pip_install "git+https://github.com/Dao-AILab/quack.git@99bd7973bf3dc6db40961e413d4bdfea6c6fee3e"
+  # QuACK 0.6.4 pins the CuTeDSL version accepted by torch._native.
+  pip_install \
+    "$flash_attn_package" \
+    quack-kernels==0.6.4 \
+    apache-tvm-ffi==0.1.11
   echo "FlashAttention 4 installation complete."
 }
 
@@ -377,7 +376,7 @@ function install_cutlass_dsl() {
   # Pin to a version accepted by torch._native's cutedsl version gate
   # (_CUTEDSL_REQUIRED_VERSIONS); apache-tvm-ffi is a required runtime dep of
   # the CuTeDSL op overrides but is not pulled in by nvidia-cutlass-dsl.
-  pip_install nvidia-cutlass-dsl==4.5.2 apache-tvm-ffi==0.1.11
+  pip_install nvidia-cutlass-dsl==4.6.2 apache-tvm-ffi==0.1.11
   echo "NVIDIA CUTLASS DSL installation complete."
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -449,7 +449,9 @@ test_python_smoke() {
 test_python_smoke_b200() {
   # Targeted smoke tests for B200 including FlashAttention CuTe coverage
   install_flash_attn_cute
-  install_cutlass_api
+  # TODO(#189590): Re-enable CUTLASS API after NVGEMM migrates to
+  # cutlass.operators. The preview package pins apache-tvm-ffi==0.1.7, which
+  # is incompatible with CuTeDSL 4.6.2 used by the rest of this job.
   time python test/run_test.py \
     --include \
       test_matmul_cuda \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -459,6 +459,7 @@ test_python_smoke_b200() {
       nn/attention/test_open_registry \
       inductor/test_flex_flash \
       inductor/test_flex_gemm \
+      python_native/test_cutedsl_smoketest \
       inductor/test_torchinductor \
       inductor/test_async_compile \
       inductor/test_nv_universal_gemm \

--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -679,6 +679,14 @@ class TestCuteDSLSmoketest(TestCase):
     Run before bumping cuteDSL version pins in torch/_native/cutedsl_utils.py.
     """
 
+    def test_runtime_version_is_supported(self):
+        from torch._native import cutedsl_utils
+
+        self.assertIn(
+            cutedsl_utils.runtime_version(),
+            cutedsl_utils._CUTEDSL_REQUIRED_VERSIONS,
+        )
+
     @unittest.skipIf(not SM80OrLater, "SM80+ required")
     def test_elementwise_add(self):
         _host, from_dlpack = _build_elementwise_add()

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -31,6 +31,7 @@ _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     Version(f"{4}.{4}.{1}"),
     Version(f"{4}.{4}.{2}"),
     Version(f"{4}.{5}.{2}"),
+    Version(f"{4}.{6}.{2}"),
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193197
* #192894
* #192664
* #192663
* #192839
* #192662
* __->__ #193646

## Human Note

split up big ghstack rebase pr into the smaller chunk that rebases quack so we can get ci in better spot

cc @slayton58 
## Agent note

FlashAttention 4 b17 leaves its QuACK and CuTeDSL dependencies open-ended. The B200 setup then
installed a separate QuACK revision and later pinned CuTeDSL independently, so the final environment
depended on resolver and installation order.

Keep the existing FlashAttention version and pin released QuACK 0.6.4, whose package metadata selects
CuTeDSL 4.6.2. Install that set in one resolver transaction, align the standalone CuTeDSL installer and
native version gate, and run the CuTeDSL smoke test after CUTLASS API installation so it checks the final
runtime. Keeping b17 avoids bundling an unrelated FlashAttention runtime upgrade into this dependency
fix.

This change was prepared with assistance from an AI coding tool.

## Test Plan

The B200 GPU smoke suite was not run locally.

```bash
bash -n .ci/pytorch/common_utils.sh
bash -n .ci/pytorch/test.sh
python -m py_compile torch/_native/cutedsl_utils.py test/python_native/test_cutedsl_smoketest.py
git diff --check
lintrunner -a

bash <<'SH'
set -euo pipefail
source .ci/pytorch/common_utils.sh
pip_install() { printf "pip_install %s\n" "$*"; }
unset DESIRED_CUDA CUDA_VERSION BUILD_ENVIRONMENT
cpu=$(install_flash_attn_cute)
[[ "$cpu" == *"flash-attn-4==4.0.0b17 quack-kernels==0.6.4 apache-tvm-ffi==0.1.11"* ]]
DESIRED_CUDA=13.2
cuda13=$(install_flash_attn_cute)
[[ "$cuda13" == *"flash-attn-4[cu13]==4.0.0b17 quack-kernels==0.6.4 apache-tvm-ffi==0.1.11"* ]]
SH

python - <<'PY'
import json
import urllib.request
from packaging.requirements import Requirement
from packaging.version import Version

selected = {
    "nvidia-cutlass-dsl": Version("4.6.2"),
    "quack-kernels": Version("0.6.4"),
    "apache-tvm-ffi": Version("0.1.11"),
}
expected = {
    "flash-attn-4": {"nvidia-cutlass-dsl", "quack-kernels", "apache-tvm-ffi"},
    "quack-kernels": {"nvidia-cutlass-dsl", "apache-tvm-ffi"},
}
for package, version in (("flash-attn-4", "4.0.0b17"), ("quack-kernels", "0.6.4")):
    with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/{version}/json") as response:
        requirements = json.load(response)["info"]["requires_dist"] or []
    checked = set()
    for raw_requirement in requirements:
        requirement = Requirement(raw_requirement)
        if requirement.name not in selected:
            continue
        if requirement.marker is not None and not requirement.marker.evaluate({"extra": "cu13"}):
            continue
        assert selected[requirement.name] in requirement.specifier, raw_requirement
        checked.add(requirement.name)
    assert expected[package] <= checked, (package, expected[package] - checked)
PY
```