### PR TITLE
[CI] Speed up B200 tests with pytest-xdist

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -457,6 +457,8 @@ test_python_smoke() {
   assert_git_not_dirty
 }
 
+# PYTHON_TEST_EXTRA_OPTION intentionally expands into multiple arguments.
+# shellcheck disable=SC2086
 test_python_smoke_b200() {
   # Targeted smoke tests for B200 including FlashAttention CuTe coverage
   install_flash_attn_cute
@@ -470,16 +472,33 @@ test_python_smoke_b200() {
       inductor/test_fp8 \
       nn/attention/test_fa4 \
       nn/attention/test_open_registry \
-      inductor/test_flex_flash \
-      inductor/test_flex_gemm \
       python_native/test_cutedsl_smoketest \
       inductor/test_torchinductor \
       inductor/test_async_compile \
       inductor/test_nv_universal_gemm \
       inductor/test_fused_attention \
-      test_varlen_attention \
       $PYTHON_TEST_EXTRA_OPTION \
       --upload-artifacts-while-running
+
+  # These suites spend most of their time compiling many independent kernels.
+  # Use xdist's dynamic scheduler to avoid a long tail, and bound each test
+  # worker's Inductor compile pool so parallelism does not multiply to 32x32.
+  time env TORCHINDUCTOR_COMPILE_THREADS=1 python test/run_test.py \
+    --include test_varlen_attention \
+    $PYTHON_TEST_EXTRA_OPTION \
+    --upload-artifacts-while-running \
+    --pytest-xdist-workers 32
+  time env TORCHINDUCTOR_COMPILE_THREADS=2 python test/run_test.py \
+    --include inductor/test_flex_flash \
+    $PYTHON_TEST_EXTRA_OPTION \
+    --upload-artifacts-while-running \
+    --pytest-xdist-workers 32
+  time env TORCHINDUCTOR_COMPILE_THREADS=1 python test/run_test.py \
+    --include inductor/test_flex_gemm \
+    $PYTHON_TEST_EXTRA_OPTION \
+    --upload-artifacts-while-running \
+    --pytest-xdist-workers 32
+
   time python test/run_test.py --include test_linalg -k "mm or addmv" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2654,6 +2654,7 @@ class CPUReproTests(TestCase):
                                 "sve_max_length": vector_bits,
                             },
                         ),
+                        config.patch({"cpp.vec_isa_ok": True}),
                     ):
                         selected_isa = cpu_vec_isa.valid_vec_isa_list()[0]
                         self.assertIsInstance(selected_isa, cpu_vec_isa.VecSVE)
@@ -2668,6 +2669,24 @@ class CPUReproTests(TestCase):
                 self.assertIsInstance(
                     cpu_vec_isa.valid_vec_isa_list()[0], cpu_vec_isa.VecNEON
                 )
+
+            cpu_vec_isa.valid_vec_isa_list.cache_clear()
+            with (
+                patch("sys.platform", "linux"),
+                patch("platform.machine", return_value="aarch64"),
+                patch(
+                    "torch.cpu.get_capabilities",
+                    return_value={
+                        "bf16": True,
+                        "sve": True,
+                        "sve2": True,
+                        "sve_max_length": 128,
+                    },
+                ),
+                config.patch({"cpp.vec_isa_ok": False}),
+            ):
+                self.assertEqual(cpu_vec_isa.valid_vec_isa_list(), [])
+                self.assertIs(cpu_vec_isa.pick_vec_isa(), cpu_vec_isa.invalid_vec_isa)
         finally:
             cpu_vec_isa.valid_vec_isa_list.cache_clear()
 

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1404,6 +1404,63 @@ class FlexGemmTestCase(TestCase):
         self.assertTrue(swap_keys and non_swap_keys)
         return swap_keys[0], non_swap_keys[0]
 
+    def limitedTunedConfigs(
+        self,
+        device,
+        group,
+        axis,
+        *,
+        output_layout=None,
+        reject_swap_ab=False,
+        reject_cluster_n=False,
+    ):
+        """Keep two valid tuned configs plus configs the tested gates must reject."""
+        from torch._inductor.heuristics.template.flex_gemm import (
+            candidate_gemm_configs_for_device,
+        )
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            FlexGemmLocalReduceGeometry,
+            validate_flex_gemm_local_reduce_config,
+        )
+        from torch._inductor.kernel.flex_gemm.output_layout import (
+            output_layout_supports_config,
+        )
+
+        candidates = candidate_gemm_configs_for_device(device)
+        geometry = FlexGemmLocalReduceGeometry(group, axis)
+
+        def supports_output_layout(config):
+            return output_layout_supports_config(output_layout, config, geometry)
+
+        valid = [
+            config
+            for config in candidates
+            if supports_output_layout(config)
+            and validate_flex_gemm_local_reduce_config(config, group, axis)
+        ]
+        self.assertGreaterEqual(len(valid), 2)
+        configs = [valid[0], valid[-1]]
+        if reject_swap_ab:
+            configs.append(
+                next(
+                    config
+                    for config in candidates
+                    if config.swap_ab
+                    and supports_output_layout(config)
+                    and validate_flex_gemm_local_reduce_config(
+                        config, group, axis, allow_swap_ab=True
+                    )
+                )
+            )
+        if reject_cluster_n:
+            configs.append(
+                next(config for config in candidates if config.cluster_n > 1)
+            )
+        return mock.patch(
+            "torch._inductor.heuristics.template.flex_gemm.candidate_gemm_configs_for_device",
+            return_value=configs,
+        )
+
     def assertMatchesLowPrecisionEager(
         self,
         actual,
@@ -5865,9 +5922,20 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         rows = torch.arange(k, device="cuda")[:, None]
         cols = torch.arange(n, device="cuda")[None, :]
         b = (2.0 ** ((rows % 4) + ((cols // group) % 4))).to(torch.bfloat16)
-        (actual, blocked_scale), (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        from torch._inductor.kernel.flex_gemm.output_layout import (
+            FlexGemmOutputStorageLayout,
         )
+
+        with self.limitedTunedConfigs(
+            a.device,
+            group,
+            1,
+            output_layout=FlexGemmOutputStorageLayout.BLOCKED_128X4,
+            reject_swap_ab=True,
+        ):
+            (actual, blocked_scale), (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
 
         expected, expected_scale = epilogue_fn(a @ b)
         torch.testing.assert_close(actual, expected)
@@ -5934,6 +6002,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @torch._inductor.config.patch("shape_padding", False)
     def test_mm_tuple_aux_blocked_output_zero_fills_padding(self):
         m, n, k, group = 129, 80, 256, 16
         config = self.localReduceOutputConfig()
@@ -6054,6 +6123,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         ),
         name_fn=lambda case: case[0],
     )
+    @torch._inductor.config.patch("shape_padding", False)
     def test_mm_tuple_aux_blocked_output_supports_swap_ab(self, case):
         _, m, n, group, scale_fn = case
         k = 64
@@ -6573,7 +6643,8 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
 
         a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
-        actual, aux = torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+        with self.limitedTunedConfigs(a.device, group, 0):
+            actual, aux = torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
 
         self.assertLocalReduceAuxMatches(actual, aux, a, b, epilogue_fn)
 
@@ -6826,9 +6897,10 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
 
         a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
-        (actual, aux), (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
+        with self.limitedTunedConfigs(a.device, group, 1, reject_cluster_n=True):
+            (actual, aux), (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
 
         high_precision_acc = a.double() @ b.double()
         self.assertMatchesLowPrecisionEager(
@@ -8078,9 +8150,10 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
 
         a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
+        with self.limitedTunedConfigs(a.device, group, 1, reject_swap_ab=True):
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
 
         self.assertEqual(actual.dtype, torch.float8_e4m3fn)
         self.assertMatchesLowPrecisionEager(
@@ -8213,9 +8286,15 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         gamma = self.makeTensor(1, n)
         b2 = self.makeTensor(n, p)
 
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b1, gamma, b2
+        config_context = (
+            self.limitedTunedConfigs(a.device, group, 1)
+            if tuned
+            else contextlib.nullcontext()
         )
+        with config_context:
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b1, gamma, b2
+            )
 
         acc1 = a @ b1
         h2 = (acc1.float() * gamma).to(torch.bfloat16)
@@ -9775,6 +9854,7 @@ class TestFlexGemmExplicitConfigDevice(FlexGemmTestCase):
         self.assertIn("FlexGemmLocalReduceCallbacks(", code)
 
     @unittest.skipIf(SM120OrLater, "SM100 config required")
+    @torch._inductor.config.patch("shape_padding", False)
     def test_mm_tuple_aux_local_reduce_swap_ab_rejects_unaligned_n(self, device):
         from torch._vendor.quack.gemm_config import GemmConfig
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1357,9 +1357,13 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         "-rfEX",
     ]
     if not is_cpp_test:
-        # C++ tests need to be run with pytest directly, not via python
-        # We have a custom pytest shard that conflicts with the normal plugin
-        pytest_args.extend(["-p", "no:xdist", "--use-pytest"])
+        # C++ tests need to be run with pytest directly, not via python.
+        if options.pytest_xdist_workers is None:
+            # The custom pytest shard conflicts with xdist.
+            pytest_args.extend(["-p", "no:xdist"])
+        else:
+            pytest_args.extend(["-n", str(options.pytest_xdist_workers)])
+        pytest_args.append("--use-pytest")
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly
@@ -1646,6 +1650,13 @@ def parse_args():
         help="runs a shard of the tests (taking into account other selections), e.g., "
         "--shard 2 3 will break up the selected tests into 3 shards and run the tests "
         "in the 2nd shard (the first number should not exceed the second)",
+    )
+    parser.add_argument(
+        "--pytest-xdist-workers",
+        type=int,
+        choices=range(1, 65),
+        metavar="N",
+        help="run non-serial tests with N pytest-xdist workers",
     )
     parser.add_argument(
         "--exclude-jit-executor",
@@ -2077,14 +2088,17 @@ def do_sharding(
 ) -> tuple[float, list[ShardedTest]]:
     which_shard, num_shards = get_sharding_opts(options)
 
-    # Do sharding
+    uses_xdist = options.pytest_xdist_workers is not None
+
+    # Xdist owns test-level concurrency, while test files run sequentially.
     shards = calculate_shards(
         num_shards,
         selected_tests,
         test_file_times,
         test_class_times=test_class_times,
-        must_serial=must_serial,
+        must_serial=(lambda _: True) if uses_xdist else must_serial,
         sort_by_time=sort_by_time,
+        allow_pytest_sharding=not uses_xdist,
     )
     return shards[which_shard - 1]
 
@@ -2137,6 +2151,8 @@ def run_tests(
 ) -> None:
     if len(selected_tests) == 0:
         return
+
+    uses_xdist = options.pytest_xdist_workers is not None
 
     # parallel = in parallel with other files
     # serial = this file on it's own.  The file might still be run in parallel with itself (ex test_ops)
@@ -2200,6 +2216,7 @@ def run_tests(
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
+            options_clone.pytest_xdist_workers = None
             options_clone.additional_args.extend(marker_args(None))
             failure = run_test_module(test, test_directory, options_clone)
             test_failed = handle_complete(failure)
@@ -2215,6 +2232,7 @@ def run_tests(
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
+            options_clone.pytest_xdist_workers = None
             options_clone.additional_args.extend(marker_args("serial"))
             failure = run_test_module(test, test_directory, options_clone)
             test_failed = handle_complete(failure)
@@ -2226,12 +2244,16 @@ def run_tests(
                 raise RuntimeError(failure.message + keep_going_message)
 
         # This is used later to constrain memory per proc on the GPU. On ROCm
-        # the number of procs is the number of GPUs, so we don't need to do this
-        os.environ["NUM_PARALLEL_PROCS"] = str(1 if torch.version.hip else NUM_PROCS)
+        # the number of procs is the number of GPUs, so we don't need to do this.
+        memory_processes = options.pytest_xdist_workers or NUM_PROCS
+        os.environ["NUM_PARALLEL_PROCS"] = str(
+            1 if torch.version.hip else memory_processes
+        )
 
         # See Note [ROCm parallel CI testing]
+        file_processes = 1 if uses_xdist else NUM_PROCS
         pool = get_context("spawn").Pool(
-            NUM_PROCS, maxtasksperchild=None if torch.version.hip else 1
+            file_processes, maxtasksperchild=None if torch.version.hip else 1
         )
 
         def parallel_test_completion_callback(failure):

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -432,6 +432,20 @@ class TestCalculateShards(unittest.TestCase):
             ),
         )
 
+    def test_disable_pytest_sharding_preserves_file_times(self) -> None:
+        test_times = {"test1": THRESHOLD * 4, "test2": THRESHOLD * 2.5}
+        shards = calculate_shards(
+            2,
+            [TestRun(t) for t in test_times],
+            test_times,
+            gen_class_times(test_times),
+            allow_pytest_sharding=False,
+        )
+
+        tests = [test for _, shard in shards for test in shard]
+        self.assertEqual([test.num_shards for test in tests], [1, 1])
+        self.assertEqual([test.get_time() for test in tests], list(test_times.values()))
+
     def test_zero_tests(self) -> None:
         self.assertListEqual([(0.0, []), (0.0, [])], calculate_shards(2, [], {}, None))
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -87,13 +87,15 @@ def get_with_pytest_shard(
     tests: Sequence[TestRun],
     test_file_times: dict[str, float],
     test_class_times: dict[str, dict[str, float]] | None,
+    *,
+    allow_pytest_sharding: bool = True,
 ) -> list[ShardedTest]:
     sharded_tests: list[ShardedTest] = []
 
     for test in tests:
         duration = get_duration(test, test_file_times, test_class_times or {})
 
-        if duration and duration > THRESHOLD:
+        if allow_pytest_sharding and duration and duration > THRESHOLD:
             num_shards = math.ceil(duration / THRESHOLD)
             for i in range(num_shards):
                 sharded_tests.append(
@@ -208,6 +210,7 @@ def calculate_shards(
     test_class_times: dict[str, dict[str, float]] | None,
     must_serial: Callable[[str], bool] | None = None,
     sort_by_time: bool = True,
+    allow_pytest_sharding: bool = True,
 ) -> list[tuple[float, list[ShardedTest]]]:
     must_serial = must_serial or (lambda x: True)
     test_class_times = test_class_times or {}
@@ -222,13 +225,26 @@ def calculate_shards(
         unknown_tests = [x for x in tests if x not in known_tests]
 
         pytest_sharded_tests = sorted(
-            get_with_pytest_shard(known_tests, test_file_times, test_class_times),
+            get_with_pytest_shard(
+                known_tests,
+                test_file_times,
+                test_class_times,
+                allow_pytest_sharding=allow_pytest_sharding,
+            ),
             key=lambda j: j.get_time(),
             reverse=True,
-        ) + get_with_pytest_shard(unknown_tests, test_file_times, test_class_times)
+        ) + get_with_pytest_shard(
+            unknown_tests,
+            test_file_times,
+            test_class_times,
+            allow_pytest_sharding=allow_pytest_sharding,
+        )
     else:
         pytest_sharded_tests = get_with_pytest_shard(
-            tests, test_file_times, test_class_times
+            tests,
+            test_file_times,
+            test_class_times,
+            allow_pytest_sharding=allow_pytest_sharding,
         )
     del tests
 

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -647,10 +647,9 @@ def valid_vec_isa_list() -> list[VecISA]:
         if (caps.get("sve2", False) or caps.get("sve", False)) and caps.get(
             "bf16", False
         ):
-            if caps.get("sve_max_length") == 128:
-                isa_list.append(VecSVE(128))
-            else:
-                isa_list.append(VecSVE(256))
+            isa = VecSVE(128 if caps.get("sve_max_length") == 128 else 256)
+            if isa:
+                isa_list.append(isa)
         else:
             isa_list.append(VecNEON())
 

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -400,6 +400,11 @@ def {{kernel_name}}_precompile(precompile_shapes, precompile_strides, precompile
     sB_0, sB_n, sB_k = trans_stride_b
     sC_m, sC_n = stride_out
 
+    compile_options = "--enable-tvm-ffi"
+    if device_capability is not None:
+        major, minor = device_capability
+        compile_options += f" --gpu-arch sm_{major}{minor}a"
+
     prep_executor = cute.compile(
         launch_build_group_ptrs_from_bases,
         base_A_u64=0,
@@ -421,7 +426,7 @@ def {{kernel_name}}_precompile(precompile_shapes, precompile_strides, precompile
         out_problem=_to_fake_cute_tensor(proxy_probs, assumed_align=4),
         out_strides_abc=_to_fake_cute_tensor(proxy_strides, assumed_align=4),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        options="--enable-tvm-ffi",
+        options=compile_options,
     )
 
     disk_cache_set(
@@ -489,7 +494,7 @@ def {{kernel_name}}_precompile(precompile_shapes, precompile_strides, precompile
         _to_fake_cute_tensor(proxy_tensormap),
         max_active_clusters,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        options="--enable-tvm-ffi",
+        options=compile_options,
     )
 
     disk_cache_set(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1572,7 +1572,9 @@ def run_tests(argv=None):
         if failed:
             raise AssertionError("Some test shards have failed")
     elif USE_PYTEST:
-        pytest_args = argv + ["--use-main-module"]
+        # xdist workers import the test file as a module, so they cannot collect
+        # tests from the coordinator's __main__ module.
+        pytest_args = argv if "-n" in argv else argv + ["--use-main-module"]
         if HW_CLASSIFICATION is not None:
             pytest_args += ['--hw-classification'] + [req.name for req in HW_CLASSIFICATION]
         test_report_path = ""


### PR DESCRIPTION
## Human Note

Make gpu go brr

also trimemd alot of time out of flex_gemm

## Agent note

The B200 FlexFlash, FlexGEMM, and variable-length attention suites compile hundreds of independent kernels.
The current static pytest sharding leaves a large tail, and each test can also create an Inductor compile pool,
multiplying CPU parallelism.

This adds an opt-in `run_test.py --pytest-xdist-workers` mode. In this mode xdist dynamically schedules tests
within one file, `run_test.py` continues to run `@serial` tests without xdist, and its existing file-level and
static pytest sharding are disabled to avoid nested concurrency. The B200 workflow uses 32 xdist workers for
the three compile-heavy suites and bounds each worker's Inductor compile pool.

The FlexGEMM timing analysis also found five behavioral tests that enabled full autotuning, compiling up to 74
candidates each, even though they only assert the selected kernel's result and generated-code properties. Those
tests now use two candidates, matching existing tuned tests in the file. Explicit and forced-config tests retain
coverage of configuration constraints and geometry extremes.

AI assistance was used to investigate the CI logs, implement the runner integration, run the local benchmarks,
and prepare this draft. The commands and timing qualifications below are included so the change can be reviewed
against direct evidence rather than relying on the generated analysis.

## Performance

The complete cold-cache FlexGEMM run drops from roughly 38 minutes in the referenced periodic log, to 17m30s
with xdist alone, and to **1m38s** after bounding the five behavioral autotuning tests. All 429 tests and 16
subtests passed with a fresh cache.

The non-AOTriton variable-length attention cases complete in 1m42s, compared with 7m08s for the full file
upstream. A fail-fast FlexFlash run reached 98 of 264 tests in 4m43s before two GB300-only numerical failures;
therefore that number is not presented as a complete-suite result.

The updated end-to-end estimate for a green B200 job is **21–25 minutes**, compared with approximately 50m44s
for the referenced periodic run. The draft B200 CI run should provide the authoritative number.

| Suite | New local result | Qualification |
| --- | ---: | --- |
| FlexGEMM | **1m38s** | complete, 429 passed / 16 subtests passed, fresh cache |
| FlexFlash | 4m43s | partial; fail-fast after 98/264 tests |
| Variable-length attention | 1m42s | 136 passed / 101 skipped; excludes local AOTriton failures |
| selected `test_linalg` tail | 2m57s | complete, 1176 passed / 797 skipped |

`inductor/test_fp8` was also evaluated. Its GPU subset took 4m13s with xdist versus 6m01s for the full file
upstream, which was not enough evidence to move it out of the existing concurrent file group.

The faster schedule exposed that several blocked-output constraint tests depended on a prior shape-padding cache
entry. They now disable unrelated GEMM shape padding, and the affected tests plus the full fresh-cache run pass.

## Test Plan

```bash
source ~/.venvs/dev/bin/activate
python tools/test/test_test_selections.py
bash -n .ci/pytorch/test.sh
git diff --check
gpu-run auto -- python test/run_test.py --include inductor/test_flex_flash -k TestHierarchicalIndex --pytest-xdist-workers 2 --verbose
gpu-run auto -- env TORCHINDUCTOR_COMPILE_THREADS=2 python test/run_test.py --include inductor/test_flex_flash --pytest-xdist-workers 32 --verbose
gpu-run auto -- env TORCHINDUCTOR_COMPILE_THREADS=1 python test/run_test.py --include inductor/test_flex_gemm --pytest-xdist-workers 32 --verbose
gpu-run auto -- env TORCHINDUCTOR_COMPILE_THREADS=1 python test/run_test.py --include test_varlen_attention -k 'not sdpa_backend_aotriton' --pytest-xdist-workers 32 --verbose
gpu-run auto -- env TORCHINDUCTOR_COMPILE_THREADS=1 python test/run_test.py --include inductor/test_fp8 -k 'not CPU' --pytest-xdist-workers 32 --verbose
lintrunner test/inductor/test_flex_gemm.py
lintrunner -a  # reports existing unrelated SC2086 findings throughout .ci/pytorch/test.sh
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo