### PR TITLE
[dynamo] Split DictKeySetVariable off SetVariable to match CPython

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -1082,6 +1082,176 @@ class FrozensetHierarchyTests(_BaseSetTests):
         self.assertEqual(s, {2, 3, 4, 10})
 
 
+class DictKeySetHierarchyTests(torch._dynamo.test_case.TestCase):
+    """`dict_keys` is not a `set`.
+
+    A `dict_keys` passed into the compiled region is traced by
+    `DictKeySetVariable`. Its CPython surface is the `collections.abc.Set` one,
+    `isdisjoint` plus the operator slots, not `set`'s named methods.
+    """
+
+    # dir(set) - dir(dict.keys()), i.e. everything a dict_keys must not have.
+    SET_ONLY_METHODS = (
+        "union",
+        "intersection",
+        "difference",
+        "symmetric_difference",
+        "issubset",
+        "issuperset",
+        "copy",
+        "add",
+        "pop",
+        "remove",
+        "discard",
+        "clear",
+        "update",
+        "intersection_update",
+        "difference_update",
+        "symmetric_difference_update",
+    )
+
+    @staticmethod
+    def keys():
+        return {1: 0, 2: 0}.keys()
+
+    @staticmethod
+    def caller(name):
+        if name in ("copy", "clear", "pop"):
+            return lambda k: getattr(k, name)()
+        return lambda k: getattr(k, name)({1})
+
+    def test_set_only_methods_raise_attribute_error(self):
+        """Compiled behaviour matches eager: AttributeError, not a value."""
+        for name in self.SET_ONLY_METHODS:
+            with self.subTest(method=name):
+                fn = self.caller(name)
+                with self.assertRaises(AttributeError):
+                    fn(self.keys())
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=False)
+                with self.assertRaises(AttributeError):
+                    compiled(self.keys())
+
+    def test_set_only_methods_are_untraceable(self):
+        """Under fullgraph there is no graph break, so it must be Unsupported."""
+        for name in self.SET_ONLY_METHODS:
+            with self.subTest(method=name):
+                torch._dynamo.reset()
+                compiled = torch.compile(
+                    self.caller(name), backend="eager", fullgraph=True
+                )
+                with self.assertRaises(Unsupported):
+                    compiled(self.keys())
+
+    def test_binary_ops_match_eager(self):
+        """dictview_or and friends accept any iterable, unlike set's slots."""
+        ops = {
+            "or_set": lambda k: k | {3},
+            "and_set": lambda k: k & {1},
+            "sub_set": lambda k: k - {1},
+            "xor_set": lambda k: k ^ {1},
+            "or_list": lambda k: k | [3],
+            "and_list": lambda k: k & [1],
+            "sub_list": lambda k: k - [1],
+            "xor_list": lambda k: k ^ [1],
+            "reflected_or": lambda k: {3} | k,
+        }
+        for name, fn in ops.items():
+            with self.subTest(op=name):
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=True)
+                self.assertEqual(compiled(self.keys()), fn(self.keys()))
+
+    def test_binary_op_with_non_iterable_raises(self):
+        fn = lambda k: k | 5  # noqa: E731
+        with self.assertRaises(TypeError):
+            fn(self.keys())
+        torch._dynamo.reset()
+        with self.assertRaises((TypeError, Unsupported)):
+            torch.compile(fn, backend="eager", fullgraph=True)(self.keys())
+
+    def test_comparisons_match_eager(self):
+        cmps = {
+            "eq_set": lambda k: k == {1, 2},
+            "eq_frozenset": lambda k: k == frozenset({1, 2}),
+            "eq_list": lambda k: k == [1, 2],
+            "ne_set": lambda k: k != {1, 2},
+            "le_set": lambda k: k <= {1, 2, 3},
+            "lt_set": lambda k: k < {1, 2, 3},
+            "ge_set": lambda k: k >= {1},
+            "gt_set": lambda k: k > {1},
+        }
+        for name, fn in cmps.items():
+            with self.subTest(cmp=name):
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=True)
+                self.assertEqual(compiled(self.keys()), fn(self.keys()))
+
+    def test_ordering_against_non_set_raises(self):
+        fn = lambda k: k <= [1, 2, 3]  # noqa: E731
+        with self.assertRaises(TypeError):
+            fn(self.keys())
+        torch._dynamo.reset()
+        with self.assertRaises((TypeError, Unsupported)):
+            torch.compile(fn, backend="eager", fullgraph=True)(self.keys())
+
+    def test_set_abc_surface_still_works(self):
+        """isdisjoint, len, containment and iteration are unaffected."""
+        ops = {
+            "isdisjoint_set": lambda k: k.isdisjoint({9}),
+            "isdisjoint_list": lambda k: k.isdisjoint([9]),
+            "isdisjoint_false": lambda k: k.isdisjoint({1}),
+            "len": lambda k: len(k),
+            "contains": lambda k: 1 in k,
+            "iter": lambda k: set(k),
+            "mapping": lambda k: dict(k.mapping),
+        }
+        for name, fn in ops.items():
+            with self.subTest(op=name):
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=True)
+                self.assertEqual(compiled(self.keys()), fn(self.keys()))
+
+    def test_dict_view_operands_match_eager(self):
+        """A view built inside the region is a DictKeysVariable, not this VT.
+
+        Comparing against one must fall through to the reflected operation.
+        """
+        ops = {
+            "eq_keys": lambda k: k == {1: 9, 2: 9}.keys(),
+            "le_keys": lambda k: k <= {1: 9, 2: 9, 3: 0}.keys(),
+            "or_keys": lambda k: k | {3: 0}.keys(),
+            "and_keys": lambda k: k & {1: 0}.keys(),
+            "eq_items": lambda k: k == {1: 9}.items(),
+            "eq_dict": lambda k: k == {1: 0, 2: 0},
+            "isdisjoint_keys": lambda k: k.isdisjoint({9: 0}.keys()),
+        }
+        for name, fn in ops.items():
+            with self.subTest(op=name):
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=True)
+                self.assertEqual(compiled(self.keys()), fn(self.keys()))
+
+    def test_dict_keys_is_not_a_set_variable(self):
+        """Structural guard against the classes being merged again."""
+        from torch._dynamo.variables.sets import (
+            BaseSetVariable,
+            DictKeySetVariable,
+            SetVariable,
+        )
+
+        self.assertFalse(issubclass(DictKeySetVariable, SetVariable))
+        self.assertTrue(issubclass(DictKeySetVariable, BaseSetVariable))
+
+    def test_regular_set_behaviour_unaffected(self):
+        def fn(s):
+            return s.union({3}), s | {4}, s == {1, 2}, s.isdisjoint({9})
+
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled({1, 2}), fn({1, 2}))
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1313,6 +1313,7 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.RangeVariable,
             variables.SetVariable,
             variables.FrozensetVariable,
+            variables.DictKeySetVariable,
             variables.TensorVariable,
             variables.TupleVariable,
         )

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2440,6 +2440,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             (
                 variables.SetVariable,
                 variables.FrozensetVariable,
+                variables.DictKeySetVariable,
                 variables.ConstDictVariable,
             ),
         ):
@@ -3205,7 +3206,14 @@ class BuiltinVariable(BaseBuiltinVariable):
         if isinstance(a, DictViewVariable):
             a = a.dv_dict
         if isinstance(
-            a, (ListVariable, ConstDictVariable, SetVariable, FrozensetVariable)
+            a,
+            (
+                ListVariable,
+                ConstDictVariable,
+                SetVariable,
+                FrozensetVariable,
+                variables.DictKeySetVariable,
+            ),
         ):
             return VariableTracker.build(tx, len(a.items) == 0)
         if isinstance(a, UserDefinedObjectVariable):
@@ -3387,7 +3395,13 @@ class DictBuiltinVariable(BaseBuiltinVariable):
         # CPython's do-not-rehash-dict-keys behavior when building a dict from
         # an existing set/frozenset/dict.
         if isinstance(
-            arg, (variables.SetVariable, variables.FrozensetVariable, ConstDictVariable)
+            arg,
+            (
+                variables.SetVariable,
+                variables.FrozensetVariable,
+                variables.DictKeySetVariable,
+                ConstDictVariable,
+            ),
         ):
             # HashableTracker keys are accepted by ConstDictVariable.__init__.
             return _make_result(dict.fromkeys(arg.items.keys(), value))  # type: ignore[arg-type]

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,7 +67,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import FrozensetVariable, SetVariable
+from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
 
 
 if TYPE_CHECKING:
@@ -249,7 +249,7 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
-    elif isinstance(var, (SetVariable, FrozensetVariable)):
+    elif isinstance(var, (SetVariable, FrozensetVariable, DictKeySetVariable)):
         for key in var.items:
             mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
@@ -4359,6 +4359,7 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     ConstDictVariable,
                     SetVariable,
                     FrozensetVariable,
+                    DictKeySetVariable,
                 ),
             ):
                 unimplemented(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -530,7 +530,7 @@ class BaseListVariable(VariableTracker):
         # CPython has a series of checks to optimize list.extend for different data types
         # ref: https://github.com/python/cpython/blob/0fd4fd4496c557b68477a99c1c231a5870c91daf/Objects/listobject.c#L1389-L1444
         from .dicts import ConstDictVariable
-        from .sets import FrozensetVariable, SetVariable
+        from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
         from .user_defined import UserDefinedObjectVariable
 
         sz = len(self.items)
@@ -538,7 +538,10 @@ class BaseListVariable(VariableTracker):
             self.items.extend(args[0].items)
         elif isinstance(args[0], UserDefinedObjectVariable):
             self.items.extend(unpack_iterable(tx, args[0]))
-        elif isinstance(args[0], (ConstDictVariable, SetVariable, FrozensetVariable)):
+        elif isinstance(
+            args[0],
+            (ConstDictVariable, SetVariable, FrozensetVariable, DictKeySetVariable),
+        ):
             items = [item.vt for item in args[0].items]
             self.items.extend(items)
         elif isinstance(args[0], ConstantVariable):

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -85,7 +85,7 @@ def vt_identity_compare(
     from .dicts import ConstDictVariable
     from .lists import ListVariable
     from .misc import ExceptionVariable, TracebackVariable
-    from .sets import FrozensetVariable, SetVariable
+    from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
 
     if isinstance(
         left,
@@ -94,6 +94,7 @@ def vt_identity_compare(
             ListVariable,
             SetVariable,
             FrozensetVariable,
+            DictKeySetVariable,
             TracebackVariable,
             ExceptionVariable,
         ),

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -85,9 +85,15 @@ class BaseSetVariable(VariableTracker):
     subclass of set, and neither is dict_keys (see #192874). This base holds
     every operation that is valid on an immutable set-like collection.
     SetVariable (mutable Python ``set``) adds the mutating operations on top.
-    FrozensetVariable inherits only this base, so a traced frozenset is no
-    longer matched by isinstance checks against SetVariable. DictKeySetVariable
-    still derives from SetVariable; that row of #192874 is not addressed here.
+    FrozensetVariable and DictKeySetVariable inherit only this base, so a
+    traced frozenset or dict_keys is not matched by isinstance checks against
+    SetVariable.
+
+    Only ``isdisjoint`` is registered in ``tp_methods`` here: that is the whole
+    named surface of ``collections.abc.Set``, and of ``dict_keys``. The other
+    read-only methods (``union``, ``copy``, ...) are implemented here but
+    registered by SetVariable and FrozensetVariable, the same way CPython's
+    ``set_methods`` and ``frozenset_methods`` tables share one implementation.
     """
 
     CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
@@ -512,12 +518,24 @@ class BaseSetVariable(VariableTracker):
             if not issubclass(other_type, (set, frozenset)):
                 return ConstantVariable.create(NotImplemented)
 
-        # Accessing set_items directly is correct: CPython's set_richcompare
+        return self._richcompare_items(
+            tx,
+            self.set_items,
+            other.set_items,  # type: ignore[attr-defined]
+            op,
+        )
+
+    def _richcompare_items(
+        self,
+        tx: "InstructionTranslatorBase",
+        self_items: set["HashableTracker"],
+        other_items: set["HashableTracker"],
+        op: str,
+    ) -> VariableTracker:
+        # Accessing the item sets directly is correct: CPython's set_richcompare
         # operates on the internal C struct (PySet_GET_SIZE, set_next,
         # set_contains_entry) -- it never calls __len__ or __contains__.
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/setobject.c#L2093-L2130
-        self_items = self.set_items
-        other_items = other.set_items  # type: ignore[attr-defined]
         if op == "__eq__":
             # len check + issubset: same length and subset implies equality.
             if len(self_items) != len(other_items):
@@ -535,13 +553,6 @@ class BaseSetVariable(VariableTracker):
 
     tp_methods = {
         "isdisjoint": Method(isdisjoint),
-        "intersection": Method(intersection),
-        "union": Method(union),
-        "difference": Method(difference),
-        "symmetric_difference": Method(symmetric_difference),
-        "issubset": Method(issubset),
-        "issuperset": Method(issuperset),
-        "copy": Method(copy),
     }
 
 
@@ -776,6 +787,13 @@ class SetVariable(BaseSetVariable):
         return self
 
     tp_methods = {
+        "intersection": Method(BaseSetVariable.intersection),
+        "union": Method(BaseSetVariable.union),
+        "difference": Method(BaseSetVariable.difference),
+        "symmetric_difference": Method(BaseSetVariable.symmetric_difference),
+        "issubset": Method(BaseSetVariable.issubset),
+        "issuperset": Method(BaseSetVariable.issuperset),
+        "copy": Method(BaseSetVariable.copy),
         "add": Method(add),
         "pop": Method(pop),
         "intersection_update": Method(intersection_update),
@@ -1019,6 +1037,9 @@ class FrozensetVariable(BaseSetVariable):
         "difference": Method(difference),
         "intersection": Method(intersection),
         "symmetric_difference": Method(symmetric_difference),
+        "union": Method(BaseSetVariable.union),
+        "issubset": Method(BaseSetVariable.issubset),
+        "issuperset": Method(BaseSetVariable.issuperset),
     }
 
     def tp_init_impl(
@@ -1050,7 +1071,15 @@ class FrozensetVariable(BaseSetVariable):
         return hash(frozenset(raw_hashes)), is_fake
 
 
-class DictKeySetVariable(SetVariable):
+class DictKeySetVariable(BaseSetVariable):
+    """A ``dict_keys`` view passed into the compiled region.
+
+    ``dict_keys`` is a ``collections.abc.Set``, not a ``set``: it has no named
+    set method other than ``isdisjoint``, and its number slots (``dictviews_or``
+    and friends) accept any iterable rather than requiring another set.
+    ref: https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L4667-L4790
+    """
+
     def debug_repr(self) -> str:
         if not self.items:
             return "dict_keys([])"
@@ -1080,3 +1109,90 @@ class DictKeySetVariable(SetVariable):
         return dict.fromkeys(
             {k.vt.as_python_constant() for k in self.set_items}, None
         ).keys()
+
+    def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
+        # dictview_repr in Objects/dictobject.c: the type name around a list repr.
+        items = ", ".join(tracked_repr(tx, k.vt) for k in self.items)
+        return VariableTracker.build(tx, f"dict_keys([{items}])")
+
+    def is_hashable(self) -> bool:
+        return False
+
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
+        raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
+
+    def _dictview_binop(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        name: str,
+        reverse: bool,
+    ) -> VariableTracker:
+        # dictviews_or/_and/_sub/_xor build a set from the left operand and
+        # update it with the right, so either side may be any iterable and the
+        # result is always a plain set.
+        left, right = (other, self) if reverse else (self, other)
+        return self._as_set_variable(tx, left).call_method(tx, name, [right], {})
+
+    @staticmethod
+    def _as_set_variable(
+        tx: "InstructionTranslatorBase", vt: VariableTracker
+    ) -> "SetVariable":
+        from .dicts import ConstDictVariable
+
+        if isinstance(vt, (BaseSetVariable, ConstDictVariable)):
+            items: list[Any] = list(vt.items.keys())
+        else:
+            items = unpack_iterable(tx, vt)
+        return SetVariable(items, mutation_type=ValueMutationNew())
+
+    def nb_or_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        return self._dictview_binop(tx, other, "union", reverse)
+
+    def nb_and_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        return self._dictview_binop(tx, other, "intersection", reverse)
+
+    def nb_subtract_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        return self._dictview_binop(tx, other, "difference", reverse)
+
+    def nb_xor_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        reverse: bool = False,
+    ) -> VariableTracker:
+        return self._dictview_binop(tx, other, "symmetric_difference", reverse)
+
+    def tp_richcompare_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        other: VariableTracker,
+        op: str,
+    ) -> VariableTracker:
+        """dictview_richcompare, for the operands this VT can read directly.
+
+        Anything else returns NotImplemented so the reflected operation runs,
+        which is what already handles a `DictKeysVariable` on the right.
+        https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L4623
+        """
+        if not isinstance(other, BaseSetVariable):
+            return ConstantVariable.create(NotImplemented)
+
+        return self._richcompare_items(
+            tx, set(self.items.keys()), set(other.items.keys()), op
+        )


### PR DESCRIPTION
## Issue

Part of #192874, the `DictKeySetVariable(SetVariable)` row. That tracker lists
eight rows, so this does not close it.

## Summary

`DictKeySetVariable` traces a `dict_keys` view that is passed *into* the compiled
region (`builder.py`, the `isinstance(value, dict_keys)` branch). Tracing
`d.keys()` inside the region produces `DictKeysVariable` instead, which is a
different class and already behaves correctly; this PR does not touch it.

Because `DictKeySetVariable` subclassed `SetVariable`, a traced `dict_keys`
picked up all 16 of `set`'s named methods through the `tp_methods` MRO merge.
Under `fullgraph=True` six of them silently returned a value for code that raises
in eager:

```python
import torch

def f(k):
    return k.union({3})          # dict_keys has no .union

torch.compile(f, backend="eager", fullgraph=True)({1: 0, 2: 0}.keys())
```

Before: `{1, 2, 3}`. After: an ordinary unsupported-call error, and eager still
raises `AttributeError: 'dict_keys' object has no attribute 'union'`.

The same applied to `intersection`, `difference`, `symmetric_difference`, `copy`
and `discard`. Eight more leaked an internal error instead of `AttributeError`:
`add`, `clear`, `intersection_update`, `difference_update` and
`symmetric_difference_update` hit `AssertionError: mutation_type is None for
DictKeySetVariable() in check_allowed_side_effect`, while `issubset`,
`issuperset` and `pop` raised `InternalTorchDynamoError`.

The inherited slots were wrong in the other direction too, and this part breaks
code that works in eager:

- `k | s`, `k & s`, `k - s`, `k ^ s` raised `Unsupported: Observed exception`
  under `fullgraph=True`. `SetVariable`'s number slots gate on
  `pyanyset_check`, which is `issubclass(python_type(), (set, frozenset))`, and
  `dict_keys` is neither, so every slot returned `NotImplemented`.
- `k == s`, `k <= s`, `k >= s` raised
  `InternalTorchDynamoError: TypeError: '<=' not supported between instances of
  'dict' and 'set'` in **both** graph-break and fullgraph modes.
  `tp_richcompare_impl` compares `self.set_items` against `other.set_items`, but
  `DictKeySetVariable.set_items` returns the internal `dict` where every other
  set VT returns a `set`.

## Fix

`dict_keys` is a `collections.abc.Set` but not a `set`. That is the whole shape
of the fix, and CPython states it precisely:

```python
>>> sorted(d for d in dir(collections.abc.Set) if not d.startswith("_"))
['isdisjoint']
>>> sorted(d for d in dir({}.keys()) if not d.startswith("_"))
['isdisjoint', 'mapping']
>>> issubclass(collections.abc.KeysView, collections.abc.Set)
True
```

`DictKeySetVariable` now derives from `BaseSetVariable`, the shared base #193580
introduced for `frozenset`, instead of `SetVariable`, so it can reach none of
`set`'s mutators or `nb_inplace_*` slots.

`BaseSetVariable.tp_methods` also had to shrink. `tp_methods` merges additively
along the MRO (a subclass table can add entries but never drop one), and the base
registered eight read-only methods, seven of which `dict_keys` does not have. So
`isdisjoint` is the only entry left on `BaseSetVariable`, matching the `Set` ABC,
and the other seven (`union`, `intersection`, `difference`,
`symmetric_difference`, `issubset`, `issuperset`, `copy`) stay *implemented* on
`BaseSetVariable` but are *registered* by `SetVariable.tp_methods` and
`FrozensetVariable.tp_methods`, as `Method(BaseSetVariable.union)` and so on, the
form `lists.py` already uses. That is also how CPython lays it out: `set_methods`
and `frozenset_methods` are separate tables sharing one C implementation.

`DictKeySetVariable` then gets the dict-view slots it should have had:
`nb_or_impl` / `nb_and_impl` / `nb_subtract_impl` / `nb_xor_impl` mirroring
`dictviews_or` and friends, which build a set from the left operand and update it
with the right, so either side may be any iterable and the result is always a
plain `set`:

```python
>>> {1: 0, 2: 0}.keys() | [3]     # a list operand is fine, unlike set.__or__
{1, 2, 3}
>>> [1, 3] - {1: 0, 2: 0}.keys()  # and it is symmetric
{3}
```

plus a `tp_richcompare_impl` mirroring `dictview_richcompare`, which accepts any
set or dict view and returns `NotImplemented` otherwise. The shared comparison
body moved to `BaseSetVariable._richcompare_items`; set's operand check stays
narrow, matching CPython, where `set_richcompare` uses `PyAnySet_Check` and lets
the reflected dict-view op handle `set == dict_keys`.

Three things `DictKeySetVariable` used to inherit from `SetVariable` and
`BaseSetVariable` does not provide are now defined on it: `is_hashable` and
`hash_impl` (`dict_keys` is unhashable), and `tp_repr_impl`, which now produces
`dict_keys([1, 2])` where it used to produce `{1, 2}`.

Eight `isinstance` checks outside `sets.py` that enumerate
`(SetVariable, FrozensetVariable)` gain `DictKeySetVariable` (`builtin.py` x3,
`higher_order_ops.py` x2, `lists.py`, `object_protocol.py`, and
`_unpack_fast_types()` in `utils.py`), following the enumeration style #193580
landed with. Four `isinstance(..., SetVariable)` checks are deliberately left
narrow, because the split makes them more accurate: `SET_ADD` and `SET_UPDATE`
in `symbolic_convert.py` assert their accumulator is a mutable set, and the
`const_dict_or_set_mutation` replay handler in `side_effects.py` emits `update`
and `clear`. A `dict_keys` is never a comprehension accumulator and is never
mutated.

## Test plan

New `DictKeySetHierarchyTests` in `test/dynamo/test_sets.py`, 10 tests. Same test
file, only `torch/_dynamo` swapped (unpatched is today's nightly, which already
has `BaseSetVariable` from #193580):

```
python test/dynamo/test_sets.py -k DictKeySetHierarchyTests
unpatched   Ran 10 tests, FAILED (failures=17, errors=22)
patched     Ran 10 tests, OK
```

Being precise about what that shows, since not all ten are regression coverage.
Five pass both before and after and are non-regression guards:
`test_set_abc_surface_still_works`, `test_binary_op_with_non_iterable_raises`,
`test_ordering_against_non_set_raises`, `test_regular_set_behaviour_unaffected`
and `test_dict_view_operands_match_eager`. That last one guards a trap this
change can fall into: a view built *inside* the region is a `DictKeysVariable`,
which this VT cannot read directly, so comparing against one has to fall through
to the reflected operation. `test_dict_keys_is_not_a_set_variable` is structural,
guarding against the classes being merged again. The existing
`FrozensetHierarchyTests.test_frozenset_readonly_ops_still_work` covers the
`tp_methods` relocation for `frozenset` (`union`, `issubset`, `issuperset`,
`copy` all still trace).

Suites run locally, all against the patched tree:

```
python test/dynamo/test_sets.py               Ran 206 tests, OK (skipped=1)
python test/dynamo/test_dicts.py              Ran 325 tests, OK (expected failures=1)
python test/dynamo/test_functions.py          Ran 565 tests, OK (skipped=9, expected failures=2)
python test/dynamo/test_higher_order_ops.py   Ran 225 tests, OK (skipped=17, expected failures=1)
python test/dynamo/test_repros.py             Ran 389 tests, OK (skipped=19, expected failures=4)
python test/dynamo/test_misc.py               Ran 860 tests, OK (skipped=14, expected failures=4) once ninja is on PATH; without it test_pybind11_enum_conversion errors with "Ninja is required to load C++ extensions"
```

Lint:

```
ruff 0.16.3      All checks passed! / 7 files already formatted
pyrefly 0.58.0   131 errors, all pre-existing missing-attribute reports against torch._C (build-generated stubs absent in a non-source checkout); 0 on lines this change adds, 0 in sets.py
```

These ran against the nightly CPU wheel `2.15.0.dev20260901+cpu` with the
repository `torch/_dynamo` overlaid, rather than a from-source build. The change
is pure Python with no C++ coupling, so the modified code is the code under test,
but no CUDA or distributed suites were run locally.

## BC-breaking?

No for user-visible behaviour: code that worked in eager keeps working, and
several cases that silently returned wrong values or leaked internal errors now
match eager. For out-of-tree code touching Dynamo internals,
`isinstance(x, SetVariable)` no longer matches a traced `dict_keys`.

## Notes

- Rebased onto #193580 as requested. The earlier revision introduced its own
  `AbstractSetVariable` bottom tier; that class is gone and `BaseSetVariable`
  plays its role.
- Authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98