### PR TITLE
[Testcase Refactoring][quantization][eager] Add GENERIC hw_classification to test_equalize_eager.py

### DIFF
--- a/test/quantization/eager/test_equalize_eager.py
+++ b/test/quantization/eager/test_equalize_eager.py
@@ -7,10 +7,15 @@ import torch.ao.quantization._equalize as _equalize
 import torch.nn as nn
 from torch.ao.quantization.fuse_modules import fuse_modules
 from torch.testing._internal.common_quantization import QuantizationTestCase
-from torch.testing._internal.common_utils import raise_on_run_directly
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+)
 
 
 class TestEqualizeEager(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def checkChannelsEqualized(self, tensor1, tensor2, output_axis, input_axis):
         """Checks the channel ranges of tensor1, tensor2 are the same,
         which is an indication that equalization has been applied correctly


### PR DESCRIPTION
## Summary

This PR marks `test/quantization/eager/test_equalize_eager.py` as device-agnostic
by adding `hw_classification = HardwareClassification.GENERIC` to
`TestEqualizeEager`, aligning with the community device-adaptation spec and
enabling hardware-agnostic test filtering.

### Why no decoupling is needed

`test_equalize_eager.py` contains only pure-CPU eager-mode quantization
equalization logic with **no accelerator-specific code**. Per the decoupling
standard, a test case only needs decoupling if it has any of the following —
none apply here:

| Check | Result |
|---|---|
| Hardcoded `"cuda"` string / device instance | ❌ None |
| CUDA-only decorators (`@onlyCUDA`, `@skipCUDAIf`, ...) | ❌ None |
| Ops/tensors pinned to CUDA device | ❌ None (all `.to(...)` are dtype-only) |
| CUDA-only device branches | ❌ None |
| `instantiate_device_type_tests` / device dispatch | ❌ None |

All test methods exercise the cross-layer equalization algorithm on `Conv2d` /
`Linear` / `ReLU` modules, entirely on CPU. No decoupling is therefore required.

### Changes

- Add `HardwareClassification` to the `common_utils` import
- `TestEqualizeEager.hw_classification = HardwareClassification.GENERIC`

No test methods, test count, or execution semantics are changed.

## Test Plan

- CPU: `python -m pytest test/quantization/eager/test_equalize_eager.py -v`
  ```
  Ran 5 tests 0.118s OK
  ```
- CUDA: covered by the Pull Request CI (same command, 5 tests)
- `pytest --collect-only`:
  ```
  5 tests collected in 4.47s
  ```