### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_contract

### DIFF
--- a/test/distributed/_composable/test_contract.py
+++ b/test/distributed/_composable/test_contract.py
@@ -5,7 +5,12 @@ from copy import deepcopy
 import torch
 import torch.nn as nn
 from torch.distributed._composable import _get_registry, contract
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 class ToyModel(nn.Module):
@@ -24,6 +29,8 @@ class ToyModel(nn.Module):
 
 
 class TestContract(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfTorchDynamo("Dynamo does not support the state key")
     def test_add_hooks(self):
         def forward_pre_hook(


### PR DESCRIPTION
Adds hw_classification (GENERIC) to the composable contract test class.
TestContract exercises device-agnostic composable-API bookkeeping (forward and
backward hooks, FQN validation, state, and the module registry) and is not
instantiated via instantiate_device_type_tests.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/_composable/test_contract.py --hw-classification GENERIC