### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fsdp_ep

### DIFF
--- a/test/distributed/checkpoint/e2e/test_fsdp_ep.py
+++ b/test/distributed/checkpoint/e2e/test_fsdp_ep.py
@@ -6,7 +6,11 @@ from torch.distributed.checkpoint.state_dict import get_state_dict
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.tensor import DTensor
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     skip_if_lt_x_gpu,
@@ -59,6 +63,8 @@ class TopModel(nn.Module):
 
 
 class TestFSDPWithEP(DTensorTestBase, VerifyStateDictMixin):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(8, torch.accelerator.device_count())
@@ -119,6 +125,14 @@ class TestFSDPWithEP(DTensorTestBase, VerifyStateDictMixin):
                         self.assertEqual(tuple(v.device_mesh.mesh), ranks)
 
         self.assertEqual(set(osd["state"].keys()), set(msd.keys()))
+
+
+instantiate_device_type_tests(
+    TestFSDPWithEP,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/e2e/test_fsdp_ep.py
+++ b/test/distributed/checkpoint/e2e/test_fsdp_ep.py
@@ -7,10 +7,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.tensor import DTensor
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     skip_if_lt_x_gpu,
@@ -72,7 +69,7 @@ class TestFSDPWithEP(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(8)
     @with_temp_dir
-    def test_e2e(self):
+    def test_e2e(self, device):
         model = TopModel(self.rank).to(self.device_type)
 
         mesh_fsdp_tp = init_device_mesh(


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the FSDP + expert-parallel state-dict
test class and instantiates it via instantiate_device_type_tests with
except_for=["cpu"] and allow_xpu=True, so it is discovered per device type
under the hardware-classification selection.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/checkpoint/e2e/test_fsdp_ep.py --hw-classification ACCELERATOR