### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fsdp_model_state

### DIFF
--- a/test/distributed/checkpoint/test_fsdp_model_state.py
+++ b/test/distributed/checkpoint/test_fsdp_model_state.py
@@ -9,8 +9,12 @@ from torch.distributed.checkpoint.default_planner import (
 )
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -19,6 +23,8 @@ from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 
 class FsdpModelStateCheckpoint(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
@@ -94,6 +100,14 @@ class FsdpModelStateCheckpoint(DTensorTestBase):
     @with_temp_dir
     def test_fsdp_model_state_with_resharding(self):
         self._test_fsdp_model_state(process_group=self._create_new_dist_group())
+
+
+instantiate_device_type_tests(
+    FsdpModelStateCheckpoint,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_fsdp_model_state.py
+++ b/test/distributed/checkpoint/test_fsdp_model_state.py
@@ -11,10 +11,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -77,7 +74,7 @@ class FsdpModelStateCheckpoint(DTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @with_comms
     @with_temp_dir
-    def test_fsdp_model_state_no_resharding(self):
+    def test_fsdp_model_state_no_resharding(self, device):
         self._test_fsdp_model_state(process_group=None)
 
     def _create_new_dist_group(self):
@@ -98,7 +95,7 @@ class FsdpModelStateCheckpoint(DTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @with_comms
     @with_temp_dir
-    def test_fsdp_model_state_with_resharding(self):
+    def test_fsdp_model_state_with_resharding(self, device):
         self._test_fsdp_model_state(process_group=self._create_new_dist_group())
 
 


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the FSDP model-state checkpoint test
class and instantiates it via instantiate_device_type_tests with
except_for=["cpu"] and allow_xpu=True, so it is discovered per device type
under the hardware-classification selection.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/checkpoint/test_fsdp_model_state.py --hw-classification ACCELERATOR