### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fsdp_optim_state

### DIFF
--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -189,7 +189,6 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
                     self.assertEqual(state, state2)
 
 
-instantiate_parametrized_tests(FsdpOptimStateCheckpoint)
 instantiate_device_type_tests(
     FsdpOptimStateCheckpoint,
     globals(),

--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -9,8 +9,10 @@ from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_
 from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -23,6 +25,8 @@ from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 
 class FsdpOptimStateCheckpoint(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _create_model(self):
         # make weight tensor dim_0 as large as the world size for scaling test
         layer1_weight_dim = self.world_size
@@ -186,5 +190,13 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
 
 
 instantiate_parametrized_tests(FsdpOptimStateCheckpoint)
+instantiate_device_type_tests(
+    FsdpOptimStateCheckpoint,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -13,7 +13,6 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
 )
@@ -61,7 +60,7 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
 
     @skip_if_lt_x_gpu(2)
     @with_comms
-    def test_get_set_state_dict_forwards_fsdp_process_group(self):
+    def test_get_set_state_dict_forwards_fsdp_process_group(self, device):
         custom_pg = dist.new_group(ranks=list(range(self.world_size)))
 
         model = self._create_model()
@@ -114,7 +113,7 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
     @with_comms
     @with_temp_dir
     @parametrize("pass_planner", [True, False])
-    def test_load_sharded_optimizer_state_dict(self, pass_planner) -> None:
+    def test_load_sharded_optimizer_state_dict(self, device, pass_planner) -> None:
         CHECKPOINT_DIR = self.temp_dir
         planner = dcp.DefaultLoadPlanner() if pass_planner else None
 


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the FSDP optimizer-state checkpoint
test class and instantiates it via instantiate_device_type_tests with
except_for=["cpu"] and allow_xpu=True, so it is discovered per device type
under the hardware-classification selection.

Also removes the now-redundant instantiate_parametrized_tests call.
instantiate_device_type_tests already expands @parametrize-decorated tests
(via their parametrize_fn attribute), so keeping both expanded the
@parametrize("pass_planner", ...) test twice: the first expansion copied
parametrize_fn onto the generated methods through @wraps, and the second
expansion then passed pass_planner to a method that no longer accepts it,
raising `TypeError: ... got an unexpected keyword argument 'pass_planner'`.
Removing the redundant call lets instantiate_device_type_tests expand the
parametrization exactly once.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/checkpoint/test_fsdp_optim_state.py --hw-classification ACCELERATOR