### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard training

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -39,6 +39,9 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import (
 )
 from torch.distributed.tensor import DTensor, init_device_mesh, Shard
 from torch.distributed.tensor.debug import CommDebugMode
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
@@ -58,6 +61,7 @@ from torch.testing._internal.common_fsdp import (
 from torch.testing._internal.common_utils import (
     device_sleep,
     get_cycles_per_ms,
+    HardwareClassification,
     MI200_ARCH,
     run_tests,
     skipIfRocm,
@@ -109,6 +113,8 @@ class ChunkedHeadModel(nn.Module):
 
 
 class TestFullyShardForwardInputs(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -160,6 +166,8 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
 
 
 class TestFullyShardRegisteredParams(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 4
@@ -292,6 +300,8 @@ class TestFullyShardRegisteredParams(FSDPTestMultiThread):
 
 
 class TestFullyShardCastAfterInit(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 2
@@ -340,6 +350,8 @@ class TestFullyShardCastAfterInit(FSDPTestMultiThread):
 
 
 class TestFullyShard1DTrainingCore(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 8
@@ -784,6 +796,8 @@ class TestFullyShard1DTrainingCore(FSDPTest):
 
 
 class TestFullyShard1DTrainingCompose(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # Since these tests run with a larger transformer model, they may see
@@ -993,7 +1007,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 total_loss += loss.detach()
                 loss.backward()
                 h_grads.append(chunk.grad.detach())
-                per_chunk_head_grads.append(self._snapshot_grad(model.head.weight.grad))
+                per_chunk_head_grads.append(type(self)._snapshot_grad(model.head.weight.grad))
             # Each chunk must contribute a non-zero delta — catches chunks
             # 2+ silently dropped due to unregistered post_backward hooks.
             for i in range(1, len(per_chunk_head_grads)):
@@ -1424,6 +1438,8 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
 
 
 class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 8
@@ -1475,6 +1491,8 @@ class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
 
 
 class TestFullyShardShardPlacementFnMultiThread(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 4
@@ -1514,6 +1532,8 @@ class TestFullyShardShardPlacementFnMultiThread(FSDPTestMultiThread):
 
 
 class TestFullyShardSharedParams(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 4
@@ -1702,6 +1722,8 @@ class TestFullyShardSharedParams(FSDPTest):
 
 
 class TestFullyShardGradientAccumulation(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 4
@@ -1967,6 +1989,8 @@ class TestFullyShardGradientAccumulation(FSDPTest):
 
 
 class TestFullyShardNDTraining(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 8
@@ -2267,6 +2291,8 @@ class TestFullyShardNDTraining(FSDPTest):
 
 
 class TestFullyShardHSDP3DTraining(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 8
@@ -2351,6 +2377,8 @@ class TestFullyShardHSDP3DTraining(FSDPTest):
 
 
 class TestFullyShardHSDPTraining(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 4
@@ -2445,6 +2473,8 @@ class TestFullyShardHSDPTraining(FSDPTest):
 
 
 class TestFullyShardCustomForwardMethod(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 2
@@ -2498,6 +2528,8 @@ class TestFullyShardCustomForwardMethod(FSDPTest):
 
 
 class TestFullyShardShareCommContext(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         min_world_size = 2
@@ -2613,6 +2645,8 @@ class TestFullyShardShareCommContext(FSDPTest):
 
 
 class TestFullyShardWorldSize1(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 1
@@ -2675,6 +2709,8 @@ class TestFullyShardWorldSize1(FSDPTest):
 
 
 class TestFullyShardCudaGraph(FSDPTest):
+    hw_classification = HardwareClassification.CUDA
+
     @property
     def world_size(self) -> int:
         return 2
@@ -2735,6 +2771,79 @@ class TestFullyShardCudaGraph(FSDPTest):
                 for graph_grad, ref_grad in zip(static_output_grads, ref_grads):
                     self.assertTrue(torch.equal(graph_grad, ref_grad))
                 model.zero_grad(set_to_none=True)
+
+
+instantiate_device_type_tests(
+    TestFullyShard1DTrainingCore,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShard1DTrainingCompose,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardShardPlacementFnMultiProcess,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardSharedParams,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardGradientAccumulation,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardNDTraining,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardHSDP3DTraining,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardHSDPTraining,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardCustomForwardMethod,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardShareCommContext,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardWorldSize1,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFullyShardCudaGraph,
+    globals(),
+    only_for=["cuda"],
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -39,9 +39,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_common import (
 )
 from torch.distributed.tensor import DTensor, init_device_mesh, Shard
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
@@ -360,7 +358,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_parity_single_group_shard_dim0(self):
+    def test_train_parity_single_group_shard_dim0(self, device):
         """
         Tests train parity with DDP for a single FSDP group when sharding
         parameters on dim-0.
@@ -378,7 +376,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_parity_single_group_shard_largest_dim(self):
+    def test_train_parity_single_group_shard_largest_dim(self, device):
         """
         Tests train parity with DDP for a single FSDP group when sharding
         parameters on their largest dim.
@@ -426,7 +424,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         "Sleep is not supported on this device",
     )
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    def test_train_parity_multi_group(self):
+    def test_train_parity_multi_group(self, device):
         """
         Tests train parity against DDP when using multiple parameter groups for
         communication (for communication and computation overlap plus memory
@@ -452,7 +450,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_train_parity_multi_group_cpu_offload_eager(self):
+    def test_train_parity_multi_group_cpu_offload_eager(self, device):
         """
         Tests train parity against DDP when using multiple parameter groups for
         communication and CPU offloading.
@@ -480,7 +478,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         "Sleep is not supported on this device",
     )
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
-    def test_train_parity_multi_group_unshard_async_op(self):
+    def test_train_parity_multi_group_unshard_async_op(self, device):
         """
         Tests train parity against DDP when using multiple parameter groups for
         communication and setting ``unshard_async_op=True``.
@@ -616,7 +614,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_non_root_forward_backward(self):
+    def test_non_root_forward_backward(self, device):
         """
         Tests running forward/backward through the root and then through a
         non-root. The non-root needs to synchronize streams/queue the callback.
@@ -662,7 +660,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         self.assertEqual(ref_model(inp).sum(), model(inp).sum())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_multi_forward_module(self):
+    def test_multi_forward_module(self, device):
         """
         Tests parity with DDP when running a module that participates multiple
         times in forward.
@@ -708,7 +706,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_explicit_prefetching(self):
+    def test_explicit_prefetching(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=8, dropout_p=0.0)
         model = Transformer(model_args)
@@ -750,7 +748,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_post_optim_event(self):
+    def test_post_optim_event(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)
         model = Transformer(model_args)
@@ -818,7 +816,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1661
-    def test_train_parity_with_activation_checkpointing(self):
+    def test_train_parity_with_activation_checkpointing(self, device):
         """
         Tests train parity against DDP when composing with activation
         checkpointing.
@@ -929,7 +927,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_partial_group_forward_then_standalone(self):
+    def test_partial_group_forward_then_standalone(self, device):
         """Chunked-loss pattern: model forward skips one module in a grouped
         ``fully_shard([norm, head])``, then that module is called standalone
         per-chunk. Validates ``_force_complete_incomplete_states`` +
@@ -1007,7 +1005,9 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 total_loss += loss.detach()
                 loss.backward()
                 h_grads.append(chunk.grad.detach())
-                per_chunk_head_grads.append(type(self)._snapshot_grad(model.head.weight.grad))
+                per_chunk_head_grads.append(
+                    type(self)._snapshot_grad(model.head.weight.grad)
+                )
             # Each chunk must contribute a non-zero delta — catches chunks
             # 2+ silently dropped due to unregistered post_backward hooks.
             for i in range(1, len(per_chunk_head_grads)):
@@ -1118,7 +1118,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                     )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_grouped_module_cast_forward_inputs(self):
+    def test_grouped_module_cast_forward_inputs(self, device):
         """``cast_forward_inputs`` applies to every module in a grouped
         ``fully_shard([a, b])``. Trigger: fp32 intermediate between ``a``
         and ``b`` would raise a dtype mismatch without the cast on ``b``.
@@ -1155,7 +1155,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
             self.assertIsNotNone(p.grad, lambda msg: f"{msg}\ngrad None for {name}")
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_partial_group_forward_grad_accum_chunked(self):
+    def test_partial_group_forward_grad_accum_chunked(self, device):
         """Chunked-loss + grad accumulation via set_requires_gradient_sync /
         set_is_last_backward: grouped [norm, head] and ungrouped variants
         produce identical accumulated grads."""
@@ -1214,7 +1214,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
             )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_partial_group_reshard_toggle(self):
+    def test_partial_group_reshard_toggle(self, device):
         """Reshard-flag toggle pattern used by torchtitan's ``ChunkedCELoss``:
         disable reshard_after_forward/backward for the chunk loop, then
         restore + call ``head.reshard()`` explicitly. Exercises force-complete
@@ -1288,7 +1288,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
             optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_reset_iter_state_after_exception(self):
+    def test_reset_iter_state_after_exception(self, device):
         """``reset_iter_state`` recovers after a mid-partial-forward exception
         (the case this PR's state-machine cleanup was designed for): the next
         forward-backward completes cleanly."""
@@ -1330,7 +1330,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
             )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_double_forward_with_nested_fsdp_and_checkpoint(self):
+    def test_double_forward_with_nested_fsdp_and_checkpoint(self, device):
         """
         Tests that calling model.forward() twice before backward() works correctly
         when using nested FSDP with activation checkpointing.
@@ -1390,7 +1390,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 self.assertIsNotNone(param.grad)
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_double_partial_forward_then_backward(self):
+    def test_double_partial_forward_then_backward(self, device):
         """Two back-to-back ``model(x, skip_head=True)`` calls before
         backward: both partial forwards must re-register their post_backward
         autograd node. ``_force_complete_incomplete_states`` resets the
@@ -1448,7 +1448,7 @@ class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_parity_shard_placement_fn_shard_largest_dim(self):
+    def test_train_parity_shard_placement_fn_shard_largest_dim(self, device):
         torch.manual_seed(42)
         model_args = ModelArgs(n_layers=3, dropout_p=0.0)
         model = Transformer(model_args)
@@ -1542,7 +1542,7 @@ class TestFullyShardSharedParams(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_parity_with_shared_params(self):
+    def test_train_parity_with_shared_params(self, device):
         self.run_subtests(
             {
                 "reshard_after_forward": [False, True],
@@ -1587,7 +1587,7 @@ class TestFullyShardSharedParams(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_shared_params_uneven_shard(self):
+    def test_train_shared_params_uneven_shard(self, device):
         """
         Test that FSDP2 correctly handles tied weights with uneven sharding
         when tied modules are placed in the same FSDP group.
@@ -1653,7 +1653,7 @@ class TestFullyShardSharedParams(FSDPTest):
         model.tok_embeddings.reshard()
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_shared_params_separate_fsdp_groups_error(self):
+    def test_shared_params_separate_fsdp_groups_error(self, device):
         """
         Test that applying fully_shard to modules with shared parameters
         in separate calls raises an error at lazy init (first forward).
@@ -1680,7 +1680,7 @@ class TestFullyShardSharedParams(FSDPTest):
             model(ids)
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_layer_by_layer_shard_no_false_positive(self):
+    def test_layer_by_layer_shard_no_false_positive(self, device):
         """
         Test that layer-by-layer materialize+shard+GC does not trigger a
         false-positive duplicate parameter error from id() reuse.
@@ -1732,7 +1732,7 @@ class TestFullyShardGradientAccumulation(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_gradient_accumulation(self):
+    def test_gradient_accumulation(self, device):
         """
         Tests gradient accumulation with/without gradient reduction and
         with/without resharding after backward.
@@ -1920,7 +1920,7 @@ class TestFullyShardGradientAccumulation(FSDPTest):
                 _optim.zero_grad(set_to_none=(iter_idx % 2))
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_1f1b_microbatching(self):
+    def test_1f1b_microbatching(self, device):
         self.run_subtests(
             {
                 "use_explicit_unshard": [False, True],
@@ -2010,7 +2010,7 @@ class TestFullyShardNDTraining(FSDPTest):
 
     @skip_if_lt_x_gpu(4, allow_cpu=True)
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
-    def test_2d_mlp_with_nd_mesh(self):
+    def test_2d_mlp_with_nd_mesh(self, device):
         global_mesh = self.init_global_mesh()
         self.run_subtests(
             {
@@ -2074,7 +2074,7 @@ class TestFullyShardNDTraining(FSDPTest):
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp", "tp"))
 
     @skip_if_lt_x_gpu(8)
-    def test_shard_placement_fn_tp_ep(self):
+    def test_shard_placement_fn_tp_ep(self, device):
         self.run_subtests(
             {
                 "tp_degree": [1, 2],
@@ -2308,7 +2308,7 @@ class TestFullyShardHSDP3DTraining(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(8, allow_cpu=True)
-    def test_3d_mlp_with_nd_mesh(self):
+    def test_3d_mlp_with_nd_mesh(self, device):
         global_mesh = self.init_global_mesh()
         self.run_subtests(
             {
@@ -2387,7 +2387,7 @@ class TestFullyShardHSDPTraining(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_train_parity_hsdp(self):
+    def test_train_parity_hsdp(self, device):
         shard_size = 2 if self.world_size > 2 else 1
         replicate_size = self.world_size // shard_size
         global_mesh = init_device_mesh(
@@ -2483,7 +2483,7 @@ class TestFullyShardCustomForwardMethod(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_register_fsdp_forward_method(self):
+    def test_register_fsdp_forward_method(self, device):
         """Based on https://github.com/pytorch/pytorch/issues/109385"""
 
         class VisionTransformer(nn.Module):
@@ -2538,7 +2538,7 @@ class TestFullyShardShareCommContext(FSDPTest):
         return min(min_world_size, torch.get_device_module(device_type).device_count())
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    def test_share_comm_context(self):
+    def test_share_comm_context(self, device):
         torch.manual_seed(42)
         n_layers = 3
         lin_dim = 16
@@ -2651,7 +2651,7 @@ class TestFullyShardWorldSize1(FSDPTest):
     def world_size(self) -> int:
         return 1
 
-    def test_train_parity_single_worldsize1(self):
+    def test_train_parity_single_worldsize1(self, device):
         """
         Tests train parity with DDP for a single FSDP group
         when sharding parameters on dim-0.
@@ -2720,7 +2720,7 @@ class TestFullyShardCudaGraph(FSDPTest):
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
-    def test_two_layer_fully_shard_cudagraph(self):
+    def test_two_layer_fully_shard_cudagraph(self, device):
         if device_type.type == "cuda":
             torch.cuda.set_device(self.rank)
         device = torch.device(device_type.type, self.rank)


### PR DESCRIPTION
Adds hw_classification to the fully_shard training test classes: 11 classes are
ACCELERATOR, 4 are GENERIC, and 1 is CUDA.

The 11 ACCELERATOR classes (FSDPTest, methods guarded by @skip_if_lt_x_gpu) are
instantiated via instantiate_device_type_tests with except_for=["cpu"]. The 4
GENERIC classes (FSDPTestMultiThread, methods without @skip_if_lt_x_gpu that run
on CPU via the threaded process group) are left as-is. TestFullyShardCudaGraph
uses torch.cuda.CUDAGraph and is instantiated with only_for=["cuda"].

One staticmethod, TestFullyShard1DTrainingCompose._snapshot_grad, is now called
via type(self)._snapshot_grad(...) instead of self._snapshot_grad(...):
instantiate_device_type_tests unwraps staticmethods into plain functions when
porting them to the device-specific class, so instance access would bind self
and pass an extra argument.

Test Plan: Ran the three commands below; each executed only the tests matching
the requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_training.py --hw-classification ACCELERATOR
python test/distributed/_composable/fsdp/test_fully_shard_training.py --hw-classification GENERIC
python test/distributed/_composable/fsdp/test_fully_shard_training.py --hw-classification CUDA