### PR TITLE
[Elastic] Fix find_free_port masking socket errors with UnboundLocalError

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,39 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+    def test_find_free_port_retries_after_socket_construction_failure(self):
+        addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        ]
+
+        real_socket = socket.socket
+        calls = {"count": 0}
+
+        def fake_socket(family, type, proto):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise OSError("socket failed")
+            return real_socket(family, type, proto)
+
+        with mock.patch("socket.getaddrinfo", return_value=addrs), mock.patch(
+            "socket.socket", side_effect=fake_socket
+        ):
+            sock = find_free_port()
+            try:
+                self.assertEqual(2, calls["count"])
+            finally:
+                sock.close()
+
+    def test_find_free_port_all_attempts_fail(self):
+        addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        ]
+
+        with mock.patch("socket.getaddrinfo", return_value=addrs), mock.patch(
+            "socket.socket", side_effect=OSError("socket failed")
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+                find_free_port()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes #191395

## Problem
`find_free_port()` in `torch/distributed/elastic/rendezvous/etcd_server.py` calls `s.close()` unconditionally in the `except OSError` block, even when `socket.socket()` itself raised before `s` was assigned. The cleanup then raises `UnboundLocalError`, masking the real socket error.

## Fix
Initialize `s = None` before the `try` and only close the socket when it was successfully created. Socket construction/bind/listen failures now print their useful diagnostics and the function continues through remaining addresses before raising the documented `RuntimeError`.

## Tests
- `test_find_free_port_retries_after_socket_construction_failure`: first socket constructor raises, asserts the second address is attempted.
- `test_find_free_port_all_attempts_fail`: all attempts raise `OSError`, asserts `RuntimeError` is raised and no `UnboundLocalError` escapes.

cc @dzhulgakov @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh