### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fsdp2_mem_tracker

### DIFF
--- a/test/distributed/_tools/test_fsdp2_mem_tracker.py
+++ b/test/distributed/_tools/test_fsdp2_mem_tracker.py
@@ -17,9 +17,7 @@ from torch.distributed.fsdp import (
     MixedPrecisionPolicy,
     OffloadPolicy,
 )
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, MLP
 from torch.testing._internal.common_utils import (
@@ -58,7 +56,7 @@ class TestTrackerFullyShard1DTrainingCore(FSDPTest):
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/129390")
     @skip_if_lt_x_gpu(2)
-    def test_tracker_multi_group_eager(self):
+    def test_tracker_multi_group_eager(self, device):
         """
         Tests tracker accuracy when using multiple parameter groups for
         communication (for communication and computation overlap plus memory
@@ -140,7 +138,7 @@ class TestTrackerFullyShard1DTrainingCore(FSDPTest):
         del optim
 
     @skip_if_lt_x_gpu(2)
-    def test_tracker_non_root_forward_backward(self):
+    def test_tracker_non_root_forward_backward(self, device):
         """
         Tests tracker accuracy when running forward/backward through a non-root.
         """
@@ -239,7 +237,7 @@ class TestTrackerFullyShard1DTrainingCompose(FSDPTest):
         return min(torch.accelerator.device_count(), 4)
 
     @skip_if_lt_x_gpu(2)
-    def test_tracker_with_activation_checkpointing(self):
+    def test_tracker_with_activation_checkpointing(self, device):
         """
         Tests tracker accuracy when composing with activation checkpointing.
         """

--- a/test/distributed/_tools/test_fsdp2_mem_tracker.py
+++ b/test/distributed/_tools/test_fsdp2_mem_tracker.py
@@ -17,9 +17,16 @@ from torch.distributed.fsdp import (
     MixedPrecisionPolicy,
     OffloadPolicy,
 )
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, MLP
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfRocm,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -43,6 +50,8 @@ def _reset_mem_stats(dev: torch.device):
 
 
 class TestTrackerFullyShard1DTrainingCore(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(4, torch.accelerator.device_count())
@@ -223,6 +232,8 @@ class TestTrackerFullyShard1DTrainingCore(FSDPTest):
 
 
 class TestTrackerFullyShard1DTrainingCompose(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(torch.accelerator.device_count(), 4)
@@ -318,6 +329,20 @@ class TestTrackerFullyShard1DTrainingCompose(FSDPTest):
         del inp
         del model
         del optim
+
+
+instantiate_device_type_tests(
+    TestTrackerFullyShard1DTrainingCore,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestTrackerFullyShard1DTrainingCompose,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds hw_classification (ACCELERATOR) to the two FSDP2 memory tracker test
classes and instantiates them via instantiate_device_type_tests with
except_for=["cpu"] and allow_xpu=True, so they are discovered per device type
under the hardware-classification selection.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/_tools/test_fsdp2_mem_tracker.py --hw-classification ACCELERATOR