### PR TITLE
[Testcase Refactoring] Add hardware classification labels to test_fully_shard_state

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state.py
@@ -5,10 +5,15 @@ import copy
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule, fully_shard
 from torch.testing._internal.common_fsdp import FSDPTestMultiThread, MLP
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 
 
 class TestFullyShardState(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self) -> int:
         return 1

--- a/test/distributed/_composable/fsdp/test_fully_shard_state.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state.py
@@ -5,10 +5,7 @@ import copy
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule, fully_shard
 from torch.testing._internal.common_fsdp import FSDPTestMultiThread, MLP
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    run_tests,
-)
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 class TestFullyShardState(FSDPTestMultiThread):


### PR DESCRIPTION
Adds hw_classification (GENERIC) to the fully_shard state test class. These
tests exercise device-agnostic FSDP logic (state object retrieval, reapply
error, class swapping, unsupported containers, deepcopy), so they are
classified GENERIC and left uninstantiated.

Test Plan: Run the command below; it should execute only the tests matching the
requested `--hw-classification` value.

python test/distributed/_composable/fsdp/test_fully_shard_state.py --hw-classification GENERIC