### PR TITLE
[Elastic] Fix FileStore rendezvous leaking the mkstemp file descriptor

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -274,6 +274,41 @@ class CreateBackendTest(TestCase):
         ):
             create_backend(self._params_filestore)
 
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    def test_create_backend_closes_tempfile_descriptor(
+        self, filestore_mock, tempfile_mock, close_mock
+    ) -> None:
+        tempfile_mock.return_value = (42, "/tmp/dummy_rendezvous_file")
+        self._params_filestore.endpoint = ""
+
+        create_backend(self._params_filestore)
+
+        # The descriptor returned by mkstemp must be closed exactly once,
+        # and the path (not the descriptor) must be passed to FileStore.
+        close_mock.assert_called_once_with(42)
+        filestore_mock.assert_called_once_with("/tmp/dummy_rendezvous_file")
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    def test_create_backend_closes_tempfile_descriptor_even_if_filestore_fails(
+        self, filestore_mock, tempfile_mock, close_mock
+    ) -> None:
+        tempfile_mock.return_value = (42, "/tmp/dummy_rendezvous_file")
+        filestore_mock.side_effect = RuntimeError("test error")
+        self._params_filestore.endpoint = ""
+
+        with self.assertRaises(RendezvousConnectionError):
+            create_backend(self._params_filestore)
+
+        close_mock.assert_called_once_with(42)
+
     @mock.patch(
         "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
     )

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -191,8 +191,11 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
     else:
         try:
             # The temporary file is readable and writable only by the user of
-            # this process.
-            _, path = tempfile.mkstemp()
+            # this process. mkstemp returns an open file descriptor, but
+            # FileStore opens the path independently, so close the descriptor
+            # right away to avoid leaking it.
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
Fixes #191394

## Problem
`_create_file_store()` calls `tempfile.mkstemp()` when no endpoint is supplied but discards the returned file descriptor without closing it. `FileStore` opens the path independently, so the descriptor remains owned by the Python process and is leaked — repeated FileStore rendezvous creation consumes file descriptors and can eventually hit the process limit.

## Fix
Close the descriptor returned by `mkstemp()` right after retaining the path. The cleanup happens before `FileStore` construction, so the descriptor is not leaked even if subsequent `FileStore` construction fails.

## Tests
- `test_create_backend_closes_tempfile_descriptor`: patches `mkstemp()` and `os.close()`, constructs the backend with no endpoint, and asserts the exact returned descriptor is closed once while the temporary path is passed to `FileStore`.
- `test_create_backend_closes_tempfile_descriptor_even_if_filestore_fails`: same, but with `FileStore` construction raising, asserting the descriptor is still closed.

cc @dzhulgakov @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh