### PR TITLE
[Distributed] Fix MemoryTracker.load() not restoring _op_index

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,5 +1,9 @@
 # Owner(s): ["oncall: distributed"]
+import contextlib
+import io
 import os
+import pickle
+import tempfile
 import unittest
 
 import torch
@@ -62,6 +66,65 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    def test_save_load_roundtrip_preserves_op_index(self):
+        """
+        A save/load round trip must preserve the operation count so that
+        summary() reports the same operators as the original tracker.
+        Regression test for GH issue 191397.
+        """
+        tracker = MemoryTracker()
+        for i in range(3):
+            tracker.memories_allocated[i] = (f"op{i}", float(i))
+            tracker.memories_active[i] = (f"op{i}", float(i))
+            tracker.memories_reserved[i] = (f"op{i}", float(i))
+        tracker._op_index = 3
+        tracker._num_alloc_retries = 1
+
+        with tempfile.NamedTemporaryFile() as f:
+            tracker.save_stats(f.name)
+            loaded = MemoryTracker()
+            loaded.load(f.name)
+
+        self.assertEqual(loaded._op_index, tracker._op_index)
+        self.assertEqual(loaded._num_alloc_retries, tracker._num_alloc_retries)
+        self.assertEqual(loaded.memories_allocated, tracker.memories_allocated)
+        self.assertEqual(loaded.memories_active, tracker.memories_active)
+        self.assertEqual(loaded.memories_reserved, tracker.memories_reserved)
+
+        orig_output = io.StringIO()
+        with contextlib.redirect_stdout(orig_output):
+            tracker.summary()
+        loaded_output = io.StringIO()
+        with contextlib.redirect_stdout(loaded_output):
+            loaded.summary()
+        self.assertEqual(loaded_output.getvalue(), orig_output.getvalue())
+
+    def test_load_stats_without_op_index_reconstructs_count(self):
+        """
+        Stats files saved before op_index was persisted must still load,
+        reconstructing the operation count from the traces.
+        """
+        stats = {
+            "memories_allocated": {0: ("op0", 0.0), 1: ("op1", 1.0)},
+            "memories_active": {0: ("op0", 0.0), 1: ("op1", 1.0)},
+            "memories_reserved": {0: ("op0", 0.0), 1: ("op1", 1.0)},
+            "markers": {},
+            "num_alloc_retries": 0,
+        }
+        with tempfile.NamedTemporaryFile() as f:
+            with open(f.name, "wb") as fh:
+                pickle.dump(stats, fh, pickle.HIGHEST_PROTOCOL)
+            loaded = MemoryTracker()
+            loaded.load(f.name)
+
+        self.assertEqual(loaded._op_index, 2)
+        self.assertEqual(loaded.memories_allocated, stats["memories_allocated"])
+
+        loaded_output = io.StringIO()
+        with contextlib.redirect_stdout(loaded_output):
+            loaded.summary()
+        self.assertIn("op1", loaded_output.getvalue())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,9 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # Backward compatibility for stats files saved before op_index was
+        # persisted: _op_index is exactly the number of recorded entries.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397

## Problem
`MemoryTracker.save_stats()` persists the memory traces but not `_op_index`, and `load()` restores the traces without reconstructing the count. Since `summary()` bounds its iteration with `_op_index` (which stays `0` after a load), a save/load round trip silently prints no operator deltas — one of the primary outputs of `MemoryTracker`.

## Fix
- `save_stats()` now persists `op_index`.
- `load()` restores it, falling back to `len(memories_allocated)` for stats files saved before this change (the count is exactly the number of recorded entries), so existing stats files keep working.

## Tests
- `test_save_load_roundtrip_preserves_op_index`: builds a tracker with several indexed entries, saves/reloads it, and asserts the restored operation count, traces, and captured `summary()` output all match the original.
- `test_load_stats_without_op_index_reconstructs_count`: loads a legacy stats file (no `op_index` key) and asserts the count is reconstructed from the traces and `summary()` prints the operators.

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh