### PR TITLE
Fix ambiguous OptionalArrayRef equality overload on MSVC

### DIFF
--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -220,7 +220,9 @@ class OptionalArrayRef final {
     return wrapped_opt_array_ref.emplace(il, std::forward<Args>(args)...);
   }
 
-  [[nodiscard]] friend bool operator==(OptionalArrayRef a1, ArrayRef<T> other) {
+  [[nodiscard]] friend bool operator==(
+      const OptionalArrayRef& a1,
+      ArrayRef<T> other) {
     if (!a1.has_value()) {
       return false;
     }

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -102,3 +102,22 @@ TEST(OptionalArrayRefTest, DanglingPointerFix) {
   ASSERT_TRUE(get_first_element(300) == 300);
   ASSERT_TRUE(get_first_element({400}) == 400);
 }
+
+TEST(OptionalArrayRefTest, ArrayRefEquality) {
+  c10::ArrayRef<int64_t> a({1, 2, 3});
+  c10::ArrayRef<int64_t> b({1, 2, 3});
+  c10::ArrayRef<int64_t> c({1, 2, 4});
+
+  // A plain ArrayRef == ArrayRef comparison must not become ambiguous.
+  ASSERT_TRUE(a == b);
+  ASSERT_FALSE(a == c);
+
+  // Preserve OptionalArrayRef == ArrayRef semantics.
+  c10::OptionalIntArrayRef optional = a;
+  ASSERT_TRUE(optional == b);
+  ASSERT_FALSE(optional == c);
+
+  // An empty OptionalArrayRef is not equal to an ArrayRef.
+  c10::OptionalIntArrayRef empty = std::nullopt;
+  ASSERT_FALSE(empty == b);
+}


### PR DESCRIPTION
## Summary

Fixes the issue reported in **#193589: Ambiguous operator== between OptionalArrayRef and HeaderOnlyArrayRef breaks plain ArrayRef == ArrayRef on MSVC**.

The existing `OptionalArrayRef` equality overload takes the `OptionalArrayRef` argument by value:

```cpp
friend bool operator==(OptionalArrayRef a1, ArrayRef<T> other)

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv