### PR TITLE
[distributed][tools] Restore MemoryTracker op_index on save/load

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,6 +1,10 @@
 # Owner(s): ["oncall: distributed"]
+import io
 import os
+import pickle
+import tempfile
 import unittest
+from contextlib import redirect_stdout
 
 import torch
 import torch.nn as nn
@@ -62,6 +66,62 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    def _tracker_with_ops(self):
+        # Inject traces directly so this does not need a GPU or a real module run.
+        tracker = MemoryTracker()
+        traces = {
+            0: ("net.forward.add_0", 10.0),
+            1: ("net.forward.mul_0", 25.0),
+            2: ("net.forward.add_1", 28.0),
+        }
+        tracker.memories_allocated = dict(traces)
+        tracker.memories_active = dict(traces)
+        tracker.memories_reserved = dict(traces)
+        tracker._op_index = len(traces)
+        tracker._num_alloc_retries = 2
+        tracker._markers = {"fw_start": 0, "fw_bw_boundary": 2}
+        return tracker
+
+    def _summary_text(self, tracker):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            tracker.summary()
+        return buf.getvalue()
+
+    def test_save_load_roundtrip_restores_op_index(self):
+        """
+        Loading stats into a fresh MemoryTracker should restore the operation
+        count and print the same operator summary as the original tracker.
+        """
+        src = self._tracker_with_ops()
+        src_summary = self._summary_text(src)
+        self.assertIn("net.forward.mul_0", src_summary)
+        self.assertIn("net.forward.add_1", src_summary)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "memory.trace")
+            src.save_stats(path)
+
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+            self.assertEqual(loaded._op_index, src._op_index)
+            self.assertEqual(loaded.memories_allocated, src.memories_allocated)
+            self.assertEqual(loaded._num_alloc_retries, src._num_alloc_retries)
+            self.assertEqual(self._summary_text(loaded), src_summary)
+
+            # Older files were written without op_index. Reconstruct it from the traces.
+            with open(path, "rb") as f:
+                stats = pickle.load(f)
+            stats.pop("op_index", None)
+            with open(path, "wb") as f:
+                pickle.dump(stats, f)
+
+            legacy = MemoryTracker()
+            legacy.load(path)
+            self.assertEqual(legacy._op_index, src._op_index)
+            self.assertEqual(self._summary_text(legacy), src_summary)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,8 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # Pre-fix files omitted op_index; reconstruct it from the traces.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
## Summary
`MemoryTracker.summary()` walks `range(1, self._op_index)`, but `save_stats()` never wrote `_op_index` into the pickle and `load()` never put it back. If you save a trace and load it into a **new** tracker (the notebook / offline path), `_op_index` stays 0 even though the traces are sitting there. The operator summary then prints nothing.

I reproduced it with three fake op entries. The original tracker prints the deltas; the loaded one does not.

Fix is to persist `op_index` in `save_stats()` and restore it in `load()`. For older files that don't have the key, fall back to `len(memories_allocated)` since the traces are keyed `0..N-1`.

The existing test didn't catch this because it reloads into the same object, which still has `_op_index` from the recording run.

Fixes #191397

## Test plan
- Added `test_save_load_roundtrip_restores_op_index` (no GPU needed). It saves, loads into a fresh `MemoryTracker`, checks `_op_index` and `summary()` match, then strips the `op_index` key to mimic an old file.
- Ran that roundtrip against current main first; it failed. Ran it again after the fix; it passed, including the legacy-file case.

### Before (current main)

```
AssertionError: 0 != 3

source tracker:
_op_index = 3
traces    = 3
Top 20 ops that generates memory are:
net.forward.mul_0: 15.0MB
net.forward.add_1: 3.0MB

pickle keys: ['markers', 'memories_active', 'memories_allocated', 'memories_reserved', 'num_alloc_retries']

loaded into a fresh MemoryTracker:
_op_index = 0
traces    = 3
Top 20 ops that generates memory are:
(empty)

FAILED (failures=1)
```

### After

```
pickle keys: [..., 'op_index']

loaded into a fresh MemoryTracker:
_op_index = 3
Top 20 ops that generates memory are:
net.forward.mul_0: 15.0MB
net.forward.add_1: 3.0MB

loaded legacy pickle (no op_index key):
_op_index = 3
net.forward.mul_0: 15.0MB
net.forward.add_1: 3.0MB

OK
```

```
python test/distributed/_tools/test_memory_tracker.py -k test_save_load_roundtrip_restores_op_index
```