### PR TITLE
Let Distribution.cdf be evaluated outside the support

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4338,6 +4338,58 @@ class TestDistributions(DistributionsTestCase):
                     ),
                 )
 
+    def test_cdf_outside_support(self):
+        # The CDF is defined on all of R: it saturates to 0 below the support and
+        # to 1 above it, so evaluating it outside the support must not raise even
+        # with validate_args enabled (e.g. plotting a CDF over a grid).
+        grid = torch.tensor([-2.0, -0.5, 0.5, 2.0])
+        cases = [
+            (Uniform(0.0, 1.0), [0.0, 0.0, 0.5, 1.0]),
+            (Exponential(1.0), [0.0, 0.0, 0.39346934, 0.86466472]),
+            (Gamma(2.0, 2.0), [0.0, 0.0, 0.26424112, 0.90842180]),
+            (HalfNormal(1.0), [0.0, 0.0, 0.38292492, 0.95449974]),
+            (HalfCauchy(1.0), [0.0, 0.0, 0.29516724, 0.70483276]),
+            (ContinuousBernoulli(probs=0.5), [0.0, 0.0, 0.5, 1.0]),
+        ]
+        for dist, expected in cases:
+            self.assertTrue(dist._validate_args)
+            actual = dist.cdf(grid)
+            self.assertEqual(
+                actual,
+                torch.tensor(expected),
+                msg=f"{dist.__class__.__name__}.cdf outside support",
+            )
+            self.assertFalse(torch.isnan(actual).any())
+
+    def test_cdf_outside_support_is_monotonic(self):
+        # Saturation must not break monotonicity of the CDF.
+        grid = torch.linspace(-5.0, 5.0, 41)
+        for dist in [
+            Uniform(0.0, 1.0),
+            Exponential(1.0),
+            Gamma(2.0, 2.0),
+            HalfNormal(1.0),
+            HalfCauchy(1.0),
+        ]:
+            cdfs = dist.cdf(grid)
+            self.assertTrue(
+                bool((cdfs[1:] - cdfs[:-1] >= -1e-6).all()),
+                msg=f"{dist.__class__.__name__}.cdf is not monotonic across the support boundary",
+            )
+            self.assertTrue(bool(((cdfs >= 0) & (cdfs <= 1)).all()))
+
+    def test_log_prob_still_validates_support(self):
+        # cdf relaxing the support check must not relax it for log_prob, whose
+        # density is only defined on the support.
+        for dist in [
+            Uniform(0.0, 1.0),
+            Exponential(1.0),
+            Gamma(2.0, 2.0),
+            HalfNormal(1.0),
+        ]:
+            with self.assertRaises(ValueError):
+                dist.log_prob(torch.tensor(-1.0))
+
     def test_valid_parameter_broadcasting(self):
         # Test correct broadcasting of parameter sizes for distributions that have multiple
         # parameters.

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -89,7 +89,7 @@ class Cauchy(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return torch.atan((value - self.loc) / self.scale) / math.pi + 0.5
 
     def icdf(self, value):

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -195,7 +195,7 @@ class ContinuousBernoulli(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         cut_probs = self._cut_probs()
         cdfs = (
             torch.pow(cut_probs, value) * torch.pow(1.0 - cut_probs, 1.0 - value)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -277,7 +277,7 @@ class Distribution:
             sample_shape = torch.Size(sample_shape)
         return torch.Size(sample_shape + self._batch_shape + self._event_shape)
 
-    def _validate_sample(self, value: Tensor) -> None:
+    def _validate_sample(self, value: Tensor, check_support: bool = True) -> None:
         """
         Argument validation for distribution methods such as `log_prob`,
         `cdf` and `icdf`. The rightmost dimensions of a value to be
@@ -287,6 +287,10 @@ class Distribution:
         Args:
             value (Tensor): the tensor whose log probability is to be
                 computed by the `log_prob` method.
+            check_support (bool): whether ``value`` is required to lie within the
+                distribution's support. True for ``log_prob``, whose density is
+                only defined there. False for ``cdf``, which is defined on all of
+                R and saturates to 0 below the support and 1 above it.
         Raises
             ValueError: when the rightmost dimensions of `value` do not match the
                 distribution's batch and event shapes.
@@ -307,6 +311,9 @@ class Distribution:
                 raise ValueError(
                     f"Value is not broadcastable with batch_shape+event_shape: {actual_shape} vs {expected_shape}."
                 )
+        if not check_support:
+            return
+
         try:
             support = self.support
         except NotImplementedError:

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -76,8 +76,9 @@ class Exponential(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 1 - torch.exp(-self.rate * value)
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (1 - torch.exp(-self.rate * value)).clamp(min=0, max=1)
 
     def icdf(self, value):
         return -torch.log1p(-value) / self.rate

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -128,5 +128,12 @@ class Gamma(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return torch.special.gammainc(self.concentration, self.rate * value)
+            self._validate_sample(value, check_support=False)
+        # gammainc returns nan for a negative argument, so saturate to 0 below the
+        # support rather than clamping after the fact
+        x = self.rate * value
+        return torch.where(
+            x < 0,
+            torch.zeros_like(x),
+            torch.special.gammainc(self.concentration, x.clamp(min=0)),
+        )

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -82,8 +82,9 @@ class HalfCauchy(TransformedDistribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 2 * self.base_dist.cdf(value) - 1
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (2 * self.base_dist.cdf(value) - 1).clamp(min=0, max=1)
 
     def icdf(self, prob):
         return self.base_dist.icdf((prob + 1) / 2)

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -74,8 +74,9 @@ class HalfNormal(TransformedDistribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 2 * self.base_dist.cdf(value) - 1
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (2 * self.base_dist.cdf(value) - 1).clamp(min=0, max=1)
 
     def icdf(self, prob):
         return self.base_dist.icdf((prob + 1) / 2)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -91,7 +91,7 @@ class Laplace(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return 0.5 - 0.5 * (value - self.loc).sign() * torch.expm1(
             -(value - self.loc).abs() / self.scale
         )

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -102,7 +102,7 @@ class Normal(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return 0.5 * (
             1 + torch.erf((value - self.loc) * self.scale.reciprocal() / math.sqrt(2))
         )

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -96,7 +96,7 @@ class Uniform(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         result = (value - self.low) / (self.high - self.low)
         return result.clamp(min=0, max=1)
 


### PR DESCRIPTION
Fixes #193690

### Problem

`cdf` validated its `value` against the distribution's **support**, but a CDF is defined on all of R — `F(x) = P(X <= x)` is `0` below the support and `1` above it. With `validate_args` on (the default), evaluating a CDF outside the support raised, so something as ordinary as plotting a CDF over a grid failed:

```python
D.Uniform(0., 1.).cdf(torch.linspace(-0.5, 1.5, 9))
# ValueError: Expected value argument (Tensor of shape (9,)) to be within the support ...
```

Same for `Exponential(1.).cdf(-1.)`, `Gamma(2., 2.).cdf(-1.)`, and the half-distributions.

### Why this is a bug rather than a deliberate strictness

The implementations already encode the intended out-of-support behaviour, and it is currently unreachable:

```python
# Uniform.cdf
if self._validate_args:
    self._validate_sample(value)      # rejects value outside [low, high]
result = (value - self.low) / (self.high - self.low)
return result.clamp(min=0, max=1)     # ...exists precisely to handle those values
```

`ContinuousBernoulli.cdf` likewise saturates with a `torch.where(value <= 0, 0, where(value >= 1, 1, ...))`. Under the default settings neither can ever fire, because validation rejects the inputs two lines earlier.

The distinction is that support validation is correct for `log_prob` — a density is only defined on the support — but not for `cdf`, where every real input has a well-defined answer. `_validate_sample`'s docstring covers "`log_prob`, `cdf` and `icdf`", which conflates the two.

### Change

- `_validate_sample` gains a `check_support: bool = True` flag. `log_prob` keeps the strict check; `cdf` passes `check_support=False` and retains the shape/broadcast validation.
- Distributions whose `cdf` formula did not already saturate now do:
  - `exponential`, `half_normal`, `half_cauchy` — `.clamp(min=0, max=1)`; their formulas go negative below the support.
  - `gamma` — routed through `torch.where`, because `gammainc` returns `nan` for a negative argument, which a clamp cannot repair.
  - `uniform` and `continuous_bernoulli` already saturated; only the flag changed.
  - `cauchy`, `laplace`, `normal` have support R, so the flag is a no-op there — changed for consistency so every `cdf` reads the same way.

Behaviour matches SciPy: `scipy.stats.uniform.cdf(2) == 1.0`.

### Tests

Three tests added to `test/distributions/test_distributions.py`:

- `test_cdf_outside_support` — exact values on both sides of the support for the six affected distributions, and asserts no `nan`.
- `test_cdf_outside_support_is_monotonic` — saturation must not break monotonicity across the boundary.
- `test_log_prob_still_validates_support` — guards against relaxing the check for `log_prob`.

The two `cdf` tests fail without the source change; the `log_prob` guard passes either way by design.

```
$ pytest test/distributions/test_distributions.py -q
1 failed, 167 passed, 69 skipped
```

The single failure is `test_gumbel_cpu`, which reproduces identically on an unpatched tree in my environment (I'm testing these pure-Python changes against a 2.13 wheel rather than a local build, so some newer tests skew), and is unrelated to this change — CI will be the authority there.

### Note

#186826 covers the opposite end of the same area — `icdf` performing *no* validation even with `validate_args=True`. I deliberately left `icdf` alone here so the two don't collide; happy to fold them together if you'd prefer one change.
