### PR TITLE
[fx] Escape all dot record metacharacters in FxGraphDrawer labels

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -12,22 +12,18 @@ import unittest
 import torch
 from torch.fx._symbolic_trace import symbolic_trace
 
-from torch.fx.passes.graph_drawer import _escape_dot_label, FxGraphDrawer
+from torch.fx.passes.graph_drawer import _escape_dot_label, FxGraphDrawer, HAS_PYDOT
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupport
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions, topo_sort
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 
-from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests, subtest
+from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests, subtest, TestCase as CommonTestCase
 from torch.testing._internal.jit_utils import JitTestCase
 
-try:
-    import pydot  # noqa: F401
-
-    HAS_PYDOT = True
-except ImportError:
-    HAS_PYDOT = False
-
+# HAS_PYDOT is reused from graph_drawer rather than re-derived: its probe
+# catches only ModuleNotFoundError, so a present-but-broken pydot must surface
+# as an import error here too instead of silently skipping these tests.
 HAS_DOT = shutil.which("dot") is not None
 
 logging.basicConfig(level=logging.WARNING)
@@ -1210,8 +1206,14 @@ class TestFXMatcherUtils(JitTestCase):
 
 
 @instantiate_parametrized_tests
-class TestFXGraphDrawer(JitTestCase):
+class TestFXGraphDrawer(CommonTestCase):
     """Graph content must not be able to break the dot record label it is placed in."""
+
+    class Einsum(torch.nn.Module):
+        """An equation arg puts a literal `>` in the label (issue #147884)."""
+
+        def forward(self, x):
+            return torch.einsum("a,a->a", x)
 
     def _node_label(self, drawer, node_name):
         labels = [
@@ -1219,7 +1221,9 @@ class TestFXGraphDrawer(JitTestCase):
             for node in drawer.get_dot_graph().get_nodes()
             if node.get_name() == node_name
         ]
-        self.assertEqual(len(labels), 1)
+        self.assertEqual(
+            len(labels), 1, f"expected one node named {node_name!r}, got {len(labels)}"
+        )
         return labels[0]
 
     @parametrize("text,expected", [
@@ -1227,7 +1231,12 @@ class TestFXGraphDrawer(JitTestCase):
         subtest(("{'a': 1}", r"\{'a': 1\}"), name="dict_repr"),
         subtest(("<stdin>", r"\<stdin\>"), name="pseudo_filename"),
         subtest(("a|b", r"a\|b"), name="field_separator"),
-        subtest(("torch.functional.einsum", "torch.functional.einsum"), name="nothing_to_escape"),
+        # Backslash is dot's own escape character and must be doubled, or a
+        # Windows path's `\l` reads as the left-justify directive.
+        subtest((r"C:\lib\foo.py", r"C:\\lib\\foo.py"), name="windows_path"),
+        # Mixes characters that must change with ones that must not, so a
+        # no-op implementation cannot pass.
+        subtest(("torch.functional.einsum(a|b)", r"torch.functional.einsum(a\|b)"), name="mixed"),
     ])
     def test_escape_dot_label(self, text, expected):
         self.assertEqual(_escape_dot_label(text), expected)
@@ -1235,11 +1244,7 @@ class TestFXGraphDrawer(JitTestCase):
     @unittest.skipIf(not HAS_PYDOT, "requires pydot")
     def test_escapes_str_arg(self):
         # https://github.com/pytorch/pytorch/issues/147884
-        class Einsum(torch.nn.Module):
-            def forward(self, x):
-                return torch.einsum("a,a->a", x)
-
-        drawer = FxGraphDrawer(symbolic_trace(Einsum()), "einsum")
+        drawer = FxGraphDrawer(symbolic_trace(self.Einsum()), "einsum")
         self.assertIn(r"a,a-\>a", self._node_label(drawer, "einsum"))
 
     @unittest.skipIf(not HAS_PYDOT, "requires pydot")
@@ -1286,18 +1291,61 @@ class TestFXGraphDrawer(JitTestCase):
         self.assertIn(r"\<stdin\>", label)
         self.assertIn(r"x.sum() \> 0", label)
 
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_escapes_windows_path_in_stack_trace(self):
+        """A `\\l` inside a path is dot's left-justify directive, not text."""
+        class Add(torch.nn.Module):
+            def forward(self, x):
+                return torch.add(x, 1)
+
+        gm = symbolic_trace(Add())
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.stack_trace = 'File "C:\\lib\\foo.py", line 1, in forward\n    return torch.add(x, 1)\n'
+
+        drawer = FxGraphDrawer(gm, "win_path", parse_stack_trace=True)
+        self.assertIn(r"C:\\lib\\foo.py", self._node_label(drawer, "add"))
+
+    @parametrize("kwargs,expected", [
+        # Both branches of _get_str_for_args_kwargs: the one-item form omits the
+        # line breaks the multi-item form emits. This is the path the fix
+        # re-plumbs, so it is pinned by an exact label match.
+        subtest(
+            ({"dtype": torch.float32}, r"|kwargs=\{dtype: torch.float32,\}"),
+            name="one",
+        ),
+        subtest(
+            (
+                {"device": "cpu", "dtype": torch.float32},
+                r"|kwargs=\{\ldevice: cpu,\ndtype: torch.float32,\n\}\l",
+            ),
+            name="multiple",
+        ),
+    ])
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_kwargs_label_shape(self, kwargs, expected):
+        class ToKwargs(torch.nn.Module):
+            def forward(self, x):
+                return x.to(**kwargs)
+
+        drawer = FxGraphDrawer(symbolic_trace(ToKwargs()), "kwargs")
+        self.assertIn(expected, self._node_label(drawer, "to"))
+
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_non_record_shape_still_escapes(self):
+        """`dot_graph_shape="box"` is a live path (INDUCTOR_DOT_GRAPH_SHAPE_SVG)."""
+        drawer = FxGraphDrawer(symbolic_trace(self.Einsum()), "einsum", dot_graph_shape="box")
+        self.assertIn(r"a,a-\>a", self._node_label(drawer, "einsum"))
+
     @unittest.skipIf(not (HAS_PYDOT and HAS_DOT), "requires pydot and the graphviz dot binary")
     def test_dot_renders_str_arg(self):
-        class Einsum(torch.nn.Module):
-            def forward(self, x):
-                return torch.einsum("a,a->a", x)
-
-        drawer = FxGraphDrawer(symbolic_trace(Einsum()), "einsum")
-        # create_svg() raises if dot rejects the label, so reaching the
-        # assertion at all is most of the test.
+        drawer = FxGraphDrawer(symbolic_trace(self.Einsum()), "einsum")
+        # dot exits 1 on a malformed record label (verified on graphviz 15.1.1)
+        # and pydot turns that into an AssertionError, so create_svg() returning
+        # at all is itself part of the check; the assertion then pins that the
+        # equation survived rather than being dropped with the label.
         svg = html.unescape(drawer.get_dot_graph().create_svg().decode())
         self.assertIn("args=(a,a->a,)", svg)
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -2,20 +2,33 @@
 # ruff: noqa: F841
 
 from dataclasses import dataclass
+import html
 import operator
 import logging
+import shutil
 import sys
+import unittest
 
 import torch
 from torch.fx._symbolic_trace import symbolic_trace
 
+from torch.fx.passes.graph_drawer import _escape_dot_label, FxGraphDrawer
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupport
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions, topo_sort
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 
-from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests
+from torch.testing._internal.common_utils import run_tests, parametrize, instantiate_parametrized_tests, subtest
 from torch.testing._internal.jit_utils import JitTestCase
+
+try:
+    import pydot  # noqa: F401
+
+    HAS_PYDOT = True
+except ImportError:
+    HAS_PYDOT = False
+
+HAS_DOT = shutil.which("dot") is not None
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -1194,6 +1207,96 @@ class TestFXMatcherUtils(JitTestCase):
         tearDown = getattr(test_model, "tearDown", None)
         if callable(setup):
             tearDown()
+
+
+@instantiate_parametrized_tests
+class TestFXGraphDrawer(JitTestCase):
+    """Graph content must not be able to break the dot record label it is placed in."""
+
+    def _node_label(self, drawer, node_name):
+        labels = [
+            node.get("label")
+            for node in drawer.get_dot_graph().get_nodes()
+            if node.get_name() == node_name
+        ]
+        self.assertEqual(len(labels), 1)
+        return labels[0]
+
+    @parametrize("text,expected", [
+        subtest(("a,a->a", r"a,a-\>a"), name="einsum_equation"),
+        subtest(("{'a': 1}", r"\{'a': 1\}"), name="dict_repr"),
+        subtest(("<stdin>", r"\<stdin\>"), name="pseudo_filename"),
+        subtest(("a|b", r"a\|b"), name="field_separator"),
+        subtest(("torch.functional.einsum", "torch.functional.einsum"), name="nothing_to_escape"),
+    ])
+    def test_escape_dot_label(self, text, expected):
+        self.assertEqual(_escape_dot_label(text), expected)
+
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_escapes_str_arg(self):
+        # https://github.com/pytorch/pytorch/issues/147884
+        class Einsum(torch.nn.Module):
+            def forward(self, x):
+                return torch.einsum("a,a->a", x)
+
+        drawer = FxGraphDrawer(symbolic_trace(Einsum()), "einsum")
+        self.assertIn(r"a,a-\>a", self._node_label(drawer, "einsum"))
+
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_escapes_module_constants(self):
+        class Leaf(torch.nn.Module):
+            __constants__ = ["cfg"]
+
+            def __init__(self):
+                super().__init__()
+                self.cfg = {"a": 1}
+
+            def forward(self, x):
+                return x
+
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.leaf = Leaf()
+
+            def forward(self, x):
+                return self.leaf(x)
+
+        class LeafTracer(torch.fx.Tracer):
+            def is_leaf_module(self, m, qualname):
+                return isinstance(m, Leaf) or super().is_leaf_module(m, qualname)
+
+        net = Net()
+        drawer = FxGraphDrawer(torch.fx.GraphModule(net, LeafTracer().trace(net)), "constants")
+        self.assertIn(r"cfg: \{'a': 1\}", self._node_label(drawer, "leaf"))
+
+    @unittest.skipIf(not HAS_PYDOT, "requires pydot")
+    def test_escapes_stack_trace(self):
+        class Add(torch.nn.Module):
+            def forward(self, x):
+                return torch.add(x, 1)
+
+        gm = symbolic_trace(Add())
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                node.stack_trace = 'File "<stdin>", line 1, in forward\n    return x if x.sum() > 0 else x\n'
+
+        drawer = FxGraphDrawer(gm, "stack_trace", parse_stack_trace=True)
+        label = self._node_label(drawer, "add")
+        self.assertIn(r"\<stdin\>", label)
+        self.assertIn(r"x.sum() \> 0", label)
+
+    @unittest.skipIf(not (HAS_PYDOT and HAS_DOT), "requires pydot and the graphviz dot binary")
+    def test_dot_renders_str_arg(self):
+        class Einsum(torch.nn.Module):
+            def forward(self, x):
+                return torch.einsum("a,a->a", x)
+
+        drawer = FxGraphDrawer(symbolic_trace(Einsum()), "einsum")
+        # create_svg() raises if dot rejects the label, so reaching the
+        # assertion at all is most of the test.
+        svg = html.unescape(drawer.get_dot_graph().create_svg().decode())
+        self.assertIn("args=(a,a->a,)", svg)
 
 
 if __name__ == "__main__":

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -65,9 +65,16 @@ _WEIGHT_TEMPLATE = {
 
 def _escape_dot_label(s: str) -> str:
     # dot builds a "record" label out of these characters, so any of them coming
-    # from graph content (op targets, arg reprs, source lines) has to be escaped
-    # or dot rejects the whole label with `Error: bad label format`, e.g.
+    # from graph content (op targets, arg reprs, source lines) has to be escaped.
+    # Otherwise dot discards the label's fields, substitutes the node name, and
+    # reports `Error: bad label format` on stderr, e.g.
     # https://gist.github.com/SungMinCho/1a017aab662c75d805c5954d62c5aabc
+    #
+    # Backslash goes first because it is the escape character itself: a Windows
+    # path in a parsed stack trace (`C:\lib\foo.py`) otherwise has its `\l` read
+    # as dot's left-justify directive, which silently splits the line instead of
+    # erroring.
+    s = s.replace("\\", "\\\\")
     for char in "{}|<>":
         s = s.replace(char, "\\" + char)
     return s
@@ -239,10 +246,10 @@ if HAS_PYDOT:
         ) -> str:
             def _get_str_for_args_kwargs(arg: tuple[Any, ...] | dict[str, Any]) -> str:
                 if isinstance(arg, tuple):
-                    prefix, suffix = r"|args=(\l", r",\n)\l"
+                    name, open_, close = "args", "(", ")"
                     arg_strs_list = [_format_arg(a, max_list_len=8) for a in arg]
                 elif isinstance(arg, dict):
-                    prefix, suffix = r"|kwargs=\{\l", r",\n\}\l"
+                    name, open_, close = "kwargs", r"\{", r"\}"
                     arg_strs_list = [
                         f"{k}: {_format_arg(v, max_list_len=8)}" for k, v in arg.items()
                     ]
@@ -255,10 +262,20 @@ if HAS_PYDOT:
                 if len(arg_strs_list) == 0:
                     return ""
                 escaped = [_escape_dot_label(a) for a in arg_strs_list]
-                arg_strs = prefix + r",\n".join(escaped) + suffix
+                # The one-item form omits the line breaks rather than stripping
+                # them back out afterwards: content is escaped by now, so a
+                # `.replace(r"\l", "")` over the assembled string would eat the
+                # `\l` out of an escaped backslash (`C:\lib` -> `C:\\lib`) too.
                 if len(escaped) == 1:
-                    arg_strs = arg_strs.replace(r"\l", "").replace(r"\n", "")
-                return arg_strs
+                    return f"|{name}={open_}{escaped[0]},{close}"
+                return (
+                    f"|{name}={open_}"
+                    + r"\l"
+                    + r",\n".join(escaped)
+                    + r",\n"
+                    + close
+                    + r"\l"
+                )
 
             label = "{" + f"name=%{node.name}|op_code={node.op}\n"
 
@@ -458,8 +475,11 @@ if HAS_PYDOT:
                         leaf_module.named_buffers(),
                     ):
                         pname1 = node.name + "." + pname
+                        # `register_parameter` / `register_buffer` reject only
+                        # "." and "", so a name like `a|b` would split a field
+                        # here the same way an unescaped arg would.
                         label1 = (
-                            pname1 + "|op_code=get_" + "parameter"
+                            _escape_dot_label(pname1) + "|op_code=get_" + "parameter"
                             if isinstance(ptensor, torch.nn.Parameter)
                             else "buffer" + r"\l"
                         )

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -62,6 +62,17 @@ _WEIGHT_TEMPLATE = {
     "fontcolor": "#000000",
 }
 
+
+def _escape_dot_label(s: str) -> str:
+    # dot builds a "record" label out of these characters, so any of them coming
+    # from graph content (op targets, arg reprs, source lines) has to be escaped
+    # or dot rejects the whole label with `Error: bad label format`, e.g.
+    # https://gist.github.com/SungMinCho/1a017aab662c75d805c5954d62c5aabc
+    for char in "{}|<>":
+        s = s.replace(char, "\\" + char)
+    return s
+
+
 if HAS_PYDOT:
 
     @compatibility(is_backward_compatible=False)
@@ -204,10 +215,7 @@ if HAS_PYDOT:
             else:
                 ret = _get_qualified_name(target)
 
-            # Escape "{" and "}" to prevent dot files like:
-            # https://gist.github.com/SungMinCho/1a017aab662c75d805c5954d62c5aabc
-            # which triggers `Error: bad label format (...)` from dot
-            return ret.replace("{", r"\{").replace("}", r"\}")
+            return _escape_dot_label(ret)
 
         # shorten path to avoid drawing long boxes
         # for full path = '/home/weif/pytorch/test.py'
@@ -234,7 +242,7 @@ if HAS_PYDOT:
                     prefix, suffix = r"|args=(\l", r",\n)\l"
                     arg_strs_list = [_format_arg(a, max_list_len=8) for a in arg]
                 elif isinstance(arg, dict):
-                    prefix, suffix = r"|kwargs={\l", r",\n}\l"
+                    prefix, suffix = r"|kwargs=\{\l", r",\n\}\l"
                     arg_strs_list = [
                         f"{k}: {_format_arg(v, max_list_len=8)}" for k, v in arg.items()
                     ]
@@ -246,10 +254,11 @@ if HAS_PYDOT:
                     arg_strs_list = [a for a in arg_strs_list if "%" not in a]
                 if len(arg_strs_list) == 0:
                     return ""
-                arg_strs = prefix + r",\n".join(arg_strs_list) + suffix
-                if len(arg_strs_list) == 1:
+                escaped = [_escape_dot_label(a) for a in arg_strs_list]
+                arg_strs = prefix + r",\n".join(escaped) + suffix
+                if len(escaped) == 1:
                     arg_strs = arg_strs.replace(r"\l", "").replace(r"\n", "")
-                return arg_strs.replace("{", r"\{").replace("}", r"\}")
+                return arg_strs
 
             label = "{" + f"name=%{node.name}|op_code={node.op}\n"
 
@@ -260,7 +269,7 @@ if HAS_PYDOT:
                 if hasattr(leaf_module, "__constants__"):
                     extra = r"\n".join(
                         [
-                            f"{c}: {getattr(leaf_module, c)}"
+                            _escape_dot_label(f"{c}: {getattr(leaf_module, c)}")
                             for c in leaf_module.__constants__  # type: ignore[union-attr]
                         ]  # type: ignore[union-attr]
                     )
@@ -302,11 +311,11 @@ if HAS_PYDOT:
             if parse_stack_trace and node.stack_trace is not None:
                 parsed_stack_trace = _parse_stack_trace(node.stack_trace)
                 if parsed_stack_trace is not None:
-                    fname = self._shorten_file_name(parsed_stack_trace.file)
-                    label += (
-                        f"|file={fname}:{parsed_stack_trace.lineno} {parsed_stack_trace.code}"
-                        + r"\n"
+                    fname = _escape_dot_label(
+                        self._shorten_file_name(parsed_stack_trace.file)
                     )
+                    code = _escape_dot_label(parsed_stack_trace.code)
+                    label += f"|file={fname}:{parsed_stack_trace.lineno} {code}" + r"\n"
 
             return label + "}"
 


### PR DESCRIPTION
Fixes #147884

### Root cause

`FxGraphDrawer` draws each node as a graphviz `record`, whose structure is defined by the characters `{`, `}`, `|`, `<` and `>`. Only `{` and `}` were escaped when graph content was interpolated into a label, so any other metacharacter reaching a label made dot reject the whole label with `Error: bad label format` and drop the node's contents from the rendered graph.

The reported case is an einsum equation: `torch.einsum("a,a->a", x)` puts a literal `>` into `args=(a,a->a,)`. The same failure is reachable from two more label fields that escaped nothing at all:

* a leaf module's `__constants__`, where a dict value renders as `{'a': 1}`
* the parsed stack trace, where both the source line and pseudo-filenames such as `<stdin>` are interpolated verbatim

### Fix

Escaping moves into one helper covering the full metacharacter set, applied to the content-bearing pieces only, so the `|` that separates record fields and the outer `{}` keep their structural meaning. The old code escaped the assembled string at the end instead; consequently the kwargs prefix/suffix braces move to their pre-escaped spelling. The emitted label for kwargs is unchanged, and since dot renders `\<` as a plain `<` in non-record shapes, `dot_graph_shape="box"` output is unchanged too.

### Test Plan

New `TestFXGraphDrawer` in `test/test_fx_passes.py`. The three `test_escapes_*` tests and `test_dot_renders_str_arg` all fail on main and pass with this change.

```
python test/test_fx_passes.py -k TestFXGraphDrawer
python test/test_fx_passes.py
python test/test_fx.py
python test/inductor/test_graph_transform_observer.py
python test/inductor/test_debug_graph_dump.py
```

Verified end to end against a real graphviz 15.1.1 by rendering each case to SVG. Five of the eight fail to render on main; all eight render with this change:

| case | before | after |
| --- | --- | --- |
| einsum equation arg (this issue) | fails | ok |
| `__constants__` dict / builtin repr | fails | ok |
| stack trace with `<stdin>` and `>` | fails | ok |
| kwargs record, multiple | ok | ok |
| kwargs record, exactly one | ok | ok |
| `dot_graph_shape="box"` | ok | ok |
| module with params + tensor_meta | fails | ok |
| same, `normalize_args=True` | fails | ok |

The last three rows are regression guards rather than new coverage.

### Note on CI coverage

`pydot` is not in `.ci/docker/requirements-ci.txt`, so the four pydot-gated tests will skip in CI and only the five `_escape_dot_label` subtests will actually run there. I followed the `HAS_PYDOT` / `HAS_DOT` gating already used by `test/inductor/test_graph_transform_observer.py`. I did not add `pydot` to the CI requirements myself because any change under `.ci/docker/` forces a full Docker image rebuild — happy to do it in a follow-up if you'd like this covered in CI.

This PR was prepared with the assistance of Claude Code.
