### PR TITLE
docs: clarify deterministic debugging with uninitialized memory

### DIFF
--- a/docs/source/notes/randomness.md
+++ b/docs/source/notes/randomness.md
@@ -244,6 +244,14 @@ by default, which will fill the uninitialized memory with a known value if
 `torch.use_deterministic_algorithms(True)` is set. This will prevent the
 possibility of this kind of nondeterministic behavior.
 
+As a result, a nondeterministic failure that disappears after enabling
+`torch.use_deterministic_algorithms(True)` is not necessarily caused by
+nondeterministic algorithms. Filling uninitialized memory can also make the
+failure deterministic. To distinguish these cases, leave deterministic
+algorithms enabled and temporarily set
+`torch.utils.deterministic.fill_uninitialized_memory` to `False`. If the
+failure becomes nondeterministic again, it may be reading uninitialized memory.
+
 However, filling uninitialized memory is detrimental to performance. So if your
 program is valid and does not use uninitialized memory as the input to an
 operation, then this setting can be turned off for better performance.


### PR DESCRIPTION
I reviewed this documentation change and confirmed that it accurately explains the interaction between deterministic algorithms and uninitialized-memory filling.

> This change adds a diagnostic caveat to the reproducibility documentation: a failure becoming deterministic after enabling deterministic algorithms may be caused by uninitialized-memory filling rather than deterministic kernel selection. It also documents how to distinguish the two cases.
>
> Generated with assistance from Codex.

Fixes #193317

Test plan:
- `git diff --check`
- Verified the referenced APIs already exist in the same reproducibility documentation.
