### PR TITLE
[kimi 2.7] Support deterministic upsample bicubic backward

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1607,6 +1607,25 @@ class TestTorchDeviceType(TestCase):
             torch.device(device).type == 'cuda')
 
     @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/113707")
+    def test_deterministic_interpolate_bicubic(self, device):
+        input = torch.randn(1, 2, 4, 4, device=device, requires_grad=True)
+        output_grad = torch.randn(1, 2, 9, 12, device=device)
+        grad = None
+        with DeterministicGuard(True):
+            for _ in range(5):
+                res = torch.nn.functional.interpolate(
+                    input,
+                    size=(9, 12),
+                    mode='bicubic',
+                    align_corners=False)
+                res.backward(output_grad)
+                if grad is None:
+                    grad = input.grad
+                else:
+                    self.assertEqual(grad, input.grad, atol=0, rtol=0)
+                input.grad = None
+
+    @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/113707")
     def test_nondeterministic_alert_interpolate_trilinear(self, device):
         input = torch.randn(1, 2, 4, 4, 4, device=device, requires_grad=True)
         res = torch.nn.functional.interpolate(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5307,6 +5307,20 @@ def interpolate(  # noqa: F811
                 align_corners,
                 scale_factors,
             )
+        # Use two nested guards so TorchScript does not analyze the runtime
+        # deterministic-algorithms query or the dynamic import below.
+        if not torch.jit.is_scripting():
+            # Select the decomposition during forward so autograd records its
+            # deterministic backward. The native CPU backward is deterministic.
+            if not input.is_cpu and torch.are_deterministic_algorithms_enabled():
+                # The decomposition accumulates through deterministic index_put.
+                # Import it lazily: a top-level import creates a cycle, while a
+                # nested import statement is unsupported by TorchScript.
+                return importlib.import_module(
+                    "torch._decomp.decompositions"
+                ).upsample_bicubic2d_vec(
+                    input, output_size, align_corners, scale_factors
+                )
         return torch._C._nn.upsample_bicubic2d(
             input,
             # pyrefly: ignore [bad-argument-type]


### PR DESCRIPTION
TorchTitan's Kimi K2.7 vision encoder resizes its learnable positional table here:

https://github.com/pytorch/torchtitan/blob/85c549b9332067f7615241e73e0c4a28d44b065f/torchtitan/models/kimi_k2_7/vision_encoder.py#L90-L106

```python
grid_table = pos_embed.permute(2, 0, 1).unsqueeze(0).float()
...
F.interpolate(grid_table, size=(h, w), mode=bicubic)
```

this PR make sure `--debug.deterministic` / `torch.use_deterministic_algorithms(True)` work. Fix is similar to  to https://github.com/pytorch/pytorch/pull/101115 
* direct ATen calls, TorchScript, and `antialias=True` are unchanged
* deterministic decomposition is slower and can have small forward rounding differences