### PR TITLE
[inductor] Preserve input placeholders during graph cleanup

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16952,6 +16952,25 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.common(fn, (x,), reference_in_float=False)
         assertGeneratedKernelCountEqual(self, 1)
 
+    def test_dtypeview_clone_copy_arg_count(self):
+        # https://github.com/pytorch/pytorch/issues/193705
+        # remove_redundant_views used to erase a graph placeholder whose only
+        # uses were folded away by a view(dtype)+clone+copy_ chain, shrinking
+        # the compiled function's arity while the runtime call site kept
+        # passing the original number of arguments.
+        def fn(x, y):
+            return (
+                x.view(torch.uint16)
+                .clone()
+                .copy_(y.view(torch.uint16))
+                .view(torch.float32)
+                .sum()
+            )
+
+        x = torch.randn(8, 8, device=self.device)
+        y = torch.randn(8, 8, device=self.device)
+        self.common(fn, (x, y), reference_in_float=False)
+
     @expectedFailureCodegenDynamic
     def test_reinterpret_dtypeview(self):
         @torch.compile

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -299,6 +299,11 @@ def remove_redundant_views(gm: torch.fx.GraphModule):
                 break
             for unused in unused_views:
                 views.pop(unused)
+                if unused.op == "placeholder":
+                    # Placeholders are graph inputs; erasing one would silently
+                    # shrink the compiled function's arity while callers keep
+                    # passing the original argument count.
+                    continue
                 graph.erase_node(unused)
 
 


### PR DESCRIPTION
## Issue

Fixes #193705

## Summary

`remove_redundant_views()` (`torch/_inductor/fx_passes/joint_graph.py`) erases any zero-user node it's tracking, including graph placeholders — shrinking the compiled function's arity while the runtime call site still passes the original argument count, causing the crashes in #193705. Fix: skip erasing placeholder nodes, consistent with how FX's own `eliminate_dead_code()` treats them via `Node.is_impure()`. Full root-cause trace and test commands are in the commit message.

## Checklist

- [x] Passes lint (ran both real lint jobs CI uses for this PR directly — see commit message)
- [x] Added/updated tests
- [ ] Updated documentation (n/a, internal compiler pass)
- [ ] Included benchmark results (n/a, correctness fix, not perf)

## BC-breaking?

No.

---
> AI assistance disclosure: developed with Claude Code, which identified the root cause via instrumented tracing of the Inductor/AOTAutograd/FX pipeline. I reviewed the diagnosis and patch end-to-end before submitting.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo