### PR TITLE
[dynamo] Split TupleIteratorVariable off ListIteratorVariable to match CPython

### DIFF
--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -471,6 +471,37 @@ class TestIterators(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(list(gen()), [1, 2, 3])
 
+    def test_tuple_iterator_not_a_list_iterator(self):
+        """tuple iterators must not subclass ListIteratorVariable (CPython parity).
+
+        In CPython, tuple_iterator is not a subclass of list_iterator; the VTs
+        should mirror that.
+        """
+        from torch._dynamo.variables.lists import (
+            ListIteratorVariable,
+            TupleIteratorVariable,
+        )
+
+        self.assertFalse(issubclass(TupleIteratorVariable, ListIteratorVariable))
+        self.assertIs(TupleIteratorVariable._cpython_type, type(iter(())))
+        self.assertIs(ListIteratorVariable._cpython_type, type(iter([])))
+
+    @make_dynamo_test
+    def test_yield_from_tuple_iterator(self):
+        """yield from over a tuple iterator still traces after the VT split."""
+
+        def gen():
+            yield from iter((1, 2, 3))
+
+        self.assertEqual(list(gen()), [1, 2, 3])
+
+    @make_dynamo_test
+    def test_tuple_iterator_python_type(self):
+        """type(iter(tuple)) inside compile must be tuple_iterator, not list_iterator."""
+        it = iter((1, 2, 3))
+        self.assertIs(type(it), type(iter(())))
+        self.assertIsNot(type(it), type(iter([])))
+
     @make_dynamo_test
     def test_comprehensions_with_iterator(self):
         """Test different comprehension types with iterators"""

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -2015,15 +2015,21 @@ def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
         ctx.log(var)
 
 
+_LIST_OR_TUPLE_ITERATOR = (
+    variables.ListIteratorVariable,
+    variables.TupleIteratorVariable,
+)
+
+
 @register_side_effect_replay_handler(
     name="list_iterator_mutation",
-    matcher=lambda ctx: isinstance(ctx.var, variables.ListIteratorVariable),
+    matcher=lambda ctx: isinstance(ctx.var, _LIST_OR_TUPLE_ITERATOR),
     priority=30,
 )
 def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    if not isinstance(var, variables.ListIteratorVariable):
+    if not isinstance(var, _LIST_OR_TUPLE_ITERATOR):
         raise AssertionError(type(var))
     for _ in range(var.index):
         cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -2015,21 +2015,20 @@ def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
         ctx.log(var)
 
 
-_LIST_OR_TUPLE_ITERATOR = (
-    variables.ListIteratorVariable,
-    variables.TupleIteratorVariable,
-)
-
-
 @register_side_effect_replay_handler(
     name="list_iterator_mutation",
-    matcher=lambda ctx: isinstance(ctx.var, _LIST_OR_TUPLE_ITERATOR),
+    # Lazy: builder imports side_effects while variables/ is still initializing.
+    matcher=lambda ctx: isinstance(
+        ctx.var, (variables.ListIteratorVariable, variables.TupleIteratorVariable)
+    ),
     priority=30,
 )
 def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    if not isinstance(var, _LIST_OR_TUPLE_ITERATOR):
+    if not isinstance(
+        var, (variables.ListIteratorVariable, variables.TupleIteratorVariable)
+    ):
         raise AssertionError(type(var))
     for _ in range(var.index):
         cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -186,6 +186,7 @@ from .variables.lists import (
     ListIteratorVariable,
     ListVariable,
     SliceVariable,
+    TupleIteratorVariable,
     TupleVariable,
 )
 from .variables.misc import (
@@ -6549,8 +6550,8 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
 
     def GET_YIELD_FROM_ITER(self, inst: Instruction) -> None:
         tos = self.stack[-1]
-        # tuple iterators subclass ListIteratorVariable; deque is a sibling
-        if not isinstance(tos, (ListIteratorVariable, DequeIteratorVariable)):
+        iter_vts = (ListIteratorVariable, TupleIteratorVariable, DequeIteratorVariable)
+        if not isinstance(tos, iter_vts):
             self.pop()
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]
             self.push(res)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1308,6 +1308,7 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.DequeVariable,
             variables.ListVariable,
             variables.ListIteratorVariable,
+            variables.TupleIteratorVariable,
             variables.DequeIteratorVariable,
             variables.RangeVariable,
             variables.SetVariable,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -2346,8 +2346,9 @@ class SliceVariable(VariableTracker):
 
 
 class BaseListIteratorVariable(IteratorVariable):
-    # In CPython list_iterator and _deque_iterator are siblings, not subclasses
-    # of one another, so the concrete VTs share this base rather than each other.
+    # In CPython list_iterator, tuple_iterator, and _deque_iterator are siblings,
+    # not subclasses of one another, so the concrete VTs share this base rather
+    # than each other.
 
     _nonvar_fields = {
         "index",
@@ -2425,9 +2426,17 @@ class ListIteratorVariable(BaseListIteratorVariable):
     _cpython_type = type(iter([]))
 
 
-class TupleIteratorVariable(ListIteratorVariable):
+class TupleIteratorVariable(BaseListIteratorVariable):
     # PyTupleIter_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L1067
     _cpython_type = type(iter(()))
+
+    def python_type(self) -> type:
+        return type(iter(()))
+
+    def as_python_constant(self) -> Any:
+        if self.index > 0:
+            raise NotImplementedError
+        return iter(tuple(x.as_python_constant() for x in self.items))
 
 
 class DequeIteratorVariable(BaseListIteratorVariable):


### PR DESCRIPTION
## Summary

In CPython, `tuple_iterator` is not a subclass of `list_iterator`:

```
>>> issubclass(type(iter(())), type(iter([])))
False
```

`dir()` on both is the same (`__iter__`, `__next__`, `__length_hint__`), so there is no extra method table to model. Dynamo still had `TupleIteratorVariable(ListIteratorVariable)`, which made every `isinstance(x, ListIteratorVariable)` check match tuple iterators too.

#193261 has landed and already introduced `BaseListIteratorVariable` for the deque split. This PR rebases on that and reparents `TupleIteratorVariable` onto the same base so list and tuple iterators are siblings.

Review feedback from #193727 (`@guilhermeleobas`) is incorporated:

- Do **not** export `BaseListIteratorVariable` (no CPython counterpart). It stays internal to `lists.py`.
- Be explicit at call sites: `ListIteratorVariable` and `TupleIteratorVariable`, not the shared base.
- `GET_YIELD_FROM_ITER` checks `ListIteratorVariable`, `TupleIteratorVariable`, and `DequeIteratorVariable`. Deque has to stay listed after #193261, because deque iterators are no longer a `ListIteratorVariable` subclass.

Also in this PR:

- `python_type()` / `as_python_constant()` on `TupleIteratorVariable` return a real `tuple_iterator`.
- `TupleIteratorVariable` is added to the unpack fast path.
- Regression tests cover the hierarchy, `yield from`, and `type(iter((1, 2, 3)))`.

Part of #192874

## Test plan

```
python test/dynamo/test_iterators.py TestIterators.test_tuple_iterator_not_a_list_iterator
python test/dynamo/test_iterators.py TestIterators.test_yield_from_tuple_iterator
python test/dynamo/test_iterators.py TestIterators.test_tuple_iterator_python_type
python test/dynamo/test_iterators.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @guilhermeleobas @williamwen42 @jansel @Skylion007 @albanD