### PR TITLE
[Inductor] Fix Python class-private name mangling in async_compile ke…

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -183,6 +183,14 @@ def test_flydsl_loader_main(value, stream):
         self.assertEqual(kernel.run(41, stream=7), (41, 7))
         self.assertIsNotNone(kernel.kernel_path)
 
+    def test_class_kernel_name_mangling(self):
+        """Directly verifies that _sanitize_kernel_name handles class-mangled names."""
+        from torch._inductor.async_compile import _sanitize_kernel_name
+
+        mangled_name = "_Runner__kernel_name_0"
+        sanitized = _sanitize_kernel_name(mangled_name)
+        self.assertEqual(sanitized, "kernel_name_0")
+
     def test_flydsl_rejects_unavailable_runtime(self):
         with patch(
             "torch._inductor.codegen.flydsl.flydsl_utils.runtime_available",
@@ -2234,6 +2242,7 @@ class TestCuteDSLSubprocessGroupedGemm(TestCase):
                 c_compiled = compiled_fn(A, B, offsets)
 
         torch.testing.assert_close(c_eager, c_compiled)
+
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -2244,6 +2244,5 @@ class TestCuteDSLSubprocessGroupedGemm(TestCase):
         torch.testing.assert_close(c_eager, c_compiled)
 
 
-
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -153,6 +153,15 @@ def _add_triton_kernel_info(kernel_name: str, info: dict[str, Any]):
         _triton_kernel_metrics[kernel_name] = info
 
 
+
+def _sanitize_kernel_name(name: str) -> str:
+    # Strip Python class-private attribute mangling (e.g., _ClassName__kernel_name -> kernel_name)
+    name = re.sub(r"^_[A-Za-z0-9_]+?__", "", name)
+    
+    # Existing sanitization logic below...
+    name = re.sub(r"[^\w]", "_", name)
+    return name
+
 def _emit_triton_kernel_compile_metric(
     kernel: CachingAutotuner,
     kernel_name: str,
@@ -673,7 +682,9 @@ class AsyncCompile:
     def _load_kernel_wrapper(self, kernel_name, main_suffix, wrapper_cls, key, path):
         """Reload a kernel module from PyCodeCache and wrap the entry point."""
         mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
+        kernel_name = _sanitize_kernel_name(kernel_name)
         main_func_name = f"{kernel_name}_{main_suffix}"
+        # f"{kernel_name}_{main_suffix}"
         return wrapper_cls(getattr(mod, main_func_name), kernel_path=path)
 
     def cutedsl(self, kernel_name: str, source_code: str, precompile_metadata=None):
@@ -731,7 +742,11 @@ class AsyncCompile:
             key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
 
+            
+            kernel_name = _sanitize_kernel_name(kernel_name)
             main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
+
+
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]
                 raise RuntimeError(
@@ -827,7 +842,9 @@ class AsyncCompile:
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
 
             # Find our special entry point named function
+            kernel_name = _sanitize_kernel_name(kernel_name)
             main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
+
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]
                 raise RuntimeError(
@@ -901,7 +918,9 @@ class AsyncCompile:
             key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
 
-            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
+            kernel_name = _sanitize_kernel_name(kernel_name)
+            main_func_name = f"{kernel_name}_{main_suffix}"
+
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]
                 raise RuntimeError(

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -85,6 +85,8 @@ size_hints_regex = re.compile(
     r"size_hints=(\{.*?\})",
 )
 
+class_private_mangling_regex = re.compile(r"^_[A-Za-z0-9_]+?__")
+non_word_char_regex = re.compile(r"[^\w]")
 
 def _pycodecache_kernel_compile_env() -> dict[str, str | None]:
     env_vars = [
@@ -156,10 +158,10 @@ def _add_triton_kernel_info(kernel_name: str, info: dict[str, Any]):
 
 def _sanitize_kernel_name(name: str) -> str:
     # Strip Python class-private attribute mangling (e.g., _ClassName__kernel_name -> kernel_name)
-    name = re.sub(r"^_[A-Za-z0-9_]+?__", "", name)
-    
-    # Existing sanitization logic below...
-    name = re.sub(r"[^\w]", "_", name)
+    name = class_private_mangling_regex.sub("", name)
+
+    # Sanitization logic
+    name = non_word_char_regex.sub("_", name)
     return name
 
 def _emit_triton_kernel_compile_metric(
@@ -681,7 +683,7 @@ class AsyncCompile:
 
     def _load_kernel_wrapper(self, kernel_name, main_suffix, wrapper_cls, key, path):
         """Reload a kernel module from PyCodeCache and wrap the entry point."""
-        mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)     
+        mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
         sanitized_name = _sanitize_kernel_name(kernel_name)
         main_func_name = f"{sanitized_name}_{main_suffix}"
         # f"{kernel_name}_{main_suffix}"
@@ -841,7 +843,6 @@ class AsyncCompile:
             # Find our special entry point named function
             sanitized_name = _sanitize_kernel_name(kernel_name)
             main_func_name = f"{sanitized_name}_{MAIN_SUFFIX}"
-            
 
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -88,6 +88,7 @@ size_hints_regex = re.compile(
 class_private_mangling_regex = re.compile(r"^_[A-Za-z0-9_]+?__")
 non_word_char_regex = re.compile(r"[^\w]")
 
+
 def _pycodecache_kernel_compile_env() -> dict[str, str | None]:
     env_vars = [
         "TORCHINDUCTOR_CACHE_DIR",
@@ -155,7 +156,6 @@ def _add_triton_kernel_info(kernel_name: str, info: dict[str, Any]):
         _triton_kernel_metrics[kernel_name] = info
 
 
-
 def _sanitize_kernel_name(name: str) -> str:
     # Strip Python class-private attribute mangling (e.g., _ClassName__kernel_name -> kernel_name)
     name = class_private_mangling_regex.sub("", name)
@@ -163,7 +163,6 @@ def _sanitize_kernel_name(name: str) -> str:
     # Sanitization logic
     name = non_word_char_regex.sub("_", name)
     return name
-
 
 
 def _emit_triton_kernel_compile_metric(

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -164,6 +164,8 @@ def _sanitize_kernel_name(name: str) -> str:
     name = non_word_char_regex.sub("_", name)
     return name
 
+
+
 def _emit_triton_kernel_compile_metric(
     kernel: CachingAutotuner,
     kernel_name: str,

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -681,9 +681,9 @@ class AsyncCompile:
 
     def _load_kernel_wrapper(self, kernel_name, main_suffix, wrapper_cls, key, path):
         """Reload a kernel module from PyCodeCache and wrap the entry point."""
-        mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
-        kernel_name = _sanitize_kernel_name(kernel_name)
-        main_func_name = f"{kernel_name}_{main_suffix}"
+        mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)     
+        sanitized_name = _sanitize_kernel_name(kernel_name)
+        main_func_name = f"{sanitized_name}_{main_suffix}"
         # f"{kernel_name}_{main_suffix}"
         return wrapper_cls(getattr(mod, main_func_name), kernel_path=path)
 
@@ -741,11 +741,8 @@ class AsyncCompile:
         else:
             key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
-
-            
-            kernel_name = _sanitize_kernel_name(kernel_name)
-            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
-
+            sanitized_name = _sanitize_kernel_name(kernel_name)
+            main_func_name = f"{sanitized_name}_{MAIN_SUFFIX}"
 
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]
@@ -842,8 +839,9 @@ class AsyncCompile:
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
 
             # Find our special entry point named function
-            kernel_name = _sanitize_kernel_name(kernel_name)
-            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
+            sanitized_name = _sanitize_kernel_name(kernel_name)
+            main_func_name = f"{sanitized_name}_{MAIN_SUFFIX}"
+            
 
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]
@@ -882,6 +880,8 @@ class AsyncCompile:
             MAIN_SUFFIX,
         )
 
+        kernel_name = _sanitize_kernel_name(kernel_name)  # <--- SANITIZE HERE ONCE
+
         kernel_code_log.info("NVIDIA Universal GEMM Kernel:\n%s", source_code)
         _compile_start()
 
@@ -917,9 +917,7 @@ class AsyncCompile:
         else:
             key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
             mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
-
-            kernel_name = _sanitize_kernel_name(kernel_name)
-            main_func_name = f"{kernel_name}_{main_suffix}"
+            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
 
             if not hasattr(mod, main_func_name):
                 available = [name for name in dir(mod) if callable(getattr(mod, name))]


### PR DESCRIPTION
### Summary
- Pre-compile regular expressions (`class_private_mangling_regex` and `non_word_char_regex`) in `torch/_inductor/async_compile.py` at module load time to avoid redundant `re.compile()` calls.
- Update `_sanitize_kernel_name` to strip class-private attribute mangling (`_ClassName__kernel_name` -> `kernel_name`).
- Add unit test `test_class_kernel_name_mangling` in `test/inductor/test_async_compile.py`.

Fixes #193718

### Test Plan
Ran local unit tests in `test/inductor/test_async_compile.py`:
```bash
python test/inductor/test_async_compile.py