### PR TITLE
[inductor][DRAFT] Reorder pointwise loops so the dominant coalescing var is innermost

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -3,7 +3,7 @@
 import contextlib
 import os
 import unittest
-from unittest import skipUnless
+from unittest import mock, skipUnless
 
 import numpy as np
 import sympy
@@ -1467,6 +1467,261 @@ class MemoryCoalescingTest(MockSchedulerTest):
             # Assert that we captured code, before checking it.
             self.assertTrue(code)
             FileCheck().check("YBLOCK").check("XBLOCK").run(code[0])
+
+    def test_get_coalescing_pointwise_reorder(self):
+        """Unit test for the reorder-decision helper (no codegen / GPU needed)."""
+        from torch._inductor import tiling_utils
+        from torch._inductor.tiling_utils import (
+            CoalesceVarAnalysis,
+            FusedNormalizedReadsWrites,
+        )
+
+        b, h, s, k = sympy.symbols("b h s k", integer=True)
+
+        def make_analysis(
+            index_vars, reduce_vars, var_ranges, coalesced_by_var, uncoalesced=None
+        ):
+            norm = FusedNormalizedReadsWrites(
+                index_vars=OrderedSet(index_vars),
+                reduce_vars=OrderedSet(reduce_vars),
+                reads={},
+                writes={},
+                var_ranges=var_ranges,
+            )
+            return CoalesceVarAnalysis(
+                coalesced_by_var=coalesced_by_var,
+                uncoalesced_addrs=uncoalesced or {},
+                norm_read_writes=norm,
+            )
+
+        reorder = tiling_utils.get_coalescing_pointwise_reorder
+
+        # Dominant *middle* var (head) is moved to innermost:
+        # [b, h, s] -> [b, s, h] == same_reorder [0, 2, 1].
+        ca = make_analysis(
+            [b, h, s],
+            [k],
+            {b: 4, h: 16, s: 576, k: 576},
+            {h: 169869376, s: 294912, k: 169869312},
+        )
+        self.assertEqual(reorder(ca), [0, 2, 1])
+
+        # Near-tie: dominance margin not met -> no reorder.
+        ca = make_analysis(
+            [b, h, s], [k], {b: 4, h: 16, s: 576, k: 576}, {h: 100, s: 90}
+        )
+        self.assertIsNone(reorder(ca))
+
+        # Dominant var range too small to be a good dense dim -> no reorder.
+        ca = make_analysis(
+            [b, h, s], [k], {b: 4, h: 4, s: 576, k: 576}, {h: 169869376, s: 294912}
+        )
+        self.assertIsNone(reorder(ca))
+
+        # Dominant var already innermost -> no reorder.
+        ca = make_analysis(
+            [b, h, s], [k], {b: 4, h: 16, s: 576, k: 576}, {s: 169869376, h: 294912}
+        )
+        self.assertIsNone(reorder(ca))
+
+        # Any uncoalesced access -> defer to the suggested_split tiling path.
+        ca = make_analysis(
+            [b, h, s],
+            [k],
+            {b: 4, h: 16, s: 576, k: 576},
+            {h: 169869376, s: 294912},
+            uncoalesced={b + s: 1000},
+        )
+        self.assertIsNone(reorder(ca))
+
+    def test_plan_coalescing_reindex(self):
+        """
+        Unit test for the re-factorization plan of a fused node. Children whose
+        pointwise dims are merged differently from the fused node's normalized
+        ranges are re-factorized onto those ranges plus the leftover trailing
+        dims; anything that does not line up exactly must bail out, since the
+        plan rewrites the flat index.
+        """
+
+        def fused(*sizes):
+            snodes = [
+                self._create_scheduler_node(self._create_buffer(f"buf{i}", size))
+                for i, size in enumerate(sizes)
+            ]
+            return torch._inductor.scheduler.FusedSchedulerNode.fuse(*snodes)
+
+        norm_pw_sizes = [sympy.Integer(n) for n in (2, 4, 8)]
+
+        # (64, 8) has [2, 4, 8] merged into 64, with 8 left over: re-factorize.
+        # (2, 4, 8) already matches the normalized ranges: nothing to do.
+        node = fused((64, 8), (2, 4, 8))
+        plan = node._plan_coalescing_reindex(norm_pw_sizes)
+        self.assertIsNotNone(plan)
+        self.assertEqual([list(sizes) for sizes in plan.values()], [[2, 4, 8, 8]])
+
+        # Pointwise numel is not a multiple of the normalized numel.
+        node = fused((5, 7), (2, 4, 8))
+        self.assertIsNone(node._plan_coalescing_reindex(norm_pw_sizes))
+
+        # Divisible (64 * 3), but no dim boundary lines up with the leftover 3.
+        node = fused((192,), (2, 4, 8))
+        self.assertIsNone(node._plan_coalescing_reindex(norm_pw_sizes))
+
+        # A symbolic target range is not a valid re-factorization target.
+        node = fused((64, 8), (2, 4, 8))
+        dynamic_sizes = [
+            sympy.Symbol("s0", integer=True, positive=True)
+        ] + norm_pw_sizes
+        self.assertIsNone(node._plan_coalescing_reindex(dynamic_sizes))
+
+    def test_reorder_dominant_middle_var_for_coalescing(self):
+        """
+        End-to-end: a softmax-backward pattern
+        (https://github.com/intel/intel-xpu-backend-for-triton/issues/7610)
+        places the only contiguous axis (head, size 16) as a *middle* pointwise
+        digit. Verify the
+        analysis identifies head as the dominant coalescing var (yet the tiling
+        path yields no `suggested_split`), and that
+        `reorder_pointwise_loops_for_coalescing` moves head to the innermost loop.
+        """
+        B, H, S, K = 4, 16, 576, 576
+
+        def f(dy, lg, bias, mx, sm):
+            dyv = dy.view(B, S, K, H)
+            lgv = lg.view(B, S, K, H)
+            mx2 = mx.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
+            sm2 = sm.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
+            y = torch.exp(lgv + bias - mx2) / sm2
+            # head-second contiguous layout forces the pathology
+            p = (dyv * y).permute(0, 3, 1, 2).contiguous()
+            yp = y.permute(0, 3, 1, 2)
+            acc = p.sum(dim=-1, keepdim=True)
+            return p - yp * acc
+
+        def dominant_and_innermost(ca):
+            ivars = list(ca.norm_read_writes.index_vars)
+            dom = max(ivars, key=lambda v: ca.coalesced_by_var.get(v, 0))
+            return dom, ivars[-1], ca.norm_read_writes.var_ranges
+
+        def fn(nodes):
+            self.assertEqual(len(nodes), 1)
+            node = nodes[0]
+
+            ca = node.get_coalesce_analysis()
+            self.assertIsNotNone(ca)
+            # Every access coalesces on *some* var, so there is no uncoalesced
+            # tiling opportunity: this is the exact trigger for the reorder pass.
+            self.assertEqual(len(ca.uncoalesced_addrs), 0)
+            self.assertIsNone(ca.suggested_split)
+
+            dom, innermost, ranges = dominant_and_innermost(ca)
+            # head (size 16) dominates coalescing but is NOT the innermost loop.
+            self.assertEqual(ranges[dom], H)
+            self.assertNotEqual(dom, innermost)
+
+            # Apply the pass directly (deterministic); the scheduler-driven call
+            # that runs right after this hook then becomes a no-op.
+            self.assertTrue(node.reorder_pointwise_loops_for_coalescing())
+
+            ca2 = node.get_coalesce_analysis()
+            dom2, innermost2, ranges2 = dominant_and_innermost(ca2)
+            # After the reorder, the dominant (head) var IS the innermost loop.
+            self.assertEqual(dom2, innermost2)
+            self.assertEqual(ranges2[innermost2], H)
+
+            return nodes
+
+        # Scaled down: the reduction sums S*K terms, so at unit scale the fp32
+        # reduction-order noise alone exceeds any useful tolerance (true for
+        # eager and for stock inductor as well, not just the reordered kernel).
+        scale = 0.05
+        dy = torch.randn(B * S * K, H, device=GPU_TYPE) * scale
+        lg = torch.randn(B * S * K, H, device=GPU_TYPE) * scale
+        bias = torch.randn(H, device=GPU_TYPE) * scale
+        mx = torch.randn(B, H, S, 1, device=GPU_TYPE) * scale
+        sm = torch.rand(B, H, S, 1, device=GPU_TYPE) + 0.5
+
+        with torch._inductor.config.patch(_post_fusion_custom_pass=fn), torch.no_grad():
+            out, code = run_and_get_code(torch.compile(f), dy, lg, bias, mx, sm)
+
+        self.assertTrue(code)
+        # The payoff: head is the dense dimension, so consecutive lanes read
+        # consecutive addresses. Before the reorder head was an interior digit
+        # (`(xindex // 576) % 16`) and every read was a strided scalar load. Accept
+        # either shape the tiling may take -- head as the low digit of a 1-D index,
+        # or head as its own innermost tile -- since which one is picked depends on
+        # the device's tiling heuristics, while "head is dense" is the invariant.
+        kernel = code[0]
+        self.assertTrue(
+            "xindex % 16" in kernel or "xnumel = 16" in kernel,
+            f"expected head (16) as the dense dim, got:\n{kernel}",
+        )
+        self.assertEqual(out, f(dy, lg, bias, mx, sm), atol=1e-3, rtol=1e-3)
+
+    def test_reorder_for_coalescing_dynamic_shapes(self):
+        """
+        The reorder rewrites the flat index (it re-factorizes merged dims), so a
+        size hint is not good enough -- being wrong would miscompile rather than
+        merely deoptimize. With a dynamic pointwise range the decision helper must
+        therefore decline, leaving the loop order untouched. Same pattern as
+        `test_reorder_dominant_middle_var_for_coalescing`, but with a symbolic
+        batch dim.
+        """
+        from torch._inductor import tiling_utils
+
+        B, H, S, K = 4, 16, 576, 576
+
+        def f(dy, lg, bias, mx, sm):
+            # `-1` keeps the batch dim symbolic under dynamic=True
+            dyv = dy.view(-1, S, K, H)
+            lgv = lg.view(-1, S, K, H)
+            mx2 = mx.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
+            sm2 = sm.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
+            y = torch.exp(lgv + bias - mx2) / sm2
+            p = (dyv * y).permute(0, 3, 1, 2).contiguous()
+            yp = y.permute(0, 3, 1, 2)
+            return p - yp * p.sum(dim=-1, keepdim=True)
+
+        scale = 0.05
+        dy = torch.randn(B * S * K, H, device=GPU_TYPE) * scale
+        lg = torch.randn(B * S * K, H, device=GPU_TYPE) * scale
+        bias = torch.randn(H, device=GPU_TYPE) * scale
+        mx = torch.randn(B, H, S, 1, device=GPU_TYPE) * scale
+        sm = torch.rand(B, H, S, 1, device=GPU_TYPE) + 0.5
+        ref = f(dy, lg, bias, mx, sm)
+
+        orig = tiling_utils.get_coalescing_pointwise_reorder
+        decisions = []
+
+        def spy(coalesce_analysis):
+            new_order = orig(coalesce_analysis)
+            decisions.append(new_order)
+            return new_order
+
+        for dynamic in (False, True):
+            torch._dynamo.reset()
+            decisions.clear()
+            with (
+                mock.patch.object(
+                    tiling_utils, "get_coalescing_pointwise_reorder", spy
+                ),
+                torch.no_grad(),
+            ):
+                out = torch.compile(f, dynamic=dynamic)(dy, lg, bias, mx, sm)
+
+            self.assertTrue(decisions, "reorder decision helper was never consulted")
+            if dynamic:
+                # symbolic pointwise ranges -> stay on the conservative path
+                self.assertTrue(
+                    all(order is None for order in decisions),
+                    f"dynamic shapes must not be reordered, got {decisions}",
+                )
+            else:
+                self.assertTrue(
+                    any(order is not None for order in decisions),
+                    "static shapes should still be reordered",
+                )
+            self.assertEqual(out, ref, atol=1e-3, rtol=1e-3)
 
 
 layouts = ("cont", "NHWC", "T")

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1301,6 +1301,15 @@ class BaseSchedulerNode:
     ) -> bool:
         return False
 
+    def reorder_pointwise_loops_for_coalescing(self) -> bool:
+        """
+        Reorder the pointwise iteration loops so the dominant coalescing var
+        becomes the innermost (dense) loop. Returns True if a reorder happened.
+        Base implementation is a no-op; overridden by SchedulerNode /
+        FusedSchedulerNode.
+        """
+        return False
+
     def update_mutated_names(self, renames: dict[str, str]) -> None:
         self.mutation_renames = {
             name: renames[name]
@@ -2449,6 +2458,37 @@ class SchedulerNode(BaseSchedulerNode):
             )
             return False
 
+    def reorder_pointwise_loops_for_coalescing(self) -> bool:
+        from .tiling_utils import get_coalescing_pointwise_reorder
+
+        # Template buffers have no `_body` to analyze or reorder.
+        if self.is_template() or not isinstance(self.node, ir.ComputedBuffer):
+            return False
+
+        coalesce_analysis = self.get_coalesce_analysis()
+        if coalesce_analysis is None:
+            return False
+
+        new_order = get_coalescing_pointwise_reorder(coalesce_analysis)
+        if not new_order:
+            return False
+
+        # The reorder is expressed over the (normalized) pointwise iteration
+        # vars. Only apply it when those map 1:1 onto this node's pointwise loop
+        # dims, so the permutation indices line up with `_body.sizes[0]`.
+        if len(new_order) != len(self._sizes[0]):
+            return False
+
+        # pyrefly: ignore [bad-assignment]
+        metrics.num_loop_reordering += 1
+        loop_ordering_log.debug(
+            "Reorder pointwise loops for coalescing on %s with order %s",
+            self.get_name(),
+            new_order,
+        )
+        self.apply_new_loop_order(new_order)
+        return True
+
     def debug_str_extra(self) -> str:
         name = self.get_name()
         lines = [
@@ -2765,6 +2805,160 @@ class FusedSchedulerNode(BaseSchedulerNode):
             if not isinstance(snode, SchedulerNode):
                 raise AssertionError("expected snode to be a SchedulerNode")
             snode.apply_new_loop_order(new_order)
+
+        refresh_group_node_dependencies(self)
+        return True
+
+    def _plan_coalescing_reindex(
+        self, norm_pw_sizes: list[sympy.Expr]
+    ) -> dict[SchedulerNode, list[sympy.Expr]] | None:
+        """
+        Children of a fused node may have their pointwise dimensions merged
+        (e.g. b*h*s collapsed to a single 36864 range), which hides the
+        coalescing var inside a merged dim where a permutation cannot reach it.
+        Plan a re-factorization of each such child onto the fused node's
+        normalized pointwise ranges, keeping any trailing dims (which map to the
+        reduction group) intact.
+
+        Fused children share a single flat pointwise enumeration (that is what
+        makes them fusable), so re-factorizing each of them onto the same
+        normalized ranges keeps them mutually consistent.
+
+        Returns None if any child cannot be expressed that way.
+        """
+
+        def static_int(expr: sympy.Expr) -> int | None:
+            """The integer value of `expr`, or None if it is not statically known."""
+            sym_expr = sympy.sympify(expr)
+            return int(sym_expr) if sym_expr.is_number else None
+
+        # The re-factorization target itself must be fully static, not just its
+        # product, since it becomes the child's new iteration ranges.
+        if any(static_int(size) is None for size in norm_pw_sizes):
+            return None
+        norm_numel = static_int(sympy_product(norm_pw_sizes))
+        if norm_numel is None:
+            return None
+
+        plan: dict[SchedulerNode, list[sympy.Expr]] = {}
+        for snode in self.snodes:
+            if not isinstance(snode, SchedulerNode):
+                return None
+            pw_sizes = list(snode._sizes[0])
+            if len(pw_sizes) == len(norm_pw_sizes) and all(
+                V.graph.sizevars.statically_known_equals(a, b)
+                for a, b in zip(pw_sizes, norm_pw_sizes)
+            ):
+                # already matches the normalized pointwise ranges
+                continue
+
+            # Re-factorizing rewrites the flat index, so every dim taking part must
+            # be statically known -- a size hint is not a guarantee, and being wrong
+            # here would miscompile rather than merely deoptimize.
+            static_sizes: list[int] = []
+            for size in pw_sizes:
+                static_size = static_int(size)
+                if static_size is None:
+                    return None
+                static_sizes.append(static_size)
+            pw_numel = math.prod(static_sizes)
+
+            # Split off the suffix of dims beyond the normalized pointwise numel;
+            # those belong to the reduction group and must be left alone.
+            target_trailing, rem = divmod(pw_numel, norm_numel)
+            if rem:
+                return None
+
+            trailing: list[sympy.Expr] = []
+            trailing_prod = 1
+            for size, static_size in zip(reversed(pw_sizes), reversed(static_sizes)):
+                if trailing_prod == target_trailing:
+                    break
+                trailing_prod *= static_size
+                trailing.insert(0, size)
+            if trailing_prod != target_trailing:
+                # no dim boundary lines up with the reduction group
+                return None
+
+            plan[snode] = list(norm_pw_sizes) + trailing
+
+        return plan
+
+    def reorder_pointwise_loops_for_coalescing(self) -> bool:
+        from .tiling_utils import get_coalescing_pointwise_reorder
+
+        if self.is_template():
+            return False
+
+        # Every child must be an analyzable/reorderable pointwise-or-reduction node:
+        # `get_coalesce_analysis` below walks each child's `_body`, and the reorder
+        # rewrites it.
+        children: list[SchedulerNode] = []
+        for snode in self.snodes:
+            if not isinstance(snode, SchedulerNode) or not isinstance(
+                snode.node, ir.ComputedBuffer
+            ):
+                return False
+            children.append(snode)
+
+        coalesce_analysis = self.get_coalesce_analysis()
+        if coalesce_analysis is None:
+            return False
+
+        new_order = get_coalescing_pointwise_reorder(coalesce_analysis)
+        if not new_order:
+            return False
+
+        norm_read_writes = coalesce_analysis.norm_read_writes
+        norm_pw_sizes = [
+            norm_read_writes.var_ranges[v] for v in norm_read_writes.index_vars
+        ]
+        if len(new_order) != len(norm_pw_sizes):
+            return False
+
+        # Un-merge any child whose pointwise dims hide the coalescing var, so the
+        # permutation below can reach it. Bail out entirely if that is not possible
+        # for some child -- a partial reorder would leave the fused children on
+        # inconsistent iteration spaces.
+        reindex_plan = self._plan_coalescing_reindex(norm_pw_sizes)
+        if reindex_plan is None:
+            return False
+
+        # The permutation is identity-extended over each child's trailing dims, so
+        # every child needs at least `len(new_order)` dims once reindexed. Check all
+        # of them before mutating any, so we never leave the children of a fused
+        # node on inconsistent iteration spaces.
+        for snode in children:
+            final_sizes = reindex_plan.get(snode, list(snode._sizes[0]))
+            if len(final_sizes) < len(new_order):
+                loop_ordering_log.debug(
+                    "Don't reorder fused node %s: child %s has %s pointwise dims, "
+                    "fewer than the %s being permuted",
+                    self.get_name(),
+                    snode.get_name(),
+                    len(final_sizes),
+                    len(new_order),
+                )
+                return False
+
+        for snode in children:
+            if snode in reindex_plan:
+                snode.apply_loop_reindexing(reindex_plan[snode])
+
+            # identity-extend the permutation over the trailing dims
+            num_dims = len(snode._sizes[0])
+            order = list(new_order) + list(range(len(new_order), num_dims))
+            snode.apply_new_loop_order(order)
+
+        # pyrefly: ignore [bad-assignment]
+        metrics.num_loop_reordering += 1
+        loop_ordering_log.debug(
+            "Reorder pointwise loops for coalescing on fused node %s with order %s "
+            "(reindexed %s children)",
+            self.get_name(),
+            new_order,
+            len(reindex_plan),
+        )
 
         refresh_group_node_dependencies(self)
         return True
@@ -4245,6 +4439,8 @@ class Scheduler:
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
+        self.reorder_loops_for_coalescing()
+
         if any(
             isinstance(node, FusedExternTritonKernelSchedulerNode)
             for node in self.nodes
@@ -5096,6 +5292,28 @@ class Scheduler:
             name_to_max_distance[node.get_name()] = max_dist
             node.min_input_distance = min_dist
             node.max_input_distance = max_dist
+
+    def reorder_loops_for_coalescing(self) -> None:
+        """
+        After fusion, reorder each node's pointwise loops so the dominant
+        coalescing var becomes the innermost (dense) loop. This complements the
+        pairwise loop reordering done during fusion (`reorder_loops_by_dep_pair`),
+        which aligns a node to a fusion partner but never consults the coalescing
+        analysis and bails on reductions. Here we can move a dominant "middle"
+        pointwise digit onto the dense dim even for reduction kernels, which the
+        tiling / codegen path (`_split_iteration_ranges`) cannot do on its own.
+        """
+        if not (
+            config.triton.coalesce_tiling_analysis and config.loop_ordering_after_fusion
+        ):
+            return
+
+        for node in self.nodes:
+            if not isinstance(node, (SchedulerNode, FusedSchedulerNode)):
+                continue
+            if not node.is_gpu():
+                continue
+            node.reorder_pointwise_loops_for_coalescing()
 
     def merge_loops(self) -> None:
         if not config.loop_ordering_after_fusion:

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -890,3 +890,86 @@ def _analyze_memory_coalescing(
         norm_read_writes=norm_read_writes,
         suggested_split=VarTiling(best_tiling[0], best_tiling[1], best_tiling_score),
     )
+
+
+# Minimum size for a pointwise dim to be worth making the innermost/dense loop.
+COALESCE_REORDER_MIN_BLOCK = 8
+# The dominant coalescing var must beat the current innermost var's coalescing
+# score by at least this factor before we reorder. Keeps the pass conservative:
+# we only move a var inner when doing so is a clear win.
+COALESCE_REORDER_DOMINANCE_MARGIN = 4
+
+
+def get_coalescing_pointwise_reorder(
+    coalesce_analysis: "CoalesceVarAnalysis",
+) -> list[int] | None:
+    """
+    Given a coalescing analysis, return a permutation of the pointwise iteration
+    loops that makes the *dominant* coalescing var the innermost (dense) loop, or
+    ``None`` if no reorder is warranted.
+
+    Motivation: the tiling / codegen path (``_split_iteration_ranges``) places the
+    *last* pointwise iteration dim on the dense (vectorized) tile. When the memory
+    accesses coalesce on a non-innermost ("middle") iteration digit, no tiling
+    candidate can move that digit onto the dense dim -- the iteration order itself
+    must change. This computes such a reorder from ``coalesced_by_var``.
+
+    The returned list follows the ``same_reorder`` convention used by
+    ``LoopBody.reorder_iter_loops``: ``new_sizes[i] = old_sizes[new_order[i]]``.
+    For pointwise order ``[b, h, s]`` where ``h`` dominates, this returns
+    ``[0, 2, 1]`` (i.e. ``[b, s, h]``, with ``h`` innermost).
+
+    All guards must hold or ``None`` is returned:
+    - there are no uncoalesced accesses (never trade a coalesced access for an
+      uncoalesced one -- that case is handled by ``suggested_split`` tiling);
+    - the dominant coalescing var is a pointwise var and is not already innermost;
+    - the dominant var's score beats the current innermost var's score by
+      ``COALESCE_REORDER_DOMINANCE_MARGIN``;
+    - the dominant var's range is statically known and at least
+      ``COALESCE_REORDER_MIN_BLOCK`` (a sensible dense width).
+    """
+    # If any access is uncoalesced, defer to the tiling (`suggested_split`) path.
+    if coalesce_analysis.uncoalesced_addrs:
+        return None
+
+    norm_read_writes = coalesce_analysis.norm_read_writes
+    index_vars = list(norm_read_writes.index_vars)
+    if len(index_vars) < 2:
+        return None
+
+    var_ranges = norm_read_writes.var_ranges
+    coalesced_by_var = coalesce_analysis.coalesced_by_var
+
+    innermost_var = index_vars[-1]
+
+    # Pick the dominant *pointwise* coalescing var (reduction vars are never
+    # reordered here -- a pointwise reorder cannot touch the reduction loop).
+    dominant_var = max(index_vars, key=lambda v: coalesced_by_var.get(v, 0))
+    if dominant_var is innermost_var:
+        return None
+
+    dominant_score = coalesced_by_var.get(dominant_var, 0)
+    innermost_score = coalesced_by_var.get(innermost_var, 0)
+    if dominant_score <= 0:
+        return None
+    if dominant_score < COALESCE_REORDER_DOMINANCE_MARGIN * innermost_score:
+        return None
+
+    # The dominant var must be a sensible dense dimension: statically known
+    # (skip dynamic shapes) and not tiny. (Note: we intentionally do not require
+    # CandidateTiling.is_good_size, whose >= 32 heuristic would reject a natural
+    # 16-wide lane dim.)
+    dominant_range = var_ranges.get(dominant_var)
+    if dominant_range is None:
+        return None
+    dominant_range = sympy.sympify(dominant_range)
+    if not dominant_range.is_number:
+        return None
+    if int(dominant_range) < COALESCE_REORDER_MIN_BLOCK:
+        return None
+
+    dominant_idx = index_vars.index(dominant_var)
+    # Move `dominant_idx` to the last (innermost) slot, preserving relative order.
+    new_order = [i for i in range(len(index_vars)) if i != dominant_idx]
+    new_order.append(dominant_idx)
+    return new_order


### PR DESCRIPTION
> **WIP / draft** — This is only a draft of an experimental fix produced using Claude Opus 5. The fix was not tested on CUDA devices.

## The bug

Reported as [intel/intel-xpu-backend-for-triton#7610](https://github.com/intel/intel-xpu-backend-for-triton/issues/7610): an inductor-generated softmax-backward reduction kernel runs at **~250 GB/s** on an Intel Data Center GPU Max 1550 (PVC), while a hand-written Triton kernel doing the same math reaches **~746 GB/s** on the same device — a ~3× gap. The kernel is entirely inductor-generated, and the gap is pure memory behaviour: every load is a strided scalar load.

Minimal reproducer (`B, H, S, K = 4, 16, 576, 576`, fp32):

```python
def f(dy, lg, bias, mx, sm):
    dyv = dy.view(B, S, K, H)
    lgv = lg.view(B, S, K, H)
    mx2 = mx.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
    sm2 = sm.squeeze(-1).permute(0, 2, 1).unsqueeze(2)
    y = torch.exp(lgv + bias - mx2) / sm2
    p = (dyv * y).permute(0, 3, 1, 2).contiguous()   # head-second layout
    yp = y.permute(0, 3, 1, 2)
    return p - yp * p.sum(dim=-1, keepdim=True)
```

## Root cause

The `permute + view` chain leaves the only contiguous axis — `head`, size 16, stride 1 — as a **middle** digit of the pointwise iteration space. For the single fused node here the normalized analysis is:

* pointwise `index_vars = [b(4), h(16), s(576)]` — `head` is the middle digit, `s` is innermost
* reduction `reduce_vars = [k(576)]`
* `coalesced_by_var = {h: 169869376, s: 294912, k: 169869312}` — **`head` dominates by ~575× over the innermost var**
* every access coalesces on *some* var, so `uncoalesced_addrs` is empty and `suggested_split is None`: the existing tiling path sees nothing to fix

The dense (vectorized) dim is chosen positionally: `_split_iteration_ranges` puts the **last** pointwise dim on the `x` tile. So no tiling candidate can put a *middle* digit on the lanes — the iteration order itself has to change. The existing reorder path (`reorder_loops_by_dep_pair`) is pairwise, runs at fusion time, never consults the coalescing analysis, and bails on reductions.

Result — the emitted load, with `head` buried as `(x0 // 576) % 16`:

```
tmp0 = tl.load(in_ptr0 + (16*r0_1 + 9216*((x0 % 576)) + 5308416*(x0 // 9216) + (((x0 // 576) % 16))), ...)
```

## The fix

A post-fusion pass that reorders the **pointwise** loops so the dominant coalescing var becomes the innermost (dense) loop. Nothing in codegen, tiling selection, or tiling scoring is touched.

1. **`tiling_utils.get_coalescing_pointwise_reorder(coalesce_analysis)`** — decides the permutation from `coalesced_by_var`. Returns `None` unless the win is unambiguous:
   * no uncoalesced accesses (never trade a coalesced access for an uncoalesced one — that case belongs to the `suggested_split` tiling path);
   * the dominant var is a pointwise var and is not already innermost;
   * it beats the current innermost var's score by ≥ 4× (`COALESCE_REORDER_DOMINANCE_MARGIN`);
   * its range is statically known and ≥ 8 (`COALESCE_REORDER_MIN_BLOCK`). Deliberately *not* `CandidateTiling.is_good_size`, whose ≥ 32 rule would reject a natural 16-wide lane dim.
2. **`SchedulerNode.reorder_pointwise_loops_for_coalescing()`** — applies it via the existing `apply_new_loop_order`, only when the normalized pointwise vars map 1:1 onto the node's loop dims. Guarded against template buffers (their `_body` is `None`).
3. **`FusedSchedulerNode.reorder_pointwise_loops_for_coalescing()`** — a fused node's children can have their pointwise dims merged *differently* (here `b*h*s` collapsed into a single 36864 range in two of three children), which hides `head` inside a merged dim where a permutation cannot reach it. `_plan_coalescing_reindex()` therefore re-factorizes each mismatched child onto the fused node's normalized pointwise ranges (`[4, 16, 576] + [576]`) using the existing `reindex_iter_loops`, then one shared, identity-extended permutation is applied to *every* child so they stay on a consistent iteration space. All checks happen before any mutation; any child that cannot be expressed that way aborts the whole reorder.
4. **`Scheduler.reorder_loops_for_coalescing()`** — runs once after fusion, gated on `config.triton.coalesce_tiling_analysis and config.loop_ordering_after_fusion`, GPU nodes only.

The reorder and the re-factorization are exact re-expressions of the flat index, so the math is unchanged. Anything not statically known bails out: a size *hint* is not a guarantee, and being wrong here would miscompile rather than merely deoptimize.

After the pass, `head` is the low digit of the 1-D index (`x % 16 == head`), so the default `{x: 36864, r0_: 576}` tiling is already coalesced — no new tiling shape is needed:

```
tmp0 = tl.load(in_ptr0 + (x0 + 16*r0_3 + 9216*x4), ...)
```

## Measured effect (Intel PVC, Max 1550)

Same process, same inputs, only difference is whether `Scheduler.reorder_loops_for_coalescing` is stubbed out. Inductor caches disabled, 10 warm-up + 50 timed iterations. Bytes moved = `4 × B × H × S × K × 4 B` = 339.7 MB.

| variant | generated load index | time | bandwidth |
|---|---|---|---|
| stock (pass disabled) | `16*r0_1 + 9216*(x0 % 576) + 5308416*(x0 // 9216) + ((x0 // 576) % 16)` — head stride 9216 | 1.364 ms | **249.1 GB/s** |
| this PR | `x0 + 16*r0_3 + 9216*x4` — **head stride 1** | 0.360 ms | **944.2 GB/s** |

**3.79×**, and it beats the hand-written reference kernel from the issue (0.456 ms / 746 GB/s) because it keeps the 1-D structure instead of needing a `{y: 2304, x: 16}` split. An independent run on the other tile of the same card gave 243.0 → 993.4 GB/s (**4.09×**), so the effect is stable.

Numerics are unchanged: max abs error vs eager 5.72e-06 (stock) vs 6.68e-06 (this PR) at input scale 0.05, i.e. relative error 3.0e-07 vs 3.5e-07. (At unit input scale the reduction sums `S*K` fp32 terms and `max|ref|` is ~9.4e7, so *both* stock and reordered kernels differ from eager by ~30 in absolute terms — fp32 reduction-order noise, not a correctness difference. Compare relative error.)

## Tests

New tests in `test/inductor/test_loop_ordering.py` (`MemoryCoalescingTest`):

* `test_get_coalescing_pointwise_reorder` — unit test of the decision helper on synthetic analyses: dominant-middle var → `[0, 2, 1]`; and `None` for a near-tie, a too-small dominant range, an already-innermost dominant var, and any uncoalesced access present.
* `test_plan_coalescing_reindex` — unit test of the fused re-factorization plan: a merged child is re-expressed as `[2, 4, 8] + [8]`, a child already matching is left alone, and it bails when the pointwise numel is not a multiple of the normalized numel, when no dim boundary lines up with the leftover, and when the target ranges are symbolic.
* `test_reorder_dominant_middle_var_for_coalescing` — end-to-end on the reproducer: asserts the trigger conditions (dominant middle coalescing var, `uncoalesced_addrs` empty, `suggested_split is None`), that the pass moves that var innermost, that the emitted kernel has head as the dense dim, and numerics vs eager.
* `test_reorder_for_coalescing_dynamic_shapes` — same pattern with a symbolic batch dim: spies on the decision helper and asserts it is consulted but declines *every* time under `dynamic=True` (while still reordering with static shapes), plus numerics for both.

Results on the PVC box (`torch` built from this branch's `_inductor`, XPU):

* `test_loop_ordering.py` — **93 passed, 1 skipped, 1 failed**. The failure is `LoopOrderingTest::test_interaction_with_triton_template`, and it fails **identically with this pass stubbed out** on this machine (autotuning picks a different `triton_mm` config here), so it is pre-existing and unrelated.
* `test_torchinductor.py -k "softmax or reduction"` — **58 passed, 13 skipped, 0 failed**.
* A broader `test_torchinductor.py` sweep (`-k "fused or pointwise or permute or view or transpose or sum or mean or var or norm or split or tile or layout or coalesc"`) was still running when this PR was opened; I will post the result as a comment.

An earlier iteration of the pass surfaced a real guard bug worth recording: without the template check, the pass called `get_coalesce_analysis()` on a `MultiTemplateBuffer` whose `_body` is `None` and broke `test_interaction_with_multi_template`. `get_coalesce_analysis` guards only on node *type*, not template-ness — existing callers avoid templates by construction, but a pass that iterates all `scheduler.nodes` has to guard itself.

## Open questions

1. **Gating.** Both `triton.coalesce_tiling_analysis` and `loop_ordering_after_fusion` default to `True` in OSS, so as written this pass is on for every backend, and I only have Intel PVC data. Options: (a) put it behind a new default-off config for now, (b) land as-is and let the perf dashboard decide, (c) land default-off and flip after dashboard runs. I'd rather not turn it on for CUDA without numbers — happy to go with whichever reviewers prefer.
2. **Dominance margin of 4×.** The motivating case is ~575×, so the exact threshold is untested in the middle of the range.
3. Should the re-factorization step (`_plan_coalescing_reindex`) be split into its own follow-up, keeping this PR to the single-node case? That would be a smaller change, but it would not fix the reported kernel — the expensive children there are exactly the merged ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo