### PR TITLE
Sync requires_grad after _set_tensor_requires_grad under torch.func

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -3416,6 +3416,41 @@ class AutogradFunctionFunctorchTests(torch._dynamo.test_case.TestCase):
         result = torch.func.grad(loss_fn)(x)
         self.assertEqual(result, torch.tensor([2.0, 2.0]))
 
+    def test_reverse_mode_custom_backward_compiled(self):
+        """The custom backward must survive compiling a torch.func reverse-mode
+        transform. https://github.com/pytorch/pytorch/issues/193279
+        """
+
+        class SinWithZeroBackward(torch.autograd.Function):
+            @staticmethod
+            def forward(x):
+                return torch.sin(x)
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                ctx.save_for_backward(*inputs)
+
+            @staticmethod
+            def backward(ctx, grad):
+                return torch.zeros_like(grad)
+
+        def loss(x):
+            return SinWithZeroBackward.apply(x).sum()
+
+        def vjp_fn(x):
+            return torch.func.vjp(loss, x)[1](torch.ones(()))[0]
+
+        x = torch.randn(4)
+        for fn, expected in (
+            (torch.func.grad(loss), torch.zeros(4)),
+            (vjp_fn, torch.zeros(4)),
+            (torch.func.jacrev(SinWithZeroBackward.apply), torch.zeros(4, 4)),
+        ):
+            torch._dynamo.reset()
+            self.assertEqual(fn(x), expected)
+            opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+            self.assertEqual(opt_fn(x), expected)
+
 
 instantiate_parametrized_tests(AutogradFunctionTests)
 

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -4619,6 +4619,21 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
+    def test_grad_requires_grad_read(self):
+        counters.clear()
+
+        def fn(x):
+            # _create_differentiable has already made x differentiable
+            return (x * (10.0 if x.requires_grad else 1.0)).sum()
+
+        def wrapper_fn(x):
+            return torch.func.grad(fn)(x)
+
+        x = torch.randn(3, 3)
+        expected = wrapper_fn(x)
+        actual = torch.compile(wrapper_fn, backend="aot_eager", fullgraph=True)(x)
+        self.assertEqual(actual, expected)
+
     def test_grad_freevar_tensor(self):
         counters.clear()
         y = torch.randn(3, 3)

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -511,6 +511,7 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
             "handle_current_stream",  # Safely implemented
             "handle_synchronize",  # Device type from function identity or arg
             "handle_functorch_autograd_grad",  # Only inspects placeholder metadata
+            "handle_set_tensor_requires_grad",  # Only re-reads the proxy's own metadata
         )
         for fn in handlers:
             if isinstance(fn, staticmethod) or inspect.ismethod(fn):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -3268,6 +3268,26 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 return ConstDictVariable(items)
             return result
 
+        @register(torch._functorch.eager_transforms._set_tensor_requires_grad)
+        def handle_set_tensor_requires_grad(
+            self, tx: "InstructionTranslatorBase", x: VariableTracker
+        ) -> VariableTracker:
+            # _create_differentiable flips requires_grad in place on the tensor
+            # functorch wrapped for grad/vjp, so re-read x's metadata from the
+            # fake tensor rather than leaving the stale requires_grad=False.
+            result = wrap_fx_proxy(
+                tx=tx,
+                proxy=tx.output.create_proxy(
+                    "call_function",
+                    torch._functorch.eager_transforms._set_tensor_requires_grad,
+                    (x.as_proxy(),),
+                    {},
+                ),
+            )
+            # pyrefly: ignore [missing-attribute]
+            x.synchronize_attributes(tx)
+            return result
+
         @register(torch._functorch.eager_transforms._autograd_grad)
         def handle_functorch_autograd_grad(
             self,


### PR DESCRIPTION
## Issue

Fixes #193279

## Summary

`_create_differentiable` flips `requires_grad` via `_set_tensor_requires_grad`, an in-graph function whose mutation never reached its `TensorVariable`. `call_apply` gates autograd customization on that stale `False` (`misc.py:1118`), so it inlined `forward` and dropped the custom `backward`. The fix re-syncs metadata after fake propagation; the graph node is unchanged. Any `x.requires_grad` read in a transform was stale too - second test.

Behaviour change: a custom `vjp` or `jvp` now hits its pre-existing graph break under `func.grad` (`misc.py:1143`, `:1158`); both were previously inlined, so a `fullgraph=True` compile that happened to be correct now errors, as `.backward()` already does. It also fails #193277's new `test_custom_jvp_under_func_grad_does_not_graph_break`; whichever lands second updates it. Happy to rebase behind it (same reporter, forward-mode half).

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No

---
AI assistance was used (Opus 5)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98