### PR TITLE
[Inductor] Reland Query DeviceInterface for device identity and capability

### DIFF
--- a/test/inductor/test_device_identity.py
+++ b/test/inductor/test_device_identity.py
@@ -1,0 +1,310 @@
+# Owner(s): ["module: inductor"]
+import unittest
+
+import torch
+from torch._dynamo.device_interface import (
+    CpuInterface,
+    CudaInterface,
+    DeviceInterface,
+    get_interface_for_device,
+    MpsInterface,
+    MtiaInterface,
+    register_interface_for_device,
+    TpuInterface,
+    XpuInterface,
+)
+from torch._inductor.runtime.hints import DeviceProperties
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestDeviceInterfaceCapabilityBits(TestCase):
+    """Test the new capability bits added to DeviceInterface (is_gpu,
+    exposes_streams, get_multi_processor_count)."""
+
+    def test_base_defaults(self):
+        """Base DeviceInterface returns safe defaults for all bits."""
+        self.assertFalse(DeviceInterface.is_gpu())
+        self.assertFalse(DeviceInterface.exposes_streams())
+
+    def test_cuda_declares_gpu(self):
+        """CUDA is a GPU with streams."""
+        self.assertTrue(CudaInterface.is_gpu())
+        self.assertTrue(CudaInterface.exposes_streams())
+
+    def test_xpu_declares_gpu(self):
+        """XPU is a GPU with streams."""
+        self.assertTrue(XpuInterface.is_gpu())
+        self.assertTrue(XpuInterface.exposes_streams())
+
+    def test_mtia_declares_gpu(self):
+        """MTIA is a GPU with streams and a hard-coded core count."""
+        self.assertTrue(MtiaInterface.is_gpu())
+        self.assertTrue(MtiaInterface.exposes_streams())
+        self.assertEqual(MtiaInterface.get_multi_processor_count(), 64)
+
+    def test_mps_is_gpu_without_streams(self):
+        """MPS is a GPU but does NOT expose streams.  This is the key
+        combination that ensures device_need_guard('mps') == False."""
+        self.assertTrue(MpsInterface.is_gpu())
+        self.assertFalse(MpsInterface.exposes_streams())
+
+    def test_cpu_is_not_gpu(self):
+        """CPU is not a GPU.  is_triton_capable must not crash even without triton."""
+        self.assertFalse(CpuInterface.is_gpu())
+        # Must not raise; returns a bool reflecting backend presence.
+        self.assertIsInstance(CpuInterface.is_triton_capable(), bool)
+
+    def test_tpu_is_not_gpu(self):
+        """TPU is not a GPU."""
+        self.assertFalse(TpuInterface.is_gpu())
+
+
+class TestIsGpuPredicate(TestCase):
+    """Test that is_gpu() queries DeviceInterface instead of a hard-coded list."""
+
+    def test_known_gpu_returns_true(self):
+        """is_gpu returns True for devices whose interface declares is_gpu()."""
+        from torch._inductor.utils import is_gpu
+
+        self.assertTrue(is_gpu("cuda"))
+        self.assertTrue(is_gpu("xpu"))
+        self.assertTrue(is_gpu("mps"))
+        self.assertTrue(is_gpu("mtia"))
+
+    def test_known_non_gpu_returns_false(self):
+        """is_gpu returns False for devices whose interface does not opt in."""
+        from torch._inductor.utils import is_gpu
+
+        self.assertFalse(is_gpu("cpu"))
+        self.assertFalse(is_gpu("tpu"))
+
+    def test_none_returns_false(self):
+        """is_gpu(None) returns False (guard against None input)."""
+        from torch._inductor.utils import is_gpu
+
+        self.assertFalse(is_gpu(None))
+
+    def test_unknown_device_returns_false(self):
+        """An unregistered device does not crash and is treated as non-GPU."""
+        from torch._inductor.utils import is_gpu
+
+        self.assertFalse(is_gpu("nonexistent_device_xyz"))
+
+    def test_privateuse1_gpu_after_opt_in(self):
+        """A PrivateUse1 backend that declares is_gpu()=True is recognized."""
+        from torch._inductor.utils import is_gpu
+
+        # Create a minimal GPU-like interface and register it
+        class AccInterface(DeviceInterface):
+            @staticmethod
+            def is_gpu() -> bool:
+                return True
+
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+        register_interface_for_device("acc_test", AccInterface)
+        try:
+            self.assertTrue(is_gpu("acc_test"))
+        finally:
+            # Clean up: remove the test registration.  The device_interfaces
+            # dict keeps registrations for the lifetime of the process, so
+            # we must explicitly delete our entry.
+            from torch._dynamo import device_interface as di
+
+            di.device_interfaces.pop("acc_test", None)
+
+
+class TestDeviceNeedGuard(TestCase):
+    """Test that device_need_guard derives from is_gpu + exposes_streams."""
+
+    def test_cuda_needs_guard(self):
+        from torch._inductor.utils import device_need_guard
+
+        self.assertTrue(device_need_guard("cuda"))
+
+    def test_mps_does_not_need_guard(self):
+        """MPS is a GPU but lacks streams -> guard not needed."""
+        from torch._inductor.utils import device_need_guard
+
+        self.assertFalse(device_need_guard("mps"))
+
+    def test_cpu_does_not_need_guard(self):
+        from torch._inductor.utils import device_need_guard
+
+        self.assertFalse(device_need_guard("cpu"))
+
+    def test_privateuse1_device_need_guard_after_opt_in(self):
+        """A PrivateUse1 backend declaring is_gpu()=True with a real Stream
+        class is recognized by device_need_guard."""
+        from torch._inductor.utils import device_need_guard
+
+        class AccStream:
+            pass
+
+        class AccInterface(DeviceInterface):
+            Stream = AccStream
+
+            @staticmethod
+            def is_gpu() -> bool:
+                return True
+
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+        register_interface_for_device("acc_guard", AccInterface)
+        try:
+            self.assertTrue(device_need_guard("acc_guard"))
+        finally:
+            from torch._dynamo import device_interface as di
+
+            di.device_interfaces.pop("acc_guard", None)
+
+
+class TestHasTriton(TestCase):
+    """Test has_triton() walks the DeviceInterface registry."""
+
+    def test_has_triton_discovers_privateuse1_device(self):
+        """A registered PrivateUse1 interface declaring is_triton_capable()
+        is discovered by has_triton()."""
+        try:
+            import triton  # noqa: F401
+        except ImportError as err:
+            raise unittest.SkipTest("triton package not available") from err
+
+        from torch.utils._triton import has_triton_package
+
+        if not has_triton_package():
+            raise unittest.SkipTest("triton package not available")
+
+        class AccInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @staticmethod
+            def is_triton_capable(device=None) -> bool:
+                return True
+
+            @classmethod
+            def raise_if_triton_unavailable(cls, device=None) -> None:
+                pass  # no-op: backend is available
+
+        register_interface_for_device("acc_triton", AccInterface)
+        torch.utils._triton.has_triton.cache_clear()
+        try:
+            self.assertTrue(torch.utils._triton.has_triton())
+        finally:
+            torch.utils._triton.has_triton.cache_clear()
+            from torch._dynamo import device_interface as di
+
+            di.device_interfaces.pop("acc_triton", None)
+
+
+class TestGetGpuType(TestCase):
+    """Test get_gpu_type() disambiguation."""
+
+    def test_returns_string(self):
+        from torch._inductor.utils import get_gpu_type
+
+        # Must clear the cache so we don't get a stale result from
+        # another test's registration.
+        get_gpu_type.cache_clear()
+        try:
+            gpu = get_gpu_type()
+            self.assertIsInstance(gpu, str)
+        finally:
+            get_gpu_type.cache_clear()
+
+    def test_falls_back_to_cuda_when_no_gpu_available(self):
+        """When no GPU is available, get_gpu_type() returns 'cuda'."""
+        from torch._inductor.utils import _gpu_types, get_gpu_type
+
+        get_gpu_type.cache_clear()
+        try:
+            gpu = get_gpu_type()
+            self.assertIsInstance(gpu, str)
+            # On a machine with no GPU, fallback is "cuda"
+            if not any(
+                get_interface_for_device(t).is_available() for t in _gpu_types()
+            ):
+                self.assertEqual(gpu, "cuda")
+        finally:
+            get_gpu_type.cache_clear()
+
+    def test_privateuse1_discovered_by_get_gpu_type(self):
+        """A PrivateUse1 backend declaring is_gpu()=True appears in the
+        gpu-type enumeration and is recognized by get_gpu_type."""
+        from torch._inductor.utils import _gpu_types, get_gpu_type
+
+        class AccInterface(DeviceInterface):
+            @staticmethod
+            def is_gpu() -> bool:
+                return True
+
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+        register_interface_for_device("acc_gpu_type", AccInterface)
+        get_gpu_type.cache_clear()
+        try:
+            self.assertIn("acc_gpu_type", _gpu_types())
+        finally:
+            get_gpu_type.cache_clear()
+            from torch._dynamo import device_interface as di
+
+            di.device_interfaces.pop("acc_gpu_type", None)
+
+    def test_privateuse1_disambiguation_via_accelerator(self):
+        """When two GPU types coexist (len(avail_gpus)!=1),
+        get_gpu_type() picks the one reported by
+        torch.accelerator.current_accelerator(), matching C++
+        getAccelerator() priority."""
+        from unittest import mock
+
+        from torch._inductor.utils import get_gpu_type
+
+        class AccInterface(DeviceInterface):
+            @staticmethod
+            def is_gpu() -> bool:
+                return True
+
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+        register_interface_for_device("acc_a", AccInterface)
+        register_interface_for_device("acc_b", AccInterface)
+        get_gpu_type.cache_clear()
+        try:
+            fake_acc = mock.MagicMock()
+            fake_acc.type = "acc_a"
+            with mock.patch.object(
+                torch.accelerator, "current_accelerator", return_value=fake_acc
+            ):
+                self.assertEqual(get_gpu_type(), "acc_a")
+        finally:
+            get_gpu_type.cache_clear()
+            from torch._dynamo import device_interface as di
+
+            di.device_interfaces.pop("acc_a", None)
+            di.device_interfaces.pop("acc_b", None)
+
+
+class TestDevicePropertiesCreate(TestCase):
+    """Test DeviceProperties.create() uses the contract method."""
+
+    def test_create_for_cpu(self):
+        """DeviceProperties.create works for CPU (the one device always available)."""
+        device = torch.device("cpu")
+        props = DeviceProperties.create(device)
+        self.assertIsInstance(props, DeviceProperties)
+        self.assertEqual(props.type, "cpu")
+        self.assertGreater(props.multi_processor_count, 0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_device_identity.py
+++ b/test/inductor/test_device_identity.py
@@ -1,6 +1,4 @@
 # Owner(s): ["module: inductor"]
-import unittest
-
 import torch
 from torch._dynamo.device_interface import (
     CpuInterface,
@@ -49,10 +47,8 @@ class TestDeviceInterfaceCapabilityBits(TestCase):
         self.assertFalse(MpsInterface.exposes_streams())
 
     def test_cpu_is_not_gpu(self):
-        """CPU is not a GPU.  is_triton_capable must not crash even without triton."""
+        """CPU is not a GPU."""
         self.assertFalse(CpuInterface.is_gpu())
-        # Must not raise; returns a bool reflecting backend presence.
-        self.assertIsInstance(CpuInterface.is_triton_capable(), bool)
 
     def test_tpu_is_not_gpu(self):
         """TPU is not a GPU."""
@@ -161,46 +157,6 @@ class TestDeviceNeedGuard(TestCase):
             from torch._dynamo import device_interface as di
 
             di.device_interfaces.pop("acc_guard", None)
-
-
-class TestHasTriton(TestCase):
-    """Test has_triton() walks the DeviceInterface registry."""
-
-    def test_has_triton_discovers_privateuse1_device(self):
-        """A registered PrivateUse1 interface declaring is_triton_capable()
-        is discovered by has_triton()."""
-        try:
-            import triton  # noqa: F401
-        except ImportError as err:
-            raise unittest.SkipTest("triton package not available") from err
-
-        from torch.utils._triton import has_triton_package
-
-        if not has_triton_package():
-            raise unittest.SkipTest("triton package not available")
-
-        class AccInterface(DeviceInterface):
-            @staticmethod
-            def is_available() -> bool:
-                return True
-
-            @staticmethod
-            def is_triton_capable(device=None) -> bool:
-                return True
-
-            @classmethod
-            def raise_if_triton_unavailable(cls, device=None) -> None:
-                pass  # no-op: backend is available
-
-        register_interface_for_device("acc_triton", AccInterface)
-        torch.utils._triton.has_triton.cache_clear()
-        try:
-            self.assertTrue(torch.utils._triton.has_triton())
-        finally:
-            torch.utils._triton.has_triton.cache_clear()
-            from torch._dynamo import device_interface as di
-
-            di.device_interfaces.pop("acc_triton", None)
 
 
 class TestGetGpuType(TestCase):

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -594,12 +594,7 @@ class CpuInterface(DeviceInterface):
 
     @staticmethod
     def is_triton_capable(device: torch.types.Device = None) -> bool:
-        try:
-            import triton.backends
-        except ModuleNotFoundError:
-            return False
-
-        return "cpu" in triton.backends.backends
+        return True
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -157,6 +157,40 @@ class DeviceInterface:
         """
         return False
 
+    @staticmethod
+    def is_gpu() -> bool:
+        """Return True if Inductor should treat this device as a GPU-class
+        accelerator (device guards, GPU codegen/fusion, cudagraph
+        eligibility).  Defaults to False so that unknown backends are
+        conservatively treated as non-GPU until they explicitly opt in."""
+        return False
+
+    @classmethod
+    def exposes_streams(cls) -> bool:
+        """Return True if this device exposes a stream abstraction.
+        Derived from whether the ``Stream`` slot has been overridden by a
+        subclass -- backends with a real Stream implementation (CUDA, XPU,
+        MTIA) automatically get True; backends that inherit the placeholder
+        (MPS) automatically get False."""
+        return cls.Stream is not DeviceInterface.Stream
+
+    @classmethod
+    def get_multi_processor_count(cls, device: torch.types.Device = None) -> int:
+        """Return the number of compute units, used for occupancy /
+        reduction heuristics / max-autotune heuristics.  Defaults to
+        reading the standard field ``multi_processor_count`` from device
+        properties; backends whose native field name differs (XPU, MTIA)
+        must override."""
+        props = cls.get_device_properties(device)
+        mp_count = getattr(props, "multi_processor_count", None)
+        if mp_count is None:
+            raise AttributeError(
+                f"{cls.__name__} must override get_multi_processor_count "
+                f"because its device properties do not expose the standard "
+                f"field 'multi_processor_count'"
+            )
+        return mp_count
+
     @classmethod
     def raise_if_triton_unavailable(cls, device: torch.types.Device = None) -> None:
         """
@@ -270,6 +304,10 @@ class CudaInterface(DeviceInterface):
         return torch.cuda.is_available()
 
     @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
     def get_compute_capability(device: torch.types.Device = None) -> int | str:
         if torch.version.hip is None:
             major, min = torch.cuda.get_device_capability(device)
@@ -375,6 +413,14 @@ class MtiaInterface(DeviceInterface):
         return ret
 
     @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @classmethod
+    def get_multi_processor_count(cls, device: torch.types.Device = None) -> int:
+        return 64
+
+    @staticmethod
     def get_compute_capability(device: torch.types.Device = None) -> Any:
         cc = torch.mtia.get_device_capability(device)
         return cc
@@ -460,6 +506,14 @@ class XpuInterface(DeviceInterface):
         return torch.xpu.is_available()
 
     @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @classmethod
+    def get_multi_processor_count(cls, device: torch.types.Device = None) -> int:
+        return cls.get_device_properties(device).gpu_subslice_count
+
+    @staticmethod
     def get_compute_capability(device: torch.types.Device = None) -> Any:
         cc = torch.xpu.get_device_capability(device)
         return cc
@@ -535,8 +589,17 @@ class CpuInterface(DeviceInterface):
         pass
 
     @staticmethod
+    def is_gpu() -> bool:
+        return False
+
+    @staticmethod
     def is_triton_capable(device: torch.types.Device = None) -> bool:
-        return True
+        try:
+            import triton.backends
+        except ModuleNotFoundError:
+            return False
+
+        return "cpu" in triton.backends.backends
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
@@ -564,6 +627,10 @@ class MpsInterface(DeviceInterface):
     @staticmethod
     def is_available() -> bool:
         return torch.backends.mps.is_available()
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
 
     @staticmethod
     def current_device() -> int:
@@ -610,6 +677,10 @@ class TpuInterface(DeviceInterface):
     @staticmethod
     def is_available() -> bool:
         return has_torch_tpu()
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return False
 
     @staticmethod
     def current_device() -> int:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
     CompiledModule = ModuleType | FileBackedGraphModule
 
 from torch._inductor.codecache import output_code_log
+from torch._inductor.utils import is_gpu
 
 
 log = logging.getLogger(__name__)
@@ -2594,7 +2595,7 @@ class GraphLowering(torch.fx.Interpreter):
         `cpp_wrapper_cpu.py`).
         """
         self.validate_can_generate_cpp_wrapper()
-        has_gpu = any(device in self.device_types for device in ["cuda", "xpu"])
+        has_gpu = any(ir.is_triton(device) for device in self.device_types)
         # CPU + user-defined Triton + AOTI + autotune block disabled is the
         # only CPU configuration that needs the two-pass dance: the autotune
         # block normally populates CpuTritonKernelCache, but here it doesn't run.
@@ -2904,7 +2905,7 @@ class GraphLowering(torch.fx.Interpreter):
         # A "cpu" device would precompile cpp_wrapper/cpu.h, which does not
         # include the CUDA headers needed to compile the kernel call sites.
         device_type = next(
-            (d for d in self.device_types if d in ("cuda", "xpu")),
+            (d for d in self.device_types if is_gpu(d)),
             next((d for d in self.device_types if d != "meta"), "cpu"),
         )
 

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -199,15 +199,7 @@ class DeviceProperties(typing.NamedTuple):
 
         device_interface = get_interface_for_device(device)
         props = device_interface.get_device_properties(device)
-        try:
-            multi_processor_count = props.multi_processor_count
-        except AttributeError:
-            if device_type == "xpu":
-                multi_processor_count = props.gpu_subslice_count
-            elif device_type == "mtia":
-                multi_processor_count = 64
-            else:
-                raise
+        multi_processor_count = device_interface.get_multi_processor_count(device)
         return cls(
             type=device_type,
             index=device.index,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -104,24 +104,49 @@ if TYPE_CHECKING:
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
 
 
+# GPU_TYPES is a static list retained for backward compatibility.
+# It will NOT include PrivateUse1 backends even after they declare
+# is_gpu()=True.  For membership tests use the is_gpu() predicate; for
+# enumeration use _gpu_types() or get_gpu_type().  Several call-sites
+# still iterate GPU_TYPES (grep for "GPU_TYPES") and will silently
+# exclude PrivateUse1 backends until migrated to is_gpu() / _gpu_types().
 GPU_TYPES = ["cuda", "mps", "xpu", "mtia"]
 T = TypeVar("T")
 
 
-# defines here before import torch._dynamo is for avoiding circular import
-# when get_gpu_type is imported from dynamo
-@functools.cache
-def get_gpu_type() -> str:
-    avail_gpus = [x for x in GPU_TYPES if getattr(torch, x).is_available()]
-    if not len(avail_gpus) <= 1:
-        raise AssertionError(
-            f"Expected at most 1 available GPU type, got {len(avail_gpus)}: {avail_gpus}"
-        )
-    gpu_type = "cuda" if len(avail_gpus) == 0 else avail_gpus.pop()
-    return gpu_type
+def _gpu_types() -> list[str]:
+    """Private: walk the registered DeviceInterface registry and return
+    device-type names for which is_gpu() returns True.  Used only by
+    get_gpu_type() and the GPU_TYPES compatibility shim."""
+    from torch._dynamo.device_interface import get_registered_device_interfaces
+
+    return [
+        d
+        for d, iface in get_registered_device_interfaces()
+        if ":" not in d and iface.is_gpu()
+    ]  # filter "cuda:0"-style indexed entries
 
 
 from torch._dynamo.device_interface import get_interface_for_device
+
+
+@functools.cache
+def get_gpu_type() -> str:
+    avail_gpus = [t for t in _gpu_types() if get_interface_for_device(t).is_available()]
+    if len(avail_gpus) == 1:
+        return avail_gpus[0]
+    # Coexistence disambiguation: PrivateUse1 first, matching the
+    # priority of C++ getAccelerator().  Guard that the accelerator is
+    # actually present and GPU-class; otherwise fall through to the
+    # first available GPU (or "cuda" if none).
+    acc = torch.accelerator.current_accelerator()
+    if acc is not None and is_gpu(acc.type) and acc.type in avail_gpus:
+        return acc.type
+    # Fallthrough: return the first available GPU (dict-registration order,
+    # best-effort), or "cuda" if none are available.
+    return avail_gpus[0] if avail_gpus else "cuda"
+
+
 from torch._dynamo.utils import detect_fake_mode
 from torch.autograd import DeviceType
 from torch.autograd.profiler_util import EventList
@@ -3438,7 +3463,12 @@ def get_cloned_parameter_buffer_name(name: str) -> str:
 
 
 def is_gpu(device: str | None) -> bool:
-    return device in GPU_TYPES
+    if device is None:
+        return False
+    try:
+        return get_interface_for_device(device).is_gpu()
+    except NotImplementedError:
+        return False
 
 
 def is_rocm() -> bool:
@@ -3522,7 +3552,11 @@ def is_triton_fp8_dtype_supported(
 
 
 def device_need_guard(device: str) -> bool:
-    return device != "mps" and is_gpu(device)  # TODO: MPS does not expose streams now
+    try:
+        iface = get_interface_for_device(device)
+    except NotImplementedError:
+        return False
+    return iface.is_gpu() and iface.exposes_streams()
 
 
 def needs_fallback_due_to_atomic_add_limitations(dtype: torch.dtype) -> bool:


### PR DESCRIPTION
Reland of #190615, which was reverted following an internal revert.

Original PR: #190615
Original landed commit: 80216c67ae7a3ac5635e1c4dacf80cfa21fd53b6
Revert commit: 2773fe021c50d2a6c0e45376ba23f9538ff5e10e

This PR reapplies the DeviceInterface device identity and capability changes from #190615.

Since #190324 has landed in the meantime, this reland drops the redundant Triton-specific changes and tests that are now covered by the upstream Triton DeviceInterface implementation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98