### PR TITLE
[Dynamo] Separate TupleIteratorVariable from ListIteratorVariable

### DIFF
--- a/test/dynamo/test_generator.py
+++ b/test/dynamo/test_generator.py
@@ -1232,6 +1232,17 @@ class TestGeneratorSend(GeneratorTestsBase):
         self.assertEqual(out[1], t.cos())
         self.assertIsNone(out[2])
 
+    def test_yield_from_tuple_iterator(self):
+        def outer(t):
+            yield from iter((t.sin(), t.cos()))
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(t):
+            return list(outer(t))
+
+        t = torch.randn(2)
+        self.assertEqual(fn(t), [t.sin(), t.cos()])
+
 
 class TestGeneratorClose(GeneratorTestsBase):
     def test_close(self):

--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -153,6 +153,21 @@ class TestIterators(torch._dynamo.test_case.TestCase):
             result.append(item + 10)
         self.assertEqual(result, [11, 12, 13, 14, 15])
 
+    def test_tuple_iterator_variable_hierarchy(self):
+        from torch._dynamo.variables.lists import (
+            BaseListIteratorVariable,
+            ListIteratorVariable,
+            TupleIteratorVariable,
+        )
+
+        self.assertTrue(issubclass(ListIteratorVariable, BaseListIteratorVariable))
+        self.assertTrue(issubclass(TupleIteratorVariable, BaseListIteratorVariable))
+        self.assertFalse(issubclass(TupleIteratorVariable, ListIteratorVariable))
+
+        self.assertIs(ListIteratorVariable._cpython_type, type(iter([])))
+        self.assertIs(TupleIteratorVariable._cpython_type, type(iter(())))
+        self.assertIs(TupleIteratorVariable([]).python_type(), type(iter(())))
+
     @make_dynamo_test
     def test_set_iteration(self):
         """Test iteration over set"""

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -2017,13 +2017,13 @@ def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
 
 @register_side_effect_replay_handler(
     name="list_iterator_mutation",
-    matcher=lambda ctx: isinstance(ctx.var, variables.ListIteratorVariable),
+    matcher=lambda ctx: isinstance(ctx.var, variables.BaseListIteratorVariable),
     priority=30,
 )
 def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    if not isinstance(var, variables.ListIteratorVariable):
+    if not isinstance(var, variables.BaseListIteratorVariable):
         raise AssertionError(type(var))
     for _ in range(var.index):
         cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -181,6 +181,7 @@ from .variables.functions import (
 from .variables.iter import MAX_ITERATOR_LIMIT
 from .variables.lazy import LazyVariableTracker
 from .variables.lists import (
+    BaseListIteratorVariable,
     BaseListVariable,
     ListIteratorVariable,
     ListVariable,
@@ -6548,7 +6549,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
 
     def GET_YIELD_FROM_ITER(self, inst: Instruction) -> None:
         tos = self.stack[-1]
-        if not isinstance(tos, ListIteratorVariable):
+        if not isinstance(tos, BaseListIteratorVariable):
             self.pop()
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]
             self.push(res)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1308,6 +1308,7 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.DequeVariable,
             variables.ListVariable,
             variables.ListIteratorVariable,
+            variables.TupleIteratorVariable,
             variables.RangeVariable,
             variables.SetVariable,
             variables.TensorVariable,

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -120,6 +120,7 @@ from .iter import (
 )
 from .lazy import LazyConstantVariable, LazyVariableTracker
 from .lists import (
+    BaseListIteratorVariable,
     BaseListVariable,
     DequeVariable,
     ListIteratorVariable,
@@ -216,6 +217,7 @@ __all__ = [
     "AutogradFunctionVariable",
     "BackwardHookVariable",
     "BaseBuiltinVariable",
+    "BaseListIteratorVariable",
     "BaseListVariable",
     "CallMethodVariable",
     "BuiltinVariable",

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -2345,10 +2345,7 @@ class SliceVariable(VariableTracker):
     tp_methods = {"indices": Method(indices)}
 
 
-class ListIteratorVariable(IteratorVariable):
-    # PyListIter_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3842
-    _cpython_type = type(iter([]))
-
+class BaseListIteratorVariable(IteratorVariable):
     _nonvar_fields = {
         "index",
         *IteratorVariable._nonvar_fields,
@@ -2389,9 +2386,6 @@ class ListIteratorVariable(IteratorVariable):
     ) -> ConstantVariable:
         return VariableTracker.build(tx, hasattr(iter([]), name))
 
-    def python_type(self) -> type:
-        return type(iter([]))
-
     def as_python_constant(self) -> Any:
         if self.index > 0:
             raise NotImplementedError
@@ -2420,9 +2414,20 @@ class ListIteratorVariable(IteratorVariable):
         codegen.extend_output(create_call_function(1, False))
 
 
-class TupleIteratorVariable(ListIteratorVariable):
+class ListIteratorVariable(BaseListIteratorVariable):
+    # PyListIter_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3842
+    _cpython_type = type(iter([]))
+
+    def python_type(self) -> type:
+        return type(iter([]))
+
+
+class TupleIteratorVariable(BaseListIteratorVariable):
     # PyTupleIter_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L1067
     _cpython_type = type(iter(()))
+
+    def python_type(self) -> type:
+        return type(iter(()))
 
 
 class DequeIteratorVariable(ListIteratorVariable):


### PR DESCRIPTION
## Summary 
Fixes part of #192874 by separating `TupleIteratorVariable` from `ListIteratorVariable`, matching CPython where `tuple_iterator` is not a subclass of `list_iterator`. 
This PR: 
- introduces `BaseListIteratorVariable` for shared iterator behavior 
- makes `ListIteratorVariable` and `TupleIteratorVariable` sibling subclasses 
- preserves the distinct CPython types through `_cpython_type` and `python_type()` 
- updates `yield from` handling and side-effect replay to use the shared base 
- explicitly includes `TupleIteratorVariable` in the iterable unpacking fast path 
- adds regression tests for the hierarchy and tuple iterator delegation Deque iterator inheritance is intentionally unchanged and remains outside this PR’s scope. 
## Testing 
- `python test/dynamo/test_iterators.py` 
- `python test/dynamo/test_generator.py` 
- `python test/dynamo/test_subgraphs.py` 
- `spin lint` 
- Python lint checks passed 
- the aggregate command’s clang-tidy phase could not run because the local checkout has no `build/` compilation database

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98