### PR TITLE
Reject key and value with different sequence lengths in SDPA

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -550,6 +550,14 @@ inline void validate_sdpa_input(
       query_.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
       "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
       query_.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead.");
+  // Nested tensors carry an irregular sequence dimension, so the sizes are not
+  // comparable this way for them.
+  if (!key.is_nested() && !value.is_nested()) {
+    TORCH_CHECK(
+        key.sym_size(-2) == value.sym_size(-2),
+        "Expected key and value to have the same sequence length, but got key.size(-2): ",
+        key.sym_size(-2), " and value.size(-2): ", value.sym_size(-2), " instead.");
+  }
   if (attn_mask_.has_value()){
     TORCH_CHECK(
       !is_causal,
@@ -999,6 +1007,8 @@ _scaled_dot_product_flash_attention_cpu(
     "scaled_dot_product_attention_flash_attention: Currently do not support dropout > 0");
   TORCH_CHECK((query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
     "scaled_dot_product_attention_flash_attention: Q/K/V should have the same head size");
+  TORCH_CHECK(key.size(2) == value.size(2),
+    "scaled_dot_product_attention_flash_attention: K/V should have the same sequence length");
   TORCH_CHECK(!attn_mask.has_value() ||
           attn_mask.value().scalar_type() == at::kFloat ||
           dtype == attn_mask.value().scalar_type(),

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2090,6 +2090,19 @@ class TestSDPAFailureModes(NNTestCase):
             value = torch.randn(shape, dtype=torch.float16, device=device)
             self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value))
 
+    @parametrize("kernel", [SDPBackend.MATH, SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION])
+    def test_invalid_inputs_different_kv_seq_lengths(self, device, kernel: SDPBackend):
+        with sdpa_kernel(backends=[kernel]):
+            # Key and value have to describe the same positions. The CPU flash
+            # kernel takes the number of keys from the value and then walks the
+            # key pointer that far, so a longer value reads past the key.
+            query = torch.randn(1, 1, 3, 8, dtype=torch.float32, device=device)
+            key = torch.randn(1, 1, 5, 8, dtype=torch.float32, device=device)
+            value = torch.randn(1, 1, 6, 8, dtype=torch.float32, device=device)
+            self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value))
+            # and with the longer one as the key
+            self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, value, key))
+
     @onlyAccelerator
     @parametrize("kernel", [SDPBackend.MATH, SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION])
     def test_invalid_inputs_different_devices(self, device, kernel: SDPBackend):


### PR DESCRIPTION
## The bug

`scaled_dot_product_attention` documents `key` as `(N, ..., S, E)` and `value` as `(N, ..., S, Ev)`, with the same `S`. Nothing enforces it, and the CPU flash-attention kernel takes its key count from the **value**: `FlashAttentionKernel.cpp` sets `kvSize` from `value.size(1)` and then walks the key pointer to that length. A value longer than the key reads past the end of the key allocation.

```python
q = torch.randn(1, 1, 3, 8)
k = torch.randn(1, 1, 5, 8)   # key   S = 5
v = torch.randn(1, 1, 6, 8)   # value S = 6
F.scaled_dot_product_attention(q, k, v)   # returns (1, 1, 3, 8), no error
```

**It is a heap over-read, not a zero pad.** Making the key a view over a buffer whose next row is `7.0`, the output matches attention over *that* row and not over a zero row:

```
output == attention over ZERO-padded key           : False
output == attention over the NEXT ROW IN MEMORY    : True
```

A large overrun faults outright:

```
q(1,1,1,8), k(1,1,1,8), v(1,1,4_000_000,8)   ->   killed by signal SIGBUS
```

**CPU flash is the only path that accepts it.** The MATH backend and the meta kernel both already raise, so the same program is valid or invalid depending on the backend that happens to be selected:

```
MATH               : RuntimeError, Expected size for first two dimensions of batch2 tensor ...
meta               : RuntimeError, same
FLASH_ATTENTION    : silently returns
EFFICIENT_ATTENTION: RuntimeError
```

## The change

Two checks, following the placement reasoning of the adjacent checks in the same file.

1. `validate_sdpa_input` gives the public operator one clear message on every device, instead of MATH's incidental `bmm` error. It is guarded on `!key.is_nested() && !value.is_nested()`, since a nested tensor's sequence dimension is irregular and not comparable this way.
2. `_scaled_dot_product_flash_attention_cpu` is reachable directly and is the one that reads out of bounds, so it gets its own check, next to the existing head-size check it mirrors (`size(3)` for head size, `size(2)` for sequence length).

## Tests

`test_invalid_inputs_different_kv_seq_lengths` in `TestSDPAFailureModes`, next to `test_invalid_inputs_different_datatypes` and parametrized over the same three backends. It asserts `RuntimeError` for key `S=5` with value `S=6` and for the reverse.

**What I ran, and what I could not.** I cannot build ATen in this environment, so I could not run the suite against the patched C++. What I did run is the test body standalone against the released 2.11.0 CPU build, which shows exactly the gap this PR closes:

```
kernel=MATH                 key 5 / value 6  RuntimeError   pass
                            key 6 / value 5  RuntimeError   pass
kernel=FLASH_ATTENTION      key 5 / value 6  NO ERROR       FAIL
                            key 6 / value 5  NO ERROR       FAIL
kernel=EFFICIENT_ATTENTION  key 5 / value 6  RuntimeError   pass
                            key 6 / value 5  RuntimeError   pass
```

So the test fails today on the `FLASH_ATTENTION` parametrization only, which is the buggy path, and the new check in `validate_sdpa_input` raises before backend dispatch, making all three pass. I would appreciate CI confirming that, and I am happy to adjust the message text or the placement.

## Notes

Prior art: I did not find an issue or PR covering K/V sequence-length validation here. #191325 touches neighbouring checks in the same file but is about zero head counts and was closed unmerged. Self-found, so there is no linked issue; happy to file one first if maintainers prefer that route.
