### PR TITLE
[BE][Ez]: Update c10::complex kernels to use sincos

### DIFF
--- a/aten/src/ATen/native/cuda/ComplexKernel.cu
+++ b/aten/src/ATen/native/cuda/ComplexKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
+#include <c10/cuda/CUDAMathCompat.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -27,9 +28,12 @@ void polar_kernel_cuda(TensorIterator& iter) {
         gpu_kernel(
             iter,
             [] GPU_LAMBDA(scalar_t a, scalar_t b) -> c10::complex<scalar_t> {
+              opmath_t sin_b;
+              opmath_t cos_b;
+              c10::cuda::compat::sincos(opmath_t(b), &sin_b, &cos_b);
               return c10::complex<scalar_t>(
-                  static_cast<scalar_t>(opmath_t(a) * std::cos(opmath_t(b))),
-                  static_cast<scalar_t>(opmath_t(a) * std::sin(opmath_t(b))));
+                  static_cast<scalar_t>(opmath_t(a) * cos_b),
+                  static_cast<scalar_t>(opmath_t(a) * sin_b));
             });
       });
 }

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -22,7 +22,7 @@ namespace at::native {
 
 // custom min and max to be used in logaddexp for  complex arguments
 template <typename scalar_t, bool min>
-__device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__host__ __device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   scalar_t xr = std::real(x);
   scalar_t yr = std::real(y);
   if (::isnan(yr) || (::isnan(std::imag(y)))) {
@@ -37,7 +37,7 @@ __device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<scalar_t>
 }
 
 template <typename scalar_t>
-__device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
+__host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
   // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
   // Using the original expression: `at::_isnan(y) ? y : std::min(x, y)` causes an error in ROCM
   const auto isnan_x = at::_isnan(x);
@@ -54,7 +54,7 @@ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   const auto xreal = std::real(x);
@@ -62,14 +62,19 @@ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& 
   const auto exp_x_abs = std::exp(xreal);
   scalar_t sin_ximag;
   scalar_t cos_ximag;
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
+#else
+  sin_ximag = std::sin(ximag);
+  cos_ximag = std::cos(ximag);
+#endif
   auto exp_x_real = exp_x_abs * cos_ximag;
   auto exp_x_imag = exp_x_abs * sin_ximag;
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   const auto ximag = std::imag(x);
@@ -79,7 +84,12 @@ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_
   }
   scalar_t sin;
   scalar_t cos;
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   c10::cuda::compat::sincos(ximag, &sin, &cos);
+#else
+  sin = std::sin(ximag);
+  cos = std::cos(ximag);
+#endif
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -87,7 +97,7 @@ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logaddexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logaddexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -242,7 +252,7 @@ void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
 #else
     AT_DISPATCH_COMPLEX_TYPES_AND(at::ScalarType::ComplexHalf, iter.dtype(), "logaddexp_cuda", [&]() {
       using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, [] C10_DEVICE (scalar_t a_, scalar_t b_) -> scalar_t {
+      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a_, scalar_t b_) -> scalar_t {
         const auto a = static_cast<opmath_t>(a_);
         const auto b = static_cast<opmath_t>(b_);
         return static_cast<scalar_t>(_log_add_exp_helper(a, b));

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -8,7 +8,6 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/OpMathType.h>
-#include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/MathConstants.h>
 #include <c10/util/complex.h>
 
@@ -54,22 +53,19 @@ __host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   const auto xreal = std::real(x);
   const auto ximag = std::imag(x);
   const auto exp_x_abs = std::exp(xreal);
-  scalar_t sin_ximag;
-  scalar_t cos_ximag;
-  c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
-  auto exp_x_real = exp_x_abs * cos_ximag;
-  auto exp_x_imag = exp_x_abs * sin_ximag;
+  auto exp_x_real = exp_x_abs * std::cos(ximag);
+  auto exp_x_imag = exp_x_abs * std::sin(ximag);
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   const auto ximag = std::imag(x);
@@ -77,9 +73,8 @@ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_
   if (!::isfinite(ximag)) {  // add this to make consistent with std::exp(x+yi)
     return {exp_x_abs, std::numeric_limits<scalar_t>::quiet_NaN()};
   }
-  scalar_t sin;
-  scalar_t cos;
-  c10::cuda::compat::sincos(ximag, &sin, &cos);
+  const auto sin = std::sin(ximag);
+  const auto cos = std::cos(ximag);
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -87,7 +82,7 @@ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logaddexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logaddexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -176,11 +171,8 @@ const auto logaddexp_complex_string = jiterator_stringify(
         const auto xreal = x.real();
         const auto ximag = x.imag();
         const auto exp_x_abs = exp(xreal);
-        T sin_ximag;
-        T cos_ximag;
-        sincos(ximag, &sin_ximag, &cos_ximag);
-        auto exp_x_real = exp_x_abs * cos_ximag;
-        auto exp_x_imag = exp_x_abs * sin_ximag;
+        auto exp_x_real = exp_x_abs * cos(ximag);
+        auto exp_x_imag = exp_x_abs * sin(ximag);
         return std::complex<T>(exp_x_real, exp_x_imag);
     }
 
@@ -192,9 +184,8 @@ const auto logaddexp_complex_string = jiterator_stringify(
         if (!isfinite(ximag)) {
             return complex_t(exp_x_abs, NAN);
         }
-        T sin_val;
-        T cos_val;
-        sincos(ximag, &sin_val, &cos_val);
+        const auto sin_val = sin(ximag);
+        const auto cos_val = cos(ximag);
         auto exp_x_real = (cos_val == T(0)) ? T(0) : exp_x_abs * cos_val;
         auto exp_x_imag = (sin_val == T(0)) ? T(0) : exp_x_abs * sin_val;
         return complex_t(exp_x_real, exp_x_imag);

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/OpMathType.h>
+#include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/MathConstants.h>
 #include <c10/util/complex.h>
 
@@ -21,7 +22,7 @@ namespace at::native {
 
 // custom min and max to be used in logaddexp for  complex arguments
 template <typename scalar_t, bool min>
-__host__ __device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   scalar_t xr = std::real(x);
   scalar_t yr = std::real(y);
   if (::isnan(yr) || (::isnan(std::imag(y)))) {
@@ -36,7 +37,7 @@ __host__ __device__ c10::complex<scalar_t> _logaddexp_minmax(const c10::complex<
 }
 
 template <typename scalar_t>
-__host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
+__device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
   // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
   // Using the original expression: `at::_isnan(y) ? y : std::min(x, y)` causes an error in ROCM
   const auto isnan_x = at::_isnan(x);
@@ -53,19 +54,22 @@ __host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   const auto xreal = std::real(x);
   const auto ximag = std::imag(x);
   const auto exp_x_abs = std::exp(xreal);
-  auto exp_x_real = exp_x_abs * std::cos(ximag);
-  auto exp_x_imag = exp_x_abs * std::sin(ximag);
+  scalar_t sin_ximag;
+  scalar_t cos_ximag;
+  c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
+  auto exp_x_real = exp_x_abs * cos_ximag;
+  auto exp_x_imag = exp_x_abs * sin_ximag;
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   const auto ximag = std::imag(x);
@@ -73,8 +77,9 @@ __host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::comple
   if (!::isfinite(ximag)) {  // add this to make consistent with std::exp(x+yi)
     return {exp_x_abs, std::numeric_limits<scalar_t>::quiet_NaN()};
   }
-  const auto sin = std::sin(ximag);
-  const auto cos = std::cos(ximag);
+  scalar_t sin;
+  scalar_t cos;
+  c10::cuda::compat::sincos(ximag, &sin, &cos);
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -82,7 +87,7 @@ __host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::comple
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logaddexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logaddexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -237,7 +242,7 @@ void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
 #else
     AT_DISPATCH_COMPLEX_TYPES_AND(at::ScalarType::ComplexHalf, iter.dtype(), "logaddexp_cuda", [&]() {
       using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a_, scalar_t b_) -> scalar_t {
+      gpu_kernel(iter, [] C10_DEVICE (scalar_t a_, scalar_t b_) -> scalar_t {
         const auto a = static_cast<opmath_t>(a_);
         const auto b = static_cast<opmath_t>(b_);
         return static_cast<scalar_t>(_log_add_exp_helper(a, b));

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/OpMathType.h>
+#include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/MathConstants.h>
 #include <c10/util/complex.h>
 
@@ -53,19 +54,22 @@ __host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   const auto xreal = std::real(x);
   const auto ximag = std::imag(x);
   const auto exp_x_abs = std::exp(xreal);
-  auto exp_x_real = exp_x_abs * std::cos(ximag);
-  auto exp_x_imag = exp_x_abs * std::sin(ximag);
+  scalar_t sin_ximag;
+  scalar_t cos_ximag;
+  c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
+  auto exp_x_real = exp_x_abs * cos_ximag;
+  auto exp_x_imag = exp_x_abs * sin_ximag;
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   const auto ximag = std::imag(x);
@@ -73,8 +77,9 @@ __host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::comple
   if (!::isfinite(ximag)) {  // add this to make consistent with std::exp(x+yi)
     return {exp_x_abs, std::numeric_limits<scalar_t>::quiet_NaN()};
   }
-  const auto sin = std::sin(ximag);
-  const auto cos = std::cos(ximag);
+  scalar_t sin;
+  scalar_t cos;
+  c10::cuda::compat::sincos(ximag, &sin, &cos);
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -82,7 +87,7 @@ __host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::comple
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logaddexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logaddexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -171,8 +176,11 @@ const auto logaddexp_complex_string = jiterator_stringify(
         const auto xreal = x.real();
         const auto ximag = x.imag();
         const auto exp_x_abs = exp(xreal);
-        auto exp_x_real = exp_x_abs * cos(ximag);
-        auto exp_x_imag = exp_x_abs * sin(ximag);
+        T sin_ximag;
+        T cos_ximag;
+        sincos(ximag, &sin_ximag, &cos_ximag);
+        auto exp_x_real = exp_x_abs * cos_ximag;
+        auto exp_x_imag = exp_x_abs * sin_ximag;
         return std::complex<T>(exp_x_real, exp_x_imag);
     }
 
@@ -184,8 +192,9 @@ const auto logaddexp_complex_string = jiterator_stringify(
         if (!isfinite(ximag)) {
             return complex_t(exp_x_abs, NAN);
         }
-        const auto sin_val = sin(ximag);
-        const auto cos_val = cos(ximag);
+        T sin_val;
+        T cos_val;
+        sincos(ximag, &sin_val, &cos_val);
         auto exp_x_real = (cos_val == T(0)) ? T(0) : exp_x_abs * cos_val;
         auto exp_x_imag = (sin_val == T(0)) ? T(0) : exp_x_abs * sin_val;
         return complex_t(exp_x_real, exp_x_imag);

--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -14,7 +14,7 @@ namespace at::native {
 
 // custom min and max to be used in logcumsumexp for complex arguments
 template <typename scalar_t, bool min>
-__device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__host__ __device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   scalar_t xr = std::real(x);
   scalar_t yr = std::real(y);
   if (::isnan(yr) || (::isnan(std::imag(y)))) {
@@ -29,7 +29,7 @@ __device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::complex<scalar
 }
 
 template <typename scalar_t>
-__device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
+__host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
   // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
   // Using the original expression: `at::_isnan(y) ? y : std::min(x, y)` causes an error in ROCM
   auto isnan_x = at::_isnan(x);
@@ -46,7 +46,7 @@ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   auto xreal = std::real(x);
@@ -54,21 +54,31 @@ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& 
   auto exp_x_abs = std::exp(xreal);
   scalar_t sin_ximag;
   scalar_t cos_ximag;
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
+#else
+  sin_ximag = std::sin(ximag);
+  cos_ximag = std::cos(ximag);
+#endif
   auto exp_x_real = exp_x_abs * cos_ximag;
   auto exp_x_imag = exp_x_abs * sin_ximag;
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   auto ximag = std::imag(x);
   auto exp_x_abs = std::numeric_limits<scalar_t>::infinity();
   scalar_t sin;
   scalar_t cos;
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   c10::cuda::compat::sincos(ximag, &sin, &cos);
+#else
+  sin = std::sin(ximag);
+  cos = std::cos(ximag);
+#endif
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -76,7 +86,7 @@ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_
 }
 
 template <typename scalar_t>
-__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logcumsumexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logcumsumexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -112,7 +122,7 @@ void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase&
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
         scalar_t init = -std::numeric_limits<scalar_t>::infinity();
-        auto log_add_exp = [] C10_DEVICE (const scalar_t x_, const scalar_t y_) -> scalar_t {
+        auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x_, const scalar_t y_) -> scalar_t {
           const opmath_t x{x_}, y{y_};
           return _log_add_exp_helper(x, y);
         };

--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -5,6 +5,7 @@
 
 #include <ATen/native/cuda/ScanKernels.h>
 #include <ATen/native/cuda/ScanUtils.cuh>
+#include <c10/cuda/CUDAMathCompat.h>
 
 #include <cmath>
 #include <limits>
@@ -13,7 +14,7 @@ namespace at::native {
 
 // custom min and max to be used in logcumsumexp for complex arguments
 template <typename scalar_t, bool min>
-__host__ __device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   scalar_t xr = std::real(x);
   scalar_t yr = std::real(y);
   if (::isnan(yr) || (::isnan(std::imag(y)))) {
@@ -28,7 +29,7 @@ __host__ __device__ c10::complex<scalar_t> _logcumsumexp_minmax(const c10::compl
 }
 
 template <typename scalar_t>
-__host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
+__device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar_t& y) {
   // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
   // Using the original expression: `at::_isnan(y) ? y : std::min(x, y)` causes an error in ROCM
   auto isnan_x = at::_isnan(x);
@@ -45,25 +46,29 @@ __host__ __device__ scalar_t _log_add_exp_helper(const scalar_t& x, const scalar
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the x is finite (not inf nor nan)
   auto xreal = std::real(x);
   auto ximag = std::imag(x);
   auto exp_x_abs = std::exp(xreal);
-  auto exp_x_real = exp_x_abs * std::cos(ximag);
-  auto exp_x_imag = exp_x_abs * std::sin(ximag);
+  scalar_t sin_ximag;
+  scalar_t cos_ximag;
+  c10::cuda::compat::sincos(ximag, &sin_ximag, &cos_ximag);
+  auto exp_x_real = exp_x_abs * cos_ximag;
+  auto exp_x_imag = exp_x_abs * sin_ximag;
   return {exp_x_real, exp_x_imag};
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
+__device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::complex<scalar_t>& x) {
   // complex exponential function, but implemented manually to get fast compilation time
   // this function only handles the case where the real part of x is infinite
   auto ximag = std::imag(x);
   auto exp_x_abs = std::numeric_limits<scalar_t>::infinity();
-  auto sin = std::sin(ximag);
-  auto cos = std::cos(ximag);
+  scalar_t sin;
+  scalar_t cos;
+  c10::cuda::compat::sincos(ximag, &sin, &cos);
   // special case if the angle is exactly the multiple of pi/2
   auto exp_x_real = (cos == 0) ? (scalar_t)0.0 : exp_x_abs * cos;
   auto exp_x_imag = (sin == 0) ? (scalar_t)0.0 : exp_x_abs * sin;
@@ -71,7 +76,7 @@ __host__ __device__ c10::complex<scalar_t> _fast_build_exp_inf(const c10::comple
 }
 
 template <typename scalar_t>
-__host__ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+__device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
   c10::complex<scalar_t> min = _logcumsumexp_minmax<scalar_t, /*min=*/true>(x, y);
   c10::complex<scalar_t> max = _logcumsumexp_minmax<scalar_t, /*min=*/false>(x, y);
   scalar_t min_real = std::real(min);
@@ -107,7 +112,7 @@ void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase&
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;
         scalar_t init = -std::numeric_limits<scalar_t>::infinity();
-        auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x_, const scalar_t y_) -> scalar_t {
+        auto log_add_exp = [] C10_DEVICE (const scalar_t x_, const scalar_t y_) -> scalar_t {
           const opmath_t x{x_}, y{y_};
           return _log_add_exp_helper(x, y);
         };


### PR DESCRIPTION
Uses the fused sincos utility for polar_kernel_cuda which is equivalent, but faster and scales the input the same for both the sin and cos functions. Mathematically and FP identical but fewer instructions and smaller binary size.