### PR TITLE
[BE] Removing dead code from MPS (4/5)

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -7,13 +7,6 @@
 
 namespace at::mps {
 
-static inline MTLLanguageVersion getMetalLanguageVersion(const id<MTLDevice>& device) {
-  // MPS Advanced Indexing needs at least Metal 2.0 (support for Argument Buffers and function constants)
-  // host_name attribute needs at least Metal 2.2 and ulong needs Metal 2.3 (supported on MacOS 11+
-  TORCH_CHECK([device supportsFamily:MTLGPUFamilyMac2], "Missing Metal support for MTLGPUFamilyMac2");
-  return MTLLanguageVersion3_0;
-}
-
 MPSDevice* MPSDevice::getInstance() {
   static MPSDevice mps_device;
   return &mps_device;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #193734
* __->__ #193733
* #193732
* #193731
* #193730

Removes getMetalLanguageVersion from MPSDevice.mm. It hardcoded MTLLanguageVersion3_0 and has no callers; runtime shader compilation picks its language version in MetalShaderLibrary::compileLibrary.

Authored with an AI assistant.