### PR TITLE
[MPS] Compute arange in double-float so its output is correctly rounded

### DIFF
--- a/aten/src/ATen/native/mps/kernels/RangeFactories.metal
+++ b/aten/src/ATen/native/mps/kernels/RangeFactories.metal
@@ -1,3 +1,4 @@
+#include <c10/metal/double_float.h>
 #include <c10/metal/indexing.h>
 #include <metal_stdlib>
 using namespace metal;
@@ -131,6 +132,42 @@ kernel void logspace_strided(
   out[off] = c10::metal::cast_to<T>(val);
 }
 
+// se = {start hi, start lo, step hi, step lo}. Evaluating start + i * step in
+// float32 is off by an ulp over perfectly ordinary ranges, because start and
+// step are rounded before the multiply and the product is rounded again.
+// Double-float carries enough significand that rounding its result to the
+// output dtype gives the correctly rounded value.
+inline float arange_fp_value(constant array<float, 4>& se, uint index) {
+  const c10::metal::df32 start{se[0], se[1]};
+  const c10::metal::df32 step{se[2], se[3]};
+  const auto i = c10::metal::df_from_long(static_cast<long>(index));
+  return c10::metal::df_add(start, c10::metal::df_mul(step, i)).hi;
+}
+
+template <typename T, typename I>
+kernel void arange_fp(
+    device T* out [[buffer(0)]],
+    constant array<float, 4>& se [[buffer(1)]],
+    constant I& stride [[buffer(2)]],
+    uint index [[thread_position_in_grid]]) {
+  const float val = arange_fp_value(se, index);
+  out[static_cast<I>(index) * stride] = c10::metal::cast_to<T>(val);
+}
+
+template <typename T>
+kernel void arange_fp_strided(
+    device T* out [[buffer(0)]],
+    constant array<float, 4>& se [[buffer(1)]],
+    constant int& ndim [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* strides [[buffer(4)]],
+    uint index [[thread_position_in_grid]]) {
+  const float val = arange_fp_value(se, index);
+  const long off =
+      c10::metal::offset_from_thread_index(index, sizes, strides, ndim);
+  out[off] = c10::metal::cast_to<T>(val);
+}
+
 template <typename T, typename C, typename I>
 kernel void arange(
     device T* out [[buffer(0)]],
@@ -224,6 +261,28 @@ kernel void arange_strided(
       constant long* strides [[buffer(5)]],                      \
       uint index [[thread_position_in_grid]]);
 
+#define REGISTER_ARANGE_FP_OP(DTYPE)                           \
+  template [[host_name("arange_" #DTYPE "_i32")]] kernel void  \
+  arange_fp<DTYPE, int>(                                       \
+      device DTYPE * out [[buffer(0)]],                        \
+      constant array<float, 4> & se [[buffer(1)]],             \
+      constant int& stride [[buffer(2)]],                      \
+      uint index [[thread_position_in_grid]]);                 \
+  template [[host_name("arange_" #DTYPE "_i64")]] kernel void  \
+  arange_fp<DTYPE, long>(                                      \
+      device DTYPE * out [[buffer(0)]],                        \
+      constant array<float, 4> & se [[buffer(1)]],             \
+      constant long& stride [[buffer(2)]],                     \
+      uint index [[thread_position_in_grid]]);                 \
+  template [[host_name("arange_strided_" #DTYPE)]] kernel void \
+  arange_fp_strided<DTYPE>(                                    \
+      device DTYPE * out [[buffer(0)]],                        \
+      constant array<float, 4> & se [[buffer(1)]],             \
+      constant int& ndim [[buffer(2)]],                        \
+      constant long* sizes [[buffer(3)]],                      \
+      constant long* strides [[buffer(4)]],                    \
+      uint index [[thread_position_in_grid]]);
+
 #define REGISTER_ARANGE_OP(DTYPE, CTYPE)                       \
   template [[host_name("arange_" #DTYPE "_i32")]] kernel void  \
   arange<DTYPE, CTYPE, int>(                                   \
@@ -270,9 +329,9 @@ REGISTER_LOGSPACE_OP(char);
 REGISTER_LOGSPACE_OP(uchar);
 REGISTER_LOGSPACE_OP(bool);
 
-REGISTER_ARANGE_OP(float, float);
-REGISTER_ARANGE_OP(half, float);
-REGISTER_ARANGE_OP(bfloat, float);
+REGISTER_ARANGE_FP_OP(float);
+REGISTER_ARANGE_FP_OP(half);
+REGISTER_ARANGE_FP_OP(bfloat);
 REGISTER_ARANGE_OP(long, long);
 REGISTER_ARANGE_OP(int, long);
 REGISTER_ARANGE_OP(short, long);

--- a/aten/src/ATen/native/mps/kernels/RangeFactories.metal
+++ b/aten/src/ATen/native/mps/kernels/RangeFactories.metal
@@ -138,10 +138,10 @@ kernel void logspace_strided(
 // Double-float carries enough significand that rounding its result to the
 // output dtype gives the correctly rounded value.
 inline float arange_fp_value(constant array<float, 4>& se, uint index) {
-  const c10::metal::df32 start{se[0], se[1]};
-  const c10::metal::df32 step{se[2], se[3]};
-  const auto i = c10::metal::df_from_long(static_cast<long>(index));
-  return c10::metal::df_add(start, c10::metal::df_mul(step, i)).hi;
+  const c10::metal::df32 start(se[0], se[1]);
+  const c10::metal::df32 step(se[2], se[3]);
+  const c10::metal::df32 i(static_cast<long>(index));
+  return c10::metal::add(start, c10::metal::mul(step, i)).hi;
 }
 
 template <typename T, typename I>

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -33,12 +33,22 @@ void arange_range_fill_mps(const Scalar& start, const Scalar& step, Tensor& resu
   auto stream = getCurrentMPSStream();
   auto encoder = stream->commandEncoder();
 
-  // Binds result and {start, step}: int64 for integer dtypes, float otherwise.
+  // The float kernels evaluate start + i * step in double-float, so each
+  // operand is passed as a hi/lo float pair rather than rounded to float here.
+  const auto split = [](double v) {
+    const auto hi = static_cast<float>(v);
+    const auto lo = std::isfinite(hi) ? static_cast<float>(v - static_cast<double>(hi)) : 0.0f;
+    return std::array<float, 2>{hi, lo};
+  };
+
+  // Binds result and {start, step}: int64 for integer dtypes, hi/lo otherwise.
   const auto bind_start_step = [&] {
     if (is_int) {
       mtl_setArgs(encoder, result, std::array<int64_t, 2>{start.to<int64_t>(), step.to<int64_t>()});
     } else {
-      mtl_setArgs(encoder, result, std::array<float, 2>{start.to<float>(), step.to<float>()});
+      const auto s = split(start.to<double>());
+      const auto d = split(step.to<double>());
+      mtl_setArgs(encoder, result, std::array<float, 4>{s[0], s[1], d[0], d[1]});
     }
   };
 

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -10,6 +10,7 @@
 #include <ATen/ops/logspace_native.h>
 #include <ATen/ops/pow.h>
 #include <ATen/ops/range_native.h>
+#include <c10/metal/double_float.h>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -33,22 +34,15 @@ void arange_range_fill_mps(const Scalar& start, const Scalar& step, Tensor& resu
   auto stream = getCurrentMPSStream();
   auto encoder = stream->commandEncoder();
 
-  // The float kernels evaluate start + i * step in double-float, so each
-  // operand is passed as a hi/lo float pair rather than rounded to float here.
-  const auto split = [](double v) {
-    const auto hi = static_cast<float>(v);
-    const auto lo = std::isfinite(hi) ? static_cast<float>(v - static_cast<double>(hi)) : 0.0f;
-    return std::array<float, 2>{hi, lo};
-  };
-
-  // Binds result and {start, step}: int64 for integer dtypes, hi/lo otherwise.
+  // Binds result and {start, step}: int64 for integer dtypes, otherwise the
+  // hi/lo pairs the float kernels evaluate start + i * step in.
   const auto bind_start_step = [&] {
     if (is_int) {
       mtl_setArgs(encoder, result, std::array<int64_t, 2>{start.to<int64_t>(), step.to<int64_t>()});
     } else {
-      const auto s = split(start.to<double>());
-      const auto d = split(step.to<double>());
-      mtl_setArgs(encoder, result, std::array<float, 4>{s[0], s[1], d[0], d[1]});
+      const c10::metal::df32 s(start.to<double>());
+      const c10::metal::df32 d(step.to<double>());
+      mtl_setArgs(encoder, result, std::array<float, 4>{s.hi, s.lo, d.hi, d.lo});
     }
   };
 

--- a/c10/metal/double_float.h
+++ b/c10/metal/double_float.h
@@ -1,61 +1,120 @@
-// Double-float arithmetic, for kernels that need more precision than float32
+// Double-float arithmetic library
 #pragma once
+#ifdef __METAL__
 #include <metal_stdlib>
+#else
+#include <cmath>
+#endif
 
 namespace c10 {
 namespace metal {
 
+namespace detail {
+inline float df_fma(float a, float b, float c) {
+#ifdef __METAL__
+  return ::metal::fma(a, b, c);
+#else
+  return std::fma(a, b, c);
+#endif
+}
+} // namespace detail
+
 // A value held as the unevaluated sum hi + lo of two float32s, with
-// |lo| <= ulp(hi) / 2, carrying roughly 48 bits of significand. Metal Shading
-// Language has no `double`, so this is how a kernel keeps an intermediate at
-// better than float32 precision.
+// |lo| <= ulp(hi) / 2. It lets a kernel carry an intermediate at better than
+// float32 precision where Metal Shading Language offers no `double`.
 //
-// The transformations below are exact under IEEE semantics and only under
-// those: they depend on the compiler not reassociating the expressions, which
-// holds because the shaders are built with -fno-fast-math (cmake/Metal.cmake)
-// and compiled at runtime with MTLMathModeSafe unless PYTORCH_MPS_FAST_MATH
+// How it compares with a real float64:
+//   - The significand is about 48 bits, the two non-overlapping float32
+//     significands, against 53 for float64. That is enough for rounding the
+//     result down to float32 to land where a float64 computation would, but
+//     it is not a float64 substitute.
+//   - The exponent range is float32's, so the largest finite value is ~3.4e38
+//     rather than ~1.8e308. This buys precision, never dynamic range.
+//   - The extra precision disappears at the ends of that range: once |hi| is
+//     subnormal the low word underflows to zero, and near the top of the
+//     range hi + lo is no longer representable either.
+//   - Results are not correctly rounded. add and mul are good to a few ulps
+//     of the 48-bit format; div is looser still, since it refines a float32
+//     quotient rather than computing an exact one.
+//   - Infinities and NaNs are handled only as far as the underlying float32
+//     operations handle them: hi carries what IEEE gives, while lo can come
+//     out NaN.
+//
+// The error-free transformations below are exact under IEEE semantics and
+// only under those: they depend on the compiler not reassociating them, which
+// holds because the metallib is built with -fno-fast-math (cmake/Metal.cmake)
+// and runtime compilation uses MTLMathModeSafe unless PYTORCH_MPS_FAST_MATH
 // asks otherwise.
 struct df32 {
   float hi;
   float lo;
+
+  df32(float hi_, float lo_) : hi(hi_), lo(lo_) {}
+
+  // Exact for |i| < 2^48, which covers any index a kernel is dispatched on.
+  explicit df32(long i)
+      : hi(static_cast<float>(i)),
+        lo(static_cast<float>(i - static_cast<long>(static_cast<float>(i)))) {}
+
+#ifndef __METAL__
+  // Host-side split, for uploading a double as the pair a shader consumes.
+  explicit df32(double v)
+      : hi(static_cast<float>(v)),
+        lo(std::isfinite(static_cast<float>(v))
+               ? static_cast<float>(
+                     v - static_cast<double>(static_cast<float>(v)))
+               : 0.0f) {}
+#endif
 };
 
 // Knuth's two-sum: the result is a + b exactly, for any a and b.
 inline df32 two_sum(float a, float b) {
   const float s = a + b;
   const float b_virtual = s - a;
-  return df32{s, (a - (s - b_virtual)) + (b - b_virtual)};
+  return df32(s, (a - (s - b_virtual)) + (b - b_virtual));
 }
 
 // Dekker's fast two-sum. Same result as two_sum, but only when |a| >= |b|.
 inline df32 quick_two_sum(float a, float b) {
   const float s = a + b;
-  return df32{s, b - (s - a)};
+  return df32(s, b - (s - a));
 }
 
 // Exact product: the residual is whatever the multiply rounded away, which
 // fma() recovers.
 inline df32 two_prod(float a, float b) {
   const float p = a * b;
-  return df32{p, ::metal::fma(a, b, -p)};
+  return df32(p, detail::df_fma(a, b, -p));
 }
 
-inline df32 df_add(df32 a, df32 b) {
+inline df32 neg(df32 a) {
+  return df32(-a.hi, -a.lo);
+}
+
+inline df32 add(df32 a, df32 b) {
   df32 s = two_sum(a.hi, b.hi);
   s.lo += a.lo + b.lo;
   return quick_two_sum(s.hi, s.lo);
 }
 
-inline df32 df_mul(df32 a, df32 b) {
+inline df32 sub(df32 a, df32 b) {
+  return add(a, neg(b));
+}
+
+inline df32 mul(df32 a, df32 b) {
   df32 p = two_prod(a.hi, b.hi);
   p.lo += a.hi * b.lo + a.lo * b.hi;
   return quick_two_sum(p.hi, p.lo);
 }
 
-// Exact for |i| < 2^48, which covers any index a kernel can be dispatched on.
-inline df32 df_from_long(long i) {
-  const float hi = static_cast<float>(i);
-  return df32{hi, static_cast<float>(i - static_cast<long>(hi))};
+// Long division on the leading words, correcting the remainder twice.
+inline df32 div(df32 a, df32 b) {
+  const float q1 = a.hi / b.hi;
+  df32 r = sub(a, mul(b, df32(q1, 0.0f)));
+  const float q2 = r.hi / b.hi;
+  r = sub(r, mul(b, df32(q2, 0.0f)));
+  const float q3 = r.hi / b.hi;
+  return add(quick_two_sum(q1, q2), df32(q3, 0.0f));
 }
 
 } // namespace metal

--- a/c10/metal/double_float.h
+++ b/c10/metal/double_float.h
@@ -1,0 +1,62 @@
+// Double-float arithmetic, for kernels that need more precision than float32
+#pragma once
+#include <metal_stdlib>
+
+namespace c10 {
+namespace metal {
+
+// A value held as the unevaluated sum hi + lo of two float32s, with
+// |lo| <= ulp(hi) / 2, carrying roughly 48 bits of significand. Metal Shading
+// Language has no `double`, so this is how a kernel keeps an intermediate at
+// better than float32 precision.
+//
+// The transformations below are exact under IEEE semantics and only under
+// those: they depend on the compiler not reassociating the expressions, which
+// holds because the shaders are built with -fno-fast-math (cmake/Metal.cmake)
+// and compiled at runtime with MTLMathModeSafe unless PYTORCH_MPS_FAST_MATH
+// asks otherwise.
+struct df32 {
+  float hi;
+  float lo;
+};
+
+// Knuth's two-sum: the result is a + b exactly, for any a and b.
+inline df32 two_sum(float a, float b) {
+  const float s = a + b;
+  const float b_virtual = s - a;
+  return df32{s, (a - (s - b_virtual)) + (b - b_virtual)};
+}
+
+// Dekker's fast two-sum. Same result as two_sum, but only when |a| >= |b|.
+inline df32 quick_two_sum(float a, float b) {
+  const float s = a + b;
+  return df32{s, b - (s - a)};
+}
+
+// Exact product: the residual is whatever the multiply rounded away, which
+// fma() recovers.
+inline df32 two_prod(float a, float b) {
+  const float p = a * b;
+  return df32{p, ::metal::fma(a, b, -p)};
+}
+
+inline df32 df_add(df32 a, df32 b) {
+  df32 s = two_sum(a.hi, b.hi);
+  s.lo += a.lo + b.lo;
+  return quick_two_sum(s.hi, s.lo);
+}
+
+inline df32 df_mul(df32 a, df32 b) {
+  df32 p = two_prod(a.hi, b.hi);
+  p.lo += a.hi * b.lo + a.lo * b.hi;
+  return quick_two_sum(p.hi, p.lo);
+}
+
+// Exact for |i| < 2^48, which covers any index a kernel can be dispatched on.
+inline df32 df_from_long(long i) {
+  const float hi = static_cast<float>(i);
+  return df32{hi, static_cast<float>(i - static_cast<long>(hi))};
+}
+
+} // namespace metal
+} // namespace c10

--- a/c10/test/metal/double_float_test.cpp
+++ b/c10/test/metal/double_float_test.cpp
@@ -1,0 +1,86 @@
+#include <c10/metal/double_float.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+using c10::metal::df32;
+
+namespace {
+
+// The value a df32 stands for, evaluated exactly: hi and lo are float32 and
+// do not overlap, so their sum is representable in double.
+double value(df32 v) {
+  return static_cast<double>(v.hi) + static_cast<double>(v.lo);
+}
+
+constexpr double kOperands[] = {1.0, 0.1, 3.7e5, -2.5e-7, 1234567.75};
+constexpr double kDivisors[] = {3.0, 0.001, -7.3e3, 6.25e-4, 1.0 / 3.0};
+
+} // namespace
+
+// A double rounds into a df32 with far more of it retained than a float32
+// keeps, though not all of it: 48 bits of significand against 53.
+TEST(DoubleFloatTest, SplitsADouble) {
+  for (double x : kOperands) {
+    EXPECT_NEAR(value(df32(x)), x, std::abs(x) * 1e-15);
+  }
+}
+
+// Non-finite inputs have no residual to carry, and must not leave a NaN in lo.
+TEST(DoubleFloatTest, SplitOfNonFiniteHasNoResidual) {
+  const df32 inf(std::numeric_limits<double>::infinity());
+  EXPECT_TRUE(std::isinf(inf.hi));
+  EXPECT_EQ(inf.lo, 0.0f);
+
+  const df32 too_large(1e300);
+  EXPECT_TRUE(std::isinf(too_large.hi));
+  EXPECT_EQ(too_large.lo, 0.0f);
+}
+
+TEST(DoubleFloatTest, ArithmeticTracksDouble) {
+  for (double x : kOperands) {
+    for (double y : kDivisors) {
+      const df32 a(x), b(y);
+      const double xa = value(a), yb = value(b);
+
+      EXPECT_NEAR(
+          value(c10::metal::add(a, b)), xa + yb, std::abs(xa + yb) * 1e-13);
+      EXPECT_NEAR(
+          value(c10::metal::sub(a, b)), xa - yb, std::abs(xa - yb) * 1e-13);
+      EXPECT_NEAR(
+          value(c10::metal::mul(a, b)), xa * yb, std::abs(xa * yb) * 1e-13);
+      // div refines a float32 quotient rather than computing an exact one, so
+      // it is the loosest of the four.
+      EXPECT_NEAR(
+          value(c10::metal::div(a, b)), xa / yb, std::abs(xa / yb) * 1e-12);
+    }
+  }
+}
+
+// two_sum and two_prod are error-free transformations: the pair they return is
+// the unrounded result, not an approximation of it.
+TEST(DoubleFloatTest, TransformationsAreExact) {
+  const float a = 1.0000001f, b = 3.9999998f;
+  EXPECT_EQ(
+      value(c10::metal::two_prod(a, b)),
+      static_cast<double>(a) * static_cast<double>(b));
+  EXPECT_EQ(
+      value(c10::metal::two_sum(a, b)),
+      static_cast<double>(a) + static_cast<double>(b));
+
+  // Catastrophic cancellation: the difference is exact even though the leading
+  // word alone loses every significant bit of it.
+  const float big = 1 << 24, small = 1.0f;
+  EXPECT_EQ(
+      value(c10::metal::two_sum(big, -small)), static_cast<double>(big) - 1.0);
+}
+
+// Indices are converted exactly well past the 2^24 where float32 stops
+// representing consecutive integers.
+TEST(DoubleFloatTest, ConvertsLargeIntegersExactly) {
+  for (long i :
+       {1L << 24, (1L << 24) + 1, (1L << 40) + 12345L, -((1L << 31) + 7L)}) {
+    EXPECT_EQ(value(df32(i)), static_cast<double>(i));
+  }
+}

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9228,6 +9228,26 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(do_arange(device='mps'), do_arange(device='cpu'))
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_arange_correctly_rounded(self, dtype):
+        """Each element is start + i * step rounded once, not accumulated in float32."""
+        ranges = [(0.0, 100.0, 0.1), (0.0, 1000.0, 0.001), (1e6, 1e6 + 100.0, 0.001),
+                  (0.0, 1e5, 0.3), (-50.0, 50.0, 0.7), (10.0, -10.0, -0.3)]
+        for start, end, step in ranges:
+            out = torch.arange(start, end, step, device='mps', dtype=dtype)
+            i = torch.arange(out.numel(), dtype=torch.float64)
+            # The kernel keeps the intermediate in double-float and rounds it to
+            # float32, so the reference rounds through float32 as well.
+            ref = (start + i * step).to(torch.float32).to(dtype)
+            self.assertEqual(out.cpu(), ref, atol=0, rtol=0,
+                             msg=f"arange({start}, {end}, {step}) mismatch for {dtype}")
+
+        # Non-contiguous out goes through the strided kernel
+        buf = torch.empty(2000, device='mps', dtype=dtype)
+        out = torch.arange(0.0, 100.0, 0.1, out=buf[::2])
+        i = torch.arange(out.numel(), dtype=torch.float64)
+        self.assertEqual(out.cpu(), (i * 0.1).to(torch.float32).to(dtype), atol=0, rtol=0)
+
     def test_arange_empty(self):
         out_mps = torch.tensor([], device="mps")
         out_cpu = torch.tensor([], device="cpu")


### PR DESCRIPTION
Per `AI_POLICY.md`: the description below was drafted with an AI coding assistant (Claude Code) and reviewed by me before submission.

This is the "propose a workaround" half of the discussion on #193545. Metal has no `double`, but a kernel that needs more than float32 for an intermediate can carry one in double-float, and `arange` turned out to be a place where the missing precision is visible on completely ordinary inputs.

> ## Motivation
>
> `torch.arange(0, 100, 0.1)` on MPS disagreed with the correctly rounded result on 199 of its 1000 elements, and `arange(0, 1000, 0.001)` on 593070 of a million. The kernel evaluated `start + i * step` entirely in float32, and the host had already rounded `start` and `step` to float32 before binding them, so three separate roundings landed on a value that only has 24 bits to spare.
>
> ## Approach
>
> The intermediate is carried in double-float: a value held as an unevaluated sum of two float32s, giving roughly 48 bits of significand, which is enough that rounding it to float32 lands on the same value a double computation would. `c10/metal/double_float.h` adds the type and the error-free transformations it needs (Knuth's two-sum, Dekker's fast two-sum, and an fma-based exact product).
>
> Those identities hold only under IEEE semantics, which is what the shaders get: the metallib is built with `-fno-fast-math` (`cmake/Metal.cmake`) and runtime compilation uses `MTLMathModeSafe` unless `PYTORCH_MPS_FAST_MATH` says otherwise.
>
> The host now passes `start` and `step` as hi/lo pairs instead of pre-rounding them, and the float, half and bfloat16 instantiations move to the new kernels. The integer instantiations compute in int64 and were already exact, so they are untouched.
>
> The alternative was to match the CPU bit for bit, but the CPU is not the right target here: its vectorized path computes a chunk base in double and then fills the vector with `Vectorized<float>::arange(base, step)` in float32 (`aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp`), so it carries the same class of error. The reference this change is measured against is the correctly rounded `start + i * step`, which MPS now hits exactly and the CPU does not.
>
> Only `arange` is changed. `linspace` and `logspace` interpolate from both endpoints and have their own accuracy story, which is left alone.
>
> ## Test plan
>
> ```
> python test/test_mps.py TestMPS -k arange -v
> python test/test_mps.py -k linspace
> python test/test_mps.py -k logspace
> python test/test_mps.py -k test_range
> ```
>
> Accuracy before and after, counting elements that differ from the correctly rounded value computed in float64 (macOS 26.6.1, Apple M4 Max):
>
> ```
> python -c "
> import torch
> for a in [(0.0,100.0,0.1),(0.0,1000.0,0.001),(1e6,1e6+100,0.001),(0.0,1e5,0.3),(-50.0,50.0,0.7)]:
>     n = torch.arange(*a).numel()
>     ref = (a[0] + torch.arange(n, dtype=torch.float64) * a[2]).to(torch.float32)
>     m = torch.arange(*a, device='mps').cpu()
>     print(a, n, (m != ref).sum().item())
> "
> ```
>
> ```
>                                     before    after
> arange(0.0, 100.0, 0.1)                199        0   of       1000
> arange(0.0, 1000.0, 0.001)          593070        0   of    1000000
> arange(1e6, 1e6 + 100, 0.001)            0        0   of     100000
> arange(0.0, 1e5, 0.3)               156300        0   of     333334
> arange(-50.0, 50.0, 0.7)                75        0   of        143
> ```
>
> The "before" numbers are from a build of `main` at the branch point, not a simulation.
