### PR TITLE
Fix B200 GPU benchmark workflow wiring

### DIFF
--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -68,9 +68,9 @@ jobs:
     secrets: inherit
 
   # B200 runner (OSDC), always use OSDC runner to test this workflow
-  opmicrobenchmark-build-b200:
+  attention-microbenchmark-build-b200:
     if: github.repository_owner == 'pytorch'
-    name: opmicrobenchmark-build-b200
+    name: attention-microbenchmark-build-b200
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
@@ -82,24 +82,24 @@ jobs:
       cuda-arch-list: '10.0'
       test-matrix: |
         { include: [
-          { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "attention_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
     secrets: inherit
 
-  opmicrobenchmark-test-b200:
-    name: opmicrobenchmark-test-b200
+  attention-microbenchmark-test-b200:
+    name: attention-microbenchmark-test-b200
     uses: ./.github/workflows/_linux-test.yml
     needs:
-      - opmicrobenchmark-build-b200
+      - attention-microbenchmark-build-b200
       - get-label-type
     with:
       timeout-minutes: 500
-      build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
-      docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
-      test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
+      build-environment: ${{ needs.attention-microbenchmark-build-b200.outputs.build-environment }}
+      docker-image: ${{ needs.attention-microbenchmark-build-b200.outputs.docker-image }}
+      test-matrix: ${{ needs.attention-microbenchmark-build-b200.outputs.test-matrix }}
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-perf-test-b200.yml
+++ b/.github/workflows/inductor-perf-test-b200.yml
@@ -147,6 +147,7 @@ jobs:
     name: cuda13.0-py3.12-gcc11-sm100
     uses: ./.github/workflows/_linux-test.yml
     needs: build
+    if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}


### PR DESCRIPTION
## Human Note
I am looking at some of our ci jobs specifcally around b200 and trying ot fix them / make them better. In this case there was some copy past between the prevous tests to blackwell and we wer just running the wrong operator benchmarks;

We should also take a look at these operator benchmarkflows and see if we are getting real value out fo them; ill do that after just making them better

## Agent Report
# Overview

Corrected two GPU CI wiring issues identified by work package A of the 2026-08-16 audit.

# Changes made

- `.github/workflows/attention_op_microbenchmark.yml`
  - The B200 matrix now runs `attention_microbenchmark_test` rather than `operator_microbenchmark_test`.
  - B200 job IDs, display names, dependencies, and output references now consistently use `attention-microbenchmark-*` identifiers.
- `.github/workflows/inductor-perf-test-b200.yml`
  - The input-driven `test` job is now restricted to `workflow_dispatch`, preventing it from running alongside the periodic or weekly job on schedules.

# Validation results

- Generated attention matrices for schedule and workflow dispatch contain the expected A100, H100, and B200 entries, all configured for `attention_microbenchmark_test`.
- Generated Inductor matrices contain all three expected B200 benchmark configs:
  - Monday-Saturday schedule: `build` and `test-periodically`.
  - Sunday schedule: `build` and `test-weekly`.
  - Workflow dispatch: `build` and `test`.
- `.github/scripts/test_filter_test_configs.py`: 12 tests passed.
- `spin quicklint`: no lint issues, including GHA schema, ACTIONLINT, and workflow-consistency checks selected for the changed files.
- `git diff --check`: clean.
- The dispatch guard matches the established structure in `.github/workflows/inductor-perf-test-nightly.yml`.

# Scope and status

Only the two requested workflow files are modified in the PyTorch worktree. The diff remains uncommitted for review. Local checks cover workflow syntax, references, event selection, and generated matrices. A real GitHub Actions dispatch remains the final end-to-end confirmation of runner allocation and reusable-workflow execution; it was not triggered because it requires a reviewed GitHub branch and consumes GPU CI capacity.


<details>
<summary>Agent Worklog</summary>

# Work package

Implement package A from the 2026-08-16 PyTorch GPU CI audit, limited to workflow wiring.

# Investigation

- Loaded the PTQ and PyTorch repository instructions, including `AI_POLICY.md`.
- Confirmed the PyTorch worktree was initially clean and detached at `1a955c70e48`.
- Found that the B200 entry in `.github/workflows/attention_op_microbenchmark.yml` was copied from the operator microbenchmark workflow: its config was `operator_microbenchmark_test`, and its build/test job identifiers were named `opmicrobenchmark-*`.
- Found that `.github/workflows/inductor-perf-test-b200.yml` had schedule-specific `test-periodically` and `test-weekly` jobs but also allowed the input-driven `test` job to run on scheduled events.
- Confirmed `.github/workflows/inductor-perf-test-nightly.yml` uses the same `if: github.event_name == 'workflow_dispatch'` guard for its corresponding input-driven test job, so the B200 fix follows the established workflow pattern.

# Changes

- Changed the B200 attention matrix config to `attention_microbenchmark_test`.
- Renamed the B200 jobs and all dependency/output references to `attention-microbenchmark-build-b200` and `attention-microbenchmark-test-b200`.
- Added `if: github.event_name == 'workflow_dispatch'` to the input-driven B200 Inductor test job.
- Kept source changes limited to the two requested workflow files.

# Validation

- Ran a focused matrix-generation check through the repository's `filter_selected_test_configs` and ARC runner-mapping functions. Output is saved at `pytorch/agent_space/workflow_matrix_validation.txt`.
  - Attention schedule and dispatch each produce A100, H100, and B200 entries, all using `attention_microbenchmark_test`.
  - The Monday-Saturday Inductor schedule selects only `build` plus `test-periodically` with all three B200 benchmark configs.
  - The Sunday Inductor schedule selects only `build` plus `test-weekly` with all three B200 benchmark configs.
  - Workflow dispatch selects only `build` plus the input-driven `test` job with the default three B200 benchmark configs.
- Targeted tests: `/home/drisspg/.ptq_workspace/jobs/20260816-pytorch-adhoc-a1de17/.venv/bin/python -m pytest .github/scripts/test_filter_test_configs.py -q` (`12 passed`).
- Prerequisite checks: `spin quicklint` (no lint issues, including the repository's GHA, ACTIONLINT, and WORKFLOWSYNC linters), `git diff --check` (clean).
- Local validation proves YAML/expression validity, dependency references, matrix filtering/mapping, and event-condition truth-table behavior. A real GitHub Actions dispatch is the remaining end-to-end check for runner allocation and reusable-workflow execution; it was not triggered because that requires a reviewed branch on GitHub and consumes GPU CI capacity.

# Review state

The two-file workflow diff is intentionally uncommitted for human review.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*