### PR TITLE
[CI] Run B200 operator microbenchmarks per operator

### DIFF
--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -85,7 +85,16 @@ jobs:
       cuda-arch-list: '10.0'
       test-matrix: |
         { include: [
-          { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_matmul_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_mm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_addmm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_bmm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_conv_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_optimizer_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_activation_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_norm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_scaled_mm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+          { config: "operator_microbenchmark_scaled_grouped_mm_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
       python-version: "3.12"
       compiler: gcc11


### PR DESCRIPTION
## Human Note
This flow is taking way to long ~ 8 hours and it doesnt really need to
   Before: 85 + 21 + 83 + 43 + 35 + ... + 143 ≈ 7.5 hours
   After:  max(85, 21, 83, 43, 35, ..., 143) ≈ 143 minutes

   assuming we get better scaling and have enough runners to run in parella we can break it up to not have bench 1 block the ful queue

## Agent Report
# Summary

Revised the B200 operator-microbenchmark workflow from one serial job to a per-operator matrix. Each of the ten existing `operator_microbenchmark_{op}_test` selectors now runs independently on `linux.dgx.b200`. The prior two-shard proposal was removed because its estimated 3.5-4.25 hour shard times did not meet work package B's p90-below-90-minutes target.

# Files Changed

- `.github/workflows/operator_microbenchmark.yml`
  - Added one B200 matrix entry for each of `matmul`, `mm`, `addmm`, `bmm`, `conv`, `optimizer`, `activation`, `norm`, `scaled_mm`, and `scaled_grouped_mm`.
  - H100, A100, and ROCm matrices are unchanged.

# Coverage and Artifact Contract

- Exactly ten unique operator selectors are present.
- The existing selector logic resolves every config correctly, including operator names containing underscores.
- Each operator still emits its original compiled and eager dashboard files, for exactly 20 expected JSON outputs:
  - `operator_microbenchmark_{op}_compile.json`
  - `operator_microbenchmark_{op}.json`
- Reusable-workflow artifact suffixes remain unique because each matrix entry has a distinct config name.

# Validation

- Workflow and embedded-matrix parse: passed.
- Exact operator coverage and uniqueness assertions: passed.
- B200-only structural-diff assertion: passed.
- Exact Bash selector behavior for all ten configs: passed.
- Expected 20-file JSON output-set assertion: passed.
- `git diff --check`: passed.
- ACTIONLINT batch within `spin lint`: passed. Overall `spin lint` remains blocked by unrelated existing SHELLCHECK findings; see `pytorch/agent_space/spin-lint.log`.

No local GPU benchmark was run because the acceptance measurement requires GitHub B200 runners.

# Remaining Uncertainty

Historical operator-body timing supports the design but does not prove the acceptance target: sampled nearest-rank p90 was approximately 85.4 minutes on 2026-08-13 and 93.6 minutes on 2026-08-16, before isolated-job setup overhead. A scheduled or dispatched B200 workflow run must verify p90 below 90 minutes and confirm all 20 JSON artifacts upload successfully under the audit's measurement contract.


<details>
<summary>Agent Worklog</summary>

# Objective

Implement work package B from the 2026-08-16 GPU CI audit: make the B200 operator-microbenchmark p90 shard runtime less than 90 minutes while preserving every expected dashboard JSON artifact and leaving non-B200 jobs unchanged.

# Investigation

- Recent scheduled runs execute all ten B200 operators serially and take roughly 7.5-8 hours. Runs `31930813391` and `31868790011` timed out in the test action; the 2026-08-16 log is saved under `pytorch/agent_space/ci_logs/`.
- The initial two-shard proposal was rejected during review because its estimated 211-255 minute and 214-224 minute shard times were well above the 90-minute acceptance target.
- `.ci/pytorch/test.sh` already supports config selectors named `operator_microbenchmark_{op}_test`. Its Bash regex extracts `{op}` into `OP_BENCHMARK_TESTS`, so each selected job runs only that operator's compiled and eager benchmarks.
- `.github/workflows/_linux-test.yml` includes the full config name and shard fields in its artifact suffix, so the ten selector configs produce distinct uploaded artifacts.
- The benchmark writes two dashboard files for each selected operator:
  - `operator_microbenchmark_{op}_compile.json`
  - `operator_microbenchmark_{op}.json`

# Change

Replaced the single B200 matrix entry with ten per-operator entries using the existing selectors:

- `matmul`
- `mm`
- `addmm`
- `bmm`
- `conv`
- `optimizer`
- `activation`
- `norm`
- `scaled_mm`
- `scaled_grouped_mm`

Only `jobs.opmicrobenchmark-build-b200.with.test-matrix` changed. H100, A100, and ROCm jobs remain byte-for-byte unchanged.

# Validation

- Parsed the workflow and its embedded matrix with PyYAML.
- Asserted that the matrix contains exactly ten unique selectors in the expected operator order, with the B200 runner and valid `1/1` shard metadata.
- Structurally compared the parsed workflow with `HEAD` and confirmed the only changed field is the B200 test matrix.
- Exercised the exact Bash selector regex for all ten config names, including `scaled_mm` and `scaled_grouped_mm`; every selector resolved to the expected operator and `test` mode.
- Asserted exact coverage of 20 expected JSON names: compiled and eager output for each operator.
- `git diff --check` passed.
- `spin lint` ran after the revision. Its ACTIONLINT-containing batch reported `ok No lint issues`; the overall repository-wide command remains nonzero because of unrelated pre-existing SHELLCHECK errors outside the changed workflow. Full output is in `pytorch/agent_space/spin-lint.log`.

# Runtime Evidence

The 2026-08-13 successful run had nine of ten operator bodies below 90 minutes, with nearest-rank p90 approximately 85.4 minutes; `norm` was the sole long outlier. In the 2026-08-16 run, `matmul` varied to approximately 93.6 minutes, making the sampled p90 approximately 93.6 minutes before per-job setup. The per-operator layout is required to approach the target with existing selectors, but a B200 workflow run is still required to establish acceptance under the audit's exact end-to-end p90 definition.

# Current State

One source file is modified and uncommitted: `.github/workflows/operator_microbenchmark.yml`.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*