### PR TITLE
Fix 7 stale CODEOWNERS paths, remove 6 dead rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,11 +38,11 @@
 /test/ao/ @jerryzh168
 /test/quantization/ @jerryzh168
 /torch/quantization/ @jerryzh168
-ao/quantization/ @jerryzh168
-nn/intrinsic/ @jerryzh168
-nn/quantized/ @jerryzh168
-nn/quantizable/ @jerryzh168
-nn/qat/ @jerryzh168
+/torch/ao/quantization/ @jerryzh168
+/torch/nn/intrinsic/ @jerryzh168
+/torch/nn/quantized/ @jerryzh168
+/torch/nn/quantizable/ @jerryzh168
+/torch/nn/qat/ @jerryzh168
 
 # Tensorpipe RPC Agent.
 /torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @lw
@@ -176,10 +176,6 @@ aten/src/ATen/hip/ @jeffdaily @jithunnair-amd
 aten/src/ATen/miopen/ @jeffdaily @jithunnair-amd
 aten/src/ATen/native/miopen/ @jeffdaily @jithunnair-amd
 c10/hip @jeffdaily @jithunnair-amd
-caffe2/core/hip @jeffdaily @jithunnair-amd
-caffe2/operators/hip @jeffdaily @jithunnair-amd
-caffe2/operators/rnn/hip @jeffdaily @jithunnair-amd
-caffe2/utils/hip @jeffdaily @jithunnair-amd
 
 # XPU-specific files
 /aten/src/ATen/xpu/ @EikanWang @gujinghui
@@ -190,7 +186,7 @@ caffe2/utils/hip @jeffdaily @jithunnair-amd
 /test/xpu/ @EikanWang @gujinghui
 /test/test_xpu.py @EikanWang @gujinghui
 /third_party/xpu.txt @EikanWang @gujinghui
-/docs/source/notes/get_start_xpu.rst @EikanWang @gujinghui
+/docs/source/notes/get_start_xpu.md @EikanWang @gujinghui
 
 # torch.export
 /torch/export/ @avikchaudhuri @tugsbayasgalan @zhxchen17 @ydwu4 @angelayi
@@ -228,7 +224,6 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 # PyTree utilities
 /torch/utils/_pytree.py @XuehaiPan
 /torch/utils/_cxx_pytree.py @XuehaiPan
-/torch/utils/pytree/ @XuehaiPan
 /torch/_dynamo/polyfills/pytree.py @XuehaiPan
 
 # Relating to libtorch ABI
@@ -250,8 +245,7 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 /aten/src/ATen/native/cuda/ScaledBlas.cpp @drisspg @slayton58
 /aten/src/ATen/cuda/CUDABlas.cpp @drisspg @slayton58
 /aten/src/ATen/cuda/CUDABlas.h @drisspg @slayton58
-/aten/src/ATen/cuda/CUDAScaledBlas.cpp @drisspg @slayton58
-/aten/src/ATen/cuda/CUDAScaledBlas.h @drisspg @slayton58
+/aten/src/ATen/native/ScaledBlas* @drisspg @slayton58
 /test/test_scaled_matmul_cuda.py @drisspg @slayton58
 
 # Sparse Tensors


### PR DESCRIPTION
## Summary
Resolves stale references in CODEOWNERS. The lines themselves were left unchanged while the paths they referenced disappeared from the tree.

7 one-line edits resolve the stale references:
- Update CODEOWNERS lines 41-45 to: `/torch/ao/quantization/`, `/torch/nn/intrinsic/`, `/torch/nn/quantized/`, `/torch/nn/quantizable/`, `/torch/nn/qat/`
- Update CODEOWNERS line 193 to: `/docs/source/notes/get_start_xpu.md`
- Update CODEOWNERS line 253 to: `/aten/src/ATen/native/ScaledBlas*`

Removed 6 dead rules: 4 `caffe2/**/hip` rules, `/torch/utils/pytree/` (already covered by `/torch/utils/_pytree.py` above), `/aten/src/ATen/cuda/CUDAScaledBlas.h` (covered by the glob).

## Test

    # the stale line
    sed -n '41p' CODEOWNERS
    # tracked files under the referenced path, 0 before this PR
    git ls-files -- 'torch/ao/quantization' | wc -l
    git ls-files -- 'aten/src/ATen/native/ScaledBlas*' | wc -l
    git ls-files -- 'caffe2/core/hip' 'caffe2/utils/hip' | wc -l

## Additional information
Since the move, the quantization rules were stale for 1459 days.
I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.