### PR TITLE
Save mutated arguments after the kernel call in generated autograd kernels

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,6 +27,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.utils.rnn as rnn_utils
+import torch.utils.checkpoint
 from torch.nn.utils import clip_grad_norm_, clip_grad_value_, clip_grads_with_norm_, get_total_norm
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.nn.utils.fusion import fuse_conv_bn_weights
@@ -12819,6 +12820,69 @@ if __name__ == '__main__':
         # Test with lower bound greater than upper bound
         with self.assertRaisesRegex(RuntimeError, "Lower bound should be less than or equal to the upper bound"):
             F.rrelu(x, lower=0.5, upper=0.3)
+
+    # aten::rrelu_with_noise fills its `noise` argument with the sampled slopes and
+    # backward scales the incoming gradient with them, so `noise` has to be saved after
+    # the kernel ran. Saving it before only works while the SavedVariable aliases the
+    # buffer: a pack hook that materializes at save time, or a checkpoint replay that
+    # early-stops at that pack point, captures the pre-call contents instead. F.rrelu
+    # passes an empty_like buffer, so a stale read is uninitialized memory and may
+    # happen to look correct; these tests pass a sentinel to make it deterministic.
+    RRELU_NOISE_SENTINEL = 7.0
+
+    def _rrelu_with_noise(self, x, inplace=False):
+        noise = torch.full_like(x, self.RRELU_NOISE_SENTINEL)
+        if inplace:
+            return torch.ops.aten.rrelu_with_noise_(x.clone(), noise, 0.1, 0.9, True)
+        return torch.ops.aten.rrelu_with_noise(x, noise, 0.1, 0.9, True)
+
+    @expectedFailureMPS  # NotImplementedError: aten::rrelu_with_noise https://github.com/pytorch/pytorch/issues/77764
+    @parametrize_test("inplace", [False, True])
+    def test_rrelu_saved_noise_hooks(self, device, inplace):
+        def grad_of_rrelu(hooks):
+            torch.manual_seed(0)
+            x = torch.randn(1024, device=device, requires_grad=True)
+            pack = (
+                torch.autograd.graph.saved_tensors_hooks(lambda t: t.clone(), lambda t: t)
+                if hooks
+                else contextlib.nullcontext()
+            )
+            with pack:
+                self._rrelu_with_noise(x, inplace).sum().backward()
+            return x.grad
+
+        self.assertEqual(grad_of_rrelu(hooks=True), grad_of_rrelu(hooks=False))
+
+    @expectedFailureMPS  # NotImplementedError: aten::rrelu_with_noise https://github.com/pytorch/pytorch/issues/77764
+    @parametrize_test("early_stop", [True, False])
+    def test_rrelu_saved_noise_non_reentrant_checkpoint(self, device, early_stop):
+        torch.manual_seed(0)
+        expected = torch.randn(1024, device=device, requires_grad=True)
+        self._rrelu_with_noise(expected).sum().backward()
+
+        torch.manual_seed(0)
+        x = torch.randn(1024, device=device, requires_grad=True)
+        with torch.utils.checkpoint.set_checkpoint_early_stop(early_stop):
+            torch.utils.checkpoint.checkpoint(
+                self._rrelu_with_noise, x, use_reentrant=False
+            ).sum().backward()
+
+        self.assertEqual(x.grad, expected.grad)
+
+    @expectedFailureMPS  # NotImplementedError: aten::rrelu_with_noise https://github.com/pytorch/pytorch/issues/77764
+    def test_rrelu_with_noise_functional_backward(self, device):
+        # The sampled slopes are returned as `noise_out`; the `noise` argument is
+        # left untouched, so backward has to use the former.
+        torch.manual_seed(0)
+        expected = torch.randn(1024, device=device, requires_grad=True)
+        self._rrelu_with_noise(expected).sum().backward()
+
+        torch.manual_seed(0)
+        x = torch.randn(1024, device=device, requires_grad=True)
+        noise = torch.full_like(x, self.RRELU_NOISE_SENTINEL)
+        torch.ops.aten.rrelu_with_noise_functional(x, noise, 0.1, 0.9, True)[0].sum().backward()
+
+        self.assertEqual(x.grad, expected.grad)
 
     @onlyCPU
     def test_softshrink(self, device):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2231,7 +2231,8 @@
 
 - name: rrelu_with_noise_functional(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> (Tensor, Tensor noise_out)
   noise: non_differentiable
-  self: rrelu_with_noise_backward(grad, self, noise, lower, upper, training, false)
+  # The sampled slopes land in the noise_out return; the noise argument is left untouched.
+  self: rrelu_with_noise_backward(grad, self, noise_out, lower, upper, training, false)
 
 - name: _softmax(Tensor self, int dim, bool half_to_float) -> Tensor
   self: _softmax_backward_data(grad, result, dim, self.scalar_type())

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1245,6 +1245,18 @@ def emit_body(
         and (not returns_void)
     )
 
+    # See Note [Saving inputs that the operator mutates]
+    mutated_arg_names = {a.name for a in f.func.arguments.post_self_positional_mutable}
+
+    def is_mutated_by_call(arg: SavedAttribute) -> bool:
+        return str(arg.nctype.name) in mutated_arg_names
+
+    saved_inputs_mutated_by_call: list[SavedAttribute] = (
+        [arg for arg in info.all_saved_inputs if is_mutated_by_call(arg)]
+        if info is not None and info.has_derivatives
+        else []
+    )
+
     def emit_save_inputs() -> list[str]:
         setup: list[str] = []
         if info is None or not info.has_derivatives:
@@ -1333,8 +1345,11 @@ def emit_body(
                 raise AssertionError
             return f"grad_fn->should_compute_output({edge_off})"
 
+        saved_inputs = [
+            arg for arg in info.all_saved_inputs if not is_mutated_by_call(arg)
+        ]
         if is_inplace_foreach:
-            save_input_stmts = save_variables(info.all_saved_inputs, False, guard_for)
+            save_input_stmts = save_variables(saved_inputs, False, guard_for)
             if save_input_stmts:
                 setup.append(
                     LOOP_OVER_VECTOR_OF_GRAD_FNS.substitute(
@@ -1342,7 +1357,7 @@ def emit_body(
                     )
                 )
         else:
-            setup.extend(save_variables(info.all_saved_inputs, False, guard_for))
+            setup.extend(save_variables(saved_inputs, False, guard_for))
             for arg in args_with_derivatives:
                 if is_tensor_list_type(arg.type):
                     setup.append(f"grad_fn->{arg.name}_size_ = {arg.name}.size();")
@@ -1863,6 +1878,26 @@ def emit_body(
                 "}\n"
             )
 
+    # Note [Saving inputs that the operator mutates]
+    # An argument annotated as mutable (e.g. `noise` in
+    # `rrelu_with_noise(Tensor self, Tensor(b!) noise, ...)`) is really an extra
+    # output: the kernel only fills it during the call, so the value the backward
+    # formula needs does not exist yet when the grad_fn is set up. Saving it
+    # up front happens to work when the SavedVariable just holds on to the
+    # argument, because it aliases the buffer the kernel writes into. It breaks
+    # as soon as a saved tensor hook materializes the data at pack time
+    # (non-reentrant checkpointing, save_on_cpu, ...): the hook then captures the
+    # pre-call contents, which for a freshly allocated buffer is uninitialized
+    # memory, and backward silently computes garbage. Save those arguments after
+    # the call instead, which is the value backward reads today anyway.
+    def emit_save_mutated_inputs() -> str:
+        stmts = save_variables(saved_inputs_mutated_by_call, False)
+        if len(stmts) == 0:
+            return ""
+        if not is_inplace_foreach:
+            return CONDITIONAL.substitute(cond="grad_fn", statements=stmts)
+        return LOOP_OVER_VECTOR_OF_GRAD_FNS.substitute(preamble="", statements=stmts)
+
     def emit_save_outputs() -> str:
         if is_out_fn:
             # out functions don't currently support differentiation
@@ -2292,6 +2327,7 @@ def emit_body(
 
     if requires_derivative:
         # Save only after the forward AD has been set up
+        body.append(emit_save_mutated_inputs())
         body.append(emit_save_outputs())
         # Fire node creation hooks only once the node is fully populated,
         # including saved outputs above.


### PR DESCRIPTION
## Issue

Fixes #193671

## Summary

Root cause and discussion are in the issue. In short: `aten::rrelu_with_noise`
takes `noise` as a mutable output argument, and the generated autograd kernel
saved it before the kernel filled it. That works only while the `SavedVariable`
aliases the buffer; a hook that materializes at pack time, or a non-reentrant
checkpoint replay that early-stops at that pack point, captures uninitialized
memory instead and backward silently scales gradients by garbage. This moves the
`SavedVariable` construction for operator-mutated arguments to after the call.

Only four generated kernels change: `rrelu_with_noise`, `rrelu_with_noise_`,
`_native_batch_norm_legit` and `_batch_norm_with_update`. The two batch norm ops
read the running stats in backward only when `training=False`, when the kernel
does not update them, so they are numerically unaffected.

Also fixes the `rrelu_with_noise_functional` derivative, which referenced the
untouched `noise` input rather than the `noise_out` return.

One thing worth flagging for review: the new save site does not apply the
`guard_for` predicate that `emit_save_inputs` uses to skip saving tensors a
backward will not need, because `guard_for` is local to that closure. It is a
no-op for all four ops today (rrelu has a single arg with a derivative, so
`guard_for` bails on `len(args_with_derivatives) <= 1`; the batch norm formulas
are multi-output without `wrap_opt_if`). Happy to hoist `guard_for` to
`emit_body` scope if you would rather have it applied uniformly.

## Reproducer, before / after

Reproducer from the issue, on a CPU source build of `8f988c9c`.

Before, five consecutive runs:

    torch 2.15.0a0+git8f988c9
    checkpoint    : 0.0
    saved hooks   : nan
    no early stop : 0.0
    forward diff  : 0.0
    --- run 1 ---  checkpoint : 1.2183011048223146e+20   saved hooks : 1.2183011048223146e+20
    --- run 2 ---  checkpoint : 5.938071552281598e+34    saved hooks : 1.0
    --- run 3 ---  checkpoint : 2.457677367050863e+21    saved hooks : 2.458235813404657e+21
    --- run 4 ---  checkpoint : 6.766431746933327e+24    saved hooks : 6.767575445065897e+24
    (no early stop : 0.0 on every run)

After, same five runs:

    torch 2.15.0a0+git8f988c9
    checkpoint    : 0.0
    saved hooks   : 0.0
    no early stop : 0.0
    forward diff  : 0.0
    (all five runs identical)

## Checklist

- [x] Passes lint (`lintrunner` reports no issues on the changed files)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.
