### PR TITLE
[Testcase Refactoring] Decouple test_compile_subprocess.py from CUDA-specific

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -18,7 +18,9 @@ import torch.library
 from torch._inductor.compile_fx import _InProcessFxCompile, FxCompile, FxCompileMode
 from torch._inductor.graph import GraphLowering
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_device_type import onlyAccelerator
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_CI,
     IS_WINDOWS,
     isRocmArchAnyOf,
@@ -30,7 +32,6 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     IS_BIG_GPU,
-    requires_gpu,
     requires_triton,
     RUN_CPU,
     RUN_GPU,
@@ -113,7 +114,7 @@ class TestSubprocess(TestCase):
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/157788")
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/157724")
-    @requires_gpu()
+    @onlyAccelerator
     @requires_triton()
     @unittest.skipIf(
         not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
@@ -271,6 +272,7 @@ class TestSubprocess(TestCase):
 if RUN_CPU:
 
     class CpuTests(TestSubprocess):
+        hw_classification = HardwareClassification.CPU
         common = check_model
         device = "cpu"
 
@@ -281,6 +283,7 @@ if RUN_CPU:
 if RUN_GPU and not TEST_WITH_ASAN:
 
     class GPUTests(TestSubprocess):
+        hw_classification = HardwareClassification.ACCELERATOR
         common = check_model_gpu
         device = GPU_TYPE
 


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR|CUDA|CPU` to tests class.

## Motivation
`torch.cuda` only recognizes CUDA. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_compile_subprocess.py --hw-classification ACCELERATOR CPU`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo