### PR TITLE
[Testcase Refactoring] Refactor test_hooks.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
 )
-from torch.testing._internal.common_utils import skipIfRocm
+from torch.testing._internal.common_utils import HardwareClassification, skipIfRocm
 from torch.utils.hooks import RemovableHandle
 
 
@@ -44,6 +44,8 @@ class ClassWithVal:
 
 
 class HooksTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_tensor_only_register_hook_in_graph_lambda(self):
         def fn(x):
             x.register_hook(lambda grad: grad * 2)
@@ -1160,6 +1162,8 @@ def forward(self, L_x_ : torch.Tensor):
 
 
 class HooksTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipIfRocm(msg="pytorch/pytorch/issues/190414")
     @onlyAccelerator
     def test_register_hook_on_intermediate_autograd_cache(self, device):


### PR DESCRIPTION
## Summary

This PR adds hw_classification annotations to test classes in test/dynamo/test_hooks.py to enable hardware-based test categorization and selection. 

## Changes

- Imported HardwareClassification from torch.testing._internal.common_utils.
- Added hw_classification = HardwareClassification.GENERIC to HooksTests class (CPU-only tests).
- Added hw_classification = HardwareClassification.ACCELERATOR to HooksTestsDevice class (accelerator-dependent tests).

## Test Plan

`python test/dynamo/test_hooks.py --hw-classification GENERIC -v`
`python test/dynamo/test_hooks.py --hw-classification ACCELERATOR -v`
- Verified locally that all cases correctly on CPU and NPU.

## Notes

This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
