### PR TITLE
Fix fmod and remainder returning NaN on the vectorized CPU path

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -251,6 +251,59 @@ void div_trunc_kernel(TensorIteratorBase& iter) {
   }
 }
 
+// Keep this out of line. Inlining it into the vectorized loop costs 2-3x even on
+// inputs that never reach it.
+template <typename scalar_t>
+C10_NOINLINE Vectorized<scalar_t> fmod_scalar_vec(
+    Vectorized<scalar_t> a,
+    Vectorized<scalar_t> b) {
+  using vec_t = Vectorized<scalar_t>;
+  __at_align__ scalar_t as[vec_t::size()];
+  __at_align__ scalar_t bs[vec_t::size()];
+  a.store(as);
+  b.store(bs);
+  for (int64_t i = 0; i < vec_t::size(); ++i) {
+    as[i] = std::fmod(as[i], bs[i]);
+  }
+  return vec_t::loadu(as);
+}
+
+// Sleef_fmod reduces by multiplying the dividend by the reciprocal of the
+// divisor, so that product overflows to infinity and the result comes back NaN
+// once abs(a / b) passes the largest finite value. Sleef documents the range as
+// undefined. std::fmod is correct there, so redo the vector when a NaN shows up.
+//
+// div_floor_floating_vec below works around the same limitation, but it only
+// needs the quotient and can drop the remainder. Here the remainder is the
+// result.
+//
+// Checking the output for NaN is cheaper than predicting overflow from the
+// inputs, and it does not depend on knowing where Sleef stops being accurate.
+// Lanes that are legitimately NaN, from a NaN input or a zero divisor, take the
+// slow path too and still come back NaN.
+//
+// Only float and double need this. Vectorized<Half> and Vectorized<BFloat16>
+// implement fmod with std::fmod per element, so they are already exact. The
+// bfloat16 remainder kernel below converts to float first, so it does need it.
+template <typename scalar_t>
+inline Vectorized<scalar_t> fmod_floating_vec(
+    const Vectorized<scalar_t>& a,
+    const Vectorized<scalar_t>& b) {
+  using vec_t = Vectorized<scalar_t>;
+  const auto r = a.fmod(b);
+  if constexpr (
+      std::is_same_v<scalar_t, float> || std::is_same_v<scalar_t, double>) {
+    // zero_mask sets a bit per zero lane, so mapping the NaN lanes to zero
+    // turns "is any lane NaN" into a nonzero test that does not depend on the
+    // mask width.
+    if (C10_UNLIKELY(
+            vec_t::blendv(vec_t(1), vec_t(0), r.isnan()).zero_mask() != 0)) {
+      return fmod_scalar_vec(a, b);
+    }
+  }
+  return r;
+}
+
 template <typename scalar_t>
 inline Vectorized<scalar_t> div_floor_floating_vec(
     const Vectorized<scalar_t>& a,
@@ -379,8 +432,8 @@ void remainder_kernel(TensorIteratorBase& iter) {
         [=](Vectorized<BFloat16> a, Vectorized<BFloat16> b) {
           auto [a0, a1] = convert_bfloat16_float(a);
           auto [b0, b1] = convert_bfloat16_float(b);
-          auto mod0 = a0.fmod(b0);
-          auto mod1 = a1.fmod(b1);
+          auto mod0 = fmod_floating_vec(a0, b0);
+          auto mod1 = fmod_floating_vec(a1, b1);
           const auto zero = Vectorized<float>(0);
           auto mask0 = (mod0 != zero) & ((b0 < zero) ^ (mod0 < zero));
           auto mask1 = (mod1 != zero) & ((b1 < zero) ^ (mod1 < zero));
@@ -401,7 +454,7 @@ void remainder_kernel(TensorIteratorBase& iter) {
                     return mod;
                   },
               [=](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
-                auto mod = a.fmod(b);
+                auto mod = fmod_floating_vec(a, b);
                 const auto zero = Vectorized<scalar_t>(0);
                 auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
                 return Vectorized<scalar_t>::blendv(mod, mod + b, mask);
@@ -1053,7 +1106,7 @@ void fmod_kernel(TensorIteratorBase& iter) {
                 return std::fmod(x, d);
               },
               [](Vectorized<scalar_t> x, Vectorized<scalar_t> d) {
-                return x.fmod(d);
+                return fmod_floating_vec(x, d);
               });
         });
   }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3244,6 +3244,52 @@ class TestBinaryUfuncsDevice(TestCase):
             result_scalar = fn(dividend, -1)
             self.assertEqual(result_scalar, expected)
 
+    @dtypes(torch.float32, torch.float64)
+    def test_fmod_remainder_extremal(self, device, dtype):
+        # Sleef_fmod is undefined once abs(a / b) overflows, so the vectorized
+        # path returned NaN where the scalar path was right. See gh-77742.
+        finfo = torch.finfo(dtype)
+        for num, denom, shape in itertools.product(
+            [finfo.max * 0.7, -finfo.max * 0.7],
+            [finfo.tiny, -finfo.tiny, 0.5, -0.5],
+            [(), (32,)],  # Scalar and vectorized
+        ):
+            a = torch.full(shape, num, dtype=dtype, device=device)
+            b = torch.full(shape, denom, dtype=dtype, device=device)
+            # Compare against the values the kernel actually got, not against
+            # num and denom, since fmod of a huge ratio is sensitive to a
+            # single ULP of rounding in the cast.
+            an, bn = a.cpu().numpy(), b.cpu().numpy()
+            # asarray because numpy hands back a scalar for the 0-d case.
+            with np.errstate(over="ignore", invalid="ignore"):
+                fmod_ref = np.asarray(np.fmod(an, bn))
+                remainder_ref = np.asarray(np.remainder(an, bn))
+            self.assertEqual(torch.fmod(a, b).cpu(), torch.from_numpy(fmod_ref))
+            self.assertEqual(
+                torch.remainder(a, b).cpu(), torch.from_numpy(remainder_ref)
+            )
+
+    @dtypes(torch.bfloat16)
+    def test_remainder_extremal_bfloat16(self, device, dtype):
+        # The bfloat16 remainder kernel converts to float and calls the same
+        # Sleef routine, and bfloat16 has float32's exponent range, so it hits
+        # the same overflow. Vectorized<BFloat16>::fmod uses std::fmod per
+        # element, so fmod itself is fine and only remainder is checked here.
+        finfo = torch.finfo(dtype)
+        for num, denom in itertools.product(
+            [finfo.max * 0.7, -finfo.max * 0.7], [finfo.tiny, -finfo.tiny, 0.5, -0.5]
+        ):
+            # The scalar path is already correct, so it is the reference.
+            expected = torch.remainder(
+                torch.full((), num, dtype=dtype, device=device),
+                torch.full((), denom, dtype=dtype, device=device),
+            )
+            actual = torch.remainder(
+                torch.full((32,), num, dtype=dtype, device=device),
+                torch.full((32,), denom, dtype=dtype, device=device),
+            )
+            self.assertEqual(actual, expected.expand(32))
+
     @dtypes(*all_types_and(torch.half))
     def test_fmod_remainder(self, device, dtype):
         # Use numpy as reference


### PR DESCRIPTION
Fixes #193753.

`torch.fmod` and `torch.remainder` return `NaN` on the vectorized CPU path where the scalar path is correct. No extremal divisor is needed, just a large dividend:

```python
>>> import torch
>>> a = torch.full((64,), 1e38)
>>> torch.fmod(a, 1e-3)[0]        # vectorized
tensor(nan)
>>> torch.fmod(a[0], 1e-3)        # scalar, same inputs
tensor(9.2320e-05)
```

### Cause

`Vectorized<T>::fmod` calls `Sleef_fmod`, and Sleef documents its result as undefined once `abs(a / b)` gets large. The mechanism is in `xfmod`: the reduction step forms `trunc(r * (1 / abs(y)))`, that product overflows to infinity, and the double-double update then turns the accumulator into `NaN`. So the failure signature is always a `NaN`.

@peterbell10 diagnosed this on #77742 in 2022 and posted the `fmod` case there. #129536 closed that issue, but it only fixed `div` with `rounding_mode="floor"`, and it did so by throwing the remainder away:

```cpp
auto floor = vec_t::blendv(a - mod, a, (basic_div.abs() == inf) & (a.abs() != inf));
```

`div_floor` can do that because it only needs the quotient. For `fmod` and `remainder` the remainder is the result, so both still call Sleef unguarded.

### Fix

`fmod_floating_vec` recomputes the vector with `std::fmod` when `Vectorized<T>::fmod` returns a `NaN` lane.

Detecting the `NaN` in the output is cheaper than predicting overflow from the inputs, and it does not depend on knowing where Sleef stops being accurate. It is deliberately a superset: a legitimate `NaN`, from a `NaN` input or a zero divisor, takes the scalar path too and still comes back `NaN`.

Keeping the fallback out of line matters. Inlined into the vectorized loop it cost about 2x even on inputs that never reach it, which I measured in isolation against the vec headers before touching the kernel.

Call sites changed: `fmod_kernel`, the generic `remainder_kernel`, and both halves of the bfloat16 `remainder` specialization. The `a.fmod(b)` inside `div_floor_floating_vec` is left alone since #129536 already covers it.

float and double are guarded. `Vectorized<Half>` and `Vectorized<BFloat16>` implement `fmod` with `std::fmod` per element, so they are already exact. bfloat16 `remainder` still needs the fix because that kernel converts to float first, and bfloat16 has float32's exponent range:

```python
>>> b = torch.full((32,), 2.37e38, dtype=torch.bfloat16)
>>> torch.remainder(b, 0.5)[0]    # before: nan, scalar path gives 0
```

### Correctness

32 combinations of `+/- max * 0.7` over `+/- tiny` and `+/- 0.5`, in float32 and float64, at shape `()` and `(32,)`, for both ops:

| | before | after |
|---|---|---|
| mismatches vs NumPy | 32 | 0 |

Every failure was on the length-32 tensors, which is what pins it to the vectorized kernel.

### Performance

Single threaded, arm64, best of 7, uniform inputs that never trigger the fallback. Run-to-run spread on this machine is about 2.5%.

| n = 2^20 | before | after | |
|---|---|---|---|
| `fmod` float32 | 1278 us | 1421 us | +11% |
| `remainder` float32 | 1454 us | 1586 us | +9% |
| `fmod` float64 | 2686 us | 2955 us | +10% |
| `remainder` float64 | 3041 us | 3253 us | +7% |

So about 10%, and it is the branch, not the check. Two things I measured and rejected: predicting the overflow from the inputs with a division instead, which came out the same or slightly worse and needs a threshold; and a branchless version, which needs two Sleef calls per vector and is far worse. Some of the remaining cost is `Vectorized<double>::zero_mask()` on NEON extracting lanes one at a time where the float version uses a horizontal add. That looks like a one-line improvement, but it is a separate change so I left it out.

Happy to take this a different way if you would rather not pay 10% here.

### Tests

`test_fmod_remainder_extremal` and `test_remainder_extremal_bfloat16` in `test/test_binary_ufuncs.py`, next to the existing `test_fmod_remainder_overflow`. Each runs at shape `()` and `(32,)`, so before this change they fail on the vectorized path and pass on the scalar one. The float reference is NumPy applied to the tensors the kernel actually saw, not to the Python floats, since `fmod` of a ratio this large moves with one ULP of rounding in the cast. The bfloat16 case uses the scalar path as the reference.

`python -m pytest test/test_binary_ufuncs.py` passes.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01