### PR TITLE
Compute floor_divide in float for Half and BFloat16

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -255,44 +255,39 @@ template <typename scalar_t>
 inline Vectorized<scalar_t> div_floor_floating_vec(
     const Vectorized<scalar_t>& a,
     const Vectorized<scalar_t>& b) {
-  using vec_t = Vectorized<scalar_t>;
-  const auto basic_div = a / b;
-  vec_t inf(std::numeric_limits<scalar_t>::infinity());
-  auto mod = a.fmod(b);
-  // Fixup for a case that isn't properly handled by Sleef_fmod
-  auto floor = vec_t::blendv(a - mod, a, (basic_div.abs() == inf) & (a.abs() != inf));
-  auto div = floor / b;
-  const auto zero = vec_t(0);
-  auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
-  const auto one = vec_t(1);
-  div = vec_t::blendv(div, div - one, mask);
-  auto floordiv = div.floor();
-  mask = (div - floordiv) > vec_t(0.5);
-  floordiv = vec_t::blendv(floordiv, floordiv + one, mask);
-  floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
-  floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
-  return floordiv;
+  if constexpr (is_reduced_floating_point_v<scalar_t>) {
+    // Half and BFloat16 cannot hold the intermediates below. a - mod alone can
+    // round back up to a, and then the quotient comes out one too high. Widen
+    // to float and round once at the end, which is what div_floor_kernel
+    // already does when the divisor is a scalar.
+    //
+    // bfloat16 did this under SVE256 only. The rounding has nothing to do with
+    // SVE, so it is unconditional now and covers Half too.
+    auto [a1, a2] = convert_to_float<scalar_t>(a);
+    auto [b1, b2] = convert_to_float<scalar_t>(b);
+    return convert_from_float<scalar_t>(
+        div_floor_floating_vec(a1, b1), div_floor_floating_vec(a2, b2));
+  } else {
+    using vec_t = Vectorized<scalar_t>;
+    const auto basic_div = a / b;
+    vec_t inf(std::numeric_limits<scalar_t>::infinity());
+    auto mod = a.fmod(b);
+    // Fixup for a case that isn't properly handled by Sleef_fmod
+    auto floor =
+        vec_t::blendv(a - mod, a, (basic_div.abs() == inf) & (a.abs() != inf));
+    auto div = floor / b;
+    const auto zero = vec_t(0);
+    auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
+    const auto one = vec_t(1);
+    div = vec_t::blendv(div, div - one, mask);
+    auto floordiv = div.floor();
+    mask = (div - floordiv) > vec_t(0.5);
+    floordiv = vec_t::blendv(floordiv, floordiv + one, mask);
+    floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
+    floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
+    return floordiv;
+  }
 }
-
-#if defined(CPU_CAPABILITY_SVE256) && defined(__ARM_FEATURE_BF16)
-
-// Since sve lacks sufficient bf16 intrinsics, do the calculations in f32 to
-// avoid rounding errors. This should not cause performance issues as
-// most of the used instructions would be cast to f32 vectors anyway.
-template<>
-inline Vectorized<c10::BFloat16> div_floor_floating_vec(
-  const Vectorized<c10::BFloat16>& a,
-  const Vectorized<c10::BFloat16>& b) {
-  auto [a1, a2] = convert_bfloat16_float(a);
-  auto [b1, b2] = convert_bfloat16_float(b);
-
-  auto res1 = div_floor_floating_vec(a1, b1);
-  auto res2 = div_floor_floating_vec(a2, b2);
-
-  return convert_float_bfloat16(res1, res2);
-}
-
-#endif
 
 void div_floor_kernel(TensorIteratorBase& iter) {
   const auto dtype = iter.common_dtype();
@@ -335,10 +330,16 @@ void div_floor_kernel(TensorIteratorBase& iter) {
       AT_DISPATCH_FLOATING_TYPES_AND2(
           kBFloat16, kHalf, dtype, "div_floor_cpu", [&]() {
             using vec_t = Vectorized<scalar_t>;
+            using opmath_t = at::opmath_type<scalar_t>;
             cpu_kernel_vec(
                 iter,
                 [](scalar_t a, scalar_t b) -> scalar_t {
-                  return c10::div_floor_floating(a, b);
+                  // Compute in float for Half and BFloat16, like the scalar
+                  // divisor branch above and div_floor_floating_vec below.
+                  // std::fmod on those types returns the same type, so without
+                  // the cast every step here rounds.
+                  return c10::div_floor_floating(
+                      static_cast<opmath_t>(a), static_cast<opmath_t>(b));
                 },
                 [](vec_t a, vec_t b) -> vec_t {
                   return div_floor_floating_vec(a, b);

--- a/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
@@ -68,9 +68,15 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
+          using accscalar_t = at::acc_type<scalar_t, true>;
           gpu_kernel_with_scalars(
               iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-                return c10::div_floor_floating(a, b);
+                // Compute in float for Half and BFloat16, like the CPU scalar
+                // branch above. std::fmod on those types returns the same
+                // type, so without the cast every step here rounds and
+                // a - mod can round back up to a.
+                return c10::div_floor_floating(
+                    static_cast<accscalar_t>(a), static_cast<accscalar_t>(b));
               });
         });
   }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1292,6 +1292,37 @@ class TestBinaryUfuncsDevice(TestCase):
             actual = torch.divide(a, zero, rounding_mode=rounding_mode)
             self.assertEqual(actual, expect, exact_dtype=exact_dtype)
 
+    @dtypes(torch.bfloat16, torch.half)
+    def test_div_floor_reduced_precision(self, device, dtype):
+        # floor_divide used to compute its intermediates in the input dtype for
+        # these two, where a - fmod(a, b) can round back up to a and the
+        # quotient then comes out one too high. The scalar divisor path already
+        # widened to float, so the answer depended on the shape. Compare
+        # everything against float math narrowed once, exactly.
+        a = make_tensor((4096,), dtype=dtype, device=device, low=-1000, high=1000)
+        b = make_tensor((4096,), dtype=dtype, device=device, low=-10, high=10)
+        b[b == 0] = 1
+
+        expected = torch.floor_divide(a.float(), b.float()).to(dtype)
+        self.assertEqual(torch.floor_divide(a, b), expected, atol=0, rtol=0)
+
+        # Short tensors take the scalar loop instead of the vectorized one.
+        for n in (1, 2, 3):
+            self.assertEqual(
+                torch.floor_divide(a[:n], b[:n]), expected[:n], atol=0, rtol=0
+            )
+
+        # 560 // 3 is 186, but 560 - fmod(560, 3) is 558, which bfloat16 cannot
+        # represent. Rounded to 560 the quotient comes out as 187.
+        num = torch.full((64,), 560.0, dtype=dtype, device=device)
+        den = torch.full((64,), 3.0, dtype=dtype, device=device)
+        self.assertEqual(
+            torch.floor_divide(num, den),
+            torch.full_like(num, 186.0),
+            atol=0,
+            rtol=0,
+        )
+
     @dtypes(*all_types_and(torch.half))
     @dtypesIfXPU(*all_types())
     def test_div_rounding_numpy(self, device, dtype):


### PR DESCRIPTION
Fixes #193754.

`torch.floor_divide` on `bfloat16` and `float16` gives a different answer depending on the length of the input:

```python
>>> import torch
>>> a, b = torch.full((2,), 560.0, dtype=torch.bfloat16), torch.full((2,), 3.0, dtype=torch.bfloat16)
>>> torch.floor_divide(a, b)[0]
tensor(187., dtype=torch.bfloat16)
>>> torch.floor_divide(a[:1], b[:1])[0]
tensor(186., dtype=torch.bfloat16)
```

186 is right.

### Cause

`div_floor_kernel` has two paths. When the divisor is a scalar it dispatches through `AT_DISPATCH_REDUCED_FLOATING_TYPES` and computes in `opmath_t`, so `bfloat16` runs in float. The tensor-tensor path computes in `scalar_t`.

A size-1 tensor is squeezed to 0-dim, which makes `iter.is_scalar(2)` true, so it takes the widened path. That is the whole length dependence.

Staying in `bfloat16` is what gets the wrong answer. From NOTE: [Floor Division in Python], the quotient is `(a - fmod(a, b)) / b`. For 560 and 3 that is `558 / 3`, but 558 needs 10 significand bits and `bfloat16` has 8, so it rounds to 560, and `560 / 3` rounds to 187.

`std::fmod` does not save this. `c10::BFloat16` has its own overload returning `c10::BFloat16`, so every step in `c10::div_floor_floating` rounds.

The error is not bounded to one unit either. Over 4096 random values the largest difference from float math was 64.

### Fix

Widen both loops in the tensor-tensor path to `opmath_t`, matching the scalar divisor path. Same one-line cast on CUDA, whose general path had the same split against its own `is_cpu_scalar(2)` branch.

In the vectorized loop this replaces the `CPU_CAPABILITY_SVE256 && __ARM_FEATURE_BF16` specialization of `div_floor_floating_vec`, which already did exactly this widening for one backend and one dtype. Since it did not widen the scalar loop next to it, SVE256 has the same length dependence today, just in the other direction.

Written as `if constexpr` on `is_reduced_floating_point_v` rather than two specializations, so the float body is not instantiated for `Half` and `BFloat16` at all. `git diff -w` on that hunk is small, the body is only reindented.

float and double are unaffected. `opmath_type<float>` is `float`, so the cast is a no-op and the `if constexpr` picks the existing body.

### Correctness

4000 random pairs per dtype, comparing the tensor-tensor result against the same op elementwise on 0-dim tensors, and against float math narrowed once:

| | vs 0-dim | vs float |
|---|---|---|
| bfloat16 before | 264 / 4000 | 264 / 4000 |
| bfloat16 after | 0 | 0 |
| float16 before | 40 / 4000 | 40 / 4000 |
| float16 after | 0 | 0 |
| float32, float64 | 0 both | 0 both |

`560 // 3` in `bfloat16` is now 186 at lengths 1, 2, 3, 8, 16, 64 and 1000, and at 0-dim.

### Performance

This is faster, not slower. Single threaded, arm64, best of 7.

| n = 2^20 | before | after | |
|---|---|---|---|
| bfloat16 | 25262 us | 2779 us | 9.1x |
| float16 | 21006 us | 2244 us | 9.4x |
| float32 | 2145 us | 2100 us | unchanged |
| float64 | 4701 us | 4552 us | unchanged |

At n = 4096: bfloat16 51.5 -> 11.8 us, float16 31.6 -> 9.1 us.

`Vectorized<BFloat16>::fmod` is `map2(q, std::fmod)` and `::floor` is `map(floor_impl)`, so the old path spilled each vector to memory and called scalar libm per lane, and `std::fmod` on `BFloat16` converted to float and back anyway. Converting once up front gets `Sleef_fmod` and `vrndmq_f32` on real float vectors. This is what the SVE comment predicted, that most of these instructions end up as f32 anyway.

### Tests

`test_div_floor_reduced_precision` in `test/test_binary_ufuncs.py`. It compares against float math narrowed once with `atol=0, rtol=0`, since the default `bfloat16` tolerance is wide enough to hide an off-by-one quotient. It also checks lengths 1, 2 and 3 so the scalar loop and the vectorized loop are both covered.

Before this change it fails on 240 / 4096 elements for `bfloat16` and 18 / 4096 for `float16`.

`test_binary_ufuncs.py` passes, 12713 passed. `test_ops.py -k "floor_divide or div_floor_rounding"` passes, 169 passed.

I do not have a CUDA machine, so that one line is only reasoned about and left to CI.


cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01