### PR TITLE
[inductor] AOTI: handle SymInt in a Scalar arg for proxy-executor fallback kernels (#193767)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5162,6 +5162,34 @@ class AOTInductorTestsTemplate:
         m = M()
         self.check_model(m, example_args)
 
+    def test_proxy_executor_symint_scalar_arg(self):
+        # A SymInt (a symbolic scalar from a dynamic shape) bound to a Number/Scalar-typed
+        # arg -- arange.default's `end`. Under lite-mode fallback, arange goes through the
+        # AOT ProxyExecutor and its symbolic `end` exercises fill_args' NumberType branch
+        # (routed via cexpr like the SymIntType branch) plus the host proxy executor's
+        # as_sym_int handling. This previously raised: expected arg to be int, float, or
+        # bool, got <class 'torch.SymInt'>.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.arange(x.shape[0], device=x.device, dtype=x.dtype) + x
+
+        # Compile at n=64 and re-run the same artifact at n=257. A second shape is what
+        # actually pins the runtime half of the fix: the symbolic `end` has to travel the
+        # int64 runtime array (correctly counted by num_ints, read back at the matching
+        # index by the host), so a run at a size the artifact was not compiled for must
+        # produce arange(257) rather than a stale or misindexed 64.
+        dynamic_shapes = ({0: torch.export.Dim("n", min=2, max=4096)},)
+        list_example_inputs = [
+            (torch.randn(64, device=self.device),),
+            (torch.randn(257, device=self.device),),
+        ]
+        self.check_model_with_multiple_inputs(
+            M(),
+            list_example_inputs,
+            options={"fallback_by_default": True},
+            dynamic_shapes=dynamic_shapes,
+        )
+
     def test_proxy_executor_error_message_preserved(self):
         @torch.library.custom_op("aoti_test::validate_input", mutates_args=())
         def validate_input(x: torch.Tensor) -> torch.Tensor:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3071,14 +3071,22 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 expr = arg.node.expr if isinstance(arg, torch.SymInt) else arg
                 new_int_args.append(cexpr(expr))
             elif isinstance(arg_type, torch.NumberType):
-                # Scalar of type int
-                if not isinstance(arg, (int, float, bool)):
-                    raise AssertionError(
-                        f"expected arg to be int, float, or bool, got {type(arg)}"
-                    )
-                # Only treat int Scalar as dynamic
-                if isinstance(arg, int):
-                    new_int_args.append(str(arg))
+                # A symbolic scalar (SymInt) bound to a Scalar slot is a dynamic int64
+                # runtime arg, mirroring the SymIntType branch above. The host proxy
+                # executor's NumberType case accepts the resulting as_sym_int tag.
+                if isinstance(arg, torch.SymInt):
+                    new_int_args.append(cexpr(arg.node.expr))
+                else:
+                    # Scalar of type int
+                    if not isinstance(arg, (int, float, bool)):
+                        raise AssertionError(
+                            f"expected arg to be int, float, or bool, got {type(arg)}"
+                        )
+                    # Only treat int Scalar as dynamic. `bool` is an int subclass
+                    # but is serialized as_bool and prefilled statically, so it
+                    # must not be counted here.
+                    if type(arg) is int:
+                        new_int_args.append(str(arg))
             elif isinstance(arg, ir.TorchBindObject):
                 # torchbind objects are loaded in proxy executor
                 pass

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -129,8 +129,10 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
       break;
     }
     case c10::TypeKind::NumberType: {
-      if (serialized_arg_type == "as_int") {
-        // Only int Scalar is treated as dynamic arg for now
+      if (serialized_arg_type == "as_int" ||
+          serialized_arg_type == "as_sym_int") {
+        // An int (or symbolic int, from a dynamic shape) Scalar is treated as a
+        // dynamic arg, mirroring the SymIntType case above.
         dynamic_args.emplace_back(index, DynamicArgType::IntType, 1);
       } else if (serialized_arg_type == "as_float") {
         stack.at(index) = serialized_arg_val.get<double>();


### PR DESCRIPTION
Summary:

Under AOTInductor all-fallback (lite mode), an op with no c-shim is dispatched through the
AOT ProxyExecutor. A `torch.SymInt` (a symbolic scalar from a dynamic shape) bound to a
`Scalar`/`Number`-typed schema argument -- e.g. `aten.arange.default(end)` where `end` is a
dynamic size -- hit `fill_args`' `NumberType` branch, which only handled int/float/bool and
raised:

    AssertionError: expected arg to be int, float, or bool, got <class 'torch.SymInt'>

This is the fourth all-fallback wall the recsys `merge` net hits, after the two return-type
allowlist fixes (D113817678, D113855912) and the float-in-Tensor-arg materialization
(D113954350). Minimized repro: D113984769.

Fix (two self-consistent halves, mirroring the existing `SymIntType` handling):
1. Codegen (`cpp_wrapper_cpu.py`, `fill_args` `NumberType` branch): route a `SymInt`
   through the int64 runtime channel via `cexpr(arg.node.expr)`, exactly like the sibling
   `SymIntType` branch. This keeps `num_ints` correct.
2. Host (`oss_proxy_executor.cpp`, `NumberType` case): accept the `as_sym_int` serialized
   tag by registering a dynamic `IntType` arg, mirroring the `SymIntType` case. Without this
   half a codegen-only patch desyncs: the compile succeeds but model load aborts because the
   host's `NumberType` case rejected `as_sym_int`.

No serializer change is needed: `serialize_input` already emits `as_sym_int` for a `SymInt`
value (dispatching on value type), and the host reads the value from the runtime int64 array
for dynamic `IntType` args (it does not read the JSON int for that case).

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
Unit test `test_proxy_executor_symint_scalar_arg` in
`caffe2/test/inductor/test_aot_inductor.py` (fbcode + xplat): `torch.arange(x.shape[0]) + x`
with a dynamic dim under `fallback_by_default=True`, which forces `arange` through the AOT
ProxyExecutor with a symbolic Scalar `end`.

The test covers **two shapes**: `check_model_with_multiple_inputs` compiles once at `n=64`,
then re-runs that same artifact at `n=257`, checking numeric parity vs eager at both.

The second shape is what pins the *runtime* half of the fix. A single-shape run only proves
the compile stopped raising; running at a size the artifact was never compiled for requires
the symbolic `end` to actually travel the int64 runtime array -- counted correctly by
`num_ints` in codegen, and read back at the matching index by the host executor's
`NumberType` / `as_sym_int` case. A `num_ints` miscount or a misindexed read would hand
`arange` a stale `64` at `n=257` and fail the parity check (or shape-mismatch outright).

```
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true fbcode//caffe2/test/inductor:test_aot_inductor -- --regex 'test_proxy_executor_symint_scalar_arg'
```

Pass 4, Fail 0, Skip 1 -- https://www.internalfb.com/intern/testinfra/testrun/1407375404703328

- `AOTInductorTestABICompatibleCpu.test_proxy_executor_symint_scalar_arg_cpu` -- ok
- `AOTInductorTestABICompatibleGpu.test_proxy_executor_symint_scalar_arg_cuda` -- ok
- `AOTInductorTestDualWrapper.test_proxy_executor_symint_scalar_arg_cuda` -- ok
- `AOTInductorTestABICompatibleMps.test_proxy_executor_symint_scalar_arg_mps` -- skipped (no MPS backend)

Also validated on AMD MI350 (gfx950) with the minimized repro D113984769: the all-fallback
compile that previously raised `got <class 'torch.SymInt'>` now succeeds.

```
buck2 run @//mode/opt-amd-gpu -m rocm70 -c fbcode.rocm_arch=mi350 -c fbcode.enable_gpu_sections=true fbcode//scripts/zhuoran/inductor_fusion_toy/test:symint_number_arg_fallback_repro
```

Authored with an AI assistant.

Reviewed By: desertfire

Differential Revision: D113985294




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo