### PR TITLE
[inductor] AOTI: skip fallback for aten.sym_stride.int in lite mode (#193768)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17997,6 +17997,40 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             FileCheck().check("torch.ops.aten.add").run(code[0])
 
+    def test_lite_mode_sym_stride(self):
+        # aten.sym_stride.int (`x.stride(dim)` under a dynamic shape) returns a SymInt,
+        # like sym_size.int, and cannot be serialized as a generic fallback kernel.
+        # skip_fallback_due_to_dynamic_shape routes it to its symbolic (no-kernel)
+        # handling so lite mode does not hit the "Unsupported return type
+        # torch.SymIntType" wall. Use a 2D tensor with a dynamic inner dim so stride(0)
+        # is symbolic (for a 1D/contiguous tensor stride(0) is the constant 1).
+        def f(x):
+            s = x.stride(0)
+            return x + s
+
+        x = torch.randn(4, 8, device=self.device)
+        torch._dynamo.mark_dynamic(x, 1)
+        opt_f = torch.compile(f, mode="lite")
+
+        # Compiles and matches eager. Without the skip_fallback_due_to_dynamic_shape
+        # entry for sym_stride.int, this raises "Unsupported return type torch.SymIntType"
+        # under the cpp wrapper (AOTI) serialization path.
+        result, code = run_and_get_code(opt_f, x)
+        self.assertEqual(result, f(x))
+
+        # The surrounding elementwise op still falls back (lite mode is active); the
+        # sym_stride.int node did not become a generic fallback kernel. Lite mode sets
+        # use_dce=False, so a fallback kernel would survive into the generated code
+        # even with nothing consuming its buffer.
+        self.assertNotIn("sym_stride", code[0])
+        if config.cpp_wrapper:
+            # Same as test_lite_mode_sym_size: `aten.add.Tensor` is in torchgen's
+            # inductor_fallback_ops, so its fallback goes through the device
+            # c-shim, not the generic aoti_torch_call_dispatcher path.
+            FileCheck().check_regex(r"aoti_torch_\w+_add_Tensor\(").run(code[0])
+        else:
+            FileCheck().check("torch.ops.aten.add").run(code[0])
+
     @lowering.force_fallback(aten.sort.default)
     def test_size_asserts_for_multi_output_fallback(self):
         @torch.compile

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4752,6 +4752,8 @@ def should_fallback_by_default(node: torch.fx.Node) -> bool:
             # `.item()` returns a Scalar, which cannot be serialized as a generic
             # fallback kernel; route it to its dedicated DynamicScalar lowering.
             torch.ops.aten._local_scalar_dense.default,
+            # `x.stride(dim)` returns a SymInt too; same symbolic handling as sym_size.
+            torch.ops.aten.sym_stride.int,
         ]
     )
 


### PR DESCRIPTION
Summary:

Fifth all-fallback wall for the recsys `merge` net. `aten.sym_stride.int` (`x.stride(dim)`
under a dynamic shape) returns a SymInt which -- like `sym_size.int` (D113855912) -- cannot
be serialized as a generic proxy-executor FallbackKernel and raises:

    InductorError: RuntimeError: Unsupported return type <class 'torch.SymIntType'>

(handle_single_output, when a fallback kernel's output is a SymInt).

Fix: add `torch.ops.aten.sym_stride.int` to `skip_fallback_due_to_dynamic_shape` in
`should_fallback_by_default` (utils.py) -- the same allowlist that already routes
`sym_size.int` and `_local_scalar_dense` to their symbolic / dedicated (no generic fallback
kernel) handling. Identical one-line pattern to D113817678 / D113855912.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
New `test_lite_mode_sym_stride` in `caffe2/test/inductor/test_torchinductor.py` (fbcode +
xplat), mirroring `test_lite_mode_sym_size`: `x.stride(0)` on a 2D tensor with a dynamic
inner dim under `torch.compile(mode="lite")`; it compiles and matches eager (without the
allowlist entry this raised "Unsupported return type torch.SymIntType" under the cpp
wrapper).

```
buck2 test //caffe2/test/inductor:test_torchinductor -- test_lite_mode_sym_stride
```

Also validated end-to-end on the merge net `--mode fallback` on AMD MI350 (gfx950): with
this entry the `sym_stride.int` wall is gone and the dense region proceeds past it (walls
1-5 all cleared).

Authored with an AI assistant.

Reviewed By: kqfu

Differential Revision: D114000090


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo