### PR TITLE
Add a PrivateUse1 from_blob hook for backend-specific TensorImpl/StorageImpl construction

### DIFF
--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <ATen/core/ATen_fwd.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
+#include <ATen/core/TensorBase.h>
 #include <ATen/detail/AcceleratorHooksInterface.h>
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
 #include <c10/core/Storage.h>
+#include <c10/core/TensorOptions.h>
 #include <c10/util/Exception.h>
+#include <c10/util/OptionalArrayRef.h>
 
 
 namespace at {
@@ -64,6 +68,28 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
   virtual void resizePrivateUse1Bytes(
       const c10::Storage& /*storage*/,
       size_t /*newsize*/) const {
+    FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
+  }
+
+  // Opt-in hook allowing a PrivateUse1 backend to take over Tensor/Storage
+  // construction inside `at::from_blob(...)`, e.g. to produce a backend
+  // subclass of TensorImpl/StorageImpl instead of the generic ones. Backends
+  // that don't need this (the common case) should leave both methods at
+  // their defaults below, which preserves the exact pre-existing behavior.
+  virtual bool hasCustomFromBlob() const {
+    return false;
+  }
+
+  virtual at::TensorBase fromBlobPrivateUse1(
+      // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+      c10::DataPtr&& data_ptr,
+      std::size_t size_bytes,
+      at::IntArrayRef sizes,
+      at::OptionalIntArrayRef strides,
+      std::optional<int64_t> storage_offset,
+      const at::TensorOptions& options,
+      bool resizeable,
+      c10::Allocator* allocator) const {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -37,6 +37,26 @@ Tensor TensorMaker::make_tensor() {
      data_ptr = makeDataPtrFromContext();
    }
 
+   // Backends registered under the PrivateUse1 dispatch key may need a
+   // custom TensorImpl/StorageImpl subclass (e.g. to attach backend-specific
+   // storage descriptors), which the generic path below cannot produce.
+   // This is strictly opt-in: hasCustomFromBlob() defaults to false, so
+   // backends that don't override it (including no PrivateUse1 backend
+   // being registered at all) fall through to the unchanged default path.
+   if (device_->type() == c10::DeviceType::PrivateUse1 &&
+       at::isPrivateUse1HooksRegistered() &&
+       at::detail::getPrivateUse1Hooks().hasCustomFromBlob()) {
+     return at::detail::getPrivateUse1Hooks().fromBlobPrivateUse1(
+         std::move(data_ptr),
+         size_bytes,
+         sizes_,
+         strides_,
+         storage_offset_,
+         opts_,
+         resizeable_,
+         allocator_);
+   }
+
    TORCH_CHECK(!resizeable_ || allocator_ != nullptr, "Must specify an allocator with allocator() if you want to use resizeable_storage()");
    Storage storage{Storage::use_byte_size_t{}, size_bytes, std::move(data_ptr), /*allocator=*/allocator_, /*resizable=*/resizeable_};
 

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -32,6 +32,8 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/operators_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/packedtensoraccessor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/privateuse1_from_blob_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/privateuse1_from_blob_optout_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduce_ops_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reportMemoryUsage_test.cpp

--- a/aten/src/ATen/test/privateuse1_from_blob_optout_test.cpp
+++ b/aten/src/ATen/test/privateuse1_from_blob_optout_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/detail/PrivateUse1HooksInterface.h>
+
+using namespace at;
+
+namespace {
+
+// A PrivateUse1 backend that registers hooks for unrelated reasons (as most
+// backends do -- generators, pinned memory, etc.) but does NOT opt into the
+// new from_blob hook. This must be a completely separate test binary from
+// privateuse1_from_blob_test.cpp: PrivateUse1HooksInterface registration is
+// a global one-shot per process, so the two fake implementations (opted-in
+// vs. opted-out) can never coexist in the same test binary.
+class MinimalHooksNoFromBlobOverride : public at::PrivateUse1HooksInterface {
+ public:
+  bool isBuilt() const override {
+    return true;
+  }
+
+  bool isAvailable() const override {
+    return true;
+  }
+
+  // Deliberately does NOT override hasCustomFromBlob()/fromBlobPrivateUse1():
+  // this is the "existing backend, unmodified" scenario.
+};
+
+bool g_registered = [] {
+  at::RegisterPrivateUse1HooksInterface(new MinimalHooksNoFromBlobOverride());
+  return true;
+}();
+
+} // namespace
+
+TEST(PrivateUse1FromBlobOptOut, FallsThroughToDefaultConstructionPath) {
+  ASSERT_TRUE(g_registered);
+  ASSERT_TRUE(at::isPrivateUse1HooksRegistered());
+  ASSERT_FALSE(at::detail::getPrivateUse1Hooks().hasCustomFromBlob());
+
+  std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f};
+  // Since hasCustomFromBlob() is false, TensorMaker::make_tensor() must take
+  // the unchanged default branch even though PrivateUse1 hooks ARE
+  // registered -- proving existing backends that don't opt in are
+  // completely unaffected by this change.
+  at::Device device(at::DeviceType::PrivateUse1, 0);
+  Tensor tensor = at::from_blob(
+      data.data(),
+      {2, 2},
+      /*deleter=*/[](void*) {},
+      at::TensorOptions().dtype(at::kFloat).device(device),
+      /*target_device=*/device);
+
+  // typeid check: this must be exactly the generic TensorImpl, not any
+  // subclass -- the default path was never touched by this change.
+  EXPECT_EQ(typeid(*tensor.unsafeGetTensorImpl()), typeid(c10::TensorImpl));
+  EXPECT_EQ(tensor.sizes(), (at::IntArrayRef{2, 2}));
+  EXPECT_EQ(tensor.device().type(), at::DeviceType::PrivateUse1);
+}

--- a/aten/src/ATen/test/privateuse1_from_blob_test.cpp
+++ b/aten/src/ATen/test/privateuse1_from_blob_test.cpp
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/detail/PrivateUse1HooksInterface.h>
+
+#include <atomic>
+
+using namespace at;
+
+namespace {
+
+// A minimal TensorImpl subclass, standing in for a real backend's (e.g.
+// NPU's) custom TensorImpl. Its only purpose is to prove that
+// fromBlobPrivateUse1() can hand back a tensor whose impl is genuinely NOT
+// the generic c10::TensorImpl.
+class TestPrivateUse1TensorImpl : public c10::TensorImpl {
+ public:
+  TestPrivateUse1TensorImpl(
+      c10::Storage&& storage,
+      c10::DispatchKey dispatch_key,
+      const caffe2::TypeMeta data_type)
+      : c10::TensorImpl(std::move(storage), dispatch_key, data_type) {}
+};
+
+std::atomic<int> g_hook_call_count{0};
+
+class TestFromBlobHooks : public at::PrivateUse1HooksInterface {
+ public:
+  bool isBuilt() const override {
+    return true;
+  }
+
+  bool isAvailable() const override {
+    return true;
+  }
+
+  bool hasCustomFromBlob() const override {
+    return true;
+  }
+
+  at::TensorBase fromBlobPrivateUse1(
+      c10::DataPtr&& data_ptr,
+      std::size_t size_bytes,
+      at::IntArrayRef sizes,
+      at::OptionalIntArrayRef strides,
+      std::optional<int64_t> storage_offset,
+      const at::TensorOptions& options,
+      bool resizeable,
+      c10::Allocator* allocator) const override {
+    g_hook_call_count++;
+
+    c10::Storage storage{
+        c10::Storage::use_byte_size_t{},
+        size_bytes,
+        std::move(data_ptr),
+        /*allocator=*/allocator,
+        /*resizable=*/resizeable};
+
+    at::TensorBase tensor = at::detail::make_tensor_base<
+        TestPrivateUse1TensorImpl>(
+        std::move(storage), options.computeDispatchKey(), options.dtype());
+
+    auto* impl = tensor.unsafeGetTensorImpl();
+    if (strides) {
+      impl->set_sizes_and_strides(sizes, *strides);
+    } else {
+      impl->set_sizes_contiguous(sizes);
+    }
+    if (storage_offset) {
+      impl->set_storage_offset(*storage_offset);
+    }
+    impl->set_requires_grad(options.requires_grad());
+    return tensor;
+  }
+};
+
+// Registered exactly once for this test binary. PrivateUse1HooksInterface
+// registration is a global one-shot (throws if called twice), so this hook
+// implementation must not be shared with any other test binary target.
+bool g_registered = [] {
+  at::RegisterPrivateUse1HooksInterface(new TestFromBlobHooks());
+  return true;
+}();
+
+} // namespace
+
+TEST(PrivateUse1FromBlob, DefaultDeviceIsUnaffected) {
+  ASSERT_TRUE(g_registered);
+  int before = g_hook_call_count.load();
+
+  std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  Tensor cpu_tensor = at::from_blob(
+      data.data(), {2, 3}, at::TensorOptions().dtype(at::kFloat));
+
+  // The hook must not fire for non-PrivateUse1 devices, and the resulting
+  // tensor must be a plain TensorImpl, exactly as before this change.
+  EXPECT_EQ(g_hook_call_count.load(), before);
+  EXPECT_EQ(
+      dynamic_cast<TestPrivateUse1TensorImpl*>(
+          cpu_tensor.unsafeGetTensorImpl()),
+      nullptr);
+  EXPECT_TRUE(cpu_tensor.is_cpu());
+  EXPECT_EQ(cpu_tensor.sizes(), (at::IntArrayRef{2, 3}));
+}
+
+TEST(PrivateUse1FromBlob, PrivateUse1RoutesThroughCustomHook) {
+  int before = g_hook_call_count.load();
+
+  std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  // A deliberately non-default, non-contiguous view: sizes {2, 3}, strides
+  // {4, 1} (i.e. row pitch of 4 over a buffer of 8 elements), storage_offset
+  // 1 -- exercising the exact data plumbing (sizes/strides/storage_offset)
+  // that a real DLPack-import round trip relies on.
+  at::Device device(at::DeviceType::PrivateUse1, 0);
+  Tensor tensor = at::from_blob(
+      data.data(),
+      {2, 3},
+      {4, 1},
+      /*storage_offset=*/1,
+      /*deleter=*/[](void*) {},
+      at::TensorOptions().dtype(at::kFloat).device(device),
+      /*target_device=*/device);
+
+  EXPECT_EQ(g_hook_call_count.load(), before + 1);
+  EXPECT_NE(
+      dynamic_cast<TestPrivateUse1TensorImpl*>(tensor.unsafeGetTensorImpl()),
+      nullptr);
+  EXPECT_EQ(tensor.sizes(), (at::IntArrayRef{2, 3}));
+  EXPECT_EQ(tensor.strides(), (at::IntArrayRef{4, 1}));
+  EXPECT_EQ(tensor.storage_offset(), 1);
+  EXPECT_EQ(tensor.scalar_type(), at::kFloat);
+  EXPECT_EQ(tensor.device().type(), at::DeviceType::PrivateUse1);
+
+  // storage_offset=1 means element [0,0] of the view is data[1] == 2.0f,
+  // while the underlying storage still starts at data[0] == 1.0f.
+  EXPECT_EQ(*static_cast<const float*>(tensor.storage().data()), 1.0f);
+  EXPECT_EQ(tensor.const_data_ptr<float>()[0], 2.0f);
+}

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/OpenRegExtra.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/aten/OpenRegExtra.cpp
@@ -6,7 +6,15 @@
 #include <torch/csrc/autograd/autograd_not_implemented_fallback.h>
 #include <torch/library.h>
 
+#include "runtime/OpenRegHooks.h"
+
 namespace at::openreg {
+
+namespace {
+int64_t from_blob_hook_call_count() {
+  return c10::openreg::g_from_blob_hook_call_count.load();
+}
+} // namespace
 
 namespace {
 at::Tensor wrapper_quantize_per_tensor(
@@ -177,6 +185,9 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
 TORCH_LIBRARY_FRAGMENT(openreg, m) {
   m.def("custom_autograd_fn_returns_self(Tensor input)-> Tensor");
   m.def("custom_autograd_fn_aliasing(Tensor(a) input)-> Tensor(a)");
+  // Test hook: how many times fromBlobPrivateUse1() has fired (see
+  // runtime/OpenRegHooks.h). Not device-specific, so no per-key impl needed.
+  m.def("_from_blob_hook_call_count() -> int", &from_blob_hook_call_count);
 }
 
 TORCH_LIBRARY_IMPL(openreg, AutogradPrivateUse1, m) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
@@ -5,13 +5,35 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
+#include <c10/core/TensorImpl.h>
 
 #include <include/openreg.h>
+
+#include <atomic>
 
 #include "OpenRegFunctions.h"
 #include "OpenRegGenerator.h"
 
 namespace c10::openreg {
+
+// Stands in for a real backend-specific TensorImpl subclass (analogous to
+// e.g. torch_npu's NPUTensorImpl): its only purpose here is to demonstrate,
+// end-to-end through Python, that fromBlobPrivateUse1() can hand back a
+// tensor whose impl is genuinely not the generic c10::TensorImpl. It adds no
+// behavior of its own.
+class OpenRegFromBlobTensorImpl : public c10::TensorImpl {
+ public:
+  OpenRegFromBlobTensorImpl(
+      c10::Storage&& storage,
+      c10::DispatchKey dispatch_key,
+      const caffe2::TypeMeta data_type)
+      : c10::TensorImpl(std::move(storage), dispatch_key, data_type) {}
+};
+
+// Counts fromBlobPrivateUse1() invocations; exposed to Python as
+// torch.ops.openreg._from_blob_hook_call_count() for tests to assert on.
+inline std::atomic<int64_t> g_from_blob_hook_call_count{0};
+
 struct OPENREG_EXPORT OpenRegHooksInterface : public at::PrivateUse1HooksInterface {
   OpenRegHooksInterface() {};
   ~OpenRegHooksInterface() override = default;
@@ -89,6 +111,51 @@ struct OPENREG_EXPORT OpenRegHooksInterface : public at::PrivateUse1HooksInterfa
 
   at::Generator getNewGenerator(DeviceIndex device_index) const override {
     return at::make_generator<OpenRegGeneratorImpl>(device_index);
+  }
+
+  // Opts into the at::from_blob() PrivateUse1 hook (see
+  // ATen/detail/PrivateUse1HooksInterface.h). This lets e.g. a DLPack
+  // import of an "openreg" tensor construct an OpenRegFromBlobTensorImpl
+  // instead of a generic c10::TensorImpl, without torch_openreg needing to
+  // fork ATen's DLConvertor.cpp the way a real out-of-tree backend
+  // (e.g. torch_npu) currently has to.
+  bool hasCustomFromBlob() const override {
+    return true;
+  }
+
+  at::TensorBase fromBlobPrivateUse1(
+      c10::DataPtr&& data_ptr,
+      std::size_t size_bytes,
+      at::IntArrayRef sizes,
+      at::OptionalIntArrayRef strides,
+      std::optional<int64_t> storage_offset,
+      const at::TensorOptions& options,
+      bool resizeable,
+      c10::Allocator* allocator) const override {
+    g_from_blob_hook_call_count++;
+
+    c10::Storage storage{
+        c10::Storage::use_byte_size_t{},
+        size_bytes,
+        std::move(data_ptr),
+        /*allocator=*/allocator,
+        /*resizable=*/resizeable};
+
+    at::TensorBase tensor = at::detail::make_tensor_base<
+        OpenRegFromBlobTensorImpl>(
+        std::move(storage), options.computeDispatchKey(), options.dtype());
+
+    auto* impl = tensor.unsafeGetTensorImpl();
+    if (strides) {
+      impl->set_sizes_and_strides(sizes, *strides);
+    } else {
+      impl->set_sizes_contiguous(sizes);
+    }
+    if (storage_offset) {
+      impl->set_storage_offset(*storage_offset);
+    }
+    impl->set_requires_grad(options.requires_grad());
+    return tensor;
   }
 };
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_utils.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_utils.py
@@ -74,6 +74,37 @@ class TestDLPack(TestCase):
         self.assertEqual(x_t.shape, y.shape)
         self.assertEqual(x_t, y)
 
+    def test_dlpack_routes_through_from_blob_privateuse1_hook(self):
+        """DLPack import ultimately calls at::from_blob(); OpenRegHooksInterface
+        opts into PrivateUse1HooksInterface::fromBlobPrivateUse1(), so
+        importing an "openreg" tensor via DLPack must go through it -- this
+        is the exact mechanism a real out-of-tree backend (e.g. torch_npu)
+        would use to avoid forking ATen's DLConvertor.cpp."""
+        before = torch.ops.openreg._from_blob_hook_call_count()
+
+        x = torch.randn(2, 3, device="openreg")
+        capsule = torch.utils.dlpack.to_dlpack(x)
+        y = torch.from_dlpack(capsule)
+
+        after = torch.ops.openreg._from_blob_hook_call_count()
+        self.assertEqual(after, before + 1)
+
+        # Values/shape/device must still round-trip correctly through the
+        # custom hook, exactly as the pre-existing DLPack tests require.
+        self.assertEqual(x.shape, y.shape)
+        self.assertEqual(x.device, y.device)
+        self.assertEqual(x.cpu(), y.cpu())
+
+        # Non-contiguous / non-zero-storage_offset case, exercising the
+        # strides + storage_offset plumbing through the hook.
+        before = torch.ops.openreg._from_blob_hook_call_count()
+        x_view = torch.randn(4, 5, device="openreg")[1:, 1:]
+        capsule2 = torch.utils.dlpack.to_dlpack(x_view)
+        y_view = torch.from_dlpack(capsule2)
+        after = torch.ops.openreg._from_blob_hook_call_count()
+        self.assertEqual(after, before + 1)
+        self.assertEqual(x_view.cpu(), y_view.cpu())
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Add a PrivateUse1 `from_blob` hook for backend-specific `TensorImpl`/`StorageImpl` construction

## Summary

This is Phase 2 of the plan laid out in [DLPack PyTorch vs torch_npu](https://github.com/pytorch/pytorch/issues/192473) (section 9.3), a community-facing follow-up to `torch_npu`'s internal DLPack fixes (Phase 1).

Out-of-tree `PrivateUse1` backends (e.g. `torch_npu`) that need a custom `TensorImpl`/`StorageImpl` subclass currently have no way to plug that into `at::from_blob()`. Since `at::fromDLPack()` calls `at::from_blob()` internally, this forces such backends to fork the entirety of ATen's `DLConvertor.cpp` — duplicating ~50-95% of it — just to swap in a backend-specific construction path. This PR adds a narrow, strictly opt-in extension point that removes that need, and is the prerequisite for a follow-up `torch_npu` change (tracked separately) that deletes its forked copy in favor of the upstream implementation.

## What changes

Two new virtuals on `PrivateUse1HooksInterface` (`aten/src/ATen/detail/PrivateUse1HooksInterface.h`), both defaulted so **every existing backend is unaffected unless it explicitly opts in**:

```cpp
virtual bool hasCustomFromBlob() const {
  return false;
}

virtual at::TensorBase fromBlobPrivateUse1(
    c10::DataPtr&& data_ptr,
    std::size_t size_bytes,
    at::IntArrayRef sizes,
    at::OptionalIntArrayRef strides,
    std::optional<int64_t> storage_offset,
    const at::TensorOptions& options,
    bool resizeable,
    c10::Allocator* allocator) const {
  FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
}
```

`TensorMaker::make_tensor()` (`aten/src/ATen/templates/Functions.cpp`) delegates to the hook only when a backend opts in:

```cpp
if (device_->type() == c10::DeviceType::PrivateUse1 &&
    at::isPrivateUse1HooksRegistered() &&
    at::detail::getPrivateUse1Hooks().hasCustomFromBlob()) {
  return at::detail::getPrivateUse1Hooks().fromBlobPrivateUse1(
      std::move(data_ptr), size_bytes, sizes_, strides_, storage_offset_,
      opts_, resizeable_, allocator_);
}
// ...unchanged default path below, byte-for-byte identical to before this PR...
```

The `DataPtr`/`size_bytes` computation above this point is unchanged and stays shared/generic — the hook only takes over final `Storage`/`TensorImpl` construction, so backends don't need to reimplement that plumbing themselves. `from_blob()`'s five public overloads are untouched.

## Why this design

- `at::from_blob()` is a plain, hand-written function — it is **not** in `native_functions.yaml` and never goes through the ATen dispatcher. A dispatch-key-based override (`TORCH_LIBRARY_IMPL(aten, PrivateUse1, ...)`) is therefore not applicable; any extension point has to be a plain C++ hook.
- `PrivateUse1HooksInterface` already has a directly analogous precedent: `resizePrivateUse1Bytes`. `native/Resize.cpp` already branches on `device_type == kPrivateUse1` and delegates to a hooks virtual instead of hardcoding storage mutation. This PR follows that exact pattern rather than introducing a new, competing registry mechanism.
- Opt-in via `hasCustomFromBlob()` (rather than dispatching unconditionally whenever *any* `PrivateUse1` hooks are registered) preserves exact current behavior for every existing `PrivateUse1` backend that doesn't need this — including the in-tree `torch_openreg` reference backend prior to this PR.

## Testing

**Two new isolated C++ gtest binaries** (`aten/src/ATen/test/privateuse1_from_blob_test.cpp`, `.../privateuse1_from_blob_optout_test.cpp`). They're separate binaries because `PrivateUse1HooksInterface` registration is a global one-shot per process (throws if registered twice), so an "opted-in" and an "opted-out" fake backend can't coexist in one test process:

- `PrivateUse1FromBlob.DefaultDeviceIsUnaffected` — CPU tensors are untouched regardless of what's registered for `PrivateUse1` elsewhere in the process.
- `PrivateUse1FromBlob.PrivateUse1RoutesThroughCustomHook` — a fake hook fires exactly once, produces a tensor whose impl is a genuinely different `TensorImpl` subclass (not just the same type with a different tag), and sizes/strides/storage_offset/dtype/device all round-trip correctly through a non-contiguous, non-zero-offset case.
- `PrivateUse1FromBlobOptOut.FallsThroughToDefaultConstructionPath` — a `PrivateUse1` backend that registers hooks (e.g. for a custom generator) but does *not* override `hasCustomFromBlob()` gets the exact unchanged default `TensorImpl`.

**Zero regressions**: existing `dlconvertor_test`, `atest`, `basic` (including `TestForBlobResizeCPU`, `TestForBlobStridesResizeCPU`, `TestForBlobStridesOverflow`), and `extension_backend_test` all pass unmodified.

**End-to-end real-world proof**: the in-tree `torch_openreg` reference `PrivateUse1` backend now opts in (`OpenRegHooksInterface::hasCustomFromBlob`/`fromBlobPrivateUse1`, with a new `OpenRegFromBlobTensorImpl` marker subclass), and a new Python test (`test_dlpack_routes_through_from_blob_privateuse1_hook` in `tests/test_utils.py`) asserts that `torch.from_dlpack()` on an `openreg` tensor now routes through the hook — via the exact production call chain a real out-of-tree backend uses:
`torch.utils.dlpack.to_dlpack/from_dlpack` → `torch._C._from_dlpack` → `at::fromDLPack` → `fromDLPackImpl` → `at::from_blob` → `TensorMaker::make_tensor()`.

Full `torch_openreg` suite: **238 passed, 16 skipped, 2 xfailed** (skips/xfails pre-exist this change and are unrelated).

## Backward compatibility

- No change to any public API surface or `from_blob` overload signature.
- The default construction path (the code below the new `if` block) is textually unchanged.
- Only `Functions.cpp` and `PrivateUse1HooksInterface.h`/`.cpp` are touched — `from_blob.h` (a very widely-included header) is untouched, keeping the incremental rebuild footprint small.
- Every existing `PrivateUse1` backend that doesn't override the two new virtuals — including `torch_openreg` prior to this PR — is byte-for-byte unaffected, proven by the opt-out test above.

## Out of scope (left for later phases)

- `torch_npu` itself is not touched by this PR. Consuming this hook to delete its forked `DLConvertor.cpp` and register its own `from_blob` factory is a follow-up change, gated on this landing.
- The RFC's optional §9.3.2 "device-mapping registry" PR is not included here — `PrivateUse1 → kDLExtDev` device mapping already exists upstream, so it wasn't necessary for this change.
