### PR TITLE
[Testcase Refactoring] Decouple test_binary_folding.py from CUDA-specific

### DIFF
--- a/test/inductor/test_binary_folding.py
+++ b/test/inductor/test_binary_folding.py
@@ -24,6 +24,7 @@ from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inducto
     check_model_gpu,
     copy_tests,
 )
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import skipCUDAIf
 
 
@@ -339,6 +340,7 @@ class BinaryFoldingTemplate(TestCase):
 if HAS_CPU and not torch.backends.mps.is_available():
 
     class FreezingCpuTests(TestCase):
+        hw_classification = HardwareClassification.CPU
         common = check_model
         device = "cpu"
         autocast = torch.cpu.amp.autocast
@@ -380,6 +382,7 @@ if HAS_CPU and not torch.backends.mps.is_available():
 if HAS_GPU:
 
     class FreezingGpuTests(TestCase):
+        hw_classification = HardwareClassification.ACCELERATOR
         common = check_model_gpu
         device = GPU_TYPE
         autocast = torch.amp.autocast(device_type=GPU_TYPE)


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Add `hw_classification = HardwareClassification.ACCELERATOR|CPU` to tests class.

## Motivation
`torch.cuda` only recognizes CUDA. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_binary_folding.py --hw-classification ACCELERATOR CPU`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo