### PR TITLE
Validate lambd in ASGD

### DIFF
--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -46,6 +46,8 @@ class ASGD(Optimizer):
             raise ValueError(f"Invalid learning rate: {lr}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+        if not 0.0 <= lambd:
+            raise ValueError(f"Invalid lambd value: {lambd}")
 
         defaults = {
             "lr": lr,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -834,6 +834,15 @@ def optim_error_inputs_func_asgd(device, dtype):
                 error_type=ValueError,
                 error_regex="Invalid weight_decay value: -0.5",
             ),
+            ErrorOptimizerInput(
+                OptimizerInput(
+                    params=None,
+                    kwargs=dict(lr=1e-2, lambd=-0.5),
+                    desc="lambd should be >= 0",
+                ),
+                error_type=ValueError,
+                error_regex="Invalid lambd value: -0.5",
+            ),
         ]
     return error_inputs
 


### PR DESCRIPTION
### Problem

`ASGD.__init__` validates `lr` and `weight_decay` but not `lambd`. A negative decay term is accepted, and since the update multiplies the parameter by `(1 - lambd * eta)`, a negative `lambd` inverts the decay — the parameter grows instead of shrinking, with no error anywhere:

```python
p = nn.Parameter(torch.ones(3))

ASGD([p], lr=0.1, lambd=1e-4)    # default:  max|param| = 0.9697 after 30 steps
ASGD([p], lr=0.1, lambd=-1e-1)   # negative: max|param| = 1.362   (diverging)
```

### Why this looks like a gap rather than a choice

Every sibling optimizer rejects its analogous parameter:

```
Adam    betas=(-0.1, 0.9)   -> ValueError: Invalid beta parameter at index 0
Adam    eps=-1              -> ValueError: Invalid epsilon value
SGD     momentum=-1         -> ValueError: Invalid momentum value
RMSprop alpha=-1            -> ValueError: Invalid alpha value
Adagrad lr_decay=-1         -> ValueError: Invalid lr_decay value
NAdam   momentum_decay=-1   -> ValueError: Invalid momentum_decay value
Rprop   etas=(-1, 2)        -> ValueError: Invalid eta values
ASGD    lambd=-1            -> accepted
```

I swept the constructors of all of these; `ASGD.lambd` was the only unvalidated one that changes the update's sign.

### Change

Reject `lambd < 0` at construction, following the existing message style in the same file, and add the matching `ErrorOptimizerInput` next to the existing `weight_decay` entry in `common_optimizers.py` so `test_errors` covers it.

`lambd=0` stays valid (it's a legitimate no-decay setting, and the default `1e-4` is unaffected).

### Note on scope

`alpha` and `t0` are also unvalidated. I left them alone deliberately: I couldn't demonstrate a concrete misbehaviour for negative values of either over a short run, and I'd rather not add bounds I can't justify. Happy to extend if you'd like them covered for consistency.

### Testing

```python
ASGD(p, lambd=-1)     -> ValueError: Invalid lambd value: -1
ASGD(p, lambd=-1e-9)  -> ValueError: Invalid lambd value: -1e-09
ASGD(p)               -> ok        (default 1e-4)
ASGD(p, lambd=0.0)    -> ok
ASGD(p, lambd=1.0)    -> ok
```

I'm testing pure-Python changes against a CPU wheel rather than a local build, so CI is the authority for `test_optim`; the new error input follows the existing pattern exactly.
