### PR TITLE
[RFC] GB300 Inductor Reduction Fix (#193774)

### DIFF
--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -275,6 +275,29 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             min(rnumel, MAX_R0_BLOCK),
             register_intensive=register_intensive,
         )
+
+        sm103_inner = (
+            triton_meta["device"].cc == 103  # B300/GB300
+            and reduction_hint == ReductionHint.INNER
+            and rnumel >= 2048
+            and not register_intensive
+        )
+        sm103_config = None
+        if sm103_inner:
+            # We found that sm_103 (b300/gb300) requires more memory level parallelism
+            # than sm_100 (B200) or sm_90 (h100) to reach the same % of HBM peak BW.
+            # At 4 elm/thread GB300 reaches 33% of peak HBM on GB300 where B200 reaches
+            # 69%, leading to poor GB300 inductor kernel perf for memory bound kernels.
+            # We also confirmed both GB300 & B200 have identical SASS therefore proving
+            # the HBM BW issues are due to sm_103 HW behavior differences.
+            # During testing we found 16 elm/thread (from 4 elm/thread) and 4096 R0
+            # (from 1024) recovers HBM util and brings GB300 to ~70% HBM BW utilization
+            # and on par or better performance with B200 for inductor reduction kernels.
+            sm103_r0 = min(rnumel, 4096)
+            sm103_config = make_config(
+                1, sm103_r0, num_warps=max(sm103_r0 // (warp_size * 16), 1)
+            )
+
         tiny_config = make_config(
             2 * (256 // rnumel) if rnumel <= 256 else 1,
             min(rnumel, MAX_R0_BLOCK),
@@ -308,6 +331,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         elif max_autotune_enabled:
             pass
         elif reduction_hint == ReductionHint.INNER:
+            if sm103_config is not None:
+                # Adding B300/GB300 config as autotuning option
+                return configs + [contiguous_config, sm103_config]
             return configs + [contiguous_config]
         elif reduction_hint == ReductionHint.OUTER:
             return configs + [outer_config]


### PR DESCRIPTION
Summary:

# Why

Many reduction kernels are running relatively slowly on GB300 compared to B200 when comparing GB300 Jobs ([example job (intern access only)](https://fburl.com/mlhub/wnh5a31e))
- [TLPARSE (intern access only)](https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7/attempt_0/version_0/rank_1/-_14_0_1/inductor_output_code_crb4rozipla43jln7u53meq5k33sgrks7xj4yx5yugxguvugmiao_123.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000)
- [TRACE (intern access only)](https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=aps_traces&trace_path=tree%2Ftraces%2Fdynocli%2Faps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7%2F0%2Frank-1.Jul_20_23_21_24.5294.pt.trace.json.gz)

During testing, we found that sm_103 (b300/gb300) requires more memory level parallelism than sm_100 (B200) or sm_90 (h100) to reach the same % of HBM peak BW. At 4 elm/thread GB300 reaches 33% of peak HBM on GB300 where B200 reaches 69%, leading to poor GB300 inductor kernel perf for memory bound kernels. We also confirmed both GB300 & B200 have identical SASS therefore proving the HBM BW issues are due to sm_103 HW behavior differences. During testing we found 16 elm/thread (from 4 elm/thread) and 4096 R0 (from 1024) recovers HBM util and brings GB300 to ~70% HBM BW utilization and on par or better performance with B200 for inductor reduction kernels.


To see how prevalent the issue is, we extracted many of the offending kernels and benchmarked against B200.

Key Offenders (intern access only):
- [`triton_red_fused__to_copy_mean_mse_loss_4`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/c55l6oeesnyrlbt7hnahkqievoq3542ifwxugmwces2mnkuvxr2d_848/triton_red_fused__to_copy_mean_mse_loss_4.py)
- [`triton_red_fused__fused_rms_norm__fused_rms_norm_backward__unsafe_view_add_cat_clone_copy_slice_slice_backward_split_with_sizes_sum_transpose_view_zeros_like_10`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cxkbi3ltxlj67fcuk2wwd5jz6trasooqal3bam72e2ssa4v6zrxq_303/triton_red_fused__fused_rms_norm__fused_rms_norm_backward__unsafe_view_add_cat_clone_copy_slice_slice_backward_split_with_sizes_sum_transpose_view_zeros_like_10.py)
- [`triton_red_fused_cat_slice_sum_transpose_view_33`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/ckuishy2yogfqowd7h572vtbxucsh5losdyisukuluwwrx3ouvx4_500/triton_red_fused_cat_slice_sum_transpose_view_33.py)
- [`triton_red_fused_cat_slice_sum_transpose_view_33`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cre5rop2lagvo5pgq73ilryxotz26fmmj35gkcab6oppe2qxxbre_353/triton_red_fused_cat_slice_sum_transpose_view_33.py)
- [`triton_red_fused_cat_slice_sum_transpose_view_33`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cre5rop2lagvo5pgq73ilryxotz26fmmj35gkcab6oppe2qxxbre_328/triton_red_fused_cat_slice_sum_transpose_view_33.py)
- [`triton_red_fused__fused_rms_norm__fused_rms_norm_backward__unsafe_view_add_cat_clone_copy_slice_slice_backward_split_with_sizes_sum_transpose_view_zeros_like_7`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/csep2atx7mowarnwbmpg6cmhblvomly5y3envhysq7pvagmrc44m_473/triton_red_fused__fused_rms_norm__fused_rms_norm_backward__unsafe_view_add_cat_clone_copy_slice_slice_backward_split_with_sizes_sum_transpose_view_zeros_like_7.py)
- [`triton_red_fused__to_copy_native_layer_norm_backward_19`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cbcxrebv6y5f43zxz2fqv5ybt2cmlvdlgeu6qwkexx5s6ty4z3e6_1382/triton_red_fused__to_copy_native_layer_norm_backward_19.py)
- [`triton_red_fused__to_copy_native_layer_norm_backward_19`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cbcxrebv6y5f43zxz2fqv5ybt2cmlvdlgeu6qwkexx5s6ty4z3e6_899/triton_red_fused__to_copy_native_layer_norm_backward_19.py)
- [`triton_red_fused__to_copy_native_layer_norm_backward_19`](https://www.internalfb.com/manifold/explorer/ads_mtia_misc/tree/ruizhezh/gb300_inductor_kernels/aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_64t-0d58559fc7___rank1/subgraphs/cbcxrebv6y5f43zxz2fqv5ybt2cmlvdlgeu6qwkexx5s6ty4z3e6_1234/triton_red_fused__to_copy_native_layer_norm_backward_19.py)


### Example from our Testing

Currently B200 and GB300 shares (`device_major == 10`) the same tiling choices in inductor to determine X/R0 and threads per block.

`triton_red_fused__to_copy_mean_mse_loss_4` is a `bf16[512, 296448]`
inner reduction used `XBLOCK=1, R0_BLOCK=1024, num_warps=8` for both b200 and gb300, but comparing runtimes:

| | achieved | % of own peak |
|---|---|---|
| H100 (3.35 TB/s) | 2132 GB/s | 63.6% |
| B200 (8 TB/s) | 5503 GB/s | 68.8% |
| GB300 (7.93 TB/s) | 2583 GB/s | **32.6%** |

**Seems like GB300 simply needs far more memory parallelism per thread to saturate the same HBM bandwidth. While B200 can saturate mem bus at 4 elem per thread, GB300 needs 8 or 16.**

**I am not fully certain on the hw mechanisms leading to this.**

# Changes

Adds a second autotune candidate for `ReductionHint.INNER` reductions on sm_103
(B300/GB300): `R0_BLOCK = min(rnumel, 4096)` with `num_warps` chosen to give 16
elm per thread instead of 4 elm per thread as before.

||before|after|
|--|--|--|
|r0_block|1024|4096|
|elem_per_thread|4|16|

This brings memory bound reduction kernel GB300 performance on par or better than B200.

Test Plan:
# Correctness

Reduction order changes with `R0_BLOCK`, so both configs were run on the real
artifact and compared. Max relative difference across all four outputs:

```
out  max_rel_diff        ref[0] (R0=1024)   new[0] (R0=4096)
  0     5.267e-07           594049.500000      594049.750000
  1     5.297e-07           594867.062500      594867.250000
  2     5.274e-07           594808.562500      594808.750000
  3     5.279e-07           595884.750000      595884.875000
```

5.3e-7 on an fp32 accumulation of 296448 bf16 terms -- reassociation only, no
change to the computation. Accumulation stays fp32 in both.

# Performance A/B (1396 kernels, flush_l2 512MB)

See https://fburl.com/gsheet/1ff74pjn (intern access only)

Many inductor kernels see better performance:

(ratio is `kernel runtime of A / kernel runtime of B`)
| GB300before/GB300after | GB300before/B200 | GB300after/B200 |
| --- | --- | --- |
| 2.4568 | 1.8975 | 0.7723673626 |
| 1.7345 | 0.9869 | 0.5689674389 |
| 1.7111 | 0.9692 | 0.5664410914 |
| 1.6758 | 0.9764 | 0.5826743573 |
| 1.6752 | 0.9768 | 0.5830542636 |
| 1.6417 | 0.9854 | 0.6002015914 |
| 1.4994 | 0.9572 | 0.6383432963 |
| 1.497 | 0.9551 | 0.638004548 |
| 1.4957 | 0.9578 | 0.6404158359 |
| 1.3626 | 1.3675 | 1.003592507 |
| 1.3614 | 1.367 | 1.004109237 |
| 1.3552 | 0.9998 | 0.7378029588 |
| 1.3524 | 1.129 | 0.8347574602 |
| 1.3517 | 0.9488 | 0.7019770325 |
| 1.3508 | 1.1254 | 0.833169259 |
| 1.3504 | 1.127 | 0.8346037587 |
| 1.3421 | 0.9429 | 0.7025422456 |
| 1.3366 | 0.949 | 0.7099972364 |
| 1.3337 | 0.945 | 0.7085534476 |
| 1.3185 | 0.9248 | 0.7013885664 |
| 1.2901 | 0.9606 | 0.7446105013 |

Differential Revision: D115814311




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo