### PR TITLE
Fix torch.remainder giving a zero result the dividend's sign

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -15,6 +15,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/TypeSafeSignMath.h>
+#include <c10/util/copysign.h>
 #include <c10/util/generic_math.h>
 
 namespace at::native {
@@ -371,7 +372,11 @@ void remainder_kernel(TensorIteratorBase& iter) {
               float a0 = static_cast<float>(a);
               float b0 = static_cast<float>(b);
               float mod0 = std::fmod(a0, b0);
-              if ((mod0 != 0) && ((b0 < 0) != (mod0 < 0))) {
+              if (mod0 == 0) {
+                // fmod gives the zero the sign of the dividend. The result
+                // takes the sign of the divisor, like Python and NumPy.
+                mod0 = std::copysign(0.0f, b0);
+              } else if ((b0 < 0) != (mod0 < 0)) {
                 mod0 += b0;
               }
               return mod0;
@@ -382,10 +387,17 @@ void remainder_kernel(TensorIteratorBase& iter) {
           auto mod0 = a0.fmod(b0);
           auto mod1 = a1.fmod(b1);
           const auto zero = Vectorized<float>(0);
-          auto mask0 = (mod0 != zero) & ((b0 < zero) ^ (mod0 < zero));
-          auto mask1 = (mod1 != zero) & ((b1 < zero) ^ (mod1 < zero));
-          a0 = Vectorized<float>::blendv(mod0, mod0 + b0, mask0);
-          a1 = Vectorized<float>::blendv(mod1, mod1 + b1, mask1);
+          a0 = Vectorized<float>::blendv(
+              mod0, mod0 + b0, (b0 < zero) ^ (mod0 < zero));
+          a1 = Vectorized<float>::blendv(
+              mod1, mod1 + b1, (b1 < zero) ^ (mod1 < zero));
+          // Give a zero result the sign of the divisor. Keeping just the sign
+          // bit of b is copysign(0, b). These selects own the zero case, so the
+          // masks above no longer exclude it. A zero divisor gives NaN, which
+          // compares false and is left alone.
+          const auto sign_bit = Vectorized<float>(-0.0f);
+          a0 = Vectorized<float>::blendv(a0, b0 & sign_bit, mod0 == zero);
+          a1 = Vectorized<float>::blendv(a1, b1 & sign_bit, mod1 == zero);
           return convert_float_bfloat16(a0, a1);
         });
   } else {
@@ -396,15 +408,29 @@ void remainder_kernel(TensorIteratorBase& iter) {
               [=](scalar_t a, scalar_t b)
                   __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
                     scalar_t mod = std::fmod(a, b);
-                    if ((mod != 0) && ((b < 0) != (mod < 0)))
+                    if (mod == 0) {
+                      // fmod gives the zero the sign of the dividend, but the
+                      // result is documented to take the sign of the divisor,
+                      // like Python and NumPy. A zero divisor gives NaN here,
+                      // not zero, so it does not reach this.
+                      mod = c10::copysign(scalar_t(0), b);
+                    } else if ((b < 0) != (mod < 0)) {
                       mod += b;
+                    }
                     return mod;
                   },
               [=](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
+                using vec_t = Vectorized<scalar_t>;
                 auto mod = a.fmod(b);
-                const auto zero = Vectorized<scalar_t>(0);
-                auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
-                return Vectorized<scalar_t>::blendv(mod, mod + b, mask);
+                const auto zero = vec_t(0);
+                auto res =
+                    vec_t::blendv(mod, mod + b, (b < zero) ^ (mod < zero));
+                // Give a zero result the sign of the divisor. Keeping just the
+                // sign bit of b is copysign(0, b), and cheaper than
+                // vec_t::copysign, which calls into Sleef. This select owns the
+                // zero case, so the mask above no longer excludes it. A zero
+                // divisor gives NaN, which compares false and is left alone.
+                return vec_t::blendv(res, b & vec_t(-scalar_t(0)), mod == zero);
               });
         });
   }

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/TypeSafeSignMath.h>
 
 #include <limits>
@@ -50,7 +51,13 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
           auto mod = ::fmod(a, b);
-          if (mod != 0 && c10::signs_differ(b, mod)) {
+          if (mod == 0) {
+            // fmod gives the zero the sign of the dividend, but the result is
+            // documented to take the sign of the divisor, like Python and
+            // NumPy. A zero divisor gives NaN here, not zero, so it does not
+            // reach this.
+            mod = c10::cuda::compat::copysign(scalar_t(0), b);
+          } else if (c10::signs_differ(b, mod)) {
             mod += b;
           }
           return mod;

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -393,7 +393,11 @@ template <
 inline float remainder(const T x, const U y) {
   const auto x_f = static_cast<float>(x);
   const auto y_f = static_cast<float>(y);
-  return x_f - y_f * floor_divide(x_f, y_f);
+  const auto rc = x_f - y_f * floor_divide(x_f, y_f);
+  // The subtraction cancels to +0.0 whatever the signs were, but the result
+  // takes the sign of the divisor, like Python and NumPy. A zero divisor
+  // gives NaN here, not zero, so it does not reach this.
+  return rc == 0 ? ::metal::copysign(0.0f, y_f) : rc;
 }
 
 template <

--- a/cmake/Metal.cmake
+++ b/cmake/Metal.cmake
@@ -9,7 +9,8 @@ endif()
 
 # Headers transitively included by .metal sources. Any change to these must
 # retrigger the metal -> air step, since xcrun metal does not emit depfiles
-# we can hand to ninja.
+# we can hand to ninja. The metal -> metallib.h step embeds these same headers
+# into the shader source, so it needs them too.
 file(GLOB METAL_HEADER_DEPS CONFIGURE_DEPENDS
      "${CMAKE_SOURCE_DIR}/c10/metal/*.h"
      "${CMAKE_SOURCE_DIR}/aten/src/ATen/native/mps/kernels/*.h")
@@ -39,7 +40,7 @@ function(metal_to_metallib_h SHADER)
     cmake_path(APPEND_STRING SHADER_HDR "_metallib.h")
 
     add_custom_command(COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py ${SHADER_ABSOLUTE} ${SHADER_HDR}
-                       DEPENDS ${SHADER_ABSOLUTE} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py
+                       DEPENDS ${SHADER_ABSOLUTE} ${METAL_HEADER_DEPS} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py
                        OUTPUT ${SHADER_HDR}
                        COMMENT "Generating metallib wrapper header for ${SHADER}"
                        VERBATIM)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3310,6 +3310,28 @@ class TestBinaryUfuncsDevice(TestCase):
                     ((torch.remainder, torch.Tensor.remainder_, np.remainder),),
                 )
 
+    # The XPU kernel lives in intel/torch-xpu-ops and has the same bug, so it
+    # has to be fixed there: BinaryRemainderKernel.cpp, RemainderFloatingFunctor.
+    @skipXPU
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_remainder_zero_sign(self, device, dtype):
+        # remainder gives the result the sign of the divisor, so a zero result
+        # should be signed too. fmod signs the zero after the dividend instead,
+        # and the fixup for that only ran when the result was nonzero.
+        values = (-6.0, -4.0, -1.0, -0.0, 0.0, 1.0, 4.0, 6.0)
+        divisors = (-3.0, -2.0, -1.0, 1.0, 2.0, 3.0)
+        for a, b in product(values, divisors):
+            # short tensors take the scalar loop, long ones the vectorized loop
+            for n in (1, 2, 3, 64):
+                actual = torch.remainder(
+                    torch.full((n,), a, dtype=dtype, device=device),
+                    torch.full((n,), b, dtype=dtype, device=device),
+                )
+                expected = torch.full_like(actual, a % b)
+                self.assertEqual(actual, expected, atol=0, rtol=0)
+                # assertEqual says -0.0 equals 0.0, so compare the sign bit
+                self.assertEqual(actual.signbit(), expected.signbit())
+
     @dtypes(torch.float, torch.double)
     def test_remainder_fmod_large_dividend(self, device, dtype):
         alarge = 1e9


### PR DESCRIPTION
Fixes #193755

`torch.remainder` is documented to return a result with the sign of the divisor. A zero result came back with the sign of the dividend instead.

```python
>>> torch.remainder(torch.tensor([2.0]), torch.tensor([-1.0]))
tensor([0.])          # want -0., which is what Python and numpy give
>>> 2.0 % -1.0
-0.0
```

## Why

`fmod` gives a zero the sign of the dividend. The fixup that corrects the sign only ran when the result was nonzero, so zeros kept `fmod`'s sign. CPU and CUDA both do this. MPS computes `x - y * floor_divide(x, y)`, where the subtraction cancels to `+0.0` whatever the signs were.

## What changed

CPU scalar and vectorized loops, the CPU bfloat16 loop, CUDA, and MPS.

In the vectorized loops, keeping just the sign bit of `b` is `copysign(0, b)` and is cheaper than `Vectorized::copysign`, which calls into Sleef. That select also makes the nonzero term in the existing mask redundant, so the net cost is one extra op.

One build fix came with it. On machines without a full metal toolchain the shader is embedded into the binary by `write_metallib_headers.py`, but that step did not depend on the headers it embeds, so editing `c10/metal/utils.h` left a stale shader. `METAL_HEADER_DEPS` is now a dependency there, same as the `metal -> air` step already does.

## Testing

New `test_remainder_zero_sign` compares against Python's `%` for half, bfloat16, float and double, at lengths 1, 2, 3 and 64 so both the scalar and vectorized loops run. It checks `signbit` separately because `assertEqual` treats `-0.0` and `0.0` as equal.

Locally on arm64:
- 3360 dividend/divisor/length combinations per dtype match Python's `%` exactly, on CPU and MPS. Before: every case where the divisor was negative and the result was zero came out wrong.
- float32 and float64 match numpy bitwise on random data at lengths 1 through 1000.
- NaN, inf and zero divisors are unchanged. A zero divisor gives NaN, so it never reaches the new branch.
- `test_binary_ufuncs.py` 12715 passed, `test_ops.py -k "remainder or fmod"` 186 passed, `test_mps.py -k "remainder or fmod or floor_divide"` 38 passed.

CUDA is not compiled locally, so that line is untested. It mirrors the CPU change and `copysign(scalar_t(0), b)` resolves to the `float` overload for half and bfloat16, same as the existing call in `BinaryDivFloorKernel.cu`.

## Cost

Vectorized body, in-cache, interleaved in one binary: +0.8% float, +3.5% double. Whole op on 1M elements, single thread: +6% float32, +8% float64, +4% bfloat16, float16 unchanged. Using `Vectorized::copysign` instead was about twice that on double.

## Out of scope

- Inductor codegen keeps the `r != 0` guard and has the same bug. #175584 is already open on that file, so I left it alone to avoid conflicting.
- XPU has the same bug in `RemainderFloatingFunctor`, which lives in intel/torch-xpu-ops. The new test is `@skipXPU` with a pointer to it.

#193763 also touches `remainder_kernel`, for NaN handling. The two are independent, whichever lands second needs a trivial rebase.


cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @kulinseth @malfet @DenisVieriu97 @jhavukainen @aditvenk @Isalia20