### PR TITLE
[Testcase Refactoring] Split Capability.distributed.fsdp into fsdp1/fsdp2, add sharded_tensor

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -327,12 +327,12 @@ class TestCapabilityGating(TestCase):
     @requires_capabilities(Capability.dtype.bf16)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
-        self.fail("This test should be skipped")
+        self.fail("Expected skip: dtype.bf16 is unsupported on this device")
 
     @requires_capabilities(Capability.attention.flash_attention)
     def test_capability_missing(self, device):
         type(self).executed_count += 1
-        self.fail("This test should raise AssertionError")
+        self.fail("Expected skip: attention.flash_attention is not declared")
 
     @requires_capabilities(
         Capability.lib.triton,
@@ -341,7 +341,9 @@ class TestCapabilityGating(TestCase):
     )
     def test_capability_combined(self, device):
         type(self).executed_count += 1
-        self.fail("Combined caps: missing should raise AssertionError before skip")
+        self.fail(
+            "Expected skip: attention.flash_attention is not declared and dtype.bf16 is not supported"
+        )
 
 
 PrivateUse1TestBase._capabilities = classmethod(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
+    Capability,
     dtypes,
     instantiate_device_type_tests,
     onlyCUDA,
@@ -14,7 +15,7 @@ from torch.testing._internal.common_device_type import (
     ops,
     precisionOverride,
     PrivateUse1TestBase,
-    requires_capabilitys,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -303,7 +304,7 @@ with _temp_test_configs(
 
 
 class TestCapabilityGating(TestCase):
-    """Verify that @requires_capabilitys gates tests on PrivateUse1 backends."""
+    """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
     executed_count = 0
 
@@ -318,33 +319,35 @@ class TestCapabilityGating(TestCase):
             )
         super().tearDownClass()
 
-    @requires_capabilitys("test.cap_supported")
+    @requires_capabilities(Capability.lib.triton)
     def test_capability_supported(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilitys("test.cap_unsupported")
+    @requires_capabilities(Capability.dtype.bf16)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
         self.fail("This test should be skipped")
 
-    @requires_capabilitys("test.cap_missing")
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_capability_missing(self, device):
         type(self).executed_count += 1
-        self.fail("This test should be skipped")
+        self.fail("This test should raise AssertionError")
 
-    @requires_capabilitys(
-        "test.cap_supported", "test.cap_unsupported", "test.cap_missing"
+    @requires_capabilities(
+        Capability.lib.triton,
+        Capability.dtype.bf16,
+        Capability.attention.flash_attention,
     )
     def test_capability_combined(self, device):
         type(self).executed_count += 1
-        self.fail("This test should be skipped")
+        self.fail("Combined caps: missing should raise AssertionError before skip")
 
 
 PrivateUse1TestBase._capabilities = classmethod(
     lambda cls: {
-        "test.cap_supported": lambda: True,
-        "test.cap_unsupported": lambda: False,
+        Capability.lib: {Capability.lib.triton: lambda: True},
+        Capability.dtype: {Capability.dtype.bf16: lambda: False},
     }
 )
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_device_type import (
     ops,
     precisionOverride,
     PrivateUse1TestBase,
+    requires_capabilitys,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -299,6 +300,54 @@ with _temp_test_configs(
     instantiate_device_type_tests(
         TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
     )
+
+
+class TestCapabilityGating(TestCase):
+    """Verify that @requires_capabilitys gates tests on PrivateUse1 backends."""
+
+    executed_count = 0
+
+    @classmethod
+    def tearDownClass(cls):
+        expected_runs = 1
+        if cls.executed_count != expected_runs:
+            raise AssertionError(
+                f"Capability gating failed! "
+                f"Expected {expected_runs} tests to run, "
+                f"but {cls.executed_count} tests executed."
+            )
+        super().tearDownClass()
+
+    @requires_capabilitys("test.cap_supported")
+    def test_capability_supported(self, device):
+        type(self).executed_count += 1
+        self.assertEqual(torch.device(device).type, "openreg")
+
+    @requires_capabilitys("test.cap_unsupported")
+    def test_capability_unsupported(self, device):
+        type(self).executed_count += 1
+        self.fail("This test should be skipped")
+
+    @requires_capabilitys("test.cap_missing")
+    def test_capability_missing(self, device):
+        type(self).executed_count += 1
+        self.fail("This test should be skipped")
+
+    @requires_capabilitys(
+        "test.cap_supported", "test.cap_unsupported", "test.cap_missing"
+    )
+    def test_capability_combined(self, device):
+        type(self).executed_count += 1
+        self.fail("This test should be skipped")
+
+
+PrivateUse1TestBase._capabilities = classmethod(
+    lambda cls: {
+        "test.cap_supported": lambda: True,
+        "test.cap_unsupported": lambda: False,
+    }
+)
+instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -310,7 +310,7 @@ class TestCapabilityGating(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        expected_runs = 1
+        expected_runs = 3
         if cls.executed_count != expected_runs:
             raise AssertionError(
                 f"Capability gating failed! "
@@ -329,21 +329,38 @@ class TestCapabilityGating(TestCase):
         type(self).executed_count += 1
         self.fail("Expected skip: dtype.bf16 is unsupported on this device")
 
-    @requires_capabilities(Capability.attention.flash_attention)
     def test_capability_missing(self, device):
-        type(self).executed_count += 1
-        self.fail("Expected skip: attention.flash_attention is not declared")
+        """@requires_capabilities raises AssertionError for undeclared capabilities."""
 
-    @requires_capabilities(
-        Capability.lib.triton,
-        Capability.dtype.bf16,
-        Capability.attention.flash_attention,
-    )
-    def test_capability_combined(self, device):
+        @requires_capabilities(Capability.attention.flash_attention)
+        def dummy(self):
+            self.fail("should not execute")
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"has not declared capabilities: attention\.flash_attention",
+        ):
+            dummy(self)
         type(self).executed_count += 1
-        self.fail(
-            "Expected skip: attention.flash_attention is not declared and dtype.bf16 is not supported"
+
+    def test_capability_combined(self, device):
+        """@requires_capabilities raises AssertionError when a combined set
+        includes an undeclared capability."""
+
+        @requires_capabilities(
+            Capability.lib.triton,
+            Capability.dtype.bf16,
+            Capability.attention.flash_attention,
         )
+        def dummy(self):
+            self.fail("should not execute")
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"has not declared capabilities: attention\.flash_attention",
+        ):
+            dummy(self)
+        type(self).executed_count += 1
 
 
 PrivateUse1TestBase._capabilities = classmethod(

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -307,6 +307,7 @@ class TestCapabilityGating(TestCase):
     """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
     executed_count = 0
+    setup_count = 0
 
     @classmethod
     def tearDownClass(cls):
@@ -316,6 +317,12 @@ class TestCapabilityGating(TestCase):
                 f"Capability gating failed! "
                 f"Expected {expected_runs} tests to run, "
                 f"but {cls.executed_count} tests executed."
+            )
+        if cls.setup_count != expected_runs:
+            raise AssertionError(
+                f"Capability preflight failed! "
+                f"Expected {expected_runs} test setups to run, "
+                f"but {cls.setup_count} setups executed."
             )
         super().tearDownClass()
 
@@ -363,13 +370,23 @@ class TestCapabilityGating(TestCase):
         type(self).executed_count += 1
 
 
-PrivateUse1TestBase._capabilities = classmethod(
-    lambda cls: {
-        Capability.lib: {Capability.lib.triton: lambda: True},
-        Capability.dtype: {Capability.dtype.bf16: lambda: False},
-    }
-)
+def _openreg_test_capabilities(_cls):
+    capabilities = PrivateUse1TestBase._capabilities()
+    capabilities[Capability.lib].update({Capability.lib.triton: lambda: True})
+    capabilities[Capability.dtype] = {Capability.dtype.bf16: lambda: False}
+    return capabilities
+
+
+def _openreg_capability_test_setup(self):
+    PrivateUse1TestBase.setUp(self)
+    type(self).setup_count += 1
+
+
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
+_capability_test_cls = globals()["TestCapabilityGatingOPENREG"]
+_capability_test_cls._capabilities = classmethod(_openreg_test_capabilities)
+_capability_test_cls.setUp = _openreg_capability_test_setup
+del _capability_test_cls
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -7,20 +7,19 @@ import torch
 import torch.nn.functional as F
 import torch.utils.flop_counter
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION,
-    PLATFORM_SUPPORTS_FP8,
-    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+from torch.nn.attention import sdpa_kernel, SDPBackend
+from torch.testing._internal.common_device_type import (
+    e4m3_type,
+    instantiate_device_type_tests,
+    requires_capabilitys,
 )
-from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
 
 
@@ -31,8 +30,6 @@ try:
 except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
-
-HAS_CUDA = torch.cuda.is_available()
 
 
 def FlopCounterMode(*args, **kwargs):
@@ -51,6 +48,8 @@ def T(*shape, requires_grad=False):
     TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
 )
 class TestFlopCounter(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_sdpa_flop_count_gqa(self):
         """sdpa_flop_count should handle GQA where KV heads < Q heads."""
         # MHA: q_heads == kv_heads
@@ -326,499 +325,6 @@ class TestFlopCounter(TestCase):
         with FlopCounterMode() as mode:
             T(4, 5).cos()
 
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION
-        or not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
-        or not PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
-    )
-    def test_sdpa(self):
-        batch_size = 4
-        n_heads = 8
-        seq_len_q = 128
-        seq_len_k = 256
-        head_dim = 64
-        head_dim_v = 64
-        dtype = torch.float16
-
-        torch.manual_seed(0)
-
-        def get_flops(
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-            backend,
-            with_backward=False,
-        ):
-            query = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_q,
-                head_dim,
-                device="cuda",
-                dtype=dtype,
-                requires_grad=True,
-            )
-            key = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_k,
-                head_dim,
-                device="cuda",
-                dtype=dtype,
-                requires_grad=True,
-            )
-            value = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_k,
-                head_dim_v,
-                device="cuda",
-                dtype=dtype,
-                requires_grad=True,
-            )
-
-            if backend == "math":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=False,
-                    enable_math=True,
-                    enable_mem_efficient=False,
-                    enable_cudnn=False,
-                )
-            elif backend == "flash":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=True,
-                    enable_math=False,
-                    enable_mem_efficient=False,
-                    enable_cudnn=False,
-                )
-            elif backend == "mem_efficient":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=False,
-                    enable_math=False,
-                    enable_mem_efficient=True,
-                    enable_cudnn=False,
-                )
-            elif backend == "cudnn":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=False,
-                    enable_math=False,
-                    enable_mem_efficient=False,
-                    enable_cudnn=True,
-                )
-
-            mode = FlopCounterMode()
-            with backend, mode:
-                out = F.scaled_dot_product_attention(
-                    query, key, value, dropout_p=0, is_causal=True
-                )
-                if with_backward:
-                    out.sum().backward()
-            return int(get_total_flops(mode))
-
-        # Sets seq_len_q == seq_len_k and dim_q == dim_v
-        run_uniform_flops = functools.partial(
-            get_flops,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_q,
-            head_dim,
-            head_dim,
-            dtype,
-        )
-
-        flops = [
-            run_uniform_flops(backend, with_backward=False)
-            for backend in ["math", "flash", "mem_efficient", "cudnn"]
-        ]
-        flops_fw_math, flops_fw_flash, flops_fw_efficient, flops_fw_cudnn = flops
-        self.assertEqual(flops_fw_math, flops_fw_flash)
-        self.assertEqual(flops_fw_math, flops_fw_efficient)
-        self.assertEqual(flops_fw_math, flops_fw_cudnn)
-
-        self.assertExpectedInline(str(flops_fw_math), """134217728""")
-
-        flops = [
-            run_uniform_flops(backend, with_backward=True)
-            for backend in ["math", "flash", "mem_efficient", "cudnn"]
-        ]
-        (
-            flops_fw_bw_math,
-            flops_fw_bw_flash,
-            flops_fw_bw_efficient,
-            flops_fw_bw_cudnn,
-        ) = flops
-        self.assertEqual(flops_fw_math * 3, flops_fw_bw_math)
-        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
-        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_efficient)
-        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_cudnn)
-
-        run_nonuniform_flops = functools.partial(
-            get_flops,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-        )
-        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
-        non_uniform_backends = ["math", "mem_efficient"]
-        flops = [
-            run_nonuniform_flops(backend, with_backward=False)
-            for backend in non_uniform_backends
-        ]
-        flops_fw_math, flops_fw_efficient = flops
-        self.assertEqual(flops_fw_math, flops_fw_efficient)
-
-        self.assertExpectedInline(str(flops_fw_math), """268435456""")
-
-        flops = [
-            run_nonuniform_flops(backend, with_backward=True)
-            for backend in non_uniform_backends
-        ]
-        flops_fw_bw_math, flops_fw_bw_efficient = flops
-        self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
-        self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
-
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Flash attention not supported (pre-SM80 hardware on CUDA)",
-    )
-    def test_sdpa_gqa(self):
-        """Test flop counting for grouped-query attention (GQA)."""
-        batch_size = 2
-        n_heads_q = 32
-        n_heads_kv = 8
-        seq_len = 128
-        head_dim = 64
-        dtype = torch.float16
-
-        query = torch.randn(
-            batch_size,
-            n_heads_q,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-        key = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-        value = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device="cuda",
-            dtype=dtype,
-        )
-
-        mode = FlopCounterMode()
-        with mode:
-            out = F.scaled_dot_product_attention(
-                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
-            )
-        gqa_flops = int(get_total_flops(mode))
-
-        # Compare with MHA (KV heads expanded to match Q heads)
-        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        mode_mha = FlopCounterMode()
-        with mode_mha:
-            out_mha = F.scaled_dot_product_attention(
-                query,
-                key_expanded,
-                value_expanded,
-                dropout_p=0,
-                is_causal=True,
-            )
-        mha_flops = int(get_total_flops(mode_mha))
-
-        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
-        self.assertEqual(gqa_flops, mha_flops)
-        self.assertTrue(gqa_flops > 0)
-
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION
-        or not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
-    )
-    def test_sdpa_nested_tensor(self):
-        def get_flops(q, k, v, backend, with_backward=False):
-            mode = FlopCounterMode()
-
-            if backend == "math":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=False,
-                    enable_math=True,
-                    enable_mem_efficient=False,
-                    enable_cudnn=False,
-                )
-            elif backend == "flash":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=True,
-                    enable_math=False,
-                    enable_mem_efficient=False,
-                    enable_cudnn=False,
-                )
-            elif backend == "mem_efficient":
-                backend = torch.backends.cuda.sdp_kernel(
-                    enable_flash=False,
-                    enable_math=False,
-                    enable_mem_efficient=True,
-                    enable_cudnn=False,
-                )
-
-            with backend, mode:
-                out = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=0, is_causal=True
-                )
-                if with_backward:
-                    if out.is_nested:
-                        out.values().sum().backward()
-                    else:
-                        out.sum().backward()
-
-            return int(get_total_flops(mode))
-
-        def get_nested_inputs(
-            batch_size,
-            n_heads,
-            max_seq_len_q,
-            max_seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-        ):
-            q_lengths = torch.tensor(
-                [
-                    max_seq_len_q // 4,
-                    max_seq_len_q // 4 * 2,
-                    max_seq_len_q // 4 * 3,
-                    max_seq_len_q // 4 * 4,
-                ]
-            )
-            k_lengths = torch.tensor(
-                [
-                    max_seq_len_k // 4,
-                    max_seq_len_k // 4 * 2,
-                    max_seq_len_k // 4 * 3,
-                    max_seq_len_k // 4 * 4,
-                ]
-            )
-            q_offsets, k_offsets = (
-                torch.cat((torch.tensor([0]), torch.cumsum(lengths, dim=0))).cuda()
-                for lengths in (q_lengths, k_lengths)
-            )
-            q_values = torch.randn(
-                q_offsets[-1],
-                head_dim * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device="cuda",
-            )
-            k_values = torch.randn(
-                k_offsets[-1],
-                head_dim * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device="cuda",
-            )
-            v_values = torch.randn(
-                k_offsets[-1],
-                head_dim_v * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device="cuda",
-            )
-
-            q = torch.nested.nested_tensor_from_jagged(q_values, q_offsets)
-            k = torch.nested.nested_tensor_from_jagged(k_values, k_offsets)
-            v = torch.nested.nested_tensor_from_jagged(v_values, k_offsets)
-
-            q = q.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
-            k = k.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
-            v = v.view(batch_size, -1, n_heads, head_dim_v).transpose(1, 2)
-
-            return q, k, v
-
-        def get_dense_flops(q, k, v, backend, with_backward=False):
-            def split_tensor(x):
-                return (
-                    y.unsqueeze(0).transpose(1, 2).detach().requires_grad_(True)
-                    for y in x.transpose(1, 2).unbind(0)
-                )
-
-            q_tensors = split_tensor(q)
-            k_tensors = split_tensor(k)
-            v_tensors = split_tensor(v)
-
-            flops = 0
-            for q_i, k_i, v_i in zip(q_tensors, k_tensors, v_tensors):
-                flops += get_flops(
-                    q_i, k_i, v_i, backend=backend, with_backward=with_backward
-                )
-
-            return flops
-
-        uniform_config = {
-            "batch_size": 4,
-            "n_heads": 8,
-            "max_seq_len_q": 128,
-            "max_seq_len_k": 128,
-            "head_dim": 64,
-            "head_dim_v": 64,
-            "dtype": torch.float16,
-        }
-
-        # max_seq_len_q != max_seq_len_k doesn't work for flash attention with dense tensors.
-        differing_config = {
-            "batch_size": 4,
-            "n_heads": 8,
-            "max_seq_len_q": 128,
-            "max_seq_len_k": 256,
-            "head_dim": 64,
-            "head_dim_v": 64,
-            "dtype": torch.float16,
-        }
-
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=False,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-        )
-
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=True,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-        )
-
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
-    )
-    def test_nested_attention_fake_tensors(self):
-        x = torch.randn(123, 4, 16, device="cuda", dtype=torch.bfloat16)
-        offsets = torch.tensor([0, 30, 60, 90, 123], device="cuda")
-        max_seqlen = 40
-        with FakeTensorMode() as fake_mode:
-            fake_x = fake_mode.from_tensor(x)
-            fake_offsets = fake_mode.from_tensor(offsets)
-
-            with FlopCounterMode() as fake_flop_counter_mode:
-                torch.ops.aten._flash_attention_forward(
-                    fake_x,
-                    fake_x,
-                    fake_x,
-                    fake_offsets,
-                    fake_offsets,
-                    max_seqlen,
-                    max_seqlen,
-                    0.0,
-                    False,
-                    False,
-                )
-
-        dense_x = torch.randn(4, 40, 4, 16, dtype=torch.bfloat16, device="cuda")
-
-        with FlopCounterMode() as real_flop_counter_mode:
-            torch.ops.aten._flash_attention_forward(
-                dense_x,
-                dense_x,
-                dense_x,
-                None,
-                None,
-                max_seqlen,
-                max_seqlen,
-                0.0,
-                False,
-                False,
-            )
-
-        self.assertEqual(
-            int(get_total_flops(fake_flop_counter_mode)),
-            int(get_total_flops(real_flop_counter_mode)),
-        )
-
     def test_flash_attention_forward_flop_layout(self):
         B, S, H, D = 2, 128, 8, 64
         q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
@@ -997,8 +503,485 @@ class TestFlopCounter(TestCase):
         self.assertEqual(called, 1)
         self.assertExpectedInline(get_total_flops(mode), """9001""")
 
-    @requires_cuda_and_triton
-    def test_flop_counter_custom_triton_manual_decomp(self):
+    @skipIfNoTorchVision
+    def test_inference_mode(self):
+        def get_flops(model):
+            with FlopCounterMode(model) as mode:
+                a = T(1, 3, 224, 224)
+                model(a).sum()
+            return mode
+
+        resnet18 = torchvision_models.resnet18()
+
+        mode_standard = get_flops(resnet18)
+
+        with torch.inference_mode():
+            mode_inference = get_flops(resnet18)
+
+        self.assertEqual(
+            get_total_flops(mode_standard), get_total_flops(mode_inference)
+        )
+
+        layer1_conv_flops_standard = mode_standard.flop_counts["ResNet.layer1"][
+            torch.ops.aten.convolution
+        ]
+        layer1_conv_flops_inference = mode_inference.flop_counts["ResNet.layer1"][
+            torch.ops.aten.convolution
+        ]
+        self.assertEqual(layer1_conv_flops_standard, layer1_conv_flops_inference)
+
+
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestFlopCounterDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_capabilitys(
+        "feat.cudnn_attention", "feat.flash_attention", "feat.mem_efficient_attention"
+    )
+    def test_sdpa(self, device):
+        batch_size = 4
+        n_heads = 8
+        seq_len_q = 128
+        seq_len_k = 256
+        head_dim = 64
+        head_dim_v = 64
+        dtype = torch.float16
+
+        torch.manual_seed(0)
+
+        def get_flops(
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+            backend,
+            with_backward=False,
+        ):
+            query = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_q,
+                head_dim,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            key = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_k,
+                head_dim,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            value = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_k,
+                head_dim_v,
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+
+            if backend == "math":
+                backend = sdpa_kernel([SDPBackend.MATH])
+            elif backend == "flash":
+                backend = sdpa_kernel([SDPBackend.FLASH_ATTENTION])
+            elif backend == "mem_efficient":
+                backend = sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION])
+            elif backend == "cudnn":
+                backend = sdpa_kernel([SDPBackend.CUDNN_ATTENTION])
+
+            mode = FlopCounterMode()
+            with backend, mode:
+                out = F.scaled_dot_product_attention(
+                    query, key, value, dropout_p=0, is_causal=True
+                )
+                if with_backward:
+                    out.sum().backward()
+            return int(get_total_flops(mode))
+
+        # Sets seq_len_q == seq_len_k and dim_q == dim_v
+        run_uniform_flops = functools.partial(
+            get_flops,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_q,
+            head_dim,
+            head_dim,
+            dtype,
+        )
+
+        flops = [
+            run_uniform_flops(backend, with_backward=False)
+            for backend in ["math", "flash", "mem_efficient", "cudnn"]
+        ]
+        flops_fw_math, flops_fw_flash, flops_fw_efficient, flops_fw_cudnn = flops
+        self.assertEqual(flops_fw_math, flops_fw_flash)
+        self.assertEqual(flops_fw_math, flops_fw_efficient)
+        self.assertEqual(flops_fw_math, flops_fw_cudnn)
+
+        self.assertExpectedInline(str(flops_fw_math), """134217728""")
+
+        flops = [
+            run_uniform_flops(backend, with_backward=True)
+            for backend in ["math", "flash", "mem_efficient", "cudnn"]
+        ]
+        (
+            flops_fw_bw_math,
+            flops_fw_bw_flash,
+            flops_fw_bw_efficient,
+            flops_fw_bw_cudnn,
+        ) = flops
+        self.assertEqual(flops_fw_math * 3, flops_fw_bw_math)
+        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
+        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_efficient)
+        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_cudnn)
+
+        run_nonuniform_flops = functools.partial(
+            get_flops,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        )
+        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
+        non_uniform_backends = ["math", "mem_efficient"]
+        flops = [
+            run_nonuniform_flops(backend, with_backward=False)
+            for backend in non_uniform_backends
+        ]
+        flops_fw_math, flops_fw_efficient = flops
+        self.assertEqual(flops_fw_math, flops_fw_efficient)
+
+        self.assertExpectedInline(str(flops_fw_math), """268435456""")
+
+        flops = [
+            run_nonuniform_flops(backend, with_backward=True)
+            for backend in non_uniform_backends
+        ]
+        flops_fw_bw_math, flops_fw_bw_efficient = flops
+        self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
+        self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
+
+    @requires_capabilitys("feat.flash_attention")
+    def test_sdpa_gqa(self, device):
+        """Test flop counting for grouped-query attention (GQA)."""
+        batch_size = 2
+        n_heads_q = 32
+        n_heads_kv = 8
+        seq_len = 128
+        head_dim = 64
+        dtype = torch.float16
+
+        query = torch.randn(
+            batch_size,
+            n_heads_q,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        key = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        value = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+        mode = FlopCounterMode()
+        with mode:
+            out = F.scaled_dot_product_attention(
+                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
+            )
+        gqa_flops = int(get_total_flops(mode))
+
+        # Compare with MHA (KV heads expanded to match Q heads)
+        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        mode_mha = FlopCounterMode()
+        with mode_mha:
+            out_mha = F.scaled_dot_product_attention(
+                query,
+                key_expanded,
+                value_expanded,
+                dropout_p=0,
+                is_causal=True,
+            )
+        mha_flops = int(get_total_flops(mode_mha))
+
+        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
+        self.assertEqual(gqa_flops, mha_flops)
+        self.assertTrue(gqa_flops > 0)
+
+    @requires_capabilitys("feat.flash_attention", "feat.mem_efficient_attention")
+    def test_sdpa_nested_tensor(self, device):
+        def get_flops(q, k, v, backend, with_backward=False):
+            mode = FlopCounterMode()
+
+            if backend == "math":
+                backend = sdpa_kernel([SDPBackend.MATH])
+            elif backend == "flash":
+                backend = sdpa_kernel([SDPBackend.FLASH_ATTENTION])
+            elif backend == "mem_efficient":
+                backend = sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION])
+
+            with backend, mode:
+                out = F.scaled_dot_product_attention(
+                    q, k, v, dropout_p=0, is_causal=True
+                )
+                if with_backward:
+                    if out.is_nested:
+                        out.values().sum().backward()
+                    else:
+                        out.sum().backward()
+
+            return int(get_total_flops(mode))
+
+        def get_nested_inputs(
+            batch_size,
+            n_heads,
+            max_seq_len_q,
+            max_seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        ):
+            q_lengths = torch.tensor(
+                [
+                    max_seq_len_q // 4,
+                    max_seq_len_q // 4 * 2,
+                    max_seq_len_q // 4 * 3,
+                    max_seq_len_q // 4 * 4,
+                ]
+            )
+            k_lengths = torch.tensor(
+                [
+                    max_seq_len_k // 4,
+                    max_seq_len_k // 4 * 2,
+                    max_seq_len_k // 4 * 3,
+                    max_seq_len_k // 4 * 4,
+                ]
+            )
+            q_offsets, k_offsets = (
+                torch.cat((torch.tensor([0]), torch.cumsum(lengths, dim=0))).to(
+                    device=device
+                )
+                for lengths in (q_lengths, k_lengths)
+            )
+            q_values = torch.randn(
+                q_offsets[-1],
+                head_dim * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device=device,
+            )
+            k_values = torch.randn(
+                k_offsets[-1],
+                head_dim * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device=device,
+            )
+            v_values = torch.randn(
+                k_offsets[-1],
+                head_dim_v * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device=device,
+            )
+
+            q = torch.nested.nested_tensor_from_jagged(q_values, q_offsets)
+            k = torch.nested.nested_tensor_from_jagged(k_values, k_offsets)
+            v = torch.nested.nested_tensor_from_jagged(v_values, k_offsets)
+
+            q = q.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            k = k.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            v = v.view(batch_size, -1, n_heads, head_dim_v).transpose(1, 2)
+
+            return q, k, v
+
+        def get_dense_flops(q, k, v, backend, with_backward=False):
+            def split_tensor(x):
+                return (
+                    y.unsqueeze(0).transpose(1, 2).detach().requires_grad_(True)
+                    for y in x.transpose(1, 2).unbind(0)
+                )
+
+            q_tensors = split_tensor(q)
+            k_tensors = split_tensor(k)
+            v_tensors = split_tensor(v)
+
+            flops = 0
+            for q_i, k_i, v_i in zip(q_tensors, k_tensors, v_tensors):
+                flops += get_flops(
+                    q_i, k_i, v_i, backend=backend, with_backward=with_backward
+                )
+
+            return flops
+
+        uniform_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 128,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        # max_seq_len_q != max_seq_len_k doesn't work for flash attention with dense tensors.
+        differing_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 256,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=False,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+        )
+
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=True,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+        )
+
+    @requires_capabilitys("feat.flash_attention")
+    def test_nested_attention_fake_tensors(self, device):
+        x = torch.randn(123, 4, 16, device=device, dtype=torch.bfloat16)
+        offsets = torch.tensor([0, 30, 60, 90, 123], device=device)
+        max_seqlen = 40
+        with FakeTensorMode() as fake_mode:
+            fake_x = fake_mode.from_tensor(x)
+            fake_offsets = fake_mode.from_tensor(offsets)
+
+            with FlopCounterMode() as fake_flop_counter_mode:
+                torch.ops.aten._flash_attention_forward(
+                    fake_x,
+                    fake_x,
+                    fake_x,
+                    fake_offsets,
+                    fake_offsets,
+                    max_seqlen,
+                    max_seqlen,
+                    0.0,
+                    False,
+                    False,
+                )
+
+        dense_x = torch.randn(4, 40, 4, 16, dtype=torch.bfloat16, device=device)
+
+        with FlopCounterMode() as real_flop_counter_mode:
+            torch.ops.aten._flash_attention_forward(
+                dense_x,
+                dense_x,
+                dense_x,
+                None,
+                None,
+                max_seqlen,
+                max_seqlen,
+                0.0,
+                False,
+                False,
+            )
+
+        self.assertEqual(
+            int(get_total_flops(fake_flop_counter_mode)),
+            int(get_total_flops(real_flop_counter_mode)),
+        )
+
+    @requires_capabilitys("lib.triton")
+    def test_flop_counter_custom_triton_manual_decomp(self, device):
         import triton
         import triton.language as tl
 
@@ -1014,8 +997,8 @@ class TestFlopCounter(TestCase):
             out = tl.sin(x)
             tl.store(out_ptr + offsets, out, mask=mask)
 
-        x = torch.randn(3, device="cuda")
-        out = torch.empty(3, device="cuda")
+        x = torch.randn(3, device=device)
+        out = torch.empty(3, device=device)
 
         @register_flop_formula(sin_kernel)
         def compute_sin_kernel_flops(*args, **kwargs) -> int:
@@ -1047,8 +1030,8 @@ class TestFlopCounter(TestCase):
             torch.ops.mylib.sin_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_cuda_and_triton
-    def test_flop_counter_custom_triton_op_two_kernels_manual_decomp(self):
+    @requires_capabilitys("lib.triton")
+    def test_flop_counter_custom_triton_op_two_kernels_manual_decomp(self, device):
         import triton
         import triton.language as tl
 
@@ -1074,8 +1057,8 @@ class TestFlopCounter(TestCase):
             out = tl.cos(x)
             tl.store(out_ptr + offsets, out, mask=mask)
 
-        x = torch.randn(3, device="cuda")
-        out = torch.empty(3, device="cuda")
+        x = torch.randn(3, device=device)
+        out = torch.empty(3, device=device)
 
         @register_flop_formula(sin_kernel)
         def compute_sin_kernel_flops(*args, **kwargs) -> int:
@@ -1121,11 +1104,11 @@ class TestFlopCounter(TestCase):
             torch.ops.mylib.trig_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_cuda_and_triton
+    @requires_capabilitys("lib.triton")
     @torch._functorch.config.patch("activation_memory_budget", 0.1)
     @torch._functorch.config.patch("activation_memory_budget_solver", "dp")
     @torch._functorch.config.patch("is_non_builtin_to_include", True)
-    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self):
+    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self, device):
         import triton
         import triton.language as tl
 
@@ -1152,7 +1135,7 @@ class TestFlopCounter(TestCase):
             tl.store(out_ptr + offsets, out, mask=mask)
 
         n_elements = int(1e7)
-        x = torch.randn(n_elements, device="cuda", requires_grad=True)
+        x = torch.randn(n_elements, device=device, requires_grad=True)
 
         cos_flops_recorded, sin_flops_recorded = 0, 0
 
@@ -1217,57 +1200,22 @@ class TestFlopCounter(TestCase):
             "Custom formula for cos_kernel not recorded during partitioning",
         )
 
-    @skipIfNoTorchVision
-    def test_inference_mode(self):
-        def get_flops(model):
-            with FlopCounterMode(model) as mode:
-                a = T(1, 3, 224, 224)
-                model(a).sum()
-            return mode
-
-        resnet18 = torchvision_models.resnet18()
-
-        mode_standard = get_flops(resnet18)
-
-        with torch.inference_mode():
-            mode_inference = get_flops(resnet18)
-
-        self.assertEqual(
-            get_total_flops(mode_standard), get_total_flops(mode_inference)
-        )
-
-        layer1_conv_flops_standard = mode_standard.flop_counts["ResNet.layer1"][
-            torch.ops.aten.convolution
-        ]
-        layer1_conv_flops_inference = mode_inference.flop_counts["ResNet.layer1"][
-            torch.ops.aten.convolution
-        ]
-        self.assertEqual(layer1_conv_flops_standard, layer1_conv_flops_inference)
-
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FP8,
-        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
-    )
-    def test_scaled_mm(self):
+    @requires_capabilitys("dtype.fp8")
+    def test_scaled_mm(self, device):
         dtype = e4m3_type
         with FlopCounterMode() as mode:
             torch._scaled_mm(
-                torch.randn((3 * 16, 5 * 16), device="cuda").to(dtype),
-                torch.randn((7 * 16, 5 * 16), device="cuda").to(dtype).t(),
-                scale_a=torch.ones((), device="cuda"),
-                scale_b=torch.ones((), device="cuda"),
+                torch.randn((3 * 16, 5 * 16), device=device).to(dtype),
+                torch.randn((7 * 16, 5 * 16), device=device).to(dtype).t(),
+                scale_a=torch.ones((), device=device),
+                scale_b=torch.ones((), device=device),
                 out_dtype=torch.bfloat16,
             )
 
         self.assertExpectedInline(get_total_flops(mode), """860160""")
 
-    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Flash attention not supported (pre-SM80 hardware on CUDA)",
-    )
-    def test_varlen_attn(self):
+    @requires_capabilitys("feat.flash_attention")
+    def test_varlen_attn(self, device):
         import torch.nn.attention.varlen
 
         n_heads = 8
@@ -1278,7 +1226,7 @@ class TestFlopCounter(TestCase):
         cu_seqs = torch.tensor(
             [0] + list(torch.tensor(seq_lens).cumsum(0).tolist()),
             dtype=torch.int32,
-            device="cuda",
+            device=device,
         )
         max_s = max(seq_lens)
 
@@ -1286,7 +1234,7 @@ class TestFlopCounter(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         )
@@ -1294,7 +1242,7 @@ class TestFlopCounter(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         )
@@ -1302,7 +1250,7 @@ class TestFlopCounter(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device="cuda",
+            device=device,
             dtype=dtype,
             requires_grad=True,
         )
@@ -1352,6 +1300,8 @@ class TestFlopCounter(TestCase):
 
 
 class TestFlexAttentionEstimation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_flex_attention_flop_registration(self):
         """flex_attention HOPs are registered in flop_registry and recognized as compute nodes."""
         from torch._inductor.fx_passes.overlap_scheduling import is_compute_node
@@ -1398,40 +1348,6 @@ class TestFlexAttentionEstimation(TestCase):
         )
         expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
         self.assertEqual(fwd_flops, expected_flops)
-
-    @xfailIfNoAcceleratorTriton
-    @unittest.skipIf(not HAS_CUDA, "requires CUDA")
-    def test_flex_attention_roofline_estimate(self):
-        """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            estimate_roofline_runtime_ms,
-        )
-
-        q_shape = (2, 16, 1024, 64)
-        k_shape = (2, 4, 1024, 64)
-        v_shape = (2, 4, 1024, 64)
-
-        graph = torch.fx.Graph()
-        q = graph.placeholder("q")
-        k = graph.placeholder("k")
-        v = graph.placeholder("v")
-        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
-        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
-        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
-
-        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
-        fwd.meta["val"] = (
-            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
-            torch.randn(
-                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
-            ),
-            torch.randn(
-                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
-            ),
-        )
-
-        est_ms = estimate_roofline_runtime_ms(fwd)
-        self.assertGreater(est_ms, 0.0)
 
     def test_sparsity_hint_annotate_propagates(self):
         """fx_traceback.annotate propagates sparsity_hint to flex_attention node."""
@@ -1520,6 +1436,45 @@ class TestFlexAttentionEstimation(TestCase):
         self.assertGreater(dense_flops, 0)
         self.assertEqual(sparse_flops, dense_flops // 2)
 
+
+class TestFlexAttentionEstimationCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @xfailIfNoAcceleratorTriton
+    def test_flex_attention_roofline_estimate(self):
+        """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            estimate_roofline_runtime_ms,
+        )
+
+        q_shape = (2, 16, 1024, 64)
+        k_shape = (2, 4, 1024, 64)
+        v_shape = (2, 4, 1024, 64)
+
+        graph = torch.fx.Graph()
+        q = graph.placeholder("q")
+        k = graph.placeholder("k")
+        v = graph.placeholder("v")
+        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
+        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
+        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
+
+        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
+        fwd.meta["val"] = (
+            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+        )
+
+        est_ms = estimate_roofline_runtime_ms(fwd)
+        self.assertGreater(est_ms, 0.0)
+
+
+instantiate_device_type_tests(TestFlopCounterDeviceType, globals(), except_for=("cpu",))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -662,10 +662,14 @@ class TestFlopCounterDeviceType(TestCase):
         )
 
         flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_flash = run_uniform_flops(SDPBackend.FLASH_ATTENTION, with_backward=False)
+        flops_fw_flash = run_uniform_flops(
+            SDPBackend.FLASH_ATTENTION, with_backward=False
+        )
         self.assertEqual(flops_fw_math, flops_fw_flash)
 
-        flops_fw_bw_flash = run_uniform_flops(SDPBackend.FLASH_ATTENTION, with_backward=True)
+        flops_fw_bw_flash = run_uniform_flops(
+            SDPBackend.FLASH_ATTENTION, with_backward=True
+        )
         self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
 
     @requires_capabilities(Capability.attention.mem_efficient_attention)
@@ -694,10 +698,14 @@ class TestFlopCounterDeviceType(TestCase):
         )
 
         flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_efficient = run_uniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=False)
+        flops_fw_efficient = run_uniform_flops(
+            SDPBackend.EFFICIENT_ATTENTION, with_backward=False
+        )
         self.assertEqual(flops_fw_math, flops_fw_efficient)
 
-        flops_fw_bw_efficient = run_uniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=True)
+        flops_fw_bw_efficient = run_uniform_flops(
+            SDPBackend.EFFICIENT_ATTENTION, with_backward=True
+        )
         self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_efficient)
 
         run_nonuniform_flops = functools.partial(
@@ -713,10 +721,14 @@ class TestFlopCounterDeviceType(TestCase):
         )
 
         flops_fw_nu_math = run_nonuniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_nu_efficient = run_nonuniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=False)
+        flops_fw_nu_efficient = run_nonuniform_flops(
+            SDPBackend.EFFICIENT_ATTENTION, with_backward=False
+        )
         self.assertEqual(flops_fw_nu_math, flops_fw_nu_efficient)
 
-        flops_fw_bw_nu_efficient = run_nonuniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=True)
+        flops_fw_bw_nu_efficient = run_nonuniform_flops(
+            SDPBackend.EFFICIENT_ATTENTION, with_backward=True
+        )
         self.assertExpectedInline(str(flops_fw_bw_nu_efficient), """939524096""")
 
     @requires_capabilities(Capability.attention.flash_attention)
@@ -779,7 +791,10 @@ class TestFlopCounterDeviceType(TestCase):
         self.assertEqual(gqa_flops, mha_flops)
         self.assertTrue(gqa_flops > 0)
 
-    @requires_capabilities(Capability.attention.flash_attention, Capability.attention.mem_efficient_attention)
+    @requires_capabilities(
+        Capability.attention.flash_attention,
+        Capability.attention.mem_efficient_attention,
+    )
     def test_sdpa_nested_tensor(self, device):
         def get_flops(q, k, v, backend, with_backward=False):
             mode = FlopCounterMode()
@@ -1524,7 +1539,9 @@ class TestFlexAttentionEstimationCUDA(TestCase):
 class TestFlopCounterCUDA(TestCase):
     hw_classification = HardwareClassification.CUDA
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN attention not supported")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN attention not supported"
+    )
     def test_sdpa_cudnn(self):
         device = "cuda"
         batch_size = 4
@@ -1549,10 +1566,14 @@ class TestFlopCounterCUDA(TestCase):
         )
 
         flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_cudnn = run_uniform_flops(SDPBackend.CUDNN_ATTENTION, with_backward=False)
+        flops_fw_cudnn = run_uniform_flops(
+            SDPBackend.CUDNN_ATTENTION, with_backward=False
+        )
         self.assertEqual(flops_fw_math, flops_fw_cudnn)
 
-        flops_fw_bw_cudnn = run_uniform_flops(SDPBackend.CUDNN_ATTENTION, with_backward=True)
+        flops_fw_bw_cudnn = run_uniform_flops(
+            SDPBackend.CUDNN_ATTENTION, with_backward=True
+        )
         self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_cudnn)
 
 

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -8,10 +8,12 @@ import torch.nn.functional as F
 import torch.utils.flop_counter
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.nn.attention import sdpa_kernel, SDPBackend
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_CUDNN_ATTENTION
 from torch.testing._internal.common_device_type import (
+    Capability,
     e4m3_type,
     instantiate_device_type_tests,
-    requires_capabilitys,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -42,6 +44,56 @@ def get_total_flops(mode):
 
 def T(*shape, requires_grad=False):
     return torch.randn(*shape, requires_grad=requires_grad)
+
+
+def _get_sdpa_flops(
+    device,
+    batch_size,
+    n_heads,
+    seq_len_q,
+    seq_len_k,
+    head_dim,
+    head_dim_v,
+    dtype,
+    sdpa_backend,
+    with_backward=False,
+):
+    query = torch.randn(
+        batch_size,
+        n_heads,
+        seq_len_q,
+        head_dim,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+    key = torch.randn(
+        batch_size,
+        n_heads,
+        seq_len_k,
+        head_dim,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+    value = torch.randn(
+        batch_size,
+        n_heads,
+        seq_len_k,
+        head_dim_v,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+
+    mode = FlopCounterMode()
+    with sdpa_kernel([sdpa_backend]), mode:
+        out = F.scaled_dot_product_attention(
+            query, key, value, dropout_p=0, is_causal=True
+        )
+        if with_backward:
+            out.sum().backward()
+    return int(get_total_flops(mode))
 
 
 @unittest.skipIf(
@@ -537,10 +589,7 @@ class TestFlopCounter(TestCase):
 class TestFlopCounterDeviceType(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @requires_capabilitys(
-        "feat.cudnn_attention", "feat.flash_attention", "feat.mem_efficient_attention"
-    )
-    def test_sdpa(self, device):
+    def test_sdpa_math(self, device):
         batch_size = 4
         n_heads = 8
         seq_len_q = 128
@@ -551,7 +600,28 @@ class TestFlopCounterDeviceType(TestCase):
 
         torch.manual_seed(0)
 
-        def get_flops(
+        # Sets seq_len_q == seq_len_k and dim_q == dim_v
+        run_uniform_flops = functools.partial(
+            _get_sdpa_flops,
+            device,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_q,
+            head_dim,
+            head_dim,
+            dtype,
+        )
+
+        flops_fw = run_uniform_flops(SDPBackend.MATH, with_backward=False)
+        self.assertExpectedInline(str(flops_fw), """134217728""")
+
+        flops_fw_bw = run_uniform_flops(SDPBackend.MATH, with_backward=True)
+        self.assertEqual(flops_fw * 3, flops_fw_bw)
+
+        run_nonuniform_flops = functools.partial(
+            _get_sdpa_flops,
+            device,
             batch_size,
             n_heads,
             seq_len_q,
@@ -559,58 +629,61 @@ class TestFlopCounterDeviceType(TestCase):
             head_dim,
             head_dim_v,
             dtype,
-            backend,
-            with_backward=False,
-        ):
-            query = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_q,
-                head_dim,
-                device=device,
-                dtype=dtype,
-                requires_grad=True,
-            )
-            key = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_k,
-                head_dim,
-                device=device,
-                dtype=dtype,
-                requires_grad=True,
-            )
-            value = torch.randn(
-                batch_size,
-                n_heads,
-                seq_len_k,
-                head_dim_v,
-                device=device,
-                dtype=dtype,
-                requires_grad=True,
-            )
+        )
 
-            if backend == "math":
-                backend = sdpa_kernel([SDPBackend.MATH])
-            elif backend == "flash":
-                backend = sdpa_kernel([SDPBackend.FLASH_ATTENTION])
-            elif backend == "mem_efficient":
-                backend = sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION])
-            elif backend == "cudnn":
-                backend = sdpa_kernel([SDPBackend.CUDNN_ATTENTION])
+        flops_fw_nu = run_nonuniform_flops(SDPBackend.MATH, with_backward=False)
+        self.assertExpectedInline(str(flops_fw_nu), """268435456""")
 
-            mode = FlopCounterMode()
-            with backend, mode:
-                out = F.scaled_dot_product_attention(
-                    query, key, value, dropout_p=0, is_causal=True
-                )
-                if with_backward:
-                    out.sum().backward()
-            return int(get_total_flops(mode))
+        flops_fw_bw_nu = run_nonuniform_flops(SDPBackend.MATH, with_backward=True)
+        self.assertExpectedInline(str(flops_fw_bw_nu), """805306368""")
+
+    @requires_capabilities(Capability.attention.flash_attention)
+    def test_sdpa_flash(self, device):
+        batch_size = 4
+        n_heads = 8
+        seq_len_q = 128
+        head_dim = 64
+        dtype = torch.float16
+
+        torch.manual_seed(0)
+
+        # Sets seq_len_q == seq_len_k and dim_q == dim_v
+        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
+        run_uniform_flops = functools.partial(
+            _get_sdpa_flops,
+            device,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_q,
+            head_dim,
+            head_dim,
+            dtype,
+        )
+
+        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
+        flops_fw_flash = run_uniform_flops(SDPBackend.FLASH_ATTENTION, with_backward=False)
+        self.assertEqual(flops_fw_math, flops_fw_flash)
+
+        flops_fw_bw_flash = run_uniform_flops(SDPBackend.FLASH_ATTENTION, with_backward=True)
+        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
+
+    @requires_capabilities(Capability.attention.mem_efficient_attention)
+    def test_sdpa_mem_efficient(self, device):
+        batch_size = 4
+        n_heads = 8
+        seq_len_q = 128
+        seq_len_k = 256
+        head_dim = 64
+        head_dim_v = 64
+        dtype = torch.float16
+
+        torch.manual_seed(0)
 
         # Sets seq_len_q == seq_len_k and dim_q == dim_v
         run_uniform_flops = functools.partial(
-            get_flops,
+            _get_sdpa_flops,
+            device,
             batch_size,
             n_heads,
             seq_len_q,
@@ -620,34 +693,16 @@ class TestFlopCounterDeviceType(TestCase):
             dtype,
         )
 
-        flops = [
-            run_uniform_flops(backend, with_backward=False)
-            for backend in ["math", "flash", "mem_efficient", "cudnn"]
-        ]
-        flops_fw_math, flops_fw_flash, flops_fw_efficient, flops_fw_cudnn = flops
-        self.assertEqual(flops_fw_math, flops_fw_flash)
+        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
+        flops_fw_efficient = run_uniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=False)
         self.assertEqual(flops_fw_math, flops_fw_efficient)
-        self.assertEqual(flops_fw_math, flops_fw_cudnn)
 
-        self.assertExpectedInline(str(flops_fw_math), """134217728""")
-
-        flops = [
-            run_uniform_flops(backend, with_backward=True)
-            for backend in ["math", "flash", "mem_efficient", "cudnn"]
-        ]
-        (
-            flops_fw_bw_math,
-            flops_fw_bw_flash,
-            flops_fw_bw_efficient,
-            flops_fw_bw_cudnn,
-        ) = flops
-        self.assertEqual(flops_fw_math * 3, flops_fw_bw_math)
-        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
-        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_efficient)
-        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_cudnn)
+        flops_fw_bw_efficient = run_uniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=True)
+        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_efficient)
 
         run_nonuniform_flops = functools.partial(
-            get_flops,
+            _get_sdpa_flops,
+            device,
             batch_size,
             n_heads,
             seq_len_q,
@@ -656,26 +711,15 @@ class TestFlopCounterDeviceType(TestCase):
             head_dim_v,
             dtype,
         )
-        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
-        non_uniform_backends = ["math", "mem_efficient"]
-        flops = [
-            run_nonuniform_flops(backend, with_backward=False)
-            for backend in non_uniform_backends
-        ]
-        flops_fw_math, flops_fw_efficient = flops
-        self.assertEqual(flops_fw_math, flops_fw_efficient)
 
-        self.assertExpectedInline(str(flops_fw_math), """268435456""")
+        flops_fw_nu_math = run_nonuniform_flops(SDPBackend.MATH, with_backward=False)
+        flops_fw_nu_efficient = run_nonuniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=False)
+        self.assertEqual(flops_fw_nu_math, flops_fw_nu_efficient)
 
-        flops = [
-            run_nonuniform_flops(backend, with_backward=True)
-            for backend in non_uniform_backends
-        ]
-        flops_fw_bw_math, flops_fw_bw_efficient = flops
-        self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
-        self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
+        flops_fw_bw_nu_efficient = run_nonuniform_flops(SDPBackend.EFFICIENT_ATTENTION, with_backward=True)
+        self.assertExpectedInline(str(flops_fw_bw_nu_efficient), """939524096""")
 
-    @requires_capabilitys("feat.flash_attention")
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_sdpa_gqa(self, device):
         """Test flop counting for grouped-query attention (GQA)."""
         batch_size = 2
@@ -735,7 +779,7 @@ class TestFlopCounterDeviceType(TestCase):
         self.assertEqual(gqa_flops, mha_flops)
         self.assertTrue(gqa_flops > 0)
 
-    @requires_capabilitys("feat.flash_attention", "feat.mem_efficient_attention")
+    @requires_capabilities(Capability.attention.flash_attention, Capability.attention.mem_efficient_attention)
     def test_sdpa_nested_tensor(self, device):
         def get_flops(q, k, v, backend, with_backward=False):
             mode = FlopCounterMode()
@@ -936,7 +980,7 @@ class TestFlopCounterDeviceType(TestCase):
             ),
         )
 
-    @requires_capabilitys("feat.flash_attention")
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_nested_attention_fake_tensors(self, device):
         x = torch.randn(123, 4, 16, device=device, dtype=torch.bfloat16)
         offsets = torch.tensor([0, 30, 60, 90, 123], device=device)
@@ -980,7 +1024,7 @@ class TestFlopCounterDeviceType(TestCase):
             int(get_total_flops(real_flop_counter_mode)),
         )
 
-    @requires_capabilitys("lib.triton")
+    @requires_capabilities(Capability.lib.triton)
     def test_flop_counter_custom_triton_manual_decomp(self, device):
         import triton
         import triton.language as tl
@@ -1030,7 +1074,7 @@ class TestFlopCounterDeviceType(TestCase):
             torch.ops.mylib.sin_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_capabilitys("lib.triton")
+    @requires_capabilities(Capability.lib.triton)
     def test_flop_counter_custom_triton_op_two_kernels_manual_decomp(self, device):
         import triton
         import triton.language as tl
@@ -1104,7 +1148,7 @@ class TestFlopCounterDeviceType(TestCase):
             torch.ops.mylib.trig_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_capabilitys("lib.triton")
+    @requires_capabilities(Capability.lib.triton)
     @torch._functorch.config.patch("activation_memory_budget", 0.1)
     @torch._functorch.config.patch("activation_memory_budget_solver", "dp")
     @torch._functorch.config.patch("is_non_builtin_to_include", True)
@@ -1200,7 +1244,7 @@ class TestFlopCounterDeviceType(TestCase):
             "Custom formula for cos_kernel not recorded during partitioning",
         )
 
-    @requires_capabilitys("dtype.fp8")
+    @requires_capabilities(Capability.dtype.fp8)
     def test_scaled_mm(self, device):
         dtype = e4m3_type
         with FlopCounterMode() as mode:
@@ -1214,7 +1258,7 @@ class TestFlopCounterDeviceType(TestCase):
 
         self.assertExpectedInline(get_total_flops(mode), """860160""")
 
-    @requires_capabilitys("feat.flash_attention")
+    @requires_capabilities(Capability.attention.flash_attention)
     def test_varlen_attn(self, device):
         import torch.nn.attention.varlen
 
@@ -1472,6 +1516,44 @@ class TestFlexAttentionEstimationCUDA(TestCase):
 
         est_ms = estimate_roofline_runtime_ms(fwd)
         self.assertGreater(est_ms, 0.0)
+
+
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestFlopCounterCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN attention not supported")
+    def test_sdpa_cudnn(self):
+        device = "cuda"
+        batch_size = 4
+        n_heads = 8
+        seq_len_q = 128
+        head_dim = 64
+        dtype = torch.float16
+
+        torch.manual_seed(0)
+
+        # Sets seq_len_q == seq_len_k and dim_q == dim_v
+        run_uniform_flops = functools.partial(
+            _get_sdpa_flops,
+            device,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_q,
+            head_dim,
+            head_dim,
+            dtype,
+        )
+
+        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
+        flops_fw_cudnn = run_uniform_flops(SDPBackend.CUDNN_ATTENTION, with_backward=False)
+        self.assertEqual(flops_fw_math, flops_fw_cudnn)
+
+        flops_fw_bw_cudnn = run_uniform_flops(SDPBackend.CUDNN_ATTENTION, with_backward=True)
+        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_cudnn)
 
 
 instantiate_device_type_tests(TestFlopCounterDeviceType, globals(), except_for=("cpu",))

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -7,21 +7,20 @@ import torch
 import torch.nn.functional as F
 import torch.utils.flop_counter
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.nn.attention import sdpa_kernel, SDPBackend
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_CUDNN_ATTENTION
-from torch.testing._internal.common_device_type import (
-    Capability,
-    e4m3_type,
-    instantiate_device_type_tests,
-    requires_capabilities,
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
+from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
+from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
 
 
@@ -32,6 +31,8 @@ try:
 except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
+
+HAS_CUDA = torch.cuda.is_available()
 
 
 def FlopCounterMode(*args, **kwargs):
@@ -46,62 +47,10 @@ def T(*shape, requires_grad=False):
     return torch.randn(*shape, requires_grad=requires_grad)
 
 
-def _get_sdpa_flops(
-    device,
-    batch_size,
-    n_heads,
-    seq_len_q,
-    seq_len_k,
-    head_dim,
-    head_dim_v,
-    dtype,
-    sdpa_backend,
-    with_backward=False,
-):
-    query = torch.randn(
-        batch_size,
-        n_heads,
-        seq_len_q,
-        head_dim,
-        device=device,
-        dtype=dtype,
-        requires_grad=True,
-    )
-    key = torch.randn(
-        batch_size,
-        n_heads,
-        seq_len_k,
-        head_dim,
-        device=device,
-        dtype=dtype,
-        requires_grad=True,
-    )
-    value = torch.randn(
-        batch_size,
-        n_heads,
-        seq_len_k,
-        head_dim_v,
-        device=device,
-        dtype=dtype,
-        requires_grad=True,
-    )
-
-    mode = FlopCounterMode()
-    with sdpa_kernel([sdpa_backend]), mode:
-        out = F.scaled_dot_product_attention(
-            query, key, value, dropout_p=0, is_causal=True
-        )
-        if with_backward:
-            out.sum().backward()
-    return int(get_total_flops(mode))
-
-
 @unittest.skipIf(
     TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
 )
 class TestFlopCounter(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def test_sdpa_flop_count_gqa(self):
         """sdpa_flop_count should handle GQA where KV heads < Q heads."""
         # MHA: q_heads == kv_heads
@@ -377,6 +326,499 @@ class TestFlopCounter(TestCase):
         with FlopCounterMode() as mode:
             T(4, 5).cos()
 
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION
+        or not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+        or not PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
+    )
+    def test_sdpa(self):
+        batch_size = 4
+        n_heads = 8
+        seq_len_q = 128
+        seq_len_k = 256
+        head_dim = 64
+        head_dim_v = 64
+        dtype = torch.float16
+
+        torch.manual_seed(0)
+
+        def get_flops(
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+            backend,
+            with_backward=False,
+        ):
+            query = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_q,
+                head_dim,
+                device="cuda",
+                dtype=dtype,
+                requires_grad=True,
+            )
+            key = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_k,
+                head_dim,
+                device="cuda",
+                dtype=dtype,
+                requires_grad=True,
+            )
+            value = torch.randn(
+                batch_size,
+                n_heads,
+                seq_len_k,
+                head_dim_v,
+                device="cuda",
+                dtype=dtype,
+                requires_grad=True,
+            )
+
+            if backend == "math":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False,
+                    enable_math=True,
+                    enable_mem_efficient=False,
+                    enable_cudnn=False,
+                )
+            elif backend == "flash":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=True,
+                    enable_math=False,
+                    enable_mem_efficient=False,
+                    enable_cudnn=False,
+                )
+            elif backend == "mem_efficient":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False,
+                    enable_math=False,
+                    enable_mem_efficient=True,
+                    enable_cudnn=False,
+                )
+            elif backend == "cudnn":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False,
+                    enable_math=False,
+                    enable_mem_efficient=False,
+                    enable_cudnn=True,
+                )
+
+            mode = FlopCounterMode()
+            with backend, mode:
+                out = F.scaled_dot_product_attention(
+                    query, key, value, dropout_p=0, is_causal=True
+                )
+                if with_backward:
+                    out.sum().backward()
+            return int(get_total_flops(mode))
+
+        # Sets seq_len_q == seq_len_k and dim_q == dim_v
+        run_uniform_flops = functools.partial(
+            get_flops,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_q,
+            head_dim,
+            head_dim,
+            dtype,
+        )
+
+        flops = [
+            run_uniform_flops(backend, with_backward=False)
+            for backend in ["math", "flash", "mem_efficient", "cudnn"]
+        ]
+        flops_fw_math, flops_fw_flash, flops_fw_efficient, flops_fw_cudnn = flops
+        self.assertEqual(flops_fw_math, flops_fw_flash)
+        self.assertEqual(flops_fw_math, flops_fw_efficient)
+        self.assertEqual(flops_fw_math, flops_fw_cudnn)
+
+        self.assertExpectedInline(str(flops_fw_math), """134217728""")
+
+        flops = [
+            run_uniform_flops(backend, with_backward=True)
+            for backend in ["math", "flash", "mem_efficient", "cudnn"]
+        ]
+        (
+            flops_fw_bw_math,
+            flops_fw_bw_flash,
+            flops_fw_bw_efficient,
+            flops_fw_bw_cudnn,
+        ) = flops
+        self.assertEqual(flops_fw_math * 3, flops_fw_bw_math)
+        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
+        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_efficient)
+        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_cudnn)
+
+        run_nonuniform_flops = functools.partial(
+            get_flops,
+            batch_size,
+            n_heads,
+            seq_len_q,
+            seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        )
+        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
+        non_uniform_backends = ["math", "mem_efficient"]
+        flops = [
+            run_nonuniform_flops(backend, with_backward=False)
+            for backend in non_uniform_backends
+        ]
+        flops_fw_math, flops_fw_efficient = flops
+        self.assertEqual(flops_fw_math, flops_fw_efficient)
+
+        self.assertExpectedInline(str(flops_fw_math), """268435456""")
+
+        flops = [
+            run_nonuniform_flops(backend, with_backward=True)
+            for backend in non_uniform_backends
+        ]
+        flops_fw_bw_math, flops_fw_bw_efficient = flops
+        self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
+        self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Flash attention not supported (pre-SM80 hardware on CUDA)",
+    )
+    def test_sdpa_gqa(self):
+        """Test flop counting for grouped-query attention (GQA)."""
+        batch_size = 2
+        n_heads_q = 32
+        n_heads_kv = 8
+        seq_len = 128
+        head_dim = 64
+        dtype = torch.float16
+
+        query = torch.randn(
+            batch_size,
+            n_heads_q,
+            seq_len,
+            head_dim,
+            device="cuda",
+            dtype=dtype,
+        )
+        key = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device="cuda",
+            dtype=dtype,
+        )
+        value = torch.randn(
+            batch_size,
+            n_heads_kv,
+            seq_len,
+            head_dim,
+            device="cuda",
+            dtype=dtype,
+        )
+
+        mode = FlopCounterMode()
+        with mode:
+            out = F.scaled_dot_product_attention(
+                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
+            )
+        gqa_flops = int(get_total_flops(mode))
+
+        # Compare with MHA (KV heads expanded to match Q heads)
+        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
+        mode_mha = FlopCounterMode()
+        with mode_mha:
+            out_mha = F.scaled_dot_product_attention(
+                query,
+                key_expanded,
+                value_expanded,
+                dropout_p=0,
+                is_causal=True,
+            )
+        mha_flops = int(get_total_flops(mode_mha))
+
+        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
+        self.assertEqual(gqa_flops, mha_flops)
+        self.assertTrue(gqa_flops > 0)
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION
+        or not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
+    )
+    def test_sdpa_nested_tensor(self):
+        def get_flops(q, k, v, backend, with_backward=False):
+            mode = FlopCounterMode()
+
+            if backend == "math":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False,
+                    enable_math=True,
+                    enable_mem_efficient=False,
+                    enable_cudnn=False,
+                )
+            elif backend == "flash":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=True,
+                    enable_math=False,
+                    enable_mem_efficient=False,
+                    enable_cudnn=False,
+                )
+            elif backend == "mem_efficient":
+                backend = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False,
+                    enable_math=False,
+                    enable_mem_efficient=True,
+                    enable_cudnn=False,
+                )
+
+            with backend, mode:
+                out = F.scaled_dot_product_attention(
+                    q, k, v, dropout_p=0, is_causal=True
+                )
+                if with_backward:
+                    if out.is_nested:
+                        out.values().sum().backward()
+                    else:
+                        out.sum().backward()
+
+            return int(get_total_flops(mode))
+
+        def get_nested_inputs(
+            batch_size,
+            n_heads,
+            max_seq_len_q,
+            max_seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        ):
+            q_lengths = torch.tensor(
+                [
+                    max_seq_len_q // 4,
+                    max_seq_len_q // 4 * 2,
+                    max_seq_len_q // 4 * 3,
+                    max_seq_len_q // 4 * 4,
+                ]
+            )
+            k_lengths = torch.tensor(
+                [
+                    max_seq_len_k // 4,
+                    max_seq_len_k // 4 * 2,
+                    max_seq_len_k // 4 * 3,
+                    max_seq_len_k // 4 * 4,
+                ]
+            )
+            q_offsets, k_offsets = (
+                torch.cat((torch.tensor([0]), torch.cumsum(lengths, dim=0))).cuda()
+                for lengths in (q_lengths, k_lengths)
+            )
+            q_values = torch.randn(
+                q_offsets[-1],
+                head_dim * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device="cuda",
+            )
+            k_values = torch.randn(
+                k_offsets[-1],
+                head_dim * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device="cuda",
+            )
+            v_values = torch.randn(
+                k_offsets[-1],
+                head_dim_v * n_heads,
+                dtype=dtype,
+                requires_grad=True,
+                device="cuda",
+            )
+
+            q = torch.nested.nested_tensor_from_jagged(q_values, q_offsets)
+            k = torch.nested.nested_tensor_from_jagged(k_values, k_offsets)
+            v = torch.nested.nested_tensor_from_jagged(v_values, k_offsets)
+
+            q = q.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            k = k.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            v = v.view(batch_size, -1, n_heads, head_dim_v).transpose(1, 2)
+
+            return q, k, v
+
+        def get_dense_flops(q, k, v, backend, with_backward=False):
+            def split_tensor(x):
+                return (
+                    y.unsqueeze(0).transpose(1, 2).detach().requires_grad_(True)
+                    for y in x.transpose(1, 2).unbind(0)
+                )
+
+            q_tensors = split_tensor(q)
+            k_tensors = split_tensor(k)
+            v_tensors = split_tensor(v)
+
+            flops = 0
+            for q_i, k_i, v_i in zip(q_tensors, k_tensors, v_tensors):
+                flops += get_flops(
+                    q_i, k_i, v_i, backend=backend, with_backward=with_backward
+                )
+
+            return flops
+
+        uniform_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 128,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        # max_seq_len_q != max_seq_len_k doesn't work for flash attention with dense tensors.
+        differing_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 256,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=False,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+            get_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=False,
+            ),
+        )
+
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="flash",
+                with_backward=True,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**uniform_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+        )
+        self.assertEqual(
+            get_dense_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+            get_flops(
+                *get_nested_inputs(**differing_config),
+                backend="mem_efficient",
+                with_backward=True,
+            ),
+        )
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Does not support all SDPA backends (pre-SM80 hardware on CUDA)",
+    )
+    def test_nested_attention_fake_tensors(self):
+        x = torch.randn(123, 4, 16, device="cuda", dtype=torch.bfloat16)
+        offsets = torch.tensor([0, 30, 60, 90, 123], device="cuda")
+        max_seqlen = 40
+        with FakeTensorMode() as fake_mode:
+            fake_x = fake_mode.from_tensor(x)
+            fake_offsets = fake_mode.from_tensor(offsets)
+
+            with FlopCounterMode() as fake_flop_counter_mode:
+                torch.ops.aten._flash_attention_forward(
+                    fake_x,
+                    fake_x,
+                    fake_x,
+                    fake_offsets,
+                    fake_offsets,
+                    max_seqlen,
+                    max_seqlen,
+                    0.0,
+                    False,
+                    False,
+                )
+
+        dense_x = torch.randn(4, 40, 4, 16, dtype=torch.bfloat16, device="cuda")
+
+        with FlopCounterMode() as real_flop_counter_mode:
+            torch.ops.aten._flash_attention_forward(
+                dense_x,
+                dense_x,
+                dense_x,
+                None,
+                None,
+                max_seqlen,
+                max_seqlen,
+                0.0,
+                False,
+                False,
+            )
+
+        self.assertEqual(
+            int(get_total_flops(fake_flop_counter_mode)),
+            int(get_total_flops(real_flop_counter_mode)),
+        )
+
     def test_flash_attention_forward_flop_layout(self):
         B, S, H, D = 2, 128, 8, 64
         q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
@@ -555,492 +997,8 @@ class TestFlopCounter(TestCase):
         self.assertEqual(called, 1)
         self.assertExpectedInline(get_total_flops(mode), """9001""")
 
-    @skipIfNoTorchVision
-    def test_inference_mode(self):
-        def get_flops(model):
-            with FlopCounterMode(model) as mode:
-                a = T(1, 3, 224, 224)
-                model(a).sum()
-            return mode
-
-        resnet18 = torchvision_models.resnet18()
-
-        mode_standard = get_flops(resnet18)
-
-        with torch.inference_mode():
-            mode_inference = get_flops(resnet18)
-
-        self.assertEqual(
-            get_total_flops(mode_standard), get_total_flops(mode_inference)
-        )
-
-        layer1_conv_flops_standard = mode_standard.flop_counts["ResNet.layer1"][
-            torch.ops.aten.convolution
-        ]
-        layer1_conv_flops_inference = mode_inference.flop_counts["ResNet.layer1"][
-            torch.ops.aten.convolution
-        ]
-        self.assertEqual(layer1_conv_flops_standard, layer1_conv_flops_inference)
-
-
-@unittest.skipIf(
-    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
-)
-class TestFlopCounterDeviceType(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    def test_sdpa_math(self, device):
-        batch_size = 4
-        n_heads = 8
-        seq_len_q = 128
-        seq_len_k = 256
-        head_dim = 64
-        head_dim_v = 64
-        dtype = torch.float16
-
-        torch.manual_seed(0)
-
-        # Sets seq_len_q == seq_len_k and dim_q == dim_v
-        run_uniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_q,
-            head_dim,
-            head_dim,
-            dtype,
-        )
-
-        flops_fw = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        self.assertExpectedInline(str(flops_fw), """134217728""")
-
-        flops_fw_bw = run_uniform_flops(SDPBackend.MATH, with_backward=True)
-        self.assertEqual(flops_fw * 3, flops_fw_bw)
-
-        run_nonuniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-        )
-
-        flops_fw_nu = run_nonuniform_flops(SDPBackend.MATH, with_backward=False)
-        self.assertExpectedInline(str(flops_fw_nu), """268435456""")
-
-        flops_fw_bw_nu = run_nonuniform_flops(SDPBackend.MATH, with_backward=True)
-        self.assertExpectedInline(str(flops_fw_bw_nu), """805306368""")
-
-    @requires_capabilities(Capability.attention.flash_attention)
-    def test_sdpa_flash(self, device):
-        batch_size = 4
-        n_heads = 8
-        seq_len_q = 128
-        head_dim = 64
-        dtype = torch.float16
-
-        torch.manual_seed(0)
-
-        # Sets seq_len_q == seq_len_k and dim_q == dim_v
-        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
-        run_uniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_q,
-            head_dim,
-            head_dim,
-            dtype,
-        )
-
-        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_flash = run_uniform_flops(
-            SDPBackend.FLASH_ATTENTION, with_backward=False
-        )
-        self.assertEqual(flops_fw_math, flops_fw_flash)
-
-        flops_fw_bw_flash = run_uniform_flops(
-            SDPBackend.FLASH_ATTENTION, with_backward=True
-        )
-        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_flash)
-
-    @requires_capabilities(Capability.attention.mem_efficient_attention)
-    def test_sdpa_mem_efficient(self, device):
-        batch_size = 4
-        n_heads = 8
-        seq_len_q = 128
-        seq_len_k = 256
-        head_dim = 64
-        head_dim_v = 64
-        dtype = torch.float16
-
-        torch.manual_seed(0)
-
-        # Sets seq_len_q == seq_len_k and dim_q == dim_v
-        run_uniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_q,
-            head_dim,
-            head_dim,
-            dtype,
-        )
-
-        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_efficient = run_uniform_flops(
-            SDPBackend.EFFICIENT_ATTENTION, with_backward=False
-        )
-        self.assertEqual(flops_fw_math, flops_fw_efficient)
-
-        flops_fw_bw_efficient = run_uniform_flops(
-            SDPBackend.EFFICIENT_ATTENTION, with_backward=True
-        )
-        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_efficient)
-
-        run_nonuniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-        )
-
-        flops_fw_nu_math = run_nonuniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_nu_efficient = run_nonuniform_flops(
-            SDPBackend.EFFICIENT_ATTENTION, with_backward=False
-        )
-        self.assertEqual(flops_fw_nu_math, flops_fw_nu_efficient)
-
-        flops_fw_bw_nu_efficient = run_nonuniform_flops(
-            SDPBackend.EFFICIENT_ATTENTION, with_backward=True
-        )
-        self.assertExpectedInline(str(flops_fw_bw_nu_efficient), """939524096""")
-
-    @requires_capabilities(Capability.attention.flash_attention)
-    def test_sdpa_gqa(self, device):
-        """Test flop counting for grouped-query attention (GQA)."""
-        batch_size = 2
-        n_heads_q = 32
-        n_heads_kv = 8
-        seq_len = 128
-        head_dim = 64
-        dtype = torch.float16
-
-        query = torch.randn(
-            batch_size,
-            n_heads_q,
-            seq_len,
-            head_dim,
-            device=device,
-            dtype=dtype,
-        )
-        key = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device=device,
-            dtype=dtype,
-        )
-        value = torch.randn(
-            batch_size,
-            n_heads_kv,
-            seq_len,
-            head_dim,
-            device=device,
-            dtype=dtype,
-        )
-
-        mode = FlopCounterMode()
-        with mode:
-            out = F.scaled_dot_product_attention(
-                query, key, value, dropout_p=0, is_causal=True, enable_gqa=True
-            )
-        gqa_flops = int(get_total_flops(mode))
-
-        # Compare with MHA (KV heads expanded to match Q heads)
-        key_expanded = key.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        value_expanded = value.repeat_interleave(n_heads_q // n_heads_kv, dim=1)
-        mode_mha = FlopCounterMode()
-        with mode_mha:
-            out_mha = F.scaled_dot_product_attention(
-                query,
-                key_expanded,
-                value_expanded,
-                dropout_p=0,
-                is_causal=True,
-            )
-        mha_flops = int(get_total_flops(mode_mha))
-
-        # GQA flops should equal MHA flops (kernel broadcasts KV heads)
-        self.assertEqual(gqa_flops, mha_flops)
-        self.assertTrue(gqa_flops > 0)
-
-    @requires_capabilities(
-        Capability.attention.flash_attention,
-        Capability.attention.mem_efficient_attention,
-    )
-    def test_sdpa_nested_tensor(self, device):
-        def get_flops(q, k, v, backend, with_backward=False):
-            mode = FlopCounterMode()
-
-            if backend == "math":
-                backend = sdpa_kernel([SDPBackend.MATH])
-            elif backend == "flash":
-                backend = sdpa_kernel([SDPBackend.FLASH_ATTENTION])
-            elif backend == "mem_efficient":
-                backend = sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION])
-
-            with backend, mode:
-                out = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=0, is_causal=True
-                )
-                if with_backward:
-                    if out.is_nested:
-                        out.values().sum().backward()
-                    else:
-                        out.sum().backward()
-
-            return int(get_total_flops(mode))
-
-        def get_nested_inputs(
-            batch_size,
-            n_heads,
-            max_seq_len_q,
-            max_seq_len_k,
-            head_dim,
-            head_dim_v,
-            dtype,
-        ):
-            q_lengths = torch.tensor(
-                [
-                    max_seq_len_q // 4,
-                    max_seq_len_q // 4 * 2,
-                    max_seq_len_q // 4 * 3,
-                    max_seq_len_q // 4 * 4,
-                ]
-            )
-            k_lengths = torch.tensor(
-                [
-                    max_seq_len_k // 4,
-                    max_seq_len_k // 4 * 2,
-                    max_seq_len_k // 4 * 3,
-                    max_seq_len_k // 4 * 4,
-                ]
-            )
-            q_offsets, k_offsets = (
-                torch.cat((torch.tensor([0]), torch.cumsum(lengths, dim=0))).to(
-                    device=device
-                )
-                for lengths in (q_lengths, k_lengths)
-            )
-            q_values = torch.randn(
-                q_offsets[-1],
-                head_dim * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device=device,
-            )
-            k_values = torch.randn(
-                k_offsets[-1],
-                head_dim * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device=device,
-            )
-            v_values = torch.randn(
-                k_offsets[-1],
-                head_dim_v * n_heads,
-                dtype=dtype,
-                requires_grad=True,
-                device=device,
-            )
-
-            q = torch.nested.nested_tensor_from_jagged(q_values, q_offsets)
-            k = torch.nested.nested_tensor_from_jagged(k_values, k_offsets)
-            v = torch.nested.nested_tensor_from_jagged(v_values, k_offsets)
-
-            q = q.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
-            k = k.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
-            v = v.view(batch_size, -1, n_heads, head_dim_v).transpose(1, 2)
-
-            return q, k, v
-
-        def get_dense_flops(q, k, v, backend, with_backward=False):
-            def split_tensor(x):
-                return (
-                    y.unsqueeze(0).transpose(1, 2).detach().requires_grad_(True)
-                    for y in x.transpose(1, 2).unbind(0)
-                )
-
-            q_tensors = split_tensor(q)
-            k_tensors = split_tensor(k)
-            v_tensors = split_tensor(v)
-
-            flops = 0
-            for q_i, k_i, v_i in zip(q_tensors, k_tensors, v_tensors):
-                flops += get_flops(
-                    q_i, k_i, v_i, backend=backend, with_backward=with_backward
-                )
-
-            return flops
-
-        uniform_config = {
-            "batch_size": 4,
-            "n_heads": 8,
-            "max_seq_len_q": 128,
-            "max_seq_len_k": 128,
-            "head_dim": 64,
-            "head_dim_v": 64,
-            "dtype": torch.float16,
-        }
-
-        # max_seq_len_q != max_seq_len_k doesn't work for flash attention with dense tensors.
-        differing_config = {
-            "batch_size": 4,
-            "n_heads": 8,
-            "max_seq_len_q": 128,
-            "max_seq_len_k": 256,
-            "head_dim": 64,
-            "head_dim_v": 64,
-            "dtype": torch.float16,
-        }
-
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=False,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-            get_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=False,
-            ),
-        )
-
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="flash",
-                with_backward=True,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**uniform_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-        )
-        self.assertEqual(
-            get_dense_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-            get_flops(
-                *get_nested_inputs(**differing_config),
-                backend="mem_efficient",
-                with_backward=True,
-            ),
-        )
-
-    @requires_capabilities(Capability.attention.flash_attention)
-    def test_nested_attention_fake_tensors(self, device):
-        x = torch.randn(123, 4, 16, device=device, dtype=torch.bfloat16)
-        offsets = torch.tensor([0, 30, 60, 90, 123], device=device)
-        max_seqlen = 40
-        with FakeTensorMode() as fake_mode:
-            fake_x = fake_mode.from_tensor(x)
-            fake_offsets = fake_mode.from_tensor(offsets)
-
-            with FlopCounterMode() as fake_flop_counter_mode:
-                torch.ops.aten._flash_attention_forward(
-                    fake_x,
-                    fake_x,
-                    fake_x,
-                    fake_offsets,
-                    fake_offsets,
-                    max_seqlen,
-                    max_seqlen,
-                    0.0,
-                    False,
-                    False,
-                )
-
-        dense_x = torch.randn(4, 40, 4, 16, dtype=torch.bfloat16, device=device)
-
-        with FlopCounterMode() as real_flop_counter_mode:
-            torch.ops.aten._flash_attention_forward(
-                dense_x,
-                dense_x,
-                dense_x,
-                None,
-                None,
-                max_seqlen,
-                max_seqlen,
-                0.0,
-                False,
-                False,
-            )
-
-        self.assertEqual(
-            int(get_total_flops(fake_flop_counter_mode)),
-            int(get_total_flops(real_flop_counter_mode)),
-        )
-
-    @requires_capabilities(Capability.lib.triton)
-    def test_flop_counter_custom_triton_manual_decomp(self, device):
+    @requires_cuda_and_triton
+    def test_flop_counter_custom_triton_manual_decomp(self):
         import triton
         import triton.language as tl
 
@@ -1056,8 +1014,8 @@ class TestFlopCounterDeviceType(TestCase):
             out = tl.sin(x)
             tl.store(out_ptr + offsets, out, mask=mask)
 
-        x = torch.randn(3, device=device)
-        out = torch.empty(3, device=device)
+        x = torch.randn(3, device="cuda")
+        out = torch.empty(3, device="cuda")
 
         @register_flop_formula(sin_kernel)
         def compute_sin_kernel_flops(*args, **kwargs) -> int:
@@ -1089,8 +1047,8 @@ class TestFlopCounterDeviceType(TestCase):
             torch.ops.mylib.sin_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_capabilities(Capability.lib.triton)
-    def test_flop_counter_custom_triton_op_two_kernels_manual_decomp(self, device):
+    @requires_cuda_and_triton
+    def test_flop_counter_custom_triton_op_two_kernels_manual_decomp(self):
         import triton
         import triton.language as tl
 
@@ -1116,8 +1074,8 @@ class TestFlopCounterDeviceType(TestCase):
             out = tl.cos(x)
             tl.store(out_ptr + offsets, out, mask=mask)
 
-        x = torch.randn(3, device=device)
-        out = torch.empty(3, device=device)
+        x = torch.randn(3, device="cuda")
+        out = torch.empty(3, device="cuda")
 
         @register_flop_formula(sin_kernel)
         def compute_sin_kernel_flops(*args, **kwargs) -> int:
@@ -1163,11 +1121,11 @@ class TestFlopCounterDeviceType(TestCase):
             torch.ops.mylib.trig_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_capabilities(Capability.lib.triton)
+    @requires_cuda_and_triton
     @torch._functorch.config.patch("activation_memory_budget", 0.1)
     @torch._functorch.config.patch("activation_memory_budget_solver", "dp")
     @torch._functorch.config.patch("is_non_builtin_to_include", True)
-    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self, device):
+    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self):
         import triton
         import triton.language as tl
 
@@ -1194,7 +1152,7 @@ class TestFlopCounterDeviceType(TestCase):
             tl.store(out_ptr + offsets, out, mask=mask)
 
         n_elements = int(1e7)
-        x = torch.randn(n_elements, device=device, requires_grad=True)
+        x = torch.randn(n_elements, device="cuda", requires_grad=True)
 
         cos_flops_recorded, sin_flops_recorded = 0, 0
 
@@ -1259,22 +1217,57 @@ class TestFlopCounterDeviceType(TestCase):
             "Custom formula for cos_kernel not recorded during partitioning",
         )
 
-    @requires_capabilities(Capability.dtype.fp8)
-    def test_scaled_mm(self, device):
+    @skipIfNoTorchVision
+    def test_inference_mode(self):
+        def get_flops(model):
+            with FlopCounterMode(model) as mode:
+                a = T(1, 3, 224, 224)
+                model(a).sum()
+            return mode
+
+        resnet18 = torchvision_models.resnet18()
+
+        mode_standard = get_flops(resnet18)
+
+        with torch.inference_mode():
+            mode_inference = get_flops(resnet18)
+
+        self.assertEqual(
+            get_total_flops(mode_standard), get_total_flops(mode_inference)
+        )
+
+        layer1_conv_flops_standard = mode_standard.flop_counts["ResNet.layer1"][
+            torch.ops.aten.convolution
+        ]
+        layer1_conv_flops_inference = mode_inference.flop_counts["ResNet.layer1"][
+            torch.ops.aten.convolution
+        ]
+        self.assertEqual(layer1_conv_flops_standard, layer1_conv_flops_inference)
+
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8,
+        "FP8 is only supported on H100+, SM 8.9 and MI300+ devices",
+    )
+    def test_scaled_mm(self):
         dtype = e4m3_type
         with FlopCounterMode() as mode:
             torch._scaled_mm(
-                torch.randn((3 * 16, 5 * 16), device=device).to(dtype),
-                torch.randn((7 * 16, 5 * 16), device=device).to(dtype).t(),
-                scale_a=torch.ones((), device=device),
-                scale_b=torch.ones((), device=device),
+                torch.randn((3 * 16, 5 * 16), device="cuda").to(dtype),
+                torch.randn((7 * 16, 5 * 16), device="cuda").to(dtype).t(),
+                scale_a=torch.ones((), device="cuda"),
+                scale_b=torch.ones((), device="cuda"),
                 out_dtype=torch.bfloat16,
             )
 
         self.assertExpectedInline(get_total_flops(mode), """860160""")
 
-    @requires_capabilities(Capability.attention.flash_attention)
-    def test_varlen_attn(self, device):
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Flash attention not supported (pre-SM80 hardware on CUDA)",
+    )
+    def test_varlen_attn(self):
         import torch.nn.attention.varlen
 
         n_heads = 8
@@ -1285,7 +1278,7 @@ class TestFlopCounterDeviceType(TestCase):
         cu_seqs = torch.tensor(
             [0] + list(torch.tensor(seq_lens).cumsum(0).tolist()),
             dtype=torch.int32,
-            device=device,
+            device="cuda",
         )
         max_s = max(seq_lens)
 
@@ -1293,7 +1286,7 @@ class TestFlopCounterDeviceType(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device=device,
+            device="cuda",
             dtype=dtype,
             requires_grad=True,
         )
@@ -1301,7 +1294,7 @@ class TestFlopCounterDeviceType(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device=device,
+            device="cuda",
             dtype=dtype,
             requires_grad=True,
         )
@@ -1309,7 +1302,7 @@ class TestFlopCounterDeviceType(TestCase):
             total_tokens,
             n_heads,
             head_dim,
-            device=device,
+            device="cuda",
             dtype=dtype,
             requires_grad=True,
         )
@@ -1359,8 +1352,6 @@ class TestFlopCounterDeviceType(TestCase):
 
 
 class TestFlexAttentionEstimation(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     def test_flex_attention_flop_registration(self):
         """flex_attention HOPs are registered in flop_registry and recognized as compute nodes."""
         from torch._inductor.fx_passes.overlap_scheduling import is_compute_node
@@ -1407,6 +1398,40 @@ class TestFlexAttentionEstimation(TestCase):
         )
         expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
         self.assertEqual(fwd_flops, expected_flops)
+
+    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(not HAS_CUDA, "requires CUDA")
+    def test_flex_attention_roofline_estimate(self):
+        """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            estimate_roofline_runtime_ms,
+        )
+
+        q_shape = (2, 16, 1024, 64)
+        k_shape = (2, 4, 1024, 64)
+        v_shape = (2, 4, 1024, 64)
+
+        graph = torch.fx.Graph()
+        q = graph.placeholder("q")
+        k = graph.placeholder("k")
+        v = graph.placeholder("v")
+        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
+        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
+        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
+
+        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
+        fwd.meta["val"] = (
+            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+        )
+
+        est_ms = estimate_roofline_runtime_ms(fwd)
+        self.assertGreater(est_ms, 0.0)
 
     def test_sparsity_hint_annotate_propagates(self):
         """fx_traceback.annotate propagates sparsity_hint to flex_attention node."""
@@ -1495,89 +1520,6 @@ class TestFlexAttentionEstimation(TestCase):
         self.assertGreater(dense_flops, 0)
         self.assertEqual(sparse_flops, dense_flops // 2)
 
-
-class TestFlexAttentionEstimationCUDA(TestCase):
-    hw_classification = HardwareClassification.CUDA
-
-    @xfailIfNoAcceleratorTriton
-    def test_flex_attention_roofline_estimate(self):
-        """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            estimate_roofline_runtime_ms,
-        )
-
-        q_shape = (2, 16, 1024, 64)
-        k_shape = (2, 4, 1024, 64)
-        v_shape = (2, 4, 1024, 64)
-
-        graph = torch.fx.Graph()
-        q = graph.placeholder("q")
-        k = graph.placeholder("k")
-        v = graph.placeholder("v")
-        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
-        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
-        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
-
-        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
-        fwd.meta["val"] = (
-            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
-            torch.randn(
-                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
-            ),
-            torch.randn(
-                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
-            ),
-        )
-
-        est_ms = estimate_roofline_runtime_ms(fwd)
-        self.assertGreater(est_ms, 0.0)
-
-
-@unittest.skipIf(
-    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
-)
-class TestFlopCounterCUDA(TestCase):
-    hw_classification = HardwareClassification.CUDA
-
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN attention not supported"
-    )
-    def test_sdpa_cudnn(self):
-        device = "cuda"
-        batch_size = 4
-        n_heads = 8
-        seq_len_q = 128
-        head_dim = 64
-        dtype = torch.float16
-
-        torch.manual_seed(0)
-
-        # Sets seq_len_q == seq_len_k and dim_q == dim_v
-        run_uniform_flops = functools.partial(
-            _get_sdpa_flops,
-            device,
-            batch_size,
-            n_heads,
-            seq_len_q,
-            seq_len_q,
-            head_dim,
-            head_dim,
-            dtype,
-        )
-
-        flops_fw_math = run_uniform_flops(SDPBackend.MATH, with_backward=False)
-        flops_fw_cudnn = run_uniform_flops(
-            SDPBackend.CUDNN_ATTENTION, with_backward=False
-        )
-        self.assertEqual(flops_fw_math, flops_fw_cudnn)
-
-        flops_fw_bw_cudnn = run_uniform_flops(
-            SDPBackend.CUDNN_ATTENTION, with_backward=True
-        )
-        self.assertEqual(flops_fw_math * 7 // 2, flops_fw_bw_cudnn)
-
-
-instantiate_device_type_tests(TestFlopCounterDeviceType, globals(), except_for=("cpu",))
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -12,7 +12,7 @@ import unittest
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
-from functools import lru_cache, partial, wraps
+from functools import cache, partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
@@ -320,39 +320,35 @@ def _update_param_kwargs(param_kwargs, name, value):
 
 
 class Capability:
-    """Registry of common test capability constants.
+    """Structured namespace of device capability identifiers.
 
-    These constants are used in two places:
+    Each constant is a ``"<category>.<name>"`` string. The inner classes group
+    them by category so tests can reference capabilities as
+    ``Capability.dtype.fp8`` instead of bare strings.
 
-    1. As arguments to ``@requires_capabilities`` when tests declare their
-       required capabilities::
+    Tests declare requirements with :func:`requires_capabilities`::
 
-            @requires_capabilities(
-                Capability.dtype.fp8,
-                Capability.lib.triton,
-            )
+        @requires_capabilities(Capability.lib.triton, Capability.dtype.fp8)
+        def test_foo(self, device): ...
 
-    2. As keys in ``_capabilities()`` implementations when device test bases
-       declare supported capabilities::
-
-            return {
-                Capability.dtype: {
-                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
-                },
-                Capability.lib: {
-                    Capability.lib.triton: lambda: has_triton(),
-                },
-            }
+    Device test bases declare what they support by overriding
+    :meth:`DeviceTypeTestBase._capabilities` with the same constants as keys.
     """
 
     class dtype:
+        """Data type capabilities (fp8, bf16, etc.)."""
+
         fp8 = "dtype.fp8"
         bf16 = "dtype.bf16"
 
     class lib:
+        """Third-party library capabilities (triton, etc.)."""
+
         triton = "lib.triton"
 
     class attention:
+        """Attention backend capabilities."""
+
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
 
@@ -430,7 +426,7 @@ class DeviceTypeTestBase(TestCase):
     # declare supported capabilities grouped by namespace. This method flattens
     # the nested map, evaluates the support checks, and caches the result.
     @classmethod
-    @lru_cache(maxsize=1)
+    @cache()
     def get_capabilities(cls) -> dict[str, bool]:
         return {
             k: fn() for sub in cls._capabilities().values() for k, fn in sub.items()
@@ -801,12 +797,11 @@ class CPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
-        from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
         from torch.utils._triton import has_triton
 
         return {
             Capability.dtype: {
-                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                Capability.dtype.fp8: lambda: True,
                 Capability.dtype.bf16: lambda: False,
             },
             Capability.lib: {
@@ -938,24 +933,19 @@ class XPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
-        from torch.testing._internal.common_cuda import (
-            PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            PLATFORM_SUPPORTS_FP8,
-            PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-        )
         from torch.utils._triton import has_triton
 
         return {
             Capability.dtype: {
-                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                Capability.dtype.fp8: lambda: True,
                 Capability.dtype.bf16: lambda: False,
             },
             Capability.lib: {
                 Capability.lib.triton: lambda: has_triton(),
             },
             Capability.attention: {
-                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-                Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                Capability.attention.flash_attention: lambda: True,
+                Capability.attention.mem_efficient_attention: lambda: True,
             },
         }
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -426,7 +426,7 @@ class DeviceTypeTestBase(TestCase):
     # declare supported capabilities grouped by namespace. This method flattens
     # the nested map, evaluates the support checks, and caches the result.
     @classmethod
-    @cache()
+    @cache
     def get_capabilities(cls) -> dict[str, bool]:
         return {
             k: fn() for sub in cls._capabilities().values() for k, fn in sub.items()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2,6 +2,7 @@
 
 import copy
 import gc
+import importlib.util
 import inspect
 import logging
 import os
@@ -344,6 +345,7 @@ class Capability:
     class lib:
         """Third-party library capabilities (triton, etc.)."""
 
+        safetensors = "lib.safetensors"
         triton = "lib.triton"
 
     class attention:
@@ -351,6 +353,64 @@ class Capability:
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+
+    class distributed:
+        """Distributed runtime capabilities."""
+
+        backend = "distributed.backend"
+        dtensor = "distributed.dtensor"
+        fsdp = "distributed.fsdp"
+
+    class memory:
+        """Device memory capabilities."""
+
+        non_blocking_copy = "memory.non_blocking_copy"
+
+    class stream:
+        """Device stream capabilities."""
+
+        generic = "stream.generic"
+
+
+def _check_capabilities(test_case, required_capabilities) -> None:
+    device_caps = type(test_case).get_capabilities()
+    missing = set(required_capabilities) - device_caps.keys()
+    unsupported = {
+        cap
+        for cap in required_capabilities
+        if cap in device_caps and not device_caps[cap]
+    }
+
+    if missing:
+        raise AssertionError(
+            f"Device '{type(test_case).device_type}' has not declared capabilities: "
+            f"{', '.join(sorted(missing))}. "
+            f"Add them to {type(test_case).__name__}._capabilities()."
+        )
+    if unsupported:
+        raise unittest.SkipTest(
+            f"Device '{type(test_case).device_type}' has unsupported capabilities: "
+            f"{', '.join(sorted(unsupported))}"
+        )
+
+
+def _distributed_backend_available(device_type: str) -> bool:
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        return False
+    try:
+        backend = dist.get_default_backend_for_device(device_type)
+    except (AttributeError, ValueError):
+        return False
+    return dist.is_backend_available(backend)
+
+
+def _device_module_available(device_type: str) -> bool:
+    try:
+        return torch.get_device_module(device_type).is_available()
+    except (AttributeError, RuntimeError):
+        return False
 
 
 class DeviceTypeTestBase(TestCase):
@@ -439,7 +499,22 @@ class DeviceTypeTestBase(TestCase):
     # the current device supports them.
     @classmethod
     def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
-        return {}
+        return {
+            Capability.lib: {
+                Capability.lib.safetensors: lambda: importlib.util.find_spec(
+                    "safetensors"
+                )
+                is not None,
+            }
+        }
+
+    def setUp(self) -> None:
+        test_method = getattr(self, self._testMethodName)
+        required_capabilities = getattr(test_method, "_required_capabilities", ())
+        if required_capabilities:
+            _check_capabilities(self, required_capabilities)
+
+        super().setUp()
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -800,19 +875,38 @@ class CPUTestBase(DeviceTypeTestBase):
     def _capabilities(cls):
         from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype: {
-                Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: False,
-            },
-            Capability.lib: {
-                Capability.lib.triton: lambda: has_triton(),
-            },
-            Capability.attention: {
-                Capability.attention.flash_attention: lambda: False,
-                Capability.attention.mem_efficient_attention: lambda: False,
-            },
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: False,
+                    Capability.attention.mem_efficient_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: False,
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: False,
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: False,
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
 
 class CUDATestBase(DeviceTypeTestBase):
@@ -837,19 +931,44 @@ class CUDATestBase(DeviceTypeTestBase):
         )
         from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype: {
-                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
-                Capability.dtype.bf16: lambda: SM80OrLater,
-            },
-            Capability.lib: {
-                Capability.lib.triton: lambda: has_triton(),
-            },
-            Capability.attention: {
-                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-                Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-            },
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                    Capability.dtype.bf16: lambda: SM80OrLater,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                    Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -939,19 +1058,44 @@ class XPUTestBase(DeviceTypeTestBase):
         )
         from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype: {
-                Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: True,
-            },
-            Capability.lib: {
-                Capability.lib.triton: lambda: has_triton(),
-            },
-            Capability.attention: {
-                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
-                Capability.attention.mem_efficient_attention: lambda: True,
-            },
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -1214,35 +1358,17 @@ def requires_capabilities(*caps: str):
     Raises AssertionError if a capability is not declared in the
     device's ``_capabilities()`` map.
     """
-    caps_set = set(caps)
+    caps_set = frozenset(caps)
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
-            device_caps = type(self).get_capabilities()
-
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in device_caps:
-                    if not device_caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
-
-            if missing:
-                raise AssertionError(
-                    f"Device '{type(self).device_type}' has not declared capabilities: "
-                    f"{', '.join(sorted(missing))}. "
-                    f"Add them to {type(self).__name__}._capabilities()."
-                )
-            if unsupported:
-                raise unittest.SkipTest(
-                    f"Device '{type(self).device_type}' has unsupported capabilities: "
-                    f"{', '.join(sorted(unsupported))}"
-                )
+            _check_capabilities(self, caps_set)
             return fn(self, *args, **kwargs)
 
+        wrapper._required_capabilities = (
+            frozenset(getattr(fn, "_required_capabilities", ())) | caps_set
+        )
         return wrapper
 
     return decorator

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -360,6 +360,9 @@ class Capability:
         backend = "distributed.backend"
         dtensor = "distributed.dtensor"
         fsdp = "distributed.fsdp"
+        fsdp1 = "distributed.fsdp1"
+        fsdp2 = "distributed.fsdp2"
+        sharded_tensor = "distributed.sharded_tensor"
 
     class memory:
         """Device memory capabilities."""
@@ -894,6 +897,9 @@ class CPUTestBase(DeviceTypeTestBase):
                         cls.device_type
                     ),
                     Capability.distributed.fsdp: lambda: False,
+                    Capability.distributed.fsdp1: lambda: False,
+                    Capability.distributed.fsdp2: lambda: False,
+                    Capability.distributed.sharded_tensor: lambda: False,
                 },
                 Capability.memory: {
                     Capability.memory.non_blocking_copy: lambda: False,
@@ -950,6 +956,15 @@ class CUDATestBase(DeviceTypeTestBase):
                         cls.device_type
                     ),
                     Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp1: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp2: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.sharded_tensor: lambda: _distributed_backend_available(
                         cls.device_type
                     ),
                 },
@@ -1077,6 +1092,15 @@ class XPUTestBase(DeviceTypeTestBase):
                         cls.device_type
                     ),
                     Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp1: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp2: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.sharded_tensor: lambda: _distributed_backend_available(
                         cls.device_type
                     ),
                 },

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -12,7 +12,7 @@ import unittest
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
-from functools import cache, partial, wraps
+from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
@@ -424,12 +424,13 @@ class DeviceTypeTestBase(TestCase):
     # Returns the capability map used by @requires_capabilities.
     # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
     # declare supported capabilities grouped by namespace. This method flattens
-    # the nested map, evaluates the support checks, and caches the result.
+    # the nested map and evaluates the support checks.
     @classmethod
-    @cache
     def get_capabilities(cls) -> dict[str, bool]:
         return {
-            k: fn() for sub in cls._capabilities().values() for k, fn in sub.items()
+            k: bool(fn())
+            for sub in cls._capabilities().values()
+            for k, fn in sub.items()
         }
 
     # Returns a nested capability map grouped by namespace.
@@ -933,18 +934,21 @@ class XPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
+        from torch.testing._internal.common_xpu import (
+            PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+        )
         from torch.utils._triton import has_triton
 
         return {
             Capability.dtype: {
                 Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: False,
+                Capability.dtype.bf16: lambda: True,
             },
             Capability.lib: {
                 Capability.lib.triton: lambda: has_triton(),
             },
             Capability.attention: {
-                Capability.attention.flash_attention: lambda: True,
+                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
                 Capability.attention.mem_efficient_attention: lambda: True,
             },
         }
@@ -1201,6 +1205,49 @@ def get_desired_device_type_test_bases(
     )
 
 
+def requires_capabilities(*caps: str):
+    """Declare that a test method requires device capabilities.
+
+    Wraps the test to call ``type(self).get_capabilities()`` at runtime
+    and skip if any required capability is unsupported by the device.
+
+    Raises AssertionError if a capability is not declared in the
+    device's ``_capabilities()`` map.
+    """
+    caps_set = set(caps)
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            device_caps = type(self).get_capabilities()
+
+            unsupported = set()
+            missing = set()
+            for c in caps_set:
+                if c in device_caps:
+                    if not device_caps[c]:
+                        unsupported.add(c)
+                else:
+                    missing.add(c)
+
+            if missing:
+                raise AssertionError(
+                    f"Device '{type(self).device_type}' has not declared capabilities: "
+                    f"{', '.join(sorted(missing))}. "
+                    f"Add them to {type(self).__name__}._capabilities()."
+                )
+            if unsupported:
+                raise unittest.SkipTest(
+                    f"Device '{type(self).device_type}' has unsupported capabilities: "
+                    f"{', '.join(sorted(unsupported))}"
+                )
+            return fn(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 # Adds 'instantiated' device-specific test cases to the given scope.
 # The tests in these test cases are derived from the generic tests in
 # generic_test_class. This function should be used instead of
@@ -1209,44 +1256,6 @@ def get_desired_device_type_test_bases(
 #
 # See note "Writing Test Templates"
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
-
-
-def requires_capabilities(*caps: str):
-    """Declare that a test method requires device capabilities.
-
-    Wraps the test to call ``type(self).get_capabilities()`` at runtime
-    and skip if any required capability is missing.
-    """
-    caps_set = set(caps)
-
-    def decorator(fn):
-        @wraps(fn)
-        def wrapper(self, *args, **kwargs):
-            caps = type(self).get_capabilities()
-
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in caps:
-                    if not caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
-
-            if missing:
-                raise unittest.SkipTest(
-                    f"Missing capabilities on device '{type(self).device_type}': "
-                    f"{', '.join(sorted(missing))}"
-                )
-            if unsupported:
-                raise unittest.SkipTest(
-                    f"Unsupported capabilities: {', '.join(sorted(unsupported))}"
-                )
-            return fn(self, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def instantiate_device_type_tests(

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -319,6 +319,44 @@ def _update_param_kwargs(param_kwargs, name, value):
     # Leave param_kwargs as-is when value is None.
 
 
+class Capability:
+    """Registry of common test capability constants.
+
+    These constants are used in two places:
+
+    1. As arguments to ``@requires_capabilities`` when tests declare their
+       required capabilities::
+
+            @requires_capabilities(
+                Capability.dtype.fp8,
+                Capability.lib.triton,
+            )
+
+    2. As keys in ``_capabilities()`` implementations when device test bases
+       declare supported capabilities::
+
+            return {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                },
+                Capability.lib: {
+                    Capability.lib.triton: lambda: has_triton(),
+                },
+            }
+    """
+
+    class dtype:
+        fp8 = "dtype.fp8"
+        bf16 = "dtype.bf16"
+
+    class lib:
+        triton = "lib.triton"
+
+    class attention:
+        flash_attention = "attention.flash_attention"
+        mem_efficient_attention = "attention.mem_efficient_attention"
+
+
 class DeviceTypeTestBase(TestCase):
     device_type: str = "generic_device_type"
 
@@ -387,19 +425,23 @@ class DeviceTypeTestBase(TestCase):
     #   ignored for now.
     test_exclusions: ClassVar[dict[str, Any] | None] = None
 
-    # Return the device capability map used by @requires_capabilities.
+    # Returns the capability map used by @requires_capabilities.
     # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
-    # declare supported capabilities. This method evaluates the callables
-    # and caches the results.
+    # declare supported capabilities grouped by namespace. This method flattens
+    # the nested map, evaluates the support checks, and caches the result.
     @classmethod
     @lru_cache(maxsize=1)
     def get_capabilities(cls) -> dict[str, bool]:
-        return {name: fn() for name, fn in cls._capabilities().items()}
+        return {
+            k: fn() for sub in cls._capabilities().values() for k, fn in sub.items()
+        }
 
-    # Returns a mapping from namespaced capability names (e.g. "lib.triton", "dtype.fp8")
-    # to callables that check whether the capability is supported.
+    # Returns a nested capability map grouped by namespace.
+    # Each namespace (e.g. Capability.dtype) groups related capabilities
+    # (e.g. Capability.dtype.fp8) mapped to callables that determine whether
+    # the current device supports them.
     @classmethod
-    def _capabilities(cls) -> dict[str, Callable[[], bool]]:
+    def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
         return {}
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
@@ -763,8 +805,17 @@ class CPUTestBase(DeviceTypeTestBase):
         from torch.utils._triton import has_triton
 
         return {
-            "lib.triton": lambda: has_triton(),
-            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
+            Capability.dtype: {
+                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                Capability.dtype.bf16: lambda: False,
+            },
+            Capability.lib: {
+                Capability.lib.triton: lambda: has_triton(),
+            },
+            Capability.attention: {
+                Capability.attention.flash_attention: lambda: False,
+                Capability.attention.mem_efficient_attention: lambda: False,
+            },
         }
 
 
@@ -783,23 +834,25 @@ class CUDATestBase(DeviceTypeTestBase):
     @classmethod
     def _capabilities(cls):
         from torch.testing._internal.common_cuda import (
-            PLATFORM_SUPPORTS_CUDNN_ATTENTION,
             PLATFORM_SUPPORTS_FLASH_ATTENTION,
             PLATFORM_SUPPORTS_FP8,
             PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
             SM80OrLater,
-            TEST_CUDNN,
         )
         from torch.utils._triton import has_triton
 
         return {
-            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
-            "dtype.bf16": lambda: SM80OrLater,
-            "lib.triton": lambda: has_triton(),
-            "lib.cudnn": lambda: TEST_CUDNN,
-            "feat.flash_attention": lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            "feat.cudnn_attention": lambda: PLATFORM_SUPPORTS_CUDNN_ATTENTION,
-            "feat.mem_efficient_attention": lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            Capability.dtype: {
+                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                Capability.dtype.bf16: lambda: SM80OrLater,
+            },
+            Capability.lib: {
+                Capability.lib.triton: lambda: has_triton(),
+            },
+            Capability.attention: {
+                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            },
         }
 
     @classmethod
@@ -893,10 +946,17 @@ class XPUTestBase(DeviceTypeTestBase):
         from torch.utils._triton import has_triton
 
         return {
-            "lib.triton": lambda: has_triton(),
-            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
-            "feat.flash_attention": lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            "feat.mem_efficient_attention": lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            Capability.dtype: {
+                Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                Capability.dtype.bf16: lambda: False,
+            },
+            Capability.lib: {
+                Capability.lib.triton: lambda: has_triton(),
+            },
+            Capability.attention: {
+                Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            },
         }
 
     @classmethod
@@ -1161,7 +1221,7 @@ def get_desired_device_type_test_bases(
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
 
 
-def requires_capabilitys(*caps: str):
+def requires_capabilities(*caps: str):
     """Declare that a test method requires device capabilities.
 
     Wraps the test to call ``type(self).get_capabilities()`` at runtime
@@ -1173,17 +1233,25 @@ def requires_capabilitys(*caps: str):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
             caps = type(self).get_capabilities()
-            unsupported = {c for c in caps_set if c in caps and not caps[c]}
-            missing = {c for c in caps_set if c not in caps}
-            if unsupported or missing:
-                parts = []
-                if unsupported:
-                    parts.append(
-                        f"Unsupported capabilities: {', '.join(sorted(unsupported))}"
-                    )
-                if missing:
-                    parts.append(f"Missing capabilities: {', '.join(sorted(missing))}")
-                raise unittest.SkipTest("; ".join(parts))
+
+            unsupported = set()
+            missing = set()
+            for c in caps_set:
+                if c in caps:
+                    if not caps[c]:
+                        unsupported.add(c)
+                else:
+                    missing.add(c)
+
+            if missing:
+                raise unittest.SkipTest(
+                    f"Missing capabilities on device '{type(self).device_type}': "
+                    f"{', '.join(sorted(missing))}"
+                )
+            if unsupported:
+                raise unittest.SkipTest(
+                    f"Unsupported capabilities: {', '.join(sorted(unsupported))}"
+                )
             return fn(self, *args, **kwargs)
 
         return wrapper

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -12,7 +12,7 @@ import unittest
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
-from functools import partial, wraps
+from functools import lru_cache, partial, wraps
 from typing import Any, ClassVar, TypeVar
 from typing_extensions import ParamSpec
 
@@ -387,6 +387,21 @@ class DeviceTypeTestBase(TestCase):
     #   ignored for now.
     test_exclusions: ClassVar[dict[str, Any] | None] = None
 
+    # Return the device capability map used by @requires_capabilities.
+    # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
+    # declare supported capabilities. This method evaluates the callables
+    # and caches the results.
+    @classmethod
+    @lru_cache(maxsize=1)
+    def get_capabilities(cls) -> dict[str, bool]:
+        return {name: fn() for name, fn in cls._capabilities().items()}
+
+    # Returns a mapping from namespaced capability names (e.g. "lib.triton", "dtype.fp8")
+    # to callables that check whether the capability is supported.
+    @classmethod
+    def _capabilities(cls) -> dict[str, Callable[[], bool]]:
+        return {}
+
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
 
@@ -742,6 +757,16 @@ class CPUTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
+    @classmethod
+    def _capabilities(cls):
+        from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
+        from torch.utils._triton import has_triton
+
+        return {
+            "lib.triton": lambda: has_triton(),
+            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
+        }
+
 
 class CUDATestBase(DeviceTypeTestBase):
     device_type = "cuda"
@@ -754,6 +779,28 @@ class CUDATestBase(DeviceTypeTestBase):
 
     def has_cudnn(self):
         return not self.no_cudnn
+
+    @classmethod
+    def _capabilities(cls):
+        from torch.testing._internal.common_cuda import (
+            PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+            PLATFORM_SUPPORTS_FLASH_ATTENTION,
+            PLATFORM_SUPPORTS_FP8,
+            PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            SM80OrLater,
+            TEST_CUDNN,
+        )
+        from torch.utils._triton import has_triton
+
+        return {
+            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
+            "dtype.bf16": lambda: SM80OrLater,
+            "lib.triton": lambda: has_triton(),
+            "lib.cudnn": lambda: TEST_CUDNN,
+            "feat.flash_attention": lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+            "feat.cudnn_attention": lambda: PLATFORM_SUPPORTS_CUDNN_ATTENTION,
+            "feat.mem_efficient_attention": lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        }
 
     @classmethod
     def get_primary_device(cls):
@@ -835,6 +882,22 @@ class MPSTestBase(DeviceTypeTestBase):
 class XPUTestBase(DeviceTypeTestBase):
     device_type = "xpu"
     primary_device: ClassVar[str]
+
+    @classmethod
+    def _capabilities(cls):
+        from torch.testing._internal.common_cuda import (
+            PLATFORM_SUPPORTS_FLASH_ATTENTION,
+            PLATFORM_SUPPORTS_FP8,
+            PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        )
+        from torch.utils._triton import has_triton
+
+        return {
+            "lib.triton": lambda: has_triton(),
+            "dtype.fp8": lambda: PLATFORM_SUPPORTS_FP8,
+            "feat.flash_attention": lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+            "feat.mem_efficient_attention": lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        }
 
     @classmethod
     def get_primary_device(cls):
@@ -1096,6 +1159,38 @@ def get_desired_device_type_test_bases(
 #
 # See note "Writing Test Templates"
 # TODO: remove "allow_xpu" option after Intel GPU support all test case instantiate by this function.
+
+
+def requires_capabilitys(*caps: str):
+    """Declare that a test method requires device capabilities.
+
+    Wraps the test to call ``type(self).get_capabilities()`` at runtime
+    and skip if any required capability is missing.
+    """
+    caps_set = set(caps)
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            caps = type(self).get_capabilities()
+            unsupported = {c for c in caps_set if c in caps and not caps[c]}
+            missing = {c for c in caps_set if c not in caps}
+            if unsupported or missing:
+                parts = []
+                if unsupported:
+                    parts.append(
+                        f"Unsupported capabilities: {', '.join(sorted(unsupported))}"
+                    )
+                if missing:
+                    parts.append(f"Missing capabilities: {', '.join(sorted(missing))}")
+                raise unittest.SkipTest("; ".join(parts))
+            return fn(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def instantiate_device_type_tests(
     generic_test_class,
     scope,


### PR DESCRIPTION
## Summary

Adds three capability identifiers under `Capability.distributed`:

- `fsdp1` — `torch.distributed.fsdp.FullyShardedDataParallel`
- `fsdp2` — `torch.distributed._composable.fsdp.fully_shard`
- `sharded_tensor` — `torch.distributed._shard.sharded_tensor.ShardedTensor`

The existing `fsdp` identifier is left as-is; nothing here removes or
changes its meaning.

## Motivation

`Capability.distributed.fsdp` doesn't distinguish `FullyShardedDataParallel`
(FSDP1) from `fully_shard` (FSDP2) — the two have materially different
internal requirements, so a single flag can't accurately gate either one.
Raised by @wjlFlyer on #192322 and #192323 (both test `FullyShardedDataParallel`
specifically). Separately, @wjlFlyer noted on #192320 that
`_create_chunk_sharded_tensor` coverage needs a `ShardedTensor`-specific
capability, which didn't exist at all.

## Changes

- `torch/testing/_internal/common_device_type.py`:
  - add `fsdp1`, `fsdp2`, `sharded_tensor` to `Capability.distributed`;
  - add corresponding entries to `CPUTestBase`/`CUDATestBase`/`XPUTestBase`
    `_capabilities()`, mirroring the existing `fsdp` entry's check in each
    (CPU: `False`; CUDA/XPU: `_distributed_backend_available(cls.device_type)`).

No behavior change for existing callers of `Capability.distributed.fsdp`.

## Test Plan

- `ruff check` / `ruff format --check` clean.
- Applies cleanly on top of #191919.

## Related

Depends on #191919 (introduces `Capability.distributed`). Part of #185590.
Unblocks #192320, #192322, #192323.

## Notes

Stacked on #191919's exact head commit; will be rebased onto `main` once
#191919 merges. If danieldale2026 submits an equivalent addition first,
this PR is superseded in favor of that one.