### PR TITLE
Widen Vectorized<Half>::fmod to float on NEON

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h
@@ -211,7 +211,14 @@ struct Vectorized16 {
         &Vectorized<float>::exp_u20);
   }
   Derived fmod(const Derived& q) const {
-    // This function is questionable with a conversion, so we use map2
+    // Sleef_fmodf is only defined for abs(x / y) < 1e38. Half cannot reach
+    // that, its largest possible ratio is 65504 / 2^-24, about 1e12, so
+    // widening to float is exact. BFloat16 has float's exponent range, so it
+    // does reach the undefined range and has to stay per element.
+    if constexpr (std::is_same_v<value_type, c10::Half>) {
+      return static_cast<const Derived*>(this)->map2_with_vec_float_method(
+          q, &Vectorized<float>::fmod);
+    }
     return map2(q, std::fmod);
   }
   Derived hypot(const Derived& b) const {


### PR DESCRIPTION
On arm64, `Vectorized<Half>::fmod` and `Vectorized<BFloat16>::fmod` both run `std::fmod` once per element:

https://github.com/pytorch/pytorch/blob/04b971abedf3167a3f929e4e7a9a5b7e8647c02c/aten/src/ATen/cpu/vec/vec128/vec128_reduced_precision_common_neon.h#L213-L216

Every other method in that class widens to float, including `atan2` and `hypot` right next to it. x86 already widens `fmod` too (`vec256_16bit_float.h`, `vec512_bfloat16.h`). This makes Half do the same and leaves BFloat16 alone.

### Why it is safe for Half

Sleef documents `Sleef_fmodf` as defined only when `abs(x / y) < 1e38`. Half cannot get there. The largest ratio it can express is `65504 / 2^-24`, about `1.1e12`, so every Half input pair is inside the documented range.

Checked exhaustively against `std::fmod` over all 2^32 Half pairs:

```
half all 2^32 pairs: value mismatches=0
```

The only differing results are NaN payloads when an input is already NaN, plus `fmod(-inf, y)`, which returns a NaN with the sign bit set instead of clear. float32 and float64 already do that on the vectorized path, so this makes Half agree with them:

```python
# fmod(-inf, 1), vectorized path
float32   -nan
float64   -nan
float16   +nan  ->  -nan   # this PR
bfloat16  +nan             # unchanged
```

### Why BFloat16 stays as it is

BFloat16 has float's exponent range, so `abs(x / y)` reaches `3.7e78` and Sleef's range does matter. Over all 2^32 BFloat16 pairs there are 528,480,772 differing values, and every one of them has `abs(a / b) >= 1e38`. None are inside the documented range. That is #193753, not something to widen into.

### The old comment

The comment said a conversion was questionable. `std::fmod` on these types is already `std::fmod(float(a), float(b))`:

https://github.com/pytorch/pytorch/blob/04b971abedf3167a3f929e4e7a9a5b7e8647c02c/c10/util/BFloat16-math.h#L216-L218

So the old code paid for the conversion anyway, once per element instead of once per vector.

### Perf

1M elements, one thread, M4 Pro:

| op | dtype | before | after |
| --- | --- | --- | --- |
| `torch.fmod` | float16 | 15821 us | 1392 us |
| `torch.remainder` | float16 | 15957 us | 1486 us |
| `torch.fmod` | bfloat16 | 17952 us | 17430 us |
| `torch.fmod` | float32 | 1320 us | 1307 us |

float16 lands about where float32 is. bfloat16 and float32 are unchanged, which is the control for the change only touching Half.

### Tests

`test_binary_ufuncs.py -k "fmod or remainder or floor_div or div"`: 1539 passed
`test_ops.py -k "(fmod or remainder) and cpu"`: 108 passed

Happy to move the exhaustive check into a test if you want it in tree, though it takes a few minutes to run.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01