### PR TITLE
[CUDA] Validate MultiMarginLoss targets in backward

### DIFF
--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -77,6 +77,7 @@ __global__ void MultiMarginLoss_backward_kernel(
   const scalar_t *input_k = input + k*dim;
   scalar_t *gradInput_k = gradInput + k*dim;
   int target_k = static_cast<int>(target[k]);
+  CUDA_KERNEL_ASSERT(target_k >= 0 && target_k < dim && "target index is out of bounds");
   scalar_t input_target_k = input_k[target_k];
 
   const scalar_t *gradOutput_k = gradOutput;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9003,6 +9003,23 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(x_cpu.grad, x.grad.cpu())
 
     @onlyCUDA
+    def test_MarginLoss_invalid_target_from_dlpack(self, device):
+        # Run in a different process to prevent the device-side assert from affecting other tests.
+        stderr = TestCase.runWithPytorchAPIUsageStderr(f"""\
+import torch
+import torch.nn.functional as F
+
+x = torch.ones((1024,), dtype=torch.float32, device='{device}', requires_grad=True)
+target = torch.tensor(0, dtype=torch.int64, device='{device}')
+target_alias = torch.from_dlpack(target)
+loss = F.multi_margin_loss(x, target, p=1, margin=0.1, reduction="mean")
+target_alias.fill_(2147483647)
+loss.backward()
+torch.cuda.synchronize()
+""")
+        self.assertIn("CUDA error: device-side assert triggered", stderr)
+
+    @onlyCUDA
     def test_MarginLoss_warnings(self, device):
         model = torch.nn.Linear(128, 22, device=device)
         loss = torch.nn.MultiMarginLoss()


### PR DESCRIPTION
Fixes pytorch/pytorch#193102

Fix the out-of-bounds index error in the MultiMarginLoss backward pass by adding target index validation.

> AI-assisted summary:
>
> ## Summary
>
> Validate `target_k` in `MultiMarginLoss_backward_kernel` before any
> dereference, matching the existing forward-kernel check. This prevents an
> invalid target modified through a DLPack alias from causing an illegal global
> memory access.
>
> Add a CUDA regression test that runs the DLPack alias case in a subprocess
> and verifies that the kernel reports a device-side assertion.
>
> ## Performance
>
> NVIDIA H200 kernel microbenchmark:
>
> | Shape | Without check | With check | Change |
> | --- | ---: | ---: | ---: |
> | `nframe=1, dim=1024` | 3.455 us | 3.454 us | -0.02% |
> | `nframe=1024, dim=1024` | 4.342 us | 4.414 us | +1.65% |
> | `nframe=1024, dim=10` | 3.116 us | 3.230 us | +3.65% |
>
> These are temporary kernel microbenchmarks; the absolute overhead is about
> 0.1 us for the small-dimension case.
>
> ## Test plan
>
> - `python3 -m py_compile test/test_nn.py` passed
> - `git diff --check` passed
> - `lintrunner -a` could not complete because the available Python 3.8
>   cannot evaluate the repository linter's `set[str]` annotation
> - H200 `compute-sanitizer --tool memcheck` reproduced the original invalid
>   reads before the fix
>
> ## BC-breaking?
>
> No.
