### PR TITLE
[Testcase Refactoring] Preserve non-test descriptors during device-test instantiation

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
      get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
-     deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes)
+     deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes, DeviceTypeTestBase)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_dtype import all_types_and_complex_and, floating_types
@@ -2152,6 +2152,52 @@ class TestTestParametrization(TestCase):
 
 
 class TestTestParametrizationDeviceType(TestCase):
+    def test_preserves_non_test_descriptors(self, device):
+        device = self.device_type
+
+        class TestParametrized(TestCase):
+            @staticmethod
+            def static_helper(x, y):
+                return x, y
+
+            @classmethod
+            def class_helper(cls):
+                return cls.device_type
+
+            def test_device_specific(self, device):
+                pass
+
+        locals_dict = dict(locals())
+        instantiate_device_type_tests(TestParametrized, locals_dict, only_for=device)
+
+        device_cls = locals_dict[f"TestParametrized{device.upper()}"]
+        self.assertIsInstance(
+            inspect.getattr_static(device_cls, "static_helper"), staticmethod
+        )
+        self.assertIsInstance(
+            inspect.getattr_static(device_cls, "class_helper"), classmethod
+        )
+        test = device_cls(f"test_device_specific_{device}")
+        self.assertEqual(test.static_helper(1, 2), (1, 2))
+        self.assertEqual(test.class_helper(), device)
+
+    def test_tolerance_defaults_on_uninitialized_thread_local(self, device):
+        import threading
+
+        base = DeviceTypeTestBase
+        original_tls = base._tls
+        try:
+            base._tls = threading.local()
+            instance = base.__new__(base)
+            self.assertEqual(instance.precision, TestCase._precision)
+            self.assertEqual(instance.rel_tol, TestCase._rel_tol)
+            instance.precision = 1e-3
+            instance.rel_tol = 1e-4
+            self.assertEqual(instance.precision, 1e-3)
+            self.assertEqual(instance.rel_tol, 1e-4)
+        finally:
+            base._tls = original_tls
+
     def test_unparametrized_names(self, device):
         # This test exists to protect against regressions in device / dtype test naming
         # due to parametrization logic.

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
      get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
-     deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes, DeviceTypeTestBase)
+     deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_dtype import all_types_and_complex_and, floating_types
@@ -2180,23 +2180,6 @@ class TestTestParametrizationDeviceType(TestCase):
         test = device_cls(f"test_device_specific_{device}")
         self.assertEqual(test.static_helper(1, 2), (1, 2))
         self.assertEqual(test.class_helper(), device)
-
-    def test_tolerance_defaults_on_uninitialized_thread_local(self, device):
-        import threading
-
-        base = DeviceTypeTestBase
-        original_tls = base._tls
-        try:
-            base._tls = threading.local()
-            instance = base.__new__(base)
-            self.assertEqual(instance.precision, TestCase._precision)
-            self.assertEqual(instance.rel_tol, TestCase._rel_tol)
-            instance.precision = 1e-3
-            instance.rel_tol = 1e-4
-            self.assertEqual(instance.precision, 1e-3)
-            self.assertEqual(instance.rel_tol, 1e-4)
-        finally:
-            base._tls = original_tls
 
     def test_unparametrized_names(self, device):
         # This test exists to protect against regressions in device / dtype test naming

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -441,7 +441,7 @@ class DeviceTypeTestBase(TestCase):
 
     @property
     def precision(self):
-        return self._tls.precision
+        return getattr(self._tls, "precision", TestCase._precision)
 
     @precision.setter
     def precision(self, prec):
@@ -449,7 +449,7 @@ class DeviceTypeTestBase(TestCase):
 
     @property
     def rel_tol(self):
-        return self._tls.rel_tol
+        return getattr(self._tls, "rel_tol", TestCase._rel_tol)
 
     @rel_tol.setter
     def rel_tol(self, prec):
@@ -1302,7 +1302,10 @@ def instantiate_device_type_tests(
                     device_type_test_class.instantiate_test(name, copy.deepcopy(test))
             # Ports non-test member. Setup / teardown have already been handled above
             elif name not in device_type_test_class.__dict__:
-                nontest = getattr(generic_test_class, name)
+                # Avoid invoking descriptors while copying members to the generated
+                # class. In particular, getattr() unwraps staticmethod and classmethod,
+                # changing how they bind when accessed through a test instance.
+                nontest = inspect.getattr_static(generic_test_class, name)
                 setattr(device_type_test_class, name, nontest)
 
         # Mimics defining the instantiated class in the caller's file

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -441,7 +441,7 @@ class DeviceTypeTestBase(TestCase):
 
     @property
     def precision(self):
-        return getattr(self._tls, "precision", TestCase._precision)
+        return self._tls.precision
 
     @precision.setter
     def precision(self, prec):
@@ -449,7 +449,7 @@ class DeviceTypeTestBase(TestCase):
 
     @property
     def rel_tol(self):
-        return getattr(self._tls, "rel_tol", TestCase._rel_tol)
+        return self._tls.rel_tol
 
     @rel_tol.setter
     def rel_tol(self, prec):


### PR DESCRIPTION
I reviewed the candidate code, the full pre-publication review evidence, and every quoted word below; I understand it and take responsibility for this submission. The PR title and the quoted body were prepared with agent assistance and I have reviewed both.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
> Preserve non-test descriptors when `instantiate_device_type_tests()` copies members from a generic test class onto generated device-test classes. This is the only change in this PR.
>
> ## Root cause
> The copy loop used ordinary `getattr()`, which invokes `staticmethod`/`classmethod` binding before the value is copied. The installed result (a plain function or a bound method) then changes how the member behaves on the generated class. `inspect.getattr_static()` returns the raw descriptor object, which `setattr` re-installs verbatim, preserving binding semantics.
>
> ## Changes
> - `torch/testing/_internal/common_device_type.py`: copy non-test members with `inspect.getattr_static()` instead of `getattr()`.
> - `test/test_testing.py`: add `test_preserves_non_test_descriptors`, which asserts the raw descriptor types (`staticmethod`/`classmethod`) on the generated class and verifies that instance access still binds correctly.
>
> ## Scope decision
> An earlier version of this PR also added a tolerance getter fallback and a same-thread tolerance test. Both were removed: the fallback could silently lose a parent-thread tolerance override, and the removed same-thread test did not exercise a thread boundary, so it did not test the scenario it was named for. Parent-to-worker tolerance propagation and any redesign of the copy loop are separate follow-ups and are not fixed here.
>
> ## Test Plan
> Executed candidate-locally on CPU. Build provenance was verified (Python under test is the candidate worktree; the native build is reused from the parent commit, valid because the parent-to-candidate native compile-input diff is empty):
>
> ```bash
> .venv/bin/python /home/daniel/workspace/pytorch-dev/worktrees/pytorch/pr193788-descriptor-only-20260912/test/test_testing.py TestTestParametrizationDeviceTypeCPU.test_preserves_non_test_descriptors_cpu -v
> .venv/bin/python /home/daniel/workspace/pytorch-dev/worktrees/pytorch/pr193788-descriptor-only-20260912/test/test_testing.py TestTestParametrizationDeviceTypeCPU -v
> .venv/bin/python -m py_compile test/test_testing.py torch/testing/_internal/common_device_type.py
> source agent_space/goal-h-h2b/environment.sh
> "$TOOL_BIN/uvx" --with-requirements requirements-build.txt --from 'spin==0.18' spin fixlint -- test/test_testing.py torch/testing/_internal/common_device_type.py
> "$TOOL_BIN/uvx" --with-requirements requirements-build.txt --from 'spin==0.18' spin quicklint -- test/test_testing.py torch/testing/_internal/common_device_type.py
> git diff --check 8575ff5477dcdea7b8726fc82e419eee338c9f4f
> git diff --check 1859e8b4716e1c0edd389ddd7b3ae480578b31a4
> ```
>
> Results: focused descriptor regression 1 executed / 1 passed; full generated CPU class 29 executed / 23 passed / 6 expected failures; 0 failed, errors, skipped, unexpected successes, or timeouts in both runs (30 total executions, counting the focused test once standalone and once inside the class). `py_compile` passed; both scoped lint commands reported no lint issues; both `git diff --check` runs were clean.
>
> ## Evidence limits
> - Candidate-local runtime evidence is CPU-only.
> - The checks and the approval currently visible on this PR belong to the earlier published head and are stale for this candidate. Candidate CI will start only once this candidate is pushed.
>
> ## Anchors
> - Base: `1859e8b4716e1c0edd389ddd7b3ae480578b31a4`.
> - Proposed candidate head: `a25652030060df581401e284c9d7390ef784e133`, a direct child of the currently published head.
> - Final diff: exactly two files — `test/test_testing.py` `+29/-0`; `torch/testing/_internal/common_device_type.py` `+4/-1`.
>
> ## Checklist
> - [x] Code reviewed and understood; pre-publication review of the exact candidate completed (verdict APPROVE, status COMPLETE).
> - [x] Scoped lint clean; candidate-local CPU tests pass with the exact counts above.
> - [ ] GitHub CI on the candidate (pending ordinary push).
