### PR TITLE
[inductor] Generalize cuda literal check in check_multiple_devices_or…

### DIFF
--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -358,9 +358,11 @@ def check_multiple_devices_or_any_cpu_nodes(
 
         return format_default_skip_message(msg)
 
+    accelerator = torch.accelerator.current_accelerator()
     if (
         len(device_node_mapping) == 1
-        and next(iter(device_node_mapping.keys())).type == "cuda"
+        and accelerator is not None
+        and next(iter(device_node_mapping.keys())).type == accelerator.type
     ):
         return None
 
@@ -648,7 +650,7 @@ def collect_cuda_data_ptrs(obj: object) -> OrderedSet[int]:
     """Debug helper that collects the data pointers of all CUDA tensors in the object."""
     if not isinstance(obj, torch.Tensor):
         return OrderedSet()
-
+    
     ptrs: OrderedSet[int] = OrderedSet()
     for base in get_plain_tensors(obj, out=[]):
         if type(base) is not torch.Tensor:

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -650,7 +650,6 @@ def collect_cuda_data_ptrs(obj: object) -> OrderedSet[int]:
     """Debug helper that collects the data pointers of all CUDA tensors in the object."""
     if not isinstance(obj, torch.Tensor):
         return OrderedSet()
-    
     ptrs: OrderedSet[int] = OrderedSet()
     for base in get_plain_tensors(obj, out=[]):
         if type(base) is not torch.Tensor:


### PR DESCRIPTION
…_any_cpu_nodes

Replace the "cuda" literal in check_multiple_devices_or_any_cpu_nodes() with torch.accelerator.current_accelerator(), so a single-device graph on any registered accelerator (not just literal "cuda") is correctly recognized instead of falling through to the "multiple devices" skip message. Same idiom already used elsewhere in the migration (e.g. sac_estimator.py).

Note: collect_cuda_data_ptrs() in this same file has a similar "cuda" check but is intentionally left untouched. It's a debug helper tied to CUDA Graph capture internals (torch.cuda.Stream/graph/synchronize) in cudagraph_trees.py, which hasn't been generalized yet. Generalizing just this check would misreport PrivateUse1 tensors as belonging to a capture pool that doesn't exist for that backend, so it stays CUDA-only until that broader work lands.

### Related RFC

This change is part of the work described in #194355.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo