### PR TITLE
[FX] Restore check_mutable_operations via addCleanup, not tearDown

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -265,25 +265,30 @@ def _parse_profiler_trace_lines(traces: str) -> list[tuple[str, str, str]]:
     return lines
 
 
+def _enable_mutable_operation_checks(test_case):
+    # Checking for mutable operations while tracing is feature flagged: enable
+    # it in testing but not by default. Restoring via addCleanup rather than
+    # tearDown matters because unittest skips tearDown entirely when setUp
+    # raises, and stops at the first statement of tearDown that raises. Either
+    # would leave this global on for every later test in the process, breaking
+    # unrelated tests that legitimately trace mutating code (TestCommonPass).
+    test_case.addCleanup(
+        setattr,
+        torch.fx.proxy.TracerBase,
+        "check_mutable_operations",
+        torch.fx.proxy.TracerBase.check_mutable_operations,
+    )
+    torch.fx.proxy.TracerBase.check_mutable_operations = True
+
+
 class TestFX(JitTestCase):
     def setUp(self):
         super().setUp()
-        # Checking for mutable operations while tracing is feature flagged
-        # Enable it in testing but not by default
-        self.orig_tracer_mutable_flag = (
-            torch.fx.proxy.TracerBase.check_mutable_operations
-        )
-        torch.fx.proxy.TracerBase.check_mutable_operations = True
+        _enable_mutable_operation_checks(self)
 
         if not (IS_FBCODE or IS_WINDOWS or IS_MACOS):
             lib_file_path = find_library_location("libtorchbind_test.so")
             torch.ops.load_library(str(lib_file_path))
-
-    def tearDown(self):
-        super().tearDown()
-        torch.fx.proxy.TracerBase.check_mutable_operations = (
-            self.orig_tracer_mutable_flag
-        )
 
     def _assert_profiler_stack_traces_for_nodes(
         self,
@@ -5225,19 +5230,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
     def setUp(self):
         super().setUp()
         self.maxDiff = None
-
-        # Checking for mutable operations while tracing is feature flagged
-        # Enable it in testing but not by default
-        self.orig_tracer_mutable_flag = (
-            torch.fx.proxy.TracerBase.check_mutable_operations
-        )
-        torch.fx.proxy.TracerBase.check_mutable_operations = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch.fx.proxy.TracerBase.check_mutable_operations = (
-            self.orig_tracer_mutable_flag
-        )
+        _enable_mutable_operation_checks(self)
 
     def _fn_to_stable_annotation_str(self, obj):
         """
@@ -5587,18 +5580,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
 class TestFunctionalTracing(JitTestCase):
     def setUp(self):
         super().setUp()
-        # Checking for mutable operations while tracing is feature flagged
-        # Enable it in testing but not by default
-        self.orig_tracer_mutable_flag = (
-            torch.fx.proxy.TracerBase.check_mutable_operations
-        )
-        torch.fx.proxy.TracerBase.check_mutable_operations = True
-
-    def tearDown(self):
-        super().tearDown()
-        torch.fx.proxy.TracerBase.check_mutable_operations = (
-            self.orig_tracer_mutable_flag
-        )
+        _enable_mutable_operation_checks(self)
 
     IGNORE_FUNCS = (
         "has_torch_function",


### PR DESCRIPTION
`TestFX`, `TestFXAPIBackwardCompatibility` and `TestFunctionalTracing` flip the global `torch.fx.proxy.TracerBase.check_mutable_operations` on in `setUp` and restore it in `tearDown`. That restore is unreliable in two ways:

- `unittest` skips `tearDown` entirely when `setUp` raises;
- these `tearDown`\'s call `super().tearDown()` before restoring the flag, and `common_utils.TestCase.tearDown` itself raises on a leaked default dtype or a leaked torch-function-mode stack.

On either path the flag stays `True` for the rest of the process, and every later test that legitimately traces mutating code starts failing, e.g. `TestCommonPass.test_correctness_CSEPass_Mutation_cpu` with "Tried to trace mutable operation aten.add_.Tensor".

Switching the restore to `addCleanup` fixes both paths, since cleanups run whether or not `setUp` succeeded and independently of `tearDown` raising. The three `tearDown` overrides then have nothing left to do and are removed.

`TestOperatorSignatures` and `TestVisionTracing` are left alone on purpose: they deliberately skip `super().setUp()`/`super().tearDown()`, so neither leak path applies to them.

Fixes the CPU case reported in https://github.com/intel/torch-xpu-ops/issues/4773.

### Test plan

```
python test/test_fx.py -v
```

Ran the full file: 1196 tests, OK (369 skipped, 5 expected failures).

Repro, before/after, from the torch-xpu-ops test tree that reported it:

```
cd third_party/torch-xpu-ops/test/xpu
PYTHONPATH=. python test_fx_xpu.py \
  TestFX.test_graph_module \
  TestCommonPass.test_correctness_CSEPass_Mutation_cpu \
  TestCommonPass.test_correctness_CSEPass_Mutation_xpu -v
```