### PR TITLE
[Testcase Refactoring] Decouple test_alignment.py from CUDA-specific

### DIFF
--- a/test/inductor/test_alignment.py
+++ b/test/inductor/test_alignment.py
@@ -7,6 +7,7 @@ import torch
 import torch._functorch.config as functorch_config
 from torch._inductor import config
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     MACOS_VERSION,
     parametrize,
@@ -271,6 +272,7 @@ class CommonTemplate:
 if RUN_CPU:
 
     class CpuTests(TestCase):
+        hw_classification = HardwareClassification.CPU
         common = check_model
         device = "cpu"
 
@@ -279,6 +281,7 @@ if RUN_CPU:
 if RUN_GPU:
 
     class GPUTests(TestCase):
+        hw_classification = HardwareClassification.ACCELERATOR
         common = check_model_gpu
         device = GPU_TYPE
 


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR|CUDA|CPU` to tests class.

## Motivation
`torch.cuda` only recognizes CUDA. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_alignment.py --hw-classification ACCELERATOR CPU`
- Verified test cases correctly on CPU, GPU, XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo