### PR TITLE
[Testcase Refactoring] Add hw-classification in logging_test

### DIFF
--- a/test/distributed/elastic/utils/logging_test.py
+++ b/test/distributed/elastic/utils/logging_test.py
@@ -7,13 +7,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import torch.distributed.elastic.utils.logging as logging
-from torch.testing._internal.common_utils import run_tests, TestCase
-
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 log = logging.get_logger()
 
 
 class LoggingTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.clazz_log = logging.get_logger()

--- a/test/distributed/elastic/utils/logging_test.py
+++ b/test/distributed/elastic/utils/logging_test.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
+
 log = logging.get_logger()
 
 


### PR DESCRIPTION
## Summary

Tags `LoggingTest` in `test/distributed/elastic/utils/logging_test.py`
with `hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/elastic/utils/logging_test.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `LoggingTest`.

## Context

`LoggingTest` is a plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so this class is classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
 python test/distributed/elastic/utils/logging_test.py , 2 testcases pass
