### PR TITLE
Fix nightly.py not copying DLLs on Windows

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -847,7 +847,7 @@ def _get_listing_windows(source_dir: Path) -> list[Path]:
         itertools.chain(
             source_dir.glob("*.pyd"),
             (source_dir / "lib").glob("*.lib"),
-            (source_dir / "lib").glob(".dll"),
+            (source_dir / "lib").glob("*.dll"),
         )
     )
 


### PR DESCRIPTION
I was setting up a dev environment on Windows with tools/nightly.py and couldn't get import torch to work afterwards:

ImportError: DLL load failed while importing _C: The specified module could not be found.

The cause is in _get_listing_windows, which globs ".dll" instead of "*.dll":

**python**
`(source_dir / "lib").glob(".dll"),`

That looks for a file literally named .dll, so it matches nothing:

**python**
```
>>> [p.name for p in d.glob(".dll")]
[]
>>> sorted(p.name for p in d.glob("*.dll"))
['c10.dll', 'fbgemm.dll', 'torch_cpu.dll']
```

_C.pyd gets copied fine, but none of the DLLs it depends on do, so the loader can't resolve it. The Linux and macOS branches just above use *.so and *.dylib correctly, so this only affects Windows, which is probably why it's gone unnoticed.

Testing: Windows 11, Python 3.13, CPU nightly, same checkout before and after the change. torch/lib went from 0 DLLs to 9, including c10.dll, torch_cpu.dll and torch_python.dll. import torch fails before the change and works after, resolving to my repo checkout.

Note : Used an AI assistant to help track down the root cause.