### PR TITLE
[inductor] Budget persistent-reduction configs against the emitted R0_BLOCK

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -167,6 +167,50 @@ class TestTritonHeuristics(TestCase):
         with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
             make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
 
+    def test_persistent_reduction_budget_uses_emitted_rblock(self):
+        # Under dynamic shapes the emitted R0_BLOCK can exceed size_hints["r0_"];
+        # configs must be budgeted against the emitted block, not the hint.
+        MAX_PERSISTENT_BLOCK_NUMEL = 4096
+        size_hints = {"x": 512, "r0_": 8}
+        emitted_rblock = 512
+
+        for device_type in ("cuda", "hip"):
+            device = DeviceProperties(
+                type=device_type,
+                index=0,
+                multi_processor_count=1,
+                cc=80,
+                major=8,
+                max_threads_per_block=1024,
+                warp_size=32,
+            )
+            triton_meta = {"device": device}
+
+            unconstrained = _persistent_reduction_configs(
+                size_hints=size_hints,
+                inductor_meta={},
+                triton_meta=triton_meta,
+            )
+            constrained = _persistent_reduction_configs(
+                size_hints=size_hints,
+                inductor_meta={"persistent_rblock": emitted_rblock},
+                triton_meta=triton_meta,
+            )
+
+            self.assertTrue(constrained)
+            for cfg in constrained:
+                xblock = cfg.kwargs["XBLOCK"]
+                if xblock == 1:
+                    continue
+                self.assertLessEqual(
+                    xblock * emitted_rblock, MAX_PERSISTENT_BLOCK_NUMEL
+                )
+
+            unconstrained_xblocks = {c.kwargs["XBLOCK"] for c in unconstrained}
+            constrained_xblocks = {c.kwargs["XBLOCK"] for c in constrained}
+            self.assertTrue(constrained_xblocks.issubset(unconstrained_xblocks))
+            self.assertLess(len(constrained_xblocks), len(unconstrained_xblocks))
+
     def test_reduction_min_block_preserves_tile_product(self):
         cfg = _enforce_reduction_config_block_minimums(
             [triton.Config({"XBLOCK": 64, "R0_BLOCK": 1024})],

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7177,6 +7177,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["native_matmul_persistent_rblock"] = rblock
         if self.add_persistent_rblock:
             out["add_persistent_rblock"] = True
+        if (rblock := self._get_emitted_persistent_rblock()) is not None:
+            out["persistent_rblock"] = rblock
         if (rblock := self._strict_reduction_rblock()) is not None:
             out["strict_reduction_rblock"] = rblock
         if (
@@ -7599,6 +7601,22 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if tree.is_reduction
         ]
         return math.prod(rblocks) if rblocks else None
+
+    def _get_emitted_persistent_rblock(self) -> int | None:
+        # The R block the kernel actually emits. Under dynamic shapes this can
+        # exceed the size hint, so config selection budgets against it.
+        if not self.persistent_reduction:
+            return None
+        try:
+            rblocks = [
+                self._get_persistent_RBLOCK(tree.numel)
+                for tree in self.range_trees
+                if tree.is_reduction
+            ]
+        except ValueError:
+            return None
+        total = math.prod(rblocks) if rblocks else 1
+        return total if total > 1 else None
 
     def _get_persistent_reduction_block(self, rnumel) -> int:
         if (rblock := self._strict_reduction_rblock()) is not None:

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -359,6 +359,12 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         xnumel = size_hints["x"]
         rnumel = get_total_reduction_numel(size_hints)
 
+        # Under dynamic shapes the emitted R0_BLOCK can exceed the size hint;
+        # budget against the block codegen will actually emit, not the hint.
+        emitted_rblock = inductor_meta.get("persistent_rblock")
+        if emitted_rblock is not None and emitted_rblock > rnumel:
+            rnumel = emitted_rblock
+
         MAX_PERSISTENT_BLOCK_NUMEL = 4096
         warp_size = triton_meta["device"].warp_size_or_default
 


### PR DESCRIPTION
### Problem
Under dynamic shapes, persistent-reduction autotune configs are budgeted against the reduction size *hint* (`size_hints`), while the emitted kernel uses `_get_persistent_RBLOCK`, which rounds a symbolic numel up to a larger static power of two. When they disagree (e.g. hint `8` vs emitted `R0_BLOCK=512`), configs many times over `MAX_PERSISTENT_BLOCK_NUMEL` slip through and are pathologically slow to codegen.

### Fix
Codegen publishes the emitted block as `inductor_meta["persistent_rblock"]`; `ReductionHeuristic` budgets against it when present. It can only raise the budgeted `rnumel`, so it only tightens the filter â no new configs. Fixed on
the base class since the budget is backend-agnostic (ROCm just surfaces it first through its wider XBLOCK range).

### Test
`test_persistent_reduction_budget_uses_emitted_rblock` in `test/inductor/test_triton_heuristics.py`: pure config-generation, no GPU. Fails on `main`, passes here.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo