### PR TITLE
[DCP] Support dynamic thread_count auto-tuning in DCP writers

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -556,6 +556,63 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     )
 
 
+class TestThreadCountAutoTuning(TestCase):
+    def test_calculate_optimal_thread_count(self) -> None:
+        with tempfile.TemporaryDirectory() as path:
+            writer = FileSystemWriter(
+                path=path,
+                thread_count=None,
+                max_threads=8,
+                min_size_per_thread=1024,  # 1 KB per thread for testing
+            )
+            self.assertIsNone(writer.thread_count)
+
+            # Create a save plan
+            state_dict = {
+                "t1": torch.ones(256, dtype=torch.float32),   # 1024 bytes (1 KB)
+                "t2": torch.ones(512, dtype=torch.float32),   # 2048 bytes (2 KB)
+                "t3": torch.ones(1024, dtype=torch.float32),  # 4096 bytes (4 KB)
+                "t4": torch.ones(2048, dtype=torch.float32),  # 8192 bytes (8 KB)
+            }
+            planner = dist.checkpoint.DefaultSavePlanner()
+            planner.set_up_planner(state_dict, is_coordinator=True)
+            plan = planner.create_local_plan()
+
+            # Total tensor size = 15360 bytes = 15 KB
+            # suggested = 15360 // 1024 = 15
+            # max_threads capped at len(items) = 4
+            thread_count = writer._calculate_optimal_thread_count(plan)
+            self.assertGreaterEqual(thread_count, 1)
+            self.assertLessEqual(thread_count, 4)
+
+            # Small plan < min_size_per_thread
+            small_writer = FileSystemWriter(
+                path=path,
+                thread_count=None,
+                max_threads=8,
+                min_size_per_thread=100 * 1024 * 1024,  # 100 MB
+            )
+            self.assertEqual(small_writer._calculate_optimal_thread_count(plan), 1)
+
+    def test_filesystem_writer_save_and_load_auto_tuned(self) -> None:
+        with tempfile.TemporaryDirectory() as path:
+            state_dict_to_save = {
+                f"tensor_{i}": torch.randn(10, 10) for i in range(8)
+            }
+            # Save with auto-tuned thread_count (None)
+            fs_writer = FileSystemWriter(path=path, thread_count=None)
+            save(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
+
+            state_dict_to_load = {
+                f"tensor_{i}": torch.zeros(10, 10) for i in range(8)
+            }
+            fs_reader = FileSystemReader(path=path)
+            load(state_dict=state_dict_to_load, storage_reader=fs_reader, no_dist=True)
+
+            for k in state_dict_to_save:
+                self.assertTrue(torch.equal(state_dict_to_save[k], state_dict_to_load[k]))
+
+
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadRot13)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
@@ -564,3 +621,4 @@ instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 if __name__ == "__main__":
     run_tests()
+

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -255,6 +255,53 @@ class TestFileSystem(TestCase):
         # os.sync() may be called on backends that don't support per-file fsync
         self.assertLessEqual(mock_os_sync.call_count, 2)
 
+    def test_fsspec_writer_thread_count_auto_tuning(self):
+        """
+        Verify that FsspecWriter works with auto-tuned thread_count (default None)
+        and with explicit thread_count overrides.
+        """
+        state_dict = {f"k_{i}": torch.randn(10, 10) for i in range(8)}
+
+        # 1. Default auto-tuning (thread_count=None, min_size_per_thread=1GB, max_threads=16)
+        writer_auto = FsspecWriter("memory://test_fsspec_auto_tune")
+        self.assertIsNone(writer_auto.thread_count)
+        self.assertEqual(writer_auto.min_size_per_thread, 1024 * 1024 * 1024)
+        self.assertEqual(writer_auto.max_threads, 16)
+
+        dcp.save(state_dict, storage_writer=writer_auto, no_dist=True)
+
+        loaded_auto = {f"k_{i}": torch.zeros(10, 10) for i in range(8)}
+        dcp.load(
+            loaded_auto,
+            storage_reader=FsspecReader("memory://test_fsspec_auto_tune"),
+            no_dist=True,
+        )
+        for k in state_dict:
+            self.assertTrue(torch.equal(state_dict[k], loaded_auto[k]))
+
+        # 2. Explicit thread_count override and custom parameters
+        writer_explicit = FsspecWriter(
+            "memory://test_fsspec_explicit_threads",
+            thread_count=4,
+            max_threads=8,
+            min_size_per_thread=64 * 1024 * 1024,
+        )
+        self.assertEqual(writer_explicit.thread_count, 4)
+        self.assertEqual(writer_explicit.max_threads, 8)
+        self.assertEqual(writer_explicit.min_size_per_thread, 64 * 1024 * 1024)
+
+        dcp.save(state_dict, storage_writer=writer_explicit, no_dist=True)
+
+        loaded_explicit = {f"k_{i}": torch.zeros(10, 10) for i in range(8)}
+        dcp.load(
+            loaded_explicit,
+            storage_reader=FsspecReader("memory://test_fsspec_explicit_threads"),
+            no_dist=True,
+        )
+        for k in state_dict:
+            self.assertTrue(torch.equal(state_dict[k], loaded_explicit[k]))
+
 
 if __name__ == "__main__":
     run_tests()
+

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -112,11 +112,13 @@ class FsspecWriter(FileSystemWriter):
         path: str | os.PathLike,
         single_file_per_rank: bool = True,
         sync_files: bool = True,
-        thread_count: int = 1,
+        thread_count: int | None = None,
         per_thread_copy_ahead: int = 10_000_000,
         overwrite: bool = True,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
+        max_threads: int = 16,
+        min_size_per_thread: int = 1024 * 1024 * 1024,
         **kwargs,
     ) -> None:
         """
@@ -126,22 +128,26 @@ class FsspecWriter(FileSystemWriter):
             path: directory where the checkpoint will be written to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
-            thread_count: Number of IO threads to use to write. Default to 1.
+            thread_count: Number of IO threads to use to write. Default to None (auto-tuned based on plan size).
             per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
+            max_threads: Maximum number of IO threads to use when auto-tuning thread_count. Default to 16.
+            min_size_per_thread: Minimum chunk size in bytes per thread when auto-tuning thread_count. Default to 1GB.
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """
         super().__init__(
-            path,
-            single_file_per_rank,
-            sync_files,
-            thread_count,
-            per_thread_copy_ahead,
+            path=path,
+            single_file_per_rank=single_file_per_rank,
+            sync_files=sync_files,
+            thread_count=thread_count,
+            per_thread_copy_ahead=per_thread_copy_ahead,
             overwrite=overwrite,
             _extensions=_extensions,
             serialization_format=serialization_format,
+            max_threads=max_threads,
+            min_size_per_thread=min_size_per_thread,
         )
         self.fs = FileSystem()
         self.path = self.fs.init_path(path, **kwargs)

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -594,11 +594,13 @@ class _FileSystemWriter(StorageWriter):
         path: str | os.PathLike,
         single_file_per_rank: bool = True,
         sync_files: bool = True,
-        thread_count: int = 1,
+        thread_count: int | None = 1,
         per_thread_copy_ahead: int = 10_000_000,
         overwrite: bool = True,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
+        max_threads: int = 16,
+        min_size_per_thread: int = 1024 * 1024 * 1024,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -609,10 +611,12 @@ class _FileSystemWriter(StorageWriter):
             path: directory where the checkpoint will be written to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
-            thread_count: Number of IO threads to use to write. Default to 1.
+            thread_count: Number of IO threads to use to write. Default to 1. If set to None, thread count is dynamically auto-tuned based on plan size.
             per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
+            max_threads: Maximum number of IO threads to use when auto-tuning thread_count. Default to 16.
+            min_size_per_thread: Minimum chunk size in bytes per thread when auto-tuning thread_count. Default to 1GB.
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """
@@ -622,6 +626,8 @@ class _FileSystemWriter(StorageWriter):
         self.single_file_per_rank = single_file_per_rank
         self.sync_files = sync_files
         self.thread_count = thread_count
+        self.max_threads = max_threads
+        self.min_size_per_thread = min_size_per_thread
         self.per_thread_copy_ahead = per_thread_copy_ahead
         self.save_id = _generate_uuid()
         self.overwrite = overwrite
@@ -681,11 +687,49 @@ class _FileSystemWriter(StorageWriter):
         ]
         return new_plans
 
+    def _calculate_optimal_thread_count(self, plan: SavePlan) -> int:
+        """
+        Dynamically calculate the optimal number of IO threads for writing.
+
+        The thread count is chosen based on:
+        1. Number of available CPU cores.
+        2. Number of write items in the save plan.
+        3. Total payload size in bytes divided by min_size_per_thread.
+        """
+        try:
+            # Respect CPU affinity / quota in containerized or shared environments
+            num_cores = len(os.sched_getaffinity(0))
+        except (AttributeError, NotImplementedError, OSError):
+            num_cores = os.cpu_count() or 1
+
+        max_threads = min(num_cores, self.max_threads)
+        num_items = len(plan.items)
+        max_threads = min(max_threads, num_items)
+
+        if max_threads <= 1:
+            return 1
+
+        total_size = sum(
+            _item_size(item) for item in plan.items if item.tensor_data is not None
+        )
+
+        if self.min_size_per_thread <= 0:
+            return max_threads
+
+        suggested_threads = total_size // self.min_size_per_thread
+
+        thread_count = max(1, min(suggested_threads, max_threads))
+        return thread_count
+
     def write_data(
         self,
         plan: SavePlan,
         planner: SavePlanner,
     ) -> Future[list[WriteResult]]:
+        thread_count = self.thread_count
+        if thread_count is None:
+            thread_count = self._calculate_optimal_thread_count(plan)
+
         storage_plan: _StoragePrefix = plan.storage_data
         file_count = 0
 
@@ -697,7 +741,7 @@ class _FileSystemWriter(StorageWriter):
 
         file_queue: queue.Queue = queue.Queue()
         if self.single_file_per_rank:
-            for bucket in _split_by_size_and_type(self.thread_count, plan.items):
+            for bucket in _split_by_size_and_type(thread_count, plan.items):
                 file_name = gen_file()
                 path = self.fs.concat_path(self.path, file_name)
                 file_queue.put((path, file_name, bucket))
@@ -707,17 +751,18 @@ class _FileSystemWriter(StorageWriter):
                 path = self.fs.concat_path(self.path, file_name)
                 file_queue.put((path, file_name, [item]))
 
-        return self._write_data(planner, file_queue)
+        return self._write_data(planner, file_queue, thread_count)
 
     def _write_data(
         self,
         planner: SavePlanner,
         file_queue: queue.Queue,
+        thread_count: int,
     ) -> Future[list[WriteResult]]:
         result_queue: queue.Queue = queue.Queue()
 
         threads = []
-        for _ in range(1, self.thread_count):
+        for _ in range(1, thread_count):
             t = threading.Thread(
                 target=_write_files_from_queue,
                 args=(
@@ -728,7 +773,7 @@ class _FileSystemWriter(StorageWriter):
                     self.transforms,
                     self.per_thread_copy_ahead,
                     self.sync_files,
-                    self.thread_count,
+                    thread_count,
                     self.serialization_format,
                 ),
             )
@@ -743,7 +788,7 @@ class _FileSystemWriter(StorageWriter):
             transforms=self.transforms,
             inflight_threshhold=self.per_thread_copy_ahead,
             use_fsync=self.sync_files,
-            thread_count=self.thread_count,
+            thread_count=thread_count,
             serialization_format=self.serialization_format,
         )
 
@@ -990,12 +1035,13 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
         path: str | os.PathLike,
         single_file_per_rank: bool = True,
         sync_files: bool = True,
-        thread_count: int = 1,
+        thread_count: int | None = 1,
         per_thread_copy_ahead: int = 10_000_000,
         cache_staged_state_dict: bool = False,
         overwrite: bool = True,
         _extensions: Sequence[StreamTransformExtension] | None = None,
         serialization_format: SerializationFormat = SerializationFormat.TORCH_SAVE,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize the writer pointing to `path`.
@@ -1004,7 +1050,7 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
             path: directory where the checkpoint will be written to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
-            thread_count: Number of IO threads to use to write. Default to 1.
+            thread_count: Number of IO threads to use to write. Defaults to 1. If set to None, thread count is dynamically auto-tuned based on plan size.
             per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             cache_staged_state_dict: Whether to cache the staged state_dict. This option decreases staging latency
                 at the cost of increased memory usage. Additionally, if this parameter is set to True, it's the expectation
@@ -1024,6 +1070,7 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
             overwrite=overwrite,
             _extensions=_extensions,
             serialization_format=serialization_format,
+            **kwargs,
         )
         BlockingAsyncStager.__init__(
             self,


### PR DESCRIPTION
Closes #193804

This change introduces dynamic auto-tuning of write `thread_count` in Distributed Checkpoint (DCP) writers (`_FileSystemWriter`, `FileSystemWriter`, and `FsspecWriter`)

## AI Generated Summary

1. **Dynamic `thread_count` Auto-Tuning**:
   - `_FileSystemWriter` now supports dynamic auto-tuning of IO threads when `thread_count=None`.
   - The optimal concurrency is determined dynamically per save invocation in `_calculate_optimal_thread_count(plan)` based on:
     - Available CPU cores.
     - Number of write items in the `SavePlan`.
     - Total tensor payload size divided by `min_size_per_thread`.
     - Capped at `max_threads`.

2. **Cloud Storage Optimization (`FsspecWriter`)**:
   - `FsspecWriter` now defaults to `thread_count=None` (triggering auto-tuning by default for remote/cloud checkpoints).
   - Configured with `min_size_per_thread=1GB` to avoid connection thrashing and GIL contention on small checkpoints while automatically scaling parallel upload streams on multi-gigabyte models.
   - Allows users to configure explicit `thread_count`, `max_threads`, and `min_size_per_thread` overrides.

3. **Local Storage Behavior (`FileSystemWriter`)**:
   - `FileSystemWriter` maintains default `thread_count=1` (preserving standard single-threaded local disk IO by default).
   - Users can opt in to auto-tuning by passing `thread_count=None`.

## Test Plan

- Added unit and roundtrip tests in `test_file_system_checkpoint_cpu.py`:
  - `test_calculate_optimal_thread_count`: Validates thread calculation across various payload sizes and verifies clamping against thread/item limits.
  - `test_filesystem_writer_save_and_load_auto_tuned`: Verifies end-to-end saving and loading with `FileSystemWriter(thread_count=None)`.
- Added unit and roundtrip tests in `test_fsspec.py`:
  - `test_fsspec_writer_thread_count_auto_tuning`: Verifies default auto-tuned saving to `memory://` filesystem and explicit parameter overrides.
- Verified state dict equivalence between single-threaded and multi-threaded auto-tuned checkpoints.
