### PR TITLE
[MPS] Fix pin_memory() recycling buffers still in use by the GPU

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -108,8 +108,11 @@ typedef bool (*BufferComparison)(const BufferBlock*, const BufferBlock*);
 
 struct BufferPool;
 struct AllocParams {
-  AllocParams(size_t Alloc_Size, size_t Requested_Size, BufferPool* Pool)
-      : search_key(Alloc_Size), pool(Pool), requested_size(Requested_Size) {}
+  AllocParams(size_t Alloc_Size, size_t Requested_Size, BufferPool* Pool, bool Allow_In_Flight_Reuse)
+      : search_key(Alloc_Size),
+        pool(Pool),
+        requested_size(Requested_Size),
+        allow_in_flight_reuse(Allow_In_Flight_Reuse) {}
   size_t size() const {
     return search_key.size;
   }
@@ -119,6 +122,8 @@ struct AllocParams {
   BufferPool* pool;
   BufferBlock* buffer_block = nullptr;
   size_t requested_size;
+  // GPU work is ordered by its stream; immediate CPU access is not.
+  bool allow_in_flight_reuse;
   // true if we exceed the low watermark limit. In this case
   // we apply strategies to relieve the pressure before allocation.
   bool has_memory_pressure = false;
@@ -293,7 +298,7 @@ class MPSHeapAllocatorImpl {
     emptyCache();
   }
   // interface exposed to at::Allocator
-  id<MTLBuffer> malloc(size_t size, uint32_t usage);
+  id<MTLBuffer> malloc(size_t size, uint32_t usage, bool allow_in_flight_reuse);
   // frees a buffer and returns it into buffer pool
   void free(void* ptr);
   // releases all the cached buffers and their associated heaps
@@ -430,7 +435,7 @@ class MPSHeapAllocatorImpl {
   bool insert_available_buffer(BufferPool& pool, BufferBlock* buffer_block);
   void erase_available_buffer(BufferPool& pool, BufferBlock* buffer_block);
   BufferBlock* get_allocated_buffer_block(const void* ptr);
-  BufferBlock* alloc_buffer_block(size_t size, uint32_t usage);
+  BufferBlock* alloc_buffer_block(size_t size, uint32_t usage, bool allow_in_flight_reuse);
   void free_buffer(BufferBlock* buffer_block);
   bool release_cached_buffers();
   // waits for buffers parked in-flight in the pool's pending-free list to finish

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -298,7 +298,10 @@ class MPSHeapAllocatorImpl {
     emptyCache();
   }
   // interface exposed to at::Allocator
-  id<MTLBuffer> malloc(size_t size, uint32_t usage, bool allow_in_flight_reuse);
+  id<MTLBuffer> malloc(size_t size, uint32_t usage);
+  // same as malloc(), but for memory the CPU accesses immediately: never
+  // reuses a cached buffer still retained by in-flight GPU work
+  id<MTLBuffer> malloc_host(size_t size, uint32_t usage);
   // frees a buffer and returns it into buffer pool
   void free(void* ptr);
   // releases all the cached buffers and their associated heaps

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -143,10 +143,13 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
 
   // A cached buffer is handed back as it is only to the stream that allocated
   // it, and only when cutting it down would not leave a reusable remainder.
+  // In-flight reuse is safe for stream-ordered GPU work, but not for a pinned
+  // allocation that the CPU can access immediately.
   auto stream_it = pool.available_buffers_by_stream.find(getCurrentMPSStream());
   if (stream_it != pool.available_buffers_by_stream.end()) {
     auto it = stream_it->second.lower_bound(&params.search_key);
-    if (it != stream_it->second.end() && (*it)->buffer && (*it)->size - alloc_size < pool.min_split) {
+    if (it != stream_it->second.end() && (*it)->buffer && (*it)->size - alloc_size < pool.min_split &&
+        (params.allow_in_flight_reuse || (*it)->retainCount() == 1)) {
       params.buffer_block = split_free_block(params, *it);
     }
   }
@@ -409,12 +412,12 @@ size_t MPSHeapAllocatorImpl::release_free_heaps(BufferPool& pool, size_t target_
   return released_size;
 }
 
-BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage) {
+BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage, bool allow_in_flight_reuse) {
   TORCH_CHECK(size < m_max_buffer_size, "Invalid buffer size: ", format_size(size));
 
   size_t alloc_size = get_allocation_size(size, usage);
   auto& pool = get_pool(size, alloc_size, usage);
-  AllocParams params(alloc_size, size, &pool);
+  AllocParams params(alloc_size, size, &pool, allow_in_flight_reuse);
   // we care about memory pressure if only we're allocating large buffers when the
   // low watermark limit has been reached
   params.has_memory_pressure = !(pool.usage & UsageFlags::SMALL) && getLowWatermarkValue() <= 0;
@@ -577,13 +580,13 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
 }
 
 // public interface to MPSAllocator
-id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage) {
+id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage, bool allow_in_flight_reuse) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   // Return any buffers parked in-flight by free() whose GPU work has since
   // completed back to their pools before serving this allocation.
   freeInactiveBuffers();
-  BufferBlock* buffer_block = alloc_buffer_block(size, usage);
+  BufferBlock* buffer_block = alloc_buffer_block(size, usage, allow_in_flight_reuse);
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
@@ -600,7 +603,7 @@ id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size
   {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-    buffer_block = alloc_buffer_block(size, UsageFlags::SCALAR);
+    buffer_block = alloc_buffer_block(size, UsageFlags::SCALAR, /*allow_in_flight_reuse=*/true);
     if (!buffer_block) {
       return nullptr;
     }
@@ -889,8 +892,10 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   }
 
   DataPtr allocate(const size_t nbytes) override {
-    __block id<MTLBuffer> buf = nbytes > 0 ? _getAllocImpl().malloc(nbytes, m_usage) : nullptr;
-    return {buf, buf, &Delete, at::Device(at::DeviceType::MPS, 0)};
+    return allocate(nbytes, /*allow_in_flight_reuse=*/true);
+  }
+  DataPtr allocateForHost(const size_t nbytes) {
+    return allocate(nbytes, /*allow_in_flight_reuse=*/false);
   }
 
   // implementation of IMPSAllocator interface
@@ -989,6 +994,11 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   }
 
  private:
+  DataPtr allocate(const size_t nbytes, bool allow_in_flight_reuse) {
+    __block id<MTLBuffer> buf = nbytes > 0 ? _getAllocImpl().malloc(nbytes, m_usage, allow_in_flight_reuse) : nullptr;
+    return {buf, buf, &Delete, at::Device(at::DeviceType::MPS, 0)};
+  }
+
   uint32_t m_usage;
 
   static void Delete(void* ptr) {
@@ -1028,9 +1038,10 @@ class MPSPinnedAllocator final : public c10::Allocator {
       return {nullptr, nullptr, &deleter, c10::Device(c10::DeviceType::CPU)};
     }
     auto& shared = _getSharedAllocator();
-    c10::DataPtr mps_dp = shared.allocate(nbytes);
-    // shared.allocate() returns a DataPtr whose data pointer is the id<MTLBuffer>
-    // itself; capture it before mps_dp is moved into the backing storage.
+    c10::DataPtr mps_dp = shared.allocateForHost(nbytes);
+    // allocateForHost() returns a DataPtr whose data pointer is the
+    // id<MTLBuffer> itself; capture it before mps_dp is moved into the backing
+    // storage.
     void* mtl_buffer = mps_dp.get();
     auto host_ptr_pair = shared.getSharedBufferPtr(mtl_buffer);
     TORCH_INTERNAL_ASSERT(host_ptr_pair.first, "MPS pinned allocator: failed to map shared buffer");

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -580,13 +580,21 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
 }
 
 // public interface to MPSAllocator
-id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage, bool allow_in_flight_reuse) {
+id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   // Return any buffers parked in-flight by free() whose GPU work has since
   // completed back to their pools before serving this allocation.
   freeInactiveBuffers();
-  BufferBlock* buffer_block = alloc_buffer_block(size, usage, allow_in_flight_reuse);
+  BufferBlock* buffer_block = alloc_buffer_block(size, usage, /*allow_in_flight_reuse=*/true);
+  return buffer_block ? buffer_block->buffer : nullptr;
+}
+
+id<MTLBuffer> MPSHeapAllocatorImpl::malloc_host(size_t size, uint32_t usage) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+  freeInactiveBuffers();
+  BufferBlock* buffer_block = alloc_buffer_block(size, usage, /*allow_in_flight_reuse=*/false);
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
@@ -892,10 +900,12 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   }
 
   DataPtr allocate(const size_t nbytes) override {
-    return allocate(nbytes, /*allow_in_flight_reuse=*/true);
+    __block id<MTLBuffer> buf = nbytes > 0 ? _getAllocImpl().malloc(nbytes, m_usage) : nullptr;
+    return {buf, buf, &Delete, at::Device(at::DeviceType::MPS, 0)};
   }
   DataPtr allocateForHost(const size_t nbytes) {
-    return allocate(nbytes, /*allow_in_flight_reuse=*/false);
+    __block id<MTLBuffer> buf = nbytes > 0 ? _getAllocImpl().malloc_host(nbytes, m_usage) : nullptr;
+    return {buf, buf, &Delete, at::Device(at::DeviceType::MPS, 0)};
   }
 
   // implementation of IMPSAllocator interface
@@ -994,11 +1004,6 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   }
 
  private:
-  DataPtr allocate(const size_t nbytes, bool allow_in_flight_reuse) {
-    __block id<MTLBuffer> buf = nbytes > 0 ? _getAllocImpl().malloc(nbytes, m_usage, allow_in_flight_reuse) : nullptr;
-    return {buf, buf, &Delete, at::Device(at::DeviceType::MPS, 0)};
-  }
-
   uint32_t m_usage;
 
   static void Delete(void* ptr) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9669,6 +9669,24 @@ class TestMPS(TestCaseMPS):
         # Non-pinned CPU tensors are not reported as pinned.
         self.assertFalse(torch.empty(4).is_pinned())
 
+    @serialTest()
+    def test_pin_memory_does_not_recycle_in_flight_buffer(self):
+        torch.mps.synchronize()
+        torch.mps.empty_cache()
+
+        numel = 1 << 18
+        device_tensor = torch.full((numel,), 40.0, device="mps")
+        result = device_tensor * 2 + 1
+        del device_tensor, result
+
+        expected = torch.full((numel,), 4.5)
+        pinned = expected.pin_memory()
+        copied = pinned.to("mps", non_blocking=True)
+        torch.mps.synchronize()
+
+        self.assertEqual(pinned, expected)
+        self.assertEqual(copied, expected)
+
     # to verify this test, run XCode Instruments "Metal System Trace" or "Logging" tool,
     # press record, then run this python test, and press stop. Next expand
     # the os_signposts->PyTorchMPS and check if events or intervals are logged


### PR DESCRIPTION
This fixes regression caused by https://github.com/pytorch/pytorch/pull/190438
`pin_memory()` could receive a freed buffer whose queued GPU work later overwrote the CPU's data. Pinned allocations for now skip cached buffers still retained by in-flight command buffers.

Reproducer:
```python
import torch
torch.mps.synchronize()
torch.mps.empty_cache()

numel = 1 << 18
device_tensor = torch.full((numel,), 40.0, device="mps")
result = device_tensor * 2 + 1
del device_tensor, result

expected = torch.full((numel,), 4.5)
pinned = expected.pin_memory()
copied = pinned.to("mps", non_blocking=True)
torch.mps.synchronize()

print(f"expected=4.5, pinned={pinned[0].item()}, copied={copied[0].item()}")
```