### PR TITLE
[mtia][inductor] resolve view args of user-defined Triton kernels in FX wrapper (#193820)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -60,7 +60,7 @@ if HAS_GPU:
     import triton
     import triton.language as tl
 
-    from torch.testing._internal.triton_utils import add_kernel_2d_autotuned
+    from torch.testing._internal.triton_utils import add_kernel, add_kernel_2d_autotuned
 
 test_config = {
     "compile_threads": 1,
@@ -1035,6 +1035,23 @@ class AOTFxirTestCase(InductorTestCase):
             inp,
             dynamic_shapes=({0: Dim.DYNAMIC}, {0: Dim.DYNAMIC}),
         )
+
+    def test_custom_triton_view_arg(self):
+        # The mm output's halves reach the kernel as reinterpret_tensor(...) views.
+        n = 8
+
+        class Model(torch.nn.Module):
+            def forward(self, x, w):
+                t = torch.mm(x, w).view(-1)
+                output = torch.zeros(n, device=x.device)
+                add_kernel[(1,)](t[:n], t[n:], output, n, BLOCK_SIZE=n)
+                return output
+
+        inp = (
+            torch.randn(2 * n, 4, device=self.device),
+            torch.randn(4, 1, device=self.device),
+        )
+        self.check(Model().to(device=self.device), inp, strict=True)
 
     def test_custom_triton_autotune_dynamic(self):
         class Model(torch.nn.Module):

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -372,18 +372,36 @@ class FxConverter:
         name = buffer.get_name()
         del self.buffer_to_node[name]
 
-    def _lookup_args(self, args: tuple[Any, ...]) -> tuple[Any, ...]:
+    def _lookup_args(
+        self, args: tuple[Any, ...], raw_args: Sequence[Any] | None
+    ) -> tuple[Any, ...]:
         """
-        Maps call args back to FX nodes.
+        Maps call args back to FX nodes. raw_args positionally pairs with args and
+        holds the IR node behind each; it is None for scheduler-generated kernels.
         """
-        return tuple(
-            self.buffer_to_node[arg]
-            if isinstance(arg, str)
-            else arg.inner_expr
-            if isinstance(arg, SymbolicCallArg)
-            else arg
-            for arg in args
-        )
+
+        def lookup(arg: Any, raw_arg: Any) -> Any:
+            if isinstance(arg, SymbolicCallArg):
+                return arg.inner_expr
+            if not isinstance(arg, str):
+                return arg
+            if arg in self.buffer_to_node:
+                return self.buffer_to_node[arg]
+            # If the buffer name cannot be resolved, try to unwrap `raw_args`.
+            # For example, the view `reinterpret_tensor(...)` will have a
+            # corresponding ir.ReinterpretView in raw_args.
+            if not isinstance(raw_arg, ir.IRNode):
+                raise AssertionError(f"Unrecognized arg type: {type(raw_arg)}")
+            return self._generate_buffer(raw_arg)
+
+        if raw_args is None:
+            raw_args = [None] * len(args)
+        elif len(raw_args) != len(args):
+            raise AssertionError(
+                f"call_args and raw_args do not match: {len(args)} vs {len(raw_args)}"
+            )
+
+        return tuple(lookup(arg, raw_arg) for arg, raw_arg in zip(args, raw_args))
 
     def _get_buffer(self, node: ir.IRNode) -> CodegenBuffer:
         """
@@ -1084,7 +1102,7 @@ class FxConverter:
             raise AssertionError(f"expected KernelCallLine, got {type(line)}")
 
         # Collect all kwargs, including autotuned block sizes.
-        call_args = self._lookup_args(line.call_args)
+        call_args = self._lookup_args(line.call_args, line.raw_args)
         kernel = self.kernels[line.kernel_name]
         tuner = kernel.tuner
 


### PR DESCRIPTION
Summary:

Compiling a model that calls a hand-written Triton kernel fails with
`InductorError: KeyError: 'reinterpret_tensor(buf0, (8,), (1,), 0)'` whenever
one of the kernel's tensor arguments is a view of another buffer, such as a
slice of a matmul result. It happens on the FX wrapper backend, the one that
emits an FX graph instead of Python source: that backend could only map a
plain buffer name back to a graph node, so a view argument, which code
generation renders as a `reinterpret_tensor(...)` call string, matched nothing
and the compile aborted. The kernel call already carries the IR node behind
every argument, so this builds the view's node from that whenever the name
lookup misses. Plain buffer names take exactly the path they did before.

Test Plan:
The change is in the FX wrapper backend's argument lookup, so both tests feed a
user-defined Triton kernel two halves of a matmul result, which reach code
generation as the `reinterpret_tensor(...)` views this diff resolves. The OSS
test compiles such a model through that backend end to end; the MTIA one runs
the same shape through the full inductor lowering. Both fail with this diff
reverted, raising the `KeyError` from the summary. The bug came from production
model `879326229` (snapshot 249), which now compiles past code generation.

```bash
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:fxir_backend \
  -- --regex 'test_custom_triton_view_arg'
```

Buck UI: https://www.internalfb.com/buck2/da7696ca-fd98-4c69-ac71-9c440cff5a96
Infra: https://www.internalfb.com/intern/testinfra/testrun/844425452630609

```bash
buck2 test fbcode//mode/opt -m ovr_config//gpu:mtia \
  fbcode//glow/fb/fx/fba/tests/inductor:test_fba_inductor \
  -- --regex 'test_full_inductor_user_triton_kernel_view_arg'
```

Buck UI: https://www.internalfb.com/buck2/a1f7c6bf-21e6-47d7-b3c9-99241a934887
Infra: https://www.internalfb.com/intern/testinfra/testrun/26458647852100141

Reviewed By: blaine-rister

Differential Revision: D116270888




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo