### PR TITLE
[MPS] Migrate flip to metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -425,6 +425,62 @@ REGISTER_INDEX_ADD_OP_ALL_INDEX_TYPES(bool);
 REGISTER_INDEX_ADD_OP_ALL_INDEX_TYPES(float2);
 REGISTER_INDEX_ADD_OP_ALL_INDEX_TYPES(half2);
 
+template <typename T>
+kernel void flip_direct(
+    device void* output [[buffer(0)]],
+    const device void* input [[buffer(1)]],
+    constant int* output_strides [[buffer(2)]],
+    constant int* input_strides [[buffer(3)]],
+    uint3 tid [[thread_position_in_grid]]) {
+  const int output_offset = int(tid.x) * output_strides[0] +
+      int(tid.y) * output_strides[1] + int(tid.z) * output_strides[2];
+  const int input_offset = int(tid.x) * input_strides[0] +
+      int(tid.y) * input_strides[1] + int(tid.z) * input_strides[2];
+  ref_at_offs<T>(output, long(output_offset)) =
+      val_at_offs<T>(input, long(input_offset));
+}
+
+template <typename T>
+kernel void flip(
+    device void* output [[buffer(0)]],
+    const device void* input [[buffer(1)]],
+    constant uint* sizes [[buffer(2)]],
+    constant int* output_strides [[buffer(3)]],
+    constant int* input_strides [[buffer(4)]],
+    constant uint& ndim [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  uint linear_idx = tid;
+  int output_offset = 0;
+  int input_offset = 0;
+
+  for (uint dim = 0; dim < ndim; dim++) {
+    const uint size = sizes[dim];
+    const uint coord = safe_mod(linear_idx, size);
+    linear_idx /= size;
+    output_offset += coord * output_strides[dim];
+    input_offset += coord * input_strides[dim];
+  }
+
+  ref_at_offs<T>(output, output_offset) = val_at_offs<T>(input, input_offset);
+}
+
+#define REGISTER_FLIP_OP(SUFFIX, T)                                           \
+  template [[host_name("flip_direct_" #SUFFIX)]] kernel void flip_direct<T>(  \
+      device void*, const device void*, constant int*, constant int*, uint3); \
+  template [[host_name("flip_" #SUFFIX)]] kernel void flip<T>(                \
+      device void*,                                                           \
+      const device void*,                                                     \
+      constant uint*,                                                         \
+      constant int*,                                                          \
+      constant int*,                                                          \
+      constant uint&,                                                         \
+      uint);
+
+REGISTER_FLIP_OP(8bit, char);
+REGISTER_FLIP_OP(16bit, short);
+REGISTER_FLIP_OP(32bit, int);
+REGISTER_FLIP_OP(64bit, long);
+
 // Dim-based index_select gather: output[..., j, ...] = input[..., index[j],
 // ...] along reduce_dim. One thread per output element; templated by element
 // bit-size (T) so a single set of kernels covers every dtype, complex included.

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -29,7 +29,6 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/native/IndexKernel.h>
-#include <ATen/ops/flip_native.h>
 #include <ATen/ops/index.h>
 #include <ATen/ops/index_add_native.h>
 #include <ATen/ops/index_copy_native.h>
@@ -493,57 +492,57 @@ Tensor& masked_select_out_mps(const Tensor& self, const Tensor& mask, Tensor& re
   return mps::masked_select_out_mps_impl(result, self, mask);
 }
 
-Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
+static void flip_kernel_mps(TensorIterator& iter, const bool quantized) {
   using namespace mps;
 
-  Tensor result = at::empty(self.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
-
-  auto total_dims = self.dim();
-  // It wraps the dims and checks that there are no repeated dims
-  auto flip_dims_b = at::dim_list_to_bitset(dims, total_dims);
-  NSMutableArray<NSNumber*>* ns_dims = [[NSMutableArray<NSNumber*> new] autorelease];
-
-  for (const auto i : c10::irange(total_dims)) {
-    if (flip_dims_b[i] && self.size(i) > 1 && self.stride(i) != 0) {
-      [ns_dims addObject:[NSNumber numberWithInt:i]];
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      flip_kernel_mps(sub_iter, quantized);
     }
+    return;
   }
 
-  // Nothing to do, we return fast
-  if (self.numel() <= 1 || ns_dims.count == 0) {
-    result.copy_(self);
-    return result;
+  const auto input = iter.input(0);
+  const auto ndim = safe_downcast<uint32_t, int64_t>(iter.ndim());
+  const bool use_direct_grid = ndim > 0 && ndim <= 3;
+  const auto bit_size = getBitSizeString(input);
+  const auto kernel_name = use_direct_grid ? fmt::format("flip_direct_{}", bit_size) : fmt::format("flip_{}", bit_size);
+  const auto pipeline_state = lib.getPipelineStateForFunc(kernel_name);
+  const auto metadata_ndim = std::max<uint32_t>(ndim, 3);
+  c10::SmallVector<uint32_t> sizes(metadata_ndim);
+  c10::SmallVector<int32_t> output_strides(metadata_ndim);
+  c10::SmallVector<int32_t> input_strides(metadata_ndim);
+  for (const auto dim : c10::irange(ndim)) {
+    sizes[dim] = static_cast<uint32_t>(iter.shape()[dim]);
+    output_strides[dim] = static_cast<int32_t>(iter.strides(0)[dim]);
+    input_strides[dim] = static_cast<int32_t>(iter.strides(1)[dim]);
   }
 
-  MPSStream* stream = getCurrentMPSStream();
-
-  using CachedGraph = mps::MPSUnaryCachedGraph;
-
-  MPSDataType inputDataType = getMPSScalarType(self.scalar_type());
-  MPSDataType outputDataType = getMPSScalarType(self.scalar_type());
-  @autoreleasepool {
-    NSString* ns_dims_key = [[ns_dims valueForKey:@"description"] componentsJoinedByString:@","];
-    // A key is used to identify the MPSGraph which was created once, and can be reused if the parameters, data types
-    // etc match the earlier created MPSGraph
-    std::string key = "flip_mps:" + getTensorsStringKey({self}) + ":" + std::string([ns_dims_key UTF8String]);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
-      MPSGraphTensor* outputTensor = [mpsGraph reverseTensor:inputTensor axes:ns_dims name:nil];
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    // Create placeholders which use the keys of the CachedGraph to create inputs and outputs of the operation
-    Placeholder inputPlaceholder =
-        Placeholder(cachedGraph->inputTensor_, self, /*mpsShape*/ nil, /*gatherTensorData=*/true, inputDataType);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->outputTensor_, result, /*mpsShape*/ nil, /*gatherTensorData=*/false, outputDataType);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  return result;
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto compute_encoder = stream->commandEncoder();
+      getMPSProfiler().beginProfileKernel(pipeline_state, "flip", {input}, stream);
+      [compute_encoder setComputePipelineState:pipeline_state];
+      bind_iter_tensors(compute_encoder, iter, 2);
+      if (use_direct_grid) {
+        mtl_setArgs<2>(compute_encoder, output_strides, input_strides);
+        const auto grid_x = static_cast<NSUInteger>(iter.shape()[0]);
+        const auto grid_y = ndim > 1 ? static_cast<NSUInteger>(iter.shape()[1]) : 1;
+        const auto grid_z = ndim > 2 ? static_cast<NSUInteger>(iter.shape()[2]) : 1;
+        const auto max_threads = [pipeline_state maxTotalThreadsPerThreadgroup];
+        const auto tg_x = std::min(grid_x, max_threads);
+        const auto tg_y = std::min(grid_y, max_threads / tg_x);
+        const auto tg_z = std::clamp(grid_z, 1UL, max_threads / (tg_x * tg_y));
+        [compute_encoder dispatchThreads:MTLSizeMake(grid_x, grid_y, grid_z)
+                   threadsPerThreadgroup:MTLSizeMake(tg_x, tg_y, tg_z)];
+      } else {
+        mtl_setArgs<2>(compute_encoder, sizes, output_strides, input_strides, ndim);
+        mtl_dispatch1DJob(compute_encoder, pipeline_state, iter.numel());
+      }
+      getMPSProfiler().endProfileKernel(pipeline_state, stream);
+    }
+  });
 }
 
 // Validate index in [0, dim_size) once (one thread per index) on the given
@@ -1229,6 +1228,7 @@ static void index_fill_mps_kernel(TensorIterator& iter,
 REGISTER_DISPATCH(index_stub, &mps::index_kernel_mps)
 REGISTER_DISPATCH(index_fill_stub, &index_fill_mps_kernel)
 REGISTER_DISPATCH(index_put_stub, &mps::index_put_kernel_mps)
+REGISTER_DISPATCH(flip_stub, &flip_kernel_mps)
 REGISTER_DISPATCH(put_stub, &put_kernel_mps)
 REGISTER_DISPATCH(take_stub, &take_kernel_mps)
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6157,8 +6157,7 @@
 - func: flip(Tensor self, int[] dims) -> Tensor
   variants: function, method
   dispatch:
-    CPU, QuantizedCPU, CUDA, QuantizedCUDA, XPU: flip
-    MPS: flip_mps
+    CPU, QuantizedCPU, CUDA, QuantizedCUDA, XPU, MPS: flip
   autogen: flip.out
   tags: core
 


### PR DESCRIPTION
This replaces MPSGraph `flip` with two Metal kernels: `flip_direct` uses a multidimensional grid for up to three dimensions which avoids avoids coordinate decoding, while `flip` decodes linear indices for higher-rank tensors.

<details>
<summary>Performance: </summary>

| Shape | Layout | Dtype | Dims | Old (us) | New (us) | Speedup |
| --- | --- | --- | --- | ---: | ---: | ---: |
| 8x32x4096 | contiguous | bfloat16 | 2 | 30.351 | 11.400 | 2.662x |
| 8x32x4096 | contiguous | float32 | 2 | 34.240 | 20.600 | 1.662x |
| 8x32x4096 | contiguous | int32 | 2 | 38.931 | 20.354 | 1.913x |
| 8x32x4096 | contiguous | int64 | 2 | 56.978 | 39.444 | 1.445x |
| 8x32x4096 | contiguous | uint8 | 2 | 27.985 | 9.124 | 3.067x |
| 8x32x4096 | strided | bfloat16 | 2 | 35.669 | 15.326 | 2.327x |
| 8x32x4096 | strided | float32 | 2 | 44.286 | 28.663 | 1.545x |
| 8x32x4096 | strided | int32 | 2 | 43.982 | 28.640 | 1.536x |
| 8x32x4096 | strided | int64 | 2 | 89.535 | 75.229 | 1.190x |
| 8x32x4096 | strided | uint8 | 2 | 30.104 | 9.354 | 3.218x |
| 8x32x4096 | contiguous | bfloat16 | 1 | 29.530 | 11.615 | 2.542x |
| 8x32x4096 | contiguous | float32 | 1 | 44.367 | 20.557 | 2.158x |
| 8x32x4096 | contiguous | int32 | 1 | 36.601 | 20.915 | 1.750x |
| 8x32x4096 | contiguous | int64 | 1 | 56.717 | 38.733 | 1.464x |
| 8x32x4096 | contiguous | uint8 | 1 | 27.925 | 9.254 | 3.018x |
| 8x32x4096 | strided | bfloat16 | 1 | 35.553 | 15.362 | 2.314x |
| 8x32x4096 | strided | float32 | 1 | 46.385 | 28.699 | 1.616x |
| 8x32x4096 | strided | int32 | 1 | 44.549 | 28.710 | 1.552x |
| 8x32x4096 | strided | int64 | 1 | 90.529 | 74.592 | 1.214x |
| 8x32x4096 | strided | uint8 | 1 | 29.487 | 9.382 | 3.143x |
| 1x3x224x224 | contiguous | bfloat16 | 2,3 | 18.327 | 3.798 | 4.826x |
| 1x3x224x224 | contiguous | float32 | 2,3 | 19.453 | 3.826 | 5.085x |
| 1x3x224x224 | contiguous | int32 | 2,3 | 18.470 | 3.873 | 4.769x |
| 1x3x224x224 | contiguous | int64 | 2,3 | 21.289 | 4.879 | 4.363x |
| 1x3x224x224 | contiguous | uint8 | 2,3 | 23.742 | 3.839 | 6.185x |
| 1x3x224x224 | strided | bfloat16 | 2,3 | 20.706 | 3.912 | 5.293x |
| 1x3x224x224 | strided | float32 | 2,3 | 21.050 | 4.117 | 5.113x |
| 1x3x224x224 | strided | int32 | 2,3 | 21.936 | 3.969 | 5.527x |
| 1x3x224x224 | strided | int64 | 2,3 | 24.543 | 5.505 | 4.458x |
| 1x3x224x224 | strided | uint8 | 2,3 | 21.404 | 3.918 | 5.463x |
| 32x3x224x224 | contiguous | bfloat16 | 2,3 | 65.174 | 48.026 | 1.357x |
| 32x3x224x224 | contiguous | float32 | 2,3 | 177.987 | 155.208 | 1.147x |
| 32x3x224x224 | contiguous | int32 | 2,3 | 172.340 | 156.987 | 1.098x |
| 32x3x224x224 | contiguous | int64 | 2,3 | 339.875 | 325.229 | 1.045x |
| 32x3x224x224 | contiguous | uint8 | 2,3 | 54.402 | 33.505 | 1.624x |
| 32x3x224x224 | strided | bfloat16 | 2,3 | 126.103 | 98.992 | 1.274x |
| 32x3x224x224 | strided | float32 | 2,3 | 257.119 | 228.276 | 1.126x |
| 32x3x224x224 | strided | int32 | 2,3 | 255.737 | 230.196 | 1.111x |
| 32x3x224x224 | strided | int64 | 2,3 | 494.625 | 462.535 | 1.069x |
| 32x3x224x224 | strided | uint8 | 2,3 | 62.163 | 36.330 | 1.711x |
| 8x3x224x224 | contiguous | bfloat16 | 2,3 | 33.695 | 12.801 | 2.632x |
| 8x3x224x224 | contiguous | float32 | 2,3 | 50.907 | 23.414 | 2.174x |
| 8x3x224x224 | contiguous | int32 | 2,3 | 48.852 | 23.111 | 2.114x |
| 8x3x224x224 | contiguous | int64 | 2,3 | 84.514 | 44.750 | 1.889x |
| 8x3x224x224 | contiguous | uint8 | 2,3 | 29.849 | 9.967 | 2.995x |
| 8x3x224x224 | strided | bfloat16 | 2,3 | 38.672 | 17.081 | 2.264x |
| 8x3x224x224 | strided | float32 | 2,3 | 51.189 | 32.597 | 1.570x |
| 8x3x224x224 | strided | int32 | 2,3 | 51.411 | 32.837 | 1.566x |
| 8x3x224x224 | strided | int64 | 2,3 | 119.892 | 98.971 | 1.211x |
| 8x3x224x224 | strided | uint8 | 2,3 | 32.633 | 9.934 | 3.285x |
| 32x4096 | contiguous | bfloat16 | 0,1 | 17.827 | 3.286 | 5.424x |
| 32x4096 | contiguous | float32 | 0,1 | 18.038 | 3.317 | 5.438x |
| 32x4096 | contiguous | int32 | 0,1 | 17.741 | 3.223 | 5.504x |
| 32x4096 | contiguous | int64 | 0,1 | 20.642 | 4.141 | 4.985x |
| 32x4096 | contiguous | uint8 | 0,1 | 18.158 | 3.214 | 5.650x |
| 32x4096 | strided | bfloat16 | 0,1 | 20.540 | 3.403 | 6.036x |
| 32x4096 | strided | float32 | 0,1 | 20.454 | 3.567 | 5.734x |
| 32x4096 | strided | int32 | 0,1 | 21.593 | 3.594 | 6.008x |
| 32x4096 | strided | int64 | 0,1 | 22.676 | 4.782 | 4.742x |
| 32x4096 | strided | uint8 | 0,1 | 20.944 | 3.285 | 6.375x |
| 32x4096 | contiguous | bfloat16 | 1 | 18.240 | 3.248 | 5.616x |
| 32x4096 | contiguous | float32 | 1 | 17.123 | 3.410 | 5.021x |
| 32x4096 | contiguous | int32 | 1 | 17.093 | 3.312 | 5.161x |
| 32x4096 | contiguous | int64 | 1 | 18.591 | 4.170 | 4.458x |
| 32x4096 | contiguous | uint8 | 1 | 17.262 | 3.210 | 5.378x |
| 32x4096 | strided | bfloat16 | 1 | 20.350 | 3.332 | 6.107x |
| 32x4096 | strided | float32 | 1 | 20.274 | 3.558 | 5.698x |
| 32x4096 | strided | int32 | 1 | 21.815 | 3.549 | 6.146x |
| 32x4096 | strided | int64 | 1 | 21.617 | 4.976 | 4.344x |
| 32x4096 | strided | uint8 | 1 | 20.031 | 3.280 | 6.107x |
| 512x512 | contiguous | bfloat16 | 0,1 | 26.185 | 4.003 | 6.542x |
| 512x512 | contiguous | float32 | 0,1 | 20.125 | 4.391 | 4.584x |
| 512x512 | contiguous | int32 | 0,1 | 19.861 | 4.279 | 4.641x |
| 512x512 | contiguous | int64 | 0,1 | 24.916 | 9.329 | 2.671x |
| 512x512 | contiguous | uint8 | 0,1 | 19.137 | 4.046 | 4.730x |
| 512x512 | strided | bfloat16 | 0,1 | 21.133 | 4.835 | 4.371x |
| 512x512 | strided | float32 | 0,1 | 22.034 | 4.986 | 4.419x |
| 512x512 | strided | int32 | 0,1 | 22.244 | 5.077 | 4.381x |
| 512x512 | strided | int64 | 0,1 | 34.347 | 15.231 | 2.255x |
| 512x512 | strided | uint8 | 0,1 | 23.493 | 4.938 | 4.758x |
| 512x512 | contiguous | bfloat16 | 1 | 19.113 | 4.118 | 4.641x |
| 512x512 | contiguous | float32 | 1 | 19.132 | 4.336 | 4.412x |
| 512x512 | contiguous | int32 | 1 | 19.137 | 4.259 | 4.493x |
| 512x512 | contiguous | int64 | 1 | 25.367 | 9.604 | 2.641x |
| 512x512 | contiguous | uint8 | 1 | 18.554 | 3.970 | 4.674x |
| 512x512 | strided | bfloat16 | 1 | 20.490 | 4.112 | 4.983x |
| 512x512 | strided | float32 | 1 | 22.771 | 4.894 | 4.653x |
| 512x512 | strided | int32 | 1 | 21.834 | 4.858 | 4.495x |
| 512x512 | strided | int64 | 1 | 33.654 | 15.184 | 2.216x |
| 512x512 | strided | uint8 | 1 | 20.616 | 4.052 | 5.088x |
| 512x512 | contiguous | bfloat16 | 0 | 18.831 | 4.058 | 4.641x |
| 512x512 | contiguous | float32 | 0 | 20.152 | 4.360 | 4.622x |
| 512x512 | contiguous | int32 | 0 | 19.368 | 4.297 | 4.508x |
| 512x512 | contiguous | int64 | 0 | 26.775 | 9.928 | 2.697x |
| 512x512 | contiguous | uint8 | 0 | 18.782 | 4.005 | 4.690x |
| 512x512 | strided | bfloat16 | 0 | 20.997 | 4.124 | 5.091x |
| 512x512 | strided | float32 | 0 | 22.027 | 5.070 | 4.345x |
| 512x512 | strided | int32 | 0 | 21.360 | 4.965 | 4.303x |
| 512x512 | strided | int64 | 0 | 33.075 | 14.929 | 2.215x |
| 512x512 | strided | uint8 | 0 | 20.334 | 4.124 | 4.930x |
| 1048576 | contiguous | bfloat16 | 0 | 28.045 | 10.938 | 2.564x |
| 1048576 | contiguous | float32 | 0 | 32.743 | 20.372 | 1.607x |
| 1048576 | contiguous | int32 | 0 | 32.227 | 20.274 | 1.590x |
| 1048576 | contiguous | int64 | 0 | 51.763 | 39.548 | 1.309x |
| 1048576 | contiguous | uint8 | 0 | 23.467 | 8.800 | 2.667x |
| 1048576 | strided | bfloat16 | 0 | 33.419 | 14.836 | 2.253x |
| 1048576 | strided | float32 | 0 | 42.630 | 28.290 | 1.507x |
| 1048576 | strided | int32 | 0 | 42.771 | 28.270 | 1.513x |
| 1048576 | strided | int64 | 0 | 85.849 | 71.323 | 1.204x |
| 1048576 | strided | uint8 | 0 | 25.208 | 8.781 | 2.871x |
| 16 | contiguous | bfloat16 | 0 | 16.515 | 5.664 | 2.916x |
| 16 | contiguous | float32 | 0 | 16.919 | 4.723 | 3.582x |
| 16 | contiguous | int32 | 0 | 16.999 | 4.851 | 3.504x |
| 16 | contiguous | int64 | 0 | 16.939 | 4.845 | 3.496x |
| 16 | contiguous | uint8 | 0 | 19.506 | 6.015 | 3.243x |
| 16 | strided | bfloat16 | 0 | 18.896 | 4.928 | 3.834x |
| 16 | strided | float32 | 0 | 19.195 | 4.607 | 4.166x |
| 16 | strided | int32 | 0 | 18.408 | 4.580 | 4.019x |
| 16 | strided | int64 | 0 | 18.439 | 4.804 | 3.838x |
| 16 | strided | uint8 | 0 | 18.446 | 5.219 | 3.534x |
| 256 | contiguous | bfloat16 | 0 | 20.710 | 4.959 | 4.177x |
| 256 | contiguous | float32 | 0 | 15.989 | 4.962 | 3.223x |
| 256 | contiguous | int32 | 0 | 15.777 | 5.028 | 3.138x |
| 256 | contiguous | int64 | 0 | 17.656 | 3.539 | 4.988x |
| 256 | contiguous | uint8 | 0 | 16.016 | 4.799 | 3.337x |
| 256 | strided | bfloat16 | 0 | 18.342 | 3.071 | 5.972x |
| 256 | strided | float32 | 0 | 18.366 | 2.779 | 6.610x |
| 256 | strided | int32 | 0 | 21.153 | 2.768 | 7.641x |
| 256 | strided | int64 | 0 | 18.718 | 2.564 | 7.299x |
| 256 | strided | uint8 | 0 | 18.394 | 3.142 | 5.855x |
| 4096 | contiguous | bfloat16 | 0 | 16.169 | 2.430 | 6.653x |
| 4096 | contiguous | float32 | 0 | 15.842 | 2.297 | 6.897x |
| 4096 | contiguous | int32 | 0 | 16.003 | 2.191 | 7.303x |
| 4096 | contiguous | int64 | 0 | 16.125 | 2.265 | 7.118x |
| 4096 | contiguous | uint8 | 0 | 16.659 | 2.632 | 6.328x |
| 4096 | strided | bfloat16 | 0 | 18.623 | 2.202 | 8.458x |
| 4096 | strided | float32 | 0 | 18.394 | 2.283 | 8.057x |
| 4096 | strided | int32 | 0 | 18.513 | 2.254 | 8.214x |
| 4096 | strided | int64 | 0 | 18.272 | 2.432 | 7.514x |
| 4096 | strided | uint8 | 0 | 18.305 | 2.175 | 8.415x |
| 65536 | contiguous | bfloat16 | 0 | 16.088 | 2.733 | 5.886x |
| 65536 | contiguous | float32 | 0 | 16.400 | 2.684 | 6.109x |
| 65536 | contiguous | int32 | 0 | 16.675 | 2.900 | 5.749x |
| 65536 | contiguous | int64 | 0 | 16.919 | 2.925 | 5.784x |
| 65536 | contiguous | uint8 | 0 | 16.666 | 2.721 | 6.125x |
| 65536 | strided | bfloat16 | 0 | 18.778 | 2.795 | 6.719x |
| 65536 | strided | float32 | 0 | 19.358 | 2.843 | 6.808x |
| 65536 | strided | int32 | 0 | 23.840 | 2.935 | 8.122x |
| 65536 | strided | int64 | 0 | 19.314 | 3.300 | 5.852x |
| 65536 | strided | uint8 | 0 | 18.830 | 2.756 | 6.831x |

</details>