### PR TITLE
Let Distribution.cdf be evaluated outside the support

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4338,6 +4338,58 @@ class TestDistributions(DistributionsTestCase):
                     ),
                 )
 
+    def test_cdf_outside_support(self):
+        # The CDF is defined on all of R: it saturates to 0 below the support and
+        # to 1 above it, so evaluating it outside the support must not raise even
+        # with validate_args enabled (e.g. plotting a CDF over a grid).
+        grid = torch.tensor([-2.0, -0.5, 0.5, 2.0])
+        cases = [
+            (Uniform(0.0, 1.0), [0.0, 0.0, 0.5, 1.0]),
+            (Exponential(1.0), [0.0, 0.0, 0.39346934, 0.86466472]),
+            (Gamma(2.0, 2.0), [0.0, 0.0, 0.26424112, 0.90842180]),
+            (HalfNormal(1.0), [0.0, 0.0, 0.38292492, 0.95449974]),
+            (HalfCauchy(1.0), [0.0, 0.0, 0.29516724, 0.70483276]),
+            (ContinuousBernoulli(probs=0.5), [0.0, 0.0, 0.5, 1.0]),
+        ]
+        for dist, expected in cases:
+            self.assertTrue(dist._validate_args)
+            actual = dist.cdf(grid)
+            self.assertEqual(
+                actual,
+                torch.tensor(expected),
+                msg=f"{dist.__class__.__name__}.cdf outside support",
+            )
+            self.assertFalse(torch.isnan(actual).any())
+
+    def test_cdf_outside_support_is_monotonic(self):
+        # Saturation must not break monotonicity of the CDF.
+        grid = torch.linspace(-5.0, 5.0, 41)
+        for dist in [
+            Uniform(0.0, 1.0),
+            Exponential(1.0),
+            Gamma(2.0, 2.0),
+            HalfNormal(1.0),
+            HalfCauchy(1.0),
+        ]:
+            cdfs = dist.cdf(grid)
+            self.assertTrue(
+                bool((cdfs[1:] - cdfs[:-1] >= -1e-6).all()),
+                msg=f"{dist.__class__.__name__}.cdf is not monotonic across the support boundary",
+            )
+            self.assertTrue(bool(((cdfs >= 0) & (cdfs <= 1)).all()))
+
+    def test_log_prob_still_validates_support(self):
+        # cdf relaxing the support check must not relax it for log_prob, whose
+        # density is only defined on the support.
+        for dist in [
+            Uniform(0.0, 1.0),
+            Exponential(1.0),
+            Gamma(2.0, 2.0),
+            HalfNormal(1.0),
+        ]:
+            with self.assertRaises(ValueError):
+                dist.log_prob(torch.tensor(-1.0))
+
     def test_valid_parameter_broadcasting(self):
         # Test correct broadcasting of parameter sizes for distributions that have multiple
         # parameters.

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -89,7 +89,7 @@ class Cauchy(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return torch.atan((value - self.loc) / self.scale) / math.pi + 0.5
 
     def icdf(self, value):

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -195,7 +195,7 @@ class ContinuousBernoulli(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         cut_probs = self._cut_probs()
         cdfs = (
             torch.pow(cut_probs, value) * torch.pow(1.0 - cut_probs, 1.0 - value)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -277,7 +277,7 @@ class Distribution:
             sample_shape = torch.Size(sample_shape)
         return torch.Size(sample_shape + self._batch_shape + self._event_shape)
 
-    def _validate_sample(self, value: Tensor) -> None:
+    def _validate_sample(self, value: Tensor, check_support: bool = True) -> None:
         """
         Argument validation for distribution methods such as `log_prob`,
         `cdf` and `icdf`. The rightmost dimensions of a value to be
@@ -287,6 +287,10 @@ class Distribution:
         Args:
             value (Tensor): the tensor whose log probability is to be
                 computed by the `log_prob` method.
+            check_support (bool): whether ``value`` is required to lie within the
+                distribution's support. True for ``log_prob``, whose density is
+                only defined there. False for ``cdf``, which is defined on all of
+                R and saturates to 0 below the support and 1 above it.
         Raises
             ValueError: when the rightmost dimensions of `value` do not match the
                 distribution's batch and event shapes.
@@ -307,6 +311,9 @@ class Distribution:
                 raise ValueError(
                     f"Value is not broadcastable with batch_shape+event_shape: {actual_shape} vs {expected_shape}."
                 )
+        if not check_support:
+            return
+
         try:
             support = self.support
         except NotImplementedError:

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -76,8 +76,9 @@ class Exponential(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 1 - torch.exp(-self.rate * value)
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (1 - torch.exp(-self.rate * value)).clamp(min=0, max=1)
 
     def icdf(self, value):
         return -torch.log1p(-value) / self.rate

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -128,5 +128,12 @@ class Gamma(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return torch.special.gammainc(self.concentration, self.rate * value)
+            self._validate_sample(value, check_support=False)
+        # gammainc returns nan for a negative argument, so saturate to 0 below the
+        # support rather than clamping after the fact
+        x = self.rate * value
+        return torch.where(
+            x < 0,
+            torch.zeros_like(x),
+            torch.special.gammainc(self.concentration, x.clamp(min=0)),
+        )

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -82,8 +82,9 @@ class HalfCauchy(TransformedDistribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 2 * self.base_dist.cdf(value) - 1
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (2 * self.base_dist.cdf(value) - 1).clamp(min=0, max=1)
 
     def icdf(self, prob):
         return self.base_dist.icdf((prob + 1) / 2)

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -74,8 +74,9 @@ class HalfNormal(TransformedDistribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
-        return 2 * self.base_dist.cdf(value) - 1
+            self._validate_sample(value, check_support=False)
+        # saturates to 0 below the support, where the raw formula goes negative
+        return (2 * self.base_dist.cdf(value) - 1).clamp(min=0, max=1)
 
     def icdf(self, prob):
         return self.base_dist.icdf((prob + 1) / 2)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -91,7 +91,7 @@ class Laplace(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return 0.5 - 0.5 * (value - self.loc).sign() * torch.expm1(
             -(value - self.loc).abs() / self.scale
         )

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -102,7 +102,7 @@ class Normal(ExponentialFamily):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         return 0.5 * (
             1 + torch.erf((value - self.loc) * self.scale.reciprocal() / math.sqrt(2))
         )

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -96,7 +96,7 @@ class Uniform(Distribution):
 
     def cdf(self, value):
         if self._validate_args:
-            self._validate_sample(value)
+            self._validate_sample(value, check_support=False)
         result = (value - self.low) / (self.high - self.low)
         return result.clamp(min=0, max=1)
 


### PR DESCRIPTION
### Problem

`cdf` validated its value against the distribution's support, but a CDF is defined on all of R: `F(x) = P(X <= x)` is 0 below the support and 1 above it. With `validate_args` on (the default), evaluating a CDF outside the support raised instead of returning those values, so something as ordinary as plotting a CDF over a grid failed:

```python
D.Uniform(0., 1.).cdf(torch.linspace(-0.5, 1.5, 9))
# ValueError: Expected value argument ... to be within the support
```

### Why this looks like a gap rather than a choice

The implementations already encode the intended behaviour: `Uniform.cdf` ends in `.clamp(min=0, max=1)` and `ContinuousBernoulli.cdf` saturates via `torch.where` — both unreachable under the default settings, because validation rejects those inputs first.

### Change

`_validate_sample` gains a `check_support` flag. `log_prob` keeps the strict support check, since a density is only defined on the support; `cdf` passes `check_support=False` and keeps the shape/broadcast checks.

Distributions whose `cdf` formula did not already saturate now do so: `exponential`, `half_normal` and `half_cauchy` clamp to `[0, 1]` (their formulas go negative below the support), and `gamma` routes through `torch.where`, because `gammainc` returns `nan` for a negative argument and a clamp cannot repair that.

### Tests

Three cases in `test/distributions/test_distributions.py`: correct saturating values outside the support, monotonicity across the support boundary, and a check that `log_prob` still rejects out-of-support values.

The full `test/distributions/test_distributions.py` suite passes (167 passed; the one failure, `test_gumbel_cpu`, reproduces identically on an unmodified checkout).

Fixes #193690

Split out of #193772, where this was flagged as an unrelated change.
