### PR TITLE
[dynamo] Type bytecode-constant tuples as tuple[object, ...]

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -1053,7 +1053,7 @@ class InputWriter:
             + f")  # {name}"
         )
 
-    def unsupported(self, name: str, arg: Any) -> None:
+    def unsupported(self, name: str, arg: object) -> None:
         # NB: Try hard not to /print/ a tensor, that will be very slow
         self._lines.append(
             f"reader.unsupported({name!r})  # unsupported type for dumping: {type(arg)}"
@@ -1079,7 +1079,7 @@ class InputWriter:
         )
 
     # TODO: this doesn't actually symint atm
-    def symint(self, name: str, val: Any) -> None:
+    def symint(self, name: str, val: object) -> None:
         if isinstance(val, torch.SymInt):
             expr_str = str(val.node.expr)
             hint = val.node.hint

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -36,7 +36,7 @@ import uuid
 from importlib import import_module
 from tempfile import TemporaryFile
 from typing import Any, IO, TYPE_CHECKING, TypedDict
-from typing_extensions import Unpack
+from typing_extensions import TypeVarTuple, Unpack
 
 import sympy
 
@@ -144,6 +144,8 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+_Ts = TypeVarTuple("_Ts")
 
 
 inductor_config = import_module("torch._inductor.config")
@@ -608,7 +610,7 @@ if "__compile_source__" in globals():
         fn: Any = kernel if isinstance(kernel, JITFunction) else kernel.fn
         return fn.__name__.split(".")[-1]
 
-    def get_triton_import_line(name: str, val: Any) -> str | None:
+    def get_triton_import_line(name: str, val: object) -> str | None:
         # User-defined Triton kernels are serialized from their source, not from
         # their original Python module.  If the source references a global
         # imported from Triton, such as `from triton.language.extra import
@@ -1381,9 +1383,9 @@ def repro_analyze(options: ReproOptions, mod: nn.Module, load_args: Any) -> None
         if new_args:
             raise AssertionError("new_args should be empty after compiled() call")
 
-    def compare_tuples(tuple1: tuple[Any], tuple2: tuple[Any]) -> str | None:
-        diff_indices = [i for i in range(len(tuple1)) if tuple1[i] != tuple2[i]]
-        diff_values = [(tuple1[i], tuple2[i]) for i in diff_indices]
+    def compare_tuples(t1: tuple[Unpack[_Ts]], t2: tuple[Unpack[_Ts]]) -> str | None:
+        diff_indices = [i for i in range(len(t1)) if t1[i] != t2[i]]
+        diff_values = [(t1[i], t2[i]) for i in diff_indices]
 
         if not diff_values:
             return None

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -127,7 +127,7 @@ def _try_except_tf_mode_template(dummy: Any) -> None:
 @dataclasses.dataclass(frozen=True)
 class ReenterWith:
     stack_index: int
-    target_values: tuple[Any, ...] | None = None
+    target_values: tuple[object, ...] | None = None
 
     def try_except_torch_function_mode(
         self, code_options: CodeOptions, cleanup: list[Instruction]
@@ -163,8 +163,7 @@ class ReenterWith:
             exit context
         """
         # NOTE: we assume that TOS is a context manager CLASS!
-        # pyrefly: ignore [implicit-any]
-        load_args = []
+        load_args: list[Instruction] = []
         if self.target_values:
             load_args = [create_load_const(val) for val in self.target_values]
         ctx_name = unique_id(f"___context_manager_{self.stack_index}")
@@ -206,8 +205,7 @@ class ReenterWith:
             (rest)
         """
         # NOTE: we assume that TOS is a context manager CLASS!
-        # pyrefly: ignore [implicit-any]
-        load_args = []
+        load_args: list[Instruction] = []
         if self.target_values:
             load_args = [create_load_const(val) for val in self.target_values]
 
@@ -298,7 +296,7 @@ def _filter_iter(
     return res
 
 
-def _load_tuple_and_call(tup: tuple[Any, ...]) -> list[Instruction]:
+def _load_tuple_and_call(tup: tuple[object, ...]) -> list[Instruction]:
     insts: list[Instruction] = []
     _initial_push_null(insts)
     insts.extend(create_load_const(val) for val in tup)
@@ -334,8 +332,8 @@ class ContinueExecutionCache:
         argnames_null: tuple[str, ...],
         setup_fns: tuple[ReenterWith, ...],
         handle_inactive_ctx: bool,
-        stack_ctx_vars: tuple[tuple[int, tuple[Any, ...]], ...],
-        argnames_ctx_vars: tuple[tuple[str, tuple[Any, ...]], ...],
+        stack_ctx_vars: tuple[tuple[int, tuple[object, ...]], ...],
+        argnames_ctx_vars: tuple[tuple[str, tuple[object, ...]], ...],
         null_idxes: tuple[int, ...],
         # mainly used to ensure distinct code objects per stack trace,
         # which prevents excessive recompilation of inner frames


### PR DESCRIPTION
These annotations describe opaque constant payloads that Dynamo threads
through to `create_load_const`, plus the matching write-side helpers in the
repro/debug utilities. None of the annotated code introspects the values as
anything other than `object`: the resume-execution paths only forward them to
`create_load_const`, and the debug/repro writers narrow with `isinstance` or
`getattr` before touching anything. `Any` therefore bought no expressiveness
while silencing type checking for every caller that passes these tuples
around, so `object` is the honest annotation.

`repro_analyze.compare_tuples` was additionally annotated `tuple[Any]`, a
one-element tuple type, which is not what any caller passes. Rather than the
`tuple[object, ...]` the rest of this change uses, both parameters now share a
single `TypeVarTuple`, `tuple[Unpack[_Ts]]`. The function indexes `t2` with
`range(len(t1))`, so a shorter `t2` raises `IndexError`; sharing one
`TypeVarTuple` is what makes that length invariant a static error rather than
a runtime one, which `tuple[object, ...]` cannot express. Note this constrains
slightly more than the body needs: a shared `TypeVarTuple` requires the two
tuples to match element by element, not just in arity, whereas the body only
ever compares with `!=`. That is fine as long as the two producers below are
eventually annotated with one shared alias; annotating them with two different
types would report an element-type mismatch the function does not care about. Its parameters are
renamed `tuple1`/`tuple2` -> `t1`/`t2` purely so the wider signature still fits
on one line rather than being wrapped by the formatter.

This is latent for the moment: both call sites pass results of
`_content_store.compute_tensor_metadata` / `read_tensor_metadata`, which have
no return annotation, so the arguments are statically `Any` and nothing is
checked against them today. It starts enforcing as soon as those two producers
are annotated. `Unpack[_Ts]` rather than PEP 646 `*_Ts` because this repo
supports Python 3.10, where the star form is a syntax error even under
`from __future__ import annotations`.

`ReenterWith` also carried two `# pyrefly: ignore [implicit-any]` suppressions
on the `load_args = []` lines that immediately consume `target_values`. The
list only ever holds `create_load_const` results, so `list[Instruction]` types
it exactly and both suppressions are deleted. That is the same "stop silencing
the checker on these paths" cleanup as the rest of the change, on the lines it
was already touching.

`code_options: dict[str, Any]` is deliberately left alone. A `CodeOptions`
TypedDict does already exist in `output_graph.py` and `ReenterWith` already
uses it for `try_except_torch_function_mode` and `try_finally`, so the
remaining `dict[str, Any]` on `ReenterWith.__call__` looks like a trivial
consistency fix -- but it is not. Those two methods are called from `PyCodegen`,
where `cg.code_options` is genuinely a `CodeOptions`, whereas `__call__` is
invoked from a `transform_code_object` callback. `transform_code_object` types
its callback as `Callable[[list[Instruction], dict[str, Any]], ...]`, so
converting `__call__` reports a new `bad-argument-type`, and converting the
callback to match reports two more (the callback is then unassignable to
`transform_code_object`, and `unreachable_codes` still takes `dict[str, Any]`).
Making this consistent means retyping `transform_code_object` and its seven
call sites across five files, which is a separate change.

Test Plan:

Type checking is the behavioral surface of this change, so the primary check
is that the CI type checker reports no new errors. Baseline (at the merge-base,
with the touched files reverted) and the post-change run both report exactly
62 errors, and the sorted error lists are byte-identical:

```
pyrefly check --config=pyrefly.toml
```

Lint is clean on the touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a \
  torch/_dynamo/debug_utils.py \
  torch/_dynamo/repro/after_aot.py \
  torch/_dynamo/resume_execution.py
```

All three files carry `from __future__ import annotations`, so the new
annotations are strings at runtime and are never evaluated; the change cannot
affect runtime behavior. Verified the modules still byte-compile:

```
python -m py_compile \
  torch/_dynamo/debug_utils.py \
  torch/_dynamo/repro/after_aot.py \
  torch/_dynamo/resume_execution.py
```

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98