### PR TITLE
[ROCm] Enable _scaled_mm OpInfo tests on FP8-capable GPUs

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -245,10 +245,11 @@ def evaluate_platform_supports_fp8():
     if torch.cuda.is_available():
         if torch.version.hip:
             archs = ['gfx94']
-            if ROCM_VERSION >= (6, 3):
-                archs.extend(['gfx120'])
             if ROCM_VERSION >= (6, 5):
-                archs.append('gfx95')
+                # OCP fp8 (e4m3fn/e5m2) in scaled_mm requires ROCm 6.5+; see
+                # the ROCM_VERSION checks in aten/src/ATen/native/cuda/ScaledBlas.cpp.
+                # gfx120 and gfx95 only support OCP, so gate them on 6.5.
+                archs.extend(['gfx95', 'gfx120'])
             if ROCM_VERSION >= (7, 14):
                 archs.append('gfx1250')
             for arch in archs:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1226,9 +1226,7 @@ ANY_DTYPE_ORDER = (
     torch.uint8,
     torch.bool,
     torch.float8_e4m3fn,
-    torch.float8_e4m3fnuz,
     torch.float8_e5m2,
-    torch.float8_e5m2fnuz,
 )
 
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1226,7 +1226,9 @@ ANY_DTYPE_ORDER = (
     torch.uint8,
     torch.bool,
     torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
     torch.float8_e5m2,
+    torch.float8_e5m2fnuz,
 )
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -30,11 +30,12 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_device_type import (
     onlyCPU, onlyCUDA, onlyNativeDeviceTypes, disablecuDNN,
     skipCUDAIfNoCusolver, skipCPUIfNoLapack, skipCPUIfNoFFT, skipCUDAIf, precisionOverride,
-    skipCPUIfNoMklSparse, toleranceOverride, tol, skipXPU, e4m3_type, E4M3_MAX_POS, E5M2_MAX_POS,
+    skipCPUIfNoMklSparse, toleranceOverride, tol, skipXPU, e4m3_type, e5m2_type, E4M3_MAX_POS, E5M2_MAX_POS,
     skipCUDAIfNoMagmaAndNoLinalgsolver,
 )
 from torch.testing._internal.common_cuda import (
-    PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+    PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM53OrLater, SM80OrLater, SM89OrLater, SM90OrLater, with_tf32_off, TEST_CUDNN,
     _get_torch_cuda_version,
 )
@@ -9355,28 +9356,28 @@ def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
     # Case 1: Both matrices e4m3
     scale1 = random.random()
     scale2 = random.random()
-    mat1 = make_mat((M, K), scale1, torch.float8_e4m3fn)
-    mat2 = make_mat((K, N), scale2, torch.float8_e4m3fn).t().contiguous().t()
-    scale_tensor1 = make_scale(scale1, torch.float8_e4m3fn)
-    scale_tensor2 = make_scale(scale2, torch.float8_e4m3fn)
+    mat1 = make_mat((M, K), scale1, e4m3_type)
+    mat2 = make_mat((K, N), scale2, e4m3_type).t().contiguous().t()
+    scale_tensor1 = make_scale(scale1, e4m3_type)
+    scale_tensor2 = make_scale(scale2, e4m3_type)
     samples.append(SampleInput(mat1, mat2, scale_tensor1, scale_tensor2))
 
     # Case 2: mat1 e4m3, mat2 e5m2
     scale1 = random.random()
     scale2 = random.random()
-    mat1 = make_mat((M, K), scale1, torch.float8_e4m3fn)
-    mat2 = make_mat((K, N), scale2, torch.float8_e5m2).t().contiguous().t()
-    scale_tensor1 = make_scale(scale1, torch.float8_e4m3fn)
-    scale_tensor2 = make_scale(scale2, torch.float8_e5m2)
+    mat1 = make_mat((M, K), scale1, e4m3_type)
+    mat2 = make_mat((K, N), scale2, e5m2_type).t().contiguous().t()
+    scale_tensor1 = make_scale(scale1, e4m3_type)
+    scale_tensor2 = make_scale(scale2, e5m2_type)
     samples.append(SampleInput(mat1, mat2, scale_tensor1, scale_tensor2))
 
     # Case 3: mat1 e5m2, mat2 e4m3
     scale1 = random.random()
     scale2 = random.random()
-    mat1 = make_mat((M, K), scale1, torch.float8_e5m2)
-    mat2 = make_mat((K, N), scale2, torch.float8_e4m3fn).t().contiguous().t()
-    scale_tensor1 = make_scale(scale1, torch.float8_e5m2)
-    scale_tensor2 = make_scale(scale2, torch.float8_e4m3fn)
+    mat1 = make_mat((M, K), scale1, e5m2_type)
+    mat2 = make_mat((K, N), scale2, e4m3_type).t().contiguous().t()
+    scale_tensor1 = make_scale(scale1, e5m2_type)
+    scale_tensor2 = make_scale(scale2, e4m3_type)
     samples.append(SampleInput(mat1, mat2, scale_tensor1, scale_tensor2))
 
     # Case 4: MXFP4 (float4_e2m1fn_x2) with E8M0 blockwise scaling
@@ -9409,7 +9410,7 @@ def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
 
 def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
     from torch.nn.functional import ScalingType, SwizzleType
-    make_mat_e4m3 = partial(make_tensor, device=device, dtype=torch.float8_e4m3fn, requires_grad=requires_grad)
+    make_mat_e4m3 = partial(make_tensor, device=device, dtype=e4m3_type, requires_grad=requires_grad)
 
     make_scale = partial(make_tensor, device=device, dtype=torch.float, requires_grad=False)
 
@@ -17102,11 +17103,11 @@ op_db: list[OpInfo] = [
         'torch._scaled_mm_v2',
         sample_inputs_func=sample_inputs_scaled_mm_v2,
         dtypes=float8_types(),
-        dtypesIfCUDA=empty_types() + (torch.float8_e4m3fn,),
+        dtypesIfCUDA=empty_types() + (e4m3_type,),
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[onlyCUDA, skipCUDAIf(not SM89OrLater or TEST_WITH_ROCM, 'Requires CUDA SM >= 8.9')],
+        decorators=[onlyCUDA, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support (SM >= 8.9 or MI300+)')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),
@@ -17132,11 +17133,11 @@ op_db: list[OpInfo] = [
         'torch._scaled_mm',
         sample_inputs_func=sample_inputs_scaled_mm,
         dtypes=float8_types(),
-        dtypesIfCUDA=empty_types() + (torch.float8_e4m3fn,),
+        dtypesIfCUDA=empty_types() + (e4m3_type,),
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[skipXPU, skipCUDAIf(not SM89OrLater or TEST_WITH_ROCM, 'Requires CUDA SM >= 8.9')],
+        decorators=[skipXPU, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support (SM >= 8.9 or MI300+)')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -36,7 +36,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    SM53OrLater, SM80OrLater, SM89OrLater, SM90OrLater, with_tf32_off, TEST_CUDNN,
+    SM53OrLater, SM80OrLater, SM90OrLater, with_tf32_off, TEST_CUDNN,
     _get_torch_cuda_version,
 )
 from torch.testing._internal.common_quantized import (
@@ -17103,11 +17103,15 @@ op_db: list[OpInfo] = [
         'torch._scaled_mm_v2',
         sample_inputs_func=sample_inputs_scaled_mm_v2,
         dtypes=float8_types(),
-        dtypesIfCUDA=empty_types() + (e4m3_type,),
+        # Deliberately e4m3fn even on gfx942 (native fnuz): this dtype only
+        # names the generated test id, which must stay stable across archs for
+        # the disable-test bot and flaky-test aggregator. Sample inputs ignore
+        # it and use e4m3_type / e5m2_type instead.
+        dtypesIfCUDA=empty_types() + (torch.float8_e4m3fn,),
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[onlyCUDA, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support (SM >= 8.9 or MI300+)')],
+        decorators=[onlyCUDA, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),
@@ -17133,11 +17137,12 @@ op_db: list[OpInfo] = [
         'torch._scaled_mm',
         sample_inputs_func=sample_inputs_scaled_mm,
         dtypes=float8_types(),
-        dtypesIfCUDA=empty_types() + (e4m3_type,),
+        # Deliberately e4m3fn even on gfx942 (native fnuz); see _scaled_mm_v2.
+        dtypesIfCUDA=empty_types() + (torch.float8_e4m3fn,),
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[skipXPU, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support (SM >= 8.9 or MI300+)')],
+        decorators=[skipXPU, skipCUDAIf(not PLATFORM_SUPPORTS_FP8, 'Requires FP8 support')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),


### PR DESCRIPTION
## Summary
- Enable `torch._scaled_mm` and `torch._scaled_mm_v2` OpInfo tests on ROCm FP8-capable GPUs by replacing the blanket `TEST_WITH_ROCM` skip with `PLATFORM_SUPPORTS_FP8`.
- Sample inputs use platform-native FP8 dtypes (`e4m3_type` / `e5m2_type`), so MI300 (gfx942) exercises `float8_e4m3fnuz` instead of hardcoded `float8_e4m3fn`.
- Test ids are identical on all platforms: `dtypesIfCUDA` keeps the literal `torch.float8_e4m3fn`, which only names the generated test id (the sample-input functions ignore the dtype argument). Arch-varying test ids would break the disable-test bot and the flaky-test aggregator, which join runs by test id.
- Align `evaluate_platform_supports_fp8` with the kernel: gfx120x (RDNA4) now requires ROCm 6.5, matching the OCP fp8 `ROCM_VERSION` checks in `ScaledBlas.cpp`, so unsupported configs skip instead of fail.

## Tests enabled (same ids on all platforms)
### `test/test_ops.py` (8 tests)
- `test_out_warning_torch__scaled_mm_cuda`, `test_out_warning_torch__scaled_mm_v2_cuda`
- `test_fake_torch__scaled_mm_cuda_float8_e4m3fn`, `test_fake_torch__scaled_mm_v2_cuda_float8_e4m3fn`
- `test_fake_autocast_torch__scaled_mm_cuda_float8_e4m3fn`, `test_fake_autocast_torch__scaled_mm_v2_cuda_float8_e4m3fn`
- `test_pointwise_ops_torch__scaled_mm_cuda_float8_e4m3fn`, `test_pointwise_ops_torch__scaled_mm_v2_cuda_float8_e4m3fn`
### `test/test_overrides.py` (2 tests)
- `test_redispatch_torch__scaled_mm_cuda_float8_e4m3fn`, `test_redispatch_torch__scaled_mm_v2_cuda_float8_e4m3fn`
### `test/test_decomp.py` (2 tests)
- `test_comprehensive_torch__scaled_mm_cuda_float8_e4m3fn`, `test_comprehensive_torch__scaled_mm_v2_cuda_float8_e4m3fn`

The `float8_e4m3fn` suffix is a stable label on every arch; on gfx942 the sample inputs are `float8_e4m3fnuz` tensors.

## Behavior by platform
| Platform | Result |
|---|---|
| NVIDIA SM >= 8.9 | Tests run (`float8_e4m3fn` / `float8_e5m2` samples) |
| MI300 (gfx942) | Tests run (`float8_e4m3fnuz` / `float8_e5m2fnuz` samples) |
| MI350 (gfx950), ROCm >= 6.5 | Tests run (`float8_e4m3fn` / `float8_e5m2` samples, plus MXFP4 sample) |
| RDNA4 (gfx120x), ROCm >= 6.5 | Tests run (`float8_e4m3fn` / `float8_e5m2` samples) |
| gfx1250, ROCm >= 7.14 | Tests run (`float8_e4m3fn` / `float8_e5m2` samples) |
| Other GPUs / older ROCm (e.g. gfx90a) | Tests skipped via `PLATFORM_SUPPORTS_FP8` |

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
