### PR TITLE
[CUDA graphs] Scope cuBLAS workspaces to captured invocations

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -485,7 +485,8 @@ inline void bgemm_internal_cublas(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_D
 
 template <>
 void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -497,7 +498,8 @@ void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
 
 template <>
 void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -509,7 +511,8 @@ void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
 
 template <>
 void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -523,7 +526,8 @@ void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::co
 
 template <>
 void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -537,7 +541,8 @@ void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::com
 
 template <typename C_Dtype>
 inline void bgemm_internal_cublas_half_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -610,7 +615,8 @@ inline void bgemm_internal_cublas_half_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYP
 template <typename C_Dtype>
 inline void bgemm_internal_cublas_bfloat16_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
   BGEMM_CHECK_ARGVALUES(at::BFloat16);
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -955,7 +961,8 @@ inline void gemm_internal_cublas(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dty
 
 template <>
 void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -967,7 +974,8 @@ void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
 
 template <>
 void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -979,7 +987,8 @@ void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
 
 template <>
 void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -993,7 +1002,8 @@ void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::comp
 
 template <>
 void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -1007,7 +1017,8 @@ void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::compl
 
 template <typename C_Dtype>
 inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -1123,7 +1134,8 @@ inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(
 
 template <typename C_Dtype>
 inline void gemm_internal_cublas_bfloat16_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -2474,7 +2486,8 @@ void trsmBatched<c10::complex<double>>(
 
 template <>
 void gemv<c10::complex<double>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<double>)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<double>);
@@ -2489,7 +2502,8 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
   // gemv is bw bound, and does not benefit from TF32. But the precision
   // loss still happens on TF32. So we disable it here.
   NoTF32Guard disable_tf32;
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<float>);
@@ -2501,7 +2515,8 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
 
 template <>
 void gemv<double>(CUDABLAS_GEMV_ARGTYPES(double)) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(double);
@@ -2514,7 +2529,8 @@ void gemv<float>(CUDABLAS_GEMV_ARGTYPES(float)) {
   // gemv is bw bound, and does not benefit from TF32. But the precision
   // loss still happens on TF32. So we disable it here.
   NoTF32Guard disable_tf32;
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(float);
@@ -2745,7 +2761,8 @@ void geqrfBatched<c10::complex<double>>(
 template <>
 void getrfBatched<double>(
     int n, double** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   TORCH_CUDABLAS_CHECK(cublasDgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2753,7 +2770,8 @@ void getrfBatched<double>(
 template <>
 void getrfBatched<float>(
     int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2766,7 +2784,8 @@ void getrfBatched<c10::complex<double>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   TORCH_CUDABLAS_CHECK(cublasZgetrfBatched(
       handle,
       n,
@@ -2785,7 +2804,8 @@ void getrfBatched<c10::complex<float>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
       n,

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -485,7 +485,7 @@ inline void bgemm_internal_cublas(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_D
 
 template <>
 void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -497,7 +497,7 @@ void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
 
 template <>
 void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -509,7 +509,7 @@ void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
 
 template <>
 void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -523,7 +523,7 @@ void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::co
 
 template <>
 void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -537,7 +537,7 @@ void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::com
 
 template <typename C_Dtype>
 inline void bgemm_internal_cublas_half_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -610,7 +610,7 @@ inline void bgemm_internal_cublas_half_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYP
 template <typename C_Dtype>
 inline void bgemm_internal_cublas_bfloat16_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
   BGEMM_CHECK_ARGVALUES(at::BFloat16);
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -955,7 +955,7 @@ inline void gemm_internal_cublas(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dty
 
 template <>
 void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -967,7 +967,7 @@ void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
 
 template <>
 void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -979,7 +979,7 @@ void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
 
 template <>
 void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -993,7 +993,7 @@ void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::comp
 
 template <>
 void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -1007,7 +1007,7 @@ void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::compl
 
 template <typename C_Dtype>
 inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -1123,7 +1123,7 @@ inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(
 
 template <typename C_Dtype>
 inline void gemm_internal_cublas_bfloat16_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = detail::cublasOpFromChar(transa);
   cublasOperation_t opb = detail::cublasOpFromChar(transb);
@@ -2474,7 +2474,7 @@ void trsmBatched<c10::complex<double>>(
 
 template <>
 void gemv<c10::complex<double>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<double>)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<double>);
@@ -2489,7 +2489,7 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
   // gemv is bw bound, and does not benefit from TF32. But the precision
   // loss still happens on TF32. So we disable it here.
   NoTF32Guard disable_tf32;
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(c10::complex<float>);
@@ -2501,7 +2501,7 @@ void gemv<c10::complex<float>>(CUDABLAS_GEMV_ARGTYPES(c10::complex<float>)) {
 
 template <>
 void gemv<double>(CUDABLAS_GEMV_ARGTYPES(double)) {
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(double);
@@ -2514,7 +2514,7 @@ void gemv<float>(CUDABLAS_GEMV_ARGTYPES(float)) {
   // gemv is bw bound, and does not benefit from TF32. But the precision
   // loss still happens on TF32. So we disable it here.
   NoTF32Guard disable_tf32;
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   cublasOperation_t op = detail::cublasOpFromChar(trans);
   _cublasAdjustLdLevel2(m, n, &lda);
   GEMV_CHECK_ARGVALUES(float);
@@ -2745,7 +2745,7 @@ void geqrfBatched<c10::complex<double>>(
 template <>
 void getrfBatched<double>(
     int n, double** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   TORCH_CUDABLAS_CHECK(cublasDgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2753,7 +2753,7 @@ void getrfBatched<double>(
 template <>
 void getrfBatched<float>(
     int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
 }
@@ -2766,7 +2766,7 @@ void getrfBatched<c10::complex<double>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   TORCH_CUDABLAS_CHECK(cublasZgetrfBatched(
       handle,
       n,
@@ -2785,7 +2785,7 @@ void getrfBatched<c10::complex<float>>(
     int* ipiv_array,
     int* info_array,
     int batchsize) {
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
       n,

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -86,6 +86,28 @@ TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
 TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle(bool setup = true);
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
 
+struct TORCH_CUDA_CPP_API CUDABlasHandle {
+  cublasHandle_t handle;
+  at::DataPtr workspace;
+
+  CUDABlasHandle(cublasHandle_t handle, at::DataPtr workspace)
+      : handle(handle), workspace(std::move(workspace)) {}
+  CUDABlasHandle(CUDABlasHandle&&) noexcept = default;
+  CUDABlasHandle& operator=(CUDABlasHandle&&) = delete;
+  CUDABlasHandle(const CUDABlasHandle&) = delete;
+  CUDABlasHandle& operator=(const CUDABlasHandle&) = delete;
+  ~CUDABlasHandle();
+
+  operator cublasHandle_t() const& {
+    return handle;
+  }
+
+  operator cublasHandle_t() && = delete;
+};
+
+TORCH_CUDA_CPP_API CUDABlasHandle
+getCurrentCUDABlasHandleWithWorkspace();
+
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API void clearCublasWorkspacesForStream(cudaStream_t stream);
 struct WorkspaceMapWithMutex {
@@ -98,6 +120,8 @@ TORCH_CUDA_CPP_API WorkspaceMapWithMutex& cublaslt_handle_stream_to_workspace();
 TORCH_CUDA_CPP_API size_t getChosenWorkspaceSize();
 TORCH_CUDA_CPP_API size_t getCUDABlasLtWorkspaceSize();
 TORCH_CUDA_CPP_API void* getCUDABlasLtWorkspace();
+TORCH_CUDA_CPP_API void* getCUDABlasLtWorkspace(
+    at::DataPtr& capture_workspace);
 TORCH_CUDA_CPP_API void setChosenWorkspaceSize(size_t size);
 TORCH_CUDA_CPP_API void setCUDABlasLtWorkspaceSize(size_t size);
 TORCH_CUDA_CPP_API void resetChosenWorkspaceSize();

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -84,29 +84,14 @@ TORCH_CUDA_CPP_API c10::Allocator* getCUDADeviceAllocator();
 /* Handles */
 TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
 TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle(bool setup = true);
+// capture_workspace owns an invocation-scoped workspace when the current
+// stream is captured through at::cuda::CUDAGraph. Its deleter clears the
+// thread-local handle before releasing the allocation. The owner must outlive
+// all uses of the returned handle and must not overlap another setup call on
+// the same thread and device. It remains empty outside capture.
+TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle(
+    at::DataPtr& capture_workspace);
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
-
-struct TORCH_CUDA_CPP_API CUDABlasHandle {
-  cublasHandle_t handle;
-  at::DataPtr workspace;
-
-  CUDABlasHandle(cublasHandle_t handle, at::DataPtr workspace)
-      : handle(handle), workspace(std::move(workspace)) {}
-  CUDABlasHandle(CUDABlasHandle&&) noexcept = default;
-  CUDABlasHandle& operator=(CUDABlasHandle&&) = delete;
-  CUDABlasHandle(const CUDABlasHandle&) = delete;
-  CUDABlasHandle& operator=(const CUDABlasHandle&) = delete;
-  ~CUDABlasHandle();
-
-  operator cublasHandle_t() const& {
-    return handle;
-  }
-
-  operator cublasHandle_t() && = delete;
-};
-
-TORCH_CUDA_CPP_API CUDABlasHandle
-getCurrentCUDABlasHandleWithWorkspace();
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API void clearCublasWorkspacesForStream(cudaStream_t stream);

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -383,8 +383,7 @@ void CUDAGraph::reset() {
       capturing_to_pool_ = false;
     }
 
-    // Clean up cuBLAS workspaces allocated on the capture stream, otherwise live allocations prevent
-    // private pool cleanup
+    // Clean up workspaces from callers using the raw cuBLAS handle API.
     clearCublasWorkspacesForStream(capture_stream_.stream());
 
     // notifyCaptureDestroy may throw. How should we handle this?

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -185,7 +185,6 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
   // prevent potentially unsafe CUDA API calls during capture.  See
   // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
   AT_CUDA_CHECK(cudaStreamBeginCapture(capture_stream_, capture_mode));
-  c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
 
   auto capture_id_opt = c10::cuda::captureIdMayInitCtx(stream);
   TORCH_INTERNAL_ASSERT(capture_id_opt.has_value(),
@@ -196,6 +195,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
     std::lock_guard<std::mutex> lock(_currently_capturing_graphs_mutex);
     _currently_capturing_graphs.emplace(capture_id_, this);
   }
+  c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
 }
 
 // capture_end is split so callers can run work on the captured cudaGraph_t
@@ -584,7 +584,6 @@ getCurrentCUDAStream(), &cond_node, nullptr, 1, cudaStreamSetCaptureDependencies
       nullptr,
       0,
       capture_mode_));
-  c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
 
   auto child_capture_id_opt = c10::cuda::captureIdMayInitCtx(child_stream);
   TORCH_INTERNAL_ASSERT(child_capture_id_opt.has_value(),
@@ -598,6 +597,7 @@ getCurrentCUDAStream(), &cond_node, nullptr, 1, cudaStreamSetCaptureDependencies
     _currently_capturing_graphs.emplace(
         conditional_graph_capture_ids_.top(), this);
   }
+  c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
 }
 #endif // !defined(USE_ROCM) && (defined(CUDA_VERSION) && CUDA_VERSION >= 12040)
 
@@ -626,7 +626,7 @@ void CUDAGraph::end_capture_to_conditional_node() {
   }
 
   CUDAStream stream = conditional_node_streams_.top().current_stream();
-  AT_CUDA_CHECK(cudaStreamEndCapture(stream.stream(), nullptr));
+  cudaError_t endCaptureErr = cudaStreamEndCapture(stream.stream(), nullptr);
   c10::cuda::CUDACachingAllocator::markCaptureEnd(capture_dev_);
 
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
@@ -651,6 +651,7 @@ void CUDAGraph::end_capture_to_conditional_node() {
       return filter(CUDAStream(CUDAStream::UNCHECKED, stream));
     });
   }
+  AT_CUDA_CHECK(endCaptureErr);
   constexpr const char* rng_with_conditional_nodes_error =
       "RNG within data-dependent conditional nodes is not supported yet.";
   TORCH_CHECK(!rng_or_generators_changed, rng_with_conditional_nodes_error);

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -315,6 +315,30 @@ at::DataPtr getNewCUDABlasLtWorkspace() {
 
 namespace {
 
+struct CUDABlasWorkspaceContext {
+  cublasHandle_t handle;
+  at::DataPtr workspace;
+};
+
+void deleteCUDABlasWorkspaceContext(void* ptr) {
+  std::unique_ptr<CUDABlasWorkspaceContext> context(
+      static_cast<CUDABlasWorkspaceContext*>(ptr));
+  auto status = cublasSetWorkspace(context->handle, nullptr, 0);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    TORCH_WARN_ONCE(
+        "Failed to clear cuBLAS workspace: ",
+        at::cuda::blas::_cublasGetErrorEnum(status));
+  }
+}
+
+at::DataPtr getNewWorkspaceForHandle(cublasHandle_t handle) {
+  auto workspace = getNewWorkspace();
+  void* data = workspace.get();
+  auto device = workspace.device();
+  auto* context = new CUDABlasWorkspaceContext{handle, std::move(workspace)};
+  return {data, context, deleteCUDABlasWorkspaceContext, device};
+}
+
 template <typename Handle>
 auto workspaceKey(Handle handle, c10::cuda::CUDAStream stream) {
   cudaStream_t cuda_stream = stream;
@@ -324,6 +348,8 @@ auto workspaceKey(Handle handle, c10::cuda::CUDAStream stream) {
 }
 
 bool isCapturing(c10::cuda::CUDAStream stream) {
+  // The lock-free gate tracks single-device captures initiated through
+  // at::cuda::CUDAGraph. Raw CUDA stream captures are outside this path.
   return c10::cuda::CUDACachingAllocator::hasActiveCapture(
              stream.device_index()) &&
       c10::cuda::isStreamCapturingMayInitCtx(stream);
@@ -415,6 +441,8 @@ void* getCUDABlasLtWorkspace() {
 void* getCUDABlasLtWorkspace(at::DataPtr& capture_workspace) {
   auto stream = c10::cuda::getCurrentCUDAStream();
   if (isCapturing(stream)) {
+    // A persistent entry may still be referenced by an older live graph, so
+    // keep it intact and use caller-owned storage for this invocation.
     capture_workspace = getNewCUDABlasLtWorkspace();
     return capture_workspace.mutable_get();
   }
@@ -428,7 +456,9 @@ void setupCUDABlasHandle(
   TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
 
   if (capture_workspace != nullptr && isCapturing(stream)) {
-    *capture_workspace = getNewWorkspace();
+    // A persistent entry may still be referenced by an older live graph, so
+    // keep it intact and use caller-owned storage for this invocation.
+    *capture_workspace = getNewWorkspaceForHandle(handle);
     TORCH_CUDABLAS_CHECK(cublasSetWorkspace(
         handle, capture_workspace->get(), getChosenWorkspaceSize()));
   } else {
@@ -502,17 +532,11 @@ cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
   return handle;
 }
 
-CUDABlasHandle getCurrentCUDABlasHandleWithWorkspace() {
-  CUDABlasHandle result{
-      getCurrentCUDABlasHandle(/*setup=*/false), at::DataPtr{}};
-  setupCUDABlasHandle(result.handle, &result.workspace);
-  return result;
-}
-
-CUDABlasHandle::~CUDABlasHandle() {
-  if (workspace) {
-    (void)cublasSetWorkspace(handle, nullptr, 0);
-  }
+cublasHandle_t getCurrentCUDABlasHandle(at::DataPtr& capture_workspace) {
+  TORCH_INTERNAL_ASSERT(!capture_workspace);
+  auto handle = getCurrentCUDABlasHandle(/*setup=*/false);
+  setupCUDABlasHandle(handle, &capture_workspace);
+  return handle;
 }
 
 cublasLtHandle_t getCurrentCUDABlasLtHandle() {

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -3,6 +3,7 @@
 #include <ATen/cuda/detail/DeviceThreadHandles.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
 
 #include <atomic>
 #include <map>
@@ -312,9 +313,71 @@ at::DataPtr getNewCUDABlasLtWorkspace() {
   return c10::cuda::CUDACachingAllocator::get()->allocate(getCUDABlasLtWorkspaceSize());
 }
 
+namespace {
+
+template <typename Handle>
+auto workspaceKey(Handle handle, c10::cuda::CUDAStream stream) {
+  cudaStream_t cuda_stream = stream;
+  return std::make_tuple(
+      static_cast<void*>(handle),
+      static_cast<void*>(cuda_stream));
+}
+
+bool isCapturing(c10::cuda::CUDAStream stream) {
+  return c10::cuda::CUDACachingAllocator::hasActiveCapture(
+             stream.device_index()) &&
+      c10::cuda::isStreamCapturingMayInitCtx(stream);
+}
+
+void* getPersistentCUDABlasLtWorkspace(c10::cuda::CUDAStream stream) {
+#ifndef USE_ROCM
+  if (unified_cublas_and_lt_workspaces()) {
+    auto handle = getCurrentCUDABlasHandle(/*setup=*/false);
+    auto key = workspaceKey(handle, stream);
+    auto& workspace = cublas_handle_stream_to_workspace();
+    {
+      std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.find(key);
+      if (workspace_it != workspace.map.end()) {
+        return workspace_it->second.first.mutable_get();
+      }
+    }
+    auto new_workspace = getNewWorkspace();
+    {
+      std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+      auto workspace_it = workspace.map.try_emplace(
+          key,
+          std::make_pair(
+              std::move(new_workspace), getChosenWorkspaceSize())).first;
+      return workspace_it->second.first.mutable_get();
+    }
+  }
+#endif
+  auto handle = getCurrentCUDABlasLtHandle();
+  auto key = workspaceKey(handle, stream);
+  auto& workspace = cublaslt_handle_stream_to_workspace();
+  auto workspace_size = getCUDABlasLtWorkspaceSize();
+  {
+    std::shared_lock<std::shared_mutex> lock(workspace.mutex);
+    auto workspace_it = workspace.map.find(key);
+    if (workspace_it != workspace.map.end() &&
+        workspace_it->second.second >= workspace_size) {
+      return workspace_it->second.first.mutable_get();
+    }
+  }
+  auto new_workspace = getNewCUDABlasLtWorkspace();
+  {
+    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
+    workspace.map.insert_or_assign(
+        key, std::make_pair(std::move(new_workspace), workspace_size));
+    return workspace.map.find(key)->second.first.mutable_get();
+  }
+}
+
+} // namespace
+
 void setWorkspaceForHandle(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
-  cudaStream_t _stream = stream;
-  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  auto key = workspaceKey(handle, stream);
 
   auto& workspace = cublas_handle_stream_to_workspace();
 
@@ -345,58 +408,59 @@ void setWorkspaceForHandle(cublasHandle_t handle, c10::cuda::CUDAStream stream) 
 }
 
 void* getCUDABlasLtWorkspace() {
-#ifndef USE_ROCM
-  if (unified_cublas_and_lt_workspaces()) {
-    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle(/*setup=*/false);
-    auto stream = c10::cuda::getCurrentCUDAStream();
-    cudaStream_t _stream = stream;
-    auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
-    auto& workspace = at::cuda::cublas_handle_stream_to_workspace();
-    {
-      std::shared_lock<std::shared_mutex> lock(workspace.mutex);
-      auto workspace_it = workspace.map.find(key);
-      if (workspace_it != workspace.map.end()) {
-        return workspace_it->second.first.mutable_get();
-      }
-    }
-    // First use for this handle+stream pair — allocate and insert directly.
-    // No need to call cublasSetWorkspace; Lt passes workspace explicitly.
-    auto new_workspace = getNewWorkspace();
-    {
-      std::unique_lock<std::shared_mutex> lock(workspace.mutex);
-      auto workspace_it = workspace.map.try_emplace(key, std::make_pair(std::move(new_workspace), getChosenWorkspaceSize())).first;
-      return workspace_it->second.first.mutable_get();
-    }
-  }
-#endif
-  cublasLtHandle_t handle = getCurrentCUDABlasLtHandle();
   auto stream = c10::cuda::getCurrentCUDAStream();
-  cudaStream_t _stream = stream;
-  auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
+  return getPersistentCUDABlasLtWorkspace(stream);
+}
 
-  auto& workspace = cublaslt_handle_stream_to_workspace();
+void* getCUDABlasLtWorkspace(at::DataPtr& capture_workspace) {
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  if (isCapturing(stream)) {
+    capture_workspace = getNewCUDABlasLtWorkspace();
+    return capture_workspace.mutable_get();
+  }
+  return getPersistentCUDABlasLtWorkspace(stream);
+}
 
-  size_t workspace_size = getCUDABlasLtWorkspaceSize();
+void setupCUDABlasHandle(
+    cublasHandle_t handle,
+    at::DataPtr* capture_workspace) {
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
 
-  // Fast path: check if workspace already exists and is large enough
-  {
-    std::shared_lock<std::shared_mutex> lock(workspace.mutex);
-    auto workspace_it = workspace.map.find(key);
-    if (workspace_it != workspace.map.end() && workspace_it->second.second >= workspace_size) {
-      return workspace_it->second.first.mutable_get();
-    }
+  if (capture_workspace != nullptr && isCapturing(stream)) {
+    *capture_workspace = getNewWorkspace();
+    TORCH_CUDABLAS_CHECK(cublasSetWorkspace(
+        handle, capture_workspace->get(), getChosenWorkspaceSize()));
+  } else {
+    // We explicitly set the cublas workspace even though CUDA 12.2+ fixed the
+    // issue where memory usage increased during graph capture.
+    // original issue: https://github.com/pytorch/pytorch/pull/83461
+    // This is because in CUDA 12.2+, the use of cudaMallocAsync in cublas
+    // will allocate memory dynamically (even if they're cheap) outside
+    // PyTorch's CUDA caching allocator. It's possible that CCA used up
+    // all the memory and cublas's cudaMallocAsync will return OOM
+    setWorkspaceForHandle(handle, stream);
   }
 
-  // Slow path: allocate workspace outside the lock
-  auto new_workspace = getNewCUDABlasLtWorkspace();
-
-  // Insert with lock, replacing any undersized entry
-  {
-    std::unique_lock<std::shared_mutex> lock(workspace.mutex);
-    workspace.map.insert_or_assign(key, std::make_pair(std::move(new_workspace), workspace_size));
-    auto workspace_it = workspace.map.find(key);
-    return workspace_it->second.first.mutable_get();
+#if !defined(USE_ROCM)
+  // On CUDA >= 11, and architecture >= Ampere, cuBLAS can use TF32 to speedup
+  // FP32 data type calculations based on the value of the allow_tf32 flag.
+  // To enable TF32, set the math mode of the handle to CUBLAS_TF32_TENSOR_OP_MATH.
+  if (!NoTF32Guard::should_disable_tf32() &&
+      at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
+  } else {
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
   }
+#else
+  hipblasAtomicsMode_t hipblas_mode;
+  if (at::globalContext().deterministicAlgorithms()) {
+    hipblas_mode = HIPBLAS_ATOMICS_NOT_ALLOWED;
+  } else {
+    hipblas_mode = HIPBLAS_ATOMICS_ALLOWED;
+  }
+  TORCH_CUDABLAS_CHECK(hipblasSetAtomicsMode(handle, hipblas_mode));
+#endif
 }
 
 cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
@@ -434,37 +498,21 @@ cublasHandle_t getCurrentCUDABlasHandle(bool setup) {
     return handle;
   }
 
-  auto stream = c10::cuda::getCurrentCUDAStream();
-  TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));
-  // We explicitly set the cublas workspace even though CUDA 12.2+ fixed the
-  // issue where memory usage increased during graph capture.
-  // original issue: https://github.com/pytorch/pytorch/pull/83461
-  // This is because in CUDA 12.2+, the use of cudaMallocAsync in cublas
-  // will allocate memory dynamically (even if they're cheap) outside
-  // PyTorch's CUDA caching allocator. It's possible that CCA used up
-  // all the memory and cublas's cudaMallocAsync will return OOM
-  setWorkspaceForHandle(handle, stream);
-
-#if !defined(USE_ROCM)
-  // On CUDA >= 11, and architecture >= Ampere, cuBLAS can use TF32 to speedup
-  // FP32 data type calculations based on the value of the allow_tf32 flag.
-  // To enable TF32, set the math mode of the handle to CUBLAS_TF32_TENSOR_OP_MATH.
-  if (!NoTF32Guard::should_disable_tf32() &&
-      at::globalContext().float32Precision(at::Float32Backend::CUDA, at::Float32Op::MATMUL) == at::Float32Precision::TF32) {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
-  } else {
-    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-  }
-#else
-  hipblasAtomicsMode_t hipblas_mode;
-  if (at::globalContext().deterministicAlgorithms()) {
-    hipblas_mode = HIPBLAS_ATOMICS_NOT_ALLOWED;
-  } else {
-    hipblas_mode = HIPBLAS_ATOMICS_ALLOWED;
-  }
-  TORCH_CUDABLAS_CHECK(hipblasSetAtomicsMode(handle, hipblas_mode));
-#endif
+  setupCUDABlasHandle(handle, nullptr);
   return handle;
+}
+
+CUDABlasHandle getCurrentCUDABlasHandleWithWorkspace() {
+  CUDABlasHandle result{
+      getCurrentCUDABlasHandle(/*setup=*/false), at::DataPtr{}};
+  setupCUDABlasHandle(result.handle, &result.workspace);
+  return result;
+}
+
+CUDABlasHandle::~CUDABlasHandle() {
+  if (workspace) {
+    (void)cublasSetWorkspace(handle, nullptr, 0);
+  }
 }
 
 cublasLtHandle_t getCurrentCUDABlasLtHandle() {

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -142,9 +142,10 @@ class CuBlasLtMatmulPreference : public CuBlasLtDescriptor<
 struct CublasLtWorkspace {
   CublasLtWorkspace() {
     size = at::cuda::getCUDABlasLtWorkspaceSize();
-    ptr = at::cuda::getCUDABlasLtWorkspace();
+    ptr = at::cuda::getCUDABlasLtWorkspace(workspace);
   }
 
+  at::DataPtr workspace;
   void* ptr;
   size_t size;
 };

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -602,7 +602,9 @@ class HipblasltGemmOp : public Callable<ParamsT> {
         return FAIL;
       }
 
-      void* workspace_buffer = at::cuda::getCUDABlasLtWorkspace();
+      at::DataPtr capture_workspace;
+      void* workspace_buffer =
+          at::cuda::getCUDABlasLtWorkspace(capture_workspace);
 
       TORCH_HIPBLASLT_CHECK(hipblasLtMatmul(op_handle,
             matmul.descriptor(),

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -148,8 +148,12 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);
+      auto handle_with_workspace =
+          at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+      auto handle =
+          (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
       auto status = rocblas_gemm_ex(
-          (rocblas_handle)at::cuda::getCurrentCUDABlasHandle(),
+          handle,
           _rocblasOpFromChar(params->transa),
           _rocblasOpFromChar(params->transb),
           params->m, params->n, params->k,
@@ -175,7 +179,10 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
 
 template <typename T>
 auto GetRocBlasGemmTypeStringAndOps() {
-  rocblas_handle handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
+  auto handle_with_workspace =
+      at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  auto handle =
+      (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
   rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();
@@ -221,8 +228,12 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);
+      auto handle_with_workspace =
+          at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+      auto handle =
+          (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
       auto status = rocblas_gemm_strided_batched_ex(
-          (rocblas_handle)at::cuda::getCurrentCUDABlasHandle(),
+          handle,
           _rocblasOpFromChar(params->transa),
           _rocblasOpFromChar(params->transb),
           params->m, params->n, params->k,
@@ -249,7 +260,10 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
 
 template <typename T>
 auto GetRocBlasGemmStridedBatchedTypeStringAndOps() {
-  rocblas_handle handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
+  auto handle_with_workspace =
+      at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  auto handle =
+      (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
   rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -148,10 +148,9 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);
-      auto handle_with_workspace =
-          at::cuda::getCurrentCUDABlasHandleWithWorkspace();
-      auto handle =
-          (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
+      at::DataPtr cublas_workspace;
+      auto handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle(
+          cublas_workspace);
       auto status = rocblas_gemm_ex(
           handle,
           _rocblasOpFromChar(params->transa),
@@ -179,10 +178,7 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
 
 template <typename T>
 auto GetRocBlasGemmTypeStringAndOps() {
-  auto handle_with_workspace =
-      at::cuda::getCurrentCUDABlasHandleWithWorkspace();
-  auto handle =
-      (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
+  auto handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
   rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();
@@ -228,10 +224,9 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
       auto compute_type = RocBlasComputeTypeFor<T>();
       auto h_a = DoCastForHalfOrBfloat16(params->alpha);
       auto h_b = DoCastForHalfOrBfloat16(params->beta);
-      auto handle_with_workspace =
-          at::cuda::getCurrentCUDABlasHandleWithWorkspace();
-      auto handle =
-          (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
+      at::DataPtr cublas_workspace;
+      auto handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle(
+          cublas_workspace);
       auto status = rocblas_gemm_strided_batched_ex(
           handle,
           _rocblasOpFromChar(params->transa),
@@ -260,10 +255,7 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
 
 template <typename T>
 auto GetRocBlasGemmStridedBatchedTypeStringAndOps() {
-  auto handle_with_workspace =
-      at::cuda::getCurrentCUDABlasHandleWithWorkspace();
-  auto handle =
-      (rocblas_handle)static_cast<cublasHandle_t>(handle_with_workspace);
+  auto handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
   rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -870,7 +870,8 @@ Tensor dot_cuda(const Tensor& self, const Tensor& other) {
       [&] {
         Tensor result = at::empty({}, self.options());
 
-        auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+        at::DataPtr cublas_workspace;
+        auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
         at::cuda::blas::PointerModeGuard pointerModeGuard(handle, CUBLAS_POINTER_MODE_DEVICE);
         at::cuda::blas::dot<scalar_t>(
             handle,
@@ -917,7 +918,8 @@ Tensor vdot_cuda(const Tensor& self, const Tensor& other) {
   return AT_DISPATCH_COMPLEX_TYPES(self.scalar_type(), "vdot", [&] {
     Tensor result = at::empty({}, self.options());
 
-    auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+    at::DataPtr cublas_workspace;
+    auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
     at::cuda::blas::PointerModeGuard pointerModeGuard(
         handle, CUBLAS_POINTER_MODE_DEVICE);
     at::cuda::blas::vdot<scalar_t>(

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -870,7 +870,7 @@ Tensor dot_cuda(const Tensor& self, const Tensor& other) {
       [&] {
         Tensor result = at::empty({}, self.options());
 
-        auto handle = at::cuda::getCurrentCUDABlasHandle();
+        auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
         at::cuda::blas::PointerModeGuard pointerModeGuard(handle, CUBLAS_POINTER_MODE_DEVICE);
         at::cuda::blas::dot<scalar_t>(
             handle,
@@ -917,7 +917,7 @@ Tensor vdot_cuda(const Tensor& self, const Tensor& other) {
   return AT_DISPATCH_COMPLEX_TYPES(self.scalar_type(), "vdot", [&] {
     Tensor result = at::empty({}, self.options());
 
-    auto handle = at::cuda::getCurrentCUDABlasHandle();
+    auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
     at::cuda::blas::PointerModeGuard pointerModeGuard(
         handle, CUBLAS_POINTER_MODE_DEVICE);
     at::cuda::blas::vdot<scalar_t>(

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -90,7 +90,7 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
   auto tau_ptr_array_data = reinterpret_cast<scalar_t**>(tau_ptr_array.data_ptr());
 
   int info;
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   at::cuda::blas::geqrfBatched(handle, m, n, input_ptr_array_data, lda, tau_ptr_array_data, &info, batch_size);
 
   // info only indicates wrong arguments to geqrfBatched call
@@ -145,7 +145,7 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   auto lu_ptr_array_data = reinterpret_cast<const scalar_t* const*>(lu_ptr_array.const_data_ptr());
   auto b_ptr_array_data = reinterpret_cast<scalar_t**>(b_ptr_array.data_ptr());
 
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   at::cuda::blas::getrsBatched(handle, trans, m, nrhs, const_cast<scalar_t**>(lu_ptr_array_data),
     lda, const_cast<int*>(pivots_data), b_ptr_array_data, lda, &info, batch_size);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
@@ -177,10 +177,10 @@ static void apply_triangular_solve(const Tensor& A, const Tensor& B, bool left, 
 
   auto alpha = scalar_t{1};
 
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   for (decltype(batch_size) i = 0; i < batch_size; i++) {
     const scalar_t* A_working_ptr = &A_data[i * A_mat_stride];
     scalar_t* B_working_ptr = &B_data[i * B_mat_stride];
-    auto handle = at::cuda::getCurrentCUDABlasHandle();
     at::cuda::blas::trsm(handle, side, uplo, trans, diag, m, n, &alpha, A_working_ptr, lda, B_working_ptr, ldb);
   }
 }
@@ -213,7 +213,7 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
   auto A_ptr_array_data = reinterpret_cast<scalar_t**>(A_ptr_array.data_ptr());
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, A_ptr_array_data, lda, B_ptr_array_data, ldb, batch_size);
 }
 
@@ -276,7 +276,7 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
   auto infos_data = infos.data_ptr<int>();
-  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
   int info;
 
   at::cuda::blas::gelsBatched<scalar_t>(

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLibBlas.cpp
@@ -90,7 +90,8 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
   auto tau_ptr_array_data = reinterpret_cast<scalar_t**>(tau_ptr_array.data_ptr());
 
   int info;
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   at::cuda::blas::geqrfBatched(handle, m, n, input_ptr_array_data, lda, tau_ptr_array_data, &info, batch_size);
 
   // info only indicates wrong arguments to geqrfBatched call
@@ -145,7 +146,8 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   auto lu_ptr_array_data = reinterpret_cast<const scalar_t* const*>(lu_ptr_array.const_data_ptr());
   auto b_ptr_array_data = reinterpret_cast<scalar_t**>(b_ptr_array.data_ptr());
 
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   at::cuda::blas::getrsBatched(handle, trans, m, nrhs, const_cast<scalar_t**>(lu_ptr_array_data),
     lda, const_cast<int*>(pivots_data), b_ptr_array_data, lda, &info, batch_size);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
@@ -177,7 +179,8 @@ static void apply_triangular_solve(const Tensor& A, const Tensor& B, bool left, 
 
   auto alpha = scalar_t{1};
 
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   for (decltype(batch_size) i = 0; i < batch_size; i++) {
     const scalar_t* A_working_ptr = &A_data[i * A_mat_stride];
     scalar_t* B_working_ptr = &B_data[i * B_mat_stride];
@@ -213,7 +216,8 @@ static void apply_triangular_solve_batched(const Tensor& A, const Tensor& B, boo
   auto A_ptr_array_data = reinterpret_cast<scalar_t**>(A_ptr_array.data_ptr());
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   at::cuda::blas::trsmBatched(handle, side, uplo, trans, diag, m, n, &alpha, A_ptr_array_data, lda, B_ptr_array_data, ldb, batch_size);
 }
 
@@ -276,7 +280,8 @@ inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
   auto B_ptr_array_data = reinterpret_cast<scalar_t**>(B_ptr_array.data_ptr());
 
   auto infos_data = infos.data_ptr<int>();
-  auto handle = at::cuda::getCurrentCUDABlasHandleWithWorkspace();
+  at::DataPtr cublas_workspace;
+  auto handle = at::cuda::getCurrentCUDABlasHandle(cublas_workspace);
   int info;
 
   at::cuda::blas::gelsBatched<scalar_t>(

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1445,9 +1445,7 @@ class DeviceCachingAllocator {
   // NCCL registration, inductor cudagraph_trees warmup, internal
   // try_mempool_fallback).
   //
-  // Plain int because all access is serialized through `mutex`. Promote to
-  // std::atomic<int> (relaxed) if begin/end ever need to race or if any
-  // reader wants lock-free access.
+  // Plain int because all access is serialized through `mutex`.
   int num_active_captures_ = 0;
 
   // tracks which pools we can use as a last resort before ooming
@@ -3627,8 +3625,6 @@ class DeviceCachingAllocator {
   //      device that has another stream capturing (eager-eligible) from the
   //      capturing stream itself (must follow capture rules).
   //
-  // The counter read is safe because all callers hold `mutex`
-  // (see num_active_captures_).
   bool is_capture_context() {
     if (C10_LIKELY(num_active_captures_ == 0)) {
       return false;
@@ -5397,5 +5393,36 @@ struct BackendStaticInitializer {
 
 std::atomic<CUDAAllocator*> allocator;
 static BackendStaticInitializer backend_static_initializer;
+
+namespace {
+static_assert(std::atomic<int>::is_always_lock_free);
+std::array<std::atomic<int>, C10_COMPILE_TIME_MAX_GPUS> active_captures{};
+
+void assertValidCaptureDevice(c10::DeviceIndex device) {
+  TORCH_INTERNAL_ASSERT(
+      device >= 0 && device < C10_COMPILE_TIME_MAX_GPUS,
+      "Invalid device index ",
+      static_cast<int>(device));
+}
+} // namespace
+
+void markCaptureBegin(c10::DeviceIndex device) {
+  assertValidCaptureDevice(device);
+  get()->markCaptureBegin(device);
+  active_captures[device].fetch_add(1, std::memory_order_relaxed);
+}
+
+void markCaptureEnd(c10::DeviceIndex device) {
+  assertValidCaptureDevice(device);
+  get()->markCaptureEnd(device);
+  auto previous = active_captures[device].fetch_sub(1, std::memory_order_relaxed);
+  TORCH_INTERNAL_ASSERT(
+      previous > 0, "markCaptureEnd called with no captures in progress");
+}
+
+bool hasActiveCapture(c10::DeviceIndex device) {
+  assertValidCaptureDevice(device);
+  return active_captures[device].load(std::memory_order_relaxed) != 0;
+}
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -5396,6 +5396,10 @@ static BackendStaticInitializer backend_static_initializer;
 
 namespace {
 static_assert(std::atomic<int>::is_always_lock_free);
+// DeviceCachingAllocator::num_active_captures_ is mutex-protected and used by
+// the native allocator. This backend-independent mirror provides a lock-free
+// gate for queries outside the allocator. Relaxed ordering is sufficient
+// because the per-stream capture query is authoritative.
 std::array<std::atomic<int>, C10_COMPILE_TIME_MAX_GPUS> active_captures{};
 
 void assertValidCaptureDevice(c10::DeviceIndex device) {
@@ -5415,7 +5419,8 @@ void markCaptureBegin(c10::DeviceIndex device) {
 void markCaptureEnd(c10::DeviceIndex device) {
   assertValidCaptureDevice(device);
   get()->markCaptureEnd(device);
-  auto previous = active_captures[device].fetch_sub(1, std::memory_order_relaxed);
+  auto previous =
+      active_captures[device].fetch_sub(1, std::memory_order_relaxed);
   TORCH_INTERNAL_ASSERT(
       previous > 0, "markCaptureEnd called with no captures in progress");
 }

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -434,13 +434,9 @@ inline void endAllocateToPool(c10::DeviceIndex device, MempoolId_t mempool_id) {
   get()->endAllocateToPool(device, mempool_id);
 }
 
-inline void markCaptureBegin(c10::DeviceIndex device) {
-  get()->markCaptureBegin(device);
-}
-
-inline void markCaptureEnd(c10::DeviceIndex device) {
-  get()->markCaptureEnd(device);
-}
+C10_CUDA_API void markCaptureBegin(c10::DeviceIndex device);
+C10_CUDA_API void markCaptureEnd(c10::DeviceIndex device);
+C10_CUDA_API bool hasActiveCapture(c10::DeviceIndex device);
 
 inline void recordHistory(
     bool enabled,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3889,6 +3889,120 @@ exit(2)
             with torch.cuda.graph(torch.cuda.CUDAGraph()):
                 torch.zeros(2**40, device="cuda")
 
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @setBlasBackendsToDefaultFinally
+    @serialTest()
+    @parametrize("backend", ("cublas", "cublaslt"))
+    def test_graph_capture_cublas_workspace_lifetime(self, backend):
+        torch.backends.cuda.preferred_blas_library(backend)
+        a = torch.randn(128, 128, device="cuda")
+        b = torch.randn(128, 128, device="cuda")
+        result = torch.empty_like(a)
+        expected = torch.mm(a, b)
+
+        torch._C._cuda_clearCublasWorkspaces()
+        torch.cuda.synchronize()
+        active_before = torch.cuda.memory_stats()["active_bytes.all.current"]
+
+        stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            torch.mm(a, b, out=result)
+
+        self.assertEqual(
+            torch.cuda.memory_stats()["active_bytes.all.current"], active_before
+        )
+        result.fill_(float("nan"))
+        torch.cuda.synchronize()
+        graph.replay()
+        self.assertEqual(result, expected)
+        graph.reset()
+
+        with torch.cuda.stream(stream):
+            torch.mm(a, b, out=result)
+        torch.cuda.synchronize()
+        active_warmed = torch.cuda.memory_stats()["active_bytes.all.current"]
+        self.assertGreater(active_warmed, active_before)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            torch.mm(a, b, out=result)
+
+        active_after = torch.cuda.memory_stats()["active_bytes.all.current"]
+        self.assertEqual(active_after, active_warmed)
+        result.fill_(float("nan"))
+        torch.cuda.synchronize()
+        graph.replay()
+        self.assertEqual(result, expected)
+
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @serialTest()
+    @blas_library_context("cublas")
+    def test_graph_capture_cublas_workspace_cross_thread(self):
+        if torch.cuda.get_device_capability()[0] != 9:
+            self.skipTest("The regression requires an SM90 split-K cuBLAS kernel")
+
+        torch._C._cuda_clearCublasWorkspaces()
+        x = torch.randn(32, 10944, device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn(2048, 10944, device="cuda", dtype=torch.bfloat16)
+        expected = torch.nn.functional.linear(x, weight)
+        output = torch.empty_like(expected)
+        torch.cuda.synchronize()
+
+        stream = torch.cuda.Stream()
+        ready = threading.Event()
+        launch = threading.Event()
+        done = threading.Event()
+        finish = threading.Event()
+        state = {}
+
+        def worker():
+            try:
+                with torch.cuda.stream(stream):
+                    torch.cuda.current_blas_handle()
+                ready.set()
+                if not launch.wait(timeout=30):
+                    raise RuntimeError("capture thread did not release worker")
+                with torch.cuda.stream(stream):
+                    torch.mm(x, weight.t(), out=output)
+                done.set()
+                if not finish.wait(timeout=30):
+                    raise RuntimeError("capture thread did not finish capture")
+            except BaseException as error:
+                state["error"] = error
+                ready.set()
+                done.set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        self.assertTrue(ready.wait(timeout=30))
+        if "error" in state:
+            raise state["error"]
+
+        graph = torch.cuda.CUDAGraph()
+        try:
+            with torch.cuda.graph(graph, stream=stream):
+                launch.set()
+                self.assertTrue(done.wait(timeout=30))
+                if "error" in state:
+                    raise state["error"]
+        finally:
+            finish.set()
+            thread.join(timeout=30)
+        self.assertFalse(thread.is_alive())
+        if "error" in state:
+            raise state["error"]
+
+        torch.cuda.empty_cache()
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(output, expected, rtol=1e-2, atol=2e-1)
+
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3937,19 +3937,10 @@ exit(2)
         graph.replay()
         self.assertEqual(result, expected)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
-    @unittest.skipIf(
-        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
-    )
-    @serialTest()
-    @blas_library_context("cublas")
-    def test_graph_capture_cublas_workspace_cross_thread(self):
-        if torch.cuda.get_device_capability()[0] != 9:
-            self.skipTest("The regression requires an SM90 split-K cuBLAS kernel")
-
+    def _capture_cublas_workspace_cross_thread(
+        self, x, weight, *, rtol, atol, check_allocation
+    ):
         torch._C._cuda_clearCublasWorkspaces()
-        x = torch.randn(32, 10944, device="cuda", dtype=torch.bfloat16)
-        weight = torch.randn(2048, 10944, device="cuda", dtype=torch.bfloat16)
         expected = torch.nn.functional.linear(x, weight)
         output = torch.empty_like(expected)
         torch.cuda.synchronize()
@@ -3983,6 +3974,9 @@ exit(2)
         self.assertTrue(ready.wait(timeout=30))
         if "error" in state:
             raise state["error"]
+        torch.cuda.synchronize()
+        active_before = torch.cuda.memory_stats()["active_bytes.all.current"]
+        allocated_before = torch.cuda.memory_stats()["active_bytes.all.allocated"]
 
         graph = torch.cuda.CUDAGraph()
         try:
@@ -3998,10 +3992,49 @@ exit(2)
         if "error" in state:
             raise state["error"]
 
+        stats = torch.cuda.memory_stats()
+        self.assertEqual(stats["active_bytes.all.current"], active_before)
+        if check_allocation and not TEST_CUDAMALLOCASYNC:
+            self.assertGreaterEqual(
+                stats["active_bytes.all.allocated"] - allocated_before,
+                torch.backends.cuda.cublas_workspace_size(),
+            )
+
         torch.cuda.empty_cache()
         graph.replay()
         torch.cuda.synchronize()
-        self.assertEqual(output, expected, rtol=1e-2, atol=2e-1)
+        self.assertEqual(output, expected, rtol=rtol, atol=atol)
+
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @serialTest()
+    @blas_library_context("cublas")
+    def test_graph_capture_cublas_workspace_cross_thread(self):
+        x = torch.randn(128, 128, device="cuda")
+        weight = torch.randn(128, 128, device="cuda")
+        self._capture_cublas_workspace_cross_thread(
+            x, weight, rtol=1.3e-6, atol=1e-5, check_allocation=True
+        )
+
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @serialTest()
+    @blas_library_context("cublas")
+    def test_graph_capture_cublas_workspace_cross_thread_sm90(self):
+        if torch.cuda.get_device_capability()[0] != 9:
+            self.skipTest("The regression requires an SM90 split-K cuBLAS kernel")
+
+        # This shape selects the workspace-consuming split-K kernel from the
+        # original SM90 regression.
+        x = torch.randn(32, 10944, device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn(2048, 10944, device="cuda", dtype=torch.bfloat16)
+        self._capture_cublas_workspace_cross_thread(
+            x, weight, rtol=1e-2, atol=2e-1, check_allocation=False
+        )
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/144922")
     @unittest.skipIf(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194109
* __->__ #193832

Human context:

CUDA graph replay does not perform workspace allocation, so captured cuBLAS and cuBLASLt invocations can use ordinary allocator-backed workspaces scoped to capture-time invocation.

`isStreamCapturing` was surprisingly expensive when queried on every eager invocation:

- Original total CPU launch overhead: roughly 6.5 us
- Naive `isStreamCapturing` proposal: +~0.39 us (~6%)
- Final PR: one relaxed atomic load and branch on the eager path, effectively unmeasurable

If a stream was warmed before capture, its persistent workspace remains cached, while captured invocations use separate graph-pool storage. We intentionally do not evict the warmed entry because an older live graph or raw-handle caller may still reference it.

AI context:

cuBLAS workspaces cached by handle and stream can outlive capture and pin allocations in a CUDA graph's private pool. Eager work on the capture stream can then inherit a workspace pointer into that private pool. The existing reset-time cleanup only releases the entry when the graph is destroyed.

Use a lock-free per-device active-capture counter as a cheap eager-path gate, then query the current stream before taking the capture path. Internal callers provide an invocation-scoped `DataPtr` owner while continuing to use the raw cuBLAS handle. During capture, the owner receives a fresh workspace and clears the shared handle before releasing it. cuBLASLt uses the same caller-owned lifetime for its workspace argument. The existing raw handle API remains unchanged.

Preexisting warmed workspaces remain in the persistent cache. Evicting them at capture boundaries is unsafe because a live graph created through the raw API may still reference them; the invocation-scoped path instead ensures new internal captured calls do not add persistent graph-pool allocations.

Test Plan:

```bash
pip install -e . -v --no-build-isolation
python test/test_cuda.py -k graph_capture_cublas_workspace
PYTORCH_ALLOC_CONF=backend:cudaMallocAsync python test/test_cuda.py -k graph_capture_cublas_workspace
python test/test_cuda.py -k cublas_workspace
build/bin/cuda_cublas_handle_pool_test
git diff --check
```

Scoped `lintrunner -a` and `spin quickfix` were attempted. The local environment could not bootstrap clang-format/clang-tidy or reach PyPI for the remaining tools.

Authored with assistance from an AI coding agent.
