### PR TITLE
Wire symmetric memory operations to the distributed watchdog

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -542,7 +542,7 @@ _run_fabric_handle_tests() {
   time python test/run_test.py --include distributed/test_symmetric_memory.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_nvshmem.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include distributed/test_shmem_triton.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include distributed/test_nccl.py -k NCCLSymmetricMemoryTest $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include distributed/test_nccl.py -k "NCCLSymmetricMemoryTest or NCCLSymmMemWatchdogTest" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include inductor/test_symm_mem_registry.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include inductor/test_low_contention_collectives.py $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -1409,6 +1409,7 @@ class SymmMemCftHandleTest(MultiProcessTestCase):
             hdl.get_multimem_cft_handle()
 
 
+@requires_cuda_p2p_access()
 class NCCLSymmMemWatchdogTest(MultiProcContinuousTest):
     """Test watchdog integration with real NCCL symmetric memory ops."""
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -1409,6 +1409,96 @@ class SymmMemCftHandleTest(MultiProcessTestCase):
             hdl.get_multimem_cft_handle()
 
 
+class NCCLSymmMemWatchdogTest(MultiProcContinuousTest):
+    """Test watchdog integration with real NCCL symmetric memory ops."""
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        if rdvz_file is None:
+            raise AssertionError("Expected rdvz_file to not be None")
+        os.environ["LOCAL_RANK"] = str(rank)
+        device = torch.device("cuda", rank)
+        torch.cuda.set_device(device)
+        store = c10d.FileStore(rdvz_file, world_size)
+        c10d.init_process_group(
+            backend="nccl",
+            world_size=world_size,
+            rank=rank,
+            store=store,
+            timeout=cls.timeout,
+            device_id=device,
+        )
+        cls.pg = c10d.distributed_c10d._get_default_group()
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @skip_if_lt_x_gpu(2)
+    def test_rendezvous_with_watchdog(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        symm_mem.set_watchdog_timeout(30.0)
+        try:
+            group_name = c10d.group.WORLD.group_name
+            t = symm_mem.empty(1024, dtype=torch.float, device=self.device)
+            hdl = symm_mem.rendezvous(t, group=group_name)
+            self.assertEqual(hdl.rank, self.rank)
+            self.assertEqual(hdl.world_size, self.world_size)
+        finally:
+            symm_mem.set_watchdog_timeout(None)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
+    @skip_if_lt_x_gpu(2)
+    def test_put_wait_signal_with_watchdog(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        symm_mem.set_watchdog_timeout(30.0)
+        try:
+            group_name = c10d.group.WORLD.group_name
+            t = symm_mem.empty(1024, dtype=torch.float, device=self.device).fill_(
+                self.rank
+            )
+            handle = symm_mem.rendezvous(t, group=group_name)
+            c10d.barrier()
+
+            if self.rank % 2 == 1:
+                dst_rank = self.rank - 1
+                symm_mem.put_signal(t, handle, dst_rank)
+                torch.cuda.synchronize()
+            elif self.rank % 2 == 0 and self.rank + 1 < handle.world_size:
+                src_rank = self.rank + 1
+                symm_mem.wait_signal(handle, src_rank)
+                torch.cuda.synchronize()
+
+            c10d.barrier()
+        finally:
+            symm_mem.set_watchdog_timeout(None)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @skip_if_lt_x_gpu(2)
+    def test_rendezvous_watchdog_cancel_on_exception(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        symm_mem.set_watchdog_timeout(30.0)
+        try:
+            non_symm_tensor = torch.ones(64, device=self.device)
+            with self.assertRaises(RuntimeError):
+                symm_mem.rendezvous(non_symm_tensor, group=c10d.group.WORLD.group_name)
+        finally:
+            symm_mem.set_watchdog_timeout(None)
+
+
 instantiate_device_type_tests(TestNCCL, globals(), only_for="cuda")
 
 if __name__ == "__main__":

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -2584,6 +2584,23 @@ class SymmMemWatchdogUnitTest(TestCase):
             symm_mem.put_signal(MagicMock(), hdl, 0)
             mock_stream_timeout.assert_not_called()
 
+    @patch(
+        "torch.distributed._symmetric_memory._stream_is_capturing", return_value=True
+    )
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_put_signal")
+    def test_put_signal_skips_stream_timeout_during_capture(
+        self,
+        mock_nccl_put: MagicMock,
+        mock_get_backend: MagicMock,
+        mock_capturing: MagicMock,
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            symm_mem.put_signal(MagicMock(), hdl, 0)
+            mock_stream_timeout.assert_not_called()
+
     # -- wait_signal --
 
     @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
@@ -2603,6 +2620,24 @@ class SymmMemWatchdogUnitTest(TestCase):
     def test_wait_signal_no_timeout_by_default(
         self, mock_nccl_wait: MagicMock, mock_get_backend: MagicMock
     ) -> None:
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            hdl.device = "cuda:0"
+            symm_mem.wait_signal(hdl, 0)
+            mock_stream_timeout.assert_not_called()
+
+    @patch(
+        "torch.distributed._symmetric_memory._stream_is_capturing", return_value=True
+    )
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_wait_signal")
+    def test_wait_signal_skips_stream_timeout_during_capture(
+        self,
+        mock_nccl_wait: MagicMock,
+        mock_get_backend: MagicMock,
+        mock_capturing: MagicMock,
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
         with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
             hdl = MagicMock(spec=[])
             hdl.device = "cuda:0"

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -2519,6 +2519,17 @@ class SymmMemWatchdogUnitTest(TestCase):
                 symm_mem.rendezvous(MagicMock(), "test_group")
             mock_handle.cancel.assert_called_once()
 
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_rendezvous_per_op_timeout_overrides_global(
+        self, MockSymmMem: MagicMock
+    ) -> None:
+        MockSymmMem.rendezvous.return_value = MagicMock()
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+            mock_cpu_timeout.return_value = MagicMock()
+            symm_mem.rendezvous(MagicMock(), "test_group", timeout=5.0)
+            mock_cpu_timeout.assert_called_once_with(5.0)
+
     # -- get_symm_mem_workspace --
 
     @patch("torch.distributed._symmetric_memory._SymmetricMemory")
@@ -2561,6 +2572,26 @@ class SymmMemWatchdogUnitTest(TestCase):
         finally:
             _group_name_to_workspace_tensor.pop("wd_test2", None)
 
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_get_workspace_per_op_timeout_overrides_global(
+        self, MockSymmMem: MagicMock
+    ) -> None:
+        from torch.distributed._symmetric_memory import _group_name_to_workspace_tensor
+
+        mock_tensor = MagicMock()
+        mock_tensor.numel.return_value = 1024
+        mock_tensor.element_size.return_value = 1
+        _group_name_to_workspace_tensor["wd_test3"] = mock_tensor
+        try:
+            MockSymmMem.rendezvous.return_value = MagicMock()
+            symm_mem.set_watchdog_timeout(30.0)
+            with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+                mock_cpu_timeout.return_value = MagicMock()
+                symm_mem.get_symm_mem_workspace("wd_test3", 512, timeout=5.0)
+                mock_cpu_timeout.assert_called_once_with(5.0)
+        finally:
+            _group_name_to_workspace_tensor.pop("wd_test3", None)
+
     # -- put_signal --
 
     @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
@@ -2600,6 +2631,16 @@ class SymmMemWatchdogUnitTest(TestCase):
             hdl = MagicMock(spec=[])
             symm_mem.put_signal(MagicMock(), hdl, 0)
             mock_stream_timeout.assert_not_called()
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_put_signal")
+    def test_put_signal_per_op_timeout_overrides_global(
+        self, mock_nccl_put: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            symm_mem.put_signal(MagicMock(), MagicMock(spec=[]), 0, timeout=5.0)
+            mock_stream_timeout.assert_called_once_with(5.0)
 
     # -- wait_signal --
 
@@ -2643,6 +2684,18 @@ class SymmMemWatchdogUnitTest(TestCase):
             hdl.device = "cuda:0"
             symm_mem.wait_signal(hdl, 0)
             mock_stream_timeout.assert_not_called()
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_wait_signal")
+    def test_wait_signal_per_op_timeout_overrides_global(
+        self, mock_nccl_wait: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            hdl.device = "cuda:0"
+            symm_mem.wait_signal(hdl, 0, timeout=5.0)
+            mock_stream_timeout.assert_called_once_with(5.0)
 
 
 @instantiate_parametrized_tests

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -7,7 +7,8 @@ import random
 import re
 import tempfile
 from contextlib import contextmanager, nullcontext
-from unittest import skipIf, skipUnless
+from unittest import skip, skipIf, skipUnless
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.distributed as dist
@@ -2480,6 +2481,133 @@ class SymmMemSingleProcTest(TestCase):
                 self.assertFalse(symm_mem.is_symm_mem_enabled_for_group(group_name))
         finally:
             dist.destroy_process_group()
+
+
+class SymmMemWatchdogUnitTest(TestCase):
+    def tearDown(self) -> None:
+        symm_mem.set_watchdog_timeout(None)
+        super().tearDown()
+
+    # -- rendezvous --
+
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_rendezvous_uses_cpu_timeout(self, MockSymmMem: MagicMock) -> None:
+        MockSymmMem.rendezvous.return_value = MagicMock()
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+            mock_handle = MagicMock()
+            mock_cpu_timeout.return_value = mock_handle
+            symm_mem.rendezvous(MagicMock(), "test_group")
+            mock_cpu_timeout.assert_called_once_with(30.0)
+            mock_handle.cancel.assert_called_once()
+
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_rendezvous_no_timeout_by_default(self, MockSymmMem: MagicMock) -> None:
+        MockSymmMem.rendezvous.return_value = MagicMock()
+        with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+            symm_mem.rendezvous(MagicMock(), "test_group")
+            mock_cpu_timeout.assert_not_called()
+
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_rendezvous_cancels_on_exception(self, MockSymmMem: MagicMock) -> None:
+        MockSymmMem.rendezvous.side_effect = RuntimeError("boom")
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+            mock_handle = MagicMock()
+            mock_cpu_timeout.return_value = mock_handle
+            with self.assertRaises(RuntimeError):
+                symm_mem.rendezvous(MagicMock(), "test_group")
+            mock_handle.cancel.assert_called_once()
+
+    # -- get_symm_mem_workspace --
+
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_get_workspace_uses_cpu_timeout(self, MockSymmMem: MagicMock) -> None:
+        from torch.distributed._symmetric_memory import _group_name_to_workspace_tensor
+
+        mock_tensor = MagicMock()
+        mock_tensor.numel.return_value = 1024
+        mock_tensor.element_size.return_value = 1
+        _group_name_to_workspace_tensor["wd_test"] = mock_tensor
+        try:
+            MockSymmMem.rendezvous.return_value = MagicMock()
+            symm_mem.set_watchdog_timeout(30.0)
+            with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+                mock_handle = MagicMock()
+                mock_cpu_timeout.return_value = mock_handle
+                symm_mem.get_symm_mem_workspace("wd_test", 512)
+                mock_cpu_timeout.assert_called_once_with(30.0)
+                mock_handle.cancel.assert_called_once()
+        finally:
+            _group_name_to_workspace_tensor.pop("wd_test", None)
+
+    @patch("torch.distributed._symmetric_memory._SymmetricMemory")
+    def test_get_workspace_cancels_on_exception(self, MockSymmMem: MagicMock) -> None:
+        from torch.distributed._symmetric_memory import _group_name_to_workspace_tensor
+
+        mock_tensor = MagicMock()
+        mock_tensor.numel.return_value = 1024
+        mock_tensor.element_size.return_value = 1
+        _group_name_to_workspace_tensor["wd_test2"] = mock_tensor
+        try:
+            MockSymmMem.rendezvous.side_effect = RuntimeError("boom")
+            symm_mem.set_watchdog_timeout(30.0)
+            with patch("torch.distributed._watchdog.cpu_timeout") as mock_cpu_timeout:
+                mock_handle = MagicMock()
+                mock_cpu_timeout.return_value = mock_handle
+                with self.assertRaises(RuntimeError):
+                    symm_mem.get_symm_mem_workspace("wd_test2", 512)
+                mock_handle.cancel.assert_called_once()
+        finally:
+            _group_name_to_workspace_tensor.pop("wd_test2", None)
+
+    # -- put_signal --
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_put_signal")
+    def test_put_signal_uses_stream_timeout(
+        self, mock_nccl_put: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            symm_mem.put_signal(MagicMock(), hdl, 0)
+            mock_stream_timeout.assert_called_once_with(30.0)
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_put_signal")
+    def test_put_signal_no_timeout_by_default(
+        self, mock_nccl_put: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            symm_mem.put_signal(MagicMock(), hdl, 0)
+            mock_stream_timeout.assert_not_called()
+
+    # -- wait_signal --
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_wait_signal")
+    def test_wait_signal_uses_stream_timeout(
+        self, mock_nccl_wait: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        symm_mem.set_watchdog_timeout(30.0)
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            hdl.device = "cuda:0"
+            symm_mem.wait_signal(hdl, 0)
+            mock_stream_timeout.assert_called_once_with(30.0)
+
+    @patch("torch.distributed._symmetric_memory.get_backend", return_value="NCCL")
+    @patch("torch.ops.symm_mem.nccl_wait_signal")
+    def test_wait_signal_no_timeout_by_default(
+        self, mock_nccl_wait: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        with patch("torch.distributed._watchdog.stream_timeout") as mock_stream_timeout:
+            hdl = MagicMock(spec=[])
+            hdl.device = "cuda:0"
+            symm_mem.wait_signal(hdl, 0)
+            mock_stream_timeout.assert_not_called()
 
 
 @instantiate_parametrized_tests

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -7,7 +7,7 @@ import random
 import re
 import tempfile
 from contextlib import contextmanager, nullcontext
-from unittest import skip, skipIf, skipUnless
+from unittest import skipIf, skipUnless
 from unittest.mock import MagicMock, patch
 
 import torch

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -24,7 +24,7 @@ from torch._prims_common import make_contiguous_strides_for
 from torch.utils._triton import has_triton
 
 
-_watchdog_timeout: float | timedelta | None = timedelta(minutes=10)
+_watchdog_timeout: float | timedelta | None = None
 
 
 def set_watchdog_timeout(timeout: float | timedelta | None) -> None:

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -35,6 +35,10 @@ def set_watchdog_timeout(timeout: float | timedelta | None) -> None:
     duration. Stream operations (e.g. put_signal, wait_signal) are guarded by
     a stream watchdog timer.
 
+    The stream watchdog is skipped during CUDA graph capture: its deadline
+    would be anchored at capture time rather than replay time, and the recorded
+    event would be baked into the graph. The CPU watchdog is unaffected.
+
     Pass ``None`` to disable the watchdog.
 
     Args:
@@ -51,6 +55,18 @@ def get_watchdog_timeout() -> float | timedelta | None:
     ``None`` if no watchdog is configured.
     """
     return _watchdog_timeout
+
+
+def _stream_is_capturing() -> bool:
+    # The stream watchdog is not supported under CUDA graph capture: its
+    # deadline is anchored when it is registered (capture time), not when the
+    # captured op actually runs (replay time), so it would false-fire, and the
+    # recorded event would be baked into the graph. Skip registration while
+    # capturing.
+    return (
+        torch.accelerator.is_available()
+        and torch.accelerator.current_stream().is_capturing()
+    )
 
 
 _group_name_to_store: dict[str, c10d.Store] = {}
@@ -2563,7 +2579,7 @@ def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"put_signal: unsupported backend: {backend}")
-    if _watchdog_timeout is not None:
+    if _watchdog_timeout is not None and not _stream_is_capturing():
         from torch.distributed._watchdog import stream_timeout
 
         stream_timeout(_watchdog_timeout)
@@ -2587,7 +2603,7 @@ def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"wait_signal: unsupported backend: {backend}")
-    if _watchdog_timeout is not None:
+    if _watchdog_timeout is not None and not _stream_is_capturing():
         from torch.distributed._watchdog import stream_timeout
 
         stream_timeout(_watchdog_timeout)

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -24,7 +24,7 @@ from torch._prims_common import make_contiguous_strides_for
 from torch.utils._triton import has_triton
 
 
-_watchdog_timeout: float | timedelta | None = None
+_watchdog_timeout: float | timedelta | None = timedelta(minutes=10)
 
 
 def set_watchdog_timeout(timeout: float | timedelta | None) -> None:

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -57,6 +57,14 @@ def get_watchdog_timeout() -> float | timedelta | None:
     return _watchdog_timeout
 
 
+def _resolve_watchdog_timeout(
+    timeout: float | timedelta | None,
+) -> float | timedelta | None:
+    # A per-op ``timeout`` overrides the global default from
+    # ``set_watchdog_timeout``; ``None`` falls back to that default.
+    return timeout if timeout is not None else _watchdog_timeout
+
+
 def _stream_is_capturing() -> bool:
     # The stream watchdog is not supported under CUDA graph capture: its
     # deadline is anchored when it is registered (capture time), not when the
@@ -152,7 +160,9 @@ _group_name_to_workspace_tensor: dict[str, torch.Tensor | None] = {}
 
 
 def get_symm_mem_workspace(
-    group_name: c10d.GroupName, min_size: int
+    group_name: c10d.GroupName,
+    min_size: int,
+    timeout: float | timedelta | None = None,
 ) -> _SymmetricMemory:
     """
     Get the symmetric memory workspace associated with the process group. If
@@ -162,6 +172,9 @@ def get_symm_mem_workspace(
     Args:
         group_name (str): the name of the process group.
         min_size (int): the size requirement for the workspace in bytes.
+        timeout (float | timedelta | None): per-op CPU watchdog timeout override.
+            Falls back to the global default from :func:`set_watchdog_timeout`
+            when ``None``.
 
     Returns:
         _SymmetricMemory: the symmetric memory workspace associated with the
@@ -192,10 +205,11 @@ def get_symm_mem_workspace(
             group_name,
         )
         _group_name_to_workspace_tensor[group_name] = tensor
-    if _watchdog_timeout is not None:
+    effective_timeout = _resolve_watchdog_timeout(timeout)
+    if effective_timeout is not None:
         from torch.distributed._watchdog import cpu_timeout
 
-        handle = cpu_timeout(_watchdog_timeout)
+        handle = cpu_timeout(effective_timeout)
         try:
             return _SymmetricMemory.rendezvous(tensor)
         finally:
@@ -2301,10 +2315,12 @@ def _resolve_group_name(group: c10d.GroupName | ProcessGroup) -> c10d.GroupName:
 
 
 def rendezvous(
-    tensor: torch.Tensor, group: c10d.GroupName | ProcessGroup
+    tensor: torch.Tensor,
+    group: c10d.GroupName | ProcessGroup,
+    timeout: float | timedelta | None = None,
 ) -> _SymmetricMemory:
     r"""
-    rendezvous(tensor, group) -> _SymmetricMemory
+    rendezvous(tensor, group, timeout=None) -> _SymmetricMemory
 
     Establish a symmetric memory tensor among participating processes. This is
     a collective operation.
@@ -2323,12 +2339,16 @@ def rendezvous(
             dtype, and device type must be identical across all participating processes.
         group (Union[str, :class:`torch.distributed.ProcessGroup`]): The group identifying the
             participating processes. This can be either a group name or a process group object.
+        timeout (float | timedelta | None): per-op CPU watchdog timeout override.
+            Falls back to the global default from :func:`set_watchdog_timeout`
+            when ``None``.
     """
     group_name = _resolve_group_name(group)
-    if _watchdog_timeout is not None:
+    effective_timeout = _resolve_watchdog_timeout(timeout)
+    if effective_timeout is not None:
         from torch.distributed._watchdog import cpu_timeout
 
-        handle = cpu_timeout(_watchdog_timeout)
+        handle = cpu_timeout(effective_timeout)
         try:
             return _SymmetricMemory.rendezvous(tensor, group_name)
         finally:
@@ -2558,9 +2578,14 @@ def get(
         raise ValueError(f"get: unsupported backend: {backend}")
 
 
-def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
+def put_signal(
+    src: torch.Tensor,
+    hdl: _SymmetricMemory,
+    peer: int,
+    timeout: float | timedelta | None = None,
+) -> None:
     r"""
-    put_signal(src, hdl, peer) -> None
+    put_signal(src, hdl, peer, timeout=None) -> None
 
     Put data to a peer's symmetric memory and signal the peer.
 
@@ -2568,6 +2593,9 @@ def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
         src (torch.Tensor): the source tensor to read data from.
         hdl (SymmetricMemory): the symmetric memory to put data to.
         peer (int): the peer to put data to.
+        timeout (float | timedelta | None): per-op stream watchdog timeout
+            override. Falls back to the global default from
+            :func:`set_watchdog_timeout` when ``None``.
     """
     backend = get_backend(src.device)
     # `hdl` is a pybind `_SymmetricMemory` object. Dispatcher expects the
@@ -2579,21 +2607,27 @@ def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"put_signal: unsupported backend: {backend}")
-    if _watchdog_timeout is not None and not _stream_is_capturing():
+    effective_timeout = _resolve_watchdog_timeout(timeout)
+    if effective_timeout is not None and not _stream_is_capturing():
         from torch.distributed._watchdog import stream_timeout
 
-        stream_timeout(_watchdog_timeout)
+        stream_timeout(effective_timeout)
 
 
-def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
+def wait_signal(
+    hdl: _SymmetricMemory, peer: int, timeout: float | timedelta | None = None
+) -> None:
     r"""
-    wait_signal(hdl, peer) -> None
+    wait_signal(hdl, peer, timeout=None) -> None
 
     Wait for a signal from a peer.
 
     Args:
         hdl (SymmetricMemory): the symmetric memory handle on which to wait for a signal.
         peer (int): the peer to wait for a signal from.
+        timeout (float | timedelta | None): per-op stream watchdog timeout
+            override. Falls back to the global default from
+            :func:`set_watchdog_timeout` when ``None``.
     """
     backend = get_backend(hdl.device)
     # See note in `put_signal` about `_SymmetricMemory` vs TorchBind type.
@@ -2603,10 +2637,11 @@ def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"wait_signal: unsupported backend: {backend}")
-    if _watchdog_timeout is not None and not _stream_is_capturing():
+    effective_timeout = _resolve_watchdog_timeout(timeout)
+    if effective_timeout is not None and not _stream_is_capturing():
         from torch.distributed._watchdog import stream_timeout
 
-        stream_timeout(_watchdog_timeout)
+        stream_timeout(effective_timeout)
 
 
 def reduce_scatter_offset(

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -24,6 +24,35 @@ from torch._prims_common import make_contiguous_strides_for
 from torch.utils._triton import has_triton
 
 
+_watchdog_timeout: float | timedelta | None = None
+
+
+def set_watchdog_timeout(timeout: float | timedelta | None) -> None:
+    """
+    Set the watchdog timeout for symmetric memory operations. This is a global
+    setting. When set, blocking operations (e.g. rendezvous) are guarded by a
+    CPU watchdog timer that fires if the operation exceeds the configured
+    duration. Stream operations (e.g. put_signal, wait_signal) are guarded by
+    a stream watchdog timer.
+
+    Pass ``None`` to disable the watchdog.
+
+    Args:
+        timeout (float | timedelta | None): timeout in seconds (float) or as a
+            timedelta. ``None`` disables the watchdog.
+    """
+    global _watchdog_timeout
+    _watchdog_timeout = timeout
+
+
+def get_watchdog_timeout() -> float | timedelta | None:
+    """
+    Return the current watchdog timeout for symmetric memory operations, or
+    ``None`` if no watchdog is configured.
+    """
+    return _watchdog_timeout
+
+
 _group_name_to_store: dict[str, c10d.Store] = {}
 
 
@@ -147,6 +176,14 @@ def get_symm_mem_workspace(
             group_name,
         )
         _group_name_to_workspace_tensor[group_name] = tensor
+    if _watchdog_timeout is not None:
+        from torch.distributed._watchdog import cpu_timeout
+
+        handle = cpu_timeout(_watchdog_timeout)
+        try:
+            return _SymmetricMemory.rendezvous(tensor)
+        finally:
+            handle.cancel()
     return _SymmetricMemory.rendezvous(tensor)
 
 
@@ -2272,6 +2309,14 @@ def rendezvous(
             participating processes. This can be either a group name or a process group object.
     """
     group_name = _resolve_group_name(group)
+    if _watchdog_timeout is not None:
+        from torch.distributed._watchdog import cpu_timeout
+
+        handle = cpu_timeout(_watchdog_timeout)
+        try:
+            return _SymmetricMemory.rendezvous(tensor, group_name)
+        finally:
+            handle.cancel()
     return _SymmetricMemory.rendezvous(tensor, group_name)
 
 
@@ -2518,6 +2563,10 @@ def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"put_signal: unsupported backend: {backend}")
+    if _watchdog_timeout is not None:
+        from torch.distributed._watchdog import stream_timeout
+
+        stream_timeout(_watchdog_timeout)
 
 
 def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
@@ -2538,6 +2587,10 @@ def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
     # TODO: other backends' dispatch goes here
     else:
         raise ValueError(f"wait_signal: unsupported backend: {backend}")
+    if _watchdog_timeout is not None:
+        from torch.distributed._watchdog import stream_timeout
+
+        stream_timeout(_watchdog_timeout)
 
 
 def reduce_scatter_offset(


### PR DESCRIPTION
### Summary 
Integrates the `torch.distributed._watchdog` timeout machinery into symmetric  memory's blocking and stream-based operations so that hangs in multi-process rendezvous or one-sided NCCL ops are detected and surfaced instead of blocking silently.

### Test Plan 

```
python test/distributed/test_symmetric_memory.py -k SymmMemWatchdogUnitTest
torchrun --nproc_per_node=2 test/distributed/test_nccl.py -k NCCLSymmMemWatchdogTest
```

Authored with AI assistance