### PR TITLE
[CRCR] Add vllm-project/vllm to the L2 allowlist

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -46,6 +46,7 @@ L2:
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre
+  - vllm-project/vllm
 
 L3:
   # Canonical test repos for CRCR.


### PR DESCRIPTION
```diff
 L2:
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre
+  - vllm-project/vllm
```

## Why

vLLM is adding a step to report its `Full CI run - torch nightly` results to CRCR (vllm-project/vllm#51830), so a torch nightly that breaks vLLM becomes visible on [hud.pytorch.org/crcr](https://hud.pytorch.org/crcr) instead of being noticed by hand.

This file is the only place that mapping lives, and it is read by both consumers:

- the relay resolves `downstream_repo_level` from it and forwards that to HUD (`aws/lambda/cross_repo_ci_relay/utils/allowlist.py`)
- the HUD page fetches it directly from `raw.githubusercontent.com/pytorch/pytorch/main/.github/allowlist.yml` (`torchci/pages/api/crcr/allowlist.ts`)

Without an entry vLLM's callbacks are neither authorized nor tiered, so no rows appear.

## Why L2

Per the levels documented at the top of this file, L2 is *Observation* — downstream CI results show on the HUD page but not on PRs. That is exactly what the nightly self-report needs: no check runs, no PR feedback, no merge gating. L3/L4 would add PR-visible check runs that nobody has asked for here.

## Verified

Parsed the edited file with the relay's own parser rather than just as YAML:

```
relay parser accepted the file
  get_repo_level('vllm-project/vllm') -> AllowlistLevel.L2
  get_repo_level('Ascend/pytorch')    -> AllowlistLevel.L2
  get_repo_level('pytorch/crcr-test') -> AllowlistLevel.L3
  get_repo_level('not/here')          -> None
```

Also checked for repos duplicated across levels, which the relay rejects — none.

## This alone is not sufficient

Two other pieces are needed before vLLM rows actually appear, neither in this PR:

1. **A Buildkite mapping in `pytorch/test-infra:aws/lambda/cross_repo_ci_relay/config/ci_providers.yml`.** That file currently contains only commented-out examples, so the relay cannot resolve vLLM's OIDC token to a repo identity. It needs the immutable `organization_id/pipeline_id` UUIDs plus `required_claims: {build_branch: [main]}`, since the vLLM pipeline builds fork PRs.
2. **`CRCR_CALLBACK_URL` and `BUILDKITE_API_TOKEN`** present in the vLLM pipeline or nightly-schedule environment.

Worth knowing that every failure path in vLLM's reporting script exits 0 and the step is `soft_fail: true` — correct so reporting never gates the nightly, but it means a missing mapping or unset variable is **silent**. Confirm success by checking for `vllm-project/vllm` rows after the next nightly, not by the build going green.