### PR TITLE
[pt2] Fix barrier deps to exclude nodes defined after sync point

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1951,6 +1951,77 @@ class GraphModule(torch.nn.Module):
                 f"sum consumer {inp} does not route through synchronize_event barrier",
             )
 
+    def test_barrier_deps_exclude_nodes_defined_after_sync(self):
+        """A get_attr constant first used after the barrier is not a barrier dep.
+
+        The constant is materialized at its first user, which is below the
+        barrier, so listing it as a dep would make the control_deps node
+        reference a value that is not yet defined.
+        """
+
+        def fn(x, w):
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                a = x @ w
+            s.synchronize()
+            return a.sum() + torch.tensor([1.0, 2.0, 3.0], device="cuda").sum()
+
+        x = torch.randn(32, 32, device="cuda")
+        w = torch.randn(32, 32, device="cuda")
+        expected = fn(x, w)
+        result, _, fw_graphs, _ = extract_graph(fn, x, w)
+        self.assertEqual(result, expected)
+
+        graph = fw_graphs[0].graph
+        order = {node: i for i, node in enumerate(graph.nodes)}
+        cds = [
+            node
+            for node in graph.nodes
+            if node.op == "call_function" and "control_deps" in str(node.target)
+        ]
+        self.assertGreater(len(cds), 0, "no control_deps node found")
+
+        # Guard against a vacuous pass. The ordering assertions below only
+        # exercise the fix while a tensor constant is still materialized
+        # *below* the barrier -- that is the whole failure condition. If
+        # constant lifting ever hoists the constant above the sync or turns it
+        # into a placeholder, the scenario stops reproducing and this test
+        # would silently stop guarding the regression, so fail loudly instead.
+        # Every control_deps carries its own get_attr for its subgraph, so
+        # those are excluded; only real constants count.
+        subgraph_attrs = {
+            cd.args[1] for cd in cds if isinstance(cd.args[1], torch.fx.Node)
+        }
+        sync_cd = None
+        for cd in cds:
+            attr = cd.args[1]
+            if isinstance(attr, torch.fx.Node) and "synchronize" in attr.name:
+                sync_cd = cd
+        self.assertIsNotNone(sync_cd, "no synchronize control_deps node found")
+
+        constants_after_sync = [
+            node
+            for node in graph.nodes
+            if node.op == "get_attr"
+            and node not in subgraph_attrs
+            and order[node] > order[sync_cd]
+        ]
+        self.assertTrue(
+            constants_after_sync,
+            "scenario no longer reproduces: no tensor constant is materialized "
+            "after the synchronize barrier, so the ordering checks below cannot "
+            "fail. Rework the graph so a constant is first used after the sync.",
+        )
+
+        for cd in cds:
+            for dep in (*cd.args[0], *cd.args[2:]):
+                if isinstance(dep, torch.fx.Node):
+                    self.assertLess(
+                        order[dep],
+                        order[cd],
+                        f"dep {dep} of {cd} is defined after it is used",
+                    )
+
 
 @unittest.skipUnless(TEST_CUDA, "requires CUDA")
 @xfailIfNoAcceleratorTriton

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -613,6 +613,15 @@ def _collect_sync_forward_deps(
         node_locations.add((partition, stream))
 
     for node in reversed(graph.nodes):
+        # Reaching a node's definition ends its liveness. A sync's control_deps is
+        # inserted at the sync, so a dep whose definition site is below that point
+        # would be referenced before it has been defined. Applies to every node
+        # kind, not just call_function: get_attr tensor constants are materialized
+        # next to their first user, which can be after the sync.
+        inherited_locations = locations.pop(node, _EMPTY_LOCATIONS)
+        for partition, stream in inherited_locations:
+            live_inputs[partition][stream].discard(node)
+
         if node.op == "call_function" and node.target in full_barriers:
             deps = OrderedSet(
                 dep
@@ -644,9 +653,6 @@ def _collect_sync_forward_deps(
         if node.op != "call_function" or node.target in _SYNC_OPS:
             continue
 
-        inherited_locations = locations.pop(node, _EMPTY_LOCATIONS)
-        for partition, stream in inherited_locations:
-            live_inputs[partition][stream].discard(node)
         execution_stream = get_stream(node)
         if execution_stream is None:
             execution_stream = 0


### PR DESCRIPTION
Summary:
Fixes a compile-time crash ("used before it has been defined") when user-annotated CUDA streams are combined with CPU-side barriers.

The liveness collection pass was including nodes whose definition sites occur *below* the barrier insertion point. When the barrier's `control_deps` node referenced those values, inductor's topological verifier rejected the graph. Moved the collection cutoff to trigger at each node's definition rather than its usage sites. Only affects graphs that use the streams API -- unannotated code paths never enter the pass, which is why CI stayed green.

Regressed in D114243554 (#189096), which replaced the forward-scanning `_collect_wait_stream_forward_deps` (immune, since it consulted an explicit `nodes_before` set) with the reverse-liveness `_collect_sync_forward_deps`. Bisect evidence: fbpkg `:503` (Jul 29, before #189096) boots and passes smoke tests; current `main` fails.

Repro / signal:
- Failing: ServiceLab experiment 1074715028541659
- Passing baseline: ServiceLab experiment 974752078914471

---
Agent Home session: https://www.internalfb.com/agent-home?session_id=dmh-fbdfee6f-57e1-4b17-a3db-89980eb386e7

Test Plan:
**This test has not been executed.** The development environment has no GPU and no torch installed, and the suite is gated on `skipUnless(TEST_CUDA)`. Everything below is from reading the code.

The new `test_barrier_deps_exclude_nodes_defined_after_sync` constructs the exact failure scenario -- a `get_attr` tensor constant materialized after a `synchronize()` barrier -- and asserts that every dep of every `control_deps` node is defined *before* that node in topological order. It should fail before this fix (constant listed as a dep while defined later) and pass after (constant excluded).

The test also asserts up front that a `get_attr` really is defined below the barrier, so it fails loudly rather than passing vacuously if constant lifting ever changes and the scenario stops reproducing.

**Request to the oncall:** please run the full target, not just the new case:

```
buck2 test @//mode/opt //caffe2/test/inductor:user_streams
```

`test_synchronize_threads_all_prior_sync_data` and `test_synchronize_event_threads_all_prior_sync_data` both assert exact consumer routing through barriers and would catch over-filtering if the hoisted cutoff discarded legitimate deps. Re-running ServiceLab experiment 1074715028541659 would confirm the original crash is gone.

Authored with the assistance of an AI coding agent; all claims above are code-reading only and have not been validated by execution.

Reviewed By: mlazos

Differential Revision: D115646338




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo