### PR TITLE
Fix logcumsumexp CUDA compile error with older CCCL versions

### DIFF
--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -106,17 +106,26 @@ __device__ c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_
   }
 }
 
+// Named function object rather than a `__device__` lambda: CUB's scan dispatch
+// queries the operator's return type in host code, which is ill-formed for an
+// extended `__device__` lambda. It must stay `__device__`-only because
+// `_log_add_exp_helper` reaches `c10::cuda::compat::sincos`, which is
+// device-only under HIP.
+template <typename scalar_t>
+struct LogAddExpOp {
+  __device__ scalar_t operator()(const scalar_t x_, const scalar_t y_) const {
+    using opmath_t = at::opmath_type<scalar_t>;
+    const opmath_t x{x_}, y{y_};
+    return _log_add_exp_helper(x, y);
+  }
+};
+
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16,
       self.scalar_type(), "logcumsumexp_cuda",
       [&]() {
-        using opmath_t = at::opmath_type<scalar_t>;
         scalar_t init = -std::numeric_limits<scalar_t>::infinity();
-        auto log_add_exp = [] C10_DEVICE (const scalar_t x_, const scalar_t y_) -> scalar_t {
-          const opmath_t x{x_}, y{y_};
-          return _log_add_exp_helper(x, y);
-        };
-        scan_dim<scalar_t>(self, result, dim, init, log_add_exp);
+        scan_dim<scalar_t>(self, result, dim, init, LogAddExpOp<scalar_t>{});
       });
 }
 


### PR DESCRIPTION
Summary:
`logcumsumexp` fails to compile on CUDA with older CCCL/CUB versions.

The scan operator passed to `cuda::cub::inclusive_scan` is an *extended*
`__device__` lambda (a lambda marked `__device__` but defined inside a host
function). Older CUB computes its intermediate accumulator type as
`decay_t<invoke_result_t<ScanOpT, InitT, InputT>>` while running in **host**
code, and nvcc forbids querying an extended `__device__` lambda's return type
from the host:

> Attempt to use an extended `__device__` lambda in a context that requires
> querying its return type in host code. Use a named function object, a
> `__host__ __device__` lambda, or `cuda::proclaim_return_type` instead.

The error repeats for every dtype the kernel dispatches over (`Half`,
`BFloat16`, `complex<float>`, `complex<double>`) until the compiler gives up
with "too many errors emitted".

Newer CCCL no longer performs this host-side query, which is why this is not
seen when building against a recent CUDA toolkit. Anyone building against an
older one hits it.

Note that simply restoring the `__host__ __device__` qualifier on the lambda is
not a valid fix. The lambda calls `_log_add_exp_helper`, which is
`__device__`-only, and that is deliberate: it reaches
`c10::cuda::compat::sincos`, which is device-only under HIP. Widening the call
chain back to `__host__ __device__` would break the ROCm build.

Instead, use a named function object -- the first alternative the compiler
itself suggests. The host-side return-type restriction applies only to extended
`__device__` lambdas, not to named functors, so `operator()` can stay
`__device__`-only. This keeps ROCm working and compiles across CCCL versions
without any new includes. `cuda::proclaim_return_type` would also work, but the
functor needs no additional dependency.

No functional change: the operator body is identical, so numerics are
unaffected.

Test Plan:
Built the CUDA ATen library against a CUDA 12.4 toolchain, whose bundled CUB
still performs the host-side return-type query. The build fails before this
change with the `static_assert` quoted in the summary and succeeds after it.

Also verified the change is a no-op for behavior: `scan_dim` takes its binary
operator by value, and the functor's `operator()` body is character-for-character
the same as the old lambda body.

Differential Revision: D116351882


