### PR TITLE
Fix Greenlight bot login in merge_rules approved_by

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -637,7 +637,7 @@
   patterns:
   - '*'
   approved_by:
-  - pytorchgreenlight[bot]
+  - pytorchgreenlight
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
**Impact:** trymerge / auto-merge for the Greenlight Review Bot rule
**Risk:** low

## What
Change the `approved_by` entry for the Greenlight Review Bot merge rule from `pytorchgreenlight[bot]` to `pytorchgreenlight`.

## Why
trymerge matches `approved_by` against the reviewer login as it appears in the PR approval data, which does not carry the `[bot]` suffix. With the suffix, Greenlight approvals never satisfied this rule, so merges gated on it wouldn't go through. Dropping `[bot]` makes the login match.