### PR TITLE
Disabling Origami for ROCm 10.0 and above.

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -32,9 +32,9 @@ PERF_SLOWDOWN_TOLERANCE = 1.05  # 5% tolerance on performance
 # Use torch.cuda.get_device_properties() to query actual device capabilities.
 
 IS_ROCM = torch.version.hip is not None
-_rocm_version = (
-    tuple(int(v) for v in torch.version.hip.split(".")[:2]) if IS_ROCM else (0, 0)
-)
+
+if IS_ROCM:
+    _rocm_version = tuple(int(v) for v in torch.version.rocm.split(".")[:2])
 ORIGAMI_ROCM_SUPPORTED = IS_ROCM and _rocm_version < (10, 0)
 
 try:

--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -32,6 +32,10 @@ PERF_SLOWDOWN_TOLERANCE = 1.05  # 5% tolerance on performance
 # Use torch.cuda.get_device_properties() to query actual device capabilities.
 
 IS_ROCM = torch.version.hip is not None
+_rocm_version = (
+    tuple(int(v) for v in torch.version.hip.split(".")[:2]) if IS_ROCM else (0, 0)
+)
+ORIGAMI_ROCM_SUPPORTED = IS_ROCM and _rocm_version < (10, 0)
 
 try:
     import origami
@@ -61,6 +65,10 @@ def tearDownModule():
 
 @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU and Triton")
 @unittest.skipIf(not IS_ROCM, "Origami integration is ROCm-only")
+@unittest.skipIf(
+    not ORIGAMI_ROCM_SUPPORTED,
+    "Origami is not supported on ROCm 10.0+",
+)
 @unittest.skipIf(not HAS_ORIGAMI, "Origami package is not installed")
 @unittest.skipIf(
     not (config.max_autotune and config.rocm.origami),
@@ -492,7 +500,7 @@ class TestOrigami(TestCase):
         snippet = (
             "import os, torch\n"
             "from torch._inductor import config\n"
-            "from torch._inductor.template_heuristics import triton as th\n"
+            "from torch._inductor.heuristics.template import triton as th\n"
             "assert os.environ.get('TORCHINDUCTOR_ORIGAMI') == '0', 'env var not set to 0'\n"
             "assert th.origami is None, f'expected None, got {th.origami!r}'\n"
             "# Even after flipping the config knob mid-process, origami stays None\n"
@@ -520,7 +528,8 @@ class TestOrigami(TestCase):
 
 
 @unittest.skipIf(
-    HAS_GPU_AND_TRITON and IS_ROCM, "Skipped on ROCm where origami is available"
+    HAS_GPU_AND_TRITON and ORIGAMI_ROCM_SUPPORTED,
+    "Skipped on ROCm < 10.0 where origami is available",
 )
 class TestOrigamiSkippedOnNonROCm(TestCase):
     """Test that origami is properly skipped on non-ROCm devices (CUDA/CPU).

--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -8,6 +8,10 @@ from unittest import mock
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor import config
+from torch._inductor.heuristics.template.triton import (
+    _rocm_version as _th_rocm_version,
+    ORIGAMI_UNSUPPORTED_ROCM_VERSION,
+)
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
@@ -33,9 +37,7 @@ PERF_SLOWDOWN_TOLERANCE = 1.05  # 5% tolerance on performance
 
 IS_ROCM = torch.version.hip is not None
 
-if IS_ROCM:
-    _rocm_version = tuple(int(v) for v in torch.version.rocm.split(".")[:2])
-ORIGAMI_ROCM_SUPPORTED = IS_ROCM and _rocm_version < (10, 0)
+ORIGAMI_ROCM_SUPPORTED = IS_ROCM and _th_rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
 
 try:
     import origami
@@ -532,8 +534,9 @@ class TestOrigami(TestCase):
     "Skipped on ROCm < 10.0 where origami is available",
 )
 class TestOrigamiSkippedOnNonROCm(TestCase):
-    """Test that origami is properly skipped on non-ROCm devices (CUDA/CPU).
+    """Test that origami is properly skipped on unsupported environments.
 
+    Covers non-ROCm hardware (CUDA/CPU) and ROCm >= ORIGAMI_UNSUPPORTED_ROCM_VERSION.
     These tests verify that:
     1. origami configuration does not cause errors when disabled
     2. origami.select_topk_configs is not called on non-ROCm hardware
@@ -644,6 +647,54 @@ class TestOrigamiSkippedOnNonROCm(TestCase):
                 compiled = torch.compile(test_fn, dynamic=False)
                 result = compiled(a, b)
                 torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-5)
+
+
+class TestOrigamiVersionGate(TestCase):
+    """Unit tests for the _rocm_version / _origami_enabled() cutoff.
+
+    No GPU or origami package required: all paths are exercised by patching
+    the module-level _rocm_version directly.
+    """
+
+    def test_origami_enabled_below_cutoff(self):
+        """_origami_enabled() returns True on ROCm just below the cutoff."""
+        import torch._inductor.heuristics.template.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (9, 9)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertTrue(th._origami_enabled())
+
+    def test_origami_disabled_at_cutoff(self):
+        """_origami_enabled() returns False at exactly the cutoff version."""
+        import torch._inductor.heuristics.template.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (10, 0)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertFalse(th._origami_enabled())
+
+    def test_origami_disabled_above_cutoff(self):
+        """_origami_enabled() returns False above the cutoff version."""
+        import torch._inductor.heuristics.template.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (10, 1)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertFalse(th._origami_enabled())
+
+    def test_origami_config_off_below_cutoff(self):
+        """_origami_enabled() respects config.rocm.origami=False even below cutoff."""
+        import torch._inductor.heuristics.template.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (9, 9)),
+            config.patch({"rocm.origami": False}),
+        ):
+            self.assertFalse(th._origami_enabled())
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2810,6 +2810,7 @@ class rocm:
     #   - config.rocm.origami (this knob)
     #   - config.max_autotune_gemm_search_space == "DEFAULT"
     #   - rocm-origami is installed (else the import gate sets it inert)
+    #   - ROCm version < 10.0 (origami not supported on 10.0+)
     # Outside DEFAULT (e.g. EXHAUSTIVE) origami is silently bypassed with a
     # one-time warning; the regular config generator runs instead.
     #

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -58,11 +58,6 @@ else:
 log = logging.getLogger(__name__)
 
 
-def _origami_enabled() -> bool:
-    """Check if origami GEMM optimization is enabled."""
-    return config.rocm.origami
-
-
 USE_META_WS = meta_ws_enabled()
 
 
@@ -74,13 +69,22 @@ def _use_template_autows() -> bool:
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None
+_rocm_version = (
+    tuple(int(v) for v in torch.version.hip.split(".")[:2]) if IS_ROCM else (0, 0)
+)
+
+
+def _origami_enabled() -> bool:
+    """Check if origami GEMM optimization is enabled."""
+    return config.rocm.origami and _rocm_version < (10, 0)
 
 
 # rocm-origami pip pkg is only available on ROCm builds and is only used when
 # both max_autotune and config.rocm.origami are enabled (env-var driven, set once
 # at config import). Cache the import here so the hot path never pays an exception
 # and CUDA/CPU/origami-disabled processes never attempt the import.
-if IS_ROCM and config.max_autotune and config.rocm.origami:
+# origami is not supported on ROCm 10.0+.
+if IS_ROCM and _rocm_version < (10, 0) and config.max_autotune and config.rocm.origami:
     try:
         import origami  # type: ignore[import-not-found]
     except ImportError:

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -69,9 +69,9 @@ def _use_template_autows() -> bool:
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None
-_rocm_version = (
-    tuple(int(v) for v in torch.version.hip.split(".")[:2]) if IS_ROCM else (0, 0)
-)
+
+if IS_ROCM:
+    _rocm_version = tuple(int(v) for v in torch.version.rocm.split(".")[:2])
 
 
 def _origami_enabled() -> bool:

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -70,8 +70,10 @@ def _use_template_autows() -> bool:
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None
 
-if IS_ROCM:
-    _rocm_version = tuple(int(v) for v in torch.version.rocm.split(".")[:2])
+_rocm_version = (
+    tuple(int(v) for v in torch.version.rocm.split(".")[:2])  # type: ignore[union-attr]
+    if torch.version.rocm is not None else (0, 0)
+)
 
 
 def _origami_enabled() -> bool:

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -75,11 +75,13 @@ _rocm_version = (
     if torch.version.rocm is not None
     else (0, 0)
 )
+# First ROCm version where origami is not supported.
+ORIGAMI_UNSUPPORTED_ROCM_VERSION = (10, 0)
 
 
 def _origami_enabled() -> bool:
     """Check if origami GEMM optimization is enabled."""
-    return config.rocm.origami and _rocm_version < (10, 0)
+    return config.rocm.origami and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
 
 
 # rocm-origami pip pkg is only available on ROCm builds and is only used when
@@ -87,7 +89,12 @@ def _origami_enabled() -> bool:
 # at config import). Cache the import here so the hot path never pays an exception
 # and CUDA/CPU/origami-disabled processes never attempt the import.
 # origami is not supported on ROCm 10.0+.
-if IS_ROCM and _rocm_version < (10, 0) and config.max_autotune and config.rocm.origami:
+if (
+    IS_ROCM
+    and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
+    and config.max_autotune
+    and config.rocm.origami
+):
     try:
         import origami  # type: ignore[import-not-found]
     except ImportError:
@@ -98,6 +105,17 @@ if IS_ROCM and _rocm_version < (10, 0) and config.max_autotune and config.rocm.o
         )
 else:
     origami = None
+    if (
+        IS_ROCM
+        and config.rocm.origami
+        and _rocm_version >= ORIGAMI_UNSUPPORTED_ROCM_VERSION
+    ):
+        log.warning(
+            "ROCm origami GEMM selection is not supported on ROCm %d.%d+ "
+            "(detected %d.%d); origami disabled.",
+            *ORIGAMI_UNSUPPORTED_ROCM_VERSION,
+            *_rocm_version,
+        )
 
 
 # TODO(rocm-origami): replace these wrappers with public accessors when the

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -72,7 +72,8 @@ IS_ROCM = torch.version.hip is not None
 
 _rocm_version = (
     tuple(int(v) for v in torch.version.rocm.split(".")[:2])  # type: ignore[union-attr]
-    if torch.version.rocm is not None else (0, 0)
+    if torch.version.rocm is not None
+    else (0, 0)
 )
 
 


### PR DESCRIPTION
This PR is disabling Origami for ROCm versions 10.0 and above.
There is an API mismatch between the Origami pypi package and the new origami library in ROCm 10.0, we cannot use Origami till the Origami team provides a new version of the pypi package.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben