### PR TITLE
[aoti] Add private libc++ build support, resolved from build_paths (#193846)

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -23,7 +23,7 @@ from collections.abc import Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import torch
 from torch._dynamo.utils import dynamo_timed
@@ -32,6 +32,9 @@ from torch._inductor.cpu_vec_isa import invalid_vec_isa, VecISA
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.torch_version import TorchVersion
 from torch.utils._ordered_set import OrderedSet
+
+
+CppStdlib = Literal["libstdc++", "libc++"]
 
 
 if config.is_fbcode():
@@ -1308,6 +1311,7 @@ def _setup_standard_sys_libs(
     cpp_compiler: str,
     aot_mode: bool,
     use_relative_path: bool,
+    cpp_stdlib: CppStdlib,
 ) -> tuple[list[str], list[str], list[str], list[str]]:
     cflags: list[str] = []
     include_dirs: list[str] = []
@@ -1317,17 +1321,38 @@ def _setup_standard_sys_libs(
         return cflags, include_dirs, passthrough_args, ldflags
 
     if config.is_fbcode():
-        # TODO(T203137008) Can we unify these flags with triton_cc_command?
-        cflags.append("nostdinc")
-        # Note that the order of include paths do matter, as a result
-        # we need to have several branches interleaved here
+        if aot_mode and cpp_stdlib == "libc++":
+            stdlib_isystem = build_paths.aoti_libcxx_include
+            # Use -nostdinc++ to strip the default C++ stdlib path, then add
+            # our AOTI libc++ headers via -I.  We avoid -stdlib++-isystem
+            # because it creates an isolated include realm that breaks
+            # libc++'s C header wrappers (ctype.h, stddef.h, etc.).
+            passthrough_args.append(" -nostdinc++")
+            # No -D_LIBCPP_* here: the package's __config_site carries the
+            # configuration and libc++'s own __config includes it, so these
+            # headers self-configure identically to how the archives were
+            # built. Passing flags as well would be a second source of truth.
+            cflags.append("fvisibility=hidden")
+            cflags.append("fvisibility-inlines-hidden")
+
+            # Note that the order of include paths do matter.
+            # libc++ headers must come first so C wrappers are found before
+            # the compiler's or glibc's versions.
+            include_dirs.append(stdlib_isystem)
+        else:
+            # Non-AOT fbcode CPU kernels still rely on the existing libstdc++
+            # toolchain path and may link split translation units that call
+            # generated inline helpers across object boundaries.
+            cflags.append("nostdinc")
+
         include_dirs.append(build_paths.sleef_include)
         include_dirs.append(build_paths.openmp_include)
         include_dirs.append(build_paths.python_include)
         include_dirs.append(build_paths.cc_include)
-        include_dirs.append(build_paths.libgcc_include)
-        include_dirs.append(build_paths.libgcc_arch_include)
-        include_dirs.append(build_paths.libgcc_backward_include)
+        if not aot_mode or cpp_stdlib == "libstdc++":
+            include_dirs.append(build_paths.libgcc_include)
+            include_dirs.append(build_paths.libgcc_arch_include)
+            include_dirs.append(build_paths.libgcc_backward_include)
         include_dirs.append(build_paths.glibc_include)
         include_dirs.append(build_paths.linux_kernel_include)
         include_dirs.append("include")
@@ -1640,17 +1665,59 @@ def _get_openmp_args(
     return cflags, ldflags, include_dir_paths, lib_dir_paths, libs, passthrough_args
 
 
-def _get_libstdcxx_args() -> tuple[list[str], list[str]]:
+def _validate_cpp_stdlib(
+    cpp_stdlib: CppStdlib, device_type: str, aot_mode: bool
+) -> None:
+    """Reject cpp_stdlib requests that would otherwise be silently ignored.
+
+    The private libc++ is only available in fbcode and wired up for AOT CPU
+    builds: the archives are linked in get_cpp_torch_device_options under
+    device_type == "cpu", and both the header setup and the link flags gate on
+    aot_mode. Any other combination either strips the default stdlib without
+    linking a replacement or quietly produces a libstdc++ artifact, so fail
+    loudly instead.
     """
-    For fbcode cpu case, we should link stdc++ instead assuming the binary where dlopen is executed is built with dynamic stdc++.
+    if cpp_stdlib != "libc++":
+        return
+    if not config.is_fbcode():
+        raise RuntimeError("cpp_stdlib='libc++' is only supported in fbcode.")
+    if device_type != "cpu":
+        raise RuntimeError(
+            "cpp_stdlib='libc++' is only supported with device_type='cpu', "
+            f"got device_type='{device_type}'"
+        )
+    if not aot_mode:
+        raise RuntimeError(
+            "cpp_stdlib='libc++' is only supported with aot_mode=True; "
+            "non-AOT builds link the default libstdc++."
+        )
+
+
+def _get_cpp_stdlib_args(
+    aot_mode: bool, cpp_stdlib: CppStdlib
+) -> tuple[list[str], list[str], list[str]]:
+    """
+    For fbcode AOTI, select either the legacy dynamic libstdc++ dependency or
+    the statically linked private __aoti-namespace libc++.
     """
     lib_dir_paths: list[str] = []
     libs: list[str] = []
-    if config.is_fbcode():
+    passthrough_args: list[str] = []
+    if config.is_fbcode() and aot_mode and cpp_stdlib == "libc++":
+        lib_dir_paths = [build_paths.aoti_libcxx_lib]
+        passthrough_args = [
+            " -nostdlib++",
+            " -Wl,-Bstatic",
+            " -laoti_c++",
+            " -laoti_c++abi",
+            " -Wl,-Bdynamic",
+            " -Wl,--exclude-libs,ALL",
+        ]
+    elif config.is_fbcode():
         lib_dir_paths = [sysconfig.get_config_var("LIBDIR")]
         libs.append("stdc++")
 
-    return lib_dir_paths, libs
+    return lib_dir_paths, libs, passthrough_args
 
 
 def get_mmap_self_macro(
@@ -1686,6 +1753,7 @@ def get_cpp_torch_options(
     use_relative_path: bool,
     use_mmap_weights: bool,
     use_mmap_weights_external: bool,
+    cpp_stdlib: CppStdlib,
 ) -> tuple[list[str], list[str], list[str], list[str], list[str], list[str], list[str]]:
     """
     This function is used to get the build args of torch related build options.
@@ -1712,7 +1780,7 @@ def get_cpp_torch_options(
         sys_libs_include_dirs,
         sys_libs_passthrough_args,
         sys_libs_ldflags,
-    ) = _setup_standard_sys_libs(cpp_compiler, aot_mode, use_relative_path)
+    ) = _setup_standard_sys_libs(cpp_compiler, aot_mode, use_relative_path, cpp_stdlib)
 
     isa_macros, isa_ps_args_build_flags = _get_build_args_of_chosen_isa(vec_isa)
 
@@ -1799,6 +1867,7 @@ class CppTorchOptions(CppOptions):
         min_optimize: bool = False,
         precompiling: bool = False,
         preprocessing: bool = False,
+        cpp_stdlib: CppStdlib = "libstdc++",
     ) -> None:
         super().__init__(
             compile_only=compile_only,
@@ -1829,6 +1898,7 @@ class CppTorchOptions(CppOptions):
             use_relative_path=use_relative_path,
             use_mmap_weights=use_mmap_weights,
             use_mmap_weights_external=use_mmap_weights_external,
+            cpp_stdlib=cpp_stdlib,
         )
 
         _append_list(self._definitions, torch_definitions)
@@ -2086,6 +2156,7 @@ def get_cpp_torch_device_options(
     device_type: str,
     aot_mode: bool = False,
     compile_only: bool = False,
+    cpp_stdlib: CppStdlib = "libstdc++",
 ) -> tuple[list[str], list[str], list[str], list[str], list[str], list[str], list[str]]:
     """
     This function is used to get the build args of device related build options.
@@ -2094,6 +2165,10 @@ def get_cpp_torch_device_options(
     3. MISC
     4. Return the build args
     """
+    # CppTorchDeviceOptions validates too, but this is a public entry point in
+    # its own right.
+    _validate_cpp_stdlib(cpp_stdlib, device_type, aot_mode)
+
     definitions: list[str] = []
     include_dirs: list[str] = []
     cflags: list[str] = []
@@ -2183,11 +2258,15 @@ def get_cpp_torch_device_options(
 
         if device_type == "cpu":
             (
-                stdcxx_lib_dir_paths,
-                stdcxx_libs,
-            ) = _get_libstdcxx_args()
-            libraries_dirs += stdcxx_lib_dir_paths
-            libraries += stdcxx_libs
+                libcxx_lib_dir_paths,
+                libcxx_libs,
+                libcxx_passthrough,
+            ) = _get_cpp_stdlib_args(aot_mode, cpp_stdlib)
+            libraries_dirs += libcxx_lib_dir_paths
+            libraries += libcxx_libs
+            if not compile_only:
+                # Only add link args, when compile_only is false.
+                passthrough_args += libcxx_passthrough
 
     if config.aot_inductor.custom_op_libs:
         libraries += config.aot_inductor.custom_op_libs
@@ -2226,7 +2305,12 @@ class CppTorchDeviceOptions(CppTorchOptions):
         precompiling: bool = False,
         preprocessing: bool = False,
         compiler: str = "",
+        cpp_stdlib: CppStdlib = "libstdc++",
     ) -> None:
+        # Validate before super().__init__, which runs the header setup that
+        # would strip the default stdlib.
+        _validate_cpp_stdlib(cpp_stdlib, device_type, aot_mode)
+
         super().__init__(
             vec_isa=vec_isa,
             include_pytorch=include_pytorch,
@@ -2240,6 +2324,7 @@ class CppTorchDeviceOptions(CppTorchOptions):
             precompiling=precompiling,
             preprocessing=preprocessing,
             compiler=compiler,
+            cpp_stdlib=cpp_stdlib,
         )
 
         device_definitions: list[str] = []
@@ -2262,6 +2347,7 @@ class CppTorchDeviceOptions(CppTorchOptions):
             device_type=device_type,
             aot_mode=aot_mode,
             compile_only=compile_only,
+            cpp_stdlib=cpp_stdlib,
         )
         _append_list(self._definitions, device_definitions)
         _append_list(self._include_dirs, device_include_dirs)


### PR DESCRIPTION
Summary:

Builds AOTI model DSOs against the private `__aoti` libc++ instead of the host libstdc++, so a model `.so` dlopen'd into a long-lived predictor cannot collide with the standard library already loaded there. Re-lands D113331390, reading the paths from `build_paths` rather than the environment. Adds a `cpp_stdlib` option that defaults to `libstdc++`, so nothing changes until a caller opts in.

Test Plan:
```
buck2 test fbcode//caffe2/test/inductor/fb:test_cpp_builder_libcxx
```

Reviewed By: desertfire

Differential Revision: D116034255




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo