### PR TITLE
autograd: release saved tensors for unrequested gradients

### DIFF
--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -93,7 +93,7 @@ Take the following steps:
   were inputs, with each of them containing the gradient w.r.t. its
   corresponding input. If your inputs didn't require gradient
   ({attr}`~ctx.needs_input_grad` is a tuple of booleans indicating
-  whether each input needs gradient computation), or were non-{class}`Tensor`
+  whether the current backward call needs each input gradient), or were non-{class}`Tensor`
   objects, you can return {class}`python:None`. Also, if you have optional
   arguments to {meth}`~Function.forward` you can return more gradients than there
   were inputs, as long as they're all {any}`python:None`.
@@ -147,6 +147,18 @@ class attributes:
   This can reduce peak memory usage in backward passes where saved tensors are only
   needed once. The default is ``False``. Note that ``saved_tensors`` can only be
   accessed once when this is enabled; a second access will raise an error.
+
+- {attr}`~Function.saved_tensors_input_dependencies`: An optional tuple with one
+  entry per value passed to ``ctx.save_for_backward``. Each entry contains the
+  forward input indices whose gradients may use that saved tensor. Before a
+  non-retained eager backward, the engine clears saved tensors whose dependent
+  input gradients are not requested; their positions in ``ctx.saved_tensors``
+  contain ``None``. Use ``None`` for an entry that may be used by any tensor
+  input. For example, multiplication can declare ``((1,), (0,))`` when it saves
+  ``(x, y)`` because ``x`` is needed for ``grad_y`` and ``y`` is needed for
+  ``grad_x``. The backward formula must guard those uses with
+  ``ctx.needs_input_grad``. The default is ``None``, which disables selective
+  release.
 
 - {attr}`~Function.boxed_grads_call`: When set to ``True`` on the
   {class}`~Function` subclass, backward receives grads as a single mutable list

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5662,6 +5662,12 @@ if IS_S390X:
 # clear_saved_tensors_on_access is incompatible with compiled autograd
 skipped_tests.add("test_clear_saved_tensors_on_access")
 skipped_tests.add("test_clear_saved_tensors_on_access_double_access_error")
+
+# Selective saved tensor release currently relies on eager PyNode and generated
+# Node apply paths.
+skipped_tests.add("test_custom_function_selective_saved_tensor_release")
+skipped_tests.add("test_custom_function_selective_release_respects_retain_graph")
+skipped_tests.add("test_generated_backward_selective_saved_tensor_release")
 skipped_tests.add("test_forward_traceback_preserves_exception_with_checkpoint")
 skipped_tests.add("test_checkpoint_error_suggests_mark_dynamic")
 skipped_tests.add("test_checkpoint_automatic_dynamic_graph_shadowing")

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9800,6 +9800,129 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(RuntimeError, "can only be accessed once"):
             y.sum().backward()
 
+    def test_custom_function_selective_saved_tensor_release(self):
+        saved_refs = []
+        seen_needs_input_grad = []
+
+        class Mul(Function):
+            saved_tensors_input_dependencies = ((1,), (0,))
+
+            @staticmethod
+            def forward(ctx, x, y):
+                saved_x = x.detach().clone()
+                saved_y = y.detach().clone()
+                saved_refs.extend(
+                    (
+                        torch._C._WeakTensorRef(saved_x),
+                        torch._C._WeakTensorRef(saved_y),
+                    )
+                )
+                ctx.save_for_backward(saved_x, saved_y)
+                return x * y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                seen_needs_input_grad.append(ctx.needs_input_grad)
+                saved_x, saved_y = ctx.saved_tensors
+                self.assertIsNone(saved_x)
+                self.assertIsNotNone(saved_y)
+                self.assertTrue(saved_refs[0].expired())
+                self.assertFalse(saved_refs[1].expired())
+                return grad_output * saved_y, None
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        grad_x = torch.autograd.grad(Mul.apply(x, y).sum(), x)
+
+        self.assertEqual(grad_x, (y,))
+        self.assertEqual(seen_needs_input_grad, [(True, False)])
+        self.assertTrue(saved_refs[1].expired())
+
+    def test_custom_function_selective_release_respects_retain_graph(self):
+        saved_refs = []
+        seen = []
+
+        class Mul(Function):
+            saved_tensors_input_dependencies = ((1,), (0,))
+
+            @staticmethod
+            def forward(ctx, x, y):
+                saved_x = x.detach().clone()
+                saved_y = y.detach().clone()
+                saved_refs.extend(
+                    (
+                        torch._C._WeakTensorRef(saved_x),
+                        torch._C._WeakTensorRef(saved_y),
+                    )
+                )
+                ctx.save_for_backward(saved_x, saved_y)
+                return x * y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                saved_x, saved_y = ctx.saved_tensors
+                seen.append((ctx.needs_input_grad, saved_x, saved_y))
+                grad_x = grad_output * saved_y if ctx.needs_input_grad[0] else None
+                grad_y = grad_output * saved_x if ctx.needs_input_grad[1] else None
+                return grad_x, grad_y
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        output = Mul.apply(x, y).sum()
+        grad_x = torch.autograd.grad(output, x, retain_graph=True)
+
+        self.assertEqual(grad_x, (y,))
+        self.assertEqual(seen[0][0], (True, False))
+        self.assertIsNotNone(seen[0][1])
+        self.assertIsNotNone(seen[0][2])
+        seen.clear()
+        self.assertFalse(saved_refs[0].expired())
+        self.assertFalse(saved_refs[1].expired())
+
+        output.backward(retain_graph=True)
+        self.assertEqual(seen[0][0], (True, True))
+        self.assertIsNotNone(seen[0][1])
+        self.assertIsNotNone(seen[0][2])
+        seen.clear()
+
+        grad_y = torch.autograd.grad(output, y)
+        self.assertEqual(grad_y, (x,))
+        self.assertEqual(seen[0][0], (False, True))
+        self.assertIsNotNone(seen[0][1])
+        self.assertIsNone(seen[0][2])
+        seen.clear()
+        self.assertTrue(saved_refs[0].expired())
+        self.assertTrue(saved_refs[1].expired())
+
+    def test_generated_backward_selective_saved_tensor_release(self):
+        saved_refs = []
+        unpack_expired_counts = []
+
+        class PackedTensor:
+            def __init__(self, tensor):
+                self.tensor = tensor
+
+        def pack(tensor):
+            packed = tensor.detach().clone()
+            saved_refs.append(torch._C._WeakTensorRef(packed))
+            return PackedTensor(packed)
+
+        def unpack(packed):
+            unpack_expired_counts.append(sum(ref.expired() for ref in saved_refs))
+            return packed.tensor
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+            output = x * y
+
+        self.assertEqual(len(saved_refs), 2)
+        grad_x = torch.autograd.grad(output.sum(), x)
+
+        self.assertEqual(grad_x, (y,))
+        self.assertEqual(unpack_expired_counts, [1])
+        self.assertTrue(all(ref.expired() for ref in saved_refs))
+
     def test_autograd_node_isinstance(self):
         # Node is a "virtual" base class of codegen'd nodes. This means that
         # isinstance and issubclass are overridden, but mro is unchanged

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -121,9 +121,11 @@ inline variable_list ${op}_apply_functional_ivalue(const variable_list& grads, c
 
 variable_list ${op}::apply(variable_list&& grads) {
   ${thread_lock}
+  ${compute_needs_input_grad_before}
+  ${release_unused_variables}
   ${asserts}
   ${unpacks}
-  ${compute_needs_input_grad}
+  ${compute_needs_input_grad_after}
   return ${op}_apply_functional(std::move(grads), needs_input_grad${,apply_functional_args});
 }
 
@@ -147,9 +149,10 @@ variable_list ${op}::apply_with_saved(const variable_list& grads, SwapSavedVaria
   variable_list output_result;
 
   PackedArgs packed_args;
+  ${compute_needs_input_grad_before}
   ${asserts}
   ${unpacks}
-  ${compute_needs_input_grad}
+  ${compute_needs_input_grad_after}
   packed_args.pack(needs_input_grad);
   ${get_packed_args}
 
@@ -612,6 +615,7 @@ def gen_autograd_functions_python(
 def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str:
     saved_variables: list[str] = []
     release_variables: list[str] = []
+    release_unused_variables: list[str] = []
     saved_list_sizes: list[str] = []
     unpack: list[str] = []
     asserts: list[str] = []
@@ -643,9 +647,27 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
         compute_index_ranges.append(f"auto {arg.name}_ix = gen.range({size});")
         input_name_to_idx[arg.name] = idx
 
+    def saved_variable_dependency(var: SavedAttribute) -> str | None:
+        dependent_inputs = {
+            name
+            for derivative in info.derivatives
+            if var in derivative.saved_inputs or var in derivative.saved_outputs
+            for name in derivative.var_names
+        }
+        if not dependent_inputs:
+            raise AssertionError(f"no derivative uses saved variable {var.nctype.name}")
+        if dependent_inputs == set(input_name_to_idx):
+            return None
+        return " || ".join(
+            f"needs_input_grad[{idx}]"
+            for name, idx in input_name_to_idx.items()
+            if name in dependent_inputs
+        )
+
     def save_var(var: SavedAttribute, is_output: bool) -> None:
         name = var.nctype.name
         type = var.nctype.type
+        dependency = saved_variable_dependency(var)
         should_append_getsetdef = True
         should_append_raw_getsetdef = False
         visit_name = name
@@ -662,7 +684,15 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             saved_variables.append(f"SavedVariable {name}_;")
             release_variables.append(f"{name}_.reset_data();")
             ptr = "getptr()" if is_output else ""
-            unpack.append(f"auto {name} = {name}_.unpack({ptr});")
+            if dependency:
+                release_unused_variables.append(
+                    f"if (!({dependency}) && !retain_variables) {{ {name}_.reset_data(); }}"
+                )
+                unpack.append(
+                    f"auto {name} = ({dependency}) ? {name}_.unpack({ptr}) : Tensor();"
+                )
+            else:
+                unpack.append(f"auto {name} = {name}_.unpack({ptr});")
             getter_definitions.append(
                 GETTER_DEFINITION_SAVEDVAR.substitute(
                     op=info.op, name=name, body=GETTER_BODY_SAVEDVAR
@@ -704,8 +734,21 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             release_variables.append(f"{name}_.clear();")
             release_variables.append(f"{name}_released_ = true;")
             ptr = "getptr()" if is_output else "nullptr"
-            unpack.append(f"auto {name} = unpack_list({name}_, {ptr});")
-            asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
+            if dependency:
+                release_unused_variables.append(
+                    f"if (!({dependency}) && !retain_variables) {{ "
+                    f"{name}_.clear(); {name}_released_ = true; }}"
+                )
+                unpack.append(
+                    f"auto {name} = ({dependency}) ? "
+                    f"unpack_list({name}_, {ptr}) : std::vector<Tensor>();"
+                )
+                asserts.append(
+                    f"if ({dependency}) {{ TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE); }}"
+                )
+            else:
+                unpack.append(f"auto {name} = unpack_list({name}_, {ptr});")
+                asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
             getter_definitions.append(
                 GETTER_DEFINITION_VEC_SAVEDVAR.substitute(
                     op=info.op, name=name, body=GETTER_BODY_VEC_SAVEDVAR
@@ -727,8 +770,21 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             # Because the SavedVariable owns a tensor and a grad_fn, removing the SavedVariable makes them go away as well.
             release_variables.append(f"{name}_.clear();")
             release_variables.append(f"{name}_released_ = true;")
-            unpack.append(f"auto {name} = unpack_opt_list({name}_);")
-            asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
+            if dependency:
+                release_unused_variables.append(
+                    f"if (!({dependency}) && !retain_variables) {{ "
+                    f"{name}_.clear(); {name}_released_ = true; }}"
+                )
+                unpack.append(
+                    f"auto {name} = ({dependency}) ? unpack_opt_list({name}_) : "
+                    "torch::List<std::optional<Tensor>>();"
+                )
+                asserts.append(
+                    f"if ({dependency}) {{ TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE); }}"
+                )
+            else:
+                unpack.append(f"auto {name} = unpack_opt_list({name}_);")
+                asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
             getter_definitions.append(
                 GETTER_DEFINITION_VEC_SAVEDVAR.substitute(
                     op=info.op, name=name, body=GETTER_BODY_VEC_SAVEDVAR
@@ -917,6 +973,8 @@ static PyObject* THP${op}_${name}_getter(THPCppFunction *self, void *_unused) {
     if uses_retain_variables(info):
         apply_functional_args.append("retain_variables")
         apply_functional_args_ref_types.append("bool")
+
+    if uses_retain_variables(info) or release_unused_variables:
         will_release_variables = WILL_RELEASE_VARIABLES.substitute()
     else:
         will_release_variables = ""
@@ -1029,6 +1087,12 @@ static PyObject* THP${op}_${name}_getter(THPCppFunction *self, void *_unused) {
     compute_needs_input_grad = COMPUTE_NEEDS_INPUT_GRAD.substitute(
         n=len(masks), compute_index_ranges=compute_index_ranges, masks=masks
     )
+    if release_unused_variables:
+        compute_needs_input_grad_before = compute_needs_input_grad
+        compute_needs_input_grad_after = ""
+    else:
+        compute_needs_input_grad_before = ""
+        compute_needs_input_grad_after = compute_needs_input_grad
     apply_functional_args_signature = [
         f"{T} {x}"
         for T, x in zip(apply_functional_args_ref_types, apply_functional_args)
@@ -1059,12 +1123,14 @@ static PyObject* THP${op}_${name}_getter(THPCppFunction *self, void *_unused) {
         compute_schema="\n".join(compute_schema),
         apply_functional_args=apply_functional_args,
         apply_functional_args_signature=apply_functional_args_signature,
-        compute_needs_input_grad=compute_needs_input_grad,
+        compute_needs_input_grad_before=compute_needs_input_grad_before,
+        compute_needs_input_grad_after=compute_needs_input_grad_after,
         num_inputs=len(input_name_to_idx),
         unpack_ivalues="\n".join(unpack_ivalues),
         compute_index_ranges=compute_index_ranges,
         saved_variables=saved_variables,
         release_variables=release_variables,
+        release_unused_variables=release_unused_variables,
         saved_list_sizes=saved_list_sizes,
         asserts=asserts,
         thread_lock=thread_lock,

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -490,8 +490,8 @@ class _SingleLevelFunction(
         pass. It also has an attribute :attr:`ctx.needs_input_grad` as a tuple
         of booleans representing whether each input needs gradient. E.g.,
         :func:`backward` will have ``ctx.needs_input_grad[0] = True`` if the
-        first input to :func:`forward` needs gradient computed w.r.t. the
-        output.
+        current backward call needs the gradient for the first input to
+        :func:`forward`.
         """
         raise NotImplementedError(
             "You must implement either the backward or vjp method for "
@@ -514,6 +514,21 @@ class _SingleLevelFunction(
     Default is False.
     """
     clear_saved_tensors_on_access = False
+
+    """
+    Optional tuple describing which forward input gradients use each value
+    passed to :meth:`FunctionCtx.save_for_backward`. Each element contains the
+    forward input indices whose gradients may use the corresponding saved
+    tensor. ``None`` conservatively means all tensor inputs.
+
+    When a backward call does not retain the graph, saved tensors that are not
+    needed for any requested input gradient are released before ``backward`` is
+    called and appear as ``None`` in ``ctx.saved_tensors``. The backward formula
+    must guard their use with ``ctx.needs_input_grad``.
+
+    Default is None, which disables selective release.
+    """
+    saved_tensors_input_dependencies = None
 
     """
     Bool that specifies if backward should receive grads as a single mutable

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/autograd/python_function.h>
 
+#include <algorithm>
 #include <atomic>
 
 #include <ATen/ATen.h>
@@ -146,7 +147,14 @@ static PyObject* unpack_saved_variables(
   // because we will never hit this line of code if the buffers are freed--
   // and in any case saved_for will be non-NULL.)
   TORCH_INTERNAL_ASSERT(saved_for);
+  const auto* dependency_state = self->saved_variable_input_dependencies.get();
+  TORCH_INTERNAL_ASSERT(
+      !dependency_state || dependency_state->released.size() == num_saved);
   for (const auto i : c10::irange(num_saved)) {
+    if (dependency_state && dependency_state->released[i]) {
+      PyTuple_SET_ITEM(saved.get(), i, Py_NewRef(Py_None));
+      continue;
+    }
     auto unpacked_var = saved_variables[i].unpack(saved_for);
     THPObjectPtr value;
     if (!unpacked_var.defined()) {
@@ -184,6 +192,31 @@ PyObject* to_py_size(const std::vector<c10::SymInt>& size) {
 
 namespace torch::autograd {
 
+static void update_needs_input_grad(const PyNode* node, THPFunction* py_fn) {
+  const auto* exec_info = get_current_graph_task_exec_info();
+  const bool task_specific = exec_info && !exec_info->empty();
+  if (!task_specific && !py_fn->needs_input_grad_is_task_specific) {
+    return;
+  }
+
+  THPObjectPtr needs_input_grad(
+      PyTuple_New(static_cast<Py_ssize_t>(py_fn->is_variable_input.size())));
+  if (!needs_input_grad) {
+    throw_python_error();
+  }
+  size_t variable_idx = 0;
+  for (const auto i : c10::irange(py_fn->is_variable_input.size())) {
+    bool needs_grad = false;
+    if (py_fn->is_variable_input[i]) {
+      needs_grad = node->task_should_compute_output(variable_idx++);
+    }
+    PyTuple_SET_ITEM(
+        needs_input_grad.get(), i, Py_NewRef(needs_grad ? Py_True : Py_False));
+  }
+  Py_SETREF(py_fn->needs_input_grad, needs_input_grad.release());
+  py_fn->needs_input_grad_is_task_specific = task_specific;
+}
+
 // NOTE: this function is written in a way that assumes it's only called for
 // backward; it's used by engine.cpp.  This is responsible for forwarding a call
 // from C++'s Node::apply to a Python method "apply".
@@ -192,6 +225,7 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;
   auto* py_fn = reinterpret_cast<THPFunction*>(pyobj());
+  update_needs_input_grad(this, py_fn);
 
   // Massage a C++ variable_list into a Python arguments tuple
   THPObjectPtr pyInputs(to_py_args(inputs, &_device_guard));
@@ -388,7 +422,35 @@ auto PyNode::release_variables() -> void {
     auto* f = reinterpret_cast<THPFunction*>(pyobj());
     if (f) {
       f->saved_variables.clear();
+      f->saved_variable_input_dependencies.reset();
       f->has_freed_buffers = 1;
+    }
+  }
+}
+
+auto PyNode::will_release_variables() -> void {
+  if (!Py_IsInitialized()) {
+    return;
+  }
+  pybind11::gil_scoped_acquire gil;
+  auto* f = reinterpret_cast<THPFunction*>(pyobj());
+  if (!f || !f->saved_variable_input_dependencies) {
+    return;
+  }
+
+  auto& dependency_state = *f->saved_variable_input_dependencies;
+  TORCH_INTERNAL_ASSERT(
+      f->saved_variables.size() == dependency_state.dependencies.size());
+  dependency_state.released.resize(f->saved_variables.size());
+  for (const auto i : c10::irange(f->saved_variables.size())) {
+    const auto& dependencies = dependency_state.dependencies[i];
+    const bool needed = std::any_of(
+        dependencies.begin(), dependencies.end(), [this](size_t input_idx) {
+          return task_should_compute_output(input_idx);
+        });
+    if (!needed && !dependency_state.released[i]) {
+      f->saved_variables[i].reset_data();
+      dependency_state.released[i] = true;
     }
   }
 }
@@ -406,6 +468,8 @@ bool PyNode::is_aot_backward() const {
 }
 
 void PyNode::compiled_args(CompiledNodeArgs& args) const {
+  auto* f = reinterpret_cast<THPFunction*>(pyobj());
+  update_needs_input_grad(this, f);
   static PyObject* method_name =
       PyUnicode_InternFromString("_compiled_autograd_key");
   THPObjectPtr pykey(PyObject_CallMethodObjArgs(pyobj(), method_name, nullptr));
@@ -425,7 +489,6 @@ void PyNode::compiled_args(CompiledNodeArgs& args) const {
   args.collect_size(static_cast<size_t>(key));
   args.collect_size(static_cast<size_t>(size));
 
-  auto* f = reinterpret_cast<THPFunction*>(pyobj());
   f->compiled_autograd_symints.clear();
   f->compiled_autograd_symints.reserve(size - 1);
   for (const auto i : c10::irange(1, size)) {
@@ -610,6 +673,7 @@ static void THPFunction_dealloc(THPFunction* self) {
   self->output_info.~vector();
   self->input_info.~vector();
   self->saved_variables.~vector();
+  self->saved_variable_input_dependencies.~unique_ptr();
   self->is_variable_input.~vector();
   std::destroy_at(&self->needs_input_grad_bits);
   if (self->cdata) {
@@ -636,6 +700,8 @@ static PyObject* THPFunction_new(
   new (&self->output_info) std::vector<VariableInfo>();
   new (&self->input_info) std::vector<VariableInfo>();
   new (&self->saved_variables) std::vector<SavedVariable>();
+  new (&self->saved_variable_input_dependencies)
+      std::unique_ptr<SavedVariableInputDependencies>();
   new (&self->is_variable_input) std::vector<bool>();
   new (&self->needs_input_grad_bits)
       std::optional<c10::SmallVector<bool, 24>>();
@@ -989,11 +1055,26 @@ static void _save_variables(
     THPFunction* self,
     PyObject* outputs,
     int64_t num_outputs) {
-  if (tensors_to_save.empty())
+  if (self->saved_variable_input_dependencies) {
+    auto& dependency_state = *self->saved_variable_input_dependencies;
+    TORCH_CHECK(
+        dependency_state.dependencies.size() == tensors_to_save.size(),
+        "saved_tensors_input_dependencies must have one entry per value "
+        "passed to save_for_backward, but got ",
+        dependency_state.dependencies.size(),
+        " dependencies for ",
+        tensors_to_save.size(),
+        " saved tensors");
+  }
+  if (tensors_to_save.empty()) {
     return;
+  }
   size_t num_saved = tensors_to_save.size();
   self->saved_variables.clear();
   self->saved_variables.reserve(num_saved);
+  if (self->saved_variable_input_dependencies) {
+    self->saved_variable_input_dependencies->released.assign(num_saved, false);
+  }
 
   std::unordered_set<at::TensorImpl*> output_impls{};
   output_impls.reserve(num_outputs);
@@ -1061,6 +1142,77 @@ struct InputFlags {
 };
 
 namespace {
+std::vector<std::vector<size_t>> parse_saved_tensor_input_dependencies(
+    PyObject* value,
+    const std::vector<bool>& is_variable_input) {
+  THPObjectPtr dependencies(PySequence_Fast(
+      value, "saved_tensors_input_dependencies must be a sequence"));
+  if (!dependencies) {
+    throw_python_error();
+  }
+
+  std::vector<size_t> input_to_edge(is_variable_input.size());
+  std::vector<size_t> all_edges;
+  all_edges.reserve(is_variable_input.size());
+  size_t edge_idx = 0;
+  for (const auto i : c10::irange(is_variable_input.size())) {
+    if (is_variable_input[i]) {
+      input_to_edge[i] = edge_idx;
+      all_edges.push_back(edge_idx++);
+    }
+  }
+
+  const auto num_saved = PySequence_Fast_GET_SIZE(dependencies.get());
+  std::vector<std::vector<size_t>> result;
+  result.reserve(num_saved);
+  for (const auto saved_idx : c10::irange(num_saved)) {
+    PyObject* item = PySequence_Fast_GET_ITEM(dependencies.get(), saved_idx);
+    if (Py_IsNone(item)) {
+      result.push_back(all_edges);
+      continue;
+    }
+
+    THPObjectPtr input_indices(PySequence_Fast(
+        item,
+        "each saved tensor dependency must be a sequence of input indices or None"));
+    if (!input_indices) {
+      throw_python_error();
+    }
+    const auto num_indices = PySequence_Fast_GET_SIZE(input_indices.get());
+    std::vector<size_t> saved_dependencies;
+    saved_dependencies.reserve(num_indices);
+    for (const auto i : c10::irange(num_indices)) {
+      PyObject* index_obj = PySequence_Fast_GET_ITEM(input_indices.get(), i);
+      const auto input_idx = PyLong_AsSsize_t(index_obj);
+      if (input_idx == -1 && PyErr_Occurred()) {
+        throw_python_error();
+      }
+      TORCH_CHECK_INDEX(
+          input_idx >= 0 &&
+              input_idx < static_cast<Py_ssize_t>(is_variable_input.size()),
+          "saved tensor ",
+          saved_idx,
+          " has invalid forward input dependency ",
+          input_idx);
+      TORCH_CHECK_TYPE(
+          is_variable_input[input_idx],
+          "saved tensor ",
+          saved_idx,
+          " depends on non-Tensor forward input ",
+          input_idx);
+      const auto dependency = input_to_edge[input_idx];
+      if (std::find(
+              saved_dependencies.begin(),
+              saved_dependencies.end(),
+              dependency) == saved_dependencies.end()) {
+        saved_dependencies.push_back(dependency);
+      }
+    }
+    result.push_back(std::move(saved_dependencies));
+  }
+  return result;
+}
+
 edge_list collect_next_edges(at::ArrayRef<const Variable*> input_vars) {
   edge_list next_edges;
   next_edges.reserve(input_vars.size());
@@ -1834,6 +1986,19 @@ PyObject* THPFunction_apply(
   ctx->needs_input_grad_bits.emplace(std::move(input_info.needs_input_grad));
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 
+  THPObjectPtr dependencies_attr(
+      PyObject_GetAttrString(cls, "saved_tensors_input_dependencies"));
+  TORCH_CHECK(
+      dependencies_attr,
+      "autograd.Function is missing saved_tensors_input_dependencies attribute");
+  if (!Py_IsNone(dependencies_attr.get())) {
+    ctx->saved_variable_input_dependencies =
+        std::make_unique<SavedVariableInputDependencies>();
+    ctx->saved_variable_input_dependencies->dependencies =
+        parse_saved_tensor_input_dependencies(
+            dependencies_attr.get(), ctx->is_variable_input);
+  }
+
   // Get clear_saved_tensors_on_access from the Function class
   THPObjectPtr clear_attr(
       PyObject_GetAttr(cls, clear_saved_tensors_on_access_name));
@@ -2112,7 +2277,14 @@ PyObject* THPFunction_raw_saved_tensors(THPFunction* self, void* _unused) {
   if (!saved) {
     return nullptr;
   }
+  const auto* dependency_state = self->saved_variable_input_dependencies.get();
+  TORCH_INTERNAL_ASSERT(
+      !dependency_state || dependency_state->released.size() == num_saved);
   for (const auto i : c10::irange(num_saved)) {
+    if (dependency_state && dependency_state->released[i]) {
+      PyTuple_SET_ITEM(saved.get(), i, Py_NewRef(Py_None));
+      continue;
+    }
     py::object obj =
         py::cast(saved_variables[i], py::return_value_policy::reference);
     PyTuple_SET_ITEM(saved.get(), i, obj.release().ptr());

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -24,6 +24,11 @@ struct Graph;
 
 namespace torch::autograd {
 
+struct SavedVariableInputDependencies {
+  std::vector<std::vector<size_t>> dependencies{};
+  std::vector<bool> released{};
+};
+
 // A Function which is implemented by a Python object (i.e., a THPFunction).
 // Calls to 'apply' are forwarded to the Python method implementation.
 //
@@ -43,6 +48,7 @@ struct PyNode : public Node {
       const variable_list& inputs,
       const SwapSavedVariables& saved);
 
+  void will_release_variables() override;
   void release_variables() override;
   std::string name() const override;
   bool is_traceable() override;
@@ -132,8 +138,11 @@ struct THPFunction {
   std::vector<torch::autograd::VariableInfo> output_info;
   std::vector<torch::autograd::VariableInfo> input_info;
   std::vector<torch::autograd::SavedVariable> saved_variables;
+  std::unique_ptr<torch::autograd::SavedVariableInputDependencies>
+      saved_variable_input_dependencies;
   // For each input, true if the input is a THPVariable
   std::vector<bool> is_variable_input;
+  bool needs_input_grad_is_task_specific = false;
   char has_freed_buffers;
 
   // Flag for clear_saved_tensors_on_access feature


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #193847

Autograd can prune gradient computation to requested inputs, but custom and
generated backward nodes still retain every saved tensor until the node
finishes because the engine does not know which input gradient uses each
saved value.

Derive that dependency information from native derivative metadata and add
an opt-in saved_tensors_input_dependencies mapping for Python Functions.
Refresh needs_input_grad for each graph task and release saved values whose
dependent gradients are not requested, while preserving retain_graph
behavior.

A class-level mapping keeps the custom Function contract static instead of
changing save_for_backward call sites. Native formulas reuse existing
metadata rather than adding annotations to derivatives.yaml.

Test Plan:

```
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && https_proxy=http://fwdproxy:8080 http_proxy=http://fwdproxy:8080 CUDACXX=/usr/local/cuda-12.2/bin/nvcc PATH=/usr/local/cuda-12.2/bin:$PATH USE_FLASH_ATTENTION=1 USE_MEM_EFF_ATTENTION=1 USE_CUDA=1 CUDA_HOME=/usr/local/cuda-12.2 USE_GOLD_LINKER=1 CMAKE_PREFIX_PATH="$CONDA_PREFIX" pip install -e . -v --no-build-isolation
python test/test_autograd.py TestAutograd.test_custom_function_selective_saved_tensor_release TestAutograd.test_custom_function_selective_release_respects_retain_graph TestAutograd.test_generated_backward_selective_saved_tensor_release
python test/inductor/test_compiled_autograd.py TestCompiledAutograd.test_custom_fn_saved_tensors TestCompiledAutograd.test_custom_fn_saved_multiple_tensors
python test/test_autograd.py -k saved_tensor
```

`spin quicklint` was also run. Patch-local findings were fixed; it remains
blocked by pre-existing clang-tidy diagnostics in surrounding autograd code.

Authored with assistance from an AI coding agent.