### PR TITLE
[Testcase Refactoring] Decouple TestBaseDataScheduler for out-of-tree backends

### DIFF
--- a/test/ao/sparsity/test_data_scheduler.py
+++ b/test/ao/sparsity/test_data_scheduler.py
@@ -7,7 +7,11 @@ import torch
 from torch import nn
 from torch.ao.pruning._experimental.data_scheduler import BaseDataScheduler
 from torch.ao.pruning._experimental.data_sparsifier import DataNormSparsifier
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ImplementedDataScheduler(BaseDataScheduler):
@@ -25,6 +29,8 @@ class ImplementedDataScheduler(BaseDataScheduler):
 
 
 class TestBaseDataScheduler(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _get_data(self):
         tensor1, param1, emb1 = (
             torch.randn(5, 5),


### PR DESCRIPTION
## Summary

Decouple `test/ao/sparsity/test_data_scheduler.py` so it can be scheduled on any
registered backend (CPU / CUDA / privateuse1 accelerators such as NPU).

Changes:
- `test/ao/sparsity/test_data_scheduler.py`
  - Import `HardwareClassification` from `torch.testing._internal.common_utils`;
  - Annotate `TestBaseDataScheduler` with
    `hw_classification = HardwareClassification.GENERIC`: the class only exercises
    device-agnostic scheduler bookkeeping (constructor checks, step ordering,
    step counts, and `state_dict` round-trips) and does not depend on any
    particular accelerator, so it is marked as GENERIC.

No test semantics, case count, or execution order are changed.

## Test Plan

- CPU:
  - `python -m pytest test/ao/sparsity/test_data_scheduler.py -v`
    -> 4 passed (test_constructor / test_order_of_steps / test_step / test_state_dict)
  - `python -m pytest test/test_ao_sparsity.py -k DataScheduler -v`
    -> 4 passed
- CUDA: covered by upstream CI (CUDA jobs).
