### PR TITLE
[Testcase Refactoring] Decouple PruningOpTest for out-of-tree backends

### DIFF
--- a/test/test_pruning_op.py
+++ b/test/test_pruning_op.py
@@ -4,12 +4,18 @@ import hypothesis.strategies as st
 from hypothesis import given
 import numpy as np
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+    skipIfTorchDynamo,
+)
 import torch.testing._internal.hypothesis_utils as hu
 hu.assert_deadline_disabled()
 
 
 class PruningOpTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     # Generate rowwise mask vector based on indicator and threshold value.
     # indicator is a vector that contains one value per weight row and it


### PR DESCRIPTION
## Summary

`test/test_pruning_op.py` only exercises `torch._rowwise_prune` on CPU tensors and does not depend on any accelerator:
- No CUDA-specific decorators (`@onlyCUDA`, etc.), no `is_cuda` parameterization, and no `torch.cuda.*` calls.
- All tensors are created on the default CPU device (`torch.rand`, `torch.randint`, `torch.from_numpy`, `torch.BoolTensor`).
- `torch._rowwise_prune` registers a CPU-only implementation, so the test cases are CPU-only.

No code decoupling is required because the tests are already device-agnostic. This PR only adds the explicit `hw_classification = HardwareClassification.GENERIC` annotation to `PruningOpTest` so the test class can be filtered by hardware classification. Test semantics, the number of cases, and execution logic are unchanged.

## Test Plan

- `python test/test_pruning_op.py` (CPU, baseline): `Ran 2 tests ... OK`
- `python test/test_pruning_op.py` (CPU, with this change): `Ran 2 tests ... OK`