### PR TITLE
[MPS] Fix beta=0 for empty addbmm and baddbmm

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1190,7 +1190,11 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     return result;
   }
   if ((opType == ADDBMM_OP_TYPE && batch1.size(0) == 0) || batch1.size(2) == 0) {
-    at::mul_out(result, input, wrapped_scalar_tensor(beta));
+    if (beta.toComplexDouble() == 0.0) {
+      result.zero_();
+    } else {
+      at::mul_out(result, input, wrapped_scalar_tensor(beta));
+    }
     return result;
   }
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1387,7 +1387,11 @@ def sample_inputs_addbmm(op_info, device, dtype, requires_grad, **kwargs):
             beta_complex, alpha_complex = beta * (1 + 2j), alpha * (2 + 3j)
             yield SampleInput(make_arg(input_shape), args=(make_arg(batch1_shape), make_arg(batch2_shape)),
                               kwargs=dict(beta=beta_complex, alpha=alpha_complex), broadcasts_input=is_broadcasting)
-        yield SampleInput(make_arg(input_shape), args=(make_arg(batch1_shape), make_arg(batch2_shape)),
+        if beta == 0 and (dtype.is_floating_point or dtype.is_complex):
+            input = torch.full(input_shape, math.nan, device=device, dtype=dtype, requires_grad=requires_grad)
+        else:
+            input = make_arg(input_shape)
+        yield SampleInput(input, args=(make_arg(batch1_shape), make_arg(batch2_shape)),
                           kwargs=dict(beta=beta, alpha=alpha), broadcasts_input=is_broadcasting)
 
 def sample_inputs_addcmul_addcdiv(op_info, device, dtype, requires_grad, **kwargs):
@@ -1468,11 +1472,16 @@ def sample_inputs_baddbmm(op_info, device, dtype, requires_grad, **kwargs):
                   ((), (S, S, S), (S, S, M), 1, 1, True),
                   ((), (S, S, S), (S, S, M), 0.6, 0.2, True),
                   ((), (0, S, S), (0, S, M), 1, 1, True),  # empty batch, see #188765
+                  ((S, S, M), (S, S, 0), (S, 0, M), 1, 0, False),
                   ]
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad, low=None, high=None)
     for (input_shape, batch1_shape, batch2_shape, alpha, beta, broadcasts_input) in test_cases:
+        if beta == 0 and (dtype.is_floating_point or dtype.is_complex):
+            input = torch.full(input_shape, math.nan, device=device, dtype=dtype, requires_grad=requires_grad)
+        else:
+            input = make_arg(input_shape)
         yield SampleInput(
-            make_arg(input_shape),
+            input,
             make_arg(batch1_shape),
             make_arg(batch2_shape),
             beta=beta,
@@ -12361,7 +12370,8 @@ op_db: list[OpInfo] = [
            ],
            sample_inputs_func=sample_inputs_addmv),
     OpInfo('addbmm',
-           ref=lambda M, batch1, batch2, beta=1, alpha=1: np.add(np.multiply(np.asarray(beta, dtype=M.dtype), M),
+           ref=lambda M, batch1, batch2, beta=1, alpha=1: np.add(np.zeros_like(M) if beta == 0 else
+                                                                 np.multiply(np.asarray(beta, dtype=M.dtype), M),
                                                                  np.multiply(np.asarray(alpha, dtype=batch1.dtype),
                                                                              np.sum(np.matmul(batch1, batch2), axis=0))),
            dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1388,7 +1388,7 @@ def sample_inputs_addbmm(op_info, device, dtype, requires_grad, **kwargs):
             yield SampleInput(make_arg(input_shape), args=(make_arg(batch1_shape), make_arg(batch2_shape)),
                               kwargs=dict(beta=beta_complex, alpha=alpha_complex), broadcasts_input=is_broadcasting)
         if beta == 0 and (dtype.is_floating_point or dtype.is_complex):
-            input = torch.full(input_shape, math.nan, device=device, dtype=dtype, requires_grad=requires_grad)
+            input = torch.full(input_shape, math.inf, device=device, dtype=dtype, requires_grad=requires_grad)
         else:
             input = make_arg(input_shape)
         yield SampleInput(input, args=(make_arg(batch1_shape), make_arg(batch2_shape)),
@@ -1477,7 +1477,7 @@ def sample_inputs_baddbmm(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad, low=None, high=None)
     for (input_shape, batch1_shape, batch2_shape, alpha, beta, broadcasts_input) in test_cases:
         if beta == 0 and (dtype.is_floating_point or dtype.is_complex):
-            input = torch.full(input_shape, math.nan, device=device, dtype=dtype, requires_grad=requires_grad)
+            input = torch.full(input_shape, math.inf, device=device, dtype=dtype, requires_grad=requires_grad)
         else:
             input = make_arg(input_shape)
         yield SampleInput(


### PR DESCRIPTION
Make empty MPS addbmm and baddbmm ignore NaN inputs when beta is zero. Reproducer:

```
import torch

for device in ("cpu", "mps"):
    x = torch.full((2, 2), torch.nan, device=device)
    a = torch.empty(1, 2, 0, device=device)
    b = torch.empty(1, 0, 2, device=device)
    print(device, torch.addbmm(x, a, b, beta=0))
```

which prints now:
```
cpu tensor([[0., 0.],
        [0., 0.]])
mps tensor([[nan, nan],
        [nan, nan]], device='mps:0')
```