### PR TITLE
Fix torch.minimum and torch.maximum returning a zero whose sign depends on tensor length

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -683,9 +683,15 @@ void maximum_kernel(TensorIteratorBase& iter) {
               [](scalar_t a, scalar_t b) -> scalar_t {
                 if (a != a || b != b) {
                   return std::numeric_limits<scalar_t>::quiet_NaN();
-                } else {
-                  return std::max(a, b);
                 }
+                // `std::max` compares with `<`, which cannot tell +0.0 from
+                // -0.0, so it returns whichever argument came first. Pick the
+                // sign explicitly, so that a zero result does not depend on
+                // whether this path or the vectorized one produced it.
+                if (a == b) {
+                  return std::signbit(a) ? b : a;
+                }
+                return std::max(a, b);
               },
               [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
                 return at::vec::maximum(a, b);
@@ -718,9 +724,15 @@ void minimum_kernel(TensorIteratorBase& iter) {
               [](scalar_t a, scalar_t b) -> scalar_t {
                 if (a != a || b != b) {
                   return std::numeric_limits<scalar_t>::quiet_NaN();
-                } else {
-                  return std::min(a, b);
                 }
+                // `std::min` compares with `<`, which cannot tell +0.0 from
+                // -0.0, so it returns whichever argument came first. Pick the
+                // sign explicitly, so that a zero result does not depend on
+                // whether this path or the vectorized one produced it.
+                if (a == b) {
+                  return std::signbit(a) ? a : b;
+                }
+                return std::min(a, b);
               },
               [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
                 return at::vec::minimum(a, b);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_device_type import (
     dtypesIfXPU,
     expectedFailureMeta,
     instantiate_device_type_tests,
+    onlyCPU,
     onlyNativeDeviceTypes,
     onlyOn,
     OpDTypes,
@@ -2491,6 +2492,36 @@ class TestBinaryUfuncsDevice(TestCase):
             else:
                 self.assertEqual(tensor_result, numpy_result)
                 self.assertEqual(out, numpy_result)
+
+    @onlyCPU
+    @dtypes(*(floating_types_and(torch.half, torch.bfloat16)))
+    def test_maximum_minimum_signed_zero(self, device, dtype):
+        # The scalar kernel used std::min / std::max, which compare with < and
+        # so cannot tell +0.0 from -0.0. They returned whichever argument came
+        # first, so the result depended on whether an element landed on the
+        # scalar tail or in the vectorized body, and therefore on the length.
+        #
+        # The expected signs are IEEE 754's minimum / maximum: the result is
+        # -0.0 for min and +0.0 for max, in either argument order. That is also
+        # what at::vec::minimum on NEON, std::fmin / std::fmax, and numpy in
+        # float32 and float64 all give. It is written out rather than taken from
+        # numpy because numpy's own float16 loop returns the first argument.
+        #
+        # A one element tensor takes the scalar path on every ISA, so this
+        # exercises the kernel that was wrong without depending on the vector
+        # width.
+        for torch_op, want_negative_zero in (
+            (torch.maximum, False),
+            (torch.minimum, True),
+        ):
+            for a_val, b_val in ((0.0, -0.0), (-0.0, 0.0)):
+                a = torch.tensor([a_val], device=device, dtype=dtype)
+                b = torch.tensor([b_val], device=device, dtype=dtype)
+                self.assertEqual(
+                    torch_op(a, b).signbit().item(),
+                    want_negative_zero,
+                    msg=f"{torch_op.__name__}({a_val}, {b_val}) in {dtype}",
+                )
 
     @dtypes(
         *product(


### PR DESCRIPTION
Fixes #193781.

`minimum_kernel` and `maximum_kernel` use `std::min` / `std::max` in the scalar lambda. Those compare with `<`, which cannot distinguish `+0.0` from `-0.0`, so they return whichever argument came first. `at::vec::minimum` on NEON is `vminq_f32`, which is sign aware, so the scalar tail and the vectorized body disagreed and the result depended on the tensor length.

```python
for n in (7, 8):
    print(n, torch.minimum(torch.full((n,), 0.0), torch.full((n,), -0.0))[0].item())
# 7  0.0   scalar path
# 8 -0.0   vectorized path
```

This picks the sign explicitly when the operands compare equal, which is the only case `std::min` and `std::max` get wrong. NaN propagation is unchanged, ordinary values take the same path as before, and the extra branch is on the scalar tail only, not in the vectorized body.

After, for every length and both argument orders, in float16, bfloat16, float32 and float64:

| | `min(+0,-0)` | `min(-0,+0)` | `max(+0,-0)` | `max(-0,+0)` |
|---|---|---|---|---|
| before, scalar | **+0** | -0 | +0 | **-0** |
| after | -0 | -0 | +0 | +0 |
| `at::vec` on NEON | -0 | -0 | +0 | +0 |
| `std::fmin` / `fmax` | -0 | -0 | +0 | +0 |

## Test

`test_maximum_minimum_signed_zero` in `test_binary_ufuncs.py`, both orders, all four float dtypes. It uses a one element tensor, which takes the scalar path on every ISA, so it pins the kernel that was wrong without depending on the vector width.

The expected signs are written out rather than taken from numpy. numpy is sign aware in float32 and float64, but its float16 loop returns the first argument, so `np.minimum` on float16 gives `+0` for `min(+0,-0)` and `-0` for `min(-0,+0)`. IEEE 754 `minimum` / `maximum`, `at::vec` on NEON and `std::fmin` / `std::fmax` all agree on the values in the table, so that is what the test asserts.

It is `@onlyCPU` because MPS returns the second argument for all four of `minimum`, `maximum`, `fmin` and `fmax`, which needs its own fix. Noted in the issue.

## Not fixed here

**x86.** `at::vec::minimum` is `_mm256_min_ps`, and MINPS is documented to return the second operand when both operands are zero, so the vectorized path there is order dependent rather than sign aware. After this change the scalar path on x86 is sign aware and the vectorized path is not, so a length dependence remains, in the other direction. It can be made sign aware with

```cpp
// min: OR sets the sign bit, so OR(+0.0, -0.0) is -0.0
_mm256_or_ps(_mm256_min_ps(a, b), _mm256_min_ps(b, a))
// max: AND clears it
_mm256_and_ps(_mm256_max_ps(a, b), _mm256_max_ps(b, a))
```

The two orders give identical bit patterns for every input except two zeros, so the logical op is a no-op everywhere else. But that is an extra min/max and a logical op in the inner loop of a hot elementwise op, and I only have arm64 to test on, so I would rather someone who can benchmark it decide. Happy to send it as a follow up.

**`amin` / `amax`** return the sign of whichever element came first, where numpy is order independent. Same root cause, different file, left for a separate PR.

## Verification

- `test/test_binary_ufuncs.py` in full: 12715 passed, 644 skipped, 28 xfailed.
- Found by a differential tester that holds the values fixed and varies the tensor length. Against this build it no longer reports `minimum` or `maximum`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @malfet @Isalia20