### PR TITLE
Avoid sum router overhead when inner-tree reduction is off (#193858)

### DIFF
--- a/benchmarks/strict_numerics/sum_reduction.py
+++ b/benchmarks/strict_numerics/sum_reduction.py
@@ -4,7 +4,10 @@ import argparse
 import os
 from itertools import cycle
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+
+
+# Native reductions register during import, so enable the rollout first.
+os.environ["PYTORCH_SUM_INNER_TREE"] = "1"
 
 from triton.testing import do_bench, do_bench_cudagraph
 
@@ -64,22 +67,22 @@ def measure(m: int, n: int, provider: str, cudagraph: bool) -> float:
     tensors = input_buffer.unbind()
     runner = _circular_runner(_sum_rows, tensors)
     benchmark = do_bench_cudagraph if cudagraph else do_bench
-    inner_tree = provider == "eager_inner_tree"
     try:
-        with patch.dict(
-            os.environ,
-            {"PYTORCH_SUM_INNER_TREE": "1" if inner_tree else "0"},
-        ):
-            if provider.startswith("eager"):
+        if provider.startswith("eager"):
+            if provider == "eager_inner_tree":
                 runner()
                 milliseconds = benchmark(runner)
             else:
-                torch._dynamo.reset()
-                with fresh_inductor_cache():
-                    compiled = torch.compile(_sum_rows)
-                    runner = _circular_runner(compiled, tensors)
+                with torch.backends.python_native.cutedsl.disabled():
                     runner()
                     milliseconds = benchmark(runner)
+        else:
+            torch._dynamo.reset()
+            with fresh_inductor_cache():
+                compiled = torch.compile(_sum_rows)
+                runner = _circular_runner(compiled, tensors)
+                runner()
+                milliseconds = benchmark(runner)
         return _gbps(m, n, milliseconds)
     finally:
         del runner
@@ -91,9 +94,8 @@ def measure(m: int, n: int, provider: str, cudagraph: bool) -> float:
 def _assert_inner_tree_route() -> None:
     tensor = torch.randn(1024, 300, device="cuda", dtype=DTYPE)
     try:
-        with patch.dict(os.environ, {"PYTORCH_SUM_INNER_TREE": "1"}):
-            inner_tree = torch.sum(tensor, 1)
-        with patch.dict(os.environ, {"PYTORCH_SUM_INNER_TREE": "0"}):
+        inner_tree = torch.sum(tensor, 1)
+        with torch.backends.python_native.cutedsl.disabled():
             aten = torch.sum(tensor, 1)
         assert not torch.equal(inner_tree, aten), (  # noqa: S101
             "eager_inner_tree did not route to CuTeDSL; refusing to label ATen "

--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -3,7 +3,10 @@
 
 import os
 import unittest
-from unittest import mock
+
+
+# Native reductions register during import, so enable the rollout first.
+os.environ["PYTORCH_SUM_INNER_TREE"] = "1"
 
 import torch
 from torch._inductor import config, metrics
@@ -93,9 +96,6 @@ FUSION_CASES = (
 class StrictNumericsTest(TestCase):
     def setUp(self):
         super().setUp()
-        env_patch = mock.patch.dict(os.environ, {"PYTORCH_SUM_INNER_TREE": "1"})
-        env_patch.start()
-        self.addCleanup(env_patch.stop)
         torch.manual_seed(0)
 
     def _run(self, fn, *args, **cfg):

--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -10,10 +10,13 @@
 # CUDA inner-tree kernel produced -- the CuTeDSL kernel reproduces them
 # bit-for-bit, which is the contract for this op.
 
-import contextlib
 import os
 import unittest
 from unittest import mock
+
+
+# Native reductions register during import, so enable the rollout first.
+os.environ["PYTORCH_SUM_INNER_TREE"] = "1"
 
 import torch
 from torch.testing._internal.common_cuda import (
@@ -199,18 +202,6 @@ class TestSumCuteDSLOverride(TestCase):
         "float64": torch.float64,
     }
 
-    @contextlib.contextmanager
-    def _inner_tree_flag(self):
-        old_value = os.environ.get("PYTORCH_SUM_INNER_TREE")
-        os.environ["PYTORCH_SUM_INNER_TREE"] = "1"
-        try:
-            yield
-        finally:
-            if old_value is None:
-                os.environ.pop("PYTORCH_SUM_INNER_TREE", None)
-            else:
-                os.environ["PYTORCH_SUM_INNER_TREE"] = old_value
-
     def _make_input(self, m, n, dtype):
         compute_dtype = torch.float64 if dtype == torch.float64 else torch.float32
         cols = torch.arange(n, device="cuda", dtype=compute_dtype)
@@ -239,36 +230,30 @@ class TestSumCuteDSLOverride(TestCase):
 
     def test_cond_accepts_covered_shapes(self):
         impl = _cutedsl_impl()
-        with self._inner_tree_flag():
-            for dtype in (torch.float32, torch.float64):
-                x = torch.randn(128, 8192, device="cuda", dtype=dtype)
-                self.assertTrue(impl._cond(x, [1]))
-                # Strided outer input (contiguous reduced dim) is still covered.
-                strided = torch.randn(256, 8192, device="cuda", dtype=dtype)[::2]
-                self.assertTrue(impl._cond(strided, [1]))
+        for dtype in (torch.float32, torch.float64):
+            x = torch.randn(128, 8192, device="cuda", dtype=dtype)
+            self.assertTrue(impl._cond(x, [1]))
+            # Strided outer input (contiguous reduced dim) is still covered.
+            strided = torch.randn(256, 8192, device="cuda", dtype=dtype)[::2]
+            self.assertTrue(impl._cond(strided, [1]))
 
     def test_cond_rejects_unsupported(self):
         impl = _cutedsl_impl()
         x = torch.randn(128, 8192, device="cuda", dtype=torch.float32)
-        # No flag -> reject.
-        self.assertFalse(impl._cond(x, [1]))
-        with self._inner_tree_flag():
-            # Multi-dim and full reductions are out of scope.
-            self.assertFalse(impl._cond(x, [0, 1]))
-            self.assertFalse(impl._cond(x, None))
-            # dtype-casting sum is out of scope.
-            self.assertFalse(impl._cond(x, [1], dtype=torch.float64))
-            # Non-contiguous reduced dim.
-            self.assertFalse(impl._cond(x[:, ::2], [1]))
-            # Integer / complex dtypes fall through to aten.
-            self.assertFalse(
-                impl._cond(torch.ones(17, 8192, device="cuda", dtype=torch.int64), [1])
-            )
-            self.assertFalse(
-                impl._cond(
-                    torch.ones(17, 8192, device="cuda", dtype=torch.complex64), [1]
-                )
-            )
+        # Multi-dim and full reductions are out of scope.
+        self.assertFalse(impl._cond(x, [0, 1]))
+        self.assertFalse(impl._cond(x, None))
+        # dtype-casting sum is out of scope.
+        self.assertFalse(impl._cond(x, [1], dtype=torch.float64))
+        # Non-contiguous reduced dim.
+        self.assertFalse(impl._cond(x[:, ::2], [1]))
+        # Integer / complex dtypes fall through to aten.
+        self.assertFalse(
+            impl._cond(torch.ones(17, 8192, device="cuda", dtype=torch.int64), [1])
+        )
+        self.assertFalse(
+            impl._cond(torch.ones(17, 8192, device="cuda", dtype=torch.complex64), [1])
+        )
 
     # --- correctness ---
 
@@ -277,8 +262,7 @@ class TestSumCuteDSLOverride(TestCase):
         x = self._make_order_sensitive_input(128, 8192, dtype)
         with torch.backends.python_native.cutedsl.disabled():
             ref = x.sum(dim=1)
-        with self._inner_tree_flag():
-            got = x.sum(dim=1)
+        got = x.sum(dim=1)
         self.assertEqual(got, ref)
 
     def test_override_out_variant(self):
@@ -286,30 +270,26 @@ class TestSumCuteDSLOverride(TestCase):
         with torch.backends.python_native.cutedsl.disabled():
             ref = x.sum(dim=1)
         out = torch.empty(128, device="cuda", dtype=torch.float32)
-        with self._inner_tree_flag():
-            torch.sum(x, dim=1, out=out)
+        torch.sum(x, dim=1, out=out)
         self.assertEqual(out, ref)
 
     def test_strided_outer_input(self):
         base = torch.ones(256, 32, device="cuda", dtype=torch.float32)
         base[1::2, :] = 5
         x = base[::2, :]
-        with self._inner_tree_flag():
-            result = x.sum(dim=1)
+        result = x.sum(dim=1)
         self.assertEqual(result, torch.full((128,), 32, device="cuda", dtype=x.dtype))
 
     def test_looped_kernel_partial_last_block(self):
         x = torch.ones(129, 256, device="cuda", dtype=torch.float32)
-        with self._inner_tree_flag():
-            result = x.sum(dim=1)
+        result = x.sum(dim=1)
         self.assertEqual(result, torch.full((129,), 256, device="cuda", dtype=x.dtype))
 
     @parametrize("dtype", [torch.int64, torch.complex64])
     def test_integer_and_complex_fall_through(self, dtype):
         # CuTeDSL declines integer/complex; the call must fall through to aten.
         x = torch.ones(17, 8192, device="cuda", dtype=dtype)
-        with self._inner_tree_flag():
-            result = x.sum(dim=1)
+        result = x.sum(dim=1)
         self.assertEqual(result, torch.full((17,), 8192, device="cuda", dtype=dtype))
 
     # --- bitwise equivalence ---
@@ -320,8 +300,7 @@ class TestSumCuteDSLOverride(TestCase):
     )
     def test_cross_warp_order_sensitive_hash_sm100(self):
         x = self._make_order_sensitive_input(17, 8192, torch.float32)
-        with self._inner_tree_flag():
-            result = x.sum(dim=1)
+        result = x.sum(dim=1)
         self.assertEqual(self._sha(result), "75d8b1a702344e90")
 
     @skipIfRocm
@@ -332,8 +311,7 @@ class TestSumCuteDSLOverride(TestCase):
             for m, n in self._SHAPES:
                 with self.subTest(dtype_name=dtype_name, m=m, n=n):
                     x = self._make_input(m, n, dtype)
-                    with self._inner_tree_flag():
-                        result = self._eager_sum(x)
+                    result = self._eager_sum(x)
                     sha = self._sha(result)
                     expected = self._EXPECTED[(dtype_name, m, n)]
                     self.assertEqual(
@@ -369,8 +347,7 @@ class TestSumCuteDSLOverride(TestCase):
                 x = self._make_prod_input(m, n, dtype)
                 with torch.backends.python_native.cutedsl.disabled():
                     ref = x.prod(dim=1)
-                with self._inner_tree_flag():
-                    got = x.prod(dim=1)
+                got = x.prod(dim=1)
                 self.assertEqual(got, ref, rtol=rtol, atol=atol)
 
     def test_prod_override_engaged(self):
@@ -381,8 +358,7 @@ class TestSumCuteDSLOverride(TestCase):
         x = self._make_prod_input(128, 8192, torch.float32)
         with torch.backends.python_native.cutedsl.disabled():
             ref = x.prod(dim=1)
-        with self._inner_tree_flag():
-            got = x.prod(dim=1)
+        got = x.prod(dim=1)
         self.assertFalse(torch.equal(got, ref))
 
     @parametrize("dtype", [torch.float16, torch.bfloat16])
@@ -409,7 +385,6 @@ class TestSumCuteDSLOverride(TestCase):
                         "inner_tree_prod_into",
                         wraps=inner_tree_kernel.inner_tree_prod_into,
                     ) as prod_into,
-                    self._inner_tree_flag(),
                 ):
                     got = x.prod(dim=1)
                 # Proves fp16/bf16 route through the CuTeDSL override, not a
@@ -419,10 +394,9 @@ class TestSumCuteDSLOverride(TestCase):
 
     def test_prod_override_out_variant(self):
         x = self._make_prod_input(128, 8192, torch.float32)
-        with self._inner_tree_flag():
-            ref = x.prod(dim=1)
-            out = torch.empty(128, device="cuda", dtype=torch.float32)
-            torch.prod(x, dim=1, out=out)
+        ref = x.prod(dim=1)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        torch.prod(x, dim=1, out=out)
         # The out= path runs the same kernel as the functional path.
         self.assertEqual(out, ref, rtol=0, atol=0)
 
@@ -432,28 +406,24 @@ class TestSumCuteDSLOverride(TestCase):
         base = torch.ones(256, 32, device="cuda", dtype=torch.float32)
         base[1::2, :] = 5
         x = base[::2, :]
-        with self._inner_tree_flag():
-            result = x.prod(dim=1)
+        result = x.prod(dim=1)
         self.assertEqual(result, torch.ones(128, device="cuda", dtype=x.dtype))
 
     def test_prod_looped_partial_last_block(self):
         x = torch.ones(129, 256, device="cuda", dtype=torch.float32)
-        with self._inner_tree_flag():
-            result = x.prod(dim=1)
+        result = x.prod(dim=1)
         self.assertEqual(result, torch.ones(129, device="cuda", dtype=x.dtype))
 
     def test_prod_deterministic(self):
         x = self._make_prod_input(64, 12000, torch.float32)
-        with self._inner_tree_flag():
-            first = x.prod(dim=1)
-            second = x.prod(dim=1)
+        first = x.prod(dim=1)
+        second = x.prod(dim=1)
         self.assertEqual(first, second, rtol=0, atol=0)
 
     @parametrize("dtype", [torch.int64, torch.complex64])
     def test_prod_integer_and_complex_fall_through(self, dtype):
         x = torch.ones(17, 8192, device="cuda", dtype=dtype)
-        with self._inner_tree_flag():
-            result = x.prod(dim=1)
+        result = x.prod(dim=1)
         self.assertEqual(result, torch.ones(17, device="cuda", dtype=dtype))
 
 

--- a/torch/_native/ops/reductions/cutedsl_impl.py
+++ b/torch/_native/ops/reductions/cutedsl_impl.py
@@ -32,9 +32,9 @@ reduced dim, dtype-casting sum, integer/complex dtypes, non-collapsing outer
 layout) falls through to aten.
 
 Dispatch note: this CuTeDSL override is the only inner-tree path -- the ATen
-CUDA backend has no inner-tree kernel of its own. When this predicate accepts,
-the CuTeDSL kernel runs; when it rejects (or ``PYTORCH_SUM_INNER_TREE`` is
-unset), the call falls through to the unchanged ATen reduction.
+CUDA backend has no inner-tree kernel of its own. When the rollout config is
+disabled, no dispatcher override is installed. When enabled, accepted calls
+run the CuTeDSL kernel and rejected calls fall through to unchanged ATen.
 """
 
 from __future__ import annotations
@@ -46,6 +46,11 @@ from torch._subclasses.fake_tensor import is_fake_tensor
 from torch._tensor_iterator import reduce_op, TensorIterator
 
 from ... import cutedsl_utils as cu
+
+
+# TODO: Move this rollout gate to a shared PyTorch config once eager native-op
+# config ownership is established.
+_INNER_TREE_ENABLED = os.getenv("PYTORCH_SUM_INNER_TREE", "") not in ("", "0")
 
 
 # Reduction input dtypes the kernel handles. fp32/fp64 are the bitwise-
@@ -75,12 +80,6 @@ def _int32_indexing_safe(self: torch.Tensor, d: int) -> bool:
     vec_size = max(1, 16 // self.element_size())
     num_batches_ub = -(-n // (32 * vec_size))
     return n <= _INT32_MAX and m <= _INT32_MAX and m * num_batches_ub <= _INT32_MAX
-
-
-def _inner_tree_enabled() -> bool:
-    # The CUDA gate is `use_inner_tree_reduction()`; the CuTeDSL predicate
-    # requires the explicit feature flag (an empty/"0" value is off).
-    return os.getenv("PYTORCH_SUM_INNER_TREE", "") not in ("", "0")
 
 
 def _normalize_dim(dim: int, ndim: int) -> int:
@@ -175,8 +174,6 @@ def _geometry(self: torch.Tensor, out: torch.Tensor, it: TensorIterator):
 def _base_cond_ok(self: torch.Tensor, dim, dtype) -> int | None:
     """Shared front gate. Returns the normalized reduced dim if the call is a
     candidate, else ``None``."""
-    if not _inner_tree_enabled():
-        return None
     if not self.is_cuda or is_fake_tensor(self):
         return None
     # dtype-casting sum (an explicit out/result dtype) is out of scope.
@@ -268,6 +265,9 @@ def _make_out_impl(reduce_into):
 
 
 def register_to_dispatch() -> None:
+    if not _INNER_TREE_ENABLED:
+        return
+
     # Eligibility (_cond/_out_cond) is reduction-agnostic; only the kernel
     # entry differs between sum and prod.
     cu.register_op_override(


### PR DESCRIPTION
Summary:

Replace the per-call `os.getenv` rollout gate with a PyTorch config and only register the sum/prod CuTeDSL dispatcher overrides when the feature is enabled at import time. The default-disabled production path therefore has no Python router or environment lookup on each reduction call.

Update the dedicated tests and strict-numerics benchmark to enable the rollout before importing `torch`, and use the CuTeDSL disable context when an ATen baseline is needed.

Follow-up to D115338972.

Test Plan:
`arc f` on all changed files
`arc lint` on all changed files
`buck2 build fbcode//caffe2:gen_zipped_modules`
Verified all fbcode/xplat mirror pairs are byte-identical

Reviewed By: karthickai

Differential Revision: D116334589




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo