### PR TITLE
[FSDP2] Gate sharded-gradient frees on optimizer events

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2619,21 +2619,21 @@ class TestFullyShardWorldSize1(FSDPTest):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    def test_set_post_optim_event_before_lazy_init(self):
+    def test_set_post_optim_grad_free_event_before_lazy_init(self):
         model = nn.Linear(8, 8, bias=False).to(device_type)
         fully_shard(model)
         state = model._get_fsdp_state()
         self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
 
         event = MagicMock()
-        model.set_post_optim_event(event)
+        model.set_post_optim_grad_free_event(event)
 
         self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertTrue(state._state_ctx.post_optim_free_ordering_enabled)
+        self.assertEqual(state._state_ctx.post_optim_free_streams, set())
         self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
 
     @skip_if_lt_x_gpu(1)
-    def test_post_optim_event_orders_grad_free_streams(self):
+    def test_post_optim_grad_free_event_orders_free_streams(self):
         device_module = torch.get_device_module(device_type)
         model = nn.Linear(8, 8, bias=False).to(device_type)
         fully_shard(
@@ -2648,8 +2648,7 @@ class TestFullyShardWorldSize1(FSDPTest):
         param = next(model.parameters())
         self.assertIsNotNone(param.grad)
         device_module.synchronize()
-        self.assertFalse(state._state_ctx.post_optim_free_ordering_enabled)
-        self.assertFalse(state._state_ctx.post_optim_free_streams)
+        self.assertIsNone(state._state_ctx.post_optim_free_streams)
 
         reduce_scatter_stream = MagicMock()
         all_reduce_stream = MagicMock()
@@ -2658,8 +2657,6 @@ class TestFullyShardWorldSize1(FSDPTest):
         comm_ctx.reduce_scatter_stream = reduce_scatter_stream
         comm_ctx.all_reduce_stream = all_reduce_stream
         state._fsdp_param_groups[0]._all_reduce_hook_stream = custom_free_stream
-        state._state_ctx.post_optim_free_streams.clear()
-        state._state_ctx.post_optim_free_streams.add(historical_free_stream)
         free_streams = (
             reduce_scatter_stream,
             all_reduce_stream,
@@ -2673,12 +2670,19 @@ class TestFullyShardWorldSize1(FSDPTest):
         event = MagicMock()
         for stream in free_streams:
             stream.wait_event.side_effect = assert_grad_is_live
-        model.set_post_optim_event(event)
+
+        all_gather_only_event = MagicMock()
+        model.set_post_optim_event(all_gather_only_event)
+        for stream in free_streams:
+            stream.wait_event.assert_not_called()
+        self.assertIsNone(state._state_ctx.post_optim_free_streams)
+
+        state._state_ctx.post_optim_free_streams = {historical_free_stream}
+        model.set_post_optim_grad_free_event(event)
 
         for stream in free_streams:
             stream.wait_event.assert_called_once_with(event)
         self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertTrue(state._state_ctx.post_optim_free_ordering_enabled)
         self.assertEqual(state._state_ctx.post_optim_free_streams, set(free_streams))
 
         model.zero_grad(set_to_none=True)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -9,7 +9,7 @@ import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import torch
 import torch.distributed as dist
@@ -2620,100 +2620,69 @@ class TestFullyShardWorldSize1(FSDPTest):
 
     @skip_if_lt_x_gpu(1)
     def test_set_post_optim_event_before_lazy_init(self):
-        device_module = torch.get_device_module(device_type)
-        with patch.object(
-            device_module,
-            "_needs_explicit_stream_ordered_free",
-            True,
-            create=True,
-        ):
-            model = nn.Linear(8, 8, bias=False).to(device_type)
-            fully_shard(model)
-            state = model._get_fsdp_state()
-            self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
+        model = nn.Linear(8, 8, bias=False).to(device_type)
+        fully_shard(model)
+        state = model._get_fsdp_state()
+        self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
 
-            event = MagicMock()
-            model.set_post_optim_event(event)
+        event = MagicMock()
+        model.set_post_optim_event(event)
 
-            self.assertIs(state._state_ctx.post_optim_event, event)
-            self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
+        self.assertIs(state._state_ctx.post_optim_event, event)
+        self.assertTrue(state._state_ctx.post_optim_free_ordering_enabled)
+        self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
 
     @skip_if_lt_x_gpu(1)
     def test_post_optim_event_orders_grad_free_streams(self):
         device_module = torch.get_device_module(device_type)
-        for needs_explicit_ordering in (True, False):
-            with (
-                self.subTest(needs_explicit_ordering=needs_explicit_ordering),
-                patch.object(
-                    device_module,
-                    "_needs_explicit_stream_ordered_free",
-                    needs_explicit_ordering,
-                    create=True,
-                ),
-            ):
-                model = nn.Linear(8, 8, bias=False).to(device_type)
-                fully_shard(
-                    model,
-                    mp_policy=MixedPrecisionPolicy(reduce_dtype=torch.bfloat16),
-                )
-                inp = torch.randn(2, 8, device=device_type.type)
-                model(inp).sum().backward()
+        model = nn.Linear(8, 8, bias=False).to(device_type)
+        fully_shard(
+            model,
+            mp_policy=MixedPrecisionPolicy(reduce_dtype=torch.bfloat16),
+        )
+        inp = torch.randn(2, 8, device=device_type.type)
+        model(inp).sum().backward()
 
-                state = model._get_fsdp_state()
-                comm_ctx = state._comm_ctx
-                state_ctx = state._state_ctx
-                param = next(model.parameters())
-                self.assertIsNotNone(param.grad)
-                device_module.synchronize()
-                if needs_explicit_ordering:
-                    self.assertIn(
-                        comm_ctx.reduce_scatter_stream,
-                        state_ctx.post_optim_free_streams,
-                    )
-                    self.assertIn(
-                        comm_ctx.all_reduce_stream,
-                        state_ctx.post_optim_free_streams,
-                    )
-                else:
-                    self.assertFalse(state_ctx.post_optim_free_streams)
+        state = model._get_fsdp_state()
+        comm_ctx = state._comm_ctx
+        param = next(model.parameters())
+        self.assertIsNotNone(param.grad)
+        device_module.synchronize()
+        self.assertFalse(state._state_ctx.post_optim_free_ordering_enabled)
+        self.assertFalse(state._state_ctx.post_optim_free_streams)
 
-                reduce_scatter_stream = MagicMock()
-                all_reduce_stream = MagicMock()
-                custom_free_stream = MagicMock()
-                historical_free_stream = MagicMock()
-                comm_ctx.reduce_scatter_stream = reduce_scatter_stream
-                comm_ctx.all_reduce_stream = all_reduce_stream
-                state._fsdp_param_groups[0]._all_reduce_hook_stream = custom_free_stream
-                state_ctx.post_optim_free_streams.clear()
-                state_ctx.post_optim_free_streams.add(historical_free_stream)
-                free_streams = (
-                    reduce_scatter_stream,
-                    all_reduce_stream,
-                    custom_free_stream,
-                    historical_free_stream,
-                )
+        reduce_scatter_stream = MagicMock()
+        all_reduce_stream = MagicMock()
+        custom_free_stream = MagicMock()
+        historical_free_stream = MagicMock()
+        comm_ctx.reduce_scatter_stream = reduce_scatter_stream
+        comm_ctx.all_reduce_stream = all_reduce_stream
+        state._fsdp_param_groups[0]._all_reduce_hook_stream = custom_free_stream
+        state._state_ctx.post_optim_free_streams.clear()
+        state._state_ctx.post_optim_free_streams.add(historical_free_stream)
+        free_streams = (
+            reduce_scatter_stream,
+            all_reduce_stream,
+            custom_free_stream,
+            historical_free_stream,
+        )
 
-                def assert_grad_is_live(*args, **kwargs):
-                    self.assertIsNotNone(param.grad)
+        def assert_grad_is_live(*args, **kwargs):
+            self.assertIsNotNone(param.grad)
 
-                event = MagicMock()
-                for stream in free_streams:
-                    stream.wait_event.side_effect = assert_grad_is_live
-                model.set_post_optim_event(event)
+        event = MagicMock()
+        for stream in free_streams:
+            stream.wait_event.side_effect = assert_grad_is_live
+        model.set_post_optim_event(event)
 
-                if needs_explicit_ordering:
-                    for stream in free_streams:
-                        stream.wait_event.assert_called_once_with(event)
-                    self.assertEqual(
-                        state_ctx.post_optim_free_streams, set(free_streams)
-                    )
-                else:
-                    for stream in free_streams:
-                        stream.wait_event.assert_not_called()
-                self.assertIs(state_ctx.post_optim_event, event)
+        for stream in free_streams:
+            stream.wait_event.assert_called_once_with(event)
+        self.assertIs(state._state_ctx.post_optim_event, event)
+        self.assertTrue(state._state_ctx.post_optim_free_ordering_enabled)
+        self.assertEqual(state._state_ctx.post_optim_free_streams, set(free_streams))
 
-                model.zero_grad(set_to_none=True)
-                self.assertIsNone(param.grad)
+        model.zero_grad(set_to_none=True)
+        self.assertIsNone(param.grad)
 
     def test_train_parity_single_worldsize1(self):
         """

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -9,7 +9,6 @@ import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import Any
-from unittest.mock import MagicMock
 
 import torch
 import torch.distributed as dist
@@ -782,6 +781,86 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             )
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
+
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
+    def test_post_optim_grad_free_event(self):
+        device_module = torch.get_device_module(device_type)
+        dim, delay_ms = 16, 500
+        for target_stream_name in ("reduce_scatter", "all_reduce", "custom"):
+            with self.subTest(target_stream=target_stream_name):
+                torch.manual_seed(42)
+                model = nn.Sequential(
+                    nn.Linear(dim, dim),
+                    nn.ReLU(),
+                    nn.Linear(dim, dim),
+                )
+                ref_model = replicate(copy.deepcopy(model).to(device_type.type))
+                model = model.to(device_type)
+                fully_shard(model)
+                custom_stream = device_module.Stream()
+                model.set_all_reduce_hook(lambda output: None, stream=custom_stream)
+                ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
+                optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+                torch.manual_seed(42 + self.rank)
+                inp = torch.randn(4, dim, device=device_type.type)
+
+                # Warm up optimizer state and FSDP lazy initialization.
+                for train_model, train_optim in (
+                    (ref_model, ref_optim),
+                    (model, optim),
+                ):
+                    train_model(inp).sum().backward()
+                    train_optim.step()
+                    train_optim.zero_grad(set_to_none=True)
+                device_module.synchronize()
+                check_sharded_parity(self, ref_model, model)
+
+                for _ in range(2):
+                    ref_loss = ref_model(inp).sum()
+                    ref_loss.backward()
+                    ref_optim.step()
+                    ref_optim.zero_grad(set_to_none=True)
+
+                    loss = model(inp).sum()
+                    loss.backward()
+                    state = model._get_fsdp_state()
+                    comm_ctx = state._comm_ctx
+                    target_stream = {
+                        "reduce_scatter": comm_ctx.reduce_scatter_stream,
+                        "all_reduce": comm_ctx.all_reduce_stream,
+                        "custom": custom_stream,
+                    }[target_stream_name]
+
+                    # Start from idle streams, then delay the real optimizer
+                    # kernels so the host reaches zero_grad while they are
+                    # still consuming the sharded gradients.
+                    device_module.synchronize()
+                    device_sleep(
+                        device_type.type,
+                        int(delay_ms * get_cycles_per_ms(device_type.type)),
+                    )
+                    optim.step()
+                    optim_done = device_module.current_stream().record_event()
+                    model.set_post_optim_grad_free_event(optim_done)
+                    self.assertFalse(optim_done.query())
+
+                    optim.zero_grad(set_to_none=True)
+                    for param in model.parameters():
+                        self.assertIsNone(param.grad)
+
+                    # The marker can complete only after the target stream's
+                    # wait on optim_done, proving the read-before-free edge.
+                    free_done = target_stream.record_event()
+                    free_done.synchronize()
+                    self.assertTrue(optim_done.query())
+                    self.assertEqual(ref_loss, loss)
+
+                check_sharded_parity(self, ref_model, model)
 
 
 class TestFullyShard1DTrainingCompose(FSDPTest):
@@ -2617,76 +2696,6 @@ class TestFullyShardWorldSize1(FSDPTest):
     @property
     def world_size(self) -> int:
         return 1
-
-    @skip_if_lt_x_gpu(1)
-    def test_set_post_optim_grad_free_event_before_lazy_init(self):
-        model = nn.Linear(8, 8, bias=False).to(device_type)
-        fully_shard(model)
-        state = model._get_fsdp_state()
-        self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
-
-        event = MagicMock()
-        model.set_post_optim_grad_free_event(event)
-
-        self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertEqual(state._state_ctx.sharded_grad_free_streams, set())
-        self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
-
-    @skip_if_lt_x_gpu(1)
-    def test_post_optim_grad_free_event_orders_free_streams(self):
-        device_module = torch.get_device_module(device_type)
-        model = nn.Linear(8, 8, bias=False).to(device_type)
-        fully_shard(
-            model,
-            mp_policy=MixedPrecisionPolicy(reduce_dtype=torch.bfloat16),
-        )
-        inp = torch.randn(2, 8, device=device_type.type)
-        model(inp).sum().backward()
-
-        state = model._get_fsdp_state()
-        comm_ctx = state._comm_ctx
-        param = next(model.parameters())
-        self.assertIsNotNone(param.grad)
-        device_module.synchronize()
-        self.assertIsNone(state._state_ctx.sharded_grad_free_streams)
-
-        reduce_scatter_stream = MagicMock()
-        all_reduce_stream = MagicMock()
-        custom_free_stream = MagicMock()
-        historical_free_stream = MagicMock()
-        comm_ctx.reduce_scatter_stream = reduce_scatter_stream
-        comm_ctx.all_reduce_stream = all_reduce_stream
-        state._fsdp_param_groups[0]._all_reduce_hook_stream = custom_free_stream
-        free_streams = (
-            reduce_scatter_stream,
-            all_reduce_stream,
-            custom_free_stream,
-            historical_free_stream,
-        )
-
-        def assert_grad_is_live(*args, **kwargs):
-            self.assertIsNotNone(param.grad)
-
-        event = MagicMock()
-        for stream in free_streams:
-            stream.wait_event.side_effect = assert_grad_is_live
-
-        all_gather_only_event = MagicMock()
-        model.set_post_optim_event(all_gather_only_event)
-        for stream in free_streams:
-            stream.wait_event.assert_not_called()
-        self.assertIsNone(state._state_ctx.sharded_grad_free_streams)
-
-        state._state_ctx.sharded_grad_free_streams = {historical_free_stream}
-        model.set_post_optim_grad_free_event(event)
-
-        for stream in free_streams:
-            stream.wait_event.assert_called_once_with(event)
-        self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertEqual(state._state_ctx.sharded_grad_free_streams, set(free_streams))
-
-        model.zero_grad(set_to_none=True)
-        self.assertIsNone(param.grad)
 
     def test_train_parity_single_worldsize1(self):
         """

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -9,6 +9,7 @@ import unittest
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.distributed as dist
@@ -2616,6 +2617,68 @@ class TestFullyShardWorldSize1(FSDPTest):
     @property
     def world_size(self) -> int:
         return 1
+
+    def test_post_optim_grad_buffer_lifetime(self):
+        device_module = torch.get_device_module(device_type)
+        for use_post_optim_event in (True, False):
+            with (
+                self.subTest(use_post_optim_event=use_post_optim_event),
+                patch.object(
+                    device_module,
+                    "_needs_explicit_stream_ordered_free",
+                    True,
+                    create=True,
+                ),
+            ):
+                model = nn.Linear(8, 8, bias=False).to(device_type)
+                fully_shard(
+                    model,
+                    mp_policy=MixedPrecisionPolicy(reduce_dtype=torch.bfloat16),
+                )
+                inp = torch.randn(2, 8, device=device_type.type)
+                model(inp).sum().backward()
+
+                state = model._get_fsdp_state()
+                comm_ctx = state._comm_ctx
+                grad = next(model.parameters()).grad
+                self.assertIsInstance(grad, DTensor)
+                grad_storage_id = grad.to_local().untyped_storage()._cdata
+                self.assertEqual(
+                    set(comm_ctx._post_optim_grad_buffers), {grad_storage_id}
+                )
+
+                # The FSDP keepalive must survive clearing ``param.grad`` until
+                # the free streams are ordered after the optimizer stream.
+                model.zero_grad(set_to_none=True)
+                self.assertTrue(comm_ctx._post_optim_grad_buffers)
+
+                reduce_scatter_stream = MagicMock()
+                all_reduce_stream = MagicMock()
+                comm_ctx.reduce_scatter_stream = reduce_scatter_stream
+                comm_ctx.all_reduce_stream = all_reduce_stream
+                free_streams = (reduce_scatter_stream, all_reduce_stream)
+
+                def assert_keepalive(*args, **kwargs):
+                    self.assertTrue(comm_ctx._post_optim_grad_buffers)
+
+                if use_post_optim_event:
+                    event = MagicMock()
+                    for stream in free_streams:
+                        stream.wait_event.side_effect = assert_keepalive
+                    model.set_post_optim_event(event)
+                    for stream in free_streams:
+                        stream.wait_event.assert_called_once_with(event)
+                    self.assertIs(state._state_ctx.post_optim_event, event)
+                else:
+                    current_stream = device_module.current_stream()
+                    for stream in free_streams:
+                        stream.wait_stream.side_effect = assert_keepalive
+                    with torch.no_grad():
+                        model(inp)
+                    for stream in free_streams:
+                        stream.wait_stream.assert_called_once_with(current_stream)
+
+                self.assertFalse(comm_ctx._post_optim_grad_buffers)
 
     def test_train_parity_single_worldsize1(self):
         """

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2618,15 +2618,36 @@ class TestFullyShardWorldSize1(FSDPTest):
     def world_size(self) -> int:
         return 1
 
-    def test_post_optim_grad_buffer_lifetime(self):
+    @skip_if_lt_x_gpu(1)
+    def test_set_post_optim_event_before_lazy_init(self):
         device_module = torch.get_device_module(device_type)
-        for use_post_optim_event in (True, False):
+        with patch.object(
+            device_module,
+            "_needs_explicit_stream_ordered_free",
+            True,
+            create=True,
+        ):
+            model = nn.Linear(8, 8, bias=False).to(device_type)
+            fully_shard(model)
+            state = model._get_fsdp_state()
+            self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
+
+            event = MagicMock()
+            model.set_post_optim_event(event)
+
+            self.assertIs(state._state_ctx.post_optim_event, event)
+            self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
+
+    @skip_if_lt_x_gpu(1)
+    def test_post_optim_event_orders_grad_free_streams(self):
+        device_module = torch.get_device_module(device_type)
+        for needs_explicit_ordering in (True, False):
             with (
-                self.subTest(use_post_optim_event=use_post_optim_event),
+                self.subTest(needs_explicit_ordering=needs_explicit_ordering),
                 patch.object(
                     device_module,
                     "_needs_explicit_stream_ordered_free",
-                    True,
+                    needs_explicit_ordering,
                     create=True,
                 ),
             ):
@@ -2640,45 +2661,59 @@ class TestFullyShardWorldSize1(FSDPTest):
 
                 state = model._get_fsdp_state()
                 comm_ctx = state._comm_ctx
-                grad = next(model.parameters()).grad
-                self.assertIsInstance(grad, DTensor)
-                grad_storage_id = grad.to_local().untyped_storage()._cdata
-                self.assertEqual(
-                    set(comm_ctx._post_optim_grad_buffers), {grad_storage_id}
-                )
-
-                # The FSDP keepalive must survive clearing ``param.grad`` until
-                # the free streams are ordered after the optimizer stream.
-                model.zero_grad(set_to_none=True)
-                self.assertTrue(comm_ctx._post_optim_grad_buffers)
+                state_ctx = state._state_ctx
+                param = next(model.parameters())
+                self.assertIsNotNone(param.grad)
+                device_module.synchronize()
+                if needs_explicit_ordering:
+                    self.assertIn(
+                        comm_ctx.reduce_scatter_stream,
+                        state_ctx.post_optim_free_streams,
+                    )
+                    self.assertIn(
+                        comm_ctx.all_reduce_stream,
+                        state_ctx.post_optim_free_streams,
+                    )
+                else:
+                    self.assertFalse(state_ctx.post_optim_free_streams)
 
                 reduce_scatter_stream = MagicMock()
                 all_reduce_stream = MagicMock()
+                custom_free_stream = MagicMock()
+                historical_free_stream = MagicMock()
                 comm_ctx.reduce_scatter_stream = reduce_scatter_stream
                 comm_ctx.all_reduce_stream = all_reduce_stream
-                free_streams = (reduce_scatter_stream, all_reduce_stream)
+                state._fsdp_param_groups[0]._all_reduce_hook_stream = custom_free_stream
+                state_ctx.post_optim_free_streams.clear()
+                state_ctx.post_optim_free_streams.add(historical_free_stream)
+                free_streams = (
+                    reduce_scatter_stream,
+                    all_reduce_stream,
+                    custom_free_stream,
+                    historical_free_stream,
+                )
 
-                def assert_keepalive(*args, **kwargs):
-                    self.assertTrue(comm_ctx._post_optim_grad_buffers)
+                def assert_grad_is_live(*args, **kwargs):
+                    self.assertIsNotNone(param.grad)
 
-                if use_post_optim_event:
-                    event = MagicMock()
-                    for stream in free_streams:
-                        stream.wait_event.side_effect = assert_keepalive
-                    model.set_post_optim_event(event)
+                event = MagicMock()
+                for stream in free_streams:
+                    stream.wait_event.side_effect = assert_grad_is_live
+                model.set_post_optim_event(event)
+
+                if needs_explicit_ordering:
                     for stream in free_streams:
                         stream.wait_event.assert_called_once_with(event)
-                    self.assertIs(state._state_ctx.post_optim_event, event)
+                    self.assertEqual(
+                        state_ctx.post_optim_free_streams, set(free_streams)
+                    )
                 else:
-                    current_stream = device_module.current_stream()
                     for stream in free_streams:
-                        stream.wait_stream.side_effect = assert_keepalive
-                    with torch.no_grad():
-                        model(inp)
-                    for stream in free_streams:
-                        stream.wait_stream.assert_called_once_with(current_stream)
+                        stream.wait_event.assert_not_called()
+                self.assertIs(state_ctx.post_optim_event, event)
 
-                self.assertFalse(comm_ctx._post_optim_grad_buffers)
+                model.zero_grad(set_to_none=True)
+                self.assertIsNone(param.grad)
 
     def test_train_parity_single_worldsize1(self):
         """

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2629,7 +2629,7 @@ class TestFullyShardWorldSize1(FSDPTest):
         model.set_post_optim_grad_free_event(event)
 
         self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertEqual(state._state_ctx.post_optim_free_streams, set())
+        self.assertEqual(state._state_ctx.sharded_grad_free_streams, set())
         self.assertFalse(hasattr(state._comm_ctx, "reduce_scatter_stream"))
 
     @skip_if_lt_x_gpu(1)
@@ -2648,7 +2648,7 @@ class TestFullyShardWorldSize1(FSDPTest):
         param = next(model.parameters())
         self.assertIsNotNone(param.grad)
         device_module.synchronize()
-        self.assertIsNone(state._state_ctx.post_optim_free_streams)
+        self.assertIsNone(state._state_ctx.sharded_grad_free_streams)
 
         reduce_scatter_stream = MagicMock()
         all_reduce_stream = MagicMock()
@@ -2675,15 +2675,15 @@ class TestFullyShardWorldSize1(FSDPTest):
         model.set_post_optim_event(all_gather_only_event)
         for stream in free_streams:
             stream.wait_event.assert_not_called()
-        self.assertIsNone(state._state_ctx.post_optim_free_streams)
+        self.assertIsNone(state._state_ctx.sharded_grad_free_streams)
 
-        state._state_ctx.post_optim_free_streams = {historical_free_stream}
+        state._state_ctx.sharded_grad_free_streams = {historical_free_stream}
         model.set_post_optim_grad_free_event(event)
 
         for stream in free_streams:
             stream.wait_event.assert_called_once_with(event)
         self.assertIs(state._state_ctx.post_optim_event, event)
-        self.assertEqual(state._state_ctx.post_optim_free_streams, set(free_streams))
+        self.assertEqual(state._state_ctx.sharded_grad_free_streams, set(free_streams))
 
         model.zero_grad(set_to_none=True)
         self.assertIsNone(param.grad)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -787,7 +787,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
-    def test_post_optim_grad_free_event(self):
+    def test_gate_sharded_grad_free_on(self):
         device_module = torch.get_device_module(device_type)
         dim, delay_ms = 16, 500
         for target_stream_name in ("reduce_scatter", "all_reduce", "custom"):
@@ -846,7 +846,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
                     )
                     optim.step()
                     optim_done = device_module.current_stream().record_event()
-                    model.set_post_optim_grad_free_event(optim_done)
+                    model.gate_sharded_grad_free_on(optim_done)
                     self.assertFalse(optim_done.query())
 
                     optim.zero_grad(set_to_none=True)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -16,6 +16,7 @@ from torch.distributed.fsdp._common_utils import (
     collect_grad_tensors,
     replace_grad_tensors,
 )
+from torch.distributed.tensor import DTensor
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 
@@ -106,6 +107,11 @@ class FSDPCommContext:
         # CUDA events for synchronization
         self.all_gather_state: AllGatherState | None = None
         self.reduce_scatter_states: list[ReduceScatterState] = []
+        # Some backends execute storage deallocation as a device operation on
+        # the allocation stream. Retain the final sharded-gradient storages
+        # until that stream is ordered after the optimizer's consumer stream.
+        # The key deduplicates views into the same reduce-scatter output.
+        self._post_optim_grad_buffers: dict[int, torch.Tensor] = {}
         # Effective cap on retained reduce_scatter_states, resolved from the
         # per-group reduce_scatter_max_input_buffers in
         # FSDPState._init_shared_state. It lives here, not per group, because
@@ -125,6 +131,14 @@ class FSDPCommContext:
             return self.all_gather_copy_in_stream, self.all_gather_stream
         current_stream = self.device_handle.current_stream()
         return current_stream, current_stream
+
+    def retain_post_optim_grad_buffer(self, grad: torch.Tensor) -> None:
+        if isinstance(grad, DTensor):
+            grad = grad._local_tensor
+        if grad.device.type == "cpu":
+            return
+        storage_id = grad.untyped_storage()._cdata
+        self._post_optim_grad_buffers.setdefault(storage_id, grad)
 
 
 # See [Note: Overlapping all-gather copy-in and all-gather]
@@ -806,6 +820,11 @@ class FSDPParamGroup:
                 work.wait()
             self._all_gather_result = None
         self._post_forward_indices.clear()
+
+    def retain_post_optim_grad_buffers(self) -> None:
+        for fsdp_param in self.fsdp_params:
+            if (grad := fsdp_param.sharded_param.grad) is not None:
+                self.comm_ctx.retain_post_optim_grad_buffer(grad)
 
     def _wait_for_post_backward(self):
         if self._post_reduce_event is not None:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -16,7 +16,6 @@ from torch.distributed.fsdp._common_utils import (
     collect_grad_tensors,
     replace_grad_tensors,
 )
-from torch.distributed.tensor import DTensor
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 
@@ -107,11 +106,6 @@ class FSDPCommContext:
         # CUDA events for synchronization
         self.all_gather_state: AllGatherState | None = None
         self.reduce_scatter_states: list[ReduceScatterState] = []
-        # Some backends execute storage deallocation as a device operation on
-        # the allocation stream. Retain the final sharded-gradient storages
-        # until that stream is ordered after the optimizer's consumer stream.
-        # The key deduplicates views into the same reduce-scatter output.
-        self._post_optim_grad_buffers: dict[int, torch.Tensor] = {}
         # Effective cap on retained reduce_scatter_states, resolved from the
         # per-group reduce_scatter_max_input_buffers in
         # FSDPState._init_shared_state. It lives here, not per group, because
@@ -131,14 +125,6 @@ class FSDPCommContext:
             return self.all_gather_copy_in_stream, self.all_gather_stream
         current_stream = self.device_handle.current_stream()
         return current_stream, current_stream
-
-    def retain_post_optim_grad_buffer(self, grad: torch.Tensor) -> None:
-        if isinstance(grad, DTensor):
-            grad = grad._local_tensor
-        if grad.device.type == "cpu":
-            return
-        storage_id = grad.untyped_storage()._cdata
-        self._post_optim_grad_buffers.setdefault(storage_id, grad)
 
 
 # See [Note: Overlapping all-gather copy-in and all-gather]
@@ -820,11 +806,6 @@ class FSDPParamGroup:
                 work.wait()
             self._all_gather_result = None
         self._post_forward_indices.clear()
-
-    def retain_post_optim_grad_buffers(self) -> None:
-        for fsdp_param in self.fsdp_params:
-            if (grad := fsdp_param.sharded_param.grad) is not None:
-                self.comm_ctx.retain_post_optim_grad_buffer(grad)
 
     def _wait_for_post_backward(self):
         if self._post_reduce_event is not None:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -54,14 +54,12 @@ class FSDPStateContext(Generic[_StateType]):
         # Optional user-provided event recorded after optimizer for the
         # all-gather streams to wait on in the root pre-forward
         self.post_optim_event: torch.Event | None = None
-        # Calling ``set_post_optim_event`` opts in to ordering gradient free
-        # streams after the optimizer event.
-        self.post_optim_free_ordering_enabled: bool = False
         # Track candidate streams on which a sharded-gradient storage may be
         # freed. Keeping historical streams covers persistent ``param.grad``
         # storage if communication or custom post-reduce streams change before
-        # a later clear.
-        self.post_optim_free_streams: set[torch.Stream] = set()
+        # a later clear. ``None`` means the user has not opted in by calling
+        # ``set_post_optim_event``; an empty set means opted in before lazy init.
+        self.post_optim_free_streams: set[torch.Stream] | None = None
 
 
 class FSDPState(_State):
@@ -345,6 +343,8 @@ class FSDPState(_State):
 
     def _wait_post_optim_event_on_grad_free_streams(self, event: torch.Event) -> None:
         streams = self._state_ctx.post_optim_free_streams
+        if streams is None:
+            raise AssertionError("Expected post-optimizer free-stream ordering")
         streams.update(self._post_optim_free_streams())
         for stream in streams:
             stream.wait_event(event)
@@ -460,10 +460,8 @@ class FSDPState(_State):
                     if rs_state.event is not None:
                         self._device_handle.current_stream().wait_event(rs_state.event)
                 self._comm_ctx.reduce_scatter_states.clear()
-                if self._state_ctx.post_optim_free_ordering_enabled:
-                    self._state_ctx.post_optim_free_streams.update(
-                        self._post_optim_free_streams()
-                    )
+                if (streams := self._state_ctx.post_optim_free_streams) is not None:
+                    streams.update(self._post_optim_free_streams())
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _register_pre_backward_hook(self, output: Any) -> Any:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -59,7 +59,7 @@ class FSDPStateContext(Generic[_StateType]):
         # storage if communication or custom post-reduce streams change before
         # a later clear. ``None`` means the user has not opted in by calling
         # ``set_post_optim_event``; an empty set means opted in before lazy init.
-        self.post_optim_free_streams: set[torch.Stream] | None = None
+        self.sharded_grad_free_streams: set[torch.Stream] | None = None
 
 
 class FSDPState(_State):
@@ -330,7 +330,7 @@ class FSDPState(_State):
                         FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
             return args, kwargs
 
-    def _post_optim_free_streams(self) -> set[torch.Stream]:
+    def _sharded_grad_free_streams(self) -> set[torch.Stream]:
         streams = {
             self._comm_ctx.reduce_scatter_stream,
             self._comm_ctx.all_reduce_stream,
@@ -342,10 +342,10 @@ class FSDPState(_State):
         return streams
 
     def _wait_post_optim_event_on_grad_free_streams(self, event: torch.Event) -> None:
-        streams = self._state_ctx.post_optim_free_streams
+        streams = self._state_ctx.sharded_grad_free_streams
         if streams is None:
             raise AssertionError("Expected post-optimizer free-stream ordering")
-        streams.update(self._post_optim_free_streams())
+        streams.update(self._sharded_grad_free_streams())
         for stream in streams:
             stream.wait_event(event)
 
@@ -460,8 +460,8 @@ class FSDPState(_State):
                     if rs_state.event is not None:
                         self._device_handle.current_stream().wait_event(rs_state.event)
                 self._comm_ctx.reduce_scatter_states.clear()
-                if (streams := self._state_ctx.post_optim_free_streams) is not None:
-                    streams.update(self._post_optim_free_streams())
+                if (streams := self._state_ctx.sharded_grad_free_streams) is not None:
+                    streams.update(self._sharded_grad_free_streams())
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _register_pre_backward_hook(self, output: Any) -> Any:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -150,6 +150,7 @@ class FSDPState(_State):
                 self._state_ctx.post_optim_event = None
             else:
                 current_stream = self._device_handle.current_stream()
+                self._release_post_optim_grad_buffers(current_stream=current_stream)
                 self._comm_ctx.all_gather_copy_in_stream.wait_stream(current_stream)
                 self._comm_ctx.all_gather_stream.wait_stream(current_stream)
             if self._device.type in [
@@ -324,6 +325,41 @@ class FSDPState(_State):
                         FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
             return args, kwargs
 
+    def _needs_explicit_stream_ordered_free(self) -> bool:
+        return getattr(
+            self._device_handle, "_needs_explicit_stream_ordered_free", False
+        )
+
+    def _post_optim_grad_streams(self) -> set[torch.Stream]:
+        streams = {
+            self._comm_ctx.reduce_scatter_stream,
+            self._comm_ctx.all_reduce_stream,
+        }
+        for state in self._state_ctx.all_states:
+            for fsdp_param_group in state._fsdp_param_groups:
+                if (stream := fsdp_param_group._all_reduce_hook_stream) is not None:
+                    streams.add(stream)
+        return streams
+
+    def _release_post_optim_grad_buffers(
+        self,
+        *,
+        event: torch.Event | None = None,
+        current_stream: torch.Stream | None = None,
+    ) -> None:
+        if not self._needs_explicit_stream_ordered_free():
+            return
+        buffers = self._comm_ctx._post_optim_grad_buffers
+        if event is not None:
+            for stream in self._post_optim_grad_streams():
+                stream.wait_event(event)
+        elif buffers:
+            if current_stream is None:
+                raise AssertionError("Expected a current stream without an event")
+            for stream in self._post_optim_grad_streams():
+                stream.wait_stream(current_stream)
+        buffers.clear()
+
     @_dynamo_disable
     def _post_forward(self, module: nn.Module, input: Any, output: Any) -> Any:
         with _spmd_no_typecheck():
@@ -435,6 +471,10 @@ class FSDPState(_State):
                     if rs_state.event is not None:
                         self._device_handle.current_stream().wait_event(rs_state.event)
                 self._comm_ctx.reduce_scatter_states.clear()
+                if self._needs_explicit_stream_ordered_free():
+                    for state in self._state_ctx.all_states:
+                        for fsdp_param_group in state._fsdp_param_groups:
+                            fsdp_param_group.retain_post_optim_grad_buffers()
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _register_pre_backward_hook(self, output: Any) -> Any:
@@ -500,6 +540,7 @@ class FSDPState(_State):
         for event in self._comm_ctx._last_post_reduce_events.values():
             current_stream.wait_event(event)
         self._comm_ctx._last_post_reduce_events.clear()
+        self._comm_ctx._post_optim_grad_buffers.clear()
         self._comm_ctx.post_forward_order.clear()
         for state in self._state_ctx.all_states:
             state._modules_to_run_forward.clear()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -58,7 +58,7 @@ class FSDPStateContext(Generic[_StateType]):
         # freed. Keeping historical streams covers persistent ``param.grad``
         # storage if communication or custom post-reduce streams change before
         # a later clear. ``None`` means the user has not opted in by calling
-        # ``set_post_optim_event``; an empty set means opted in before lazy init.
+        # ``set_post_optim_grad_free_event``.
         self.sharded_grad_free_streams: set[torch.Stream] | None = None
 
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -54,11 +54,13 @@ class FSDPStateContext(Generic[_StateType]):
         # Optional user-provided event recorded after optimizer for the
         # all-gather streams to wait on in the root pre-forward
         self.post_optim_event: torch.Event | None = None
-        # Keep every candidate stream on which a sharded-gradient storage may
-        # be freed. This is root-scoped since roots sharing communication
-        # streams may use independent optimizers and custom post-reduce
-        # streams. Keep historical streams since ``param.grad`` may continue
-        # to alias an older allocation across optimizer steps.
+        # Calling ``set_post_optim_event`` opts in to ordering gradient free
+        # streams after the optimizer event.
+        self.post_optim_free_ordering_enabled: bool = False
+        # Track candidate streams on which a sharded-gradient storage may be
+        # freed. Keeping historical streams covers persistent ``param.grad``
+        # storage if communication or custom post-reduce streams change before
+        # a later clear.
         self.post_optim_free_streams: set[torch.Stream] = set()
 
 
@@ -330,11 +332,6 @@ class FSDPState(_State):
                         FSDPParamGroup._prefetch_unshard(target_param_group, "forward")
             return args, kwargs
 
-    def _needs_explicit_stream_ordered_free(self) -> bool:
-        return getattr(
-            self._device_handle, "_needs_explicit_stream_ordered_free", False
-        )
-
     def _post_optim_free_streams(self) -> set[torch.Stream]:
         streams = {
             self._comm_ctx.reduce_scatter_stream,
@@ -347,8 +344,6 @@ class FSDPState(_State):
         return streams
 
     def _wait_post_optim_event_on_grad_free_streams(self, event: torch.Event) -> None:
-        if not self._needs_explicit_stream_ordered_free():
-            return
         streams = self._state_ctx.post_optim_free_streams
         streams.update(self._post_optim_free_streams())
         for stream in streams:
@@ -465,7 +460,7 @@ class FSDPState(_State):
                     if rs_state.event is not None:
                         self._device_handle.current_stream().wait_event(rs_state.event)
                 self._comm_ctx.reduce_scatter_states.clear()
-                if self._needs_explicit_stream_ordered_free():
+                if self._state_ctx.post_optim_free_ordering_enabled:
                     self._state_ctx.post_optim_free_streams.update(
                         self._post_optim_free_streams()
                     )

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -54,6 +54,12 @@ class FSDPStateContext(Generic[_StateType]):
         # Optional user-provided event recorded after optimizer for the
         # all-gather streams to wait on in the root pre-forward
         self.post_optim_event: torch.Event | None = None
+        # Keep every candidate stream on which a sharded-gradient storage may
+        # be freed. This is root-scoped since roots sharing communication
+        # streams may use independent optimizers and custom post-reduce
+        # streams. Keep historical streams since ``param.grad`` may continue
+        # to alias an older allocation across optimizer steps.
+        self.post_optim_free_streams: set[torch.Stream] = set()
 
 
 class FSDPState(_State):
@@ -150,7 +156,6 @@ class FSDPState(_State):
                 self._state_ctx.post_optim_event = None
             else:
                 current_stream = self._device_handle.current_stream()
-                self._release_post_optim_grad_buffers(current_stream=current_stream)
                 self._comm_ctx.all_gather_copy_in_stream.wait_stream(current_stream)
                 self._comm_ctx.all_gather_stream.wait_stream(current_stream)
             if self._device.type in [
@@ -330,7 +335,7 @@ class FSDPState(_State):
             self._device_handle, "_needs_explicit_stream_ordered_free", False
         )
 
-    def _post_optim_grad_streams(self) -> set[torch.Stream]:
+    def _post_optim_free_streams(self) -> set[torch.Stream]:
         streams = {
             self._comm_ctx.reduce_scatter_stream,
             self._comm_ctx.all_reduce_stream,
@@ -341,24 +346,13 @@ class FSDPState(_State):
                     streams.add(stream)
         return streams
 
-    def _release_post_optim_grad_buffers(
-        self,
-        *,
-        event: torch.Event | None = None,
-        current_stream: torch.Stream | None = None,
-    ) -> None:
+    def _wait_post_optim_event_on_grad_free_streams(self, event: torch.Event) -> None:
         if not self._needs_explicit_stream_ordered_free():
             return
-        buffers = self._comm_ctx._post_optim_grad_buffers
-        if event is not None:
-            for stream in self._post_optim_grad_streams():
-                stream.wait_event(event)
-        elif buffers:
-            if current_stream is None:
-                raise AssertionError("Expected a current stream without an event")
-            for stream in self._post_optim_grad_streams():
-                stream.wait_stream(current_stream)
-        buffers.clear()
+        streams = self._state_ctx.post_optim_free_streams
+        streams.update(self._post_optim_free_streams())
+        for stream in streams:
+            stream.wait_event(event)
 
     @_dynamo_disable
     def _post_forward(self, module: nn.Module, input: Any, output: Any) -> Any:
@@ -472,9 +466,9 @@ class FSDPState(_State):
                         self._device_handle.current_stream().wait_event(rs_state.event)
                 self._comm_ctx.reduce_scatter_states.clear()
                 if self._needs_explicit_stream_ordered_free():
-                    for state in self._state_ctx.all_states:
-                        for fsdp_param_group in state._fsdp_param_groups:
-                            fsdp_param_group.retain_post_optim_grad_buffers()
+                    self._state_ctx.post_optim_free_streams.update(
+                        self._post_optim_free_streams()
+                    )
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _register_pre_backward_hook(self, output: Any) -> Any:
@@ -540,7 +534,6 @@ class FSDPState(_State):
         for event in self._comm_ctx._last_post_reduce_events.values():
             current_stream.wait_event(event)
         self._comm_ctx._last_post_reduce_events.clear()
-        self._comm_ctx._post_optim_grad_buffers.clear()
         self._comm_ctx.post_forward_order.clear()
         for state in self._state_ctx.all_states:
             state._modules_to_run_forward.clear()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -58,7 +58,7 @@ class FSDPStateContext(Generic[_StateType]):
         # freed. Keeping historical streams covers persistent ``param.grad``
         # storage if communication or custom post-reduce streams change before
         # a later clear. ``None`` means the user has not opted in by calling
-        # ``set_post_optim_grad_free_event``.
+        # ``gate_sharded_grad_free_on``.
         self.sharded_grad_free_streams: set[torch.Stream] | None = None
 
 

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -632,15 +632,12 @@ class FSDPModule:
         waits on the event, the event is discarded, so this API should be
         called with a new event each iteration.
 
-        For backends that require explicit stream ordering before device-side
-        deallocation, this method immediately orders every possible sharded-
-        gradient allocation/free stream after ``event``. Backends opt in with
-        ``_needs_explicit_stream_ordered_free`` on their device module. This
-        method must be called after optimizer work is enqueued and before any
-        operation that may clear or replace the gradients. This is required
-        for every optimizer step, including the final iteration. An optimizer
-        step-post hook is one way to record and set the event before
-        ``zero_grad``.
+        Calling this method also immediately orders every possible sharded-
+        gradient allocation/free stream after ``event``. It must be called
+        after optimizer work is enqueued and before any operation that may
+        clear or replace the gradients. This is required for every optimizer
+        step, including the final iteration. An optimizer step-post hook is one
+        way to record and set the event before ``zero_grad``.
         ``event`` must be ordered after every optimizer stream that consumes
         the gradients. This cannot protect a gradient cleared inside the
         optimizer step or by an optimizer-in-backward hook before this method
@@ -651,6 +648,7 @@ class FSDPModule:
                 to wait communication streams on.
         """
         state = self._get_fsdp_state()
+        state._state_ctx.post_optim_free_ordering_enabled = True
         state._state_ctx.post_optim_event = event
         if hasattr(state._comm_ctx, "reduce_scatter_stream"):
             state._wait_post_optim_event_on_grad_free_streams(event)

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -621,8 +621,8 @@ class FSDPModule:
 
     def set_post_optim_event(self, event: torch.Event) -> None:
         """
-        Sets a post-optimizer-step event for the root FSDP module to wait its
-        communication streams on.
+        Sets a post-optimizer-step event for the root FSDP module to wait the
+        all-gather streams on.
 
         By default, the root FSDP module waits the all-gather streams on the
         current stream to ensure that the optimizer step has finished before
@@ -632,24 +632,39 @@ class FSDPModule:
         waits on the event, the event is discarded, so this API should be
         called with a new event each iteration.
 
-        Calling this method also immediately orders every possible sharded-
-        gradient allocation/free stream after ``event``. It must be called
-        after optimizer work is enqueued and before any operation that may
-        clear or replace the gradients. This is required for every optimizer
-        step, including the final iteration. An optimizer step-post hook is one
-        way to record and set the event before ``zero_grad``.
-        ``event`` must be ordered after every optimizer stream that consumes
-        the gradients. This cannot protect a gradient cleared inside the
-        optimizer step or by an optimizer-in-backward hook before this method
-        is called.
-
         Args:
             event (torch.Event): Event recorded after the optimizer step
-                to wait communication streams on.
+                to wait all-gather streams on.
         """
+        self._get_fsdp_state()._state_ctx.post_optim_event = event
+
+    def set_post_optim_grad_free_event(self, event: torch.Event) -> None:
+        """
+        Sets a post-optimizer-step event for the root FSDP module to order
+        sharded-gradient frees after.
+
+        This method opts in to immediately ordering every possible sharded-
+        gradient allocation/free stream after ``event``. It also uses the
+        event for the next-forward all-gather ordering provided by
+        :meth:`set_post_optim_event`.
+
+        This method must be called after optimizer work is enqueued and before
+        any operation that may clear or replace the gradients. This is required
+        for every optimizer step, including the final iteration. An optimizer
+        step-post hook is one way to record and set the event before
+        ``zero_grad``. ``event`` must be ordered after every optimizer stream
+        that consumes the gradients. This cannot protect a gradient cleared
+        inside the optimizer step or by an optimizer-in-backward hook before
+        this method is called.
+
+        Args:
+            event (torch.Event): Event recorded after the optimizer step to
+                wait sharded-gradient allocation/free streams on.
+        """
+        self.set_post_optim_event(event)
         state = self._get_fsdp_state()
-        state._state_ctx.post_optim_free_ordering_enabled = True
-        state._state_ctx.post_optim_event = event
+        if state._state_ctx.post_optim_free_streams is None:
+            state._state_ctx.post_optim_free_streams = set()
         if hasattr(state._comm_ctx, "reduce_scatter_stream"):
             state._wait_post_optim_event_on_grad_free_streams(event)
 

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -633,20 +633,27 @@ class FSDPModule:
         called with a new event each iteration.
 
         For backends that require explicit stream ordering before device-side
-        deallocation, FSDP also retains the sharded gradient buffers through
-        the optimizer step. This method orders their allocation streams after
-        ``event`` before releasing those buffers. Such backends should call
-        this method for every optimizer step, including the final iteration,
-        to release the buffers promptly. An optimizer step-post hook is one way
-        to guarantee that the event is recorded before gradients are cleared.
+        deallocation, this method immediately orders every possible sharded-
+        gradient allocation/free stream after ``event``. Backends opt in with
+        ``_needs_explicit_stream_ordered_free`` on their device module. This
+        method must be called after optimizer work is enqueued and before any
+        operation that may clear or replace the gradients. This is required
+        for every optimizer step, including the final iteration. An optimizer
+        step-post hook is one way to record and set the event before
+        ``zero_grad``.
+        ``event`` must be ordered after every optimizer stream that consumes
+        the gradients. This cannot protect a gradient cleared inside the
+        optimizer step or by an optimizer-in-backward hook before this method
+        is called.
 
         Args:
             event (torch.Event): Event recorded after the optimizer step
                 to wait communication streams on.
         """
         state = self._get_fsdp_state()
-        state._release_post_optim_grad_buffers(event=event)
         state._state_ctx.post_optim_event = event
+        if hasattr(state._comm_ctx, "reduce_scatter_stream"):
+            state._wait_post_optim_event_on_grad_free_streams(event)
 
     @deprecated("Use `set_gradient_divide_factor` instead")
     def set_reduce_scatter_divide_factor(self, factor: float) -> None:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -621,8 +621,8 @@ class FSDPModule:
 
     def set_post_optim_event(self, event: torch.Event) -> None:
         """
-        Sets a post-optimizer-step event for the root FSDP module to wait the
-        all-gather streams on.
+        Sets a post-optimizer-step event for the root FSDP module to wait its
+        communication streams on.
 
         By default, the root FSDP module waits the all-gather streams on the
         current stream to ensure that the optimizer step has finished before
@@ -632,11 +632,21 @@ class FSDPModule:
         waits on the event, the event is discarded, so this API should be
         called with a new event each iteration.
 
+        For backends that require explicit stream ordering before device-side
+        deallocation, FSDP also retains the sharded gradient buffers through
+        the optimizer step. This method orders their allocation streams after
+        ``event`` before releasing those buffers. Such backends should call
+        this method for every optimizer step, including the final iteration,
+        to release the buffers promptly. An optimizer step-post hook is one way
+        to guarantee that the event is recorded before gradients are cleared.
+
         Args:
             event (torch.Event): Event recorded after the optimizer step
-                to wait all-gather streams on.
+                to wait communication streams on.
         """
-        self._get_fsdp_state()._state_ctx.post_optim_event = event
+        state = self._get_fsdp_state()
+        state._release_post_optim_grad_buffers(event=event)
+        state._state_ctx.post_optim_event = event
 
     @deprecated("Use `set_gradient_divide_factor` instead")
     def set_reduce_scatter_divide_factor(self, factor: float) -> None:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -663,8 +663,8 @@ class FSDPModule:
         """
         self.set_post_optim_event(event)
         state = self._get_fsdp_state()
-        if state._state_ctx.post_optim_free_streams is None:
-            state._state_ctx.post_optim_free_streams = set()
+        if state._state_ctx.sharded_grad_free_streams is None:
+            state._state_ctx.sharded_grad_free_streams = set()
         if hasattr(state._comm_ctx, "reduce_scatter_stream"):
             state._wait_post_optim_event_on_grad_free_streams(event)
 

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -661,12 +661,16 @@ class FSDPModule:
             event (torch.Event): Event recorded after the optimizer step to
                 wait sharded-gradient allocation/free streams on.
         """
-        self.set_post_optim_event(event)
         state = self._get_fsdp_state()
+        if state._is_root is not True:
+            raise RuntimeError(
+                "set_post_optim_grad_free_event() must be called on the root "
+                "FSDP module after lazy initialization"
+            )
+        self.set_post_optim_event(event)
         if state._state_ctx.sharded_grad_free_streams is None:
             state._state_ctx.sharded_grad_free_streams = set()
-        if hasattr(state._comm_ctx, "reduce_scatter_stream"):
-            state._wait_post_optim_event_on_grad_free_streams(event)
+        state._wait_post_optim_event_on_grad_free_streams(event)
 
     @deprecated("Use `set_gradient_divide_factor` instead")
     def set_reduce_scatter_divide_factor(self, factor: float) -> None:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -638,14 +638,13 @@ class FSDPModule:
         """
         self._get_fsdp_state()._state_ctx.post_optim_event = event
 
-    def set_post_optim_grad_free_event(self, event: torch.Event) -> None:
+    def gate_sharded_grad_free_on(self, event: torch.Event) -> None:
         """
-        Sets a post-optimizer-step event for the root FSDP module to order
-        sharded-gradient frees after.
+        Gates sharded-gradient frees on a post-optimizer-step event.
 
-        This method opts in to immediately ordering every possible sharded-
-        gradient allocation/free stream after ``event``. It also uses the
-        event for the next-forward all-gather ordering provided by
+        This method immediately makes every possible sharded-gradient
+        allocation/free stream wait on ``event``. It also uses the event for
+        the next-forward all-gather ordering provided by
         :meth:`set_post_optim_event`.
 
         This method must be called after optimizer work is enqueued and before
@@ -664,8 +663,8 @@ class FSDPModule:
         state = self._get_fsdp_state()
         if state._is_root is not True:
             raise RuntimeError(
-                "set_post_optim_grad_free_event() must be called on the root "
-                "FSDP module after lazy initialization"
+                "gate_sharded_grad_free_on() must be called on the root FSDP "
+                "module after lazy initialization"
             )
         self.set_post_optim_event(event)
         if state._state_ctx.sharded_grad_free_streams is None:


### PR DESCRIPTION
Some backends execute storage deallocation as device work on the allocation stream. FSDP2 already orders reduce-scatter production before the optimizer consumer stream, but clearing param.grad after optimizer.step() can enqueue a free on the allocation stream before asynchronous optimizer reads finish.

Add gate_sharded_grad_free_on() as an explicit opt-in without changing the existing set_post_optim_event() contract. The new method reuses the event for next-forward all-gather ordering and immediately makes reduce-scatter, all-reduce, custom post-reduce, and previously observed free streams wait on it. The trainer records the event after all optimizer consumers are enqueued and calls this method before zero_grad() or any other operation that clears or replaces the gradient. Stream FIFO then gates the subsequent free on completion of the optimizer read.

The root uses an optional sharded-gradient free-stream set for opt-in state: None means not opted in, while a set tracks current and historical free streams for persistent gradient storage. The new API requires an initialized root since it is only valid after optimizer work has been enqueued. This avoids record_stream, extra tensor keepalives, and interference with existing set_post_optim_event() callers. The contract must be followed for every gradient clear, including the final iteration; it does not cover gradients cleared inside optimizer.step() or optimizer-in-backward.

Test plan:

- lintrunner --take PYFMT,FLAKE8,TYPEIGNORE,TYPENOSKIP on the changed files (passed)
- CUDA_VISIBLE_DEVICES=0,1 python test/distributed/_composable/fsdp/test_fully_shard_training.py TestFullyShard1DTrainingCore.test_gate_sharded_grad_free_on (passed; real AdamW kernels, CUDA events, RS/AR/custom streams, and zero_grad)
- CUDA_VISIBLE_DEVICES=0,1 python test/distributed/_composable/fsdp/test_fully_shard_training.py TestFullyShard1DTrainingCore.test_post_optim_event (passed)