### PR TITLE
Add more ops support for functional all_reduce_coalesced

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -409,9 +409,11 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
         output.sum().backward()
 
-        # Grad G = world_size is split across the `half` tied extremum holders.
+        # Grad G = world_size is split evenly across the extremum holders: the
+        # `half` low ranks for min, the `world_size - half` high ranks for max.
         holds_extremum = (reduce_op_name == "min") == (rank < half)
-        expected_val = self.world_size / half if holds_extremum else 0.0
+        num_holders = half if reduce_op_name == "min" else self.world_size - half
+        expected_val = self.world_size / num_holders if holds_extremum else 0.0
         expected_grad = torch.full(shape, fill_value=expected_val, device=device)
         self.assertEqual(input_tensor.grad, expected_grad)
 
@@ -644,7 +646,8 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         loss.backward()
 
         holds_extremum = (reduce_op_name == "min") == (rank < half)
-        expected_val = self.world_size / half if holds_extremum else 0.0
+        num_holders = half if reduce_op_name == "min" else self.world_size - half
+        expected_val = self.world_size / num_holders if holds_extremum else 0.0
         for input_tensor in input_tensors:
             expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
             self.assertEqual(input_tensor.grad, expected_grad)
@@ -1001,6 +1004,36 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
                     expected_grad = torch.full(
                         shape, fill_value=grad_val, device=self.device
                     )
+                self.assertEqual(input_tensor.grad, expected_grad)
+
+    @with_comms
+    def test_all_reduce_min_max_ties_compile(self):
+        """min/max backward splits grad evenly across tied holders under compile.
+
+        Every rank holds the same value, so all ranks tie for both min and max
+        and the summed grad (world_size) is divided by world_size, matching
+        ATen's evenly_distribute_backward.
+        """
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+
+        for reduce_op in ["min", "max"]:
+            with self.subTest(reduce_op=reduce_op):
+
+                @torch.compile(fullgraph=True)
+                def compiled_fn(tensor):
+                    output = fcols.all_reduce(tensor, reduce_op, group=group_name)
+                    return output.sum()
+
+                input_tensor = torch.full(
+                    shape, fill_value=1.0, device=self.device, requires_grad=True
+                )
+
+                loss = compiled_fn(input_tensor)
+                loss.backward()
+
+                self.assertIsNotNone(input_tensor.grad)
+                expected_grad = torch.full(shape, fill_value=1.0, device=self.device)
                 self.assertEqual(input_tensor.grad, expected_grad)
 
     @with_comms

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -210,26 +210,56 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             self.assertEqual(chunk, expected_chunk)
 
     @parametrize("device", devices)
-    def test_all_reduce_coalesced_forward(self, device):
+    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
+    def test_all_reduce_coalesced_forward(self, device, reduce_op):
         """Test all_reduce_coalesced does all_reduce on each tensor.
 
         Tensors are VARYING (different across ranks).
-        Forward aggregates varying tensors via all_reduce(sum).
+        Forward aggregates varying tensors via all_reduce.
         """
+        shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
 
         # Each rank contributes its rank value
         input_tensors = [
-            torch.full((3, 3), fill_value=float(rank), device=device),
-            torch.full((2, 2), fill_value=float(rank), device=device),
+            torch.full(shape, fill_value=float(rank), device=device) for shape in shapes
         ]
-        outputs = fcols.all_reduce_coalesced(input_tensors, "sum", group=group_name)
+        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
 
-        # Forward does all_reduce: sum of 0+1+2+3 = 6
-        expected_value = self.world_size * (self.world_size - 1) / 2
+        rank_values = [float(r) for r in range(self.world_size)]
+        if reduce_op == "sum":
+            expected_val = sum(rank_values)
+        elif reduce_op == "avg":
+            expected_val = sum(rank_values) / self.world_size
+        elif reduce_op == "min":
+            expected_val = min(rank_values)
+        elif reduce_op == "max":
+            expected_val = max(rank_values)
         for output, input_tensor in zip(outputs, input_tensors):
-            expected = torch.full_like(input_tensor, fill_value=expected_value)
+            expected = torch.full_like(input_tensor, fill_value=expected_val)
+            self.assertEqual(output, expected)
+
+    @parametrize("device", devices)
+    def test_all_reduce_coalesced_premul_sum_forward(self, device):
+        """Test all_reduce_coalesced forward with PREMUL_SUM ReduceOp."""
+        shapes = [(3, 3), (2, 2)]
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        factor = 0.5
+
+        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
+        input_tensors = [
+            torch.full(shape, fill_value=float(rank + 1), device=device)
+            for shape in shapes
+        ]
+        outputs = fcols.all_reduce_coalesced(
+            input_tensors, reduceOp=premul_sum_op, group=group_name
+        )
+
+        expected_val = factor * sum(float(r + 1) for r in range(self.world_size))
+        for output, input_tensor in zip(outputs, input_tensors):
+            expected = torch.full_like(input_tensor, fill_value=expected_val)
             self.assertEqual(output, expected)
 
     @parametrize("device", devices)
@@ -522,31 +552,116 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
-    def test_all_reduce_coalesced_backward(self, device):
+    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
+    def test_all_reduce_coalesced_backward(self, device, reduce_op):
         """Test all_reduce_coalesced backward does all_reduce on each gradient.
 
         Tensors AND gradients are VARYING (different across ranks).
-        Backward aggregates each gradient via all_reduce(sum).
+        Backward aggregates each gradient via all_reduce().
         """
+        shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
 
-        input_tensors = [
-            torch.randn(3, 3, requires_grad=True, device=device),
-            torch.randn(2, 2, requires_grad=True, device=device),
-        ]
-        outputs = fcols.all_reduce_coalesced(input_tensors, "sum", group=group_name)
+        if reduce_op in ("min", "max"):
+            # Use distinct per-rank values so there's a unique extremum holder
+            input_tensors = [
+                torch.full(
+                    shape, fill_value=float(rank), requires_grad=True, device=device
+                )
+                for shape in shapes
+            ]
+        else:
+            input_tensors = [
+                torch.randn(*shape, requires_grad=True, device=device)
+                for shape in shapes
+            ]
+        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
 
         # Backward with ones
         loss = sum(output.sum() for output in outputs)
         loss.backward()
 
-        # Each gradient should be aggregated (backward is all_reduce)
+        if reduce_op == "sum":
+            expected_val = float(self.world_size)
+        elif reduce_op == "avg":
+            expected_val = 1.0
+        elif reduce_op == "min":
+            # Grad flows only to the rank that held the min (rank 0)
+            expected_val = float(self.world_size) if rank == 0 else 0.0
+        elif reduce_op == "max":
+            # Grad flows only to the rank that held the max (last rank)
+            expected_val = (
+                float(self.world_size) if rank == self.world_size - 1 else 0.0
+            )
         for input_tensor in input_tensors:
             self.assertIsNotNone(input_tensor.grad)
-            expected_grad = torch.full_like(
-                input_tensor, fill_value=float(self.world_size)
-            )
+            expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
             self.assertEqual(input_tensor.grad, expected_grad)
+
+    @parametrize("device", devices)
+    def test_all_reduce_coalesced_premul_sum_backward(self, device):
+        """Test all_reduce_coalesced backward with PREMUL_SUM ReduceOp."""
+        shapes = [(3, 3), (2, 2)]
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        factor = 0.5
+
+        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
+        input_tensors = [
+            torch.full(
+                shape, fill_value=float(rank + 1), requires_grad=True, device=device
+            )
+            for shape in shapes
+        ]
+        outputs = fcols.all_reduce_coalesced(
+            input_tensors, reduceOp=premul_sum_op, group=group_name
+        )
+
+        loss = sum(output.sum() for output in outputs)
+        loss.backward()
+
+        # Backward: all_reduce(1, premul_sum(0.5)) = 0.5 * world_size
+        expected_val = factor * float(self.world_size)
+        for input_tensor in input_tensors:
+            expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
+            self.assertEqual(input_tensor.grad, expected_grad)
+
+    @parametrize("device", devices)
+    @parametrize("reduce_op", ["min", "max"])
+    def test_all_reduce_coalesced_nan_backward(self, device, reduce_op):
+        """Test all_reduce_coalesced backward passes all-reduced grad for NaN inputs."""
+        shapes = [(3, 3), (2, 2)]
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+
+        input_tensors = [
+            torch.full(shape, fill_value=float(rank), requires_grad=True, device=device)
+            for shape in shapes
+        ]
+        # Inject a NaN on rank 0
+        if rank == 0:
+            with torch.no_grad():
+                for input_tensor in input_tensors:
+                    input_tensor[0, 0] = float("nan")
+
+        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
+        loss = sum(output.sum() for output in outputs)
+        loss.backward()
+
+        # NaN elements receive the all-reduced grad (world_size) rather than NaN
+        all_reduced_grad = float(self.world_size)
+        for input_tensor in input_tensors:
+            grad = input_tensor.grad
+            if rank == 0:
+                self.assertEqual(grad[0, 0], all_reduced_grad)
+                # Non-NaN elements on the extremum-holding rank get world_size
+                if reduce_op == "min":
+                    self.assertEqual(grad[0, 1], all_reduced_grad)
+                else:
+                    self.assertEqual(grad[0, 1], 0.0)
+            else:
+                self.assertFalse(grad.isnan().any())
 
     @parametrize("device", devices)
     def test_all_gather_into_tensor_coalesced_backward(self, device):

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
+import unittest
 from functools import partial, wraps
 
 import torch
@@ -51,6 +52,13 @@ min_max_reduce_ops = [
     subtest(("min", dist.ReduceOp.MIN), name="min_obj"),
     subtest(("max", "max"), name="max_str"),
     subtest(("max", dist.ReduceOp.MAX), name="max_obj"),
+]
+
+# min/max tie backward sums the holder count in float32; bf16 exercises the
+# promotion round-trip that keeps the grad dtype.
+tie_dtypes = [
+    subtest(torch.float32, name="fp32"),
+    subtest(torch.bfloat16, name="bf16"),
 ]
 
 
@@ -389,33 +397,37 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(grad, expected_grad)
 
     @parametrize("device", devices)
+    @parametrize("dtype", tie_dtypes)
     @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
-    def test_all_reduce_min_max_ties_backward(self, device, reduce_op_name, reduce_op):
+    def test_all_reduce_min_max_ties_backward(
+        self, device, dtype, reduce_op_name, reduce_op
+    ):
         """min/max backward splits grad evenly across tied extremum holders.
 
-        The lower half of the ranks hold the min and the upper half hold the
-        max, so the summed grad (world_size) is divided by the number of tied
-        ranks, matching ATen's evenly_distribute_backward.
+        Element i is held by ranks r with r + i < world_size, so the holder
+        count varies per element from world_size (all ranks tie) down to 1
+        (unique holder). The summed grad (world_size) is divided by the
+        per-element holder count, matching ATen's evenly_distribute_backward.
         """
-        shape = (3, 3)
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
-        half = self.world_size // 2
+        ws = self.world_size
 
-        value = 0.0 if rank < half else 1.0
-        input_tensor = torch.full(
-            shape, fill_value=value, requires_grad=True, device=device
-        )
+        # Example (ws=4): idx=[0,1,2,3]; element i is held by ranks r with
+        # r+i<4, so per-element counts=[4,3,2,1] (all ranks tie at i=0, unique
+        # at i=3). Rank 1 has holds=[T,T,T,F] -> grad=[4/4,4/3,4/2,0].
+        idx = torch.arange(ws, device=device)
+        holds = (rank + idx) < ws
+        extremum, other = (0.0, 1.0) if reduce_op_name == "min" else (1.0, 0.0)
+        input_tensor = torch.where(holds, extremum, other).to(dtype).requires_grad_()
+
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
         output.sum().backward()
 
-        # Grad G = world_size is split evenly across the extremum holders: the
-        # `half` low ranks for min, the `world_size - half` high ranks for max.
-        holds_extremum = (reduce_op_name == "min") == (rank < half)
-        num_holders = half if reduce_op_name == "min" else self.world_size - half
-        expected_val = self.world_size / num_holders if holds_extremum else 0.0
-        expected_grad = torch.full(shape, fill_value=expected_val, device=device)
+        count = (ws - idx).to(torch.float32)
+        expected_grad = torch.where(holds, ws / count, 0.0).to(dtype)
         self.assertEqual(input_tensor.grad, expected_grad)
+        self.assertEqual(input_tensor.grad.dtype, dtype)
 
     @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
@@ -621,36 +633,45 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             self.assertEqual(grad, expected_grad)
 
     @parametrize("device", devices)
+    @parametrize("dtype", tie_dtypes)
     @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
     def test_all_reduce_coalesced_min_max_ties_backward(
-        self, device, reduce_op_name, reduce_op
+        self, device, dtype, reduce_op_name, reduce_op
     ):
         """all_reduce_coalesced min/max backward splits grad evenly across ties.
 
-        The lower half of the ranks hold the min and the upper half hold the
-        max, so each tensor's summed grad (world_size) is divided by the number
-        of tied ranks, matching ATen's evenly_distribute_backward.
+        As in the single-tensor case, element i (along the last dim) is held by
+        ranks r with r + i < world_size, so the holder count varies per element.
+        Each tensor's summed grad (world_size) is divided by the per-element
+        count, matching ATen's evenly_distribute_backward.
         """
-        shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
-        half = self.world_size // 2
+        ws = self.world_size
 
-        value = 0.0 if rank < half else 1.0
+        # Example (ws=4): idx=[0,1,2,3]; element i is held by ranks r with
+        # r+i<4, so per-element counts=[4,3,2,1] (all ranks tie at i=0, unique
+        # at i=3). Rank 1 has holds=[T,T,T,F] -> grad=[4/4,4/3,4/2,0].
+        idx = torch.arange(ws, device=device)
+        holds = (rank + idx) < ws
+        extremum, other = (0.0, 1.0) if reduce_op_name == "min" else (1.0, 0.0)
+        values = torch.where(holds, extremum, other).to(dtype)
+        count = (ws - idx).to(torch.float32)
+        expected = torch.where(holds, ws / count, 0.0).to(dtype)
+
+        # Differently-shaped tensors sharing the last-dim tie pattern, to check
+        # the counts are batched per tensor rather than as one scalar.
+        shapes = [(ws,), (2, ws)]
         input_tensors = [
-            torch.full(shape, fill_value=value, requires_grad=True, device=device)
-            for shape in shapes
+            values.expand(shape).contiguous().requires_grad_() for shape in shapes
         ]
         outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
         loss = sum(output.sum() for output in outputs)
         loss.backward()
 
-        holds_extremum = (reduce_op_name == "min") == (rank < half)
-        num_holders = half if reduce_op_name == "min" else self.world_size - half
-        expected_val = self.world_size / num_holders if holds_extremum else 0.0
         for input_tensor in input_tensors:
-            expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
-            self.assertEqual(input_tensor.grad, expected_grad)
+            self.assertEqual(input_tensor.grad, expected.expand_as(input_tensor))
+            self.assertEqual(input_tensor.grad.dtype, dtype)
 
     @parametrize("device", devices)
     def test_all_gather_into_tensor_coalesced_backward(self, device):
@@ -1010,13 +1031,21 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
     def test_all_reduce_min_max_ties_compile(self):
         """min/max backward splits grad evenly across tied holders under compile.
 
-        Every rank holds the same value, so all ranks tie for both min and max
-        and the summed grad (world_size) is divided by world_size, matching
-        ATen's evenly_distribute_backward.
+        Element i is held by ranks r with r + i < world_size, so the holder
+        count varies per element and the compiled backward must divide the
+        summed grad by the per-element count, matching eager.
         """
-        shape = (3, 3)
         group_name = dist.group.WORLD.group_name
+        ws = self.world_size
+        rank = self.rank
 
+        idx = torch.arange(ws, device=self.device)
+        holds = (rank + idx) < ws
+        count = (ws - idx).to(torch.float32)
+        expected_grad = torch.where(holds, ws / count, 0.0)
+
+        # Only the string form is traceable under fullgraph; a ReduceOp object
+        # graph-breaks in dynamo (the object form is covered by the eager tests).
         for reduce_op in ["min", "max"]:
             with self.subTest(reduce_op=reduce_op):
 
@@ -1025,16 +1054,60 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
                     output = fcols.all_reduce(tensor, reduce_op, group=group_name)
                     return output.sum()
 
-                input_tensor = torch.full(
-                    shape, fill_value=1.0, device=self.device, requires_grad=True
-                )
+                extremum, other = (0.0, 1.0) if reduce_op == "min" else (1.0, 0.0)
+                input_tensor = torch.where(holds, extremum, other).requires_grad_()
 
-                loss = compiled_fn(input_tensor)
-                loss.backward()
+                compiled_fn(input_tensor).backward()
 
                 self.assertIsNotNone(input_tensor.grad)
-                expected_grad = torch.full(shape, fill_value=1.0, device=self.device)
                 self.assertEqual(input_tensor.grad, expected_grad)
+
+    # Known-broken: under torch.compile the coalesced min/max backward returns
+    # all-zero grads (eager is correct). The AOT joint graph is right, but
+    # Inductor's lowering of the multi-output wait_tensors op mishandles waiting
+    # the forward's coalesced output again in the backward: unlike the
+    # single-tensor wait_tensor (which gets an alias inserted), the re-wait
+    # yields wrong data, so the `input == output` extremum mask is all-False.
+    # Fixing that lives in torch/_inductor comm lowering, out of scope here.
+    @unittest.expectedFailure
+    @with_comms
+    def test_all_reduce_coalesced_min_max_ties_compile(self):
+        """coalesced min/max backward splits grad evenly across ties under compile.
+
+        Mirrors the single-tensor compile test for all_reduce_coalesced, whose
+        schema and Inductor lowering this PR touches, so the coalesced min/max
+        backward is traced and lowered.
+        """
+        group_name = dist.group.WORLD.group_name
+        ws = self.world_size
+        rank = self.rank
+
+        idx = torch.arange(ws, device=self.device)
+        holds = (rank + idx) < ws
+        count = (ws - idx).to(torch.float32)
+        expected_grad = torch.where(holds, ws / count, 0.0)
+
+        # Only the string form is traceable under fullgraph; a ReduceOp object
+        # graph-breaks in dynamo (the object form is covered by the eager tests).
+        for reduce_op in ["min", "max"]:
+            with self.subTest(reduce_op=reduce_op):
+
+                @torch.compile(fullgraph=True)
+                def compiled_fn(a, b):
+                    outs = fcols.all_reduce_coalesced(
+                        [a, b], reduce_op, group=group_name
+                    )
+                    return outs[0].sum() + outs[1].sum()
+
+                extremum, other = (0.0, 1.0) if reduce_op == "min" else (1.0, 0.0)
+                values = torch.where(holds, extremum, other)
+                a = values.clone().requires_grad_()
+                b = values.clone().requires_grad_()
+
+                compiled_fn(a, b).backward()
+
+                self.assertEqual(a.grad, expected_grad)
+                self.assertEqual(b.grad, expected_grad)
 
     @with_comms
     def test_all_gather_tensor_compile(self):

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    subtest,
 )
 
 
@@ -29,6 +30,28 @@ DEVICE = "cuda"
 devices = ["cpu"]
 if acc := torch.accelerator.current_accelerator(True):
     devices += [acc.type]
+
+
+# (name, reduce_op) parametrization data covering the string and ReduceOp-object
+# form of each op. sum/avg/min/max have both forms; premul_sum is object-only.
+reduce_ops = [
+    subtest(("sum", "sum"), name="sum_str"),
+    subtest(("sum", dist.ReduceOp.SUM), name="sum_obj"),
+    subtest(("avg", "avg"), name="avg_str"),
+    subtest(("avg", dist.ReduceOp.AVG), name="avg_obj"),
+    subtest(("min", "min"), name="min_str"),
+    subtest(("min", dist.ReduceOp.MIN), name="min_obj"),
+    subtest(("max", "max"), name="max_str"),
+    subtest(("max", dist.ReduceOp.MAX), name="max_obj"),
+    subtest(("premul_sum", dist.ReduceOp.PREMUL_SUM(0.5)), name="premul_sum_obj"),
+]
+
+min_max_reduce_ops = [
+    subtest(("min", "min"), name="min_str"),
+    subtest(("min", dist.ReduceOp.MIN), name="min_obj"),
+    subtest(("max", "max"), name="max_str"),
+    subtest(("max", dist.ReduceOp.MAX), name="max_obj"),
+]
 
 
 def with_comms(func=None):
@@ -68,48 +91,29 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
-    def test_all_reduce_forward(self, device, reduce_op):
-        """Test all_reduce does all_reduce in forward.
-
-        Tensor is VARYING (different across ranks).
-        Forward aggregates varying tensors via all_reduce.
-        """
+    @parametrize("reduce_op_name, reduce_op", reduce_ops)
+    def test_all_reduce_forward(self, device, reduce_op_name, reduce_op):
+        """Test all_reduce aggregates varying per-rank tensors in forward."""
         shape = (3, 3)
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
 
-        # Each rank contributes its rank value (tensor is varying)
+        values = [float(r) for r in range(self.world_size)]
+        if reduce_op_name == "sum":
+            expected_val = sum(values)
+        elif reduce_op_name == "avg":
+            expected_val = sum(values) / self.world_size
+        elif reduce_op_name == "min":
+            expected_val = min(values)
+        elif reduce_op_name == "max":
+            expected_val = max(values)
+        elif reduce_op_name == "premul_sum":
+            expected_val = 0.5 * sum(values)
+        else:
+            raise ValueError(f"unexpected reduce_op_name: {reduce_op_name}")
+
         input_tensor = torch.full(shape, fill_value=float(rank), device=device)
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
-
-        rank_values = [float(r) for r in range(self.world_size)]
-        if reduce_op == "sum":
-            expected_val = sum(rank_values)
-        elif reduce_op == "avg":
-            expected_val = sum(rank_values) / self.world_size
-        elif reduce_op == "min":
-            expected_val = min(rank_values)
-        elif reduce_op == "max":
-            expected_val = max(rank_values)
-        expected = torch.full(shape, fill_value=expected_val, device=device)
-        self.assertEqual(output, expected)
-
-    @parametrize("device", devices)
-    def test_all_reduce_premul_sum_forward(self, device):
-        """Test all_reduce forward with PREMUL_SUM ReduceOp."""
-        shape = (3, 3)
-        group_name = dist.group.WORLD.group_name
-        rank = dist.get_rank()
-        factor = 0.5
-
-        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
-        input_tensor = torch.full(shape, fill_value=float(rank + 1), device=device)
-        output = fcols.all_reduce(
-            input_tensor, reduceOp=premul_sum_op, group=group_name
-        )
-
-        expected_val = factor * sum(float(r + 1) for r in range(self.world_size))
         expected = torch.full(shape, fill_value=expected_val, device=device)
         self.assertEqual(output, expected)
 
@@ -210,54 +214,31 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             self.assertEqual(chunk, expected_chunk)
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
-    def test_all_reduce_coalesced_forward(self, device, reduce_op):
-        """Test all_reduce_coalesced does all_reduce on each tensor.
-
-        Tensors are VARYING (different across ranks).
-        Forward aggregates varying tensors via all_reduce.
-        """
+    @parametrize("reduce_op_name, reduce_op", reduce_ops)
+    def test_all_reduce_coalesced_forward(self, device, reduce_op_name, reduce_op):
+        """Test all_reduce_coalesced aggregates each varying per-rank tensor."""
         shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
 
-        # Each rank contributes its rank value
+        values = [float(r) for r in range(self.world_size)]
+        if reduce_op_name == "sum":
+            expected_val = sum(values)
+        elif reduce_op_name == "avg":
+            expected_val = sum(values) / self.world_size
+        elif reduce_op_name == "min":
+            expected_val = min(values)
+        elif reduce_op_name == "max":
+            expected_val = max(values)
+        elif reduce_op_name == "premul_sum":
+            expected_val = 0.5 * sum(values)
+        else:
+            raise ValueError(f"unexpected reduce_op_name: {reduce_op_name}")
+
         input_tensors = [
             torch.full(shape, fill_value=float(rank), device=device) for shape in shapes
         ]
         outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
-
-        rank_values = [float(r) for r in range(self.world_size)]
-        if reduce_op == "sum":
-            expected_val = sum(rank_values)
-        elif reduce_op == "avg":
-            expected_val = sum(rank_values) / self.world_size
-        elif reduce_op == "min":
-            expected_val = min(rank_values)
-        elif reduce_op == "max":
-            expected_val = max(rank_values)
-        for output, input_tensor in zip(outputs, input_tensors):
-            expected = torch.full_like(input_tensor, fill_value=expected_val)
-            self.assertEqual(output, expected)
-
-    @parametrize("device", devices)
-    def test_all_reduce_coalesced_premul_sum_forward(self, device):
-        """Test all_reduce_coalesced forward with PREMUL_SUM ReduceOp."""
-        shapes = [(3, 3), (2, 2)]
-        group_name = dist.group.WORLD.group_name
-        rank = dist.get_rank()
-        factor = 0.5
-
-        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
-        input_tensors = [
-            torch.full(shape, fill_value=float(rank + 1), device=device)
-            for shape in shapes
-        ]
-        outputs = fcols.all_reduce_coalesced(
-            input_tensors, reduceOp=premul_sum_op, group=group_name
-        )
-
-        expected_val = factor * sum(float(r + 1) for r in range(self.world_size))
         for output, input_tensor in zip(outputs, input_tensors):
             expected = torch.full_like(input_tensor, fill_value=expected_val)
             self.assertEqual(output, expected)
@@ -320,47 +301,42 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
-    def test_all_reduce_backward(self, device, reduce_op):
-        """Test all_reduce backward does all_reduce.
-
-        Both tensor AND gradients are VARYING (different across ranks).
-        Backward aggregates gradients via all_reduce().
-        """
+    @parametrize("reduce_op_name, reduce_op", reduce_ops)
+    def test_all_reduce_backward(self, device, reduce_op_name, reduce_op):
+        """Test all_reduce backward aggregates per-rank gradients."""
         shape = (3, 3)
         group_name = dist.group.WORLD.group_name
-
         rank = dist.get_rank()
 
-        if reduce_op in ("min", "max"):
-            # Use distinct per-rank values so there's a unique extremum holder
-            input_tensor = torch.full(
-                shape, fill_value=float(rank), requires_grad=True, device=device
+        # For min/max grad flows only to the extremum holder (rank 0 for min,
+        # the last rank for max), which distinct per-rank inputs guarantee.
+        if reduce_op_name == "sum":
+            expected_val = float(self.world_size)
+        elif reduce_op_name == "avg":
+            expected_val = 1.0
+        elif reduce_op_name == "premul_sum":
+            expected_val = 0.5 * self.world_size
+        elif reduce_op_name == "min":
+            expected_val = float(self.world_size) if rank == 0 else 0.0
+        elif reduce_op_name == "max":
+            expected_val = (
+                float(self.world_size) if rank == self.world_size - 1 else 0.0
             )
         else:
-            input_tensor = torch.randn(*shape, requires_grad=True, device=device)
+            raise ValueError(f"unexpected reduce_op_name: {reduce_op_name}")
+
+        # Distinct per-rank values so min/max have a unique extremum holder.
+        input_tensor = torch.full(
+            shape, fill_value=float(rank), requires_grad=True, device=device
+        )
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
+        output.sum().backward()  # grad_output is all ones
 
-        # Backward with ones
-        output.sum().backward()
-
-        if reduce_op == "sum":
-            expected_grad = torch.full(
-                shape, fill_value=float(self.world_size), device=device
-            )
-        elif reduce_op == "avg":
-            expected_grad = torch.full(shape, fill_value=1.0, device=device)
-        elif reduce_op == "min":
-            # Grad flows only to the rank that held the min (rank 0)
-            grad_val = float(self.world_size) if rank == 0 else 0.0
-            expected_grad = torch.full(shape, fill_value=grad_val, device=device)
-        elif reduce_op == "max":
-            # Grad flows only to the rank that held the max (last rank)
-            grad_val = float(self.world_size) if rank == self.world_size - 1 else 0.0
-            expected_grad = torch.full(shape, fill_value=grad_val, device=device)
+        expected_grad = torch.full(shape, fill_value=expected_val, device=device)
         self.assertEqual(input_tensor.grad, expected_grad)
 
-        if reduce_op not in ("min", "max"):
+        # For linear ops, backward is exactly the all_reduce of grad_outputs.
+        if reduce_op_name not in ("min", "max"):
             grad_outputs = torch.rand_like(output, device=device)
             (grad_input,) = torch.autograd.grad(
                 output, input_tensor, grad_outputs=grad_outputs
@@ -371,38 +347,8 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
-    def test_all_reduce_premul_sum_backward(self, device):
-        """Test all_reduce backward with PREMUL_SUM ReduceOp."""
-        shape = (3, 3)
-        group_name = dist.group.WORLD.group_name
-        rank = dist.get_rank()
-        factor = 0.5
-
-        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
-
-        input_tensor = torch.full(
-            shape, fill_value=float(rank + 1), requires_grad=True, device=device
-        )
-        output = fcols.all_reduce(
-            input_tensor, reduceOp=premul_sum_op, group=group_name
-        )
-
-        # Forward: premul_sum(0.5) premultiplies then sums
-        expected_fwd = factor * sum(float(r + 1) for r in range(self.world_size))
-        self.assertEqual(
-            output, torch.full(shape, fill_value=expected_fwd, device=device)
-        )
-
-        output.sum().backward()
-        # Backward: all_reduce(1, premul_sum(0.5)) = 0.5 * world_size
-        expected_grad = torch.full(
-            shape, fill_value=factor * float(self.world_size), device=device
-        )
-        self.assertEqual(input_tensor.grad, expected_grad)
-
-    @parametrize("device", devices)
-    @parametrize("reduce_op", ["min", "max"])
-    def test_all_reduce_nan_backward(self, device, reduce_op):
+    @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
+    def test_all_reduce_nan_backward(self, device, reduce_op_name, reduce_op):
         """Test all_reduce backward routes grad correctly for NaN inputs.
 
         Note: the multi-threaded PG reduces min/max via torch.min/torch.max,
@@ -433,9 +379,9 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         grad = input_tensor.grad
         self.assertFalse(grad.isnan().any())
         expected_grad = torch.zeros_like(input_tensor)
-        if reduce_op == "min" and rank == 0:
+        if reduce_op_name == "min" and rank == 0:
             expected_grad.fill_(G)
-        elif reduce_op == "max" and rank == self.world_size - 1:
+        elif reduce_op_name == "max" and rank == self.world_size - 1:
             expected_grad.fill_(G)
             expected_grad[0, 0] = 0.0
         if rank == 0:
@@ -562,84 +508,46 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["sum", "avg", "min", "max"])
-    def test_all_reduce_coalesced_backward(self, device, reduce_op):
-        """Test all_reduce_coalesced backward does all_reduce on each gradient.
-
-        Tensors AND gradients are VARYING (different across ranks).
-        Backward aggregates each gradient via all_reduce().
-        """
+    @parametrize("reduce_op_name, reduce_op", reduce_ops)
+    def test_all_reduce_coalesced_backward(self, device, reduce_op_name, reduce_op):
+        """Test all_reduce_coalesced backward aggregates each per-rank gradient."""
         shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
 
-        if reduce_op in ("min", "max"):
-            # Use distinct per-rank values so there's a unique extremum holder
-            input_tensors = [
-                torch.full(
-                    shape, fill_value=float(rank), requires_grad=True, device=device
-                )
-                for shape in shapes
-            ]
-        else:
-            input_tensors = [
-                torch.randn(*shape, requires_grad=True, device=device)
-                for shape in shapes
-            ]
-        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
-
-        # Backward with ones
-        loss = sum(output.sum() for output in outputs)
-        loss.backward()
-
-        if reduce_op == "sum":
+        # For min/max grad flows only to the extremum holder (rank 0 for min,
+        # the last rank for max), which distinct per-rank inputs guarantee.
+        if reduce_op_name == "sum":
             expected_val = float(self.world_size)
-        elif reduce_op == "avg":
+        elif reduce_op_name == "avg":
             expected_val = 1.0
-        elif reduce_op == "min":
-            # Grad flows only to the rank that held the min (rank 0)
+        elif reduce_op_name == "premul_sum":
+            expected_val = 0.5 * self.world_size
+        elif reduce_op_name == "min":
             expected_val = float(self.world_size) if rank == 0 else 0.0
-        elif reduce_op == "max":
-            # Grad flows only to the rank that held the max (last rank)
+        elif reduce_op_name == "max":
             expected_val = (
                 float(self.world_size) if rank == self.world_size - 1 else 0.0
             )
-        for input_tensor in input_tensors:
-            self.assertIsNotNone(input_tensor.grad)
-            expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
-            self.assertEqual(input_tensor.grad, expected_grad)
+        else:
+            raise ValueError(f"unexpected reduce_op_name: {reduce_op_name}")
 
-    @parametrize("device", devices)
-    def test_all_reduce_coalesced_premul_sum_backward(self, device):
-        """Test all_reduce_coalesced backward with PREMUL_SUM ReduceOp."""
-        shapes = [(3, 3), (2, 2)]
-        group_name = dist.group.WORLD.group_name
-        rank = dist.get_rank()
-        factor = 0.5
-
-        premul_sum_op = dist.ReduceOp.PREMUL_SUM(factor)
+        # Distinct per-rank values so min/max have a unique extremum holder.
         input_tensors = [
-            torch.full(
-                shape, fill_value=float(rank + 1), requires_grad=True, device=device
-            )
+            torch.full(shape, fill_value=float(rank), requires_grad=True, device=device)
             for shape in shapes
         ]
-        outputs = fcols.all_reduce_coalesced(
-            input_tensors, reduceOp=premul_sum_op, group=group_name
-        )
-
-        loss = sum(output.sum() for output in outputs)
+        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
+        loss = sum(output.sum() for output in outputs)  # grad_output is all ones
         loss.backward()
 
-        # Backward: all_reduce(1, premul_sum(0.5)) = 0.5 * world_size
-        expected_val = factor * float(self.world_size)
         for input_tensor in input_tensors:
             expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
             self.assertEqual(input_tensor.grad, expected_grad)
 
     @parametrize("device", devices)
-    @parametrize("reduce_op", ["min", "max"])
-    def test_all_reduce_coalesced_nan_backward(self, device, reduce_op):
+    @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
+    def test_all_reduce_coalesced_nan_backward(self, device, reduce_op_name, reduce_op):
         """Test all_reduce_coalesced backward routes grad correctly for NaN inputs.
 
         Note: the multi-threaded PG reduces min/max via torch.min/torch.max,
@@ -674,9 +582,9 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             grad = input_tensor.grad
             self.assertFalse(grad.isnan().any())
             expected_grad = torch.zeros_like(input_tensor)
-            if reduce_op == "min" and rank == 0:
+            if reduce_op_name == "min" and rank == 0:
                 expected_grad.fill_(G)
-            elif reduce_op == "max" and rank == self.world_size - 1:
+            elif reduce_op_name == "max" and rank == self.world_size - 1:
                 expected_grad.fill_(G)
                 expected_grad[0, 0] = 0.0
             if rank == 0:

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -389,6 +389,33 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(grad, expected_grad)
 
     @parametrize("device", devices)
+    @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
+    def test_all_reduce_min_max_ties_backward(self, device, reduce_op_name, reduce_op):
+        """min/max backward splits grad evenly across tied extremum holders.
+
+        The lower half of the ranks hold the min and the upper half hold the
+        max, so the summed grad (world_size) is divided by the number of tied
+        ranks, matching ATen's evenly_distribute_backward.
+        """
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        half = self.world_size // 2
+
+        value = 0.0 if rank < half else 1.0
+        input_tensor = torch.full(
+            shape, fill_value=value, requires_grad=True, device=device
+        )
+        output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
+        output.sum().backward()
+
+        # Grad G = world_size is split across the `half` tied extremum holders.
+        holds_extremum = (reduce_op_name == "min") == (rank < half)
+        expected_val = self.world_size / half if holds_extremum else 0.0
+        expected_grad = torch.full(shape, fill_value=expected_val, device=device)
+        self.assertEqual(input_tensor.grad, expected_grad)
+
+    @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
     def test_all_gather_tensor_backward(self, device, gather_dim):
         """Test all_gather_tensor backward does reduce_scatter.
@@ -590,6 +617,37 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
             if rank == 0:
                 expected_grad[0, 0] = G
             self.assertEqual(grad, expected_grad)
+
+    @parametrize("device", devices)
+    @parametrize("reduce_op_name, reduce_op", min_max_reduce_ops)
+    def test_all_reduce_coalesced_min_max_ties_backward(
+        self, device, reduce_op_name, reduce_op
+    ):
+        """all_reduce_coalesced min/max backward splits grad evenly across ties.
+
+        The lower half of the ranks hold the min and the upper half hold the
+        max, so each tensor's summed grad (world_size) is divided by the number
+        of tied ranks, matching ATen's evenly_distribute_backward.
+        """
+        shapes = [(3, 3), (2, 2)]
+        group_name = dist.group.WORLD.group_name
+        rank = dist.get_rank()
+        half = self.world_size // 2
+
+        value = 0.0 if rank < half else 1.0
+        input_tensors = [
+            torch.full(shape, fill_value=value, requires_grad=True, device=device)
+            for shape in shapes
+        ]
+        outputs = fcols.all_reduce_coalesced(input_tensors, reduce_op, group=group_name)
+        loss = sum(output.sum() for output in outputs)
+        loss.backward()
+
+        holds_extremum = (reduce_op_name == "min") == (rank < half)
+        expected_val = self.world_size / half if holds_extremum else 0.0
+        for input_tensor in input_tensors:
+            expected_grad = torch.full_like(input_tensor, fill_value=expected_val)
+            self.assertEqual(input_tensor.grad, expected_grad)
 
     @parametrize("device", devices)
     def test_all_gather_into_tensor_coalesced_backward(self, device):

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -403,7 +403,13 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     @parametrize("device", devices)
     @parametrize("reduce_op", ["min", "max"])
     def test_all_reduce_nan_backward(self, device, reduce_op):
-        """Test all_reduce backward passes through all-reduced grad for NaN inputs."""
+        """Test all_reduce backward routes grad correctly for NaN inputs.
+
+        Note: the multi-threaded PG reduces min/max via torch.min/torch.max,
+        which propagate NaN, so the reduced output at the NaN position is NaN.
+        Real backends (e.g. NCCL) do not guarantee NaN propagation through
+        min/max, so the reduced output there may differ from this test.
+        """
         shape = (3, 3)
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
@@ -419,18 +425,22 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
         output.sum().backward()
 
+        # Output is NaN only at [0, 0] (NaN propagates through the threaded PG).
+        # Grad G = world_size flows to the NaN holder (rank 0) at [0, 0], and to
+        # the extremum holder elsewhere: rank 0 for min (value 0), the last rank
+        # for max (value world_size - 1). Every other element is 0.
+        G = float(self.world_size)
         grad = input_tensor.grad
-        # NaN elements receive the all-reduced grad (world_size) rather than NaN
-        all_reduced_grad = float(self.world_size)
+        self.assertFalse(grad.isnan().any())
+        expected_grad = torch.zeros_like(input_tensor)
+        if reduce_op == "min" and rank == 0:
+            expected_grad.fill_(G)
+        elif reduce_op == "max" and rank == self.world_size - 1:
+            expected_grad.fill_(G)
+            expected_grad[0, 0] = 0.0
         if rank == 0:
-            self.assertEqual(grad[0, 0], all_reduced_grad)
-            # Non-NaN elements on the extremum-holding rank get world_size
-            if reduce_op == "min":
-                self.assertEqual(grad[0, 1], all_reduced_grad)
-            else:
-                self.assertEqual(grad[0, 1], 0.0)
-        else:
-            self.assertFalse(grad.isnan().any())
+            expected_grad[0, 0] = G
+        self.assertEqual(grad, expected_grad)
 
     @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
@@ -630,7 +640,13 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     @parametrize("device", devices)
     @parametrize("reduce_op", ["min", "max"])
     def test_all_reduce_coalesced_nan_backward(self, device, reduce_op):
-        """Test all_reduce_coalesced backward passes all-reduced grad for NaN inputs."""
+        """Test all_reduce_coalesced backward routes grad correctly for NaN inputs.
+
+        Note: the multi-threaded PG reduces min/max via torch.min/torch.max,
+        which propagate NaN, so the reduced output at the NaN position is NaN.
+        Real backends (e.g. NCCL) do not guarantee NaN propagation through
+        min/max, so the reduced output there may differ from this test.
+        """
         shapes = [(3, 3), (2, 2)]
         group_name = dist.group.WORLD.group_name
         rank = dist.get_rank()
@@ -649,19 +665,23 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         loss = sum(output.sum() for output in outputs)
         loss.backward()
 
-        # NaN elements receive the all-reduced grad (world_size) rather than NaN
-        all_reduced_grad = float(self.world_size)
+        # Output is NaN only at [0, 0] (NaN propagates through the threaded PG).
+        # Grad G = world_size flows to the NaN holder (rank 0) at [0, 0], and to
+        # the extremum holder elsewhere: rank 0 for min (value 0), the last rank
+        # for max (value world_size - 1). Every other element is 0.
+        G = float(self.world_size)
         for input_tensor in input_tensors:
             grad = input_tensor.grad
+            self.assertFalse(grad.isnan().any())
+            expected_grad = torch.zeros_like(input_tensor)
+            if reduce_op == "min" and rank == 0:
+                expected_grad.fill_(G)
+            elif reduce_op == "max" and rank == self.world_size - 1:
+                expected_grad.fill_(G)
+                expected_grad[0, 0] = 0.0
             if rank == 0:
-                self.assertEqual(grad[0, 0], all_reduced_grad)
-                # Non-NaN elements on the extremum-holding rank get world_size
-                if reduce_op == "min":
-                    self.assertEqual(grad[0, 1], all_reduced_grad)
-                else:
-                    self.assertEqual(grad[0, 1], 0.0)
-            else:
-                self.assertFalse(grad.isnan().any())
+                expected_grad[0, 0] = G
+            self.assertEqual(grad, expected_grad)
 
     @parametrize("device", devices)
     def test_all_gather_into_tensor_coalesced_backward(self, device):

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -119,16 +119,17 @@ std::vector<at::Tensor> all_reduce_coalesced_(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   auto group = c10d::resolve_process_group(std::move(group_name));
-  return all_reduce_coalesced_(inputs, std::move(reduce_op), std::move(group));
+  return all_reduce_coalesced_(
+      inputs, to_reduce_op(reduce_op), std::move(group));
 }
 
 std::vector<at::Tensor> all_reduce_coalesced_(
     std::vector<at::Tensor> inputs,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string reduce_op,
+    c10::intrusive_ptr<c10d::ReduceOp> reduce_op,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   c10d::AllreduceCoalescedOptions opts;
-  opts.reduceOp = *to_reduce_op(reduce_op);
+  opts.reduceOp = *reduce_op;
 
   auto work = group->allreduce_coalesced(inputs, opts);
   for (const auto& tensor : inputs) {
@@ -143,12 +144,13 @@ std::vector<at::Tensor> all_reduce_coalesced(
     std::string reduce_op,
     std::string group_name) {
   auto group = c10d::resolve_process_group(std::move(group_name));
-  return all_reduce_coalesced(inputs, std::move(reduce_op), std::move(group));
+  return all_reduce_coalesced(
+      inputs, to_reduce_op(reduce_op), std::move(group));
 }
 
 std::vector<at::Tensor> all_reduce_coalesced(
     std::vector<at::Tensor> inputs,
-    std::string reduce_op,
+    c10::intrusive_ptr<c10d::ReduceOp> reduce_op,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   std::vector<at::Tensor> outputs;
   outputs.reserve(inputs.size());
@@ -592,29 +594,29 @@ TORCH_LIBRARY(_c10d_functional, m) {
       {at::Tag::pt2_compliant_tag});
 
   m.def(
-      "all_reduce_coalesced(Tensor[] inputs, str reduce_op, Any group_name) -> Tensor[]",
+      "all_reduce_coalesced(Tensor[] inputs, Any reduce_op, Any group_name) -> Tensor[]",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           [](std::vector<at::Tensor> inputs,
-             std::string reduce_op,
+             const c10::IValue& reduce_op,
              const c10::IValue& group) {
             return c10d::all_reduce_coalesced(
                 inputs,
-                std::move(reduce_op),
+                get_reduce_op(reduce_op, "all_reduce_coalesced"),
                 get_process_group(group, "all_reduce_coalesced"));
           }),
       {at::Tag::pt2_compliant_tag});
 
   m.def(
-      "all_reduce_coalesced_(Tensor[](a!) inputs, str reduce_op, Any group_name) -> Tensor[](a!)",
+      "all_reduce_coalesced_(Tensor[](a!) inputs, Any reduce_op, Any group_name) -> Tensor[](a!)",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           [](std::vector<at::Tensor> inputs,
-             std::string reduce_op,
+             const c10::IValue& reduce_op,
              const c10::IValue& group) {
             return c10d::all_reduce_coalesced_(
                 inputs,
-                std::move(reduce_op),
+                get_reduce_op(reduce_op, "all_reduce_coalesced_"),
                 get_process_group(group, "all_reduce_coalesced_"));
           }),
       {at::Tag::pt2_compliant_tag});

--- a/torch/csrc/distributed/c10d/Functional.hpp
+++ b/torch/csrc/distributed/c10d/Functional.hpp
@@ -12,11 +12,6 @@ C10_EXPORT at::Tensor& all_reduce_(
 
 C10_EXPORT at::Tensor& all_reduce_(
     at::Tensor& input,
-    std::string reduce_op,
-    c10::intrusive_ptr<ProcessGroup> group);
-
-C10_EXPORT at::Tensor& all_reduce_(
-    at::Tensor& input,
     c10::intrusive_ptr<ReduceOp> reduce_op,
     c10::intrusive_ptr<ProcessGroup> group);
 
@@ -27,18 +22,7 @@ C10_EXPORT at::Tensor all_reduce(
 
 C10_EXPORT at::Tensor all_reduce(
     const at::Tensor& input,
-    std::string reduce_op,
-    c10::intrusive_ptr<ProcessGroup> group);
-
-C10_EXPORT at::Tensor all_reduce(
-    const at::Tensor& input,
     c10::intrusive_ptr<ReduceOp> reduce_op,
-    c10::intrusive_ptr<ProcessGroup> group);
-
-C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
-    std::vector<at::Tensor> inputs,
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string reduce_op,
     c10::intrusive_ptr<ProcessGroup> group);
 
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
@@ -53,11 +37,6 @@ C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
     std::string reduce_op,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name);
-
-C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced(
-    std::vector<at::Tensor> inputs,
-    std::string reduce_op,
-    c10::intrusive_ptr<ProcessGroup> group);
 
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced(
     std::vector<at::Tensor> inputs,

--- a/torch/csrc/distributed/c10d/Functional.hpp
+++ b/torch/csrc/distributed/c10d/Functional.hpp
@@ -44,6 +44,12 @@ C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
     std::vector<at::Tensor> inputs,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    c10::intrusive_ptr<ReduceOp> reduce_op,
+    c10::intrusive_ptr<ProcessGroup> group);
+
+C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
+    std::vector<at::Tensor> inputs,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string reduce_op,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name);
@@ -51,6 +57,11 @@ C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced_(
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced(
     std::vector<at::Tensor> inputs,
     std::string reduce_op,
+    c10::intrusive_ptr<ProcessGroup> group);
+
+C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced(
+    std::vector<at::Tensor> inputs,
+    c10::intrusive_ptr<ReduceOp> reduce_op,
     c10::intrusive_ptr<ProcessGroup> group);
 
 C10_EXPORT std::vector<at::Tensor> all_reduce_coalesced(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -687,6 +687,13 @@ def _is_reduceop_supported(op: str | ReduceOp):
     )
 
 
+def _min_max_extremum_mask(fwd_input: torch.Tensor, fwd_output: torch.Tensor):
+    # A NaN input is the extremum only when the reduced output is also NaN;
+    # gating on both keeps the extremum mask disjoint from the NaN mask even if
+    # the backend drops NaN through min/max.
+    return (fwd_input == fwd_output) | (fwd_input.isnan() & fwd_output.isnan())
+
+
 def all_reduce_backward(ctx, grad_output: torch.Tensor):
     """
     Backward for all_reduce: all_reduce with same reduce_op.
@@ -715,14 +722,16 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     if _is_min_max(reduce_op):
         fwd_input, fwd_output = ctx.saved_tensors
         fwd_output = wait_tensor(fwd_output)
-        # Route grad to the extremum holder (input == output). A NaN input is
-        # the extremum only when the reduced output is also NaN; gating on both
-        # keeps the two masks disjoint even if the backend drops NaN in min/max.
-        output = torch.ops.aten.where.self(
-            fwd_input.isnan() & fwd_output.isnan(),
-            output,
-            torch.ops.aten.where.ScalarOther(fwd_input == fwd_output, output, 0),
+        # Split the summed grad evenly across extremum holders like ATen's
+        # evenly_distribute_backward. Ties may span ranks, so the holder count
+        # is itself an all_reduce(sum) of the local extremum mask.
+        mask = _min_max_extremum_mask(fwd_input, fwd_output)
+        tie_count = wait_tensor(
+            torch.ops._c10d_functional.all_reduce(
+                mask.to(output.dtype), "sum", group_name
+            )
         )
+        output = torch.ops.aten.where.ScalarOther(mask, output / tie_count, 0)
     return output, None, None
 
 
@@ -956,20 +965,24 @@ def all_reduce_coalesced_backward(ctx, grad_outputs: list[torch.Tensor]):
         n = len(grad_inputs)
         fwd_inputs = saved[:n]
         fwd_outputs = [wait_tensor(o) for o in saved[n:]]
-        # Route grad to the extremum holder (input == output). A NaN input is
-        # the extremum only when the reduced output is also NaN; gating on both
-        # keeps the two masks disjoint even if the backend drops NaN in min/max.
+        # Split each summed grad evenly across extremum holders like ATen's
+        # evenly_distribute_backward. Ties may span ranks, so holder counts are
+        # an all_reduce(sum) of the local extremum masks, batched into one
+        # coalesced collective.
+        masks = [
+            _min_max_extremum_mask(fwd_input, fwd_output)
+            for fwd_input, fwd_output in zip(fwd_inputs, fwd_outputs)
+        ]
+        tie_counts = wait_tensors(
+            torch.ops._c10d_functional.all_reduce_coalesced(
+                [mask.to(g.dtype) for mask, g in zip(masks, grad_inputs)],
+                "sum",
+                group_name,
+            )
+        )
         grad_inputs = [
-            torch.ops.aten.where.self(
-                fwd_input.isnan() & fwd_output.isnan(),
-                grad_input,
-                torch.ops.aten.where.ScalarOther(
-                    fwd_input == fwd_output, grad_input, 0
-                ),
-            )
-            for grad_input, fwd_input, fwd_output in zip(
-                grad_inputs, fwd_inputs, fwd_outputs
-            )
+            torch.ops.aten.where.ScalarOther(mask, g / count, 0)
+            for g, mask, count in zip(grad_inputs, masks, tie_counts)
         ]
     return (grad_inputs, None, None)
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -701,13 +701,14 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     output = wait_tensor(output)
     if _is_min_max(reduce_op):
         fwd_input, fwd_output = ctx.saved_tensors
-        fwd_input_isnan = fwd_input.isnan()
+        fwd_output = wait_tensor(fwd_output)
+        # Route grad to the extremum holder (input == output). A NaN input is
+        # the extremum only when the reduced output is also NaN; gating on both
+        # keeps the two masks disjoint even if the backend drops NaN in min/max.
         output = torch.ops.aten.where.self(
-            fwd_input_isnan,
+            fwd_input.isnan() & fwd_output.isnan(),
             output,
-            torch.ops.aten.where.ScalarOther(
-                fwd_input == wait_tensor(fwd_output), output, 0
-            ),
+            torch.ops.aten.where.ScalarOther(fwd_input == fwd_output, output, 0),
         )
     return output, None, None
 
@@ -940,13 +941,17 @@ def all_reduce_coalesced_backward(ctx, grad_outputs: list[torch.Tensor]):
     if _is_min_max(reduce_op):
         saved = ctx.saved_tensors
         n = len(grad_inputs)
-        fwd_inputs, fwd_outputs = saved[:n], saved[n:]
+        fwd_inputs = saved[:n]
+        fwd_outputs = [wait_tensor(o) for o in saved[n:]]
+        # Route grad to the extremum holder (input == output). A NaN input is
+        # the extremum only when the reduced output is also NaN; gating on both
+        # keeps the two masks disjoint even if the backend drops NaN in min/max.
         grad_inputs = [
             torch.ops.aten.where.self(
-                fwd_input.isnan(),
+                fwd_input.isnan() & fwd_output.isnan(),
                 grad_input,
                 torch.ops.aten.where.ScalarOther(
-                    fwd_input == wait_tensor(fwd_output), grad_input, 0
+                    fwd_input == fwd_output, grad_input, 0
                 ),
             )
             for grad_input, fwd_input, fwd_output in zip(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -184,6 +184,11 @@ def all_reduce(
 
     :: N.B. If you pass a PG or a 1D list to perform a MPMD collective, the compiler won't be able to recover
     that information and perform collective algebraic optimization. Use other forms of input for that.
+
+    :: N.B. ``premul_sum`` backward assumes the pre-multiplier is identical on
+    every rank. With a per-rank (or tensor) factor the backward is incorrect: it
+    re-applies ``premul_sum`` to the gradient, yielding ``sum_s k_s * g_s``,
+    instead of scaling the summed gradient locally by this rank's ``k_r``.
     """
     group = _resolve_group(group, tag)
     reduce_op = reduceOp.lower() if isinstance(reduceOp, str) else reduceOp
@@ -412,6 +417,11 @@ def all_reduce_coalesced(
 
     :: N.B. If you pass a PG or a 1D list to perform a MPMD collective, the compiler won't be able to recover
     that information and perform collective algebraic optimization. Use other forms of input for that.
+
+    :: N.B. ``premul_sum`` backward assumes the pre-multiplier is identical on
+    every rank. With a per-rank (or tensor) factor the backward is incorrect: it
+    re-applies ``premul_sum`` to the gradient, yielding ``sum_s k_s * g_s``,
+    instead of scaling the summed gradient locally by this rank's ``k_r``.
     """
     group = _resolve_group(group, tag)
     reduce_op = reduceOp.lower() if isinstance(reduceOp, str) else reduceOp

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -724,14 +724,18 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
         fwd_output = wait_tensor(fwd_output)
         # Split the summed grad evenly across extremum holders like ATen's
         # evenly_distribute_backward. Ties may span ranks, so the holder count
-        # is itself an all_reduce(sum) of the local extremum mask.
+        # is itself an all_reduce(sum) of the local extremum mask. The count is
+        # summed in float32 (not the grad dtype) so it stays exact -- fp16/bf16
+        # cannot represent large integer counts. Scale in the promoted dtype,
+        # then cast back to the grad dtype.
         mask = _min_max_extremum_mask(fwd_input, fwd_output)
         tie_count = wait_tensor(
             torch.ops._c10d_functional.all_reduce(
-                mask.to(output.dtype), "sum", group_name
+                mask.to(torch.float32), "sum", group_name
             )
         )
-        output = torch.ops.aten.where.ScalarOther(mask, output / tie_count, 0)
+        scaled = (output / tie_count).to(output.dtype)
+        output = torch.ops.aten.where.ScalarOther(mask, scaled, 0)
     return output, None, None
 
 
@@ -964,24 +968,26 @@ def all_reduce_coalesced_backward(ctx, grad_outputs: list[torch.Tensor]):
         saved = ctx.saved_tensors
         n = len(grad_inputs)
         fwd_inputs = saved[:n]
-        fwd_outputs = [wait_tensor(o) for o in saved[n:]]
+        fwd_outputs = wait_tensors(list(saved[n:]))
         # Split each summed grad evenly across extremum holders like ATen's
         # evenly_distribute_backward. Ties may span ranks, so holder counts are
         # an all_reduce(sum) of the local extremum masks, batched into one
-        # coalesced collective.
+        # coalesced collective. Counts are summed in float32 (not the grad dtype)
+        # so they stay exact -- fp16/bf16 cannot represent large integer counts.
+        # Scale in the promoted dtype, then cast back to each grad dtype.
         masks = [
             _min_max_extremum_mask(fwd_input, fwd_output)
             for fwd_input, fwd_output in zip(fwd_inputs, fwd_outputs)
         ]
         tie_counts = wait_tensors(
             torch.ops._c10d_functional.all_reduce_coalesced(
-                [mask.to(g.dtype) for mask, g in zip(masks, grad_inputs)],
+                [mask.to(torch.float32) for mask in masks],
                 "sum",
                 group_name,
             )
         )
         grad_inputs = [
-            torch.ops.aten.where.ScalarOther(mask, g / count, 0)
+            torch.ops.aten.where.ScalarOther(mask, (g / count).to(g.dtype), 0)
             for g, mask, count in zip(grad_inputs, masks, tie_counts)
         ]
     return (grad_inputs, None, None)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -392,7 +392,10 @@ def reduce_scatter_tensor_autograd(
 
 
 def all_reduce_coalesced(
-    self: list[torch.Tensor], reduceOp: str, group: RANK_TYPES, tag: str = ""
+    self: list[torch.Tensor],
+    reduceOp: str | dist.ReduceOp,
+    group: RANK_TYPES,
+    tag: str = "",
 ) -> list[torch.Tensor]:
     """
     Reduces a list of tensors across all machines in such a way that all get
@@ -411,9 +414,10 @@ def all_reduce_coalesced(
     that information and perform collective algebraic optimization. Use other forms of input for that.
     """
     group = _resolve_group(group, tag)
+    reduce_op = reduceOp.lower() if isinstance(reduceOp, str) else reduceOp
     tensor_list = torch.ops._c10d_functional.all_reduce_coalesced(  # type: ignore[attr-defined]
         self,
-        reduceOp.lower(),
+        reduce_op,
         _group_or_group_name(group),
     )
     return _maybe_wrap_tensors(tensor_list)
@@ -921,19 +925,35 @@ def all_reduce_coalesced_backward(ctx, grad_outputs: list[torch.Tensor]):
     """
     group_name = ctx.group_name
     reduce_op = ctx.reduce_op
-
-    if reduce_op != "sum":
+    if not _is_reduceop_supported(reduce_op):
         raise RuntimeError(
-            f"all_reduce_coalesced backward only supports 'sum' reduction, got '{reduce_op}'"
+            f"all_reduce_coalesced backward only supports `sum`, `premul_sum`, `avg`, `max`, `min` reductions, got '{reduce_op}'"
         )
-
-    # Backward does all_reduce on list of gradients
+    grad_reduce_op = "sum" if _is_min_max(reduce_op) else reduce_op
     grad_inputs = torch.ops._c10d_functional.all_reduce_coalesced(
         [grad_output.contiguous() for grad_output in grad_outputs],
-        reduce_op,
+        grad_reduce_op,
         group_name,
     )
-    return (wait_tensors(grad_inputs), None, None)
+    grad_inputs = wait_tensors(grad_inputs)
+
+    if _is_min_max(reduce_op):
+        saved = ctx.saved_tensors
+        n = len(grad_inputs)
+        fwd_inputs, fwd_outputs = saved[:n], saved[n:]
+        grad_inputs = [
+            torch.ops.aten.where.self(
+                fwd_input.isnan(),
+                grad_input,
+                torch.ops.aten.where.ScalarOther(
+                    fwd_input == wait_tensor(fwd_output), grad_input, 0
+                ),
+            )
+            for grad_input, fwd_input, fwd_output in zip(
+                grad_inputs, fwd_inputs, fwd_outputs
+            )
+        ]
+    return (grad_inputs, None, None)
 
 
 def all_reduce_coalesced_setup_context(ctx, inputs, output):
@@ -947,7 +967,9 @@ def all_reduce_coalesced_setup_context(ctx, inputs, output):
     """
     tensor_list, reduce_op, group_name = inputs
     ctx.group_name = group_name
-    ctx.reduce_op = reduce_op.lower()
+    ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op
+    if _is_min_max(reduce_op):
+        ctx.save_for_backward(*tensor_list, *output)
 
 
 torch.library.register_autograd(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -724,7 +724,7 @@ def all_reduce_setup_context(ctx, inputs, output):
     input, reduce_op, group_name = inputs
     ctx.group_name = group_name
     ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op
-    if _is_min_max(reduce_op):
+    if _is_min_max(ctx.reduce_op):
         ctx.save_for_backward(input, output)
 
 
@@ -973,7 +973,7 @@ def all_reduce_coalesced_setup_context(ctx, inputs, output):
     tensor_list, reduce_op, group_name = inputs
     ctx.group_name = group_name
     ctx.reduce_op = reduce_op.lower() if isinstance(reduce_op, str) else reduce_op
-    if _is_min_max(reduce_op):
+    if _is_min_max(ctx.reduce_op):
         ctx.save_for_backward(*tensor_list, *output)
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -656,22 +656,35 @@ torch.library.register_autograd(
 )
 
 
+def _reduce_op_type(op: str | ReduceOp):
+    """Normalize a reduce op to a lowercase str or a ReduceOp.RedOpType.
+
+    ReduceOp.SUM/AVG/MIN/MAX are RedOpType enum members, while
+    ReduceOp.PREMUL_SUM(factor) is a ReduceOp instance exposing `.op`.
+    """
+    if isinstance(op, str):
+        return op
+    return op.op if hasattr(op, "op") else op
+
+
 def _is_min_max(op: str | ReduceOp):
-    if isinstance(op, ReduceOp):
-        return op.op in (ReduceOp.MIN, ReduceOp.MAX)
-    return op in ("min", "max")
+    op = _reduce_op_type(op)
+    if isinstance(op, str):
+        return op in ("min", "max")
+    return op in (ReduceOp.MIN, ReduceOp.MAX)
 
 
 def _is_reduceop_supported(op: str | ReduceOp):
-    if isinstance(op, ReduceOp):
-        return op.op in (
-            ReduceOp.SUM,
-            ReduceOp.AVG,
-            ReduceOp.PREMUL_SUM,
-            ReduceOp.MAX,
-            ReduceOp.MIN,
-        )
-    return op in ("sum", "avg", "premul_sum", "max", "min")
+    op = _reduce_op_type(op)
+    if isinstance(op, str):
+        return op in ("sum", "avg", "premul_sum", "max", "min")
+    return op in (
+        ReduceOp.SUM,
+        ReduceOp.AVG,
+        ReduceOp.PREMUL_SUM,
+        ReduceOp.MIN,
+        ReduceOp.MAX,
+    )
 
 
 def all_reduce_backward(ctx, grad_output: torch.Tensor):


### PR DESCRIPTION
Similar to #190942's approach, this PR adds more ops supports (forward/backward) for functional `all_reduce_coalesced`.