### PR TITLE
[precompile] Add the dynamo tracer to torch.compiler.precompile

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -64,8 +64,10 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
       With the default ``make_fx`` tracer, capture is non-strict. Control flow is
       specialized to the example inputs, and shapes are static -- each size is baked in.
-      The exception is a tensor dim explicitly marked unbacked (inductor backend only)
-      with ``torch._dynamo.decorators.mark_unbacked`` on the inputs before the call; such
+      The exception is a tensor dim explicitly marked unbacked with
+      ``torch._dynamo.decorators.mark_unbacked`` on the inputs before the call (with
+      ``make_fx`` this requires the inductor backend; with ``tracer="dynamo"`` either
+      backend works); such
       a dim is captured as an unbacked symint, so one artifact serves any runtime size of
       it, and a graph that needs to guard on it fails at capture. Each input's dtype and
       device are specialized too (a runtime mismatch is rejected), and the inductor backend
@@ -89,14 +91,33 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        ``"eager"`` keeps the captured ATen graph (layout-flexible, no kernels; shapes
        are still specialized to the example).
    :param tracer: capture front-end. ``"make_fx"`` (default) is a non-strict make_fx
-       trace and the only tracer implemented today; ``"dynamo"`` is planned and raises
-       ``NotImplementedError`` for now.
+       trace. ``"dynamo"`` analyzes the Python (bytecode) rather than tracing one path and
+       inlines the transformed bytecode Dynamo produces into ``python_code``, lowering the
+       compiled subgraph through the same ``backend`` choices; it honors ``mark_unbacked``
+       dynamic shapes (on either backend, though ``mark_unbacked(strict=True)`` raises --
+       Dynamo captures a strict mark as a guardable backed dim), ``decompositions``, and
+       training steps (a ``.backward()`` / ``torch.autograd.grad`` is traced into the graph
+       and the parameter gradients are accumulated onto the runtime model like eager). A
+       ``fn`` whose Python graph-breaks for other reasons
+       raises. Unlike ``make_fx``, the dynamo driver does NOT re-validate the
+       runtime model/inputs, so on the eager backend a drifted model (broken weight tying,
+       a retyped/reshaped weight) or a broadcast-compatible input-shape mismatch can
+       silently miscompute where ``make_fx`` would raise; pass a model and inputs matching
+       the example. The dynamo artifact inlines marshalled bytecode plus a pickled state
+       blob, so it is locked to the Python version that produced it AND, because its import
+       aliases can reference private ``torch._dynamo`` modules, to a compatible torch build,
+       unlike ``make_fx`` source (Python-version portable on either backend; use
+       ``backend='eager'`` for portability across torch builds too, since the default
+       ``make_fx`` inductor artifact inlines private ``torch._inductor`` modules).
    :param decompositions: Optional decomposition table (``dict`` of ``OpOverload`` to a
-       decomposition function) forwarded to ``make_fx``; defaults to ``None``.
+       decomposition function) controlling how ATen ops are broken down in the captured
+       graph; defaults to ``None``. ``tracer="make_fx"`` forwards it to ``make_fx`` during
+       capture; ``tracer="dynamo"`` applies the same table by re-tracing Dynamo's captured
+       subgraph with it.
    :returns: ``(python_code, cache)`` -- a self-contained Python source string (the
        single source of truth for the calling convention) and a binary acceleration
        cache (no weights, no calling-convention metadata; it carries a small
-       format/version/backend/code_hash integrity tag that ``load`` verifies).
+       format/version/backend/tracer/code_hash integrity tag that ``load`` verifies).
    :raises PrecompileError: if capture, lowering, or a runtime call violates the
        contract (see the exception below).
 
@@ -132,8 +153,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        calling conventions are not supported.
    :raises PrecompileError: if ``python_code`` is not a valid precompile artifact (it
        fails to parse or is missing its calling-convention metadata), if ``cache`` is
-       paired with a different ``python_code`` (mismatched ``backend`` tag or
-       ``code_hash``), or if a runtime call violates the precompile contract.
+       paired with a different ``python_code`` (mismatched ``backend`` tag, ``tracer``
+       tag, or ``code_hash``), or if a runtime call violates the precompile contract.
 
 .. autoexception:: torch.compiler.PrecompileError
 ```

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1,5 +1,8 @@
 # Owner(s): ["oncall: pt2"]
 import copy
+import datetime
+import enum
+import functools
 import io
 import os
 import pickle
@@ -7,12 +10,18 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import types
 import unittest
 
 import torch
 import torch.utils._pytree as _pytree
 from torch._dynamo.decorators import mark_dynamic, mark_unbacked
-from torch._precompile import PrecompileError
+from torch._precompile import (
+    _frame_modules,
+    _MODULE_SEARCH_BUDGET,
+    _MODULE_SEARCH_DEPTH,
+    PrecompileError,
+)
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
@@ -20,6 +29,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skipIfCrossRef,
     skipIfTorchDynamo,
     TestCase,
 )
@@ -28,6 +38,141 @@ from torch.testing._internal.common_utils import (
 # A module-level (global) model + a function referencing it, to exercise the
 # constant-tensor guard against a baked global.
 _GLOBAL_TENSOR = torch.randn(3)
+
+# Globals holding a tensor NESTED inside a container or an nn.Module, plus a plain scalar
+# global, to exercise the dynamo tracer's baked-constant guard (which must look through
+# containers/modules) and its uncovered-external-ref handling (a plain global folded into
+# the output must be baked, not left dangling).
+_GLOBAL_TENSOR_LIST = [torch.randn(3)]
+_GLOBAL_TENSOR_DICT = {"w": torch.randn(3)}
+_GLOBAL_SUBMODULE = torch.nn.Linear(4, 3).eval()
+_GLOBAL_SCALE = 10
+
+
+# A tensor held as a plain attribute of an arbitrary (non-pytree / non-Module) global
+# object. The dynamo tracer's baked-constant guard must look THROUGH such an object's
+# __dict__: a tensor reached via _GLOBAL_HOLDER.weight is embedded by value into the
+# artifact, so it must be rejected (invariant 1), matching the make_fx tracer's get_attr
+# scan which bakes-and-rejects the same access.
+class _TensorHolder:
+    def __init__(self, t):
+        self.weight = t
+
+
+_GLOBAL_HOLDER = _TensorHolder(torch.randn(3))
+
+
+# A tensor held in a __slots__ slot (no __dict__), and one held as an UNREGISTERED plain
+# attribute on an nn.Module (not a param/buffer). Both are baked by value when the owning
+# object is a captured global, so the dynamo tracer's invariant-1 scan must reach them --
+# through __slots__ and through the module's own __dict__ -- matching what make_fx rejects.
+class _SlotHolder:
+    __slots__ = ("weight",)
+
+    def __init__(self, t):
+        self.weight = t
+
+
+class _UnregisteredAttrModule(torch.nn.Module):
+    def __init__(self, t):
+        super().__init__()
+        self.foo = t
+
+
+_GLOBAL_SLOT_HOLDER = _SlotHolder(torch.randn(3))
+_GLOBAL_UNREGISTERED_MODULE = _UnregisteredAttrModule(torch.randn(3))
+
+
+_GRAD_RAIL_MODULE = types.ModuleType("_precompile_grad_rail_mod")
+_GRAD_RAIL_MODULE.__file__ = "_precompile_grad_rail_mod.py"
+exec(
+    compile(
+        "import torch\nmodel = torch.nn.Linear(4, 3)\n",
+        _GRAD_RAIL_MODULE.__file__,
+        "exec",
+    ),
+    _GRAD_RAIL_MODULE.__dict__,
+)
+sys.modules["_precompile_grad_rail_mod"] = _GRAD_RAIL_MODULE
+
+
+def _grad_rail_module_global_step(xx, tt):
+    torch.nn.functional.mse_loss(_GRAD_RAIL_MODULE.model(xx), tt).backward()
+
+
+class _StarvedInner:
+    def __init__(self, model):
+        self.model = model
+
+
+class _StarvedHolder:
+    """A holder whose model the module walk provably cannot reach.
+
+    The walk is breadth first with a per-argument object budget, so starving it
+    takes breadth AHEAD of the model plus one step of depth: ``bucket`` fills the
+    next frontier before ``inner`` is expanded, and ``inner.model`` is never
+    enqueued. A plain big sibling attribute no longer starves it (that is what
+    breadth first bought), so a test that wants the unreachable case has to be
+    built this way or it silently tests the reachable one.
+    """
+
+    def __init__(self, model):
+        self.bucket = [object() for _ in range(_MODULE_SEARCH_BUDGET + 10)]
+        self.inner = _StarvedInner(model)
+
+    def step(self, xx, tt):
+        torch.nn.functional.mse_loss(self.inner.model(xx), tt).backward()
+
+    def grad_step(self, xx, tt):
+        loss = torch.nn.functional.mse_loss(self.inner.model(xx), tt)
+        return torch.autograd.grad(loss, list(self.inner.model.parameters()))
+
+    def zeroing_step(self, xx, tt):
+        for p in self.inner.model.parameters():
+            p.grad = None
+        torch.nn.functional.mse_loss(self.inner.model(xx), tt).backward()
+
+
+class _Phase(enum.Enum):
+    GEN = 1
+
+
+# A functools.partial carrying a tensor: pickle bakes that tensor BY VALUE via the partial's
+# __reduce__, even though it lives outside __dict__/__slots__, so the invariant-1 scan (which
+# keys off what pickle serializes by value) must reject it. Contrast _global_helper_with_attr:
+# a module-level function is pickled BY REFERENCE, so a tensor merely attached to it is NOT
+# baked and must NOT be (falsely) rejected.
+_GLOBAL_PARTIAL = functools.partial(torch.mul, torch.randn(3))
+
+
+def _global_helper_with_attr():
+    return None
+
+
+_global_helper_with_attr.cache = torch.randn(3)
+
+
+# A bound method carries its __self__ (and any tensor __self__ holds) into the pickle BY
+# VALUE, so a bound method captured by fn (e.g. as a default callback) bakes that tensor and
+# must be rejected (invariant 1) -- the scan replays pickle's traversal, which reaches the
+# tensor through __self__.
+class _MethodHolder:
+    def __init__(self, t):
+        self.t = t
+
+    def add(self, z):
+        return z + self.t
+
+
+_GLOBAL_METHOD_HOLDER = _MethodHolder(torch.randn(3))
+
+
+# A global container holding a tensor FOLLOWED by an unpicklable object (a module-level
+# lambda pickle cannot serialize). _baked_tensors pickles the container, records the tensor
+# via its persistent_id hook mid-traversal, then swallows the lambda's PicklingError and
+# returns the tensor found BEFORE the failure -- so invariant 1's actionable "hard-coded"
+# error fires at capture rather than the generic "not picklable" error at metadata build.
+_GLOBAL_TENSOR_THEN_UNPICKLABLE = [torch.randn(3), lambda z: z]
 
 
 # A custom pytree node whose context (a set) is not JSON-dumpable and which has no
@@ -291,13 +436,16 @@ class TestPrecompile(TestCase):
 
         blob = torch.load(io.BytesIO(cache), weights_only=False)
         # The artifact is the only compiled blob; the rest is the integrity tag (the
-        # format/version/backend tag plus a code_hash binding the cache to its python_code).
+        # format/version/backend/tracer tag plus a code_hash binding the cache to its
+        # python_code).
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertEqual(blob["format"], _CACHE_FORMAT)
         self.assertEqual(blob["version"], _CACHE_VERSION)
         self.assertEqual(blob["backend"], "inductor")
+        self.assertEqual(blob["tracer"], "make_fx")
         self.assertIsInstance(blob["artifact"], bytes)
         # The calling convention is recoverable from python_code alone.
         from torch._precompile import _parse_artifact_metadata
@@ -339,7 +487,8 @@ class TestPrecompile(TestCase):
         _code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
         blob = torch.load(io.BytesIO(cache), weights_only=True)  # must not raise
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertEqual(blob["format"], _CACHE_FORMAT)
         self.assertEqual(blob["version"], _CACHE_VERSION)
@@ -871,15 +1020,1909 @@ class TestPrecompile(TestCase):
             )
             self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), m(x))
 
-    def test_tracer_dynamo_not_implemented(self):
-        # "dynamo" is a valid (planned) tracer value but is not implemented yet; it must
-        # raise NotImplementedError, not silently fall back to make_fx.
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_roundtrip(self, backend):
+        # The dynamo tracer captures via Dynamo, inlines the transformed bytecode, and
+        # (like make_fx) lowers the subgraph through the chosen backend. The reload runs
+        # the same computation as eager, and a different but structurally identical model
+        # swapped in at runtime works (invariant 2) -- no weights are baked in.
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+        ).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), m(x))
+            m2 = torch.nn.Sequential(
+                torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+            ).eval()
+            self.assertEqual(f_c(m2, x), m2(x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_self_contained_exec(self, backend):
+        # python_code runs on its own (no cache): the dynamo driver rehydrates the inlined
+        # transformed bytecode and wires the inlined subgraph, so exec'ing it and calling
+        # forward reproduces eager.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        with self.assertRaisesRegex(NotImplementedError, "tracer='dynamo'"):
+        code, _ = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+        )
+        ns = {"__name__": "_a"}
+        exec(compile(code, "<a>", "exec"), ns)
+        self.assertEqual(ns["forward"](m, x), m(x))
+
+    def test_tracer_dynamo_inlines_bytecode(self):
+        # The dynamo tracer's mechanism: the transformed bytecode is INLINED into
+        # python_code (marshalled), tagged with TRACER = 'dynamo'. This is what
+        # distinguishes it from the make_fx artifact (which inlines a rendered graph).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, _ = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        self.assertIn("TRACER = 'dynamo'", code)
+        self.assertIn("_DYNAMO_CODE = ", code)
+        self.assertIn("_build_dynamo_forward()", code)
+
+    def test_tracer_dynamo_baked_global_tensor_rejected(self):
+        # Invariant 1 holds for the dynamo tracer too: a tensor closed over by fn (here a
+        # module global) would be embedded by value; Dynamo surfaces it as a used-global,
+        # and precompile rejects it just like the make_fx tracer's get_attr scan.
+        def f(xx):
+            return xx + _GLOBAL_TENSOR
+
+        with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+            torch.compiler.precompile(f, torch.randn(3), tracer="dynamo")
+
+    # Crossref wraps torch functions in a checker Dynamo treats as skipped, so a
+    # backward traced INTO the graph -- which every tracer="dynamo" training
+    # capture does -- cannot be captured as one full graph. The whole training
+    # family below is therefore unrunnable under crossref and carries this skip;
+    # every other config still runs it.
+    @skipIfCrossRef
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_training_accumulates_like_eager(self, backend):
+        # A training step captures with the dynamo tracer: precompile pins
+        # trace_autograd_ops so Dynamo rewrites the backward in-graph instead of
+        # graph-breaking. The artifact returns fn's own result (None) and ACCUMULATES the
+        # harvested grads onto the runtime model, matching eager .backward() on every call
+        # -- the second call is the one that catches a baked assign-instead-of-accumulate
+        # (Note [precompile dynamo training grad accumulation]).
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        captured = fresh()
+        train_step(captured, x, t)
+        code, cache = torch.compiler.precompile(
+            train_step, captured, x, t, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            run, ref = fresh(), fresh()
+            train_step(run, x, t)
+            train_step(ref, x, t)
+            for _ in range(3):
+                self.assertIsNone(f_c(run, x, t))
+                train_step(ref, x, t)
+                self.assertEqual(run.weight.grad, ref.weight.grad)
+                self.assertEqual(run.bias.grad, ref.bias.grad)
+            # A warm-state artifact must not silently change its captured branch.
+            run.zero_grad(set_to_none=True)
+            with self.assertRaisesRegex(PrecompileError, "captured with .grad"):
+                f_c(run, x, t)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_preserves_cold_grad_branch(self):
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            scale = 2 if model.weight.grad is None else 3
+            (torch.nn.functional.mse_loss(model(xx), tt) * scale).backward()
+            return scale
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            train_step, fresh(), x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        self.assertEqual(f_c(run, x, t), train_step(ref, x, t))
+        self.assertEqual(run.weight.grad, ref.weight.grad)
+        with self.assertRaisesRegex(
+            PrecompileError, "captured with .grad equal to None"
+        ):
+            f_c(run, x, t)
+
+    @skipIfCrossRef
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_training_self_contained_exec(self, backend):
+        # A training artifact is self-contained too: exec'ing python_code alone (no cache,
+        # no load()) gives a forward that runs the backward and updates the model's grads,
+        # while validating the same incoming gradient state used at capture.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, _ = torch.compiler.precompile(
+            train_step, fresh(), x, t, tracer="dynamo", backend=backend
+        )
+        ns = {"__name__": "_a"}
+        exec(compile(code, "<a>", "exec"), ns)
+        run, ref = fresh(), fresh()
+        ns["forward"](run, x, t)
+        train_step(ref, x, t)
+        self.assertEqual(run.weight.grad, ref.weight.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_optimizer_loop(self):
+        # The whole point of accumulating correctly: a zero_grad / step loop converges to
+        # the same weights as eager.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            train_step, fresh(), x, t, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        run_opt = torch.optim.SGD(run.parameters(), lr=0.1)
+        ref_opt = torch.optim.SGD(ref.parameters(), lr=0.1)
+        for _ in range(3):
+            run_opt.zero_grad()
+            f_c(run, x, t)
+            run_opt.step()
+            ref_opt.zero_grad()
+            train_step(ref, x, t)
+            ref_opt.step()
+        self.assertEqual(run.weight, ref.weight)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_frozen_param_keeps_none_grad(self):
+        # Only params the captured backward actually accumulates into are recorded, so a
+        # frozen param keeps .grad = None exactly as eager leaves it (invariant 5).
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            m = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 3))
+            m[0].weight.requires_grad_(False)
+            m[0].bias.requires_grad_(False)
+            return m
+
+        code, cache = torch.compiler.precompile(
+            train_step, fresh(), x, t, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        f_c(run, x, t)
+        train_step(ref, x, t)
+        self.assertIsNone(run[0].weight.grad)
+        self.assertIsNone(ref[0].weight.grad)
+        self.assertEqual(run[1].weight.grad, ref[1].weight.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_warm_capture(self):
+        # Capturing a model whose params ALREADY carry grads takes the single-pass path
+        # (no seeding needed, the accumulate form is what Dynamo bakes anyway) and must
+        # preserve warm accumulation when the runtime model is warm too.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        warm = fresh()
+        train_step(warm, x, t)  # grads exist at capture time
+        code, cache = torch.compiler.precompile(train_step, warm, x, t, tracer="dynamo")
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        train_step(run, x, t)
+        train_step(ref, x, t)
+        f_c(run, x, t)
+        train_step(ref, x, t)
+        self.assertEqual(run.weight.grad, ref.weight.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_capture_does_not_touch_example_grads(self):
+        # The diagnostic re-capture temporarily seeds grads to discover the state checks;
+        # it must restore the caller's model exactly.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        m = torch.nn.Linear(4, 3)
+        torch.compiler.precompile(train_step, m, x, t, tracer="dynamo")
+        self.assertTrue(all(p.grad is None for p in m.parameters()))
+
+    def test_tracer_dynamo_autograd_grad_returned(self):
+        # torch.autograd.grad is captured too, and (unlike .backward()) it only RETURNS the
+        # grads: nothing is scattered, so the runtime model's .grad stays None.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def grad_step(model, xx, tt):
+            loss = torch.nn.functional.mse_loss(model(xx), tt)
+            return torch.autograd.grad(loss, list(model.parameters()))
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            grad_step, fresh(), x, t, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        self.assertEqual(f_c(run, x, t), grad_step(ref, x, t))
+        self.assertTrue(all(p.grad is None for p in run.parameters()))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_input_requiring_grad_rejected(self):
+        # Only module parameters get a harvested gradient (invariant 5). A user input that
+        # requires grad would carry the same trace-time .grad specialization with no place
+        # to correct it, so it is rejected rather than silently baked.
+        x, t = torch.randn(5, 4, requires_grad=True), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        m = torch.nn.Linear(4, 3)
+        with self.assertRaisesRegex(PrecompileError, "only harvests gradients"):
+            torch.compiler.precompile(train_step, m, x, t, tracer="dynamo")
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_unreachable_model_rejected(self):
+        # The whole point of the two-pass capture is to bake the ACCUMULATING form
+        # of the backward, which needs a GRAD_PARAM_STATES entry naming each param
+        # so the driver can validate its incoming .grad. A param the module walk never
+        # reached gets no entry and can silently take a different captured branch.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+        holder = _StarvedHolder(torch.nn.Linear(4, 3))
+        with self.assertRaisesRegex(
+            PrecompileError, "cannot re-create at runtime"
+        ) as cm:
+            torch.compiler.precompile(
+                holder.step, x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertIn("L['self'].inner.model._parameters['weight']", str(cm.exception))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_partial_attribution_rejected(self):
+        # PARTIAL attribution is the dangerous shape and the reason the check is a
+        # per-tensor one: submodules held in a plain list are invisible to
+        # named_parameters(), so GRAD_PARAM_STATES is non-empty (the registered head
+        # is in it) while the list's params are not. Anything that only asked "did we
+        # find any params at all" passed this and froze extra[0]'s grads from step 1.
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.head = torch.nn.Linear(4, 3)
+                object.__setattr__(self, "extra", [torch.nn.Linear(4, 4)])
+
+            def forward(self, xx):
+                return self.head(self.extra[0](xx))
+
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        with self.assertRaisesRegex(
+            PrecompileError, "cannot re-create at runtime"
+        ) as cm:
+            torch.compiler.precompile(
+                step, Net(), x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertIn("L['model'].extra[0]._parameters['weight']", str(cm.exception))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_requires_grad_buffer_rejected(self):
+        # A requires_grad BUFFER is a legal autograd target that named_parameters()
+        # can never name, so there is no entry to write for it. Refusing aligns the
+        # dynamo tracer with the make_fx tracer, which already has its own buffer
+        # error; the word _buffers in the path is the whole diagnosis.
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 3)
+                self.register_buffer("scale", torch.ones(3, requires_grad=True))
+
+            def forward(self, xx):
+                return self.lin(xx) * self.scale
+
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        with self.assertRaisesRegex(
+            PrecompileError, "cannot re-create at runtime"
+        ) as cm:
+            torch.compiler.precompile(
+                step, Net(), x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertIn("_buffers['scale']", str(cm.exception))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_model_behind_a_module_global_rejected(self):
+        # Invariant 1 rejects a model baked into fn's globals or closure, but a model
+        # behind a MODULE global slips through it: the module is recorded by reference
+        # and re-imported at load, so _reject_baked_tensors never sees its params. The
+        # walk cannot reach it either (it is not an argument), so this is exactly the
+        # unattributed case and diverges from eager at step 1.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+        with self.assertRaisesRegex(
+            PrecompileError, "cannot re-create at runtime"
+        ) as cm:
+            torch.compiler.precompile(
+                _grad_rail_module_global_step, x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertIn("model._parameters['weight']", str(cm.exception))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_model_deeper_than_the_search_rejected(self):
+        # The walk stops at _MODULE_SEARCH_DEPTH, and past it the failure was silent.
+        class D:
+            def __init__(self, child):
+                self.child = child
+
+        node: object = torch.nn.Linear(4, 3)
+        for _ in range(_MODULE_SEARCH_DEPTH + 3):
+            node = D(node)
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(holder, xx, tt):
+            h = holder
+            for _ in range(_MODULE_SEARCH_DEPTH + 3):
+                h = h.child
+            torch.nn.functional.mse_loss(h(xx), tt).backward()
+
+        with self.assertRaisesRegex(
+            PrecompileError, "cannot re-create at runtime"
+        ) as cm:
+            torch.compiler.precompile(
+                step, node, x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertIn("_parameters['weight']", str(cm.exception))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_refusal_does_not_recommend_make_fx(self):
+        # Every other precompile refusal offers tracer='make_fx' as the way out, and
+        # here that advice is a circle: make_fx cannot reach the tensor either and
+        # refuses these shapes with its own errors.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+        holder = _StarvedHolder(torch.nn.Linear(4, 3))
+        with self.assertRaises(PrecompileError) as cm:
+            torch.compiler.precompile(
+                holder.step, x, t, tracer="dynamo", backend="eager"
+            )
+        self.assertNotIn("use tracer='make_fx'", str(cm.exception))
+
+    def test_tracer_dynamo_unreachable_model_with_pure_autograd_grad_accepted(self):
+        # Nothing is scattered, so there is no .grad to attribute and the rail must
+        # not fire just because a model happens to be out of the walk's reach.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def fresh():
+            torch.manual_seed(0)
+            return _StarvedHolder(torch.nn.Linear(4, 3))
+
+        code, cache = torch.compiler.precompile(
+            fresh().grad_step, x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        self.assertEqual(f_c(run, x, t), ref.grad_step(x, t))
+        self.assertTrue(all(p.grad is None for p in run.inner.model.parameters()))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_in_trace_grad_none_with_unreachable_model_accepted(self):
+        # An unreachable model is only wrong when the artifact has to MATERIALIZE a
+        # .grad for it. When fn nulls .grad itself, eager assigns too, so the assign
+        # form the capture bakes is right and refusing would be a false alarm. The
+        # rail can tell because it asks the re-capture rather than the source: seed,
+        # re-capture, and if no .grad came back as a graph input then fn nulled it.
+        # A predicate over "requires_grad graph inputs we could not attribute" -- the
+        # obvious formulation -- refuses this, which is why the test is here.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def fresh():
+            torch.manual_seed(0)
+            return _StarvedHolder(torch.nn.Linear(4, 3))
+
+        code, cache = torch.compiler.precompile(
+            fresh().zeroing_step, x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        for _ in range(3):
+            f_c(run, x, t)
+            ref.zeroing_step(x, t)
+            for got, want in zip(
+                run.inner.model.parameters(), ref.inner.model.parameters()
+            ):
+                self.assertEqual(got.grad, want.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_in_fn_zero_grad_matches_eager(self):
+        # The canonical training step calls zero_grad(set_to_none=True) itself, so
+        # the capture's seeds are nulled inside the trace and the accumulate form is
+        # never reached. Shipping the SEEDED capture for that shape left a spare
+        # LOAD_ATTR grad in the residual bytecode that the epilogue never popped:
+        # fn returns None in eager, and the artifact returned the stale .grad tensor
+        # from call 2 on. Reverting to the unseeded capture is what fixes it.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(model, xx, tt):
+            model.zero_grad(set_to_none=True)
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            step, fresh(), x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        for _ in range(3):
+            self.assertIsNone(f_c(run, x, t))
+            step(ref, x, t)
+            for got, want in zip(run.parameters(), ref.parameters()):
+                self.assertEqual(got.grad, want.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_in_fn_zero_grad_preserves_prior_grad_branch(self):
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(model, xx, tt):
+            scale = 2 if model.weight.grad is None else 3
+            model.zero_grad(set_to_none=True)
+            (torch.nn.functional.mse_loss(model(xx), tt) * scale).backward()
+            return scale
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            step, fresh(), x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+
+        self.assertEqual(f_c(run, x, t), step(ref, x, t))
+        for got, want in zip(run.parameters(), ref.parameters()):
+            self.assertEqual(got.grad, want.grad)
+
+        self.assertEqual(step(ref, x, t), 3)
+        with self.assertRaisesRegex(PrecompileError, "captured with .grad"):
+            f_c(run, x, t)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_warm_in_fn_zero_grad_rejects_cold_runtime(self):
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(model, xx, tt):
+            scale = 2 if model.weight.grad is None else 3
+            model.zero_grad(set_to_none=True)
+            (torch.nn.functional.mse_loss(model(xx), tt) * scale).backward()
+            return scale
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        capture = fresh()
+        self.assertEqual(step(capture, x, t), 2)
+        code, cache = torch.compiler.precompile(
+            step, capture, x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+
+        warm_run, warm_ref = fresh(), fresh()
+        step(warm_run, x, t)
+        step(warm_ref, x, t)
+        self.assertEqual(f_c(warm_run, x, t), step(warm_ref, x, t))
+        for got, want in zip(warm_run.parameters(), warm_ref.parameters()):
+            self.assertEqual(got.grad, want.grad)
+
+        with self.assertRaisesRegex(PrecompileError, "captured with .grad"):
+            f_c(fresh(), x, t)
+
+    def test_tracer_dynamo_autograd_grad_does_not_observe_the_seed(self):
+        # Seeding is a capture-time mutation of the caller's model, so fn can SEE it:
+        # `p.grad is not None` traced as True where eager reads False. When the
+        # re-capture turns out to need no accumulate at all -- autograd.grad only
+        # returns grads -- the seeds bought nothing, and the first (unseeded) capture
+        # is the one that has to ship.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def grad_step(model, xx, tt):
+            seen = model.weight.grad is not None
+            loss = torch.nn.functional.mse_loss(model(xx), tt)
+            return seen, torch.autograd.grad(loss, [model.weight])
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            grad_step, fresh(), x, t, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(f_c(fresh(), x, t)[0], grad_step(fresh(), x, t)[0])
+
+    def _exec_dynamo_training_artifact(self):
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, _ = torch.compiler.precompile(
+            train_step, fresh(), x, t, tracer="dynamo", backend="eager"
+        )
+        ns = {"__name__": "_a"}
+        exec(compile(code, "<a>", "exec"), ns)
+        return ns["forward"], train_step, fresh, x, t
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_exec_forward_accepts_keyword_arguments(self):
+        # The exec'd artifact is documented as taking the same args fn took, and
+        # for inference it IS fn, so it honors fn's signature. The training path
+        # wraps fn to materialize .grad first, and that wrapper has to forward
+        # keywords too rather than narrowing the calling convention.
+        forward, train_step, fresh, x, t = self._exec_dynamo_training_artifact()
+        run, ref = fresh(), fresh()
+        forward(run, x, tt=t)
+        train_step(ref, x, t)
+        self.assertEqual(run.weight.grad, ref.weight.grad)
+        self.assertEqual(run.bias.grad, ref.bias.grad)
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_exec_forward_rejects_a_misplaced_model(self):
+        # GRAD_PARAM_STATES records the model's POSITION, so a call that does not
+        # put a module there has to say so, rather than surfacing as an IndexError
+        # or an AttributeError on whatever else landed in the slot.
+        forward, _train_step, fresh, x, t = self._exec_dynamo_training_artifact()
+        with self.assertRaisesRegex(
+            PrecompileError, "Pass the model in the same position"
+        ):
+            forward(model=fresh(), xx=x, tt=t)
+        with self.assertRaisesRegex(
+            PrecompileError, "Pass the model in the same position"
+        ):
+            forward(x, fresh(), t)
+
+    @parametrize(
+        "shape",
+        [
+            "module_fn",
+            "positional",
+            "in_a_list",
+            "bound_method",
+            "in_a_holder",
+            "two_in_a_list",
+            "same_module_twice",
+            "int_keyed_dict",
+            "tuple_keyed_dict",
+            "slots_holder",
+            "after_a_big_argument",
+            "beside_a_big_sibling",
+        ],
+    )
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_accumulates_whatever_holds_the_params(self, shape):
+        # GRAD_PARAM_STATES records the FRAME arg index and the PATH from it to
+        # the owning module. Frame args prepend the bound self, so scanning the
+        # caller's args missed the module entirely for an nn.Module fn (baking
+        # the ASSIGN form: step 0 matches eager and nothing after does) and
+        # shifted every position by one for a bound method. A one-level
+        # container scan then still missed a plain object holding the model,
+        # and re-searching by parameter name could not tell two same-shaped
+        # modules in one container apart -- it stamped the first one twice and
+        # left the second at .grad = None.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        class TrainMod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 3)
+
+            def forward(self, xx, tt):
+                torch.nn.functional.mse_loss(self.lin(xx), tt).backward()
+
+        def fresh_mod():
+            torch.manual_seed(0)
+            return TrainMod()
+
+        def step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def step_list(models, xx, tt):
+            torch.nn.functional.mse_loss(models[0](xx), tt).backward()
+
+        class Trainer:
+            def step(self, model, xx, tt):
+                torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        trainer = Trainer()
+        if shape == "module_fn":
+            fn, cap, call, mk, eager = (
+                fresh_mod(),
+                (x, t),
+                lambda r: (r, x, t),
+                fresh_mod,
+                lambda r: r(x, t),
+            )
+        elif shape == "positional":
+            fn, cap, call, mk, eager = (
+                step,
+                (fresh(), x, t),
+                lambda r: (r, x, t),
+                fresh,
+                lambda r: step(r, x, t),
+            )
+        elif shape == "in_a_list":
+            fn, cap, call, mk, eager = (
+                step_list,
+                ([fresh()], x, t),
+                lambda r: ([r], x, t),
+                fresh,
+                lambda r: step_list([r], x, t),
+            )
+        elif shape == "bound_method":
+            fn, cap, call, mk, eager = (
+                trainer.step,
+                (fresh(), x, t),
+                lambda r: (trainer, r, x, t),
+                fresh,
+                lambda r: trainer.step(r, x, t),
+            )
+        elif shape == "in_a_holder":
+            # A plain (non-Module) object holding the model -- the commonest
+            # training shape, and one a container-only search missed silently.
+            class Holder:
+                def __init__(self, model):
+                    self.model = model
+
+                def step(self, xx, tt):
+                    torch.nn.functional.mse_loss(self.model(xx), tt).backward()
+
+            holders = {}
+
+            def mk_holder():
+                h = Holder(fresh())
+                holders[id(h.model)] = h
+                return h.model
+
+            fn = Holder(fresh()).step
+            cap = (x, t)
+            mk = mk_holder
+            call = lambda r: (holders[id(r)], x, t)  # noqa: E731
+            eager = lambda r: holders[id(r)].step(x, t)  # noqa: E731
+        elif shape == "same_module_twice":
+            # One module reachable from TWO arguments. A `seen` set shared
+            # across the frame recorded only the first path and then crashed
+            # replaying it against the second argument.
+            def step_logged(log, model, xx, tt):
+                torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+            # The SAME object in both slots at capture is what makes a
+            # frame-wide `seen` set skip the second position; at runtime the
+            # log holds something else, so only the arg-1 path finds the model
+            # being trained. Recording just the first path seeds the wrong
+            # module and the trained one is left unseeded.
+            captured = fresh()
+            others = {}
+
+            def mk_logged():
+                m = fresh()
+                others[id(m)] = torch.nn.Linear(4, 3)
+                return m
+
+            fn = step_logged
+            cap = ({"last": captured}, captured, x, t)
+            mk = mk_logged
+            call = lambda r: ({"last": others[id(r)]}, r, x, t)  # noqa: E731
+            eager = lambda r: step_logged({"last": others[id(r)]}, r, x, t)  # noqa: E731
+        elif shape == "int_keyed_dict":
+            # A non-str dict key is an ordinary shape; the driver's obj[key]
+            # replay does not care what the key is.
+            def step_dict(models, xx, tt):
+                torch.nn.functional.mse_loss(models[0](xx), tt).backward()
+
+            dicts = {}
+
+            def mk_dict():
+                m = fresh()
+                dicts[id(m)] = {0: m}
+                return m
+
+            fn = step_dict
+            cap = ({0: fresh()}, x, t)
+            mk = mk_dict
+            call = lambda r: (dicts[id(r)], x, t)  # noqa: E731
+            eager = lambda r: step_dict(dicts[id(r)], x, t)  # noqa: E731
+        elif shape == "tuple_keyed_dict":
+            # A tuple key is as ordinary as an int one, and pins the contract
+            # the artifact actually has: any key whose repr() is a literal that
+            # reads back equal, not just str / int.
+            def step_tuple(models, xx, tt):
+                torch.nn.functional.mse_loss(models[("a", 1)](xx), tt).backward()
+
+            tuples = {}
+
+            def mk_tuple():
+                m = fresh()
+                tuples[id(m)] = {("a", 1): m}
+                return m
+
+            fn = step_tuple
+            cap = ({("a", 1): fresh()}, x, t)
+            mk = mk_tuple
+            call = lambda r: (tuples[id(r)], x, t)  # noqa: E731
+            eager = lambda r: step_tuple(tuples[id(r)], x, t)  # noqa: E731
+        elif shape == "after_a_big_argument":
+            # The search for the model is budgeted, and the budget is spent PER
+            # ARGUMENT: one counter shared by the frame let a big EARLIER
+            # argument exhaust it before the walk reached the model, so the same
+            # training step captured correctly or not depending on the order its
+            # arguments happened to be in.
+            junk = [object() for _ in range(_MODULE_SEARCH_BUDGET + 10)]
+
+            def step_after(_junk, model, xx, tt):
+                torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+            fn = step_after
+            cap = (junk, fresh(), x, t)
+            mk = fresh
+            call = lambda r: (junk, r, x, t)  # noqa: E731
+            eager = lambda r: step_after(junk, r, x, t)  # noqa: E731
+        elif shape == "beside_a_big_sibling":
+            # The same starvation one level down, inside ONE argument: a
+            # depth-first walk opened self.dataset and never reached self.model.
+            class BigTrainer:
+                def __init__(self, model):
+                    self.dataset = [object() for _ in range(_MODULE_SEARCH_BUDGET + 10)]
+                    self.model = model
+
+                def step(self, xx, tt):
+                    torch.nn.functional.mse_loss(self.model(xx), tt).backward()
+
+            trainers = {}
+
+            def mk_big():
+                h = BigTrainer(fresh())
+                trainers[id(h.model)] = h
+                return h.model
+
+            fn = BigTrainer(fresh()).step
+            cap = (x, t)
+            mk = mk_big
+            call = lambda r: (trainers[id(r)], x, t)  # noqa: E731
+            eager = lambda r: trainers[id(r)].step(x, t)  # noqa: E731
+        elif shape == "slots_holder":
+            # A __slots__ holder has no __dict__ at all, so a vars()-only walk
+            # missed the model -- silently, since a capture with nothing to
+            # seed bakes the assign form.
+            class Slotted:
+                __slots__ = ("model",)
+
+                def __init__(self, model):
+                    self.model = model
+
+                def step(self, xx, tt):
+                    torch.nn.functional.mse_loss(self.model(xx), tt).backward()
+
+            slotted = {}
+
+            def mk_slotted():
+                h = Slotted(fresh())
+                slotted[id(h.model)] = h
+                return h.model
+
+            fn = Slotted(fresh()).step
+            cap = (x, t)
+            mk = mk_slotted
+            call = lambda r: (slotted[id(r)], x, t)  # noqa: E731
+            eager = lambda r: slotted[id(r)].step(x, t)  # noqa: E731
+        else:
+            # Two same-shaped modules in ONE container: indistinguishable by
+            # parameter name, so a name search stamps the first one twice and
+            # leaves the second with .grad = None.
+            def step_two(models, xx, tt):
+                loss = torch.nn.functional.mse_loss(models[0](xx), tt)
+                loss = loss + torch.nn.functional.mse_loss(models[1](xx), tt)
+                loss.backward()
+
+            pairs = {}
+
+            def mk_pair():
+                a, b = fresh(), torch.nn.Linear(4, 3)
+                pairs[id(a)] = [a, b]
+                return a
+
+            fn = step_two
+            cap = ([fresh(), torch.nn.Linear(4, 3)], x, t)
+            mk = mk_pair
+            call = lambda r: (pairs[id(r)], x, t)  # noqa: E731
+            eager = lambda r: step_two(pairs[id(r)], x, t)  # noqa: E731
+
+        fn(*cap)
+        code, cache = torch.compiler.precompile(
+            fn, *cap, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = mk(), mk()
+        eager(run)
+        eager(ref)
+        # Three ACCUMULATING steps: the second is what catches a baked assign.
+        for _ in range(3):
+            f_c(*call(run))
+            eager(ref)
+            got = run.lin.weight.grad if shape == "module_fn" else run.weight.grad
+            want = ref.lin.weight.grad if shape == "module_fn" else ref.weight.grad
+            self.assertEqual(got, want)
+
+    def test_module_search_budget_is_spent_per_argument(self):
+        # The walk that finds the modules a training capture has to seed is
+        # budgeted. Sharing one budget across the frame let a big earlier
+        # argument exhaust it, and a model the walk misses is a model whose
+        # backward bakes the OVERWRITING form -- silently, and only for some
+        # argument orders.
+        big = [object() for _ in range(_MODULE_SEARCH_BUDGET + 10)]
+        model = torch.nn.Linear(4, 3)
+
+        def fn(_junk, m, xx):
+            return m(xx)
+
+        found = _frame_modules(fn, (big, model, torch.randn(2, 4)))
+        self.assertEqual([(pos, path) for pos, path, _m in found], [(1, ())])
+        self.assertIs(found[0][2], model)
+
+    def test_module_search_budget_reaches_past_a_ten_thousand_item_sibling(self):
+        # Pins the size of the budget, not just its per-argument accounting. The
+        # frontier cap means the walk stops ENQUEUEING once the budget is spoken
+        # for, so a large budget costs O(budget) rather than O(argument): 8
+        # pathological 300k-object arguments measured 22ms at 2000 and 28ms at
+        # 20000. A trainer holding a five-figure dataset next to a nested model
+        # is an ordinary shape, and at the old size it is refused outright.
+        class Inner:
+            def __init__(self, model):
+                self.model = model
+
+        class Holder:
+            def __init__(self, model):
+                self.bucket = [object() for _ in range(10000)]
+                self.inner = Inner(model)
+
+        model = torch.nn.Linear(4, 3)
+
+        def fn(holder, xx):
+            return holder.inner.model(xx)
+
+        found = _frame_modules(fn, (Holder(model), torch.randn(2, 4)))
+        self.assertEqual(
+            [(pos, path) for pos, path, _m in found],
+            [(0, (("attr", "inner"), ("attr", "model")))],
+        )
+
+    def test_module_search_finds_a_model_beside_a_big_sibling(self):
+        # Same thing inside ONE argument: the walk is breadth first so the
+        # budget cuts off the deepest layer, not whichever attribute happened to
+        # be visited first. A trainer holding a big dataset next to its model is
+        # the ordinary shape, and depth first never got past the dataset.
+        class Holder:
+            def __init__(self, model):
+                self.dataset = [object() for _ in range(_MODULE_SEARCH_BUDGET + 10)]
+                self.model = model
+
+        model = torch.nn.Linear(4, 3)
+
+        def fn(holder, xx):
+            return holder.model(xx)
+
+        found = _frame_modules(fn, (Holder(model), torch.randn(2, 4)))
+        self.assertEqual(
+            [(pos, path) for pos, path, _m in found], [(0, (("attr", "model"),))]
+        )
+        self.assertIs(found[0][2], model)
+
+    @skipIfCrossRef
+    @parametrize("kind", ["enum", "datetime", "frozenset"])
+    def test_tracer_dynamo_training_refuses_an_unwritable_dict_key(self, kind):
+        # The path to the model is recorded in the artifact as SOURCE TEXT
+        # (repr) and read back with ast.literal_eval / exec, so a key whose repr
+        # is not a literal produced a file that captured fine and then could not
+        # be loaded: an enum key emitted "<Phase.GEN: 1>" and load() rejected the
+        # whole file as "not a precompile artifact", while a datetime key parsed
+        # but would not literal_eval and came back as "malformed metadata".
+        key = {
+            "enum": _Phase.GEN,
+            "datetime": datetime.datetime(2024, 1, 1),
+            "frozenset": frozenset({1}),
+        }[kind]
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def step(models, xx, tt):
+            torch.nn.functional.mse_loss(models[key](xx), tt).backward()
+
+        with self.assertRaisesRegex(PrecompileError, "keyed by"):
+            torch.compiler.precompile(
+                step,
+                {key: torch.nn.Linear(4, 3)},
+                x,
+                t,
+                tracer="dynamo",
+                backend="eager",
+            )
+
+    @staticmethod
+    def _module_with(src: str, name: str):
+        """A real module whose globals are exactly what the source binds."""
+        mod = types.ModuleType(name)
+        mod.__file__ = f"{name}.py"
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+        sys.modules[name] = mod
+        return mod
+
+    @parametrize("tracer", ["dynamo", "make_fx"])
+    @parametrize("backend", ["eager", "inductor"])
+    def test_capture_under_a_torch_function_mode_applies_it_once(self, tracer, backend):
+        # Capture clears the caller's torch_function modes so Dynamo can apply them
+        # SYMBOLICALLY while tracing. The captured graph is torch-level Python, so
+        # lowering it with the modes restored re-traces through every one of them a
+        # second time and bakes a doubly-transformed kernel. Nothing catches that:
+        # the artifact needs no mode at all to reproduce the wrong number, so there
+        # is no guard to drop and no error to raise -- it is simply wrong forever.
+        class PlusOne(torch.overrides.TorchFunctionMode):
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                kwargs = kwargs or {}
+                if func is torch.add and not isinstance(args[1], torch.Tensor):
+                    return func(args[0], args[1] + 1, **kwargs)
+                return func(*args, **kwargs)
+
+        def fn(xx):
+            return torch.add(xx, 1.0)
+
+        x = torch.zeros(3)
+        with PlusOne():
+            expected = fn(x).clone()
+            code, cache = torch.compiler.precompile(
+                fn, x, tracer=tracer, backend=backend
+            )
+        # Served with NO mode: the artifact must already carry the one application.
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(x), expected)
+
+    def test_tracer_dynamo_module_global_round_trips_by_sys_modules_key(self):
+        # A module GLOBAL is by-reference state: recording it in IMPORT_SOURCES
+        # rather than pickling it is what lets a bare module reference next to a
+        # model call capture at all. The sys.modules KEY matters, not __name__,
+        # because re-import at load goes through the key. The stdlib's own
+        # example of the two disagreeing (_collections_abc names itself
+        # "collections.abc") stopped being one in 3.14, where both keys reach a
+        # single module object, so the disagreement is built here instead.
+        key, lie = "_precompile_modglobal_target", "_precompile_modglobal_lie"
+        target = self._module_with("VALUE = 'from the keyed module'\n", key)
+        target.__name__ = lie
+        name = "_precompile_modglobal_mod"
+        mod = self._module_with(
+            f"import {key} as dep\n"
+            "def fn(model, xx):\n"
+            "    return model(xx), dep.VALUE\n",
+            name,
+        )
+        try:
+            m, x = torch.nn.Linear(4, 4), torch.randn(2, 4)
+            code, cache = torch.compiler.precompile(
+                mod.fn, m, x, tracer="dynamo", backend="eager"
+            )
+            self.assertIn(f"'{key}'", code)
+            self.assertNotIn(f"'{lie}'", code)
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x)[1], mod.fn(m, x)[1])
+        finally:
+            sys.modules.pop(name, None)
+            sys.modules.pop(key, None)
+
+    def test_tracer_dynamo_module_global_shadowing_a_builtin(self):
+        # get_runtime_env pre-seeds used_globals with a BUILTIN of the same
+        # name, and the driver applies used_globals AFTER IMPORT_SOURCES, so
+        # leaving it there lets the builtin win and the artifact loads broken
+        # instead of failing at capture.
+        name = "_precompile_shadow_mod"
+        mod = self._module_with(
+            "import torch as vars\n"
+            "def fn(model, xx):\n"
+            "    return model(xx), vars.__version__\n",
+            name,
+        )
+        try:
+            m, x = torch.nn.Linear(4, 4), torch.randn(2, 4)
+            code, cache = torch.compiler.precompile(
+                mod.fn, m, x, tracer="dynamo", backend="eager"
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x)[1], torch.__version__)
+        finally:
+            sys.modules.pop(name, None)
+
+    def test_tracer_dynamo_rejects_a_partial_cleanly(self):
+        # get_traced_fn refuses a partial deep inside fullgraph_capture; that
+        # raw RuntimeError used to escape.
+        def base(model, xx, k=1.0):
+            return model(xx) * k
+
+        m, x = torch.nn.Linear(4, 4), torch.randn(2, 4)
+        with self.assertRaisesRegex(PrecompileError, "cannot capture a partial"):
+            torch.compiler.precompile(
+                functools.partial(base, k=3.0), m, x, tracer="dynamo"
+            )
+
+    def test_tracer_dynamo_graph_break_still_rejected(self):
+        # Training no longer graph-breaks, but other unsupported Python still does, and
+        # must still surface a clean PrecompileError pointing at tracer="make_fx".
+        m = torch.nn.Linear(4, 4)
+        x = torch.randn(5, 4)
+
+        def fn(model, xx):
+            y = model(xx)
+            print(y.sum().item())  # a data-dependent print: graph break
+            return y
+
+        with self.assertRaisesRegex(PrecompileError, "make_fx"):
+            torch.compiler.precompile(fn, m, x, tracer="dynamo")
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_mark_unbacked_runs_across_sizes(self, backend):
+        # Dynamic shapes are opt-in via mark_unbacked for the dynamo tracer too: Dynamo
+        # captures the marked dim as an UNBACKED symint, so the ONE artifact serves any
+        # runtime size of that dim on either backend (the make_fx tracer's eager backend
+        # rejects dynamic dims; the dynamo subgraph carries its own runtime asserts, so it
+        # does not have to).
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 3)
+        ).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            for bs in (8, 16, 1, 0):
+                xt = torch.randn(bs, 4)
+                self.assertEqual(f_c(m, xt), m(xt))
+
+    def test_tracer_dynamo_mark_unbacked_bounds_enforced(self):
+        # mark_unbacked's min/max become ShapeEnv runtime asserts, which Dynamo emits into
+        # the subgraph itself -- so the artifact rejects an out-of-range runtime size even
+        # though the thin dynamo driver has no bounds check of its own (the make_fx tracer
+        # instead re-checks the bounds in its driver).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0, min=4, max=16)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(f_c(m, torch.randn(6, 4)).shape, (6, 3))
+        with self.assertRaisesRegex(RuntimeError, "u0 >= 4"):
+            f_c(m, torch.randn(2, 4))
+
+    def test_tracer_dynamo_mark_unbacked_shape_id_mismatch_rejected(self):
+        # Two dims sharing a shape_id bind to ONE unbacked symbol, so their sizes must be
+        # equal at runtime; the equality is enforced by the captured graph's own assert.
+        m = torch.nn.Linear(4, 4).eval()
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 4)
+        mark_unbacked(x, 0, shape_id="b")
+        mark_unbacked(y, 0, shape_id="b")
+        code, cache = torch.compiler.precompile(
+            lambda model, a, b: model(a) + b, m, x, y, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        a, b = torch.randn(3, 4), torch.randn(3, 4)
+        self.assertEqual(f_c(m, a, b), m(a) + b)
+        with self.assertRaises((RuntimeError, AssertionError)):
+            f_c(m, torch.randn(3, 4), torch.randn(5, 4))
+
+    def test_tracer_dynamo_mark_unbacked_guard_required_rejected(self):
+        # An unbacked dim cannot be guarded on, so a size-dependent branch fails LOUDLY at
+        # capture (Dynamo raises GuardOnDataDependentSymNode, which precompile relabels to
+        # the same error the make_fx tracer raises) rather than baking one branch.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0)
+
+        def fn(model, xx):
+            return model(xx) * 2 if xx.shape[0] > 4 else model(xx)
+
+        with self.assertRaisesRegex(PrecompileError, "guard on a dim marked"):
+            torch.compiler.precompile(fn, m, x, tracer="dynamo")
+
+    def test_tracer_dynamo_mark_unbacked_hint_override_honored(self):
+        # hint_override is a perf-only autotuning size hint (never a guard), so it is not
+        # rejected here either: Dynamo threads it onto the symbol during fakeification and
+        # the single artifact stays valid for any runtime size.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0, hint_override=16)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        for xt in (x, torch.randn(32, 4)):
+            self.assertEqual(f_c(m, xt), m(xt))
+
+    def test_tracer_dynamo_mark_unbacked_strict_rejected(self):
+        # strict means something different to Dynamo than to make_fx: it records only a
+        # RelaxedUnspecConstraint, so the dim is BACKED dynamic and Dynamo may guard on it
+        # -- and the dynamo artifact does not check guards. Reject rather than bake an
+        # artifact whose dropped guard silently miscomputes at another size.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0, strict=True)
+        with self.assertRaisesRegex(PrecompileError, "strict=True"):
             torch.compiler.precompile(
                 lambda model, xx: model(xx), m, x, tracer="dynamo"
             )
+
+    def test_tracer_dynamo_cross_tracer_cache_rejected(self):
+        # A cache from the make_fx tracer paired with dynamo python_code is a mismatched
+        # pairing and must be rejected (the code_hash and the tracer tag both catch it),
+        # not run under foreign metadata.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        dyn_code, _ = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        _, mf_cache = torch.compiler.precompile(lambda model, xx: model(xx), m, x)
+        with self.assertRaisesRegex(PrecompileError, "tracer"):
+            torch.compiler.precompile.load(dyn_code, mf_cache)
+
+    @parametrize(
+        "kind", ["bare", "list", "dict", "module", "closure_list", "closure_module"]
+    )
+    def test_tracer_dynamo_baked_tensor_rejected(self, kind):
+        # Invariant 1 for the dynamo tracer must look THROUGH containers and nn.Modules:
+        # a tensor closed over by fn -- bare, nested in a list/dict, or inside an
+        # nn.Module (as a global or a closure) -- would be embedded by value, so it is
+        # rejected just like the make_fx tracer's get_attr scan.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        local_list = [torch.randn(3)]
+        local_mod = torch.nn.Linear(4, 3).eval()
+        fns = {
+            "bare": lambda mm, xx: mm(xx) + _GLOBAL_TENSOR.sum(),
+            "list": lambda mm, xx: mm(xx) + _GLOBAL_TENSOR_LIST[0].sum(),
+            "dict": lambda mm, xx: mm(xx) + _GLOBAL_TENSOR_DICT["w"].sum(),
+            "module": lambda mm, xx: mm(xx) + _GLOBAL_SUBMODULE(xx),
+            "closure_list": lambda mm, xx: mm(xx) + local_list[0].sum(),
+            "closure_module": lambda xx: local_mod(xx),
+        }
+        fn = fns[kind]
+        call_args = (x,) if kind == "closure_module" else (m, x)
+        with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+            torch.compiler.precompile(fn, *call_args, tracer="dynamo")
+
+    def test_tracer_dynamo_mark_dynamic_rejected(self):
+        # mark_dynamic (backed dynamic shapes) is not wired through the dynamo tracer;
+        # like the make_fx tracer it must reject rather than silently specialize the dim,
+        # since specializing a marked dim would bake a shape the artifact should not assume.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        mark_dynamic(x, 0)
+        with self.assertRaisesRegex(PrecompileError, "mark_dynamic"):
+            torch.compiler.precompile(
+                lambda model, xx: model(xx), m, x, tracer="dynamo"
+            )
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_returned_global_constant_baked(self, backend):
+        # A plain module-level constant folded straight into fn's output is referenced by
+        # the transformed bytecode but is NOT a graph input, so it must be baked into the
+        # artifact (else it would NameError at load). Baking a non-tensor constant is
+        # consistent with the specialization contract; check both backends.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def with_scale(model, xx):
+            return model(xx), _GLOBAL_SCALE
+
+        code, cache = torch.compiler.precompile(
+            with_scale, m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            out = f_c(m, x)
+            self.assertEqual(out[0], m(x))
+            self.assertEqual(out[1], _GLOBAL_SCALE)
+
+    def test_tracer_dynamo_namedtuple_output_clean_error(self):
+        # A namedtuple output makes Dynamo bake a bound method / type as a bytecode
+        # constant, which marshal cannot serialize; surface a clean PrecompileError
+        # (pointing at plain outputs / make_fx) rather than a raw ValueError.
+        import collections
+
+        NT = collections.namedtuple("NT", ["a", "b"])
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with self.assertRaisesRegex(PrecompileError, "unmarshallable"):
+            torch.compiler.precompile(
+                lambda model, xx: NT(model(xx), model(xx) + 1), m, x, tracer="dynamo"
+            )
+
+    def test_tracer_dynamo_no_compute_inductor_rejected_eager_ok(self):
+        # A fn with no tensor compute has no subgraph for inductor to lower: inductor rejects
+        # it (mirroring make_fx), eager runs the bytecode standalone. Two distinct no-compute
+        # sub-cases, both covered: (a) a passthrough (``return xx``) yields a one-placeholder
+        # pass-through gm (the NoRunnableInductorModuleError branch); (b) a pure Python
+        # constant (``return 7``) yields capture.gm is None (the capture.gm is None branch).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with self.assertRaisesRegex(PrecompileError, "eager"):
+            torch.compiler.precompile(
+                lambda model, xx: xx, m, x, tracer="dynamo", backend="inductor"
+            )
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: xx, m, x, tracer="dynamo", backend="eager"
+        )
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), x)
+        with self.assertRaisesRegex(PrecompileError, "eager"):
+            torch.compiler.precompile(
+                lambda model, xx: 7, m, x, tracer="dynamo", backend="inductor"
+            )
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: 7, m, x, tracer="dynamo", backend="eager"
+        )
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), 7)
+
+    def test_tracer_dynamo_builtin_shadowing_global_baked(self):
+        # Regression: a module global that SHADOWS a builtin name (`sum`) and is folded into
+        # fn's output must be baked as the real global's value, not the builtin. Dynamo's
+        # get_runtime_env pre-seeds used_globals[ref] with the BUILTIN for a builtin-shadowing
+        # external ref, so _capture_dynamo must override it with the module global -- else the
+        # reload silently returns <built-in function sum>. Give fn a custom __globals__ where
+        # `sum` is a real list, so the shadow never leaks into this test module's namespace.
+        import types as _types
+
+        def _body(model, xx):
+            return model(xx), sum
+
+        g = dict(globals())
+        g["sum"] = [1, 2, 3]
+        f = _types.FunctionType(_body.__code__, g)
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            f, m, x, tracer="dynamo", backend="eager"
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, "eager"):
+            out = f_c(m, x)
+            self.assertEqual(out[0], m(x))
+            self.assertEqual(out[1], [1, 2, 3])
+
+    def test_tracer_dynamo_zero_input_subgraph(self):
+        # A subgraph that HAS compute but no graph inputs (fn's tensor compute depends on no
+        # param/buffer or user input, e.g. torch.ones(3) * 2): the inductor backend cannot
+        # detect a fake mode off the (empty) placeholders, so it is rejected up front with a
+        # clean PrecompileError pointing at eager (not a raw RuntimeError from
+        # compile_to_python), while eager runs it and returns the constant tensor.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with self.assertRaisesRegex(PrecompileError, "no graph inputs"):
+            torch.compiler.precompile(
+                lambda model, xx: torch.ones(3) * 2.0,
+                m,
+                x,
+                tracer="dynamo",
+                backend="inductor",
+            )
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: torch.ones(3) * 2.0,
+            m,
+            x,
+            tracer="dynamo",
+            backend="eager",
+        )
+        self.assertEqual(
+            torch.compiler.precompile.load(code, cache)(m, x), torch.ones(3) * 2.0
+        )
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_nested_multi_tensor_output(self, backend):
+        # Under dynamo the transformed bytecode (NOT the driver's OUT_SPEC path make_fx uses)
+        # reassembles fn's output, so a multi-tensor / nested output exercises a distinct
+        # mechanism: the subgraph returns several tensors in a fixed order the bytecode must
+        # re-thread into the tuple/dict. Assert each leaf on both backends (a mis-ordered
+        # flatten or a dropped dict leaf would silently corrupt the output structure).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def f(model, xx):
+            y = model(xx)
+            return y, y * 2, {"k": y + 1}
+
+        code, cache = torch.compiler.precompile(
+            f, m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            out = f_c(m, x)
+            ref = f(m, x)
+            self.assertEqual(out[0], ref[0])
+            self.assertEqual(out[1], ref[1])
+            self.assertEqual(out[2]["k"], ref[2]["k"])
+
+    def test_tracer_dynamo_nontensor_output_inductor_ok(self):
+        # DIVERGENCE from make_fx: Dynamo puts a non-tensor Python output (float / complex /
+        # str) in the transformed bytecode, not the subgraph inductor lowers, so it round-
+        # trips on tracer='dynamo' + backend='inductor' where make_fx REJECTS the same output
+        # (test_nontensor_output_inductor_clean_error). Pin that so a regression to make_fx's
+        # rejection under dynamo is caught. The value is folded as a default arg (baked).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        for val in (3.14, 2 + 3j, "hi"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx, b=val: (model(xx), b),
+                m,
+                x,
+                tracer="dynamo",
+                backend="inductor",
+            )
+            for _label, f_c in _default_and_inlined_loaders(code, cache, "inductor"):
+                out = f_c(m, x)
+                self.assertEqual(out[0], m(x))
+                self.assertEqual(out[1], val)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_dtensor_subclass(self, backend):
+        # The dynamo-tracer analog of test_dtensor_subclass: a DTensor param/input must
+        # round-trip on both backends. The dynamo eager emit inlines the subgraph against an
+        # empty _GraphSelf and splats flat args, and inductor lowers via AOTAutograd's subclass
+        # wrap/unwrap -- neither is exercised by the dense-input dynamo tests, so cover both.
+        import torch.distributed as dist
+
+        if not dist.is_available() or not dist.is_gloo_available():
+            self.skipTest("gloo not available")
+
+        from torch.distributed.tensor import DeviceMesh, distribute_tensor, Replicate
+        from torch.testing._internal.common_utils import find_free_port
+
+        saved_env = {k: os.environ.get(k) for k in ("MASTER_ADDR", "MASTER_PORT")}
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        dist.init_process_group("gloo", rank=0, world_size=1)
+        try:
+            mesh = DeviceMesh("cpu", list(range(1)))
+            m = torch.nn.Linear(4, 3).eval()
+            for name, p in list(m.named_parameters()):
+                setattr(
+                    m,
+                    name,
+                    torch.nn.Parameter(
+                        distribute_tensor(p.detach(), mesh, [Replicate()])
+                    ),
+                )
+            x = distribute_tensor(torch.randn(5, 4), mesh, [Replicate()])
+            ref = m(x)
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+            )
+            # Exercise BOTH reload paths on the DTensor artifact: load() takes the
+            # bundled-artifact path (primes the cache, then execs python_code), while the
+            # direct exec below runs the self-contained python_code with no cache.
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x).to_local(), ref.to_local())
+            ns = {"__name__": "_dt"}
+            exec(compile(code, "<dt>", "exec"), ns)
+            self.assertEqual(ns["forward"](m, x).to_local(), ref.to_local())
+        finally:
+            dist.destroy_process_group()
+            for k, v in saved_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_decompositions_honored(self, backend):
+        # Dynamo never consults a decomposition table during capture, so the dynamo tracer
+        # honors ``decompositions`` by re-tracing the captured subgraph with it (make_fx
+        # applies the same table during its own capture). The table is invoked and the
+        # result still matches eager.
+        called = []
+
+        def my_relu_decomp(t):
+            called.append(True)
+            return (t > 0) * t
+
+        decomps = {torch.ops.aten.relu.default: my_relu_decomp}
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            m,
+            x,
+            tracer="dynamo",
+            backend=backend,
+            decompositions=decomps,
+        )
+        self.assertTrue(called)  # the table was used during capture
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), m(x))
+
+    def test_tracer_dynamo_decompositions_with_dynamic_shapes(self):
+        # The two capture options compose: the decomposition re-trace runs on Dynamo's own
+        # (symbolic) fake placeholder values, so it preserves the unbacked dim and the
+        # artifact still serves any runtime size.
+        called = []
+
+        def my_relu_decomp(t):
+            called.append(True)
+            return (t > 0) * t
+
+        decomps = {torch.ops.aten.relu.default: my_relu_decomp}
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval()
+        x = torch.randn(5, 4)
+        mark_unbacked(x, 0)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo", decompositions=decomps
+        )
+        self.assertTrue(called)
+        f_c = torch.compiler.precompile.load(code, cache)
+        for bs in (5, 11):
+            xt = torch.randn(bs, 4)
+            self.assertEqual(f_c(m, xt), m(xt))
+
+    def test_tracer_dynamo_version_locked_clean_error(self):
+        # The dynamo artifact inlines marshalled CPython bytecode, which is Python-version
+        # specific; a corrupt/foreign-version blob must surface a clean PrecompileError naming
+        # the version lock-in (from _build_dynamo_forward), not a raw marshal/pickle error. Exec
+        # the (corrupted) self-contained code directly -- load()'s code_hash check would fire
+        # first and mask the rehydrate path.
+        import base64 as _b64
+        import re as _re
+
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, _cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        bad = _b64.b64encode(b"not a marshalled code object").decode("ascii")
+        corrupted = _re.sub(
+            r"_DYNAMO_CODE = '[^']*'", f"_DYNAMO_CODE = {bad!r}", code, count=1
+        )
+        self.assertNotEqual(corrupted, code)
+        ns = {"__name__": "_v"}
+        with self.assertRaisesRegex(PrecompileError, "Python version"):
+            exec(compile(corrupted, "<v>", "exec"), ns)
+
+    def test_reject_nonliftable_get_attrs(self):
+        # The eager dynamo backend inlines the subgraph against an empty _GraphSelf(), so a
+        # get_attr to a non-tensor / non-GraphModule value (a symint, torchbind object, or bare
+        # module) must be rejected at capture rather than raise a raw AttributeError at runtime.
+        # Unit-test the guard directly on a hand-built graph (Dynamo rarely emits such a node in
+        # the canonical model(x) path, so an integration trigger would be fragile).
+        from torch._precompile import _reject_nonliftable_get_attrs
+
+        g = torch.fx.Graph()
+        node = g.get_attr("scalar_const")
+        g.output((node,))
+        root = torch.nn.Module()
+        root.scalar_const = 5
+        gm = torch.fx.GraphModule(root, g)
+        with self.assertRaisesRegex(PrecompileError, "not a liftable graph input"):
+            _reject_nonliftable_get_attrs(gm)
+
+    def test_tracer_dynamo_module_fn_folded_global(self):
+        # When fn IS an nn.Module, Dynamo traces fn.forward, whose globals live in the
+        # traced code's f_globals -- not fn.__globals__ (an nn.Module has none). A
+        # module-level constant folded into the output must still be carried into the
+        # artifact from that traced-code globals dict; otherwise the reload NameErrors.
+        # Regression for resolving uncovered external_refs via gco.f_globals.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 3)
+
+            def forward(self, xx):
+                return self.lin(xx), _GLOBAL_SCALE
+
+        m = M().eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(m, x, tracer="dynamo")
+        for _label, f_c in _default_and_inlined_loaders(code, cache, "inductor"):
+            out = f_c(m, x)
+            self.assertEqual(out[0], m(x)[0])
+            self.assertEqual(out[1], _GLOBAL_SCALE)
+
+    def test_tracer_dynamo_default_tensor_arg_rejected(self):
+        # A tensor supplied as a function default (positional or keyword-only) is pickled
+        # into the artifact and restored via types.FunctionType(argdefs=...) /
+        # __kwdefaults__ -- baked by value -- so invariant 1 must reject it just like the
+        # make_fx tracer, scanning argdefs/kwdefaults alongside globals/closure.
+        weight = torch.randn(4, 4)
+        m = torch.nn.Linear(4, 4).eval()
+        x = torch.randn(5, 4)
+
+        def f_pos(model, xx, w=weight):
+            return model(xx) + xx @ w
+
+        def f_kw(model, xx, *, w=weight):
+            return model(xx) + xx @ w
+
+        for fn in (f_pos, f_kw):
+            with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+                torch.compiler.precompile(fn, m, x, tracer="dynamo", backend="eager")
+
+    @parametrize(
+        "kind",
+        ["dict_object", "slots_object", "unregistered_module_attr", "partial"],
+    )
+    def test_tracer_dynamo_baked_tensor_in_object_rejected(self, kind):
+        # A tensor pickle would embed BY VALUE via a captured global must be rejected
+        # (invariant 1): held as a plain attribute (__dict__), a __slots__ slot, an
+        # UNREGISTERED tensor attribute on an nn.Module, or a functools.partial's captured
+        # arg (outside __dict__/__slots__ but baked by the partial's __reduce__). This
+        # matches what make_fx rejects (it bakes the same access as a get_attr constant).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        fns = {
+            "dict_object": lambda mm, xx: mm(xx) + _GLOBAL_HOLDER.weight.sum(),
+            "slots_object": lambda mm, xx: mm(xx) + _GLOBAL_SLOT_HOLDER.weight.sum(),
+            "unregistered_module_attr": (
+                lambda mm, xx: mm(xx) + _GLOBAL_UNREGISTERED_MODULE.foo.sum()
+            ),
+            "partial": lambda mm, xx: _GLOBAL_PARTIAL(mm(xx)),
+        }
+        with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+            torch.compiler.precompile(fns[kind], m, x, tracer="dynamo", backend="eager")
+
+    def test_tracer_dynamo_baked_tensor_before_unpicklable_rejected(self):
+        # Diagnostic precedence for invariant 1's order-dependent scan: when a captured
+        # global holds a tensor FOLLOWED by an unpicklable object, _baked_tensors records
+        # the tensor mid-traversal, swallows the later PicklingError, and returns it -- so
+        # capture raises the actionable "hard-coded" error (pass the tensor as an argument),
+        # NOT the generic "not picklable" error a purely-unpicklable value gives at metadata
+        # build. Pins that a regression collecting tensors only after a successful full
+        # pickle dump (returning [] here) would silently degrade the diagnostic.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def f(mm, xx):
+            return mm(xx) + _GLOBAL_TENSOR_THEN_UNPICKLABLE[0].sum()
+
+        with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+            torch.compiler.precompile(f, m, x, tracer="dynamo", backend="eager")
+
+    def test_tracer_dynamo_bound_method_default_tensor_rejected(self):
+        # A bound method captured as a default arg pickles its __self__ BY VALUE, so the
+        # tensor __self__ holds is baked into the artifact; invariant 1 must reject it. The
+        # scan replays pickle's traversal, so it reaches the tensor through __self__ (make_fx
+        # rejects the same access). Guards against treating bound methods as by-reference.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def fn(model, xx, cb=_GLOBAL_METHOD_HOLDER.add):
+            return cb(model(xx))
+
+        with self.assertRaisesRegex(PrecompileError, "hard-coded"):
+            torch.compiler.precompile(fn, m, x, tracer="dynamo", backend="eager")
+
+    def test_tracer_dynamo_by_reference_callable_not_rejected(self):
+        # A tensor merely ATTACHED to a by-reference object (a module-level function,
+        # pickled by reference and re-imported at load) is NOT baked by value, so it must
+        # NOT trigger the invariant-1 rejection. The scan keys off what pickle serializes
+        # by value, not on attribute presence -- avoiding a false positive.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: (model(xx), _global_helper_with_attr),
+            m,
+            x,
+            tracer="dynamo",
+            backend="eager",
+        )
+        out = torch.compiler.precompile.load(code, cache)(m, x)
+        self.assertEqual(out[0], m(x))
+        self.assertIs(out[1], _global_helper_with_attr)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_nontensor_closure_roundtrip(self, backend):
+        # fn closing over NON-tensor values (a float scale, a dict) drives the dynamo
+        # driver's closure-cell reconstruction (_rebuild_cell + the cells wiring). Every
+        # other closure test closes over a tensor and is rejected BEFORE reconstruction,
+        # so this is the only coverage of the accept-and-rebuild path.
+        def make(sc, cf):
+            return lambda model, xx: model(xx) * sc + cf["bias"]
+
+        fn = make(3.0, {"bias": 1.0})
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            fn, m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), fn(m, x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_defaults_roundtrip(self, backend):
+        # fn with a positional default and a keyword-only default drives the driver's
+        # argdefs / kwdefaults restoration; the defaults must be honored at the runtime
+        # call (omitting them would TypeError / use a wrong value if they were dropped).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def fn(model, xx, scale=2.0, *, bias=1.0):
+            return model(xx) * scale + bias
+
+        code, cache = torch.compiler.precompile(
+            fn, m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), fn(m, x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_multiple_module_args(self, backend):
+        # Two separate nn.Module args exercise the len(mods)>1 interning path and the
+        # unboxed->boxed subgraph bridge with graph inputs from two distinct modules; a
+        # structurally identical swap confirms no weights are baked (invariant 2).
+        a = torch.nn.Linear(4, 3).eval()
+        b = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda ma, mb, xx: ma(xx) + mb(xx),
+            a,
+            b,
+            x,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(a, b, x), a(x) + b(x))
+            a2 = torch.nn.Linear(4, 3).eval()
+            b2 = torch.nn.Linear(4, 3).eval()
+            self.assertEqual(f_c(a2, b2, x), a2(x) + b2(x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_tied_weights_roundtrip(self, backend):
+        # A module with a tied weight (two Linears sharing one weight tensor) round-trips
+        # under the dynamo tracer; the shared weight must be read consistently at runtime,
+        # so a mis-interned or duplicated read would surface as a wrong result here.
+        class Tied(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.nn.Linear(4, 4, bias=False)
+                self.b = torch.nn.Linear(4, 4, bias=False)
+                self.b.weight = self.a.weight
+
+            def forward(self, xx):
+                return self.b(self.a(xx))
+
+        m = Tied().eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), m(x))
+
+    def test_tracer_dynamo_input_drift_not_validated(self):
+        # DOCUMENTED GAP: unlike the make_fx driver, the dynamo driver does NOT re-validate
+        # runtime inputs, so a shape-drifted input on the eager backend is accepted (and may
+        # silently miscompute) where make_fx raises a clean PrecompileError. This test pins
+        # that intended-for-now asymmetry so adding validation later is a visible, conscious
+        # change rather than a silent regression -- and confirms make_fx DOES reject it.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(3, 4)
+
+        def f(model, xx):
+            return model(xx).sum() / xx.shape[0]
+
+        code, cache = torch.compiler.precompile(
+            f, m, x, tracer="dynamo", backend="eager"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        x2 = torch.randn(5, 4)
+        try:
+            drifted = f_c(m, x2)
+        except PrecompileError:
+            self.fail(
+                "dynamo driver unexpectedly validated input drift; the documented gap "
+                "changed -- update the docs and this test"
+            )
+        # Pin the "may silently miscompute" half of the gap, not just "no error raised":
+        # the eager dynamo driver baked xx.shape[0]=3 from the traced example, so the (5,4)
+        # input's sum is divided by 3 instead of 5 -- a wrong result. If a future change made
+        # the eager path recompute shape[0] correctly (fixing the miscompute without raising),
+        # this assertion fails, forcing a conscious docs+test update rather than silent rot.
+        self.assertFalse(torch.allclose(drifted, f(m, x2)))
+        mf_code, mf_cache = torch.compiler.precompile(f, m, x, backend="eager")
+        with self.assertRaisesRegex(PrecompileError, "shape"):
+            torch.compiler.precompile.load(mf_code, mf_cache)(m, x2)
+
+    def test_tracer_dynamo_pickle_state_corrupt_clean_error(self):
+        # A corrupt _DYNAMO_STATE (pickle blob) surfaces a clean PrecompileError about the
+        # captured state / environment, NOT the Python-version lock-in message (that is only
+        # for the marshalled bytecode) -- distinct diagnostics for distinct failures.
+        import base64 as _b64
+        import re as _re
+
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, _cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        bad = _b64.b64encode(b"not a pickle blob").decode("ascii")
+        corrupted = _re.sub(
+            r"_DYNAMO_STATE = '[^']*'", f"_DYNAMO_STATE = {bad!r}", code, count=1
+        )
+        self.assertNotEqual(corrupted, code)
+        ns = {"__name__": "_p"}
+        with self.assertRaisesRegex(PrecompileError, "captured state"):
+            exec(compile(corrupted, "<p>", "exec"), ns)
+
+    def test_tracer_dynamo_import_source_unresolvable_clean_error(self):
+        # The third rehydrate diagnostic: an IMPORT_SOURCES alias that names a module not
+        # importable in this environment (the artifact can reference private torch._dynamo
+        # runtime modules, so it is locked to a compatible torch build) surfaces a clean
+        # PrecompileError about the torch-build lock, distinct from the Python-version and
+        # captured-state messages. Rewrite IMPORT_SOURCES to a bogus module and exec directly
+        # (load()'s code_hash check would otherwise fire first and mask the rehydrate path).
+        import re as _re
+
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, _cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        corrupted = _re.sub(
+            r"IMPORT_SOURCES = \{[^}]*\}",
+            "IMPORT_SOURCES = {'x': 'no_such_module_precompile_xyz'}",
+            code,
+            count=1,
+        )
+        self.assertNotEqual(corrupted, code)
+        ns = {"__name__": "_i"}
+        with self.assertRaisesRegex(PrecompileError, "could not import a module"):
+            exec(compile(corrupted, "<i>", "exec"), ns)
+
+    def test_tracer_dynamo_wrong_type_blobs_clean_error(self):
+        # Hardening: marshal / pickle can SUCCEED yet return the wrong type (a corrupt blob
+        # that is valid marshal of an int, or valid pickle of a non-dict). The driver must
+        # still surface a clean PrecompileError -- not a raw TypeError from types.FunctionType
+        # or a KeyError from the state[...] accesses. Exec the doctored code directly.
+        import base64 as _b64
+        import marshal as _marshal
+        import pickle as _pickle
+        import re as _re
+
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, _cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), m, x, tracer="dynamo"
+        )
+        non_code = _b64.b64encode(_marshal.dumps(0)).decode("ascii")
+        bad_code = _re.sub(
+            r"_DYNAMO_CODE = '[^']*'", f"_DYNAMO_CODE = {non_code!r}", code, count=1
+        )
+        self.assertNotEqual(bad_code, code)
+        with self.assertRaisesRegex(PrecompileError, "Python version"):
+            exec(compile(bad_code, "<c>", "exec"), {"__name__": "_c"})
+
+        non_dict = _b64.b64encode(_pickle.dumps([1, 2, 3])).decode("ascii")
+        bad_state = _re.sub(
+            r"_DYNAMO_STATE = '[^']*'", f"_DYNAMO_STATE = {non_dict!r}", code, count=1
+        )
+        self.assertNotEqual(bad_state, code)
+        with self.assertRaisesRegex(PrecompileError, "captured state"):
+            exec(compile(bad_state, "<s>", "exec"), {"__name__": "_s"})
+
+    def test_tracer_dynamo_unpicklable_state_clean_error(self):
+        # The build-side counterpart to the marshal/unmarshallable guard: fn's captured state
+        # (globals / closure / arg-kw defaults) is pickled into _DYNAMO_STATE, so an
+        # unpicklable NON-tensor value there (here a local lambda default, which invariant 1
+        # does not reject because it holds no tensor) must surface a clean PrecompileError
+        # rather than a raw PicklingError. The default is baked by value via argdefs.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def fn(model, xx, _cb=lambda z: z):
+            return model(xx)
+
+        with self.assertRaisesRegex(PrecompileError, "not picklable"):
+            torch.compiler.precompile(fn, m, x, tracer="dynamo", backend="eager")
+
+    def test_tracer_dynamo_static_under_dynamic_config(self):
+        # The dynamo tracer must capture STATIC shapes like the make_fx tracer (invariant 3)
+        # regardless of the ambient torch._dynamo config OR per-code-object shape history:
+        # precompile pins both assume_static_by_default and automatic_dynamic_shapes, so
+        # neither a globally flipped default (a) nor a prior precompile of the SAME fn at
+        # another shape (b, reachable with DEFAULT config) yields an out-of-contract dynamic
+        # artifact. Without the pins the eager subgraph would carry a SymInt dim.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with torch._dynamo.config.patch(assume_static_by_default=False):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), m, x, tracer="dynamo", backend="eager"
+            )
+        self.assertNotIn("SymInt", code)
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), m(x))
+
+        # (b) automatic_dynamic (on by DEFAULT): precompiling the SAME fn (one code object)
+        # first at one shape then another would otherwise promote the batch dim to dynamic on
+        # the second capture. Reuse one fn across two shapes; both must stay static.
+        def f(model, xx):
+            return model(xx)
+
+        c1, _ = torch.compiler.precompile(
+            f, m, torch.randn(5, 4), tracer="dynamo", backend="eager"
+        )
+        c2, _ = torch.compiler.precompile(
+            f, m, torch.randn(7, 4), tracer="dynamo", backend="eager"
+        )
+        self.assertNotIn("SymInt", c1)
+        self.assertNotIn("SymInt", c2)
+
+    def test_load_cache_without_tracer_key(self):
+        # BC: a cache produced before the dynamo tracer existed carries no "tracer" key in
+        # its envelope. load() must still pair it with its make_fx python_code via the
+        # blob.get("tracer", "make_fx") default rather than KeyError. Simulate a legacy
+        # envelope by deleting the key. Assert the cache envelope was actually CONSUMED (no
+        # "could not read the cache envelope" warning): a KeyError from a reverted fix would
+        # be swallowed by load()'s except and fall back to JIT, which still returns the
+        # right answer -- so an output-only assertion would not guard the .get default.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(lambda model, xx: model(xx), m, x)
+        blob = torch.load(io.BytesIO(cache), weights_only=True)
+        del blob["tracer"]
+        buf = io.BytesIO()
+        torch.save(blob, buf)
+        with self.assertLogs("torch._precompile", level="WARNING") as cm:
+            f_c = torch.compiler.precompile.load(code, buf.getvalue())
+        self.assertFalse(
+            any("could not read the cache envelope" in msg for msg in cm.output),
+            f"legacy cache envelope was not consumed (fell back to JIT): {cm.output}",
+        )
+        self.assertEqual(f_c(m, x), m(x))
 
     def test_tracer_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
@@ -1011,7 +3054,8 @@ class TestPrecompile(TestCase):
 
         blob = torch.load(io.BytesIO(cache), weights_only=False)
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertIsNone(blob["artifact"])  # eager has no compiled blob to bundle
         self.assertEqual(blob["format"], _CACHE_FORMAT)
@@ -1487,6 +3531,16 @@ class TestPrecompile(TestCase):
             PrecompileError, "missing calling-convention metadata"
         ):
             torch.compiler.precompile.load("x = 1\n", buf.getvalue())
+
+    def test_nonliteral_calling_convention_metadata_rejected(self):
+        code, cache = torch.compiler.precompile(
+            lambda x: x.sin(), torch.randn(2), backend="eager"
+        )
+        bad_code = code.replace("BACKEND = 'eager'", "BACKEND = object()", 1)
+        with self.assertRaisesRegex(
+            PrecompileError, "BACKEND.*calling-convention metadata"
+        ):
+            torch.compiler.precompile.load(bad_code, cache)
 
     def test_singleton_pickle_deepcopy_roundtrip(self):
         # torch.compiler.precompile is a process-wide singleton; pickle and deepcopy
@@ -2601,6 +4655,113 @@ class TestPrecompileNumerics(TestCase):
         code, cache = torch.compiler.precompile(lambda a: a.t(), x, backend="eager")
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(x), x.t())
+
+    def test_tracer_dynamo_roundtrip_device(self, device):
+        # The dynamo tracer's inductor lowering emits device kernels (it lowers the
+        # Dynamo-produced subgraph through the same AOTAutograd + Inductor codegen as
+        # make_fx), and its eager backend inlines the subgraph as device-agnostic source.
+        # Run a numeric roundtrip device-generically -- like the make_fx numeric tests -- so
+        # the dynamo capture + subgraph lowering is exercised on CUDA, not only CPU. Both
+        # backends must round-trip to eager.
+        m = (
+            torch.nn.Sequential(
+                torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+            )
+            .to(device)
+            .eval()
+        )
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        for backend in ("inductor", "eager"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x), m(x))
+
+    def test_tracer_dynamo_dynamic_shapes_device(self, device):
+        # The dynamo tracer's mark_unbacked capture, run device-generically: the unbacked
+        # symint reaches the inductor lowering (CUDA kernels included) and the eager
+        # backend inlines the symbolic subgraph, so one artifact matches eager across
+        # runtime batch sizes on either backend.
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 3)
+        )
+        m.to(device).eval()
+        x = make_tensor((8, 4), device=device, dtype=torch.float32)
+        mark_unbacked(x, 0)
+        for backend in ("inductor", "eager"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), m, x, tracer="dynamo", backend=backend
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            for bs in (8, 16, 1):
+                xt = make_tensor((bs, 4), device=device, dtype=torch.float32)
+                self.assertEqual(f_c(m, xt), m(xt))
+
+    @skipIfCrossRef
+    def test_tracer_dynamo_training_device(self, device):
+        # The dynamo tracer's training capture, device-generically: the traced backward
+        # lowers to device kernels (inductor) / runs as inlined source (eager), and the
+        # harvested grads match eager on both.
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3).to(device)
+
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        t = make_tensor((5, 3), device=device, dtype=torch.float32)
+        for backend in ("inductor", "eager"):
+            code, cache = torch.compiler.precompile(
+                train_step, fresh(), x, t, tracer="dynamo", backend=backend
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            run, ref = fresh(), fresh()
+            f_c(run, x, t)
+            train_step(ref, x, t)
+            self.assertEqual(run.weight.grad, ref.weight.grad)
+            self.assertEqual(run.bias.grad, ref.bias.grad)
+
+    def test_tracer_dynamo_eager_custom_builtins(self, device):
+        # The dynamo eager emitter (_emit_dynamo_eager_subgraph) injects fx's full
+        # _custom_builtins set (inf / nan / device / ...) into the standalone subgraph
+        # source, its own copy of the loop the make_fx eager path uses. Every other dynamo
+        # eager test bakes only tensors needing plain ``torch``, so this guards that loop:
+        # dropping it would raise NameError at load. (a) masked_fill to -inf bakes a bare
+        # ``inf`` token; (b) a train-mode BatchNorm bakes a ``device`` constant. Both must
+        # round-trip to eager (mirrors test_backend_eager_inf_constant / _batchnorm).
+        def inf_fn(model, xx):
+            y = model(xx)
+            return torch.relu(y).masked_fill(y < 0, float("-inf"))
+
+        m = torch.nn.Linear(4, 4).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        code, cache = torch.compiler.precompile(
+            inf_fn, m, x, tracer="dynamo", backend="eager"
+        )
+        self.assertEqual(
+            torch.compiler.precompile.load(code, cache)(m, x), inf_fn(m, x)
+        )
+
+        def fresh_bn():
+            torch.manual_seed(0)
+            bn = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.BatchNorm1d(4))
+            bn.train()
+            return bn.to(device)
+
+        xb = make_tensor((8, 4), device=device, dtype=torch.float32)
+        ref_out = fresh_bn()(xb)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            fresh_bn(),
+            xb,
+            tracer="dynamo",
+            backend="eager",
+        )
+        self.assertEqual(
+            torch.compiler.precompile.load(code, cache)(fresh_bn(), xb), ref_out
+        )
 
 
 instantiate_device_type_tests(TestPrecompileNumerics, globals())

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -116,7 +116,8 @@ _COMPILE_LOCK = threading.RLock()
 # We do NOT reimplement any of this. We CAPTURE AOTAutograd's exact codegen'd wrapper
 # source together with the (pre-exec) globals dict each wrapper closed over: a
 # thread-local sink in codegen.py records one GeneratedSource per wrapper.
-# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path)
+# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path --
+# see compile_to_python's ``grad_enabled`` for the one graph shape that needs grad on)
 # with a capture-only inner compiler: it grabs the dense inner graph and returns a
 # placeholder callable, so AOTAutograd still codegen's the runtime-wrapper chain AROUND
 # that placeholder -- which is what the sink records. Inductor does not run in that pass;
@@ -828,7 +829,12 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     strides has static sizes, and treating it as static would silently specialize the
     artifact to the example strides. (Unbacked symints appearing only in intermediates,
     not on any placeholder, are still missed here, but such a graph fails loudly
-    downstream when emit_value rejects the still-symbolic metadata.)"""
+    downstream when emit_value rejects the still-symbolic metadata.)
+
+    Both metadata keys are checked, like ``_resolve_fake_mode``: make_fx stashes the fake
+    under "val", while a Dynamo graph (which torch.compiler.precompile's dynamo tracer
+    feeds here) stashes it under "example_value" -- reading only "val" would call a
+    dynamic Dynamo graph static and silently specialize it to the example sizes."""
     import torch
 
     def _is_symbolic(v: Any) -> bool:
@@ -837,15 +843,16 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     for node in gm.graph.nodes:
         if node.op != "placeholder":
             continue
-        val = node.meta.get("val")
-        if _is_symbolic(val):
-            return True
-        if isinstance(val, torch.Tensor) and (
-            any(_is_symbolic(s) for s in val.shape)
-            or any(_is_symbolic(s) for s in val.stride())
-            or _is_symbolic(val.storage_offset())
-        ):
-            return True
+        for key in ("val", "example_value"):
+            val = node.meta.get(key)
+            if _is_symbolic(val):
+                return True
+            if isinstance(val, torch.Tensor) and (
+                any(_is_symbolic(s) for s in val.shape)
+                or any(_is_symbolic(s) for s in val.stride())
+                or _is_symbolic(val.storage_offset())
+            ):
+                return True
     return False
 
 
@@ -854,8 +861,20 @@ def compile_to_python(
     example_inputs: Sequence[Any],
     *,
     options: dict[str, Any] | None = None,
+    grad_enabled: bool = False,
 ) -> tuple[str, bytes | None]:
     """Compile ``gm`` to ``(python_code, cache)``; see the module docstring.
+
+    ``grad_enabled`` runs the AOTAutograd capture pass under ``enable_grad`` instead of the
+    default ``no_grad``. Pass it ONLY for a graph that performs autograd INTERNALLY -- a
+    Dynamo graph captured with ``trace_autograd_ops``, whose traced ``torch.autograd.grad``
+    call needs a live autograd graph to differentiate and otherwise fails the capture pass
+    with "element 0 of tensors does not require grad". Such a graph is still an INFERENCE
+    graph at the AOT boundary (its backward lives inside the traced call, so AOTAutograd
+    still emits exactly one forward module). Do NOT pass it for an ordinary graph whose
+    INPUTS require grad: ``no_grad`` is what pins AOTAutograd to the inference path there,
+    and enabling grad would make it emit a joint forward+backward the standalone composer
+    cannot compose.
 
     THREADING: serialized by a process-global lock (``_COMPILE_LOCK``). The wrapper-source
     capture is thread-local, but the AOTAutograd pass and the inner inductor compile both
@@ -951,7 +970,7 @@ def compile_to_python(
             "from_graph" if _graph_has_dynamic_shapes(gm) else "from_example_inputs"
         )
         with (
-            torch.no_grad(),
+            torch.enable_grad() if grad_enabled else torch.no_grad(),
             _standalone_context(gm, shapes_mode, aot=False),
             capture_generated_sources(captured),
         ):

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1,14 +1,21 @@
-"""Ahead-of-time precompilation (``make_fx`` tracer by default; Dynamo planned).
+"""Ahead-of-time precompilation (``make_fx`` tracer by default; ``dynamo`` also available).
 
     python_code, cache = torch.compiler.precompile(fn, model, *example_inputs)
     f_c = torch.compiler.precompile.load(python_code, cache)
     out = f_c(model, *example_inputs)   # pass the model again at runtime
 
-precompile captures your computation with ``make_fx`` -- a NON-STRICT trace of the ATen
-ops that run when ``fn`` executes once on the example inputs. It does not analyze your
-Python, so it comes with an explicit contract (the programming model): stay inside it
-and the artifact faithfully reproduces ``fn``; step outside it and you get an artifact
-that computes the wrong thing.
+precompile captures your computation with ``make_fx`` (the default ``tracer``) -- a
+NON-STRICT trace of the ATen ops that run when ``fn`` executes once on the example
+inputs. It does not analyze your Python, so it comes with an explicit contract (the
+programming model): stay inside it and the artifact faithfully reproduces ``fn``; step
+outside it and you get an artifact that computes the wrong thing.
+
+The ``dynamo`` tracer is an alternative capture front-end that analyzes the Python
+(bytecode) rather than tracing one path. It inlines the TRANSFORMED BYTECODE Dynamo
+produces into ``python_code`` (marshalled, rehydrated at load) and lowers the compiled
+subgraph through the same backends; forward and training computations, ``mark_unbacked``
+dynamic shapes, and a ``decompositions`` table all work with it. See the ``tracer`` note at
+the bottom of Note [precompile programming model].
 
 ``precompile`` returns a self-contained, executable ``python_code`` string plus a
 companion integrity-tagged ``cache``. With ``backend="inductor"`` (the default) the
@@ -127,7 +134,11 @@ it.
 #    ``.backward()`` step), not the grads. The grad scatter is the ONLY mutation
 #    precompile performs, and it happens in Python outside the graph, so the graph stays
 #    functional. precompile does not own optimizer state; bring your own optimizer and
-#    zero grads as usual.
+#    zero grads as usual. The dynamo tracer reaches the SAME observable behavior by a
+#    different route (see the tracer note): the backward stays a traced autograd call
+#    inside the graph and Dynamo's own bytecode does the accumulate, so there is no
+#    harvested-output list -- but which params get a grad is still fixed at trace time,
+#    frozen params still keep ``.grad = None``, and the accumulate still matches eager.
 #
 # 6. Shapes are static by default (dynamic dims are opt-in via mark_unbacked, invariant
 #    3), each input's dtype/device is baked, and the inductor backend also specializes
@@ -197,16 +208,101 @@ it.
 # whole runnable artifact).
 #
 # tracer: the capture front-end, orthogonal to backend. "make_fx" (default) is a
-# non-strict trace and is the only tracer implemented today -- everything above (the
-# invariants, the contract) describes its behavior. "dynamo" is planned (a Dynamo-based
-# front-end that analyzes Python rather than specializing to one traced path) and
-# currently raises NotImplementedError.
+# non-strict trace -- everything above (the invariants, the contract) describes its
+# behavior. "dynamo" is a Dynamo-based front-end that analyzes the Python (bytecode)
+# instead of specializing to one traced path.
+#
+# The "dynamo" tracer's TRICK, and how it differs from make_fx: Dynamo does not hand back
+# a single graph we can render as source. It hands back (a) a TRANSFORMED bytecode -- a
+# rewrite of fn that extracts the runtime model's params/buffers, calls a compiled
+# subgraph, and reassembles fn's output -- plus (b) the subgraph (an fx GraphModule) for
+# the backend to lower. So precompile INLINES the transformed bytecode into python_code
+# (marshalled to a base64 blob, rehydrated by the driver via marshal.loads +
+# types.FunctionType) and lowers the subgraph through the SAME backends as make_fx
+# ("inductor" -> aot_autograd.compile_to_python source, "eager" -> the inlined subgraph),
+# wiring the subgraph in under the backend id the bytecode calls. The transformed bytecode
+# IS the calling convention: it reads params off the runtime model itself (given a
+# structurally identical runtime model it reads the right weights, invariant 2), which is
+# why the dynamo driver is thin (rehydrate + wire) and carries none of the make_fx
+# PARAM_NAMES / OUT_SPEC metadata.
+#
+# TRAINING works here too, by a different mechanism than make_fx. make_fx traces THROUGH
+# .backward(), so its artifact is one flat graph of fwd+bwd ATen ops with the grads as
+# extra outputs and a Python-level scatter in the driver (invariant 5). Dynamo instead
+# rewrites the backward into an in-graph torch.autograd.grad plus the .grad updates around
+# it -- so precompile pins trace_autograd_ops (otherwise Dynamo graph-breaks on the
+# backward), runs the artifact under enable_grad (the traced call differentiates a live
+# autograd graph the same call builds; a forward capture keeps no_grad), and lowers with
+# compile_to_python(grad_enabled=True) for the same reason. No grad-scatter metadata is
+# needed: the transformed bytecode does the .grad update itself, on the runtime model.
+# Dynamo's rewrite SPECIALIZES on whether p.grad is None at trace time -- both user code
+# and the backward's assign-vs-accumulate update can observe that choice. The source
+# artifact therefore keeps the original capture and validates the same incoming state in
+# its driver. A cold-state artifact is called after zero_grad(set_to_none=True); a warm
+# artifact accumulates into existing grads. Only params can have that state validated, as
+# on the make_fx path (invariant 5): a user input that requires grad is rejected.
+#
+# Dynamic shapes and decompositions work here too, by different mechanisms than make_fx.
+# Dynamic shapes: mark_unbacked is Dynamo's OWN decorator, so Dynamo captures the marked
+# dim as an UNBACKED symint directly -- unguardable, so a graph that needs to guard on it
+# fails loudly at capture (the same PrecompileError the make_fx tracer raises) instead of
+# baking a size, which is what makes a guard-free artifact sound. Dynamo emits the
+# ShapeEnv's runtime asserts (mark_unbacked's min/max, a shared shape_id's equality) into
+# the subgraph itself, so they hold on BOTH backends -- unlike the make_fx tracer, whose
+# eager backend has no such asserts and therefore rejects dynamic dims outright. The
+# STRICT variant is rejected here: Dynamo reads it as a RelaxedUnspecConstraint, i.e. a
+# BACKED dynamic dim it may guard on, and this artifact does not check guards (see
+# _reject_strict_unbacked_marks); mark_dynamic / specialize_on are rejected as on the
+# make_fx path. Decompositions: Dynamo captures torch-level IR and never consults a
+# decomposition table, so precompile applies it by re-tracing the captured subgraph with
+# make_fx (see _decompose_subgraph) -- the same table shaping the same ATen graph, just
+# applied one step later than the make_fx tracer applies it.
+#
+# Scope and differences from make_fx (each is an implementation gap, not a fundamental
+# limit): a graph-breaking fn (one whose Python Dynamo cannot capture as a single graph)
+# raises a PrecompileError pointing back at tracer="make_fx", which traces non-strictly and
+# so has no such limit. It does NOT check Dynamo's guards at
+# runtime, NOR does
+# it reproduce the make_fx drivers' upfront runtime validation (the param/buffer structural
+# check, invariant 2, and the per-input shape/dtype/device checks, invariants 3/6): safety
+# comes from the same specialization contract as make_fx (control flow and unmarked shapes
+# are specialized to the example) plus the captured graph's own asserts -- on the INDUCTOR
+# backend the baked assert_size_stride (which catches a runtime input/weight whose SHAPE or
+# STRIDE differs from the example, but not its DTYPE) and, for a dynamic capture, the
+# ShapeEnv range / equality asserts on both backends -- not from a reconstructed guard
+# manager. So a contract-violating runtime
+# input/model may fail with a raw kernel error rather than a clean PrecompileError, and on
+# the EAGER backend (no assert_size_stride) a broadcast-compatible shape mismatch can
+# silently miscompute -- pass inputs and a model matching the example, as the contract
+# requires. Because Dynamo bakes the trace-time environment (e.g. the current accelerator
+# stream) into the bytecode, the artifact is environment-specialized like the make_fx one.
+# Unlike the make_fx tracer's rendered source, this artifact inlines MARSHALLED CPython
+# bytecode plus a PICKLED state blob, so it is LOCKED to the producing Python version:
+# loading it under a different CPython (3.10-3.14) fails with a clean PrecompileError (see
+# _build_dynamo_forward). It is ALSO locked to a compatible torch build, because its import
+# aliases can reference private torch._dynamo runtime modules (also surfaced as a clean
+# PrecompileError). Regenerate per Python version / torch build, or use make_fx for portable
+# source (backend='eager' for torch-build portability -- the default make_fx inductor artifact
+# itself inlines private torch._inductor modules, so it too is torch-build-locked; the
+# Python-version portability holds for either make_fx backend). A tensor closed over by fn (a
+# global, captured local, or DEFAULT ARGUMENT value,
+# including one nested in a container, an nn.Module, a plain/__slots__ object attribute, or
+# a functools.partial / bound method) is rejected (invariant 1) here too -- Dynamo surfaces
+# it as a used-global / closure content / argdef, not a graph get_attr constant, so the
+# check scans those by replaying pickle's own traversal (see _baked_tensors and
+# _reject_baked_tensors).
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
 import logging
+import marshal
+import operator
+import pickle
+import sys
+import types
 from types import MappingProxyType
 from typing import Any, cast, NewType, TYPE_CHECKING
 
@@ -222,8 +318,10 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
+    from torch._dynamo import convert_frame
+    from torch._dynamo.source import Source
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -396,6 +494,50 @@ def _reject_unsupported_marks(user_flat: list[object]) -> None:
                 "precompile cannot honor (it produces a single artifact, not per-value "
                 "specializations). Remove specialize_on."
             )
+
+
+def _reject_strict_unbacked_marks(user_flat: list[object]) -> None:
+    """Reject ``mark_unbacked(..., strict=True)`` for the dynamo tracer (invariant 3).
+
+    The strict variant means something DIFFERENT to Dynamo than it does to the make_fx
+    tracer. make_fx capture is precompile's own (_fakeify_with_unbacked), so it makes a
+    strict dim unbacked exactly like a plain one; Dynamo instead records only a
+    RelaxedUnspecConstraint, making the dim a BACKED dynamic symbol -- one Dynamo may guard
+    on (a shape-dependent branch just adds ``s0 > 4``) and errors on only if the dim gets
+    fully specialized. The dynamo artifact does not check Dynamo's guards at runtime, so
+    such a guard would be silently dropped and a different runtime size would take the
+    wrong path. Plain mark_unbacked gives a genuinely unguardable dim, which is what the
+    guard-free artifact needs, so point there.
+    """
+    if any(
+        isinstance(t, torch.Tensor)
+        and getattr(t, "_dynamo_strict_unbacked_indices", None)
+        for t in user_flat
+    ):
+        raise PrecompileError(
+            "precompile: an input has a mark_unbacked(strict=True) dim, which "
+            "tracer='dynamo' cannot honor: Dynamo captures a strict mark as a BACKED "
+            "dynamic dim it may guard on, and the dynamo artifact does not check Dynamo's "
+            "guards at runtime. Use plain mark_unbacked (strict=False), which captures a "
+            "genuinely unguardable dim, or use tracer='make_fx'."
+        )
+
+
+def _unbacked_guard_error(e: BaseException) -> PrecompileError:
+    """The shared capture-time error for a guard on a mark_unbacked dim (both tracers).
+
+    A mark_unbacked dim is captured as an unbacked symint (no hint), so a computation that
+    needs to guard on / specialize its size (a shape-dependent branch, a reshape that pins
+    it) cannot be captured. Unbacked dims cannot be guarded, so rather than bake a
+    silently-wrong artifact, fail here.
+    """
+    return PrecompileError(
+        "precompile: fn needs to guard on a dim marked with mark_unbacked "
+        "(it branches on or specializes that size), which is not allowed for "
+        "an unbacked dynamic dim. Do not mark that dim (capture it static), "
+        "or restructure fn to avoid the size-dependent operation. Underlying: "
+        f"{(str(e).splitlines() or [''])[0]}"
+    )
 
 
 def _read_unbacked_marks(user_flat: list[object]) -> list[dict[int, _MarkSpec]]:
@@ -603,6 +745,29 @@ def _assert_no_control_flow_subgraphs(gm: torch.fx.GraphModule) -> None:
         )
 
 
+def _reject_nonliftable_get_attrs(gm: torch.fx.GraphModule) -> None:
+    """Reject a captured dynamo subgraph get_attr whose target is neither a Tensor nor a
+    GraphModule (a symbolic size, a torchbind script object, or a bare nn.Module). The
+    eager backend inlines gm.code against an EMPTY _GraphSelf(), so such a get_attr would
+    resolve to nothing and raise a raw AttributeError at runtime; reject it at capture
+    with a concrete reason instead. Tensor and GraphModule get_attrs are already handled
+    by _check_no_constant_tensors / _assert_no_control_flow_subgraphs.
+    """
+    offending = [
+        (target, type(attr).__name__)
+        for target, attr in _resolved_get_attrs(gm)
+        if not isinstance(attr, (torch.Tensor, torch.fx.GraphModule))
+    ]
+    if offending:
+        raise PrecompileError(
+            "precompile tracer='dynamo' captured a subgraph get_attr that is not a "
+            "liftable graph input (e.g. a symbolic size, a torchbind script object, or a "
+            "bare nn.Module); the eager backend inlines the subgraph and cannot resolve "
+            f"it. Offending (target, type): {offending}. Pass such state as an explicit "
+            "argument, or use tracer='make_fx'."
+        )
+
+
 def _intern_param_buffers(
     mods: list[torch.nn.Module],
 ) -> tuple[
@@ -628,6 +793,7 @@ def _intern_param_buffers(
 
         def _name(mi: _ModuleIndex, n: str) -> str:
             return f"m{mi}.{n}"
+
     else:
 
         def _name(mi: _ModuleIndex, n: str) -> str:
@@ -771,9 +937,11 @@ def _capture(
     if any(marks):
         flat_args, fake_mode = _fakeify_with_unbacked(pb_flat, user_flat, marks)
         user_input_shapes = [
-            None
-            if base is None
-            else tuple(None if i in per else s for i, s in enumerate(base))
+            (
+                None
+                if base is None
+                else tuple(None if i in per else s for i, s in enumerate(base))
+            )
             for base, per in zip(user_input_shapes, marks)
         ]
 
@@ -864,17 +1032,7 @@ def _capture(
                     tracing_mode=tracing_mode,
                 )(flat_args)
             except GuardOnDataDependentSymNode as e:
-                # A mark_unbacked dim was captured as an unbacked symint (no hint), but
-                # the computation needs to guard on / specialize its size (e.g. a
-                # shape-dependent branch or a reshape that pins it). Unbacked dims cannot
-                # be guarded, so rather than bake a silently-wrong artifact, fail here.
-                raise PrecompileError(
-                    "precompile: fn needs to guard on a dim marked with mark_unbacked "
-                    "(it branches on or specializes that size), which is not allowed for "
-                    "an unbacked dynamic dim. Do not mark that dim (capture it static), "
-                    "or restructure fn to avoid the size-dependent operation. Underlying: "
-                    f"{str(e).splitlines()[0]}"
-                ) from e
+                raise _unbacked_guard_error(e) from e
     finally:
         for a, g in zip(real_flat, saved_grads):
             if isinstance(a, torch.Tensor):
@@ -954,6 +1112,1108 @@ class _Capture:
         # The fake_mode (with ShapeEnv) used for a dynamic-shape capture, threaded to the
         # lowering (dynamic_shapes="from_tracing_context"); None for a static capture.
         self.fake_mode = fake_mode
+
+
+def _baked_tensors(value: object) -> list[torch.Tensor]:
+    """Return the tensors pickle would embed BY VALUE when serializing ``value`` -- exactly
+    the tensors a captured global / closure / default holding ``value`` bakes into the
+    artifact's _DYNAMO_STATE. Rather than reimplement pickle's traversal (and mis-handle
+    __slots__, functools.partial, bound methods, custom __reduce__, dict keys, protocol
+    quirks, ...), this RUNS pickle's own traversal with a persistent_id hook that records
+    every Tensor pickle is about to serialize by value and short-circuits it (so its storage
+    is never written). Consequences fall out for free: a tensor in a container, an nn.Module,
+    a plain / __slots__ / custom-__reduce__ object, or a bound method's ``__self__`` is
+    caught, while a by-reference object (a function, class, or module -- re-imported at load,
+    nothing baked) contributes nothing. The hook fires on isinstance(Tensor) BEFORE the
+    object's own reducer, so a tensor SUBCLASS that opts into a by-reference __reduce__ is
+    conservatively (and harmlessly) rejected too -- an accepted tradeoff for not executing
+    arbitrary reducer code. If ``value`` is not fully picklable, returns the tensors found
+    BEFORE the failure (so a tensor preceding an unpicklable object still yields the precise
+    invariant-1 error; an all-unpicklable value returns [] and the real pickle of the
+    artifact state fails loudly on its own). Mirrors the make_fx get_attr constant scan.
+    """
+    found: list[torch.Tensor] = []
+
+    class _TensorFinder(pickle.Pickler):
+        def persistent_id(self, obj: object) -> object:
+            if isinstance(obj, torch.Tensor):
+                found.append(obj)
+                return len(found)
+            return None
+
+    try:
+        _TensorFinder(io.BytesIO(), protocol=pickle.DEFAULT_PROTOCOL).dump(value)
+    except Exception:
+        pass
+    return found
+
+
+def _reject_baked_tensors(
+    used_globals: Mapping[str, object],
+    closure_contents: list[object],
+    defaults: Sequence[object] = (),
+) -> None:
+    """Enforce invariant 1 for the dynamo tracer: reject a live tensor referenced from a
+    module global, a closure cell, or a default argument value, which would be embedded
+    by VALUE into the artifact rather than passed at runtime.
+
+    This is the dynamo tracer's analogue of _check_no_constant_tensors (the make_fx
+    tracer's get_attr scan): Dynamo surfaces a closed-over tensor as a used-global or a
+    closure content (a global tensor becomes a graph input sourced from its GlobalSource,
+    which get_runtime_env records in used_globals -- as the whole container when the
+    tensor is nested), and fn's argdefs + kwdefaults are pickled into _DYNAMO_STATE too, so
+    a tensor default (``def f(m, x, w=W)``) is baked as well. Each source is scanned with
+    _baked_tensors, which uses pickle's own traversal to find exactly the tensors that get
+    baked (see _baked_tensors for what that covers).
+    """
+    offending = []
+    for name, v in used_globals.items():
+        offending += [(name, tuple(t.shape), str(t.dtype)) for t in _baked_tensors(v)]
+    for v in closure_contents:
+        offending += [
+            ("<closure>", tuple(t.shape), str(t.dtype)) for t in _baked_tensors(v)
+        ]
+    for v in defaults:
+        offending += [
+            ("<default arg>", tuple(t.shape), str(t.dtype)) for t in _baked_tensors(v)
+        ]
+    if offending:
+        raise PrecompileError(
+            "precompile traced a tensor that is neither a graph input (module "
+            "parameter/buffer or user input) nor an intermediate: it is closed over by "
+            "fn (a global, captured local, or default argument value, including one "
+            "nested in a container, an nn.Module, or a plain object attribute) and would "
+            "be hard-coded into the artifact. Offending constants (name, shape, dtype): "
+            f"{offending}. Fix by passing the tensor as an explicit argument; for module "
+            "state register it as a parameter/buffer, and pass the owning nn.Module as an "
+            "explicit argument rather than closing over it."
+        )
+
+
+class _DynamoCapture:
+    """The pieces the dynamo tracer produces: the transformed bytecode + the names it
+    references (import aliases, plain globals, closure, arg/kw defaults, the compiled
+    subgraph's backend id), plus the subgraph GraphModule + the example inputs for the
+    backend to lower. ``backend_id`` / ``gm`` are None when fn produced no tensor compute
+    (the transformed bytecode is then the whole artifact). ``dynamic`` records whether the
+    subgraph was captured with dynamic (mark_unbacked) dims, in which case
+    ``example_inputs`` are Dynamo's own symbolic FAKE tensors rather than the real ones.
+    ``trains`` marks a capture that performs autograd (the graph carries a traced
+    ``torch.autograd.grad``), and ``grad_param_states`` then names every parameter whose
+    capture specializes on whether ``.grad`` is ``None``. The emitted driver validates
+    that state before entering user code.
+    """
+
+    def __init__(
+        self,
+        *,
+        bytecode: types.CodeType,
+        import_sources: dict[str, str],
+        used_globals: dict[str, object],
+        closure_contents: list[object],
+        argdefs: tuple[object, ...] | None,
+        kwdefaults: dict[str, object] | None,
+        backend_id: str | None,
+        gm: torch.fx.GraphModule | None,
+        example_inputs: Sequence[object],
+        dynamic: bool = False,
+        trains: bool = False,
+        grad_param_states: (
+            list[tuple[int, list[tuple[str, object]], str, bool]] | None
+        ) = None,
+    ) -> None:
+        self.bytecode = bytecode
+        self.import_sources = import_sources
+        self.used_globals = used_globals
+        self.closure_contents = closure_contents
+        self.argdefs = argdefs
+        self.kwdefaults = kwdefaults
+        self.backend_id = backend_id
+        self.gm = gm
+        self.example_inputs = example_inputs
+        self.dynamic = dynamic
+        self.trains = trains
+        self.grad_param_states = grad_param_states or []
+
+
+def _graph_traces_autograd(gm: torch.fx.GraphModule) -> bool:
+    """True if the captured dynamo subgraph performs autograd itself -- i.e. fn ran a
+    backward and Dynamo (with trace_autograd_ops) rewrote it into an in-graph
+    ``torch.autograd.grad`` call plus the ``.grad`` updates around it.
+
+    Both ``Tensor.backward()`` and a direct ``torch.autograd.grad(...)`` funnel through
+    that one target, so this single check identifies a training capture. Such a graph is
+    the reason the training path needs grad ENABLED where an inference capture runs under
+    no_grad (invariant 5): the traced call differentiates a live autograd graph.
+    """
+    return any(
+        node.op == "call_function" and node.target is torch.autograd.grad
+        for node in gm.graph.nodes
+    )
+
+
+# How deep to look for an nn.Module inside a frame argument. A path is a tuple of
+# ("index"|"key"|"attr", accessor) steps; the driver replays exactly these.
+_MODULE_SEARCH_DEPTH = 6
+# Objects walked PER FRAME ARGUMENT, so an argument that happens to reference a
+# large object graph cannot dominate capture time. Per argument rather than one
+# counter shared by the frame: a shared one let a big EARLIER argument (a vocab,
+# an in-memory dataset) exhaust the walk before it reached the model in a later
+# argument, so whether the artifact was correct depended on the argument ORDER.
+# The walk below stops expanding as soon as the budget is gone, so the cost is
+# O(budget) rather than O(size of the argument), which is what makes a budget
+# this large cheaper on a pathological argument than the old 2000 was.
+_MODULE_SEARCH_BUDGET = 20000
+_ModulePath = tuple[tuple[str, object], ...]
+_GradParamState = tuple[int, list[tuple[str, object]], str, bool]
+_GradParamCandidate = tuple[int, _ModulePath, str, torch.Tensor]
+
+
+def _walk_for_modules(
+    value: object, budget: list[int]
+) -> list[tuple[_ModulePath, torch.nn.Module]]:
+    """Find every nn.Module reachable from ``value``, each with the PATH to it.
+
+    A path rather than just a position, because two same-shaped modules in one
+    container are indistinguishable by parameter name: re-searching by name
+    found the first one for both and validated the wrong parameter twice.
+
+    The walk starts over for each ARGUMENT (a fresh ``seen`` set and a fresh
+    budget, see _frame_modules), never once for the whole frame: one module
+    reachable from two arguments has to be recorded at BOTH paths, because the
+    runtime call may put a different object at each and the driver replays each
+    path independently. Sharing the set recorded only the first and then crashed
+    on the second.
+
+    A module found is not descended into: its own parameters come from
+    named_parameters(), and its children are reached through it.
+
+    BREADTH first, so the budget cuts off the deepest layer rather than whatever
+    the first attribute happened to lead into. A trainer holding both a big
+    ``self.dataset`` and ``self.model`` is the ordinary shape, and depth first
+    opened the dataset and never reached the model -- silently, since the artifact
+    then cannot validate the backward's captured gradient state.
+    """
+    found: list[tuple[_ModulePath, torch.nn.Module]] = []
+    seen: set[int] = {id(value)}
+    frontier: list[tuple[_ModulePath, object]] = [((), value)]
+    for depth in range(_MODULE_SEARCH_DEPTH + 1):
+        if not frontier:
+            break
+        nxt: list[tuple[_ModulePath, object]] = []
+        for path, obj in frontier:
+            if budget[0] <= 0:
+                break
+            budget[0] -= 1
+            if isinstance(obj, torch.nn.Module):
+                found.append((path, obj))
+                continue
+            # Never walk into a module object: it is a namespace, not model
+            # state, and `torch` alone reaches ~48k objects.
+            if isinstance(obj, (types.ModuleType, type)):
+                continue
+            if depth == _MODULE_SEARCH_DEPTH:
+                continue
+            edges: Iterator[tuple[tuple[str, object], object]]
+            if isinstance(obj, (list, tuple)):
+                edges = ((("index", i), v) for i, v in enumerate(obj))
+            elif isinstance(obj, dict):
+                # Any hashable key, not just str: {0: model} is an ordinary
+                # shape. A key the artifact cannot write down is refused later,
+                # by _param_grad_inputs, and only if a model is actually found
+                # behind it (_representable_as_source).
+                edges = ((("key", k), v) for k, v in obj.items())
+            else:
+                edges = ((("attr", n), v) for n, v in _attribute_edges(obj))
+            for step, inner in edges:
+                # Stop EXPANDING once the frontier already covers the remaining
+                # budget: without this the walk still pays a full iteration of a
+                # 300k-element argument to enqueue objects it will never look at.
+                if len(nxt) >= budget[0]:
+                    break
+                if id(inner) in seen:
+                    continue
+                seen.add(id(inner))
+                nxt.append((path + (step,), inner))
+        frontier = nxt
+    return found
+
+
+def _attribute_edges(value: object) -> Iterator[tuple[str, object]]:
+    """(name, value) for each instance attribute, lazily -- the walk stops
+    consuming this as soon as its budget is gone."""
+    for name in _attribute_names(value):
+        try:
+            yield name, getattr(value, name)
+        except Exception:
+            # A property can raise; it is not somewhere a model lives.
+            continue
+
+
+def _attribute_names(value: object) -> list[str]:
+    """Instance attribute names, covering __slots__ as well as __dict__.
+
+    A __slots__ holder has no __dict__ at all, so a vars()-only walk missed the
+    model entirely -- and missing it is silent without a runtime gradient-state check.
+    """
+    names = list(getattr(value, "__dict__", {}) or {})
+    for klass in type(value).__mro__:
+        slots = klass.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        names.extend(s for s in slots if s != "__dict__")
+    return names
+
+
+def _frame_modules(
+    fn: Callable[..., object], args: tuple[object, ...]
+) -> list[tuple[int, _ModulePath, torch.nn.Module]]:
+    """Every nn.Module the artifact's ``forward`` will receive, positioned.
+
+    Positions are over the FRAME args, not the caller's ``args``: Dynamo traces
+    ``get_traced_fn(fn)`` and ``convert_frame._get_frame`` PREPENDS the bound
+    self, so for an nn.Module ``fn`` -- or a bound method -- the module carrying
+    the parameters is argument 0 and is absent from ``args`` entirely.
+    """
+    from torch._dynamo.convert_frame import get_traced_fn
+
+    _traced, bound_self = get_traced_fn(fn)
+    frame_args: list[object] = ([bound_self] if bound_self is not None else []) + list(
+        args
+    )
+    found = []
+    truncated = False
+    for pos, a in enumerate(frame_args):
+        budget = [_MODULE_SEARCH_BUDGET]
+        for path, module in _walk_for_modules(a, budget):
+            found.append((pos, path, module))
+        truncated = truncated or budget[0] <= 0
+    if truncated and not found:
+        # Only when the search came back EMPTY and we know it was cut short:
+        # that is the combination that silently bakes the overwriting form of a
+        # backward (this walk runs only for a training capture). Having found
+        # some module but missed another is not detectable here, and is what the
+        # per-tensor attribution check at the end of _capture_dynamo is for.
+        log.warning(
+            "precompile: no nn.Module was found in fn's arguments, and the search "
+            "for one stopped early after %d objects in at least one argument. A "
+            "training capture that finds no model cannot bake the accumulating form "
+            "of its backward. Pass the model as its own argument, or hold it in a "
+            "shallower container.",
+            _MODULE_SEARCH_BUDGET,
+        )
+    return found
+
+
+def _module_import_name(module: types.ModuleType) -> str | None:
+    """The sys.modules KEY for ``module``, which is what re-imports to it.
+
+    ``__name__`` is not: ``_collections_abc`` sets its own to "collections.abc",
+    which imports to the three-line shim instead. Real models inline through
+    such modules, so resolve the key and refuse rather than record a name that
+    binds something else at load.
+    """
+    name = getattr(module, "__name__", None)
+    if name is not None and sys.modules.get(name) is module:
+        return name
+    for key, candidate in list(sys.modules.items()):
+        if candidate is module:
+            return key
+    return None
+
+
+def _representable_as_source(key: object) -> bool:
+    """Whether ``key`` survives the artifact, which stores it as SOURCE TEXT.
+
+    GRAD_PARAM_STATES is emitted with repr() and read back by ast.literal_eval
+    (load) and exec (the driver), so a key is usable exactly when its repr is a
+    literal that reads back EQUAL -- equality (and matching hash) rather than
+    identity because that is all the driver's ``obj[key]`` lookup needs. An enum
+    member reprs as ``<K.A: 1>``, which is not even parseable: the capture
+    succeeded and load() then rejected the whole file as "not a precompile
+    artifact".
+    """
+    import ast
+
+    try:
+        rebuilt = ast.literal_eval(repr(key))
+    except Exception:
+        return False
+    try:
+        return bool(rebuilt == key) and hash(rebuilt) == hash(key)
+    except Exception:
+        # __eq__ / __hash__ are user code and can raise or return a non-bool
+        # (a Tensor key); either way the key is not one we can write down.
+        return False
+
+
+def _grad_target_inputs(gm: torch.fx.GraphModule, n_inputs: int) -> set[int]:
+    """Graph-input indices of the tensors the traced backward differentiates.
+
+    Dynamo lowers both ``Tensor.backward()`` and ``torch.autograd.grad`` to ONE in-graph
+    ``torch.autograd.grad(loss, inputs)`` node, so that node's ``inputs`` list is exactly
+    the set of leaves that can receive a ``.grad``. An unrecognized shape falls back to
+    every input: analyzing more can only turn a silent wrong answer into a refusal.
+    """
+    phs = list(gm.graph.find_nodes(op="placeholder"))
+    if len(phs) != n_inputs:
+        raise PrecompileError(
+            f"internal: the captured dynamo subgraph has {len(phs)} placeholders but "
+            f"{n_inputs} example inputs, so precompile cannot tell which tensors its "
+            "backward differentiates."
+        )
+    idx = {id(n): i for i, n in enumerate(phs)}
+    targets: set[int] = set()
+    saw = False
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target is torch.autograd.grad:
+            saw = True
+            inputs = node.args[1] if len(node.args) > 1 else node.kwargs.get("inputs")
+            if not isinstance(inputs, (list, tuple)):
+                return set(range(len(phs)))
+            targets.update(idx[id(v)] for v in inputs if id(v) in idx)
+    return targets if saw else set()
+
+
+def _seed_grad_targets(
+    gm: torch.fx.GraphModule, example_inputs: Sequence[object]
+) -> list[torch.Tensor]:
+    """Give every tensor the traced backward differentiates a temporary zero ``.grad``
+    if it has none, so a diagnostic re-capture exposes the gradient inputs. Returns what
+    was seeded.
+
+    Note [precompile dynamo training grad accumulation]
+    Dynamo's backward rewrite SPECIALIZES on whether ``p.grad`` is None at trace time: with
+    no grad it emits ``new = empty_like(p); new.copy_(g)`` and the bytecode ASSIGNS it; with
+    a grad present it additionally emits ``p.grad.add_(new)``. torch.compile protects that
+    choice with a guard. The diagnostic capture exposes every existing ``.grad`` as a
+    graph input so precompile can name the owning parameter and emit the equivalent
+    runtime state check. The artifact itself remains the original, unseeded capture.
+
+    Seeding is driven by the GRAPH, not by the module walk, because the walk is the thing
+    that can miss a param -- and a param the walk missed is precisely the one that would
+    silently lose its state check. Seeding it makes its ``.grad`` a graph INPUT, which is
+    what the attribution check in _param_grad_inputs can see and refuse. The seed is
+    therefore not just a fixup, it is the ORACLE: whether the re-capture still bakes the
+    assign form is exactly how precompile learns that fn nulls that ``.grad`` itself
+    (``zero_grad(set_to_none=True)``, ``p.grad = None``), in which case the assign form is
+    what eager does too. Keyed on requires_grad rather than isinstance(Parameter): a
+    requires_grad BUFFER or a bare tensor attribute is a legal autograd target that
+    named_parameters() can never name, and it has to be caught, not skipped.
+    """
+    seeded: list[torch.Tensor] = []
+    try:
+        for i in sorted(_grad_target_inputs(gm, len(example_inputs))):
+            t = example_inputs[i]
+            if (
+                isinstance(t, torch.Tensor)
+                and t.requires_grad
+                and t.is_leaf
+                and t.grad is None
+            ):
+                t.grad = torch.zeros_like(t)
+                seeded.append(t)
+    except BaseException:
+        # Seeding mutates the CALLER's model, so a failure part way through --
+        # an OOM on zeros_like for a large model -- must not leave grads behind.
+        for t in seeded:
+            t.grad = None
+        raise
+    return seeded
+
+
+def _dot_grad_graph_inputs(
+    example_inputs: Sequence[object], sources: Mapping[int, Source]
+) -> dict[int, str]:
+    """``{graph-input index: access path}`` for every input that is some tensor's ``.grad``.
+
+    Two detectors, unioned, because each fails open on its own and refusing is the safe
+    direction: the SOURCE label is precise and names a path for the error message but is
+    Dynamo's spelling and could be renamed; IDENTITY cannot be renamed but cannot see a
+    ``.grad`` whose owner the forward never read.
+    """
+    from torch._dynamo.source import AttrSource, GradSource
+
+    found: dict[int, str] = {}
+    for i, src in (sources or {}).items():
+        if isinstance(src, GradSource) or (
+            isinstance(src, AttrSource) and src.member == "grad"
+        ):
+            found[i] = src.name
+    owners = {
+        id(t.grad)
+        for t in example_inputs
+        if isinstance(t, torch.Tensor) and t.grad is not None
+    }
+    for i, t in enumerate(example_inputs):
+        if isinstance(t, torch.Tensor) and id(t) in owners and i not in found:
+            src = (sources or {}).get(i)
+            found[i] = src.name if src is not None else f"graph input #{i}"
+    return found
+
+
+def _validate_grad_param_path(pos: int, path: _ModulePath, name: str) -> None:
+    for kind, acc in path:
+        if kind == "key" and not _representable_as_source(acc):
+            raise PrecompileError(
+                "precompile tracer='dynamo': fn's argument "
+                f"{pos} reaches the nn.Module owning parameter "
+                f"{name!r} through a dict keyed by {acc!r} (a "
+                f"{type(acc).__name__}). The artifact records that "
+                "path as source text, so the key has to be one whose "
+                "repr() is a Python literal that reads back equal -- "
+                "a str, int, bool, float, bytes, None, or a tuple of "
+                "those. Key the dict by the module's name instead, or "
+                "hold the modules in a list or an attribute."
+            )
+
+
+def _grad_param_candidates(
+    fn: Callable[..., object], args: tuple[object, ...]
+) -> list[_GradParamCandidate]:
+    return [
+        (pos, path, name, param)
+        for pos, path, module in _frame_modules(fn, args)
+        for name, param in module.named_parameters(remove_duplicate=False)
+    ]
+
+
+def _source_local_path(
+    source: Source,
+) -> tuple[str, tuple[tuple[str, object], ...]] | None:
+    from torch._guards import ChainedSource, Source as RuntimeSource
+    from torch._dynamo.source import (
+        AttrSource,
+        DictGetItemSource,
+        GenericAttrSource,
+        GetItemSource,
+        LocalSource,
+        NNModuleSource,
+        OptimizerSource,
+        SkipGuardSource,
+    )
+
+    steps: list[tuple[str, object]] = []
+    current = source
+    while isinstance(current, ChainedSource):
+        if isinstance(current, (NNModuleSource, OptimizerSource, SkipGuardSource)):
+            pass
+        elif isinstance(current, (AttrSource, GenericAttrSource)):
+            steps.append(("attr", current.member))
+        elif isinstance(current, GetItemSource) and not current.index_is_slice:
+            steps.append(("item", current.index))
+        elif isinstance(current, DictGetItemSource) and not isinstance(
+            current.index, RuntimeSource
+        ):
+            steps.append(("item", current.index))
+        else:
+            return None
+        current = current.base
+    if not isinstance(current, LocalSource):
+        return None
+    return current.local_name, tuple(reversed(steps))
+
+
+def _source_frame_position(
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    local_name: str,
+    path: tuple[tuple[str, object], ...],
+) -> tuple[int, tuple[tuple[str, object], ...]] | None:
+    import inspect
+
+    from torch._dynamo.convert_frame import get_traced_fn
+
+    traced, bound_self = get_traced_fn(fn)
+    frame_args = ([bound_self] if bound_self is not None else []) + list(args)
+    position = 0
+    for parameter in inspect.signature(
+        traced, follow_wrapped=False
+    ).parameters.values():
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            if position < len(frame_args):
+                if parameter.name == local_name:
+                    return position, path
+                position += 1
+        elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            if parameter.name != local_name:
+                position = len(frame_args)
+                continue
+            if not path or path[0][0] != "item" or not isinstance(path[0][1], int):
+                return None
+            index = path[0][1]
+            if index < 0 or position + index >= len(frame_args):
+                return None
+            return position + index, path[1:]
+    return None
+
+
+def _canonical_source_path(
+    value: object, path: tuple[tuple[str, object], ...]
+) -> tuple[_ModulePath, object] | None:
+    result: list[tuple[str, object]] = []
+    current = value
+    try:
+        for kind, accessor in path:
+            if kind == "attr":
+                current = getattr(current, str(accessor))
+                result.append(("attr", accessor))
+            else:
+                result.append(
+                    (
+                        "index" if isinstance(current, (list, tuple)) else "key",
+                        accessor,
+                    )
+                )
+                current = operator.getitem(current, accessor)
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return None
+    return tuple(result), current
+
+
+def _grad_param_state_from_source(
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    capture_output: convert_frame.CaptureOutput,
+    source: Source,
+    candidates: Sequence[_GradParamCandidate],
+    initially_none: Mapping[int, bool],
+) -> _GradParamState | None:
+    from torch._dynamo.convert_frame import get_traced_fn
+    from torch._dynamo.source import AttrSource, GradSource
+
+    if isinstance(source, GradSource):
+        param_source = source.base
+    elif isinstance(source, AttrSource) and source.member == "grad":
+        param_source = source.base
+    else:
+        return None
+    parsed = _source_local_path(param_source)
+    if parsed is None:
+        return None
+    positioned = _source_frame_position(fn, args, *parsed)
+    if positioned is None:
+        return None
+    pos, raw_path = positioned
+    _traced, bound_self = get_traced_fn(fn)
+    frame_args = ([bound_self] if bound_self is not None else []) + list(args)
+    canonical = _canonical_source_path(frame_args[pos], raw_path)
+    if canonical is None:
+        return None
+    source_path, source_value = canonical
+    try:
+        parameter = (
+            capture_output.graph_capture_output.output_graph.resolve_source_value(
+                param_source
+            )
+        )
+    except Exception:
+        return None
+    if source_value is not parameter:
+        return None
+    matches = [
+        candidate
+        for candidate in candidates
+        if candidate[0] == pos
+        and candidate[3] is parameter
+        and source_path[: len(candidate[1])] == candidate[1]
+    ]
+    if not matches:
+        return None
+    _, path, name, _parameter = max(matches, key=lambda candidate: len(candidate[1]))
+    _validate_grad_param_path(pos, path, name)
+    return (
+        pos,
+        list(path),
+        name,
+        initially_none.get(id(parameter), parameter.grad is None),
+    )
+
+
+def _user_grad_guard_sources(
+    capture_output: convert_frame.CaptureOutput,
+) -> list[Source]:
+    from torch._dynamo.source import AttrSource, GradSource
+
+    found: list[Source] = []
+    for guard in capture_output.graph_capture_output.output_graph.guards:
+        source = guard.originating_source
+        if not (
+            isinstance(source, GradSource)
+            or isinstance(source, AttrSource)
+            and source.member == "grad"
+        ):
+            continue
+        user_stack = guard.user_stack or ()
+        if any(
+            frame.name == "zero_grad" and "/torch/" in frame.filename.replace("\\", "/")
+            for frame in user_stack
+        ):
+            continue
+        if source not in found:
+            found.append(source)
+    return found
+
+
+def _guarded_grad_param_states(
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    capture_output: convert_frame.CaptureOutput,
+    candidates: Sequence[_GradParamCandidate],
+    initially_none: Mapping[int, bool],
+) -> list[_GradParamState]:
+    states = []
+    for source in _user_grad_guard_sources(capture_output):
+        state = _grad_param_state_from_source(
+            fn, args, capture_output, source, candidates, initially_none
+        )
+        if state is None:
+            raise PrecompileError(
+                "precompile tracer='dynamo': fn observes incoming .grad state at "
+                f"{source.name}, but precompile cannot re-create that parameter "
+                "through the same nn.Module argument path at runtime. Pass the "
+                "owning module as an explicit, directly reachable argument."
+            )
+        states.append(state)
+    return states
+
+
+def _merge_grad_param_states(
+    *groups: Sequence[_GradParamState],
+) -> list[_GradParamState]:
+    merged: list[_GradParamState] = []
+    seen: dict[tuple[int, _ModulePath, str], bool] = {}
+    for group in groups:
+        for pos, path, name, expected_none in group:
+            key = (pos, tuple(path), name)
+            if key in seen and seen[key] != expected_none:
+                raise AssertionError("conflicting capture-time .grad states")
+            if key not in seen:
+                seen[key] = expected_none
+                merged.append((pos, path, name, expected_none))
+    return merged
+
+
+def _param_grad_inputs(
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    capture_output: convert_frame.CaptureOutput,
+    candidates: Sequence[_GradParamCandidate],
+    initially_none: Mapping[int, bool],
+) -> tuple[list[_GradParamState], list[str], bool]:
+    """``(grad_param_states, unattributed, any_grad_inputs)``.
+
+    ``grad_param_states`` names every param whose ``.grad`` the graph took as an INPUT, by
+    tensor IDENTITY (not by parsing Dynamo's mangled placeholder names), as ``(frame arg
+    index, path from that arg to the owning module, param name, expected_none)``.
+    ``unattributed`` is every OTHER ``.grad`` graph input: the artifact specializes on
+    that state but cannot validate it at runtime, so the caller refuses. Same loop builds
+    both, so the check and its remedy cannot drift apart.
+    """
+    bi = capture_output.backend_input
+    example_inputs = list(bi.example_inputs) if bi is not None else []
+    sources = getattr(
+        capture_output.graph_capture_output.output_graph.export_metadata,
+        "graph_input_idx_to_local_source",
+        {},
+    )
+    found = []
+    grad_inputs = _dot_grad_graph_inputs(example_inputs, sources)
+    unattributed = []
+    for i, source_path in sorted(grad_inputs.items()):
+        source = sources.get(i)
+        state = (
+            _grad_param_state_from_source(
+                fn, args, capture_output, source, candidates, initially_none
+            )
+            if source is not None
+            else None
+        )
+        if state is None:
+            unattributed.append(source_path.removesuffix(".grad"))
+        else:
+            found.append(state)
+    return found, unattributed, bool(grad_inputs)
+
+
+def _decompose_subgraph(
+    gm: torch.fx.GraphModule,
+    fake_inputs: list[object],
+    decompositions: dict,
+    trains: bool = False,
+) -> torch.fx.GraphModule:
+    """Apply ``decompositions`` to a captured dynamo subgraph by re-tracing it with make_fx.
+
+    Dynamo captures torch-level IR and never consults a decomposition table, so the dynamo
+    tracer honors ``decompositions`` the only way it can: make_fx re-traces the captured
+    subgraph WITH the table, which is the same thing the make_fx tracer does during its own
+    capture (the table shapes the captured ATen graph, and the backend then lowers /
+    inlines that graph). The re-trace runs on Dynamo's own FAKE placeholder values, never
+    the real example tensors, so it costs no real compute, cannot mutate the caller's
+    model, and preserves the (possibly unbacked-symbolic) input shapes. Placeholder count
+    and order are unchanged (fx's DCE never drops a placeholder), so the transformed
+    bytecode still calls the subgraph with exactly the same arguments.
+    """
+    from torch._dispatch.python import enable_python_dispatcher
+    from torch._dynamo.utils import detect_fake_mode
+
+    # Take the mode off the fakes THEMSELVES rather than from BackendInput.fake_mode: the
+    # two are distinct FakeTensorMode objects (they share a ShapeEnv), and running the ops
+    # under a mode other than the one that made the tensors raises "Mixing fake modes NYI".
+    fake_mode = detect_fake_mode(fake_inputs)
+    if fake_mode is None:
+        raise PrecompileError(
+            "internal: the captured dynamo subgraph has no fake placeholder values, so "
+            "the decompositions table cannot be applied by re-tracing it."
+        )
+    # tracing_mode="real" hands the fake inputs to the trace UNTOUCHED -- the "symbolic" /
+    # "fake" modes would refakeify them under a fresh source and allocate new symbols,
+    # losing Dynamo's unbacked ones. The ambient fake mode is what actually executes the
+    # ops and the python dispatcher is what lets a symbolic-shaped trace reach the meta
+    # kernels; this is how AOTAutograd itself re-traces a graph with a decomposition table.
+    #
+    # A TRAINING graph is re-traced under enable_grad: its ``torch.autograd.grad`` needs a
+    # live autograd graph to differentiate. Re-tracing then RUNS the autograd engine on the
+    # fakes, so the backward lands in the new graph as ordinary ATen ops (the traced call
+    # itself disappears) -- which is exactly the shape the make_fx tracer produces, and why
+    # the caller re-derives ``trains`` from the returned graph rather than reusing its own.
+    grad_cm = torch.enable_grad() if trains else torch.no_grad()
+    with grad_cm, fake_mode, enable_python_dispatcher():
+        return make_fx(gm, decomposition_table=decompositions)(*fake_inputs)
+
+
+def _capture_dynamo(
+    fn: Callable[..., object],
+    args: tuple[object, ...],
+    decompositions: dict | None = None,
+) -> _DynamoCapture:
+    """Capture ``fn(*args)`` with Dynamo (tracer="dynamo").
+
+    Unlike the make_fx tracer (a non-strict trace of the single path the example takes),
+    Dynamo analyzes the Python bytecode and emits a TRANSFORMED bytecode: it extracts the
+    model's params/buffers, calls a compiled subgraph, and reassembles fn's output, plus
+    the subgraph (an fx GraphModule) for the backend to lower. precompile inlines that
+    transformed bytecode into the artifact (marshalled) and lowers the subgraph exactly
+    the way the make_fx inductor path does. See Note [precompile programming model].
+
+    Dynamic shapes are opt-in via ``mark_unbacked``, which Dynamo honors natively: a marked
+    dim becomes an UNBACKED symint it cannot guard on, so the subgraph stays symbolic and
+    the artifact serves any runtime size of that dim. ``decompositions`` is applied by
+    re-tracing the captured subgraph (see _decompose_subgraph).
+
+    A TRAINING step (fn runs ``.backward()`` or ``torch.autograd.grad``) is captured too:
+    precompile pins ``trace_autograd_ops`` so Dynamo rewrites the backward into an in-graph
+    ``torch.autograd.grad`` rather than graph-breaking, then CAPTURES TWICE when needed so
+    the accumulating form of the ``.grad`` update is the one baked (Note [precompile dynamo
+    training grad accumulation]). Other graph-breaking Python still raises a
+    PrecompileError pointing at tracer="make_fx".
+    """
+    # get_traced_fn refuses anything that is not a function, bound method or
+    # nn.Module -- a functools.partial, a callable object -- and Dynamo reaches
+    # it deep inside fullgraph_capture, where the raw RuntimeError escapes the
+    # handler below. Check up front so the caller gets a clean error naming the
+    # shapes that do work.
+    from torch._dynamo.convert_frame import get_traced_fn as _get_traced_fn
+
+    try:
+        _get_traced_fn(fn)
+    except RuntimeError as e:
+        raise PrecompileError(
+            f"precompile tracer='dynamo' cannot capture a {type(fn).__name__}: Dynamo "
+            f"traces a function, a bound method or an nn.Module. Pass partial.func with "
+            f"its arguments as explicit arguments, or the object's __call__, or use "
+            f"tracer='make_fx'. Underlying: {e}"
+        ) from e
+
+    from torch._dynamo import config as dynamo_config, convert_frame
+    from torch._dynamo.exc import UncapturedHigherOrderOpError, Unsupported, UserError
+    from torch._dynamo.utils import dynamo_timed, get_metrics_context
+    from torch._dynamo.variables.torch_function import (
+        torch_function_mode_stack_state_mgr,
+    )
+    from torch._functorch._aot_autograd.to_standalone_python import (
+        _graph_has_dynamic_shapes,
+    )
+    from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
+
+    args = tuple(args)
+
+    def _run_capture() -> convert_frame.CaptureOutput:
+        with (
+            # Pin static-shape capture so an UNMARKED dim specializes to the example like
+            # the make_fx tracer (invariant 3), independent of the ambient torch._dynamo
+            # config AND of per-code-object shape history: assume_static_by_default guards the
+            # config default, and automatic_dynamic_shapes=False stops Dynamo promoting a dim
+            # to dynamic when the SAME fn was already precompiled at another shape this process
+            # (both otherwise yield an out-of-contract DYNAMIC artifact here). Neither affects
+            # a mark_unbacked dim: an explicit mark takes precedence and still captures
+            # unbacked (the marks precompile cannot honor are rejected upstream). The same
+            # automatic_dynamic pin is what makes the training RE-capture below safe: a
+            # second capture of the same code object cannot promote a dim to dynamic.
+            #
+            # trace_autograd_ops lets Dynamo trace a backward (rewriting it into an in-graph
+            # torch.autograd.grad) instead of graph-breaking on it, which is what extends the
+            # dynamo tracer to training steps. It is inert for an inference fn -- it gates
+            # only the Tensor.backward / autograd.grad handlers -- so it is pinned ON here
+            # rather than left to the caller to discover.
+            dynamo_config.patch(
+                assume_static_by_default=True,
+                automatic_dynamic_shapes=False,
+                trace_autograd_ops=True,
+            ),
+            get_metrics_context(),
+            dynamo_timed("precompile_dynamo_capture"),
+            torch_function_mode_stack_state_mgr,
+        ):
+            return convert_frame.fullgraph_capture(fn, args, {})
+
+    grad_param_states: list[tuple[int, list[tuple[str, object]], str, bool]] = []
+    unattributed_grads: list[str] = []
+    try:
+        capture_output = _run_capture()
+        bi = capture_output.backend_input
+        trains = bi is not None and _graph_traces_autograd(bi.graph_module)
+        if trains:
+            # Training: a diagnostic re-capture temporarily supplies every missing
+            # ``.grad`` so the accumulating form exposes those tensors as graph inputs.
+            # That lets the driver name and validate their capture-time state. The first,
+            # unseeded capture is always the artifact, preserving any user branch on
+            # ``p.grad is None``. A warm capture needs no second pass.
+            if bi is None:
+                raise AssertionError("a training capture always has a backend input")
+            first_capture = capture_output
+            candidates = _grad_param_candidates(fn, args)
+            initially_none = {
+                id(parameter): parameter.grad is None
+                for _pos, _path, _name, parameter in candidates
+            }
+            guarded_states = _guarded_grad_param_states(
+                fn, args, first_capture, candidates, initially_none
+            )
+            seeded = _seed_grad_targets(bi.graph_module, bi.example_inputs)
+            try:
+                if seeded:
+                    capture_output = _run_capture()
+                graph_states, unattributed_grads, _any_grad_inputs = _param_grad_inputs(
+                    fn, args, capture_output, candidates, initially_none
+                )
+                grad_param_states = _merge_grad_param_states(
+                    guarded_states, graph_states
+                )
+                if seeded:
+                    # The first capture is the only one that observed the caller's real
+                    # gradient state. The seeded capture exists solely to reveal which
+                    # parameters the accumulating form reads so the driver can validate
+                    # that state. Shipping it would silently change user branches on
+                    # ``p.grad is None`` before the backward.
+                    capture_output = first_capture
+            finally:
+                for p in seeded:
+                    p.grad = None
+    except (Unsupported, UncapturedHigherOrderOpError, UserError) as e:
+        # Dynamo could not capture fn as one full graph (a graph break / uncaptured HOP /
+        # user error) -- e.g. a Tensor.backward() call. These are exactly the exceptions
+        # fullgraph_capture re-raises. Surface a clear PrecompileError instead of the raw
+        # dynamo error, and point at the make_fx tracer (which handles training). Guard the
+        # first-line extraction: ``"".splitlines()`` is [], so an empty dynamo message would
+        # otherwise raise IndexError from inside this very handler.
+        #
+        # A guard on a mark_unbacked dim arrives wrapped in one of these too (Dynamo
+        # converts the GuardOnDataDependentSymNode as it unwinds), and "could not capture
+        # fn as a single full graph" would misdiagnose it -- the graph is fine, the MARK is
+        # what fn cannot honor. Detect it in the cause chain and use the same message the
+        # make_fx tracer raises for the same situation.
+        cause: BaseException | None = e
+        while cause is not None:
+            if isinstance(cause, GuardOnDataDependentSymNode):
+                raise _unbacked_guard_error(cause) from e
+            cause = cause.__cause__ or cause.__context__
+        reason = (str(e).splitlines() or [""])[0]
+        raise PrecompileError(
+            "precompile tracer='dynamo' could not capture fn as a single full graph "
+            f"({reason}). Forward and training (.backward() / autograd.grad) computations "
+            "are supported; for other graph-breaking Python, use tracer='make_fx'."
+        ) from e
+    except GuardOnDataDependentSymNode as e:
+        raise _unbacked_guard_error(e) from e
+
+    gco = capture_output.graph_capture_output
+    bi = capture_output.backend_input
+    runtime_env = gco.get_runtime_env()
+
+    # get_runtime_env records only the globals the transformed bytecode reads as GRAPH
+    # INPUTS (plus a builtins fallback). A global the bytecode references elsewhere -- e.g.
+    # a plain constant folded straight into the output (``return model(x), SCALE``) -- is in
+    # external_refs but NOT (correctly) in used_globals, so without this it would NameError
+    # at runtime. Resolve those uncovered refs from the TRACED code's globals and carry them
+    # along (baking a module constant is consistent with the specialization contract); a
+    # tensor among them is caught by _reject_baked_tensors below (invariant 1). Use
+    # gco.f_globals, NOT fn.__globals__: Dynamo traces get_traced_fn(fn) -- fn.forward for an
+    # nn.Module, the unwrapped target for a functools.partial -- whose globals live in
+    # gco.f_globals (the same dict get_runtime_env built used_globals from). fn.__globals__
+    # is {} for a raw nn.Module fn, which would drop the folded-in global and NameError.
+    #
+    # A real module global always WINS over get_runtime_env's builtin fallback: when a global
+    # shadows a builtin name (``sum = [...]``; ``id``, ``type``, ...) get_runtime_env
+    # pre-seeds used_globals[ref] with the BUILTIN, so override it with fn_globals[ref] rather
+    # than skip on ``ref in used_globals`` -- else the artifact bakes the builtin and silently
+    # miscomputes (and a shadowing tensor global would slip past invariant 1). The override is
+    # a no-op for a ref already recorded as a graph-input global (used_globals[ref] already
+    # equals fn_globals[ref]); skip __builtins_dict__ refs, which get_runtime_env deliberately
+    # stores as the _safe_builtins_dict-filtered (picklable) dict rather than the raw one.
+    used_globals = dict(runtime_env.used_globals)
+    import_sources = dict(runtime_env.import_sources)
+    fn_globals = gco.f_globals
+    for ref in runtime_env.external_refs:
+        if (
+            ref in import_sources
+            or ref == (bi.backend_id if bi is not None else None)
+            or ref.startswith("__builtins_dict__")
+        ):
+            continue
+        if ref not in fn_globals:
+            continue
+        value = fn_globals[ref]
+        if isinstance(value, types.ModuleType):
+            # A module is not picklable, so putting it in used_globals fails the
+            # capture outright with an unactionable error -- `torch` and `math`
+            # both land here whenever the residual bytecode loads the bare name
+            # rather than Dynamo's mangled __import_ alias. It is by-reference
+            # state, so record it the way the aliases are recorded and let the
+            # driver re-import it at load.
+            #
+            # By sys.modules KEY, not __name__: _collections_abc sets its own
+            # __name__ to "collections.abc", which re-imports to a DIFFERENT
+            # module. Same trap _defining_module_name documents.
+            import_name = _module_import_name(value)
+            if import_name is None:
+                raise PrecompileError(
+                    f"precompile: fn reads the global {ref!r}, which holds module "
+                    f"{getattr(value, '__name__', value)!r} that is not in sys.modules, "
+                    f"so the artifact cannot re-import it at load. Pass what you need "
+                    f"from it as an explicit argument instead."
+                )
+            import_sources[ref] = import_name
+            # get_runtime_env pre-seeds used_globals[ref] with a BUILTIN of the
+            # same name when one exists (`import torch as vars`). The driver
+            # applies used_globals AFTER IMPORT_SOURCES, so leaving it would let
+            # the builtin win and produce a wrong artifact rather than an error.
+            used_globals.pop(ref, None)
+            continue
+        used_globals[ref] = value
+
+    # Invariant 1: reject a tensor closed over by fn (global, captured local, or default
+    # argument value, including one nested in a container or nn.Module); Dynamo surfaces
+    # it in used_globals / closure / argdefs+kwdefaults rather than as a graph get_attr
+    # constant. argdefs/kwdefaults are pickled into _DYNAMO_STATE and restored, so a tensor
+    # default is baked too and must be scanned alongside globals/closure.
+    closure_contents = [c.cell_contents for c in (runtime_env.closure or ())]
+    defaults = [
+        *(runtime_env.argdefs or ()),
+        *((runtime_env.kwdefaults or {}).values()),
+    ]
+    _reject_baked_tensors(used_globals, closure_contents, defaults)
+
+    if trains:
+        # Only PARAMETERS get a scattered gradient (invariant 5), mirroring the make_fx
+        # tracer, which rejects a user input that received one. Here the whole ``.grad``
+        # update is inside Dynamo's rewrite, so precompile cannot re-point it -- and a
+        # non-parameter leaf would carry the same trace-time ``.grad is None``
+        # specialization with no place to correct it. Reject up front rather than bake it.
+        offending = [
+            tuple(t.shape)
+            for t in pytree.tree_leaves(
+                tuple(a for a in args if not isinstance(a, torch.nn.Module))
+            )
+            if isinstance(t, torch.Tensor) and t.requires_grad
+        ]
+        if offending:
+            raise PrecompileError(
+                "precompile tracer='dynamo': fn runs a backward and a user input requires "
+                f"grad (shapes {offending}); precompile only harvests gradients for module "
+                "parameters, so that input's gradient would be baked with a trace-time "
+                "assumption about its .grad. Pass the tensor as a module parameter, detach "
+                "it (or set requires_grad=False) before the call, or use tracer='make_fx'."
+            )
+
+        if unattributed_grads:
+            raise PrecompileError(
+                "precompile tracer='dynamo': fn's backward accumulates a gradient into "
+                f"{len(unattributed_grads)} tensor(s) that precompile cannot re-create at "
+                "runtime, because it could not find the nn.Module that owns them among "
+                f"fn's arguments: {unattributed_grads}. The artifact specializes on "
+                "whether each of those gradients exists, but it can validate that state "
+                "only for a parameter it can name. Running without the check can silently "
+                "take a different captured branch or overwrite an accumulated gradient. "
+                "precompile searches each argument (including the "
+                "bound self of a method or nn.Module fn) through attributes, lists, tuples "
+                f"and dicts, at most {_MODULE_SEARCH_DEPTH} steps deep and "
+                f"{_MODULE_SEARCH_BUDGET} objects wide, then names parameters with "
+                "named_parameters(). Fix by passing the owning module as its own argument; "
+                "by moving the model ahead of the large unrelated attribute that exhausted "
+                "the search; by registering submodules with nn.ModuleList / nn.ModuleDict "
+                "rather than a plain list or dict; and by registering a trainable tensor "
+                "with register_parameter rather than as a requires_grad buffer or a bare "
+                "attribute. tracer='make_fx' does not help here -- it cannot reach the "
+                "tensor either and refuses too."
+            )
+
+    gm = bi.graph_module if bi is not None else None
+    example_inputs: Sequence[object] = bi.example_inputs if bi is not None else []
+    dynamic = False
+    if gm is not None:
+        # _graph_has_dynamic_shapes is the SAME predicate compile_to_python uses to pick its
+        # shapes mode, so reading it here keeps the example inputs we hand it consistent
+        # with how it will treat the graph.
+        dynamic = _graph_has_dynamic_shapes(gm)
+        # Dynamo stashes each placeholder's fake under "example_value". For a DYNAMIC
+        # capture those fakes (not bi.example_inputs, which are the REAL tensors) are what
+        # the backend must lower: they carry Dynamo's unbacked symbols, whereas refakeifying
+        # the reals under the lowering's own TracingContext -- which does not carry Dynamo's
+        # symbol cache -- would allocate fresh symbols and silently specialize the artifact
+        # to the example sizes. A static capture keeps the real inputs (they refakeify to
+        # exactly the same static fakes, and the lowering asks for a fresh ShapeEnv there).
+        fake_inputs = [
+            n.meta.get("example_value") for n in gm.graph.find_nodes(op="placeholder")
+        ]
+        if dynamic:
+            example_inputs = fake_inputs
+        if decompositions is not None:
+            gm = _decompose_subgraph(gm, fake_inputs, decompositions, trains)
+            # Re-derive: re-tracing a training graph inlines its backward as plain ATen ops,
+            # so the result no longer performs autograd itself and must be lowered / run the
+            # inference way (grad_param_states still stands -- the .grad state the
+            # inlined backward feeds is unchanged).
+            trains = _graph_traces_autograd(gm)
+            if dynamic:
+                # The re-trace records its placeholders' fakes under make_fx's "val" key.
+                example_inputs = [
+                    n.meta["val"] for n in gm.graph.find_nodes(op="placeholder")
+                ]
+        # A get_attr tensor in the subgraph is a baked constant (invariant 1), and a
+        # captured control-flow subgraph is not lowerable to standalone source -- reject
+        # both, reusing the make_fx tracer's guards on the captured graph. Checked AFTER
+        # the decomposition re-trace, so a constant a decomposition introduces is caught too.
+        _check_no_constant_tensors(gm)
+        _assert_no_control_flow_subgraphs(gm)
+
+    return _DynamoCapture(
+        bytecode=runtime_env.bytecode,
+        import_sources=import_sources,
+        used_globals=used_globals,
+        closure_contents=closure_contents,
+        argdefs=runtime_env.argdefs,
+        kwdefaults=runtime_env.kwdefaults,
+        backend_id=bi.backend_id if bi is not None else None,
+        gm=gm,
+        example_inputs=example_inputs,
+        dynamic=dynamic,
+        trains=trains,
+        grad_param_states=grad_param_states,
+    )
 
 
 _GENERATED_HEADER = """\
@@ -1078,33 +2338,18 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
     executing it (exec'ing the inlined Inductor output would JIT the kernels, the
     very work the cache exists to skip).
 
-    python_code is the single source of truth: ``_build_metadata_section`` emits the
-    constants below as top-level literal assignments, so an AST walk + literal_eval
-    recovers them safely. The cache then only needs to carry the compiled artifact.
+    python_code is the single source of truth: the metadata builders emit the constants
+    below as top-level literal assignments, so an AST walk + literal_eval recovers them
+    safely. The cache then only needs to carry the compiled artifact.
+
+    The required constant set is tracer-dependent: the make_fx tracer emits the full
+    calling-convention set the inlined driver reads (PARAM_NAMES, OUT_SPEC, ...), while
+    the dynamo tracer's driver reads its own (BACKEND_ID, IMPORT_SOURCES) and rehydrates
+    the rest from opaque blobs. TRACER is absent on artifacts predating the dynamo tracer,
+    so its absence means make_fx.
     """
     import ast
 
-    wanted = {
-        "BACKEND",
-        "MODULE_POSITIONS",
-        "NUM_POSITIONAL_ARGS",
-        "PARAM_NAMES",
-        "BUFFER_NAMES",
-        "PARAM_SHAPES",
-        "BUFFER_SHAPES",
-        "PARAM_DTYPES",
-        "BUFFER_DTYPES",
-        "PARAM_DEVICES",
-        "BUFFER_DEVICES",
-        "GRAD_PARAM_INDICES",
-        "IN_SPEC",
-        "OUT_SPEC",
-        "USER_INPUT_SHAPES",
-        "USER_INPUT_DTYPES",
-        "USER_INPUT_DEVICES",
-        "USER_INPUT_BOUNDS",
-    }
-    found: dict[str, object] = {}
     try:
         tree = ast.parse(python_code)
     except SyntaxError as e:
@@ -1112,6 +2357,59 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
             "python_code is not valid Python; it does not look like a "
             "torch.compiler.precompile artifact."
         ) from e
+    # Read TRACER first (a top-level literal assignment) to pick the required constant set
+    # below: the make_fx and dynamo drivers read different calling-convention literals, so
+    # the presence check has to know which set applies. TRACER is absent on artifacts
+    # predating the dynamo tracer, so its absence means make_fx.
+    tracer = "make_fx"
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "TRACER"
+        ):
+            try:
+                tracer = cast(str, ast.literal_eval(node.value))
+            except (ValueError, SyntaxError):
+                pass
+            break
+    if tracer == "dynamo":
+        # Validate every top-level literal the dynamo driver reads, including the two opaque
+        # blobs, so a truncated / edited artifact missing one fails here with the clean
+        # "missing calling-convention metadata" error rather than surfacing a misleading
+        # Python-version error from _build_dynamo_forward at exec time.
+        wanted = {
+            "BACKEND",
+            "TRACER",
+            "BACKEND_ID",
+            "IMPORT_SOURCES",
+            "GRAD_PARAM_STATES",
+            "_DYNAMO_CODE",
+            "_DYNAMO_STATE",
+        }
+    else:
+        wanted = {
+            "BACKEND",
+            "MODULE_POSITIONS",
+            "NUM_POSITIONAL_ARGS",
+            "PARAM_NAMES",
+            "BUFFER_NAMES",
+            "PARAM_SHAPES",
+            "BUFFER_SHAPES",
+            "PARAM_DTYPES",
+            "BUFFER_DTYPES",
+            "PARAM_DEVICES",
+            "BUFFER_DEVICES",
+            "GRAD_PARAM_INDICES",
+            "IN_SPEC",
+            "OUT_SPEC",
+            "USER_INPUT_SHAPES",
+            "USER_INPUT_DTYPES",
+            "USER_INPUT_DEVICES",
+            "USER_INPUT_BOUNDS",
+        }
+    found: dict[str, object] = {}
     for node in tree.body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
@@ -1119,7 +2417,13 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
         if not isinstance(target, ast.Name):
             continue
         if target.id in wanted:
-            found[target.id] = ast.literal_eval(node.value)
+            try:
+                found[target.id] = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError) as e:
+                raise PrecompileError(
+                    f"python_code {target.id!r} calling-convention metadata is "
+                    f"malformed; it must be a Python literal."
+                ) from e
         else:
             # Not a metadata name we consume (the driver section emits only
             # function defs today, but a future artifact revision could add a
@@ -1258,6 +2562,189 @@ def _emit_driver_source(forward_fn_name: str) -> str:
     return "\n" + body + "\n\n\n" + _DRIVER_MAIN
 
 
+_DYNAMO_GENERATED_HEADER = """\
+# Generated by torch.compiler.precompile (tracer="dynamo") -- do not edit.
+#
+# Self-contained, executable artifact. Unlike the make_fx tracer (which inlines a single
+# traced graph), the dynamo tracer analyzes fn's Python and inlines the TRANSFORMED
+# BYTECODE Dynamo produced (marshalled, rehydrated by the driver below): it extracts the
+# model's params/buffers, calls the compiled subgraph, and reassembles fn's output.
+# Provide the model(s) at runtime exactly as fn took them:
+#
+#     ns = {}
+#     exec(open("this_file.py").read(), ns)
+#     out = ns["forward"](model, my_input)      # same args as the traced fn
+#
+# The runtime model must be structurally identical to the traced one (same
+# parameter/buffer names, order, and weight tying); only the weight VALUES may differ.
+# Dynamo specializes to the example (shapes, control flow), and the environment it was
+# traced in (e.g. the accelerator stream) is baked into the bytecode, so this artifact
+# is environment-specialized like the make_fx one. See Note [precompile programming
+# model] in torch/_precompile.py.
+"""
+
+
+def _build_dynamo_metadata_section(compiled: PrecompiledModule) -> list[str]:
+    """Emit the dynamo tracer's calling-convention metadata: the inspectable literals
+    (BACKEND / TRACER / BACKEND_ID / IMPORT_SOURCES) plus two opaque blobs -- the
+    transformed bytecode (marshalled) and the reconstruction state (the globals it reads,
+    its closure contents, and arg/kw defaults, pickled). The driver rehydrates them."""
+    capture = compiled._dynamo_capture
+    if capture is None:
+        raise PrecompileError(
+            "internal: cannot build dynamo metadata before _compile()"
+        )
+    # marshal serializes code objects + basic constants, but NOT arbitrary objects baked
+    # as bytecode constants -- e.g. the bound method / type Dynamo emits to reconstruct a
+    # collections.namedtuple (or other custom class) output. Surface that as a clear
+    # PrecompileError rather than a raw "unmarshallable object" ValueError.
+    try:
+        code_blob = base64.b64encode(marshal.dumps(capture.bytecode)).decode("ascii")
+    except ValueError as e:
+        raise PrecompileError(
+            "precompile tracer='dynamo' could not serialize fn's transformed bytecode "
+            "(it references an unmarshallable constant). This fires when fn returns a "
+            "value Dynamo reconstructs via a baked type or bound method, e.g. a "
+            "collections.namedtuple or a custom class. Return a plain tuple / list / dict "
+            f"of tensors, or use tracer='make_fx'. Underlying: {e}"
+        ) from e
+    # Only the genuinely non-literal reconstruction state is pickled (the inspectable
+    # literals above stay as readable source). A tensor reachable from any of these was
+    # already rejected at capture (invariant 1), so what remains is plain globals / closure
+    # contents / arg-kw defaults.
+    try:
+        state_blob = base64.b64encode(
+            pickle.dumps(
+                {
+                    "used_globals": capture.used_globals,
+                    "closure": capture.closure_contents,
+                    "argdefs": capture.argdefs,
+                    "kwdefaults": capture.kwdefaults,
+                }
+            )
+        ).decode("ascii")
+    except Exception as e:
+        # pickle invokes arbitrary user __reduce__ / __getstate__ code and can raise any
+        # exception type (RuntimeError, RecursionError on deep nesting, ...), so catch
+        # broadly and relabel -- matching _baked_tensors, which replays the same traversal
+        # under an equally broad except. Exception (not BaseException) still lets
+        # KeyboardInterrupt / SystemExit propagate.
+        raise PrecompileError(
+            "precompile tracer='dynamo' could not serialize fn's captured globals / "
+            "closure into the artifact (they are not picklable). This fires when fn "
+            "closes over an unpicklable object (e.g. a module handle or a local lambda); "
+            f"refer to such state through explicit arguments instead. Underlying: {e}"
+        ) from e
+    return [
+        "# " + "=" * 70,
+        "# 2. Dynamo calling-convention metadata",
+        "# " + "=" * 70,
+        # python_code is the single source of truth for the calling convention; load()
+        # reads BACKEND / TRACER back out of it (see _parse_artifact_metadata). The two
+        # blobs are consumed by the inlined driver, not by load().
+        f"BACKEND = {compiled._backend!r}",
+        "TRACER = 'dynamo'",
+        f"BACKEND_ID = {capture.backend_id!r}",
+        f"IMPORT_SOURCES = {capture.import_sources!r}",
+        # Training only: (positional arg index, path, parameter name, expected_none) for
+        # every parameter whose captured backward specializes on its incoming .grad.
+        # The driver validates the state before user code so the artifact preserves
+        # capture-time ``p.grad is None`` branches instead of silently normalizing them.
+        f"GRAD_PARAM_STATES = {capture.grad_param_states!r}",
+        f"_DYNAMO_CODE = {code_blob!r}",
+        f"_DYNAMO_STATE = {state_blob!r}",
+        "",
+    ]
+
+
+def _emit_dynamo_eager_subgraph(
+    gm: torch.fx.GraphModule, trains: bool = False
+) -> list[str]:
+    """Inline the captured dynamo subgraph (eager backend) and wrap it in a ``call``
+    with the same (boxed) contract the inductor path emits, so the driver is backend-
+    agnostic. The dynamo subgraph's ``forward`` takes the graph inputs positionally
+    (one per placeholder) and returns a tuple; ``call(flat_inputs)`` splats the list
+    into it and normalizes the result to a list.
+
+    A forward capture runs under no_grad. A TRAINING capture runs under enable_grad
+    instead: its traced ``torch.autograd.grad`` differentiates an autograd graph that the
+    same call has to build, so no_grad would fail it outright ("element 0 of tensors does
+    not require grad"). enable_grad rather than "inherit the caller's mode" because the
+    artifact captured a training step -- it cannot do anything useful under an ambient
+    no_grad, so it pins what it needs (the graph itself disables grad again around the
+    ``.grad`` update, exactly as Dynamo traced it).
+    """
+    from torch.fx.graph import _custom_builtins
+
+    graph_src = gm.code.replace("def forward(", "def _graph_forward(", 1)
+    parts = ["import torch as _torch"]
+    # gm.code relies on fx's custom builtins (torch, device, inf, nan, NoneType, fx_pytree,
+    # pytree) being in scope -- fx injects them when a real GraphModule runs. Reproduce the
+    # FULL set (not just torch) so a graph that bakes a device / inf / nan constant (e.g.
+    # BatchNorm, masked_fill to -inf) runs standalone instead of raising NameError. Sourced
+    # from fx so it stays correct.
+    for _cb in _custom_builtins.values():
+        parts.append(_cb.import_str)
+    parts.append(graph_src)
+    parts.append("")
+    parts.append("class _GraphSelf:")
+    parts.append("    pass")
+    parts.append("")
+    parts.append("")
+    parts.append("def call(args):")
+    grad_cm = "enable_grad" if trains else "no_grad"
+    parts.append(f"    with _torch.{grad_cm}():")
+    parts.append("        out = _graph_forward(_GraphSelf(), *args)")
+    parts.append("    return list(out) if isinstance(out, (list, tuple)) else [out]")
+    parts.append("")
+    return parts
+
+
+def _emit_dynamo_driver_source() -> str:
+    """Emit the dynamo driver (rehydrate the inlined bytecode) as text for inlining, the
+    same getsource path _emit_driver_source uses. The last statement binds the public
+    ``forward`` to the reconstructed function."""
+    import inspect
+
+    from torch import _precompile_driver as driver
+
+    blocks = [
+        inspect.getsource(driver._rebuild_cell),
+        inspect.getsource(driver._build_dynamo_forward),
+    ]
+    body = "\n\n".join(block.rstrip() for block in blocks)
+    return "\n" + body + "\n\n\nforward = _build_dynamo_forward()\n\n\n" + _DRIVER_MAIN
+
+
+def _build_dynamo_python_source(compiled: PrecompiledModule) -> str:
+    capture = compiled._dynamo_capture
+    if capture is None:
+        raise PrecompileError("internal: not compiled; call _compile() first")
+    parts = [_DYNAMO_GENERATED_HEADER, ""]
+    parts.append("# " + "=" * 70)
+    if capture.gm is None:
+        # fn produced no tensor compute: the transformed bytecode is the whole artifact
+        # (it references no compiled subgraph), so there is nothing to inline here; the
+        # driver rehydrates that bytecode below with BACKEND_ID None (no subgraph).
+        parts.append("# 1. (no compiled subgraph: fn produced no tensor compute)")
+        parts.append("# " + "=" * 70)
+    elif compiled._backend == "inductor":
+        parts.append("# 1. Compiled subgraph (AOTAutograd + Inductor): exposes call")
+        parts.append("# " + "=" * 70)
+        parts.append(compiled._graph_python)
+    else:
+        parts.append("# 1. Captured dynamo subgraph (eager backend): exposes ``call``")
+        parts.append("# " + "=" * 70)
+        parts.extend(_emit_dynamo_eager_subgraph(capture.gm, capture.trains))
+    parts.append("")
+    parts.extend(_build_dynamo_metadata_section(compiled))
+    parts.append("# " + "=" * 70)
+    parts.append("# 3. Driver: rehydrate the inlined transformed bytecode")
+    parts.append("# " + "=" * 70)
+    parts.append(_emit_dynamo_driver_source())
+    return "\n".join(parts)
+
+
 def _assert_supported(gm: torch.fx.GraphModule) -> None:
     """Enforce invariant 4 of Note [precompile programming model]: reject boundary
     effects the AOT backend's standalone composition does not handle. Detected
@@ -1328,6 +2815,13 @@ class PrecompiledModule:
         self._in_spec: pytree.TreeSpec | None = None
         self._out_spec: pytree.TreeSpec | None = None
         self._gm: torch.fx.GraphModule | None = None
+        # Dynamo tracer (tracer="dynamo"): the transformed bytecode + the names it
+        # references, populated by _compile() when tracer == "dynamo". The bytecode is
+        # marshalled and the state pickled into python_code; the subgraph is lowered like
+        # the make_fx inductor path (backend="inductor", via self._graph_python /
+        # self._artifact_bytes) or inlined as eager graph source (backend="eager",
+        # self._gm). None on the make_fx path and on the load() path.
+        self._dynamo_capture: _DynamoCapture | None = None
         # Inductor backend: the composed self-contained graph module (from
         # aot_autograd.compile_to_python, exposing ``call(flat_inputs)``) and the
         # opaque artifact-cache bytes (None if uncacheable), populated by _compile().
@@ -1374,18 +2868,17 @@ class PrecompiledModule:
         return obj
 
     def _compile(self, args: tuple[object, ...]) -> None:
-        # make_fx is the only implemented tracer; "dynamo" is a planned alternative
-        # capture front-end. Reject it here (the single capture-dispatch point) before
-        # running fn, so the failure is clear rather than a wrong default.
-        if self._tracer != "make_fx":
-            raise NotImplementedError(
-                f"precompile tracer={self._tracer!r} is not implemented yet; use "
-                "tracer='make_fx' (the default)."
-            )
+        # tracer selects the capture front-end (orthogonal to backend); dispatch here,
+        # the single capture-dispatch point, before running fn -- so a dynamo capture
+        # never falls through to the make_fx path below with the wrong front-end.
+        if self._tracer == "dynamo":
+            self._compile_dynamo(args)
+            return
         if self._backend == "eager" and _has_unbacked_marks(args):
             raise NotImplementedError(
-                "precompile: mark_unbacked (dynamic shapes) is only supported with "
-                "backend='inductor'; eager + unbacked is not supported."
+                "precompile: mark_unbacked (dynamic shapes) with tracer='make_fx' is only "
+                "supported with backend='inductor'; make_fx + eager + unbacked is not "
+                "supported (tracer='dynamo' supports either backend)."
             )
         capture = _capture(self._fn, args, self._decompositions)
         self._module_positions = capture.module_positions
@@ -1443,7 +2936,7 @@ class PrecompiledModule:
         # ShapeEnv through automatically, so there is no dynamic_shapes knob to pass and
         # no manual TracingContext to install: a static capture specializes to the
         # example shapes, an unbacked capture keeps the symbols.
-        options: dict[str, Any] = {"size_asserts": True}
+        options: dict[str, object] = {"size_asserts": True}
         if capture.fake_mode is not None and hasattr(_ind_config, "scalar_asserts"):
             options["scalar_asserts"] = True
         try:
@@ -1475,6 +2968,125 @@ class PrecompiledModule:
                 ) from e
             raise
 
+    def _compile_dynamo(self, args: tuple[object, ...]) -> None:
+        # The dynamo tracer inlines the transformed bytecode; the subgraph is realized by
+        # the SAME backends as the make_fx tracer, and dynamic shapes are opt-in via
+        # mark_unbacked exactly as there -- on BOTH backends here, since Dynamo emits the
+        # ShapeEnv's runtime asserts into the subgraph itself (the make_fx tracer's eager
+        # backend has no such asserts, hence its inductor-only restriction). Dynamo honors
+        # the mark itself, so the dim is captured UNBACKED -- unguardable, hence sound
+        # without a runtime guard check. The marks precompile cannot honor at all
+        # (mark_dynamic / specialize_on) are rejected by _reject_unsupported_marks, and
+        # strict marks -- which Dynamo captures BACKED -- by _reject_strict_unbacked_marks,
+        # rather than silently baking a wrong artifact.
+        user_flat = pytree.tree_leaves(
+            tuple(a for a in args if not isinstance(a, torch.nn.Module))
+        )
+        _reject_unsupported_marks(user_flat)
+        _reject_strict_unbacked_marks(user_flat)
+        capture = _capture_dynamo(self._fn, tuple(args), self._decompositions)
+        self._dynamo_capture = capture
+
+        if self._backend == "eager":
+            # eager: keep the captured subgraph and run it as-is (no inductor lowering).
+            # gm is None when fn had no tensor op -- the bytecode is the whole artifact.
+            # The eager emit inlines the subgraph against an empty _GraphSelf(), so reject
+            # any get_attr that is not a liftable graph input (symint / torchbind / module).
+            if capture.gm is not None:
+                _reject_nonliftable_get_attrs(capture.gm)
+            self._gm = capture.gm
+            return
+
+        if capture.gm is None:
+            # inductor + no tensor compute: there is no subgraph to lower (fn returns its
+            # inputs / Python constants). Mirror the make_fx inductor path and reject with
+            # a clear error rather than emitting a backend='inductor' artifact with no
+            # kernels; the eager backend handles these.
+            raise PrecompileError(
+                "the inductor backend cannot lower a computation with no tensor compute "
+                "-- the traced fn returns its inputs or Python constants unchanged. "
+                "Return a computed tensor, or use backend='eager'."
+            )
+
+        if not capture.example_inputs:
+            # inductor + a subgraph that HAS compute but no graph inputs (fn's tensor
+            # compute depends on no lifted param/buffer or user input, e.g.
+            # ``torch.ones(3) * 2``). AOTAutograd's standalone lowering detects its fake
+            # mode off the graph's placeholders -- of which there are none -- and raises a
+            # raw RuntimeError deep in compile_to_python (neither NoRunnableInductorModule
+            # nor InductorError, so the handlers below miss it). Reject up front with a
+            # clean PrecompileError pointing at eager (which runs it fine), like the
+            # no-compute case above.
+            raise PrecompileError(
+                "the inductor backend cannot lower a subgraph with no graph inputs -- the "
+                "traced fn's tensor compute depends on no model parameter/buffer or user "
+                "input (e.g. it builds a constant tensor). Make the compute depend on an "
+                "input, or use backend='eager'."
+            )
+
+        # inductor: lower the subgraph to self-contained source exposing
+        # call(flat_inputs), reusing the make_fx inductor path. For a STATIC capture
+        # capture.example_inputs are REAL (the model's params/buffers + user inputs), so
+        # AOTAutograd re-fakeifies them under its own fake mode -- do NOT install the dynamo
+        # tracing context, which would mix fake modes. For a DYNAMIC (mark_unbacked) capture
+        # they are Dynamo's own symbolic fakes instead, which the lowering passes straight
+        # through (it recovers their fake mode off the graph), so the unbacked symbols
+        # survive. size_asserts is pinned on for the same memory-format contract
+        # (invariant 6) the make_fx inductor path enforces, and a dynamic capture also pins
+        # scalar_asserts so the ShapeEnv's runtime range / shape_id-equality asserts (the
+        # only enforcement of mark_unbacked's min/max here -- the thin dynamo driver has no
+        # bounds check of its own) survive into the artifact.
+        import torch._inductor.config as _ind_config
+        from torch._dynamo.variables.torch_function import (
+            torch_function_mode_stack_state_mgr,
+        )
+        from torch._functorch import aot_autograd
+        from torch._inductor.exc import InductorError
+        from torch._inductor.standalone_compile import NoRunnableInductorModuleError
+
+        options: dict[str, object] = {"size_asserts": True}
+        if capture.dynamic and hasattr(_ind_config, "scalar_asserts"):
+            options["scalar_asserts"] = True
+        try:
+            # With the caller's torch_function modes CLEARED, the way convert_frame
+            # holds them across a backend. Dynamo already applied them symbolically
+            # while capturing, and capture.gm is torch-level Python, so lowering it
+            # with the modes live re-traces through every one of them a SECOND time
+            # and bakes a doubly-transformed kernel -- silently, since the artifact
+            # then needs no mode at all to reproduce the wrong number.
+            with torch_function_mode_stack_state_mgr:
+                self._graph_python, self._artifact_bytes = (
+                    aot_autograd.compile_to_python(
+                        capture.gm,
+                        capture.example_inputs,
+                        options=options,
+                        # A training capture differentiates INSIDE the graph, so the AOT
+                        # capture pass has to run with grad on; see compile_to_python's
+                        # grad_enabled.
+                        grad_enabled=capture.trains,
+                    )
+                )
+        except NoRunnableInductorModuleError as e:
+            # The subgraph has no lowerable compute (e.g. fn returns an input unchanged,
+            # so the graph is a pass-through). Mirror the make_fx inductor path's clean
+            # error rather than leaking the raw lowering error.
+            raise PrecompileError(
+                "the inductor backend cannot lower a subgraph with no compute -- the "
+                "traced fn returns its inputs or Python constants unchanged, producing no "
+                "Inductor kernel. Return a computed tensor, or use backend='eager'."
+            ) from e
+        except InductorError as e:
+            # Dynamo puts non-tensor outputs in the bytecode (not the subgraph), so this
+            # is unlikely, but relabel it clearly if it does fire (mirrors the make_fx
+            # inductor path).
+            if "Unexpected output types" in str(e):
+                raise PrecompileError(
+                    "the inductor backend cannot lower the captured subgraph whose "
+                    "output mixes a non-tensor Python value with computed tensors. Use "
+                    "backend='eager'."
+                ) from e
+            raise
+
     def __call__(self, *args: object) -> object:
         # A PrecompiledModule is runnable only after load(); precompile() itself
         # returns (python_code, cache) rather than a runnable.
@@ -1503,6 +3115,10 @@ class PrecompiledModule:
                 "python_code you passed in is the source artifact (load() does not "
                 "re-capture, so there is no python_code to re-emit from this object)."
             )
+        if self._tracer == "dynamo":
+            if self._dynamo_capture is None:
+                raise PrecompileError("internal: not compiled; call _compile() first")
+            return _build_dynamo_python_source(self)
         if self._backend == "eager":
             if self._gm is None:
                 raise PrecompileError("internal: not compiled; call _compile() first")
@@ -1542,6 +3158,7 @@ class PrecompiledModule:
                 "format": _CACHE_FORMAT,
                 "version": _CACHE_VERSION,
                 "backend": self._backend,
+                "tracer": self._tracer,
                 "code_hash": code_hash,
                 "artifact": self._artifact_bytes,
             },
@@ -1642,38 +3259,74 @@ class _PrecompileApi:
           Useful for
           inspecting/debugging exactly what was traced without an Inductor dependency.
 
-        ``tracer`` selects the capture front-end:
+        ``tracer`` selects the capture front-end (orthogonal to ``backend``):
 
         - ``"make_fx"`` (default): a NON-STRICT make_fx trace -- it records the ATen ops
           that actually run when ``fn`` executes once on the example inputs and does not
           analyze your Python, so control flow and shapes are specialized to the example
-          (the source of the programming-model contract). The only tracer implemented
-          today.
-        - ``"dynamo"``: planned (a Dynamo-based front-end that analyzes the Python);
-          raises ``NotImplementedError`` for now.
+          (the source of the programming-model contract).
+        - ``"dynamo"``: a Dynamo-based front-end that analyzes the Python (bytecode)
+          rather than tracing one path. The TRANSFORMED bytecode Dynamo produces (which
+          extracts the model's params/buffers, calls the compiled subgraph, and
+          reassembles the output) is inlined into ``python_code`` (marshalled); the
+          subgraph is lowered through the same ``backend`` choices, and ``mark_unbacked``
+          dynamic shapes and ``decompositions`` are honored (see below). Scoped to
+          TRAINING steps too: a ``.backward()`` / ``torch.autograd.grad`` is traced INTO
+          the graph (precompile pins Dynamo's ``trace_autograd_ops`` so it does not
+          graph-break), and the artifact accumulates the resulting parameter gradients onto
+          the runtime model exactly like eager. A fn whose Python graph-breaks for other
+          reasons raises a ``PrecompileError`` pointing at ``tracer="make_fx"``.
+          Dynamo's runtime guards are not embedded, and -- UNLIKE the ``make_fx`` tracer --
+          the dynamo driver does NOT re-validate the runtime model/inputs at load: it does
+          not reproduce the ``make_fx`` driver's param/buffer structural check (invariant 2)
+          or per-input shape/dtype/device checks (invariants 3/6). Safety comes from the
+          same specialization contract plus, on the inductor backend, the baked
+          ``assert_size_stride`` (which catches a runtime input/weight whose SHAPE or STRIDE
+          differs, but not its DTYPE); on the EAGER backend nothing is re-checked, so a
+          drifted runtime model (broken weight tying, a retyped/reshaped weight) or a
+          broadcast-compatible input-shape mismatch can SILENTLY miscompute where
+          ``make_fx`` would raise. Pass a model and inputs matching the example, as the
+          contract requires. See the ``tracer`` note in Note [precompile programming model].
+          The dynamo artifact inlines marshalled bytecode plus a pickled state blob, so it
+          is locked to the producing Python version (unlike the portable ``make_fx`` source)
+          AND, because its import aliases can reference private ``torch._dynamo`` runtime
+          modules, to a compatible torch build; load it under the same CPython and a
+          matching torch build (or use ``make_fx`` with ``backend='eager'`` for portable
+          source; the default ``make_fx`` inductor artifact itself inlines private
+          ``torch._inductor`` modules, so it is also torch-build-locked -- only the
+          Python-version portability holds for either ``make_fx`` backend).
 
         ``decompositions`` is an optional decomposition table (a dict mapping each
-        ``OpOverload`` to a decomposition function) forwarded to ``make_fx`` as its
-        ``decomposition_table`` during capture, so you can control how ATen ops are
-        broken down in the captured graph. Defaults to ``None`` (make_fx's default).
+        ``OpOverload`` to a decomposition function) that controls how ATen ops are broken
+        down in the captured graph. Defaults to ``None`` (make_fx's default). The
+        ``make_fx`` tracer forwards it to ``make_fx`` as its ``decomposition_table``
+        during capture; the ``dynamo`` tracer applies the same table by re-tracing
+        Dynamo's captured subgraph with it (Dynamo itself never consults a decomposition
+        table), so the resulting graph is decomposed the same way on either tracer.
 
-        Dynamic shapes are opt-in via ``torch._dynamo.decorators.mark_unbacked``
-        (inductor backend only), NOT a precompile kwarg: mark dims on the inputs before
-        calling, e.g. ``mark_unbacked(x, 0); precompile(fn, model, x)`` frees ``x``'s
-        batch dim. Marked dims are captured as UNBACKED symints, which cannot be guarded
-        on, so one artifact serves any runtime size of them (invariant 3); a graph that
-        needs to guard on / specialize a marked dim fails at capture with a
-        ``PrecompileError``. Dims sharing a ``shape_id`` reuse one symbol (equal by
-        construction); ``min``/``max`` become runtime asserts. Other dims stay static.
-        Dims that MUST be equal at runtime (e.g. two inputs combined by a broadcast that
-        requires equal sizes, ``model(a) + model(b)``) MUST be given a SHARED ``shape_id``
-        so a mismatch is rejected; marking two such dims INDEPENDENTLY currently bakes a
-        SILENT equal-size assumption and a runtime mismatch does NOT raise the loud failure
-        eager gives (invariant 3). This is a harvesting gap, not an inherent limit of the
-        standalone artifact: the capture ShapeEnv DOES record the equality (as a deferred
-        runtime assert, e.g. ``Eq(u0, u1)``), but precompile does not yet harvest/enforce
-        those relational asserts in the driver -- only the decorator's declared min/max feed
-        the runtime bound checks. A shared ``shape_id`` is the way to get the check today.
+        Dynamic shapes are opt-in via ``torch._dynamo.decorators.mark_unbacked``, NOT a
+        precompile kwarg: mark dims on the inputs before calling, e.g.
+        ``mark_unbacked(x, 0); precompile(fn, model, x)`` frees ``x``'s batch dim. Marked
+        dims are captured as UNBACKED symints, which cannot be guarded on, so one artifact
+        serves any runtime size of them (invariant 3); a graph that needs to guard on /
+        specialize a marked dim fails at capture with a ``PrecompileError``. Dims sharing a
+        ``shape_id`` reuse one symbol (equal by construction); ``min``/``max`` become
+        runtime asserts. Other dims stay static. With ``tracer="make_fx"`` this requires
+        ``backend="inductor"``; with ``tracer="dynamo"`` both backends work (Dynamo emits
+        the runtime asserts into the subgraph itself), and ``mark_unbacked(strict=True)``
+        is rejected there because Dynamo reads it as a BACKED (guardable) dim.
+
+        One ``tracer="make_fx"`` caveat: dims that MUST be equal at runtime (e.g. two
+        inputs combined by a broadcast that requires equal sizes, ``model(a) + model(b)``)
+        MUST be given a SHARED ``shape_id`` so a mismatch is rejected; marking two such
+        dims INDEPENDENTLY bakes a SILENT equal-size assumption there and a runtime
+        mismatch does NOT raise the loud failure eager gives (invariant 3). This is a
+        harvesting gap, not an inherent limit of the standalone artifact: the capture
+        ShapeEnv DOES record the equality (as a deferred runtime assert, e.g.
+        ``Eq(u0, u1)``), but the make_fx path does not yet harvest/enforce those relational
+        asserts in its driver -- only the decorator's declared min/max feed its runtime
+        bound checks. A shared ``shape_id`` is the way to get the check there;
+        ``tracer="dynamo"`` enforces it either way, since the asserts ride in the graph.
 
         Returns ``(python_code, cache)`` -- a self-contained, executable Python
         source string (the single source of truth for the calling convention) and a
@@ -1706,7 +3359,10 @@ class _PrecompileApi:
         model's ``parameters()`` ``.grad`` fields, exactly like eager ``.backward()``,
         so a ``zero_grad()`` / ``optimizer.step()`` loop works unchanged; the artifact
         returns ``fn``'s own result (``None`` for a bare ``.backward()`` step), not the
-        grads (invariant 5).
+        grads (invariant 5). This holds for either ``tracer`` -- only the mechanism
+        differs (``make_fx`` harvests the grads as graph outputs and scatters them in the
+        driver; ``dynamo`` traces the backward as an in-graph autograd call whose own
+        bytecode does the accumulate).
 
         Input mutation (incl. module buffers, e.g. BatchNorm running stats in
         training mode), tensor subclasses (e.g. DTensor), and outputs aliasing inputs
@@ -1757,8 +3413,8 @@ class _PrecompileApi:
 
         Raises ``PrecompileError`` if ``python_code`` is malformed or is not a
         ``torch.compiler.precompile`` artifact (it fails to parse, or is missing the
-        calling-convention metadata), if the cache's ``backend`` tag does not match
-        ``python_code``, or if the cache's ``code_hash`` does not match
+        calling-convention metadata), if the cache's ``backend`` or ``tracer`` tag does
+        not match ``python_code``, or if the cache's ``code_hash`` does not match
         ``sha256(python_code)`` -- i.e. the cache and python_code came from different
         ``precompile()`` calls. A cache whose ``format``/``version`` does not match (a
         foreign or different-build envelope) is NOT fatal: the cache is acceleration
@@ -1776,6 +3432,10 @@ class _PrecompileApi:
         # artifact and to read BACKEND for the cache-pairing check below.
         meta = _parse_artifact_metadata(python_code)
         backend = cast(str, meta["BACKEND"])
+        # TRACER is absent on artifacts predating the dynamo tracer, so treat its absence
+        # as make_fx (matching _parse_artifact_metadata and the cache-envelope default);
+        # this keeps the pairing check below correct for older make_fx python_code.
+        tracer = cast(str, meta.get("TRACER", "make_fx"))
 
         # weights_only=True is safe (plain str/int/bytes dict). The inner artifact bytes
         # are the inductor save_cache_artifacts bundle, used below to prime the kernel
@@ -1804,6 +3464,15 @@ class _PrecompileApi:
                     raise PrecompileError(
                         f"cache backend {blob.get('backend')!r} does not match the "
                         f"python_code backend {backend!r}; the cache and python_code "
+                        "came from different precompile() calls."
+                    )
+                # A tracer tag was added alongside the dynamo tracer; treat its absence as
+                # make_fx so an older make_fx cache still pairs with its python_code. A
+                # differing tag means a wrong (code, cache) pairing, so hard-fail.
+                if blob.get("tracer", "make_fx") != tracer:
+                    raise PrecompileError(
+                        f"cache tracer {blob.get('tracer', 'make_fx')!r} does not match "
+                        f"the python_code tracer {tracer!r}; the cache and python_code "
                         "came from different precompile() calls."
                     )
                 # Reject a cache whose code_hash does not match this python_code (a

--- a/torch/_precompile_driver.py
+++ b/torch/_precompile_driver.py
@@ -54,6 +54,21 @@ if TYPE_CHECKING:
     USER_INPUT_DEVICES: list[str | None] = []
     USER_INPUT_BOUNDS: list[dict[int, tuple[int | None, int | None]] | None] = []
 
+    # Dynamo-tracer calling-convention metadata, emitted (only for tracer="dynamo") by
+    # torch._precompile._build_dynamo_metadata_section ahead of the driver. BACKEND_ID is
+    # the global name the transformed bytecode calls the compiled subgraph by (None when
+    # the trace produced no subgraph); IMPORT_SOURCES maps each import alias the bytecode
+    # references to its module name; _DYNAMO_CODE is base64(marshal(transformed bytecode));
+    # _DYNAMO_STATE is base64(pickle({used_globals, closure, argdefs, kwdefaults})).
+    BACKEND_ID: str | None = None
+    IMPORT_SOURCES: dict[str, str] = {}
+    # (frame arg index, path from that arg to the owning module, param name,
+    # expected_none) per parameter whose incoming .grad state affects the captured
+    # backward. The path is a list of ("index"|"key"|"attr", accessor) steps.
+    GRAD_PARAM_STATES: list[tuple[int, list[tuple[str, object]], str, bool]] = []
+    _DYNAMO_CODE: str = ""
+    _DYNAMO_STATE: str = ""
+
     # The compiled/captured graph's entry point, emitted before the driver.
     def call(flat_inputs: list[object]) -> list[object]: ...
 
@@ -62,7 +77,8 @@ def _extract_param_buffers(mods):
     """Lift the runtime modules' params then buffers, interning by identity, in the
     same order as capture, so the list lines up with the compiled/captured graph. Returns
     (pb, names) where names mirrors PARAM_NAMES + BUFFER_NAMES. This ordering AND the
-    naming must match torch._precompile._intern_param_buffers verbatim (its INVARIANT)."""
+    naming must match torch._precompile._intern_param_buffers verbatim (its INVARIANT).
+    """
     multi = len(mods) > 1
     seen = set()
     pb = []
@@ -366,3 +382,185 @@ def _inductor_forward(*args):
             else:
                 p.grad.add_(g)
     return _pytree.tree_unflatten(out, _pytree.treespec_loads(OUT_SPEC))
+
+
+def _rebuild_cell(value):
+    # Rebuild a closure cell holding ``value``: Python exposes no public cell
+    # constructor, so close over ``value`` in a throwaway function and steal its cell.
+    # Mirrors torch._dynamo.aot_compile.AOTCompilePickler._unpickle_cell; used to
+    # restore the transformed bytecode's free variables from their captured contents.
+    def _inner():
+        return value
+
+    if _inner.__closure__ is None:
+        raise AssertionError("closure must not be None")
+    return _inner.__closure__[0]
+
+
+def _build_dynamo_forward():
+    """Reconstruct the Dynamo-transformed function (tracer="dynamo") from the inlined
+    bytecode + state, and return it as the runnable ``forward``.
+
+    Unlike the make_fx drivers, the transformed bytecode IS the calling convention: it
+    extracts the runtime model's params/buffers itself (so structural drift surfaces as
+    the model is read, invariant 2), calls the compiled subgraph, and reassembles fn's
+    output. This driver only rehydrates that bytecode (marshalled into _DYNAMO_CODE) and
+    wires the names it references: module aliases from IMPORT_SOURCES, plain globals from
+    _DYNAMO_STATE's used_globals, and BACKEND_ID -> the compiled subgraph. The returned
+    function takes the same args fn took (the model(s) in their positions plus the
+    runtime inputs). Nothing reads an external cache: the subgraph's kernels JIT-compile
+    from the inlined source on first call (the cache, when present, only primes them).
+    """
+    import base64
+    import importlib
+    import marshal
+    import pickle
+    import sys
+    import types
+
+    try:
+        code = marshal.loads(base64.b64decode(_DYNAMO_CODE))
+        if not isinstance(code, types.CodeType):
+            # marshal can successfully deserialize a non-code object (int, list, ...) from a
+            # corrupt blob; types.FunctionType below would then raise a raw TypeError. Turn
+            # that into the same clean diagnostic the decode/load failures below emit.
+            raise ValueError("marshalled blob is not a code object")
+    except Exception as e:
+        # The inlined bytecode is marshalled CPython bytecode, specific to the Python
+        # version that produced it; loading it under a different CPython (or a corrupt
+        # blob) fails here. Surface a clean PrecompileError naming the version lock-in
+        # rather than a raw marshal error.
+        from torch._precompile import PrecompileError as _PrecompileError
+
+        raise _PrecompileError(
+            "precompile: could not rehydrate the tracer='dynamo' artifact's inlined "
+            "bytecode. It embeds marshalled CPython bytecode, which is specific to the "
+            "Python version that produced it; loading it under a different Python (this "
+            f"is {sys.version_info.major}.{sys.version_info.minor}) fails. Regenerate the "
+            "artifact under this Python version, or use tracer='make_fx' (portable "
+            f"source). Underlying: {type(e).__name__}: {e}"
+        ) from e
+    try:
+        state = pickle.loads(base64.b64decode(_DYNAMO_STATE))
+        required = {"used_globals", "closure", "argdefs", "kwdefaults"}
+        if not isinstance(state, dict) or not required <= state.keys():
+            # A corrupt blob can unpickle to a non-dict (or a dict missing a key); the
+            # state[...] accesses below would then raise a raw TypeError / KeyError. Turn
+            # that into the same clean captured-state diagnostic as an unpickle failure.
+            raise ValueError("captured-state blob is not the expected dict")
+    except Exception as e:
+        # The pickled state (the globals / closure / defaults fn referenced) failed to
+        # unpickle. Unlike the marshalled bytecode this is NOT a Python-version lock: it
+        # usually means a captured object's class or module is not importable in this
+        # environment. Surface that distinctly rather than misdirecting to the Python
+        # version.
+        from torch._precompile import PrecompileError as _PrecompileError
+
+        raise _PrecompileError(
+            "precompile: could not unpickle the tracer='dynamo' artifact's captured state "
+            "(the globals / closure / default arguments fn referenced). This usually "
+            "means a captured object's class or module is not importable here (an "
+            "environment / torch-build mismatch), not a Python-version issue. Load in an "
+            "environment matching the producer, or use tracer='make_fx'. Underlying: "
+            f"{type(e).__name__}: {e}"
+        ) from e
+    try:
+        f_globals: dict[str, object] = {
+            alias: importlib.import_module(name)
+            for alias, name in IMPORT_SOURCES.items()
+        }
+    except Exception as e:
+        # The transformed bytecode's import aliases can include PRIVATE torch._dynamo
+        # runtime modules, so the artifact is locked to a compatible torch build (not just
+        # the Python version); a renamed / moved module fails here. Surface a clean error
+        # rather than a raw ImportError from the artifact's module exec.
+        from torch._precompile import PrecompileError as _PrecompileError
+
+        raise _PrecompileError(
+            "precompile: could not import a module the tracer='dynamo' artifact "
+            "references (IMPORT_SOURCES). The dynamo artifact can reference private "
+            "torch._dynamo runtime modules, so it is locked to a compatible torch build; "
+            "regenerate under a matching torch build, or use tracer='make_fx' "
+            f"(backend='eager' for portable source). Underlying: {type(e).__name__}: {e}"
+        ) from e
+    f_globals.update(state["used_globals"])
+    if BACKEND_ID is not None:
+
+        def _compiled_subgraph(*args):
+            # The transformed bytecode calls the subgraph UNBOXED (one positional arg per
+            # graph input, reconstructed from its source); ``call`` takes the flat list
+            # (boxed). Bridge unboxed -> boxed here so the emitted subgraph is exactly the
+            # shared inductor/eager ``call`` the make_fx path already emits.
+            return call(list(args))
+
+        f_globals[BACKEND_ID] = _compiled_subgraph
+    closure = state["closure"]
+    cells = tuple(_rebuild_cell(v) for v in closure) if closure else None
+    fn = types.FunctionType(code, f_globals, closure=cells, argdefs=state["argdefs"])
+    if state["kwdefaults"]:
+        fn.__kwdefaults__ = state["kwdefaults"]
+    if not GRAD_PARAM_STATES:
+        return fn
+
+    import torch
+
+    def forward(*args, **kwargs):
+        # Dynamo specializes both user branches on ``p.grad is None`` and the
+        # backward's assign-vs-accumulate update. Validate the capture-time state before
+        # user code rather than manufacturing zero gradients, which would silently turn
+        # a fresh first step into a warm one.
+        for _pos, _path, _name, _expected_none in GRAD_PARAM_STATES:
+            # Replay the exact path capture recorded, rather than searching for
+            # a module that has a parameter of this name: two same-shaped
+            # modules in one container are indistinguishable by name, so a
+            # search stamps the first one twice and leaves the second unseeded.
+            _obj = args[_pos] if _pos < len(args) else None
+            for _kind, _acc in _path:
+                if _obj is None:
+                    break
+                try:
+                    if _kind == "index":
+                        _obj = _obj[_acc]
+                    elif _kind == "key":
+                        _obj = _obj[_acc]
+                    else:
+                        _obj = getattr(_obj, str(_acc))
+                except (LookupError, AttributeError, TypeError):
+                    _obj = None
+            _p = None
+            if isinstance(_obj, torch.nn.Module):
+                try:
+                    _p = _obj.get_parameter(_name)
+                except AttributeError:
+                    _p = None
+            if _p is None:
+                from torch._precompile import PrecompileError as _PrecompileError
+
+                _where = "".join(
+                    f"[{_a!r}]" if _k != "attr" else f".{_a}" for _k, _a in _path
+                )
+                raise _PrecompileError(
+                    f"precompile: this training artifact accumulates a gradient into "
+                    f"parameter {_name!r} of the model at positional argument "
+                    f"{_pos}{_where} (0-based, counting the bound self for a method or "
+                    f"nn.Module fn). This call passed {len(args)} positional "
+                    f"argument(s) and nothing with that parameter is at that path. Pass "
+                    f"the model in the same position and shape as at capture."
+                )
+            _actual_none = _p.grad is None
+            if _actual_none != _expected_none:
+                from torch._precompile import PrecompileError as _PrecompileError
+
+                _expected = "None" if _expected_none else "a Tensor"
+                _actual = "None" if _actual_none else "a Tensor"
+                raise _PrecompileError(
+                    f"precompile: parameter {_name!r} was captured with .grad "
+                    f"equal to {_expected}, but the runtime model has {_actual}. "
+                    "tracer='dynamo' training artifacts preserve capture-time "
+                    "branches on .grad and therefore require the same incoming "
+                    "gradient state. Call zero_grad(set_to_none=True) before a "
+                    "cold-state artifact, or recapture with the intended state."
+                )
+        return fn(*args, **kwargs)
+
+    return forward


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Add `tracer="dynamo"` to `torch.compiler.precompile`. The new path packages Dynamo-transformed bytecode with its compiled subgraph, supports forward and training captures, dynamic marks, and decompositions, and keeps runtime parameters and buffers out of the artifact. Unsupported captures and unsafe gradient attribution fail with `PrecompileError` instead of producing a silently incorrect artifact.

Differential Revision: [D116222524](https://our.internmc.facebook.com/intern/diff/D116222524/)